### PR TITLE
Fixed OverridePropertyRule with PowerMock

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
@@ -40,17 +40,18 @@ import static com.hazelcast.test.OverridePropertyRule.set;
 @Category(QuickTest.class)
 public class MemberToMemberDiscoveryTest extends HazelcastTestSupport {
 
-    private Config config;
-
     @Rule
-    public final OverridePropertyRule overridePropertyRule = set("hazelcast.wait.seconds.before.join", "10");
+    public final OverridePropertyRule overrideJoinWaitSecondsRule = set("hazelcast.wait.seconds.before.join", "10");
+    @Rule
+    public final OverridePropertyRule overridePreferIpv4Rule = set("java.net.preferIPv4Stack", "true");
+
+    private Config config;
 
     @Before
     public void setUp() {
         String xmlFileName = "hazelcast-multicast-plugin.xml";
         InputStream xmlResource = MulticastDiscoveryStrategy.class.getClassLoader().getResourceAsStream(xmlFileName);
         config = new XmlConfigBuilder(xmlResource).build();
-        System.setProperty("java.net.preferIPv4Stack", "true");
     }
 
     @After
@@ -59,18 +60,18 @@ public class MemberToMemberDiscoveryTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void formClusterWithTwoMembersTest() throws InterruptedException {
+    public void formClusterWithTwoMembersTest() {
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
         Hazelcast.newHazelcastInstance(config);
         assertClusterSizeEventually(2, instance);
     }
 
     @Test(expected = ValidationException.class)
-    public void invalidPortPropertyTest() throws InterruptedException {
+    public void invalidPortPropertyTest() {
         String xmlFileName = "hazelcast-multicast-plugin-invalid-port.xml";
         InputStream xmlResource = MulticastDiscoveryStrategy.class.getClassLoader().getResourceAsStream(xmlFileName);
         config = new XmlConfigBuilder(xmlResource).build();
+
         Hazelcast.newHazelcastInstance(config);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRulePowerMockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRulePowerMockTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.net.NetworkInterface;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.test.OverridePropertyRule.set;
+import static java.util.Collections.enumeration;
+import static java.util.Collections.list;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+/**
+ * Tests the {@link OverridePropertyRule} with multiple instances and the {@link PowerMockRunner}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(OverridePropertyRulePowerMockTest.TestClass.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OverridePropertyRulePowerMockTest {
+
+    @Rule
+    public OverridePropertyRule overridePropertyRule = set("hazelcast.custom.system.property", "5");
+    @Rule
+    public OverridePropertyRule overridePreferIpv4Rule = set("java.net.preferIPv4Stack", "true");
+
+    private NetworkInterface networkInterface = mock(NetworkInterface.class);
+
+    @Before
+    public void setUp() {
+        mockStatic(NetworkInterface.class);
+    }
+
+    @Test
+    public void testNonExistingProperty() {
+        assertNull(System.getProperty("notExists"));
+    }
+
+    @Test
+    public void testCustomSystemProperty() {
+        assertEquals("5", System.getProperty("hazelcast.custom.system.property"));
+    }
+
+    @Test
+    public void testHazelcastProperty() {
+        assertEquals("true", System.getProperty("java.net.preferIPv4Stack"));
+    }
+
+    @Test
+    public void testHazelcastPropertyWithGetBoolean() {
+        assertTrue(Boolean.getBoolean("java.net.preferIPv4Stack"));
+    }
+
+    @Test
+    public void testCustomPropertyWithPowerMock() throws Exception {
+        TestClass testClass = createTestClass();
+
+        assertEquals("5", testClass.getProperty("hazelcast.custom.system.property"));
+    }
+
+    @Test
+    public void testHazelcastPropertyWithPowerMock() throws Exception {
+        TestClass testClass = createTestClass();
+
+        assertEquals("true", testClass.getProperty("java.net.preferIPv4Stack"));
+    }
+
+    private TestClass createTestClass() throws Exception {
+        NetworkInterface networkInterface = mock(NetworkInterface.class);
+        List<NetworkInterface> networkInterfaces = new ArrayList<NetworkInterface>();
+        networkInterfaces.add(networkInterface);
+        when(NetworkInterface.getNetworkInterfaces()).thenReturn(enumeration(networkInterfaces));
+
+        return new TestClass();
+    }
+
+    public class TestClass {
+
+        String getProperty(String property) throws Exception {
+            // assert that PowerMock is working
+            ArrayList<NetworkInterface> networkInterfaces = list(NetworkInterface.getNetworkInterfaces());
+            assertEquals(1, networkInterfaces.size());
+            assertEquals(networkInterface, networkInterfaces.get(0));
+
+            return System.getProperty(property);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRuleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRuleTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.OverridePropertyRule.set;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@link OverridePropertyRule} with multiple instances and a Hazelcast specific runner.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OverridePropertyRuleTest {
+
+    @Rule
+    public OverridePropertyRule overridePropertyRule = set("hazelcast.custom.system.property", "5");
+    @Rule
+    public OverridePropertyRule overridePreferIpv4Rule = set("java.net.preferIPv4Stack", "true");
+
+    @Test
+    public void testNonExistingProperty() {
+        assertNull(System.getProperty("notExists"));
+    }
+
+    @Test
+    public void testCustomSystemProperty() {
+        assertEquals("5", System.getProperty("hazelcast.custom.system.property"));
+    }
+
+    @Test
+    public void testHazelcastProperty() {
+        assertEquals("true", System.getProperty("java.net.preferIPv4Stack"));
+    }
+
+    @Test
+    public void testHazelcastPropertyWithGetBoolean() {
+        assertTrue(Boolean.getBoolean("java.net.preferIPv4Stack"));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,10 @@
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>
-        <powermock.version>1.6.3</powermock.version>
+        <powermock.version>1.6.6</powermock.version>
         <jmh.version>1.16</jmh.version>
         <bytebuddy.version>1.6.12</bytebuddy.version>
+        <commons-lang3.version>3.4</commons-lang3.version>
         <felix.utils.version>1.10.0</felix.utils.version>
 
         <findbugs.version>1.3.2</findbugs.version>
@@ -1306,19 +1307,13 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
+            <artifactId>powermock-api-mockito</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-module-junit4</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
@@ -1352,6 +1347,12 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
             <version>${bytebuddy.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons-lang3.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
* updated `PowerMock` dependency
* added `OverridePropertyRuleTest`
* added `OverridePropertyRulePowerMockTest`
* added `equals()` and `hashcode()` tests for `DefaultAddressPicker`
* cleanup of `DefaultAddressPickerTest`
* cleanup of `DefaultAddressPickerInterfacesTest`
* cleanup of `MemberToMemberDiscoveryTest`

For some reason the `DefaultAddressPickerInterfacesTest` started to fail on Jenkins and locally. The reason was that multiple `@Rule` annotations didn't work correctly with the `PowerMockRunner` (only the last one was applied), so important property changes were lost. In this case the `OverridePropertyRule ruleSysPropPreferIpv4 = set(PREFER_IPV4_STACK, "true")`, which lead to IPv6 addresses to be picked up.

This PR updates `PowerMock` to the latest version, adds tests for the `OverridePropertyRule`, fixes missing code coverage for the `DefaultAddressPicker` and provides a little cleanup for the related tests.

Fixes https://github.com/hazelcast/hazelcast/issues/12459