### PR TITLE
Minor IO cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
@@ -35,8 +35,9 @@ import static java.util.Collections.newSetFromMap;
 import static java.util.concurrent.atomic.AtomicIntegerFieldUpdater.newUpdater;
 
 /**
- * An abstract {@link Channel} implementation. This class is a pure implementation detail, the fact that it exposes some
- * functionality like access to the socket channel is because the current Channel implementations need the SocketChannel.
+ * An abstract {@link Channel} implementation. This class is a pure implementation
+ * detail, the fact that it exposes some functionality like access to the socket
+ * channel is because the current Channel implementations need the SocketChannel.
  */
 public abstract class AbstractChannel implements Channel {
 
@@ -145,8 +146,9 @@ public abstract class AbstractChannel implements Channel {
     }
 
     /**
-     * Template method that is called when the socket channel closed. It is called before the {@code socketChannel} is closed.
-     * <p>
+     * Template method that is called when the socket channel closed. It is
+     * called before the {@code socketChannel} is closed.
+     *
      * It will be called only once.
      */
     protected void onClose() throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
@@ -25,55 +25,65 @@ import java.nio.ByteBuffer;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * A Channel is a construct that can send/receive like Packets/ClientMessages etc. Connections use a channel to do the real
- * work; but there is no dependency of the com.hazelcast.internal.networking to a Connection (no cycles). This means that a
+ * A Channel is a construct that can send/receive like Packets/ClientMessages etc.
+ * Connections use a channel to do the real work; but there is no dependency of the
+ * com.hazelcast.internal.networking to a Connection (no cycles). This means that a
  * Channel can be used perfectly without Connection.
  *
- * The standard channel implementation is the {@link com.hazelcast.internal.networking.nio.NioChannel} that uses TCP in
- * combination with selectors to transport data. In the future also other channel implementations could be added, e.g.
- * UDP based.
+ * The standard channel implementation is the
+ * {@link com.hazelcast.internal.networking.nio.NioChannel} that uses TCP in combination
+ * with selectors to transport data. In the future also other channel implementations
+ * could be added, e.g. UDP based.
  *
- * Channel data is read using a {@link ChannelInboundHandler}. E.g data from a socket is received and needs to get processed.
- * The {@link ChannelInboundHandler} can convert this to e.g. a Packet.
+ * Channel data is read using a {@link ChannelInboundHandler}. E.g data from a socket
+ * is received and needs to get processed. The {@link ChannelInboundHandler} can convert
+ * this to e.g. a Packet.
  *
- * Channel data is written using a {@link ChannelOutboundHandler}. E.g. a packet needs to be converted to bytes.
+ * Channel data is written using a {@link ChannelOutboundHandler}. E.g. a packet needs
+ * to be converted to bytes.
  *
  * A Channel gets initialized using the {@link ChannelInitializer}.
  *
  * <h1>Future note</h1>
- * Below you can find some notes about the future of the Channel. This will hopefully act as a guide how to move forward.
+ * Below you can find some notes about the future of the Channel. This will hopefully
+ * act as a guide how to move forward.
  *
  * <h2>Fragmentation</h2>
- * Packets are currently not fragmented, meaning that they are send as 1 atomic unit and this can cause a 2 way communication
- * blackout for operations (since either operation or response can get blocked). Fragmentation needs to be added to make sure
+ * Packets are currently not fragmented, meaning that they are send as 1 atomic unit
+ * and this can cause a 2 way communication blackout for operations (since either
+ * operation or response can get blocked). Fragmentation needs to be added to make sure
  * the system doesn't suffer from head of line blocking.
  *
  * <h2>Ordering</h2>
- * In a channel messages don't need to be ordered. Currently they are, but as soon as we add packet fragmentation, packets
- * can get out of order. Under certain conditions you want to keep ordering, e.g. for events. In this case it should be possible
+ * In a channel messages don't need to remain ordered. Currently they are, but as soon as
+ * we add packet fragmentation, packets can get out of order. Under certain conditions
+ * you want to keep ordering, e.g. for events. In this case it should be possible
  * to have multiple streams in a channel. Within a stream there will be ordering.
  *
  * <h2>Reliability</h2>
- * A channel doesn't provide reliability. TCP/IP does provide reliability, but 1: who says we want to keep using TCP/IP, but
- * if a TCP/IP connection is lost and needs to be re-established, packets are lost. Reliability can be added, just like TCP/IP
+ * A channel doesn't provide reliability. TCP/IP does provide reliability, but 1: who
+ * says we want to keep using TCP/IP, but if a TCP/IP connection is lost and needs
+ * to be re-established, packets are lost. Reliability can be added, just like TCP/IP
  * adds it; we don't discard the data until it has been acknowledged.
  *
  * <h2>Flow and congestion control</h2>
- * On the Channel level we have no flow of congestion control; frames are always accepted no matter if on the sending side
- * the write-queue is overloaded, or on the receiving side the system is overloaded (e.g. many pending operations on the
- * operation queue). Just like with TCP/IP, flow and congestion control should be added.
+ * On the Channel level we have no flow of congestion control; frames are always accepted
+ * no matter if on the sending side the write-queue is overloaded, or on the receiving side
+ * the system is overloaded (e.g. many pending operations on the operation queue). Just like
+ * with TCP/IP, flow and congestion control should be added.
  *
  * <h2>UDP</h2>
- * With ordering, reliability and flow and congestion control in place, we can ask ourselves the question if UDP is not a
- * more practical solution.
+ * With ordering, reliability and flow and congestion control in place, we can ask
+ * ourselves the question if UDP is not a more practical solution.
  */
 public interface Channel extends Closeable {
 
     /**
      * Returns the attribute map.
      *
-     * Attribute map can be used to store data into a socket. For example to find the Connection for a Channel, one can
-     * store the Connection in this channel using some well known key.
+     * Attribute map can be used to store data into a socket. For example to find the
+     * Connection for a Channel, one can store the Connection in this channel using some
+     * well known key.
      *
      * @return the attribute map.
      */
@@ -82,10 +92,12 @@ public interface Channel extends Closeable {
     /**
      * @see java.nio.channels.SocketChannel#socket()
      *
-     * This method will be removed from the interface. Only an explicit cast to NioChannel will expose the Socket.
+     * This method will be removed from the interface. Only an explicit cast to NioChannel
+     * will expose the Socket.
      *
-     * It is very important that the socket isn't closed directly; but one goes through the {@link #close()} method so that
-     * interal administration of the channel is in sync with that of the socket.
+     * It is very important that the socket isn't closed directly; but one goes through the
+     * {@link #close()} method so that interal administration of the channel is in sync with
+     * that of the socket.
      */
     Socket socket();
 
@@ -100,17 +112,24 @@ public interface Channel extends Closeable {
     SocketAddress localSocketAddress();
 
     /**
-     * Returns the last {@link com.hazelcast.util.Clock#currentTimeMillis()} a read of the socket was done.
+     * Returns the last {@link com.hazelcast.util.Clock#currentTimeMillis()} a read
+     * of the socket was done.
+     *
+     * This method is thread-safe.
      *
      * @return the last time a read from the socket was done.
      */
     long lastReadTimeMillis();
 
     /**
-     * Returns the last {@link com.hazelcast.util.Clock#currentTimeMillis()} that a write to the socket completed.
+     * Returns the last {@link com.hazelcast.util.Clock#currentTimeMillis()} that a
+     * write to the socket completed.
      *
-     * Writing to the socket doesn't mean that data has been send or received; it means that data was written to the
-     * SocketChannel. It could very well be that this data is stuck somewhere in an io-buffer.
+     * Writing to the socket doesn't mean that data has been send or received; it means
+     * that data was written to the SocketChannel. It could very well be that this data
+     * is stuck somewhere in an io-buffer.
+     *
+     * This method is thread-safe.
      *
      * @return the last time something was written to the socket.
      */
@@ -155,6 +174,8 @@ public interface Channel extends Closeable {
     /**
      * Closes the Channel.
      *
+     * This method is thread-safe.
+     *
      * When the channel already is closed, the call is ignored.
      */
     void close() throws IOException;
@@ -169,6 +190,8 @@ public interface Channel extends Closeable {
     /**
      * Adds a ChannelCloseListener.
      *
+     * This method is thread-safe.
+     *
      * @param listener the listener to register.
      * @throws NullPointerException if listener is null.
      */
@@ -177,10 +200,14 @@ public interface Channel extends Closeable {
     /**
      * Checks if this side is the Channel is in client mode or server mode.
      *
-     * A channel is in client-mode if it initiated the connection, and in server-mode if it was the one accepting the connection.
+     * A channel is in client-mode if it initiated the connection, and in
+     * server-mode if it was the one accepting the connection.
      *
-     * One of the reasons this property is valuable is for protocol/handshaking so that it is clear distinction between the
-     * side that initiated the connection, or accepted the connection.
+     * One of the reasons this property is valuable is for protocol/handshaking
+     * so that it is clear distinction between the side that initiated the connection,
+     * or accepted the connection.
+     *
+     * This method is thread-safe.
      *
      * @return true if this channel is in client-mode, false when in server-mode.
      * @see SSLEngine#getUseClientMode()
@@ -188,8 +215,10 @@ public interface Channel extends Closeable {
     boolean isClientMode();
 
     /**
-     * Queues the {@link OutboundFrame} to be written at some point in the future. No guarantee is made that the
-     * frame actually is going to be written or received.
+     * Queues the {@link OutboundFrame} to be written at some point in the future.
+     * No guarantee is made that the frame actually is going to be written or received.
+     *
+     * This method is thread-safe.
      *
      * @param frame the frame to write.
      * @return true if the frame was queued; false if rejected.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelCloseListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelCloseListener.java
@@ -19,7 +19,8 @@ package com.hazelcast.internal.networking;
 /**
  * A listener called when a {@link Channel} is closed.
  *
- * One of the potential usages is to release resources attached to a channel e.g. deregistration of metrics.
+ * One of the potential usages is to release resources attached to a channel e.g.
+ * deregistration of metrics.
  */
 public interface ChannelCloseListener {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelErrorHandler.java
@@ -17,19 +17,21 @@
 package com.hazelcast.internal.networking;
 
 /**
- * A strategy for controlling what needs to be done in case of an Exception being thrown when the {@link EventLoopGroup} processes
- * events.
+ * A strategy for controlling what needs to be done in case of an Exception
+ * being thrown when the {@link EventLoopGroup} processes events.
  *
- * For example if a connection is making use of the Channel, the Connection could close itself when an error was encountered.
+ * For example if a connection is making use of the Channel, the Connection
+ * could close itself when an error was encountered.
  */
 public interface ChannelErrorHandler {
 
     /**
      * Called when an error happened.
      *
-     * @param channel the Channel that ran into an error. It could be that the Channel is null if error
+     * @param channel the Channel that ran into an error. It could be that
+     *                the Channel is null if error
      *                was thrown not related to a particular Channel.
-     * @param cause the Throwable causing problems
+     * @param cause   the Throwable causing problems
      */
     void onError(Channel channel, Throwable cause);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/OutboundFrame.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/OutboundFrame.java
@@ -26,8 +26,8 @@ package com.hazelcast.internal.networking;
  * <li>ClientMessage: for the new client to member communication</li>
  * </ol>
  *
- * Till so far, all communication over a single connection, will be of a single Frame-class. E.g. member
- * to member only uses Packets.
+ * Till so far, all communication over a single connection, will be of a single
+ * Frame-class. E.g. member to member only uses Packets.
  *
  * There is no need for an InboundFrame interface.
  *
@@ -39,9 +39,10 @@ public interface OutboundFrame {
     /**
      * Checks if this Frame is urgent.
      *
-     * Frames that are urgent, have priority above regular frames. This is useful to implement
-     * System Operations so that they can be send faster than regular operations; especially when the system is
-     * under load you want these operations have precedence.
+     * Frames that are urgent, have priority above regular frames. This is useful
+     * to implement System Operations so that they can be send faster than regular
+     * operations; especially when the system is under load you want these operations
+     * have precedence.
      *
      * @return true if urgent, false otherwise.
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/ChannelInboundHandlerWithCounters.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/ChannelInboundHandlerWithCounters.java
@@ -20,8 +20,9 @@ import com.hazelcast.internal.networking.ChannelInboundHandler;
 import com.hazelcast.internal.util.counters.Counter;
 
 /**
- * Trigger for the ChannelReader to inject the appropriate counters. This is a temporary solution, it would be
- * best if the counters could be defined directly on handlers and automatically get registered + unregistered.
+ * Trigger for the ChannelReader to inject the appropriate counters. This is a
+ * temporary solution, it would be best if the counters could be defined directly
+ * on handlers and automatically get registered + unregistered.
  */
 public abstract class ChannelInboundHandlerWithCounters implements ChannelInboundHandler {
     protected Counter normalPacketsRead;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/MigratablePipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/MigratablePipeline.java
@@ -42,7 +42,7 @@ public interface MigratablePipeline {
      *
      * @return current owner
      */
-    NioThread getOwner();
+    NioThread owner();
 
     /**
      * Get 'load' recorded by the current pipeline. It can be used to calculate whether
@@ -50,5 +50,5 @@ public interface MigratablePipeline {
      *
      * @return total load recorded by this pipeline
      */
-    long getLoad();
+    long load();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -24,8 +24,9 @@ import java.nio.channels.SocketChannel;
 import static com.hazelcast.nio.IOUtil.closeResource;
 
 /**
- * A {@link com.hazelcast.internal.networking.Channel} implementation tailored for non blocking IO using
- * {@link java.nio.channels.Selector} in combination with a non blocking {@link SocketChannel}.
+ * A {@link com.hazelcast.internal.networking.Channel} implementation tailored
+ * for non blocking IO using {@link java.nio.channels.Selector} in combination
+ * with a non blocking {@link SocketChannel}.
  */
 public class NioChannel extends AbstractChannel {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioEventLoopGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioEventLoopGroup.java
@@ -47,26 +47,31 @@ import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.INFO;
 
 /**
- * A non blocking {@link EventLoopGroup} implementation that makes use of {@link java.nio.channels.Selector} to have a
- * limited set of io threads, handle an arbitrary number of connections.
+ * A non blocking {@link EventLoopGroup} implementation that makes use of
+ * {@link java.nio.channels.Selector} to have a limited set of io threads, handle
+ * an arbitrary number of connections.
  *
  * Each {@link NioChannel} has 2 parts:
  * <ol>
- * <li>{@link NioInboundPipeline}: triggered by the NioThread when data is available in the socket. The NioInboundPipeline
- * takes care of reading data from the socket and calling the appropriate
+ * <li>{@link NioInboundPipeline}: triggered by the NioThread when data is available
+ * in the socket. The NioInboundPipeline takes care of reading data from the socket
+ * and calling the appropriate
  * {@link com.hazelcast.internal.networking.ChannelInboundHandler}</li>
- * <li>{@link NioOutboundPipeline}: triggered by the NioThread when either space is available in the socket for writing,
- * or when there is something that needs to be written e.g. a Packet. The NioOutboundPipeline takes care of calling the
- * appropriate {@link com.hazelcast.internal.networking.ChannelOutboundHandler} to convert the
- * {@link com.hazelcast.internal.networking.OutboundFrame} to bytes in in the ByteBuffer and writing it to the socket.
+ * <li>{@link NioOutboundPipeline}: triggered by the NioThread when either space
+ * is available in the socket for writing, or when there is something that needs to
+ * be written e.g. a Packet. The NioOutboundPipeline takes care of calling the
+ * appropriate {@link com.hazelcast.internal.networking.ChannelOutboundHandler}
+ * to convert the {@link com.hazelcast.internal.networking.OutboundFrame} to bytes
+ * in in the ByteBuffer and writing it to the socket.
  * </li>
  * </ol>
  *
- * By default the {@link NioThread} blocks on the Selector, but it can be put in a 'selectNow' mode that makes it
- * spinning on the selector. This is an experimental feature and will cause the io threads to run hot. For this reason, when
- * this feature is enabled, the number of io threads should be reduced (preferably 1).
+ * By default the {@link NioThread} blocks on the Selector, but it can be put in a
+ * 'selectNow' mode that makes it spinning on the selector. This is an experimental
+ * feature and will cause the io threads to run hot. For this reason, when this feature
+ * is enabled, the number of io threads should be reduced (preferably 1).
  */
-public class NioEventLoopGroup implements EventLoopGroup {
+public final class NioEventLoopGroup implements EventLoopGroup {
 
     private final AtomicInteger nextInputThreadIndex = new AtomicInteger();
     private final AtomicInteger nextOutputThreadIndex = new AtomicInteger();
@@ -273,7 +278,7 @@ public class NioEventLoopGroup implements EventLoopGroup {
         public void run() {
             for (NioChannel channel : channels) {
                 final NioInboundPipeline inboundPipeline = channel.inboundPipeline;
-                NioThread inputThread = inboundPipeline.getOwner();
+                NioThread inputThread = inboundPipeline.owner();
                 if (inputThread != null) {
                     inputThread.addTaskAndWakeup(new Runnable() {
                         @Override
@@ -284,7 +289,7 @@ public class NioEventLoopGroup implements EventLoopGroup {
                 }
 
                 final NioOutboundPipeline outboundPipeline = channel.outboundPipeline;
-                NioThread outputThread = outboundPipeline.getOwner();
+                NioThread outputThread = outboundPipeline.owner();
                 if (outputThread != null) {
                     outputThread.addTaskAndWakeup(new Runnable() {
                         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
@@ -70,7 +70,7 @@ public final class NioInboundPipeline extends NioPipeline {
     }
 
     @Override
-    public long getLoad() {
+    public long load() {
         switch (LOAD_TYPE) {
             case LOAD_BALANCING_HANDLE:
                 return processCount.get();

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -89,7 +89,7 @@ public final class NioOutboundPipeline extends NioPipeline implements Runnable {
     }
 
     @Override
-    public long getLoad() {
+    public long load() {
         switch (LOAD_TYPE) {
             case LOAD_BALANCING_HANDLE:
                 return processCount.get();

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
@@ -95,8 +95,8 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable {
     }
 
     @Override
-    public NioThread getOwner() {
-        return owner;
+    public NioThread owner() {
+            return owner;
     }
 
     public void start() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -352,7 +352,7 @@ public class NioThread extends Thread implements OperationHostileThread {
 
     private NioThread getTargetIOThread(Runnable task) {
         if (task instanceof MigratablePipeline) {
-            return ((MigratablePipeline) task).getOwner();
+            return ((MigratablePipeline) task).owner();
         } else {
             return this;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorOptimizer.java
@@ -32,9 +32,10 @@ import static java.lang.Class.forName;
 import static java.lang.System.arraycopy;
 
 /**
- * The SelectorOptimizer optimizes the Selector so less litter is being created. The Selector uses a HashSet, but this creates
- * an object for every add of a selection key. With this SelectorOptimizer a SelectionKeysSet, which contains an  an array,
- * is being used since every key is going to be inserted only once.
+ * The SelectorOptimizer optimizes the Selector so less litter is being created.
+ * The Selector uses a HashSet, but this creates an object for every add of a
+ * selection key. With this SelectorOptimizer a SelectionKeysSet, which contains
+ * an  an array, is being used since every key is going to be inserted only once.
  *
  * This trick comes from Netty.
  */
@@ -51,7 +52,7 @@ public final class SelectorOptimizer {
      * @return the created Selector.
      * @throws NullPointerException if logger is null.
      */
-    public static Selector newSelector(ILogger logger) {
+    static Selector newSelector(ILogger logger) {
         checkNotNull(logger, "logger");
 
         Selector selector;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
@@ -168,7 +168,7 @@ public class IOBalancer {
             return new MonkeyMigrationStrategy();
         } else {
             logger.finest("Using normal IO Balancer Strategy.");
-            return new EventCountBasicMigrationStrategy();
+            return new LoadMigrationStrategy();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadMigrationStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadMigrationStrategy.java
@@ -31,7 +31,7 @@ import java.util.Set;
  * overload of the {@link LoadImbalance#destinationSelector} after a migration.
  *
  */
-class EventCountBasicMigrationStrategy implements MigrationStrategy {
+class LoadMigrationStrategy implements MigrationStrategy {
 
     /**
      * You can use this property to tune whether the migration will be attempted at all. The higher the number is

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
@@ -156,14 +156,14 @@ class LoadTracker {
     private void updateHandlerState(MigratablePipeline pipeline) {
         long pipelineEventCount = getEventCountSinceLastCheck(pipeline);
         handlerEventsCounter.set(pipeline, pipelineEventCount);
-        NioThread owner = pipeline.getOwner();
+        NioThread owner = pipeline.owner();
         selectorEvents.add(owner, pipelineEventCount);
         Set<MigratablePipeline> handlersOwnedBy = selectorToHandlers.get(owner);
         handlersOwnedBy.add(pipeline);
     }
 
     private long getEventCountSinceLastCheck(MigratablePipeline pipeline) {
-        long eventCount = pipeline.getLoad();
+        long eventCount = pipeline.load();
         Long lastEventCount = lastEventCounter.getAndSet(pipeline, eventCount);
         return eventCount - lastEventCount;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/package-info.java
@@ -15,7 +15,12 @@
  */
 
 /**
- * Contains the socket connection functionality. So effectively it contains all the networking that is shared between
- * client and server.
+ * Contains the socket connection functionality. So effectively it contains all
+ * the networking that is shared between client and server.
+ *
+ * This package should not contains server/client etc specific behavior. It should
+ * remain neutral, so that the networking package remains reusable for all kinds of
+ * purposes. E.g. if we want to totally isolate WAN replication, it should be
+ * possible without needing to make (many) modifications to this page.
  */
 package com.hazelcast.internal.networking;

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
@@ -587,8 +587,8 @@ public final class IOUtil {
      * @return the debug String
      */
     public static String toDebugString(String name, ByteBuffer byteBuffer) {
-        return name + "(pos:" + byteBuffer.position() + " cap:" + byteBuffer.capacity()
-                + " remain:" + byteBuffer.remaining() + " lim:" + byteBuffer.limit() + ")";
+        return name + "(pos:" + byteBuffer.position() + " lim:" + byteBuffer.limit()
+                + " remain:" + byteBuffer.remaining() + " cap:" + byteBuffer.capacity() + ")";
     }
 
     private static final class ClassLoaderAwareObjectInputStream extends ObjectInputStream {

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
@@ -109,10 +109,10 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
     }
 
     private void add(Map<NioThread, Set<MigratablePipeline>> handlersPerSelector, MigratablePipeline handler) {
-        Set<MigratablePipeline> handlers = handlersPerSelector.get(handler.getOwner());
+        Set<MigratablePipeline> handlers = handlersPerSelector.get(handler.owner());
         if (handlers == null) {
             handlers = new HashSet<MigratablePipeline>();
-            handlersPerSelector.put(handler.getOwner(), handlers);
+            handlersPerSelector.put(handler.owner(), handlers);
         }
         handlers.add(handler);
     }
@@ -132,7 +132,7 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
         MigratablePipeline activeHandler = iterator.next();
         if (handlers.size() == 2) {
             MigratablePipeline deadHandler = iterator.next();
-            if (activeHandler.getLoad() < deadHandler.getLoad()) {
+            if (activeHandler.load() < deadHandler.load()) {
                 MigratablePipeline tmp = deadHandler;
                 deadHandler = activeHandler;
                 activeHandler = tmp;
@@ -141,11 +141,11 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
             // the maximum number of events seen on the dead connection is 3. 10 should be save to assume the
             // connection is dead.
             assertTrue("at most 10 event should have been received, number of events received:"
-                    + deadHandler.getLoad(), deadHandler.getLoad() < 10);
+                    + deadHandler.load(), deadHandler.load() < 10);
         }
 
-        assertTrue("activeHandlerEvent count should be at least 1000, but was:" + activeHandler.getLoad(),
-                activeHandler.getLoad() > 1000);
+        assertTrue("activeHandlerEvent count should be at least 1000, but was:" + activeHandler.load(),
+                activeHandler.load() > 1000);
     }
 
     private String debug(TcpIpConnectionManager connectionManager) {
@@ -158,8 +158,8 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
 
             for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
                 NioInboundPipeline socketReader = ((NioChannel) connection.getChannel()).inboundPipeline();
-                if (socketReader.getOwner() == in) {
-                    sb.append("\t").append(socketReader).append(" eventCount:").append(socketReader.getLoad()).append("\n");
+                if (socketReader.owner() == in) {
+                    sb.append("\t").append(socketReader).append(" eventCount:").append(socketReader.load()).append("\n");
                 }
             }
         }
@@ -169,8 +169,8 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
 
             for (TcpIpConnection connection : connectionManager.getActiveConnections()) {
                 NioOutboundPipeline socketWriter = ((NioChannel) connection.getChannel()).outboundPipeline();
-                if (socketWriter.getOwner() == in) {
-                    sb.append("\t").append(socketWriter).append(" eventCount:").append(socketWriter.getLoad()).append("\n");
+                if (socketWriter.owner() == in) {
+                    sb.append("\t").append(socketWriter).append(" eventCount:").append(socketWriter.load()).append("\n");
                 }
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadMigrationStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadMigrationStrategyTest.java
@@ -41,24 +41,24 @@ import static org.mockito.Mockito.mock;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
+public class LoadMigrationStrategyTest extends HazelcastTestSupport {
 
     private Map<NioThread, Set<MigratablePipeline>> selectorToHandlers;
     private ItemCounter<MigratablePipeline> handlerEventsCounter;
     private LoadImbalance imbalance;
 
-    private EventCountBasicMigrationStrategy strategy;
+    private LoadMigrationStrategy strategy;
 
     @Before
     public void setUp() {
         selectorToHandlers = new HashMap<NioThread, Set<MigratablePipeline>>();
         handlerEventsCounter = new ItemCounter<MigratablePipeline>();
         imbalance = new LoadImbalance(selectorToHandlers, handlerEventsCounter);
-        strategy = new EventCountBasicMigrationStrategy();
+        strategy = new LoadMigrationStrategy();
     }
 
     @Test
-    public void testImbalanceDetected_shouldReturnFalseWhenNoKnownMinimum() throws Exception {
+    public void testImbalanceDetected_shouldReturnFalseWhenNoKnownMinimum() {
         imbalance.minimumEvents = Long.MIN_VALUE;
 
         boolean imbalanceDetected = strategy.imbalanceDetected(imbalance);
@@ -66,7 +66,7 @@ public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testImbalanceDetected_shouldReturnFalseWhenNoKnownMaximum() throws Exception {
+    public void testImbalanceDetected_shouldReturnFalseWhenNoKnownMaximum() {
         imbalance.maximumEvents = Long.MAX_VALUE;
 
         boolean imbalanceDetected = strategy.imbalanceDetected(imbalance);
@@ -74,7 +74,7 @@ public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testImbalanceDetected_shouldReturnFalseWhenBalanced() throws Exception {
+    public void testImbalanceDetected_shouldReturnFalseWhenBalanced() {
         imbalance.maximumEvents = 1000;
         imbalance.minimumEvents = (long) (1000 * 0.8);
 
@@ -83,7 +83,7 @@ public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testImbalanceDetected_shouldReturnTrueWhenNotBalanced() throws Exception {
+    public void testImbalanceDetected_shouldReturnTrueWhenNotBalanced() {
         imbalance.maximumEvents = 1000;
         imbalance.minimumEvents = (long) (1000 * 0.8) - 1;
 
@@ -92,7 +92,7 @@ public class EventCountBasicMigrationStrategyTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testFindHandlerToMigrate() throws Exception {
+    public void testFindPipelinesToMigrate() {
         NioThread sourceSelector = mock(NioThread.class);
         NioThread destinationSelector = mock(NioThread.class);
         imbalance.sourceSelector = sourceSelector;

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTrackerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTrackerTest.java
@@ -56,25 +56,25 @@ public class LoadTrackerTest {
     @Test
     public void testUpdateImbalance() throws Exception {
         MigratablePipeline selector1Handler1 = mock(MigratablePipeline.class);
-        when(selector1Handler1.getLoad()).thenReturn(0L)
+        when(selector1Handler1.load()).thenReturn(0L)
                 .thenReturn(100L);
-        when(selector1Handler1.getOwner())
+        when(selector1Handler1.owner())
                 .thenReturn(selector1);
         loadTracker.addPipeline(selector1Handler1);
 
         MigratablePipeline selector2Handler1 = mock(MigratablePipeline.class);
-        when(selector2Handler1.getLoad())
+        when(selector2Handler1.load())
                 .thenReturn(0L)
                 .thenReturn(200L);
-        when(selector2Handler1.getOwner())
+        when(selector2Handler1.owner())
                 .thenReturn(selector2);
         loadTracker.addPipeline(selector2Handler1);
 
         MigratablePipeline selector2Handler3 = mock(MigratablePipeline.class);
-        when(selector2Handler3.getLoad())
+        when(selector2Handler3.load())
                 .thenReturn(0L)
                 .thenReturn(100L);
-        when(selector2Handler3.getOwner())
+        when(selector2Handler3.owner())
                 .thenReturn(selector2);
         loadTracker.addPipeline(selector2Handler3);
 
@@ -94,18 +94,18 @@ public class LoadTrackerTest {
     public void testUpdateImbalance_notUsingSingleHandlerSelectorAsSource() throws Exception {
         MigratablePipeline selector1Handler1 = mock(MigratablePipeline.class);
         // the first selector has a handler with a large number of events
-        when(selector1Handler1.getLoad()).thenReturn(10000L);
-        when(selector1Handler1.getOwner()).thenReturn(selector1);
+        when(selector1Handler1.load()).thenReturn(10000L);
+        when(selector1Handler1.owner()).thenReturn(selector1);
         loadTracker.addPipeline(selector1Handler1);
 
         MigratablePipeline selector2Handler = mock(MigratablePipeline.class);
-        when(selector2Handler.getLoad()).thenReturn(200L);
-        when(selector2Handler.getOwner()).thenReturn(selector2);
+        when(selector2Handler.load()).thenReturn(200L);
+        when(selector2Handler.owner()).thenReturn(selector2);
         loadTracker.addPipeline(selector2Handler);
 
         MigratablePipeline selector2Handler2 = mock(MigratablePipeline.class);
-        when(selector2Handler2.getLoad()).thenReturn(200L);
-        when(selector2Handler2.getOwner()).thenReturn(selector2);
+        when(selector2Handler2.load()).thenReturn(200L);
+        when(selector2Handler2.owner()).thenReturn(selector2);
         loadTracker.addPipeline(selector2Handler2);
 
         LoadImbalance loadImbalance = loadTracker.updateImbalance();


### PR DESCRIPTION
The MigratableHandler owner() instead of getOwner and load() vs getLoad()

Minor javadoc cleanups

Some removal of finals where not needed.

This comes from the IO pipeline PR and trying to separate all low risk stuff from the important work.