### PR TITLE
Set interrupted flag back on catching InterruptedExceptions

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -70,6 +70,7 @@ import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLET
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowedTypeFirst;
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
+import static java.lang.Thread.currentThread;
 
 /**
  * Abstract {@link com.hazelcast.cache.ICache} implementation which provides shared internal implementations
@@ -702,6 +703,7 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
                 logger.finest("Countdown latch wait timeout after " + MAX_COMPLETION_LATCH_WAIT_TIME + " milliseconds!");
             }
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             sneakyThrow(e);
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -70,7 +70,7 @@ import java.util.concurrent.locks.Lock;
 
 import static com.hazelcast.util.StringUtil.lowerCaseInternal;
 import static java.lang.String.format;
-
+import static java.lang.Thread.currentThread;
 
 /**
  * A demo application to demonstrate a Hazelcast client. This is probably NOT something you want to use in production.
@@ -488,6 +488,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             try {
                 f.get();
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 e.printStackTrace();
             } catch (ExecutionException e) {
                 e.printStackTrace();
@@ -699,6 +700,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         try {
             println(getMap().putAsync(args[1], args[2]).get());
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         } catch (ExecutionException e) {
             e.printStackTrace();
@@ -721,6 +723,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         try {
             println(getMap().getAsync(args[1]).get());
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         } catch (ExecutionException e) {
             e.printStackTrace();
@@ -815,6 +818,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             try {
                 locked = getMap().tryLock(key, time, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 locked = false;
             }
         }
@@ -938,6 +942,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             try {
                 locked = getMultiMap().tryLock(key, time, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 locked = false;
             }
         }
@@ -983,6 +988,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
                     println(lock.tryLock(time, TimeUnit.SECONDS));
                 } catch (InterruptedException e) {
                     e.printStackTrace();
+                    currentThread().interrupt();
                 }
             }
         }
@@ -1191,6 +1197,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             boolean offered = getQueue().offer(args[1], timeout, TimeUnit.SECONDS);
             println(offered);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         }
     }
@@ -1199,6 +1206,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         try {
             println(getQueue().take());
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         }
     }
@@ -1211,6 +1219,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         try {
             println(getQueue().poll(timeout, TimeUnit.SECONDS));
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         }
     }
@@ -1309,6 +1318,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
             }
             println("Result: " + future.get());
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         } catch (ExecutionException e) {
             e.printStackTrace();
@@ -1326,6 +1336,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
                 println(f.get());
             }
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         } catch (ExecutionException e) {
             e.printStackTrace();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
@@ -36,6 +36,7 @@ import java.util.concurrent.locks.Condition;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkPositive;
+import static java.lang.Thread.currentThread;
 
 /**
  * Proxy implementation of {@link ILock}.
@@ -127,6 +128,7 @@ public class ClientLockProxy extends PartitionSpecificClientProxy implements ILo
         try {
             return tryLock(0, null);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return false;
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -173,6 +173,7 @@ import static com.hazelcast.util.Preconditions.checkNotInstanceOf;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.SortingUtil.getSortedQueryResultSet;
 import static com.hazelcast.util.ThreadUtil.getThreadId;
+import static java.lang.Thread.currentThread;
 import static java.util.Collections.emptyMap;
 
 /**
@@ -640,6 +641,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
         try {
             return tryLock(key, 0, null);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return false;
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -83,6 +83,7 @@ import static com.hazelcast.map.impl.ListenerAdapters.createListenerAdapter;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkPositive;
 import static com.hazelcast.util.Preconditions.isNotNull;
+import static java.lang.Thread.currentThread;
 
 /**
  * Proxy implementation of {@link MultiMap}.
@@ -371,6 +372,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
         try {
             return tryLock(key, 0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return false;
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
@@ -59,6 +59,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.lang.Thread.currentThread;
 
 /**
  * Proxy implementation of {@link IQueue}.
@@ -166,6 +167,7 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
         try {
             return offer(e, 0, TimeUnit.SECONDS);
         } catch (InterruptedException ex) {
+            currentThread().interrupt();
             return false;
         }
     }
@@ -270,6 +272,7 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
         try {
             return poll(0, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return null;
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSemaphoreProxy.java
@@ -29,6 +29,8 @@ import com.hazelcast.core.ISemaphore;
 
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.Thread.currentThread;
+
 /**
  * Proxy implementation of {@link ISemaphore}.
  */
@@ -113,6 +115,7 @@ public class ClientSemaphoreProxy extends PartitionSpecificClientProxy implement
         try {
             return tryAcquire(permits, 0, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return false;
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnQueueProxy.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.serialization.Data;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.ThreadUtil.getThreadId;
+import static java.lang.Thread.currentThread;
 
 /**
  * Proxy implementation of {@link TransactionalQueue}.
@@ -47,6 +48,7 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
         try {
             return offer(e, 0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e1) {
+            currentThread().interrupt();
             return false;
         }
     }
@@ -72,6 +74,7 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
         try {
             return poll(0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return null;
         }
     }
@@ -89,6 +92,7 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
         try {
             return peek(0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return null;
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -107,6 +107,7 @@ import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.ServiceLoader.classIterator;
+import static java.lang.Thread.currentThread;
 
 /**
  * The ProxyManager handles client proxy instantiation and retrieval at start and runtime by registering
@@ -366,6 +367,7 @@ public final class ProxyManager {
         try {
             Thread.sleep(invocationRetryPauseMillis);
         } catch (InterruptedException ignored) {
+            currentThread().interrupt();
             EmptyStatement.ignore(ignored);
         }
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.spi.properties.GroupProperty.TASK_SCHEDULER_REMOVE_ON_CANCEL;
+import static java.lang.Thread.currentThread;
 
 public final class ClientExecutionServiceImpl implements ClientExecutionService, MetricsProvider {
 
@@ -130,6 +131,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService,
                         + " seconds");
             }
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             logger.warning(name + " executor await termination is interrupted", e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -57,6 +57,7 @@ import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
 import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLETION;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowedTypeFirst;
 import static com.hazelcast.util.SetUtil.createHashSet;
+import static java.lang.Thread.currentThread;
 
 /**
  * Abstract {@link com.hazelcast.cache.ICache} implementation which provides shared internal implementations
@@ -417,6 +418,7 @@ abstract class AbstractInternalCacheProxy<K, V>
 
             }
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             ExceptionUtil.sneakyThrow(e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/AbstractExecutorServiceCancelMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/AbstractExecutorServiceCancelMessageTask.java
@@ -29,6 +29,8 @@ import java.net.UnknownHostException;
 import java.security.Permission;
 import java.util.concurrent.ExecutionException;
 
+import static java.lang.Thread.currentThread;
+
 public abstract class AbstractExecutorServiceCancelMessageTask<P> extends AbstractCallableMessageTask<P> {
 
     private static final int CANCEL_TRY_COUNT = 50;
@@ -47,6 +49,7 @@ public abstract class AbstractExecutorServiceCancelMessageTask<P> extends Abstra
         try {
             result = (Boolean) future.get();
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             logException(e);
         } catch (ExecutionException e) {
             logException(e);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxyImpl.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.Preconditions.checkFalse;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.lang.Thread.currentThread;
 
 /**
  * Proxy implementation for the Queue.
@@ -62,6 +63,7 @@ public class QueueProxyImpl<E> extends QueueProxySupport implements IQueue<E>, I
         try {
             return offer(e, 0, TimeUnit.SECONDS);
         } catch (InterruptedException ex) {
+            currentThread().interrupt();
             return false;
         }
     }
@@ -139,7 +141,7 @@ public class QueueProxyImpl<E> extends QueueProxySupport implements IQueue<E>, I
         try {
             return poll(0, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
-            //todo: interrupt status is lost
+            currentThread().interrupt();
             return null;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
@@ -25,6 +25,7 @@ import com.hazelcast.util.EmptyStatement;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.lang.Thread.currentThread;
 
 /**
  * Provides proxy for the Transactional Queue.
@@ -42,6 +43,7 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E
         try {
             return offer(e, 0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException ignored) {
+            currentThread().interrupt();
             EmptyStatement.ignore(ignored);
         }
         return false;
@@ -67,7 +69,7 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E
         try {
             return poll(0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException ignored) {
-            //todo: interrupt status swallowed
+            currentThread().interrupt();
             EmptyStatement.ignore(ignored);
         }
         return null;
@@ -87,7 +89,7 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E
         try {
             return peek(0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException ignored) {
-            //todo: interrupt status swallowed
+            currentThread().interrupt();
             EmptyStatement.ignore(ignored);
         }
         return null;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockProxySupport.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.concurrent.lock.LockServiceImpl.SERVICE_NAME;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowInterrupted;
 import static com.hazelcast.util.ThreadUtil.getThreadId;
+import static java.lang.Thread.currentThread;
 
 public final class LockProxySupport {
 
@@ -117,6 +118,7 @@ public final class LockProxySupport {
         try {
             return tryLock(nodeEngine, key, 0, TimeUnit.MILLISECONDS, -1, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return false;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreProxy.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowInterrupted;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
+import static java.lang.Thread.currentThread;
 
 public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> implements ISemaphore {
 
@@ -125,6 +126,7 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
         try {
             return tryAcquire(1, 0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return false;
         }
     }
@@ -134,6 +136,7 @@ public class SemaphoreProxy extends AbstractDistributedObject<SemaphoreService> 
         try {
             return tryAcquire(permits, 0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return false;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -41,7 +41,6 @@ import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.Partition;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.util.Clock;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.BufferedReader;
@@ -73,6 +72,7 @@ import static com.hazelcast.util.StringUtil.equalsIgnoreCase;
 import static com.hazelcast.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.util.StringUtil.trim;
 import static java.lang.String.format;
+import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -459,6 +459,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             try {
                 f.get();
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 e.printStackTrace();
             } catch (ExecutionException e) {
                 e.printStackTrace();
@@ -675,6 +676,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         try {
             println(getMap().putAsync(args[1], args[2]).get());
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         } catch (ExecutionException e) {
             e.printStackTrace();
@@ -697,6 +699,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         try {
             println(getMap().getAsync(args[1]).get());
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         } catch (ExecutionException e) {
             e.printStackTrace();
@@ -794,6 +797,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             try {
                 locked = getMap().tryLock(key, time, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 locked = false;
             }
         }
@@ -917,6 +921,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             try {
                 locked = getMultiMap().tryLock(key, time, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 locked = false;
             }
         }
@@ -961,6 +966,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
                 try {
                     println(lock.tryLock(time, TimeUnit.SECONDS));
                 } catch (InterruptedException e) {
+                    currentThread().interrupt();
                     e.printStackTrace();
                 }
             }
@@ -1171,6 +1177,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             boolean offered = getQueue().offer(args[1], timeout, TimeUnit.SECONDS);
             println(offered);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         }
     }
@@ -1179,6 +1186,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         try {
             println(getQueue().take());
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         }
     }
@@ -1191,6 +1199,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
         try {
             println(getQueue().poll(timeout, TimeUnit.SECONDS));
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         }
     }
@@ -1290,6 +1299,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
             }
             println("Result: " + future.get());
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         } catch (ExecutionException e) {
             e.printStackTrace();
@@ -1307,6 +1317,7 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
                 println(f.get());
             }
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             e.printStackTrace();
         } catch (ExecutionException e) {
             e.printStackTrace();

--- a/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/SimulateLoadTask.java
@@ -23,6 +23,8 @@ import com.hazelcast.nio.serialization.BinaryInterface;
 import java.io.Serializable;
 import java.util.concurrent.Callable;
 
+import static java.lang.Thread.currentThread;
+
 /**
  * A simulated load test.
  */
@@ -53,6 +55,7 @@ public final class SimulateLoadTask implements Callable, Serializable, Hazelcast
         try {
             Thread.sleep(delay * ONE_THOUSAND);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             throw new RuntimeException(e);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.Preconditions.checkPositive;
+import static java.lang.Thread.currentThread;
 import static java.util.Collections.newSetFromMap;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -99,6 +100,7 @@ public class FlakeIdGeneratorProxy
                             try {
                                 Thread.sleep(result.waitTimeMillis);
                             } catch (InterruptedException e) {
+                                currentThread().interrupt();
                                 throw rethrow(e);
                             }
                         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -41,6 +41,7 @@ import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
 import static com.hazelcast.util.Preconditions.checkHasText;
 import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.lang.String.format;
+import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -211,6 +212,7 @@ public final class HazelcastInstanceFactory {
                         SECONDS.sleep(ADDITIONAL_SLEEP_SECONDS_FOR_NON_FIRST_MEMBERS);
                     }
                 } catch (InterruptedException ignored) {
+                    currentThread().interrupt();
                     EmptyStatement.ignore(ignored);
                 }
             }
@@ -240,6 +242,7 @@ public final class HazelcastInstanceFactory {
                 // noinspection BusyWait
                 SECONDS.sleep(1);
             } catch (InterruptedException ignored) {
+                currentThread().interrupt();
                 EmptyStatement.ignore(ignored);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -105,6 +105,7 @@ import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_POLICY;
 import static com.hazelcast.util.StringUtil.isNullOrEmpty;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
+import static java.lang.Thread.currentThread;
 import static java.security.AccessController.doPrivileged;
 
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:visibilitymodifier", "checkstyle:classdataabstractioncoupling",
@@ -549,6 +550,7 @@ public class Node {
             try {
                 Thread.sleep(THREAD_SLEEP_DURATION_MS);
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 logger.warning("Interrupted while waiting for shutdown!");
                 return;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -77,6 +77,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.UNKNOWN;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.VERSION;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
+import static java.lang.Thread.currentThread;
 
 public class TextCommandServiceImpl implements TextCommandService {
 
@@ -325,6 +326,7 @@ public class TextCommandServiceImpl implements TextCommandService {
         try {
             return hazelcast.getQueue(queueName).poll(seconds, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             return null;
         }
     }
@@ -397,6 +399,7 @@ public class TextCommandServiceImpl implements TextCommandService {
                         textWriteHandler.enqueue(textCommand);
                     }
                 } catch (InterruptedException e) {
+                    currentThread().interrupt();
                     return;
                 } catch (OutOfMemoryError e) {
                     OutOfMemoryErrorDispatcher.onOutOfMemory(e);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -52,6 +52,7 @@ import static com.hazelcast.cluster.ClusterState.FROZEN;
 import static com.hazelcast.cluster.ClusterState.IN_TRANSITION;
 import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmptyResponseHandler;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
+import static java.lang.Thread.currentThread;
 
 public abstract class AbstractJoiner implements Joiner {
 
@@ -200,6 +201,7 @@ public abstract class AbstractJoiner implements Joiner {
                     //noinspection BusyWait
                     TimeUnit.SECONDS.sleep(1);
                 } catch (InterruptedException ignored) {
+                    currentThread().interrupt();
                     EmptyStatement.ignore(ignored);
                 }
             }
@@ -248,6 +250,7 @@ public abstract class AbstractJoiner implements Joiner {
                 //noinspection BusyWait
                 Thread.sleep(SPLIT_BRAIN_SLEEP_TIME_MILLIS);
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 EmptyStatement.ignore(e);
                 return null;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -29,6 +29,8 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.lang.Thread.currentThread;
+
 public class MulticastJoiner extends AbstractJoiner {
 
     private static final long JOIN_RETRY_INTERVAL = 1000L;
@@ -96,6 +98,7 @@ public class MulticastJoiner extends AbstractJoiner {
             try {
                 Thread.sleep(JOIN_RETRY_INTERVAL);
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 EmptyStatement.ignore(e);
             }
 
@@ -137,6 +140,7 @@ public class MulticastJoiner extends AbstractJoiner {
                 }
             }
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             logger.fine(e);
         } catch (Exception e) {
             logger.warning(e);

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
@@ -34,6 +34,7 @@ import static com.hazelcast.spi.properties.GroupProperty.HEALTH_MONITORING_THRES
 import static com.hazelcast.spi.properties.GroupProperty.HEALTH_MONITORING_THRESHOLD_MEMORY_PERCENTAGE;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
 import static java.lang.String.format;
+import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -114,6 +115,7 @@ public class HealthMonitor {
         try {
             monitorThread.join();
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             EmptyStatement.ignore(e);
         }
         logger.finest("HealthMonitor stopped");
@@ -162,6 +164,7 @@ public class HealthMonitor {
                     try {
                         SECONDS.sleep(delaySeconds);
                     } catch (InterruptedException e) {
+                        currentThread().interrupt();
                         return;
                     }
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -95,6 +95,7 @@ import static com.hazelcast.util.MapUtil.createHashMap;
 import static java.lang.Math.ceil;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.lang.Thread.currentThread;
 
 /**
  * The {@link InternalPartitionService} implementation.
@@ -218,6 +219,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             try {
                 Thread.sleep(PARTITION_OWNERSHIP_WAIT_MILLIS);
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 throw ExceptionUtil.rethrow(e);
             }
         }
@@ -877,6 +879,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                 timeoutMillis -= awaitStep;
             } while (timeoutMillis > 0);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             logger.info("Safe shutdown is interrupted!");
         }
         return false;
@@ -1251,6 +1254,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                 } catch (MemberLeftException e) {
                     EmptyStatement.ignore(e);
                 } catch (InterruptedException e) {
+                    currentThread().interrupt();
                     logger.fine("FetchMostRecentPartitionTableTask is interrupted.");
                 } catch (ExecutionException e) {
                     Throwable cause = e.getCause();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
@@ -43,6 +43,7 @@ import static com.hazelcast.internal.partition.impl.PartitionServiceState.REPLIC
 import static com.hazelcast.internal.partition.impl.PartitionServiceState.REPLICA_NOT_SYNC;
 import static com.hazelcast.internal.partition.impl.PartitionServiceState.SAFE;
 import static com.hazelcast.spi.partition.IPartitionService.SERVICE_NAME;
+import static java.lang.Thread.currentThread;
 
 /**
  * Verifies up-to-dateness of each of partition replicas owned by this member.
@@ -194,6 +195,7 @@ public class PartitionReplicaStateChecker {
             //noinspection BusyWait
             Thread.sleep(sleep);
         } catch (InterruptedException ie) {
+            currentThread().interrupt();
             logger.finest("Busy wait interrupted", ie);
         }
         return timeoutInMillis - sleep;
@@ -219,6 +221,7 @@ public class PartitionReplicaStateChecker {
             boolean receivedAllResponses = semaphore.tryAcquire(permits, REPLICA_SYNC_CHECK_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             return receivedAllResponses && ok.get();
         } catch (InterruptedException ignored) {
+            currentThread().interrupt();
             return false;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsProvider.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -277,6 +278,7 @@ public class LocalMapStatsProvider {
         try {
             MILLISECONDS.sleep(WAIT_PARTITION_TABLE_UPDATE_MILLIS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             throw ExceptionUtil.rethrow(e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -89,6 +89,7 @@ import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.lang.Thread.currentThread;
 
 public class MultiMapService implements ManagedService, RemoteService, FragmentedMigrationAwareService,
         EventPublishingService<EventData, EntryListener>, TransactionalService, StatisticsAwareService<LocalMultiMapStats>,
@@ -476,6 +477,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
             try {
                 Thread.sleep(REPLICA_ADDRESS_SLEEP_WAIT_MILLIS);
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 throw ExceptionUtil.rethrow(e);
             }
             replicaAddress = partition.getReplicaAddress(replicaIndex);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpAcceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpAcceptor.java
@@ -40,6 +40,7 @@ import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.ThreadUtil.createThreadPoolName;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
+import static java.lang.Thread.currentThread;
 import static java.nio.channels.SelectionKey.OP_ACCEPT;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -122,6 +123,7 @@ public class TcpIpAcceptor implements MetricsProvider {
         try {
             acceptorThread.join(SHUTDOWN_TIMEOUT_MILLIS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             logger.finest(e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -64,6 +64,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.lang.Math.ceil;
 import static java.lang.Math.log10;
+import static java.lang.Thread.currentThread;
 
 /**
  * Proxy implementation of {@link com.hazelcast.core.ReplicatedMap} interface.
@@ -125,6 +126,7 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
         try {
             TimeUnit.MILLISECONDS.sleep(WAIT_INTERVAL_MILLIS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             throw rethrow(e);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DelegatingScheduledFutureStripper.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DelegatingScheduledFutureStripper.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.lang.Thread.currentThread;
 
 /**
  * Simple adapter that unwraps the Future delegation done in
@@ -93,6 +94,7 @@ public class DelegatingScheduledFutureStripper<V>
         try {
             return (Future) original.get();
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             sneakyThrow(e);
         } catch (ExecutionException e) {
             sneakyThrow(e);

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySender.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/impl/MulticastDiscoverySender.java
@@ -28,6 +28,8 @@ import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.MulticastSocket;
 
+import static java.lang.Thread.currentThread;
+
 public class MulticastDiscoverySender implements Runnable {
 
     private static final int SLEEP_DURATION = 2000;
@@ -82,6 +84,7 @@ public class MulticastDiscoverySender implements Runnable {
         try {
             Thread.sleep(SLEEP_DURATION);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             logger.finest("Thread sleeping interrupted. This may due to graceful shutdown.");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFuture.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
+import static java.lang.Thread.currentThread;
 
 /**
  * Wraps a {@code java.util.concurrent.Future} to make it a {@code com.hazelcast.core.ICompletableFuture}.
@@ -59,6 +60,7 @@ class BasicCompletableFuture<V> extends AbstractCompletableFuture<V> {
         } catch (TimeoutException ex) {
             sneakyThrow(ex);
         } catch (InterruptedException ex) {
+            currentThread().interrupt();
             sneakyThrow(ex);
         } catch (ExecutionException ex) {
             setResult(ex);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -53,6 +53,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.ThreadUtil.createThreadPoolName;
+import static java.lang.Thread.currentThread;
 
 @SuppressWarnings("checkstyle:classfanoutcomplexity")
 public final class ExecutionServiceImpl implements InternalExecutionService {
@@ -318,11 +319,13 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
         try {
             scheduledExecutorService.awaitTermination(AWAIT_TIME, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             logger.finest(e);
         }
         try {
             cachedExecutorService.awaitTermination(AWAIT_TIME, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
+            currentThread().interrupt();
             logger.finest(e);
         }
         executors.clear();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
@@ -299,8 +299,8 @@ public final class SlowOperationDetector {
             try {
                 detectorThread.join(SLOW_OPERATION_THREAD_MAX_WAIT_TIME_TO_FINISH);
             } catch (InterruptedException ignored) {
+                currentThread().interrupt();
                 EmptyStatement.ignore(ignored);
-                // TODO: Interrupt flag is consumed here
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -43,7 +43,6 @@ import com.hazelcast.util.ExceptionUtil;
 import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -57,6 +56,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.transaction.impl.xa.XAService.SERVICE_NAME;
+import static java.lang.Thread.currentThread;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -261,6 +261,7 @@ public final class XAResourceImpl extends AbstractDistributedObject<XAService> i
                     xids.add(xid);
                 }
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 throw new XAException(XAException.XAER_RMERR);
             } catch (MemberLeftException e) {
                 logger.warning("Member left while recovering", e);

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/StripedExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/StripedExecutor.java
@@ -191,6 +191,7 @@ public final class StripedExecutor implements Executor {
                     offered = workQueue.offer(command, timeout, timeUnit);
                 }
             } catch (InterruptedException e) {
+                currentThread().interrupt();
                 throw new RejectedExecutionException("Thread is interrupted while offering work");
             }
 


### PR DESCRIPTION
Setting back interrupted flag in production code where InterruptedException catch blocks have only ignored the exception without taking care of the request.

Out of scope:
- Classes that manage their stoppage via using volatile boolean `alive` flags
- Classes implementing custom interrupt handling logic
- Methods declared to be uninterruptible

The classes not in the scope should be reviewed separately in #12452.

EE part: hazelcast/hazelcast-enterprise#1950