### PR TITLE
Compatibility fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -33,6 +33,7 @@ import static com.hazelcast.util.EmptyStatement.ignore;
 public final class BuildInfoProvider {
 
     public static final String HAZELCAST_INTERNAL_OVERRIDE_VERSION = "hazelcast.internal.override.version";
+    public static final String HAZELCAST_INTERNAL_OVERRIDE_ENTERPRISE = "hazelcast.internal.override.enterprise";
     private static final String HAZELCAST_INTERNAL_OVERRIDE_BUILD = "hazelcast.build";
 
     private static final ILogger LOGGER;
@@ -144,14 +145,16 @@ public final class BuildInfoProvider {
     }
 
     private static final class Overrides {
-        private static final Overrides DISABLED = new Overrides(null, -1);
+        private static final Overrides DISABLED = new Overrides(null, -1, null);
 
         private String version;
         private int buildNo;
+        private Boolean enterprise;
 
-        private Overrides(String version, int build) {
+        private Overrides(String version, int build, Boolean enterprise) {
             this.version = version;
             this.buildNo = build;
+            this.enterprise = enterprise;
         }
 
         private BuildInfo apply(String version, String build, String revision, int buildNumber,
@@ -164,20 +167,30 @@ public final class BuildInfoProvider {
                 LOGGER.info("Overriding hazelcast version with system property value " + this.version);
                 version = this.version;
             }
+            if (this.enterprise != null) {
+                LOGGER.info("Overriding hazelcast enterprise flag with system property value " + this.enterprise);
+                enterprise = this.enterprise;
+            }
             return new BuildInfo(version, build, revision, buildNumber, enterprise, serialVersion, upstreamBuildInfo);
 
         }
 
         private static boolean isEnabled() {
             return System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_BUILD) != null
-                    || System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION) != null;
+                    || System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION) != null
+                    || System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_ENTERPRISE) != null;
         }
 
         private static Overrides fromProperties() {
             String version = System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
             int build = Integer.getInteger(HAZELCAST_INTERNAL_OVERRIDE_BUILD, -1);
+            Boolean enterprise = null;
+            String enterpriseOverride = System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_ENTERPRISE);
+            if (enterpriseOverride != null) {
+                enterprise = Boolean.valueOf(enterpriseOverride);
+            }
 
-            return new Overrides(version, build);
+            return new Overrides(version, build, enterprise);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -175,12 +175,6 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        // RU_COMPAT_3_9
-        // fix for PostJoinMapOperation not being Versioned in 3.9.x: write 0 index info count
-        Version outputVersion = out.getVersion();
-        if (outputVersion.isUnknown() || outputVersion.isEqualTo(V3_9)) {
-            out.writeInt(0);
-        }
         out.writeInt(interceptorInfoList.size());
         for (InterceptorInfo interceptorInfo : interceptorInfoList) {
             interceptorInfo.writeData(out);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -46,6 +46,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.instance.BuildInfoProvider.getBuildInfo;
 import static com.hazelcast.internal.cluster.Versions.V3_9;
 import static com.hazelcast.util.MapUtil.createHashMap;
 
@@ -190,9 +191,9 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         // RU_COMPAT_39
-        // Version 3.9.x still sends index info's because PostJoinMapOperation was not marked Versioned
+        // Version 3.9.x still sends index info's from EE because PostJoinMapOperation was not marked Versioned
         Version inputversion = in.getVersion();
-        if (inputversion.isUnknown() || inputversion.isEqualTo(V3_9)) {
+        if ((inputversion.isUnknown() || inputversion.isEqualTo(V3_9)) && getBuildInfo().isEnterprise()) {
             // just consume the bytes
             int indexesCount = in.readInt();
             for (int i = 0; i < indexesCount; i++) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -44,7 +44,6 @@ import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.UuidUtil;
 import com.hazelcast.util.executor.StripedExecutor;
 import com.hazelcast.util.function.Supplier;
-import com.hazelcast.version.Version;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -58,7 +57,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.logging.Level;
 
-import static com.hazelcast.internal.cluster.Versions.V3_9;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterSerial;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
@@ -604,10 +602,6 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
 
     @Override
     public Operation getPreJoinOperation() {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
-        if (clusterVersion.isLessThan(V3_9)) {
-            return null;
-        }
         // pre-join operations are only sent by master member
         return getOnJoinRegistrationOperation();
     }
@@ -615,10 +609,6 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
     @Override
     public Operation getPostJoinOperation() {
         ClusterService clusterService = nodeEngine.getClusterService();
-        Version clusterVersion = clusterService.getClusterVersion();
-        if (clusterVersion.isLessThan(V3_9)) {
-            return getOnJoinRegistrationOperation();
-        }
         // Send post join registration operation only if this is the newly joining member.
         // Master will send registrations with pre-join operation.
         return clusterService.isMaster() ? null : getOnJoinRegistrationOperation();

--- a/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 
 import java.util.regex.Pattern;
 
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_ENTERPRISE;
 import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -124,5 +125,19 @@ public class BuildInfoProviderTest extends HazelcastTestSupport {
         BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
         assertEquals("99.99.99", buildInfo.getVersion());
         System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
+    }
+
+    @Test
+    public void testOverrideEdition() {
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_ENTERPRISE, "true");
+        BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
+        assertTrue(buildInfo.isEnterprise());
+        System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_ENTERPRISE);
+    }
+
+    @Test
+    public void testEdition_whenNotOverridden() {
+        BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
+        assertFalse(buildInfo.isEnterprise());
     }
 }


### PR DESCRIPTION
Fixes for `PostJoinMapOperation` upgrade compatibility from 3.9 to 3.10.
See individual commit messages for additional info.