### PR TITLE
Check local member uuid under the cluster service lock

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -727,7 +727,8 @@ public class ClusterJoinManager {
 
                 // member list must be updated on master before preparation of pre-/post-join ops so other operations which have
                 // to be executed on stable cluster can detect the member list version change and retry in case of topology change
-                if (!clusterService.updateMembers(newMembersView, node.getThisAddress(), clusterService.getThisUuid())) {
+                String thisUuid = clusterService.getThisUuid();
+                if (!clusterService.updateMembers(newMembersView, node.getThisAddress(), thisUuid, thisUuid)) {
                     return;
                 }
 
@@ -744,7 +745,7 @@ public class ClusterJoinManager {
                     Operation op = new FinalizeJoinOp(member.getUuid(), newMembersView, preJoinOp, postJoinOp, time,
                             clusterService.getClusterId(), startTime, clusterStateManager.getState(),
                             clusterService.getClusterVersion(), partitionRuntimeState, true);
-                    op.setCallerUuid(clusterService.getThisUuid());
+                    op.setCallerUuid(thisUuid);
                     invokeClusterOp(op, member.getAddress());
                 }
                 for (MemberImpl member : memberMap.getMembers()) {
@@ -753,7 +754,7 @@ public class ClusterJoinManager {
                     }
                     Operation op = new MembersUpdateOp(member.getUuid(), newMembersView, time,
                             partitionRuntimeState, true);
-                    op.setCallerUuid(clusterService.getThisUuid());
+                    op.setCallerUuid(thisUuid);
                     invokeClusterOp(op, member.getAddress());
                 }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
@@ -76,17 +76,16 @@ public class FinalizeJoinOp extends MembersUpdateOp {
 
     @Override
     public void run() throws Exception {
-        checkLocalMemberUuid();
-
         ClusterServiceImpl clusterService = getService();
         Address callerAddress = getConnectionEndpointOrThisAddress();
         String callerUuid = getCallerUuid();
+        String targetUuid = getTargetUuid();
 
         checkDeserializationFailure(clusterService);
 
         preparePostOp(preJoinOp);
-        finalized = clusterService.finalizeJoin(getMembersView(), callerAddress, callerUuid,
-                clusterId, clusterState, clusterVersion, clusterStartTime, masterTime, preJoinOp);
+        finalized = clusterService.finalizeJoin(getMembersView(), callerAddress, callerUuid, targetUuid, clusterId, clusterState,
+                clusterVersion, clusterStartTime, masterTime, preJoinOp);
 
         if (!finalized) {
             return;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
@@ -64,12 +64,10 @@ public class MembersUpdateOp extends AbstractClusterOperation implements Version
 
     @Override
     public void run() throws Exception {
-        checkLocalMemberUuid();
-
         ClusterServiceImpl clusterService = getService();
         Address callerAddress = getConnectionEndpointOrThisAddress();
         String callerUuid = getCallerUuid();
-        if (clusterService.updateMembers(getMembersView(), callerAddress, callerUuid)) {
+        if (clusterService.updateMembers(getMembersView(), callerAddress, callerUuid, targetUuid)) {
             processPartitionState();
         }
     }
@@ -80,6 +78,10 @@ public class MembersUpdateOp extends AbstractClusterOperation implements Version
 
     final MembersView getMembersView() {
         return new MembersView(getMemberListVersion(), unmodifiableList(memberInfos));
+    }
+
+    final String getTargetUuid() {
+        return targetUuid;
     }
 
     final Address getConnectionEndpointOrThisAddress() {
@@ -99,14 +101,6 @@ public class MembersUpdateOp extends AbstractClusterOperation implements Version
         ClusterServiceImpl clusterService = getService();
         Node node = clusterService.getNodeEngine().getNode();
         node.partitionService.processPartitionRuntimeState(partitionRuntimeState);
-    }
-
-    final void checkLocalMemberUuid() {
-        ClusterServiceImpl clusterService = getService();
-        if (!clusterService.getThisUuid().equals(targetUuid)) {
-            String msg = "target UUID " + targetUuid + " is different than this node's UUID " + clusterService.getThisUuid();
-            throw new IllegalStateException(msg);
-        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -40,7 +40,6 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.RequireAssertEnabled;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -55,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -78,6 +78,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -549,7 +550,6 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
     }
 
     @Test
-    @RequireAssertEnabled
     public void memberReceives_memberUpdateNotContainingItself() throws Exception {
         Config config = new Config();
         config.setProperty(MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE));
@@ -575,8 +575,8 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         try {
             future.get();
             fail("Membership update should fail!");
-        } catch (AssertionError error) {
-            // AssertionError expected (requires assertions enabled)
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof IllegalArgumentException);
         }
     }
 


### PR DESCRIPTION
Force start causes members to change their uuids. After a member force-starts, it should ignore all member list updates sent to his previous identity. Before this fix, this check was done outside of the cluster service lock and caused some racy paths.

OSS fix of https://github.com/hazelcast/hazelcast-enterprise/issues/1906