### PR TITLE
Test DynamicConfigurationAwareConfig overrides all public methods of Config

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/ClientDynamicClusterConfig.java
@@ -411,6 +411,46 @@ public class ClientDynamicClusterConfig extends Config {
     }
 
     @Override
+    public EventJournalConfig findMapEventJournalConfig(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public EventJournalConfig findCacheEventJournalConfig(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public EventJournalConfig getMapEventJournalConfig(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public EventJournalConfig getCacheEventJournalConfig(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Map<String, EventJournalConfig> getMapEventJournalConfigs() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Map<String, EventJournalConfig> getCacheEventJournalConfigs() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Config setMapEventJournalConfigs(Map<String, EventJournalConfig> eventJournalConfigs) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Config setCacheEventJournalConfigs(Map<String, EventJournalConfig> eventJournalConfigs) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
     public Config addFlakeIdGeneratorConfig(FlakeIdGeneratorConfig flakeIdGeneratorConfig) {
         ClientMessage request = DynamicConfigAddFlakeIdGeneratorConfigCodec.encodeRequest(
                 flakeIdGeneratorConfig.getName(),
@@ -819,6 +859,11 @@ public class ClientDynamicClusterConfig extends Config {
     }
 
     @Override
+    public Map<String, SemaphoreConfig> getSemaphoreConfigsAsMap() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
     public Config setSemaphoreConfigs(Map<String, SemaphoreConfig> semaphoreConfigs) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
@@ -1115,6 +1160,36 @@ public class ClientDynamicClusterConfig extends Config {
 
     @Override
     public Config setFlakeIdGeneratorConfigs(Map<String, FlakeIdGeneratorConfig> map) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public MapConfig getMapConfigOrNull(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public CacheSimpleConfig findCacheConfigOrNull(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public PNCounterConfig findPNCounterConfig(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Map<String, PNCounterConfig> getPNCounterConfigs() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public PNCounterConfig getPNCounterConfig(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Config setPNCounterConfigs(Map<String, PNCounterConfig> pnCounterConfigs) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientDynamicConfigurationAwareConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientDynamicConfigurationAwareConfigTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfigTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientDynamicConfigurationAwareConfigTest extends DynamicConfigurationAwareConfigTest {
+
+    @Override
+    protected Class<? extends Config> getDynamicConfigClass() {
+        return ClientDynamicClusterConfig.class;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfigTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -32,13 +33,19 @@ import static org.junit.Assert.fail;
 @Category({QuickTest.class, ParallelTest.class})
 public class DynamicConfigurationAwareConfigTest {
 
+    protected Class<? extends Config> getDynamicConfigClass() {
+        return DynamicConfigurationAwareConfig.class;
+    }
+
     @Test
     public void testDecorateAllPublicMethodsFromTest() {
         // this test makes sure when you add a new method into Config class
         // then you also adds it into the Dynamic Configuration Aware decorator.
 
-        // in other words: if this test is failing then update the DynamicConfigurationAwareConfig
-        Method[] methods = DynamicConfigurationAwareConfig.class.getMethods();
+        // in other words: if this test is failing then update the class returned by
+        // getDynamicConfigClass()
+        Class<? extends Config> dynamicConfigClass = getDynamicConfigClass();
+        Method[] methods = dynamicConfigClass.getMethods();
         for (Method method : methods) {
             if (isMethodStatic(method)) {
                 continue;
@@ -49,10 +56,10 @@ public class DynamicConfigurationAwareConfigTest {
             }
 
             //all other public method should be overridden by the dynamic config aware decorator
-            if (!isMethodDeclaredByClass(method, DynamicConfigurationAwareConfig.class)) {
+            if (!isMethodDeclaredByClass(method, dynamicConfigClass)) {
                 Class<?> declaringClass = method.getDeclaringClass();
                 fail("Method " + method + " is declared by " + declaringClass + " whilst it should be"
-                        + " declared by " + DynamicConfigurationAwareConfig.class);
+                        + " declared by " + dynamicConfigClass);
             }
         }
     }


### PR DESCRIPTION
Fixes #12010

I didn't get the comment in the original issue: _"it may only make sense to address this once all new config's are in place for 3.10, as each new config will require additional methods in the DynamicConfigTemplate in hazelcast-client-protocol."_ So I hope I understand the test-case correctly. 