### PR TITLE
Fixed visibility issue in split-brain recovery

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainerCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorContainerCollector.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cardinality.impl;
+
+import com.hazelcast.config.CardinalityEstimatorConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.merge.AbstractNamedContainerCollector;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
+
+class CardinalityEstimatorContainerCollector extends AbstractNamedContainerCollector<CardinalityEstimatorContainer> {
+
+    private final Config config;
+    private final ConcurrentMap<CardinalityEstimatorContainer, String> containerNames;
+    private final ConcurrentMap<CardinalityEstimatorContainer, MergePolicyConfig> containerPolicies;
+
+    CardinalityEstimatorContainerCollector(NodeEngine nodeEngine,
+                                           ConcurrentMap<String, CardinalityEstimatorContainer> containers) {
+        super(nodeEngine, containers);
+        this.config = nodeEngine.getConfig();
+        this.containerNames = createConcurrentHashMap(containers.size());
+        this.containerPolicies = createConcurrentHashMap(containers.size());
+    }
+
+    /**
+     * The {@link CardinalityEstimatorContainer} doesn't know its name or configuration, so we create these lookup maps.
+     * This is cheaper than storing this information permanently in the container.
+     */
+    @Override
+    protected void onIteration(String containerName, CardinalityEstimatorContainer container) {
+        CardinalityEstimatorConfig cardinalityEstimatorConfig = config.findCardinalityEstimatorConfig(containerName);
+
+        containerNames.put(container, containerName);
+        containerPolicies.put(container, cardinalityEstimatorConfig.getMergePolicyConfig());
+    }
+
+    public String getContainerName(CardinalityEstimatorContainer container) {
+        return containerNames.get(container);
+    }
+
+    @Override
+    protected MergePolicyConfig getMergePolicyConfig(CardinalityEstimatorContainer container) {
+        return containerPolicies.get(container);
+    }
+
+    @Override
+    protected void destroy(CardinalityEstimatorContainer container) {
+    }
+
+    @Override
+    protected void destroyBackup(CardinalityEstimatorContainer container) {
+    }
+
+    @Override
+    public void onDestroy() {
+        containerNames.clear();
+        containerPolicies.clear();
+    }
+
+    @Override
+    protected int getMergingValueCount() {
+        int size = 0;
+        for (Collection<CardinalityEstimatorContainer> containers : getCollectedContainers().values()) {
+            size += containers.size();
+        }
+        return size;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -19,9 +19,7 @@ package com.hazelcast.cardinality.impl;
 import com.hazelcast.cardinality.impl.operations.MergeOperation;
 import com.hazelcast.cardinality.impl.operations.ReplicationOperation;
 import com.hazelcast.config.CardinalityEstimatorConfig;
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.cluster.Versions;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
@@ -32,26 +30,22 @@ import com.hazelcast.spi.QuorumAwareService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.SplitBrainMergePolicy;
-import com.hazelcast.spi.merge.DiscardMergePolicy;
-import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
+import com.hazelcast.spi.impl.merge.AbstractContainerMerger;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ContextMutexFactory;
 
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getPartitionKey;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -69,7 +63,6 @@ public class CardinalityEstimatorService
     private static final Object NULL_OBJECT = new Object();
 
     private NodeEngine nodeEngine;
-    private SplitBrainMergePolicyProvider mergePolicyProvider;
     private final ConcurrentMap<String, CardinalityEstimatorContainer> containers =
             new ConcurrentHashMap<String, CardinalityEstimatorContainer>();
     private final ConstructorFunction<String, CardinalityEstimatorContainer> cardinalityEstimatorContainerConstructorFunction =
@@ -106,7 +99,6 @@ public class CardinalityEstimatorService
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
         this.nodeEngine = nodeEngine;
-        this.mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
     }
 
     @Override
@@ -166,24 +158,6 @@ public class CardinalityEstimatorService
         }
     }
 
-    @Override
-    public Runnable prepareMergeRunnable() {
-        Map<String, CardinalityEstimatorContainer> state =
-                new HashMap<String, CardinalityEstimatorContainer>();
-
-        for (Map.Entry<String, CardinalityEstimatorContainer> entry : containers.entrySet()) {
-            SplitBrainMergePolicy mergePolicy = getMergePolicy(entry.getKey());
-
-            int partition = getPartitionId(entry.getKey());
-            if (nodeEngine.getPartitionService().isPartitionOwner(partition)
-                    && !(mergePolicy instanceof DiscardMergePolicy)) {
-                state.put(entry.getKey(), entry.getValue());
-            }
-        }
-
-        return new Merger(state);
-    }
-
     private void clearPartitionReplica(int partitionId, int durabilityThreshold) {
         final Iterator<Map.Entry<String, CardinalityEstimatorContainer>> iterator = containers.entrySet().iterator();
         while (iterator.hasNext()) {
@@ -212,81 +186,40 @@ public class CardinalityEstimatorService
         return quorumName == NULL_OBJECT ? null : (String) quorumName;
     }
 
-    private SplitBrainMergePolicy getMergePolicy(String name) {
-        String mergePolicyName = nodeEngine.getConfig().findCardinalityEstimatorConfig(name).getMergePolicyConfig().getPolicy();
-        return mergePolicyProvider.getMergePolicy(mergePolicyName);
+    @Override
+    public Runnable prepareMergeRunnable() {
+        CardinalityEstimatorContainerCollector collector = new CardinalityEstimatorContainerCollector(nodeEngine, containers);
+        collector.run();
+        return new Merger(collector);
     }
 
-    private class Merger implements Runnable {
+    private class Merger extends AbstractContainerMerger<CardinalityEstimatorContainer> {
 
-        private static final long TIMEOUT_FACTOR = 500;
-
-        private final ILogger logger = nodeEngine.getLogger(CardinalityEstimatorService.class);
-        private final Semaphore semaphore = new Semaphore(0);
-        private final ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
-            @Override
-            public void onResponse(Object response) {
-                semaphore.release(1);
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                logger.warning("Error while running cardinality estimator merge operation: " + t.getMessage());
-                semaphore.release(1);
-            }
-        };
-
-        private final Map<String, CardinalityEstimatorContainer> snapshot;
-
-        Merger(Map<String, CardinalityEstimatorContainer> snapshot) {
-            this.snapshot = snapshot;
+        Merger(CardinalityEstimatorContainerCollector collector) {
+            super(collector, nodeEngine);
         }
 
         @Override
-        public void run() {
-            // we cannot merge into a 3.9 cluster, since not all members may understand the MergeOperation
-            // RU_COMPAT_3_9
-            if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-                logger.info("Cluster needs to run version " + Versions.V3_10 + " to merge cardinality estimator instances");
-                return;
-            }
+        protected String getLabel() {
+            return "cardinality estimator";
+        }
 
-            int size = 0;
-            int operationCount = 0;
-
-            try {
+        @Override
+        public void runInternal() {
+            CardinalityEstimatorContainerCollector collector = (CardinalityEstimatorContainerCollector) this.collector;
+            Map<Integer, Collection<CardinalityEstimatorContainer>> containerMap = collector.getCollectedContainers();
+            for (Map.Entry<Integer, Collection<CardinalityEstimatorContainer>> entry : containerMap.entrySet()) {
                 // TODO: batching support (tkountis)
-                for (Map.Entry<String, CardinalityEstimatorContainer> entry : snapshot.entrySet()) {
-                    String containerName = entry.getKey();
-                    CardinalityEstimatorContainer container = entry.getValue();
-                    int partitionId = getPartitionId(containerName);
-                    operationCount++;
+                int partitionId = entry.getKey();
+                Collection<CardinalityEstimatorContainer> containerList = entry.getValue();
 
-                    SplitBrainMergePolicy mergePolicy = getMergePolicy(containerName);
+                for (CardinalityEstimatorContainer container : containerList) {
+                    String containerName = collector.getContainerName(container);
+                    SplitBrainMergePolicy mergePolicy = getMergePolicy(collector.getMergePolicyConfig(container));
+
                     MergeOperation operation = new MergeOperation(containerName, mergePolicy, container.hll);
-                    try {
-                        nodeEngine.getOperationService()
-                                .invokeOnPartition(SERVICE_NAME, operation, partitionId)
-                                .andThen(mergeCallback);
-                    } catch (Throwable t) {
-                        throw rethrow(t);
-                    }
-                    size++;
+                    invoke(SERVICE_NAME, operation, partitionId);
                 }
-
-                snapshot.clear();
-            } catch (Exception e) {
-                logger.warning("Split-brain healing of cardinality estimators didn't complete successfully...", e);
-                throw rethrow(e);
-            }
-
-            try {
-                if (!semaphore.tryAcquire(operationCount, size * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS)) {
-                    logger.warning("Split-brain healing for cardinality estimators didn't finish within the timeout...");
-                }
-            } catch (InterruptedException e) {
-                logger.finest("Interrupted while waiting for split-brain healing of cardinality estimators...");
-                Thread.currentThread().interrupt();
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainerCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionContainerCollector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.collection;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.merge.AbstractNamedContainerCollector;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentMap;
+
+class CollectionContainerCollector extends AbstractNamedContainerCollector<CollectionContainer> {
+
+    CollectionContainerCollector(NodeEngine nodeEngine, ConcurrentMap<String, CollectionContainer> containers) {
+        super(nodeEngine, containers);
+    }
+
+    @Override
+    protected MergePolicyConfig getMergePolicyConfig(CollectionContainer container) {
+        return container.getConfig().getMergePolicyConfig();
+    }
+
+    @Override
+    protected void destroy(CollectionContainer container) {
+        // owned data is stored in the collection
+        container.getCollection().clear();
+    }
+
+    @Override
+    protected void destroyBackup(CollectionContainer container) {
+        // backup data is stored in the map
+        container.getMap().clear();
+    }
+
+    @Override
+    protected int getMergingValueCount() {
+        int size = 0;
+        for (Collection<CollectionContainer> containers : getCollectedContainers().values()) {
+            for (CollectionContainer container : containers) {
+                size += container.size();
+            }
+        }
+        return size;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
@@ -20,12 +20,10 @@ import com.hazelcast.collection.impl.collection.operations.CollectionMergeOperat
 import com.hazelcast.collection.impl.collection.operations.CollectionOperation;
 import com.hazelcast.collection.impl.common.DataAwareItemEvent;
 import com.hazelcast.collection.impl.txncollection.operations.CollectionTransactionRollbackOperation;
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.ItemEvent;
 import com.hazelcast.core.ItemEventType;
 import com.hazelcast.core.ItemListener;
 import com.hazelcast.instance.MemberImpl;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
@@ -42,9 +40,8 @@ import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.TransactionalService;
-import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.impl.merge.AbstractContainerMerger;
 import com.hazelcast.spi.merge.MergingValueHolder;
-import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -57,12 +54,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.spi.impl.merge.MergingHolders.createMergeHolder;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
-import static com.hazelcast.util.MapUtil.createHashMap;
 
 public abstract class CollectionService implements ManagedService, RemoteService, EventPublishingService<CollectionEvent,
         ItemListener<Data>>, TransactionalService, MigrationAwareService, QuorumAwareService, SplitBrainHandlerService {
@@ -70,7 +64,6 @@ public abstract class CollectionService implements ManagedService, RemoteService
     protected final NodeEngine nodeEngine;
     protected final SerializationService serializationService;
     protected final IPartitionService partitionService;
-    protected final SplitBrainMergePolicyProvider mergePolicyProvider;
 
     private final ILogger logger;
 
@@ -78,7 +71,6 @@ public abstract class CollectionService implements ManagedService, RemoteService
         this.nodeEngine = nodeEngine;
         this.serializationService = nodeEngine.getSerializationService();
         this.partitionService = nodeEngine.getPartitionService();
-        this.mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
         this.logger = nodeEngine.getLogger(getClass());
     }
 
@@ -104,7 +96,7 @@ public abstract class CollectionService implements ManagedService, RemoteService
 
     public abstract CollectionContainer getOrCreateContainer(String name, boolean backup);
 
-    public abstract Map<String, ? extends CollectionContainer> getContainerMap();
+    public abstract ConcurrentMap<String, ? extends CollectionContainer> getContainerMap();
 
     public abstract String getServiceName();
 
@@ -192,133 +184,67 @@ public abstract class CollectionService implements ManagedService, RemoteService
     }
 
     public void addContainer(String name, CollectionContainer container) {
-        final Map map = getContainerMap();
-        map.put(name, container);
+        getRawContainerMap().put(name, container);
+    }
+
+    @SuppressWarnings("unchecked")
+    private ConcurrentMap<String, CollectionContainer> getRawContainerMap() {
+        return (ConcurrentMap<String, CollectionContainer>) getContainerMap();
     }
 
     @Override
     public Runnable prepareMergeRunnable() {
-        Map<String, ? extends CollectionContainer> containers = getContainerMap();
-        Map<Integer, Map<CollectionContainer, List<CollectionItem>>> itemMap
-                = createHashMap(partitionService.getPartitionCount());
-
-        for (CollectionContainer container : containers.values()) {
-            String name = container.getName();
-            Data partitionAwareName = serializationService.toData(name, StringPartitioningStrategy.INSTANCE);
-            int partitionId = partitionService.getPartitionId(partitionAwareName);
-            if (partitionService.isPartitionOwner(partitionId)) {
-                // add your owned entries to the map so they will be merged
-                if (!(getMergePolicy(container) instanceof DiscardMergePolicy)) {
-                    Map<CollectionContainer, List<CollectionItem>> containerMap = itemMap.get(partitionId);
-                    if (containerMap == null) {
-                        containerMap = new HashMap<CollectionContainer, List<CollectionItem>>();
-                        itemMap.put(partitionId, containerMap);
-                    }
-                    containerMap.put(container, new ArrayList<CollectionItem>(container.getCollection()));
-                }
-            }
-            // clear all items either owned or backup
-            container.clear();
-        }
-        containers.clear();
-
-        return new Merger(itemMap);
+        CollectionContainerCollector collector = new CollectionContainerCollector(nodeEngine, getRawContainerMap());
+        collector.run();
+        return new Merger(collector);
     }
 
-    private SplitBrainMergePolicy getMergePolicy(CollectionContainer container) {
-        String mergePolicyName = container.getConfig().getMergePolicyConfig().getPolicy();
-        return mergePolicyProvider.getMergePolicy(mergePolicyName);
-    }
+    private class Merger extends AbstractContainerMerger<CollectionContainer> {
 
-    private class Merger implements Runnable {
-
-        private static final long TIMEOUT_FACTOR = 500;
-
-        private final ILogger logger = nodeEngine.getLogger(CollectionService.class);
-        private final Semaphore semaphore = new Semaphore(0);
-        private final ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
-            @Override
-            public void onResponse(Object response) {
-                semaphore.release(1);
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                logger.warning("Error while running collection merge operation: " + t.getMessage());
-                semaphore.release(1);
-            }
-        };
-
-        private final Map<Integer, Map<CollectionContainer, List<CollectionItem>>> itemMap;
-
-        Merger(Map<Integer, Map<CollectionContainer, List<CollectionItem>>> itemMap) {
-            this.itemMap = itemMap;
+        Merger(CollectionContainerCollector collector) {
+            super(collector, nodeEngine);
         }
 
         @Override
-        public void run() {
-            // we cannot merge into a 3.9 cluster, since not all members may understand the CollectionMergeOperation
-            // RU_COMPAT_3_9
-            if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-                logger.info("Cluster needs to run version " + Versions.V3_10 + " to merge collection instances");
-                return;
-            }
+        protected String getLabel() {
+            return "collection";
+        }
 
-            int itemCount = 0;
-            int operationCount = 0;
+        @Override
+        public void runInternal() {
             List<MergingValueHolder<Data>> mergingValues;
-            for (Map.Entry<Integer, Map<CollectionContainer, List<CollectionItem>>> partitionEntry : itemMap.entrySet()) {
-                int partitionId = partitionEntry.getKey();
-                Map<CollectionContainer, List<CollectionItem>> containerMap = partitionEntry.getValue();
-                for (Map.Entry<CollectionContainer, List<CollectionItem>> containerEntry : containerMap.entrySet()) {
-                    CollectionContainer container = containerEntry.getKey();
-                    Collection<CollectionItem> itemList = containerEntry.getValue();
+            for (Map.Entry<Integer, Collection<CollectionContainer>> entry : collector.getCollectedContainers().entrySet()) {
+                int partitionId = entry.getKey();
+                Collection<CollectionContainer> containerList = entry.getValue();
+                for (CollectionContainer container : containerList) {
+                    Collection<CollectionItem> itemList = container.getCollection();
 
                     String name = container.getName();
                     int batchSize = container.getConfig().getMergePolicyConfig().getBatchSize();
-                    SplitBrainMergePolicy mergePolicy = getMergePolicy(container);
+                    SplitBrainMergePolicy mergePolicy = getMergePolicy(container.getConfig().getMergePolicyConfig());
 
                     mergingValues = new ArrayList<MergingValueHolder<Data>>();
                     for (CollectionItem item : itemList) {
                         MergingValueHolder<Data> mergingValue = createMergeHolder(serializationService, item);
                         mergingValues.add(mergingValue);
-                        itemCount++;
 
                         if (mergingValues.size() == batchSize) {
-                            sendBatch(partitionId, name, mergePolicy, mergingValues, mergeCallback);
+                            sendBatch(partitionId, name, mergePolicy, mergingValues);
                             mergingValues = new ArrayList<MergingValueHolder<Data>>(batchSize);
-                            operationCount++;
                         }
                     }
                     itemList.clear();
                     if (mergingValues.size() > 0) {
-                        sendBatch(partitionId, name, mergePolicy, mergingValues, mergeCallback);
-                        operationCount++;
+                        sendBatch(partitionId, name, mergePolicy, mergingValues);
                     }
                 }
-            }
-            itemMap.clear();
-
-            try {
-                if (!semaphore.tryAcquire(operationCount, itemCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS)) {
-                    logger.warning("Split-brain healing for collections didn't finish within the timeout...");
-                }
-            } catch (InterruptedException e) {
-                logger.finest("Interrupted while waiting for split-brain healing of collections...");
-                Thread.currentThread().interrupt();
             }
         }
 
         private void sendBatch(int partitionId, String name, SplitBrainMergePolicy mergePolicy,
-                               List<MergingValueHolder<Data>> mergingValues, ExecutionCallback<Object> mergeCallback) {
+                               List<MergingValueHolder<Data>> mergingValues) {
             CollectionOperation operation = new CollectionMergeOperation(name, mergePolicy, mergingValues);
-            try {
-                nodeEngine.getOperationService()
-                        .invokeOnPartition(getServiceName(), operation, partitionId)
-                        .andThen(mergeCallback);
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
+            invoke(getServiceName(), operation, partitionId);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListService.java
@@ -73,7 +73,7 @@ public class ListService extends CollectionService {
     }
 
     @Override
-    public Map<String, ? extends CollectionContainer> getContainerMap() {
+    public ConcurrentMap<String, ? extends CollectionContainer> getContainerMap() {
         return containerMap;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainerCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainerCollector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.queue;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.merge.AbstractNamedContainerCollector;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentMap;
+
+class QueueContainerCollector extends AbstractNamedContainerCollector<QueueContainer> {
+
+    QueueContainerCollector(NodeEngine nodeEngine, ConcurrentMap<String, QueueContainer> containers) {
+        super(nodeEngine, containers);
+    }
+
+    @Override
+    protected MergePolicyConfig getMergePolicyConfig(QueueContainer container) {
+        return container.getConfig().getMergePolicyConfig();
+    }
+
+    @Override
+    protected void destroy(QueueContainer container) {
+        // owned data is stored in the item queue
+        container.getItemQueue().clear();
+    }
+
+    @Override
+    protected void destroyBackup(QueueContainer container) {
+        // backup data is stored in the backup map
+        container.getBackupMap().clear();
+    }
+
+    @Override
+    protected int getMergingValueCount() {
+        int size = 0;
+        for (Collection<QueueContainer> containers : getCollectedContainers().values()) {
+            for (QueueContainer container : containers) {
+                size += container.size();
+            }
+        }
+        return size;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetService.java
@@ -73,7 +73,7 @@ public class SetService extends CollectionService {
     }
 
     @Override
-    public Map<String, ? extends CollectionContainer> getContainerMap() {
+    public ConcurrentMap<String, ? extends CollectionContainer> getContainerMap() {
         return containerMap;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainer.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.concurrent.atomiclong;
 
-import com.hazelcast.config.AtomicLongConfig;
-import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.MergingValueHolder;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -26,24 +24,9 @@ import static com.hazelcast.spi.impl.merge.MergingHolders.createMergeHolder;
 
 public class AtomicLongContainer {
 
-    private final String name;
-    private final AtomicLongConfig config;
-    private final SerializationService serializationService;
-
     private long value;
 
-    public AtomicLongContainer(String name, NodeEngine nodeEngine) {
-        this.name = name;
-        this.config = nodeEngine.getConfig().findAtomicLongConfig(name);
-        this.serializationService = nodeEngine.getSerializationService();
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public AtomicLongConfig getConfig() {
-        return config;
+    public AtomicLongContainer() {
     }
 
     public long get() {
@@ -82,11 +65,13 @@ public class AtomicLongContainer {
     /**
      * Merges the given {@link MergingValueHolder} via the given {@link SplitBrainMergePolicy}.
      *
-     * @param mergingValue the {@link MergingValueHolder} instance to merge
-     * @param mergePolicy  the {@link SplitBrainMergePolicy} instance to apply
+     * @param mergingValue         the {@link MergingValueHolder} instance to merge
+     * @param mergePolicy          the {@link SplitBrainMergePolicy} instance to apply
+     * @param serializationService the {@link SerializationService} to inject dependencies
      * @return the new value if merge is applied, otherwise {@code null}
      */
-    public Long merge(MergingValueHolder<Long> mergingValue, SplitBrainMergePolicy mergePolicy, boolean isExistingContainer) {
+    public Long merge(MergingValueHolder<Long> mergingValue, SplitBrainMergePolicy mergePolicy, boolean isExistingContainer,
+                      SerializationService serializationService) {
         serializationService.getManagedContext().initialize(mergingValue);
         serializationService.getManagedContext().initialize(mergePolicy);
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainerCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainerCollector.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.concurrent.atomiclong;
+
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.merge.AbstractNamedContainerCollector;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
+
+class AtomicLongContainerCollector extends AbstractNamedContainerCollector<AtomicLongContainer> {
+
+    private final Config config;
+    private final ConcurrentMap<AtomicLongContainer, String> containerNames;
+    private final ConcurrentMap<AtomicLongContainer, MergePolicyConfig> containerPolicies;
+
+    AtomicLongContainerCollector(NodeEngine nodeEngine, ConcurrentMap<String, AtomicLongContainer> containers) {
+        super(nodeEngine, containers);
+        this.config = nodeEngine.getConfig();
+        this.containerNames = createConcurrentHashMap(containers.size());
+        this.containerPolicies = createConcurrentHashMap(containers.size());
+    }
+
+    /**
+     * The {@link AtomicLongContainer} doesn't know its name or configuration, so we create these lookup maps.
+     * This is cheaper than storing this information permanently in the container.
+     */
+    @Override
+    protected void onIteration(String containerName, AtomicLongContainer container) {
+        AtomicLongConfig atomicLongConfig = config.findAtomicLongConfig(containerName);
+
+        containerNames.put(container, containerName);
+        containerPolicies.put(container, atomicLongConfig.getMergePolicyConfig());
+    }
+
+    public String getContainerName(AtomicLongContainer container) {
+        return containerNames.get(container);
+    }
+
+    @Override
+    protected MergePolicyConfig getMergePolicyConfig(AtomicLongContainer container) {
+        return containerPolicies.get(container);
+    }
+
+    @Override
+    protected void destroy(AtomicLongContainer container) {
+    }
+
+    @Override
+    protected void destroyBackup(AtomicLongContainer container) {
+    }
+
+    @Override
+    public void onDestroy() {
+        containerNames.clear();
+        containerPolicies.clear();
+    }
+
+    @Override
+    protected int getMergingValueCount() {
+        int size = 0;
+        for (Collection<AtomicLongContainer> containers : getCollectedContainers().values()) {
+            size += containers.size();
+        }
+        return size;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
@@ -19,10 +19,7 @@ package com.hazelcast.concurrent.atomiclong;
 import com.hazelcast.concurrent.atomiclong.operations.AtomicLongReplicationOperation;
 import com.hazelcast.concurrent.atomiclong.operations.MergeOperation;
 import com.hazelcast.config.AtomicLongConfig;
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.cluster.Versions;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
@@ -33,29 +30,24 @@ import com.hazelcast.spi.QuorumAwareService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.SplitBrainMergePolicy;
-import com.hazelcast.spi.merge.DiscardMergePolicy;
-import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
+import com.hazelcast.spi.impl.merge.AbstractContainerMerger;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ContextMutexFactory;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.internal.config.ConfigValidator.checkBasicConfig;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getPartitionKey;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 public class AtomicLongService
         implements ManagedService, RemoteService, MigrationAwareService, QuorumAwareService, SplitBrainHandlerService {
@@ -68,7 +60,7 @@ public class AtomicLongService
     private final ConstructorFunction<String, AtomicLongContainer> atomicLongConstructorFunction =
             new ConstructorFunction<String, AtomicLongContainer>() {
                 public AtomicLongContainer createNew(String key) {
-                    return new AtomicLongContainer(key, nodeEngine);
+                    return new AtomicLongContainer();
                 }
             };
 
@@ -86,7 +78,6 @@ public class AtomicLongService
     };
 
     private NodeEngine nodeEngine;
-    private SplitBrainMergePolicyProvider mergePolicyProvider;
 
     public AtomicLongService() {
     }
@@ -102,7 +93,6 @@ public class AtomicLongService
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
         this.nodeEngine = nodeEngine;
-        this.mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
     }
 
     @Override
@@ -200,99 +190,38 @@ public class AtomicLongService
 
     @Override
     public Runnable prepareMergeRunnable() {
-        IPartitionService partitionService = nodeEngine.getPartitionService();
-        Map<Integer, List<AtomicLongContainer>> containerMap = new HashMap<Integer, List<AtomicLongContainer>>();
-
-        for (Map.Entry<String, AtomicLongContainer> entry : containers.entrySet()) {
-            AtomicLongContainer container = entry.getValue();
-            if (!(getMergePolicy(container) instanceof DiscardMergePolicy)) {
-                String name = entry.getKey();
-                int partitionId = partitionService.getPartitionId(StringPartitioningStrategy.getPartitionKey(name));
-                if (partitionService.isPartitionOwner(partitionId)) {
-                    // add your owned values to the map so they will be merged
-                    List<AtomicLongContainer> containerList = containerMap.get(partitionId);
-                    if (containerList == null) {
-                        containerList = new ArrayList<AtomicLongContainer>(containers.size());
-                        containerMap.put(partitionId, containerList);
-                    }
-                    containerList.add(container);
-                }
-            }
-        }
-        containers.clear();
-
-        return new Merger(containerMap);
+        AtomicLongContainerCollector collector = new AtomicLongContainerCollector(nodeEngine, containers);
+        collector.run();
+        return new Merger(collector);
     }
 
-    private SplitBrainMergePolicy getMergePolicy(AtomicLongContainer container) {
-        String mergePolicyName = container.getConfig().getMergePolicyConfig().getPolicy();
-        return mergePolicyProvider.getMergePolicy(mergePolicyName);
-    }
+    private class Merger extends AbstractContainerMerger<AtomicLongContainer> {
 
-    private class Merger implements Runnable {
-
-        private static final long TIMEOUT_FACTOR = 500;
-
-        private final ILogger logger = nodeEngine.getLogger(AtomicLongService.class);
-        private final Semaphore semaphore = new Semaphore(0);
-        private final ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
-            @Override
-            public void onResponse(Object response) {
-                semaphore.release(1);
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                logger.warning("Error while running AtomicLong merge operation: " + t.getMessage());
-                semaphore.release(1);
-            }
-        };
-
-        private final Map<Integer, List<AtomicLongContainer>> containerMap;
-
-        Merger(Map<Integer, List<AtomicLongContainer>> containerMap) {
-            this.containerMap = containerMap;
+        Merger(AtomicLongContainerCollector collector) {
+            super(collector, nodeEngine);
         }
 
         @Override
-        public void run() {
-            // we cannot merge into a 3.9 cluster, since not all members may understand the MergeOperation
-            // RU_COMPAT_3_9
-            if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-                logger.info("Cluster needs to run version " + Versions.V3_10 + " to merge AtomicLong instances");
-                return;
-            }
+        protected String getLabel() {
+            return "AtomicLong";
+        }
 
-            int valueCount = 0;
-            for (Map.Entry<Integer, List<AtomicLongContainer>> entry : containerMap.entrySet()) {
+        @Override
+        public void runInternal() {
+            AtomicLongContainerCollector collector = (AtomicLongContainerCollector) this.collector;
+            for (Map.Entry<Integer, Collection<AtomicLongContainer>> entry : collector.getCollectedContainers().entrySet()) {
                 // TODO: add batching (which is a bit complex, since AtomicLong is a single-value data structure,
                 // so we need an operation for multiple AtomicLong instances, which doesn't exist so far)
                 int partitionId = entry.getKey();
-                List<AtomicLongContainer> containerList = entry.getValue();
+                Collection<AtomicLongContainer> containerList = entry.getValue();
 
                 for (AtomicLongContainer container : containerList) {
-                    String name = container.getName();
-                    valueCount++;
+                    String name = collector.getContainerName(container);
+                    SplitBrainMergePolicy mergePolicy = getMergePolicy(collector.getMergePolicyConfig(container));
 
-                    MergeOperation operation = new MergeOperation(name, getMergePolicy(container), container.get());
-                    try {
-                        nodeEngine.getOperationService()
-                                .invokeOnPartition(SERVICE_NAME, operation, partitionId)
-                                .andThen(mergeCallback);
-                    } catch (Throwable t) {
-                        throw rethrow(t);
-                    }
+                    MergeOperation operation = new MergeOperation(name, mergePolicy, container.get());
+                    invoke(SERVICE_NAME, operation, partitionId);
                 }
-            }
-            containerMap.clear();
-
-            try {
-                if (!semaphore.tryAcquire(valueCount, valueCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS)) {
-                    logger.warning("Split-brain healing for AtomicLong instances didn't finish within the timeout...");
-                }
-            } catch (InterruptedException e) {
-                logger.finest("Interrupted while waiting for split-brain healing of AtomicLong instances...");
-                Thread.currentThread().interrupt();
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/MergeOperation.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.MergingValueHolder;
+import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 
@@ -54,8 +55,9 @@ public class MergeOperation extends AtomicLongBackupAwareOperation {
         AtomicLongService service = getService();
         boolean isExistingContainer = service.containsAtomicLong(name);
 
-        MergingValueHolder<Long> mergeHolder = createMergeHolder(getNodeEngine().getSerializationService(), mergingValue);
-        backupValue = getLongContainer().merge(mergeHolder, mergePolicy, isExistingContainer);
+        SerializationService serializationService = getNodeEngine().getSerializationService();
+        MergingValueHolder<Long> mergeHolder = createMergeHolder(serializationService, mergingValue);
+        backupValue = getLongContainer().merge(mergeHolder, mergePolicy, isExistingContainer, serializationService);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainer.java
@@ -16,9 +16,7 @@
 
 package com.hazelcast.concurrent.atomicreference;
 
-import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.MergingValueHolder;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -27,24 +25,9 @@ import static com.hazelcast.spi.impl.merge.MergingHolders.createMergeHolder;
 
 public class AtomicReferenceContainer {
 
-    private final String name;
-    private final AtomicReferenceConfig config;
-    private final SerializationService serializationService;
-
     private Data value;
 
-    public AtomicReferenceContainer(NodeEngine nodeEngine, String name) {
-        this.name = name;
-        this.config = nodeEngine.getConfig().findAtomicReferenceConfig(name);
-        this.serializationService = nodeEngine.getSerializationService();
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public AtomicReferenceConfig getConfig() {
-        return config;
+    public AtomicReferenceContainer() {
     }
 
     public Data get() {
@@ -83,11 +66,13 @@ public class AtomicReferenceContainer {
     /**
      * Merges the given {@link MergingValueHolder} via the given {@link SplitBrainMergePolicy}.
      *
-     * @param mergingValue the {@link MergingValueHolder} instance to merge
-     * @param mergePolicy  the {@link SplitBrainMergePolicy} instance to apply
+     * @param mergingValue         the {@link MergingValueHolder} instance to merge
+     * @param mergePolicy          the {@link SplitBrainMergePolicy} instance to apply
+     * @param serializationService the {@link SerializationService} to inject dependencies
      * @return the new value if merge is applied, otherwise {@code null}
      */
-    public Data merge(MergingValueHolder<Data> mergingValue, SplitBrainMergePolicy mergePolicy, boolean isExistingContainer) {
+    public Data merge(MergingValueHolder<Data> mergingValue, SplitBrainMergePolicy mergePolicy, boolean isExistingContainer,
+                      SerializationService serializationService) {
         serializationService.getManagedContext().initialize(mergingValue);
         serializationService.getManagedContext().initialize(mergePolicy);
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainerCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainerCollector.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.concurrent.atomicreference;
+
+import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
+import com.hazelcast.config.AtomicReferenceConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.merge.AbstractNamedContainerCollector;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
+
+class AtomicReferenceContainerCollector extends AbstractNamedContainerCollector<AtomicReferenceContainer> {
+
+    private final Config config;
+    private final ConcurrentMap<AtomicReferenceContainer, String> containerNames;
+    private final ConcurrentMap<AtomicReferenceContainer, MergePolicyConfig> containerPolicies;
+
+    AtomicReferenceContainerCollector(NodeEngine nodeEngine, ConcurrentMap<String, AtomicReferenceContainer> containers) {
+        super(nodeEngine, containers);
+        this.config = nodeEngine.getConfig();
+        this.containerNames = createConcurrentHashMap(containers.size());
+        this.containerPolicies = createConcurrentHashMap(containers.size());
+    }
+
+    /**
+     * The {@link AtomicLongContainer} doesn't know its name or configuration, so we create these lookup maps.
+     * This is cheaper than storing this information permanently in the container.
+     */
+    @Override
+    protected void onIteration(String containerName, AtomicReferenceContainer container) {
+        AtomicReferenceConfig atomicReferenceConfig = config.findAtomicReferenceConfig(containerName);
+
+        containerNames.put(container, containerName);
+        containerPolicies.put(container, atomicReferenceConfig.getMergePolicyConfig());
+    }
+
+    public String getContainerName(AtomicReferenceContainer container) {
+        return containerNames.get(container);
+    }
+
+    @Override
+    protected MergePolicyConfig getMergePolicyConfig(AtomicReferenceContainer container) {
+        return containerPolicies.get(container);
+    }
+
+    @Override
+    protected void destroy(AtomicReferenceContainer container) {
+        container.set(null);
+    }
+
+    @Override
+    protected void destroyBackup(AtomicReferenceContainer container) {
+        container.set(null);
+    }
+
+    @Override
+    public void onDestroy() {
+        containerNames.clear();
+        containerPolicies.clear();
+    }
+
+    @Override
+    protected int getMergingValueCount() {
+        int size = 0;
+        for (Collection<AtomicReferenceContainer> containers : getCollectedContainers().values()) {
+            size += containers.size();
+        }
+        return size;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
@@ -19,9 +19,7 @@ package com.hazelcast.concurrent.atomicreference;
 import com.hazelcast.concurrent.atomicreference.operations.AtomicReferenceReplicationOperation;
 import com.hazelcast.concurrent.atomicreference.operations.MergeOperation;
 import com.hazelcast.config.AtomicReferenceConfig;
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.cluster.Versions;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.ManagedService;
@@ -34,28 +32,23 @@ import com.hazelcast.spi.QuorumAwareService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.SplitBrainMergePolicy;
-import com.hazelcast.spi.merge.DiscardMergePolicy;
-import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
+import com.hazelcast.spi.impl.merge.AbstractContainerMerger;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ContextMutexFactory;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.internal.config.ConfigValidator.checkBasicConfig;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 public class AtomicReferenceService
         implements ManagedService, RemoteService, MigrationAwareService, QuorumAwareService, SplitBrainHandlerService {
@@ -69,7 +62,7 @@ public class AtomicReferenceService
     private final ConstructorFunction<String, AtomicReferenceContainer> atomicReferenceConstructorFunction =
             new ConstructorFunction<String, AtomicReferenceContainer>() {
                 public AtomicReferenceContainer createNew(String key) {
-                    return new AtomicReferenceContainer(nodeEngine, key);
+                    return new AtomicReferenceContainer();
                 }
             };
 
@@ -87,7 +80,6 @@ public class AtomicReferenceService
     };
 
     private NodeEngine nodeEngine;
-    private SplitBrainMergePolicyProvider mergePolicyProvider;
 
     public AtomicReferenceService() {
     }
@@ -103,7 +95,6 @@ public class AtomicReferenceService
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
         this.nodeEngine = nodeEngine;
-        this.mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
     }
 
     @Override
@@ -202,99 +193,38 @@ public class AtomicReferenceService
 
     @Override
     public Runnable prepareMergeRunnable() {
-        IPartitionService partitionService = nodeEngine.getPartitionService();
-        Map<Integer, List<AtomicReferenceContainer>> containerMap = new HashMap<Integer, List<AtomicReferenceContainer>>();
-
-        for (Map.Entry<String, AtomicReferenceContainer> entry : containers.entrySet()) {
-            AtomicReferenceContainer container = entry.getValue();
-            if (!(getMergePolicy(container) instanceof DiscardMergePolicy)) {
-                String name = entry.getKey();
-                int partitionId = partitionService.getPartitionId(StringPartitioningStrategy.getPartitionKey(name));
-                if (partitionService.isPartitionOwner(partitionId)) {
-                    // add your owned values to the map so they will be merged
-                    List<AtomicReferenceContainer> containerList = containerMap.get(partitionId);
-                    if (containerList == null) {
-                        containerList = new ArrayList<AtomicReferenceContainer>(containers.size());
-                        containerMap.put(partitionId, containerList);
-                    }
-                    containerList.add(container);
-                }
-            }
-        }
-        containers.clear();
-
-        return new Merger(containerMap);
+        AtomicReferenceContainerCollector collector = new AtomicReferenceContainerCollector(nodeEngine, containers);
+        collector.run();
+        return new Merger(collector);
     }
 
-    private SplitBrainMergePolicy getMergePolicy(AtomicReferenceContainer container) {
-        String mergePolicyName = container.getConfig().getMergePolicyConfig().getPolicy();
-        return mergePolicyProvider.getMergePolicy(mergePolicyName);
-    }
+    private class Merger extends AbstractContainerMerger<AtomicReferenceContainer> {
 
-    private class Merger implements Runnable {
-
-        private static final long TIMEOUT_FACTOR = 500;
-
-        private final ILogger logger = nodeEngine.getLogger(AtomicReferenceService.class);
-        private final Semaphore semaphore = new Semaphore(0);
-        private final ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
-            @Override
-            public void onResponse(Object response) {
-                semaphore.release(1);
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                logger.warning("Error while running AtomicReference merge operation: " + t.getMessage());
-                semaphore.release(1);
-            }
-        };
-
-        private final Map<Integer, List<AtomicReferenceContainer>> containerMap;
-
-        Merger(Map<Integer, List<AtomicReferenceContainer>> containerMap) {
-            this.containerMap = containerMap;
+        Merger(AtomicReferenceContainerCollector collector) {
+            super(collector, nodeEngine);
         }
 
         @Override
-        public void run() {
-            // we cannot merge into a 3.9 cluster, since not all members may understand the MergeOperation
-            // RU_COMPAT_3_9
-            if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-                logger.info("Cluster needs to run version " + Versions.V3_10 + " to merge AtomicReference instances");
-                return;
-            }
+        protected String getLabel() {
+            return "AtomicReference";
+        }
 
-            int valueCount = 0;
-            for (Map.Entry<Integer, List<AtomicReferenceContainer>> entry : containerMap.entrySet()) {
+        @Override
+        public void runInternal() {
+            AtomicReferenceContainerCollector collector = (AtomicReferenceContainerCollector) this.collector;
+            for (Map.Entry<Integer, Collection<AtomicReferenceContainer>> entry : collector.getCollectedContainers().entrySet()) {
                 // TODO: add batching (which is a bit complex, since AtomicReference is a single-value data structure,
                 // so we need an operation for multiple AtomicReference instances, which doesn't exist so far)
                 int partitionId = entry.getKey();
-                List<AtomicReferenceContainer> containerList = entry.getValue();
+                Collection<AtomicReferenceContainer> containerList = entry.getValue();
 
                 for (AtomicReferenceContainer container : containerList) {
-                    String name = container.getName();
-                    valueCount++;
+                    String name = collector.getContainerName(container);
+                    SplitBrainMergePolicy mergePolicy = getMergePolicy(collector.getMergePolicyConfig(container));
 
-                    MergeOperation operation = new MergeOperation(name, getMergePolicy(container), container.get());
-                    try {
-                        nodeEngine.getOperationService()
-                                .invokeOnPartition(SERVICE_NAME, operation, partitionId)
-                                .andThen(mergeCallback);
-                    } catch (Throwable t) {
-                        throw rethrow(t);
-                    }
+                    MergeOperation operation = new MergeOperation(name, mergePolicy, container.get());
+                    invoke(SERVICE_NAME, operation, partitionId);
                 }
-            }
-            containerMap.clear();
-
-            try {
-                if (!semaphore.tryAcquire(valueCount, valueCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS)) {
-                    logger.warning("Split-brain healing for AtomicReference instances didn't finish within the timeout...");
-                }
-            } catch (InterruptedException e) {
-                logger.finest("Interrupted while waiting for split-brain healing of AtomicReference instances...");
-                Thread.currentThread().interrupt();
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/MergeOperation.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.MergingValueHolder;
+import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 
@@ -55,8 +56,9 @@ public class MergeOperation extends AtomicReferenceBackupAwareOperation {
         AtomicReferenceService service = getService();
         boolean isExistingContainer = service.containsReferenceContainer(name);
 
-        MergingValueHolder<Data> mergeHolder = createMergeHolder(getNodeEngine().getSerializationService(), mergingValue);
-        backupValue = getReferenceContainer().merge(mergeHolder, mergePolicy, isExistingContainer);
+        SerializationService serializationService = getNodeEngine().getSerializationService();
+        MergingValueHolder<Data> mergeHolder = createMergeHolder(serializationService, mergingValue);
+        backupValue = getReferenceContainer().merge(mergeHolder, mergePolicy, isExistingContainer, serializationService);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -219,6 +219,10 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         return objectNamespace;
     }
 
+    public int getPartitionId() {
+        return partitionId;
+    }
+
     /**
      * Merges the given {@link MergingEntryHolder} via the given {@link SplitBrainMergePolicy}.
      *

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainerCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainerCollector.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.multimap.impl;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.merge.AbstractContainerCollector;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+class MultiMapContainerCollector extends AbstractContainerCollector<MultiMapContainer> {
+
+    private final MultiMapPartitionContainer[] partitionContainers;
+
+    MultiMapContainerCollector(NodeEngine nodeEngine, MultiMapPartitionContainer[] partitionContainers) {
+        super(nodeEngine);
+        this.partitionContainers = partitionContainers;
+    }
+
+    @Override
+    protected Iterator<MultiMapContainer> containerIterator(int partitionId) {
+        MultiMapPartitionContainer partitionContainer = partitionContainers[partitionId];
+        if (partitionContainer == null) {
+            return new EmptyIterator();
+        }
+        return partitionContainer.containerMap.values().iterator();
+    }
+
+    @Override
+    protected MergePolicyConfig getMergePolicyConfig(MultiMapContainer container) {
+        return container.getConfig().getMergePolicyConfig();
+    }
+
+    @Override
+    protected void destroy(MultiMapContainer container) {
+        container.destroy();
+    }
+
+    @Override
+    protected void destroyBackup(MultiMapContainer container) {
+        container.destroy();
+    }
+
+    @Override
+    protected int getMergingValueCount() {
+        int size = 0;
+        for (Collection<MultiMapContainer> containers : getCollectedContainers().values()) {
+            for (MultiMapContainer container : containers) {
+                size += container.size();
+            }
+        }
+        return size;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -154,6 +154,15 @@ public class ArrayRingbuffer<E> implements Ringbuffer<E> {
     }
 
     @Override
+    public void clear() {
+        for (int i = 0; i < ringItems.length; i++) {
+            ringItems[i] = null;
+        }
+        tailSequence = -1;
+        headSequence = tailSequence + 1;
+    }
+
+    @Override
     public void setSerializationService(SerializationService serializationService) {
         this.serializationService = serializationService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/Ringbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/Ringbuffer.java
@@ -167,6 +167,11 @@ public interface Ringbuffer<E> {
     void setSerializationService(SerializationService serializationService);
 
     /**
+     * Clears the data in the ringbuffer.
+     */
+    void clear();
+
+    /**
      * Merges the given {@link MergingValueHolder} with the given {@link SplitBrainMergePolicy}.
      *
      * @param mergingValue      the {@link MergingValueHolder} instance to merge

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainer.java
@@ -600,6 +600,13 @@ public class RingbufferContainer<T, E> implements IdentifiedDataSerializable, No
     }
 
     /**
+     * Clears the data in the ringbuffer.
+     */
+    public void clear() {
+        ringbuffer.clear();
+    }
+
+    /**
      * Merges the given {@link MergingValueHolder} via the given {@link SplitBrainMergePolicy}.
      *
      * @param mergingValue the {@link MergingValueHolder} instance to merge

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainerCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferContainerCollector.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.ringbuffer.impl;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.merge.AbstractContainerCollector;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+class RingbufferContainerCollector extends AbstractContainerCollector<RingbufferContainer> {
+
+    private final Map<Integer, Map<ObjectNamespace, RingbufferContainer>> containers;
+
+    RingbufferContainerCollector(NodeEngine nodeEngine, Map<Integer, Map<ObjectNamespace, RingbufferContainer>> containers) {
+        super(nodeEngine);
+        this.containers = containers;
+    }
+
+    @Override
+    protected Iterator<RingbufferContainer> containerIterator(int partitionId) {
+        Map<ObjectNamespace, RingbufferContainer> containerMap = containers.get(partitionId);
+        if (containerMap == null) {
+            return new EmptyIterator();
+        }
+        return containerMap.values().iterator();
+    }
+
+    @Override
+    protected MergePolicyConfig getMergePolicyConfig(RingbufferContainer container) {
+        return container.getConfig().getMergePolicyConfig();
+    }
+
+    @Override
+    protected void destroy(RingbufferContainer container) {
+        container.clear();
+    }
+
+    @Override
+    protected void destroyBackup(RingbufferContainer container) {
+        container.clear();
+    }
+
+    @Override
+    protected boolean isMergeable(RingbufferContainer container) {
+        String containerServiceName = container.getNamespace().getServiceName();
+        return RingbufferService.SERVICE_NAME.equals(containerServiceName);
+    }
+
+    @Override
+    protected int getMergingValueCount() {
+        int size = 0;
+        for (Collection<RingbufferContainer> containers : getCollectedContainers().values()) {
+            for (RingbufferContainer container : containers) {
+                size += container.size();
+            }
+        }
+        return size;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -19,9 +19,7 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.cluster.Versions;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.quorum.QuorumService;
@@ -42,9 +40,8 @@ import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.impl.NodeEngineImpl;
-import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.impl.merge.AbstractContainerMerger;
 import com.hazelcast.spi.merge.MergingValueHolder;
-import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ConstructorFunction;
@@ -56,7 +53,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -64,16 +60,12 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.internal.config.ConfigValidator.checkRingbufferConfig;
 import static com.hazelcast.spi.impl.merge.MergingHolders.createMergeHolder;
 import static com.hazelcast.spi.partition.MigrationEndpoint.DESTINATION;
 import static com.hazelcast.spi.partition.MigrationEndpoint.SOURCE;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
-import static com.hazelcast.util.ExceptionUtil.rethrow;
-import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.MapUtil.isNullOrEmpty;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -119,7 +111,6 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
     private SerializationService serializationService;
     private IPartitionService partitionService;
     private QuorumService quorumService;
-    private SplitBrainMergePolicyProvider mergePolicyProvider;
 
     public RingbufferService(NodeEngineImpl nodeEngine) {
         init(nodeEngine, null);
@@ -131,7 +122,6 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
         this.serializationService = nodeEngine.getSerializationService();
         this.partitionService = nodeEngine.getPartitionService();
         this.quorumService = nodeEngine.getQuorumService();
-        this.mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
     }
 
     // just for testing
@@ -347,126 +337,56 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
 
     @Override
     public Runnable prepareMergeRunnable() {
-        Map<Integer, List<RingbufferContainer>> partitionContainerMap = createHashMap(containers.size());
-        for (Entry<Integer, Map<ObjectNamespace, RingbufferContainer>> entry : containers.entrySet()) {
-            int partitionId = entry.getKey();
-            if (!partitionService.isPartitionOwner(partitionId)) {
-                continue;
-            }
-
-            List<RingbufferContainer> containerList = partitionContainerMap.get(partitionId);
-            if (containerList == null) {
-                containerList = new LinkedList<RingbufferContainer>();
-                partitionContainerMap.put(partitionId, containerList);
-            }
-            for (RingbufferContainer container : entry.getValue().values()) {
-                String serviceName = container.getNamespace().getServiceName();
-                // we just merge ringbuffer containers which are not used by other services
-                if (SERVICE_NAME.equals(serviceName) && !(getMergePolicy(container) instanceof DiscardMergePolicy)) {
-                    containerList.add(container);
-                }
-                container.cleanup();
-            }
-        }
-
-        // clear all items either owned or backup
-        reset();
-
-        return new Merger(partitionContainerMap);
+        RingbufferContainerCollector collector = new RingbufferContainerCollector(nodeEngine, containers);
+        collector.run();
+        return new Merger(collector);
     }
 
-    private SplitBrainMergePolicy getMergePolicy(RingbufferContainer container) {
-        String mergePolicyName = container.getConfig().getMergePolicyConfig().getPolicy();
-        return mergePolicyProvider.getMergePolicy(mergePolicyName);
-    }
+    private class Merger extends AbstractContainerMerger<RingbufferContainer> {
 
-    private class Merger implements Runnable {
-
-        private static final long TIMEOUT_FACTOR = 500;
-
-        private final ILogger logger = nodeEngine.getLogger(RingbufferService.class);
-        private final Semaphore semaphore = new Semaphore(0);
-        private final ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
-            @Override
-            public void onResponse(Object response) {
-                semaphore.release(1);
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                logger.warning("Error while running ringbuffer merge operation: " + t.getMessage());
-                semaphore.release(1);
-            }
-        };
-
-        private final Map<Integer, List<RingbufferContainer>> partitionContainerMap;
-
-        Merger(Map<Integer, List<RingbufferContainer>> partitionContainerMap) {
-            this.partitionContainerMap = partitionContainerMap;
+        Merger(RingbufferContainerCollector collector) {
+            super(collector, nodeEngine);
         }
 
         @Override
-        public void run() {
-            // we cannot merge into a 3.9 cluster, since not all members may understand the MergeOperation
-            // RU_COMPAT_3_9
-            if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-                logger.info("Cluster needs to run version " + Versions.V3_10 + " to merge ringbuffer instances");
-                return;
-            }
+        protected String getLabel() {
+            return "ringbuffer";
+        }
 
-            int itemCount = 0;
-            int operationCount = 0;
+        @Override
+        protected void runInternal() {
             List<MergingValueHolder<Object>> mergingValues;
-            for (Entry<Integer, List<RingbufferContainer>> entry : partitionContainerMap.entrySet()) {
+            for (Entry<Integer, Collection<RingbufferContainer>> entry : collector.getCollectedContainers().entrySet()) {
                 int partitionId = entry.getKey();
-                List<RingbufferContainer> containerList = entry.getValue();
+                Collection<RingbufferContainer> containerList = entry.getValue();
 
                 for (RingbufferContainer container : containerList) {
                     Ringbuffer ringbuffer = container.getRingbuffer();
                     int batchSize = container.getConfig().getMergePolicyConfig().getBatchSize();
-                    SplitBrainMergePolicy mergePolicy = getMergePolicy(container);
+                    SplitBrainMergePolicy mergePolicy = getMergePolicy(container.getConfig().getMergePolicyConfig());
 
                     mergingValues = new ArrayList<MergingValueHolder<Object>>(batchSize);
                     for (long sequence = ringbuffer.headSequence(); sequence <= ringbuffer.tailSequence(); sequence++) {
                         Object item = ringbuffer.read(sequence);
                         MergingValueHolder<Object> mergingValue = createMergeHolder(serializationService, sequence, item);
                         mergingValues.add(mergingValue);
-                        itemCount++;
 
                         if (mergingValues.size() == batchSize) {
-                            sendBatch(partitionId, container.getNamespace(), mergePolicy, mergingValues, mergeCallback);
+                            sendBatch(partitionId, container.getNamespace(), mergePolicy, mergingValues);
                             mergingValues = new ArrayList<MergingValueHolder<Object>>(batchSize);
-                            operationCount++;
                         }
                     }
                     if (mergingValues.size() > 0) {
-                        sendBatch(partitionId, container.getNamespace(), mergePolicy, mergingValues, mergeCallback);
-                        operationCount++;
+                        sendBatch(partitionId, container.getNamespace(), mergePolicy, mergingValues);
                     }
                 }
-            }
-            partitionContainerMap.clear();
-
-            try {
-                if (!semaphore.tryAcquire(operationCount, itemCount * TIMEOUT_FACTOR, TimeUnit.MILLISECONDS)) {
-                    logger.warning("Split-brain healing for ringbuffers didn't finish within the timeout...");
-                }
-            } catch (InterruptedException e) {
-                logger.finest("Interrupted while waiting for split-brain healing of ringbuffers...");
-                Thread.currentThread().interrupt();
             }
         }
 
         private void sendBatch(int partitionId, ObjectNamespace namespace, SplitBrainMergePolicy mergePolicy,
-                               List<MergingValueHolder<Object>> mergingValues, ExecutionCallback<Object> mergeCallback) {
+                               List<MergingValueHolder<Object>> mergingValues) {
             MergeOperation operation = new MergeOperation(namespace, mergePolicy, mergingValues);
-            try {
-                nodeEngine.getOperationService()
-                        .invokeOnPartition(SERVICE_NAME, operation, partitionId)
-                        .andThen(mergeCallback);
-            } catch (Throwable t) {
-                throw rethrow(t);
-            }
+            invoke(SERVICE_NAME, operation, partitionId);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/AbstractScheduledExecutorContainerHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/AbstractScheduledExecutorContainerHolder.java
@@ -22,6 +22,7 @@ import com.hazelcast.util.ConstructorFunction;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -53,6 +54,10 @@ public abstract class AbstractScheduledExecutorContainerHolder
 
     public Collection<ScheduledExecutorContainer> getContainers() {
         return Collections.unmodifiableCollection(containers.values());
+    }
+
+    public Iterator<ScheduledExecutorContainer> iterator() {
+        return containers.values().iterator();
     }
 
     public void destroy() {

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainerCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainerCollector.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.scheduledexecutor.impl;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.ScheduledExecutorConfig;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.merge.AbstractContainerCollector;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+class ScheduledExecutorContainerCollector extends AbstractContainerCollector<ScheduledExecutorContainer> {
+
+    private final ScheduledExecutorPartition[] partitions;
+
+    ScheduledExecutorContainerCollector(NodeEngine nodeEngine, ScheduledExecutorPartition[] partitions) {
+        super(nodeEngine);
+        this.partitions = partitions;
+    }
+
+    @Override
+    protected Iterator<ScheduledExecutorContainer> containerIterator(int partitionId) {
+        ScheduledExecutorPartition partition = partitions[partitionId];
+        if (partition == null) {
+            return new EmptyIterator();
+        }
+        return partition.iterator();
+    }
+
+    @Override
+    public MergePolicyConfig getMergePolicyConfig(ScheduledExecutorContainer container) {
+        ScheduledExecutorConfig config = container.getNodeEngine().getConfig()
+                .findScheduledExecutorConfig(container.getName());
+        return config.getMergePolicyConfig();
+    }
+
+    @Override
+    protected void destroy(ScheduledExecutorContainer container) {
+        container.destroy();
+    }
+
+    @Override
+    protected void destroyBackup(ScheduledExecutorContainer container) {
+        container.destroy();
+    }
+
+    @Override
+    protected int getMergingValueCount() {
+        int size = 0;
+        for (Collection<ScheduledExecutorContainer> containers : getCollectedContainers().values()) {
+            for (ScheduledExecutorContainer container : containers) {
+                size += container.tasks.size();
+            }
+        }
+        return size;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractContainerCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractContainerCollector.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.ManagedService;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.SplitBrainHandlerService;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
+import com.hazelcast.spi.partition.IPartitionService;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Collects non-threadsafe containers for {@link SplitBrainHandlerService}
+ * capable data structures.
+ * <p>
+ * The {@link com.hazelcast.internal.cluster.impl.ClusterMergeTask ClusterMergeTask}
+ * collects all mergeable data from all Hazelcast services. The problem is that it
+ * runs on an arbitrary thread, but the data is only modified by specific
+ * {@link com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread partition threads}.
+ * This can cause visibility issues due to a missing happens-before relation.
+ * <p>
+ * The collector fetches the data via {@link PartitionSpecificRunnable} (which
+ * run on the partition threads) and stores them in a {@link ConcurrentHashMap}.
+ * This guarantees the visibility for the {@code ClusterMergeTask}.
+ * <p>
+ * The collector can be implemented for data structures which reference their containers by
+ * <ul>
+ * <li>partition IDs using {@link AbstractContainerCollector}</li>
+ * <li>container name using {@link AbstractNamedContainerCollector}</li>
+ * </ul>
+ * <b>Note:</b> The collector will retain the collected containers for the merge runnable.
+ * So {@link ManagedService#reset()} is not allowed to clear or destroy those containers.
+ * To ensure this the collector removes the link between the data structure and a container
+ * via {@link Iterator#remove()} in {@link CollectContainerRunnable#run()}.
+ * <p>
+ * The cleanup of the containers itself is done in {@link #destroy()} via {@link #destroy(Object)}
+ * after the merge is done, or directly if the container is not collected. Containers from backup
+ * partitions are directly cleaned via {@link #destroyBackup(Object)}.
+ *
+ * @param <C> container of the data structure
+ */
+public abstract class AbstractContainerCollector<C> {
+
+    private final ConcurrentMap<Integer, Collection<C>> containersByPartitionId
+            = new ConcurrentHashMap<Integer, Collection<C>>();
+
+    private final OperationExecutor operationExecutor;
+    private final IPartitionService partitionService;
+    private final SplitBrainMergePolicyProvider mergePolicyProvider;
+
+    private CountDownLatch latch;
+
+    protected AbstractContainerCollector(NodeEngine nodeEngine) {
+        this.operationExecutor = ((OperationServiceImpl) nodeEngine.getOperationService()).getOperationExecutor();
+        this.partitionService = nodeEngine.getPartitionService();
+        this.mergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
+    }
+
+    /**
+     * Collects the containers from the data structure in a thread-safe way.
+     */
+    public final void run() {
+        int partitionCount = partitionService.getPartitionCount();
+        latch = new CountDownLatch(partitionCount);
+
+        for (int partitionId = 0; partitionId < partitionCount; partitionId++) {
+            operationExecutor.execute(new CollectContainerRunnable(partitionId));
+        }
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Returns the collected containers by partition ID.
+     *
+     * @return the collected containers
+     */
+    public final ConcurrentMap<Integer, Collection<C>> getCollectedContainers() {
+        return containersByPartitionId;
+    }
+
+    /**
+     * Destroys all collected containers.
+     */
+    public final void destroy() {
+        for (Collection<C> containers : containersByPartitionId.values()) {
+            for (C container : containers) {
+                destroy(container);
+            }
+        }
+        containersByPartitionId.clear();
+        onDestroy();
+    }
+
+    /**
+     * Will be called by {@link #destroy()}.
+     * <p>
+     * Can be overridden by implementations to cleanup local resources.
+     */
+    protected void onDestroy() {
+        // NOP
+    }
+
+    /**
+     * Returns all containers of the data structure for the given partition ID.
+     *
+     * @return {@link Iterator} over the containers of the given partition
+     */
+    protected abstract Iterator<C> containerIterator(int partitionId);
+
+    /**
+     * Returns the {@link MergePolicyConfig} of the container.
+     *
+     * @return the {@link MergePolicyConfig} of the container
+     */
+    protected abstract MergePolicyConfig getMergePolicyConfig(C container);
+
+    /**
+     * Destroys the owned data in the container.
+     * <p>
+     * Is called if a container is not collected or after the merge has been done.
+     */
+    protected abstract void destroy(C container);
+
+    /**
+     * Destroys the backup data in the container.
+     * <p>
+     * Is called if the container is not collected, since it's in a backup partition.
+     */
+    protected abstract void destroyBackup(C container);
+
+    /**
+     * Returns the number of collected merging values in this collector.
+     * <p>
+     * The count is used to calculate the timeout value to wait for merge operations to complete.
+     * <p>
+     * <b>Note:</b> Depending on the data structure, this can be the number of collected containers
+     * or the number of merging values within the collected containers.
+     *
+     * @return the number of collected merge values
+     */
+    protected abstract int getMergingValueCount();
+
+    /**
+     * Determines if the container should be merged.
+     * <p>
+     * Can be overridden if there are additional restrictions beside the merge policy,
+     * if a container is mergeable or not.
+     *
+     * @return {@code true} if the container is mergeable, {@code false} otherwise
+     */
+    protected boolean isMergeable(C container) {
+        return true;
+    }
+
+    /**
+     * Empty iterator for {@link #containerIterator(int)} calls, if the requested partition is empty.
+     */
+    protected final class EmptyIterator implements Iterator<C> {
+
+        public EmptyIterator() {
+        }
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public C next() {
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * Collects containers from a specific partition ID.
+     */
+    private final class CollectContainerRunnable implements PartitionSpecificRunnable {
+
+        private final Collection<C> containers = new LinkedList<C>();
+
+        private final int partitionId;
+
+        CollectContainerRunnable(int partitionId) {
+            this.partitionId = partitionId;
+        }
+
+        @Override
+        public int getPartitionId() {
+            return partitionId;
+        }
+
+        @Override
+        public void run() {
+            try {
+                Iterator<C> iterator = containerIterator(partitionId);
+                while (iterator.hasNext()) {
+                    C container = iterator.next();
+                    collect(container);
+                    iterator.remove();
+                }
+            } finally {
+                if (!containers.isEmpty()) {
+                    containersByPartitionId.put(partitionId, containers);
+                }
+                latch.countDown();
+            }
+        }
+
+        private void collect(C container) {
+            // just collect owned partitions
+            if (partitionService.isPartitionOwner(partitionId)) {
+                MergePolicyConfig mergePolicyconfig = getMergePolicyConfig(container);
+                SplitBrainMergePolicy mergePolicy = mergePolicyProvider.getMergePolicy(mergePolicyconfig.getPolicy());
+                if (isMergeable(container) && !(mergePolicy instanceof DiscardMergePolicy)) {
+                    containers.add(container);
+                } else {
+                    destroy(container);
+                }
+            } else {
+                destroyBackup(container);
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractContainerMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractContainerMerger.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+
+/**
+ * Merges data structures which have been collected via an {@link AbstractContainerCollector}.
+ *
+ * @param <C> container of the data structure
+ */
+public abstract class AbstractContainerMerger<C> implements Runnable {
+
+    private static final long TIMEOUT_FACTOR = 500;
+    private static final long MINIMAL_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(5);
+
+    protected final AbstractContainerCollector<C> collector;
+
+    private final Semaphore semaphore = new Semaphore(0);
+    private final ExecutionCallback<Object> mergeCallback = new ExecutionCallback<Object>() {
+        @Override
+        public void onResponse(Object response) {
+            semaphore.release(1);
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+            logger.warning("Error while running " + getLabel() + " merge operation: " + t.getMessage());
+            semaphore.release(1);
+        }
+    };
+
+    private final ILogger logger;
+    private final ClusterService clusterService;
+    private final OperationService operationService;
+    private final SplitBrainMergePolicyProvider splitBrainMergePolicyProvider;
+
+    private int operationCount;
+
+    protected AbstractContainerMerger(AbstractContainerCollector<C> collector, NodeEngine nodeEngine) {
+        this.collector = collector;
+        this.logger = nodeEngine.getLogger(AbstractContainerMerger.class);
+        this.clusterService = nodeEngine.getClusterService();
+        this.operationService = nodeEngine.getOperationService();
+        this.splitBrainMergePolicyProvider = nodeEngine.getSplitBrainMergePolicyProvider();
+    }
+
+    @Override
+    public final void run() {
+        // we cannot merge into a 3.9 cluster, since not all members may understand the new merge operation
+        // RU_COMPAT_3_9
+        if (clusterService.getClusterVersion().isLessThan(Versions.V3_10)) {
+            logger.info("Cluster needs to run version " + Versions.V3_10 + " to merge " + getLabel() + " instances");
+            return;
+        }
+        int valueCount = collector.getMergingValueCount();
+        if (valueCount == 0) {
+            return;
+        }
+
+        runInternal();
+
+        assert operationCount > 0 : "No merge operations have been invoked in AbstractContainerMerger";
+
+        try {
+            long timeoutMillis = Math.max(valueCount * TIMEOUT_FACTOR, MINIMAL_TIMEOUT_MILLIS);
+            if (!semaphore.tryAcquire(operationCount, timeoutMillis, TimeUnit.MILLISECONDS)) {
+                logger.warning("Split-brain healing for " + getLabel() + " didn't finish within the timeout...");
+            }
+        } catch (InterruptedException e) {
+            logger.finest("Interrupted while waiting for split-brain healing of " + getLabel() + "...");
+            Thread.currentThread().interrupt();
+        } finally {
+            collector.destroy();
+        }
+    }
+
+    /**
+     * Returns a label of the service for customized error messages.
+     */
+    protected abstract String getLabel();
+
+    /**
+     * Executes the service specific merging logic.
+     */
+    protected abstract void runInternal();
+
+    /**
+     * Returns the {@link SplitBrainMergePolicy} instance of a given {@link MergePolicyConfig}.
+     *
+     * @param mergePolicyConfig the {@link MergePolicyConfig} to retrieve the merge policy from
+     * @return the {@link SplitBrainMergePolicy} instance
+     */
+    protected SplitBrainMergePolicy getMergePolicy(MergePolicyConfig mergePolicyConfig) {
+        String mergePolicyName = mergePolicyConfig.getPolicy();
+        return splitBrainMergePolicyProvider.getMergePolicy(mergePolicyName);
+    }
+
+    /**
+     * Invokes the given merge operation.
+     *
+     * @param serviceName the service name
+     * @param operation   the merge operation
+     * @param partitionId the partition ID of the operation
+     */
+    protected void invoke(String serviceName, Operation operation, int partitionId) {
+        try {
+            operationCount++;
+            operationService
+                    .invokeOnPartition(serviceName, operation, partitionId)
+                    .andThen(mergeCallback);
+        } catch (Throwable t) {
+            throw rethrow(t);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractNamedContainerCollector.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractNamedContainerCollector.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.partition.IPartitionService;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Base implementation of {@link AbstractContainerCollector}
+ * for data structures which reference their containers by name.
+ *
+ * @param <C> container of the data structure
+ */
+public abstract class AbstractNamedContainerCollector<C> extends AbstractContainerCollector<C> {
+
+    protected final ConcurrentMap<String, C> containers;
+
+    private final IPartitionService partitionService;
+
+    protected AbstractNamedContainerCollector(NodeEngine nodeEngine, ConcurrentMap<String, C> containers) {
+        super(nodeEngine);
+        this.containers = containers;
+        this.partitionService = nodeEngine.getPartitionService();
+    }
+
+    @Override
+    protected final Iterator<C> containerIterator(int partitionId) {
+        return new ContainerIterator(partitionId);
+    }
+
+    /**
+     * Will be called by {@link ContainerIterator#hasNext()}.
+     * <p>
+     * Can be overridden by implementations to save the relation between container name and container.
+     *
+     * @param containerName the name of the removed container
+     * @param container     the removed container
+     */
+    protected void onIteration(String containerName, C container) {
+        // NOP
+    }
+
+    int getContainerPartitionId(String containerName) {
+        String partitionKey = StringPartitioningStrategy.getPartitionKey(containerName);
+        return partitionService.getPartitionId(partitionKey);
+    }
+
+    class ContainerIterator implements Iterator<C> {
+
+        private final Iterator<Map.Entry<String, C>> containerEntryIterator;
+        private final int partitionId;
+
+        private boolean hasNextWasCalled;
+        private Map.Entry<String, C> currentContainerEntry;
+
+        ContainerIterator(int partitionId) {
+            this.containerEntryIterator = containers.entrySet().iterator();
+            this.partitionId = partitionId;
+        }
+
+        @Override
+        public boolean hasNext() {
+            hasNextWasCalled = true;
+            while (containerEntryIterator.hasNext()) {
+                Map.Entry<String, C> next = containerEntryIterator.next();
+                if (getContainerPartitionId(next.getKey()) == partitionId) {
+                    onIteration(next.getKey(), next.getValue());
+                    currentContainerEntry = next;
+                    return true;
+                }
+            }
+            currentContainerEntry = null;
+            return false;
+        }
+
+        /**
+         * @throws IllegalStateException when called before {@link #hasNext()}
+         */
+        @Override
+        public C next() {
+            if (!hasNextWasCalled) {
+                throw new IllegalStateException("This iterator needs hasNext() to be called before next()");
+            }
+            hasNextWasCalled = false;
+            if (currentContainerEntry != null) {
+                return currentContainerEntry.getValue();
+            }
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public void remove() {
+            if (currentContainerEntry != null) {
+                containerEntryIterator.remove();
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/AbstractContainerCollectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/AbstractContainerCollectorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractContainerCollectorTest extends HazelcastTestSupport {
+
+    private NodeEngineImpl nodeEngine;
+
+    @Before
+    public void setUp() {
+        HazelcastInstance hazelcastInstance = createHazelcastInstance();
+        nodeEngine = getNodeEngineImpl(hazelcastInstance);
+        warmUpPartitions(hazelcastInstance);
+    }
+
+    @Test
+    public void testAbstractContainerCollector() {
+        TestContainerCollector collector = new TestContainerCollector(nodeEngine, true, true);
+        assertEqualsStringFormat("Expected the to have %d containers, but found %d", 1, collector.containers.size());
+
+        collector.run();
+
+        assertEqualsStringFormat("Expected %d merging values, but found %d", 1, collector.getMergingValueCount());
+        assertEquals("Expected the collected containers to be removed from the container map", 0, collector.containers.size());
+    }
+
+    @Test
+    public void testAbstractContainerCollector_withoutContainers() {
+        TestContainerCollector collector = new TestContainerCollector(nodeEngine, false, true);
+        assertEqualsStringFormat("Expected the to have %d containers, but found %d", 0, collector.containers.size());
+
+        collector.run();
+
+        assertEqualsStringFormat("Expected %d merging values, but found %d", 0, collector.getMergingValueCount());
+        assertEquals("Expected the collected containers to be removed from the container map", 0, collector.containers.size());
+    }
+
+    @Test
+    public void testAbstractContainerCollector_withoutMergeableContainers() {
+        TestContainerCollector collector = new TestContainerCollector(nodeEngine, true, false);
+        assertEqualsStringFormat("Expected the to have %d containers, but found %d", 1, collector.containers.size());
+
+        collector.run();
+
+        assertEqualsStringFormat("Expected %d merging values, but found %d", 0, collector.getMergingValueCount());
+        assertEquals("Expected the collected containers to be removed from the container map", 0, collector.containers.size());
+    }
+
+    @Test
+    public void testEmptyIterator() {
+        TestContainerCollector collector = new TestContainerCollector(nodeEngine, false, false);
+        Iterator<Object> iterator = collector.containerIterator(0);
+
+        assertInstanceOf(AbstractContainerCollector.EmptyIterator.class, iterator);
+        assertFalse("Expected no next elements in iterator", iterator.hasNext());
+        try {
+            iterator.next();
+            fail("Expected EmptyIterator.next() to throw NoSuchElementException");
+        } catch (NoSuchElementException expected) {
+            ignore(expected);
+        }
+        try {
+            iterator.remove();
+            fail("Expected EmptyIterator.remove() to throw UnsupportedOperationException");
+        } catch (UnsupportedOperationException expected) {
+            ignore(expected);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/AbstractContainerMergerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/AbstractContainerMergerTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.RequireAssertEnabled;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.spi.impl.merge.TestMergeOperation.OperationMode.BLOCKS;
+import static com.hazelcast.spi.impl.merge.TestMergeOperation.OperationMode.THROWS_EXCEPTION;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractContainerMergerTest extends HazelcastTestSupport {
+
+    private NodeEngineImpl nodeEngine;
+    private TestContainerCollector collector;
+    private TestContainerCollector emptyCollector;
+
+    @Before
+    public void setUp() {
+        HazelcastInstance hazelcastInstance = createHazelcastInstance();
+        nodeEngine = getNodeEngineImpl(hazelcastInstance);
+        warmUpPartitions(hazelcastInstance);
+
+        collector = new TestContainerCollector(nodeEngine, true, true);
+        collector.run();
+
+        emptyCollector = new TestContainerCollector(nodeEngine, false, true);
+        emptyCollector.run();
+    }
+
+    /**
+     * Tests that the merger finished under normal conditions.
+     */
+    @Test
+    @RequireAssertEnabled
+    public void testMergerRun() {
+        TestMergeOperation operation = new TestMergeOperation();
+        TestContainerMerger merger = new TestContainerMerger(collector, nodeEngine, operation);
+
+        merger.run();
+
+        assertTrue("Expected the merge operation to be invoked", operation.hasBeenInvoked);
+        assertTrue("Expected collected containers to be destroyed", collector.onDestroyHasBeenCalled);
+    }
+
+    /**
+     * Tests that the merger finishes, even if the merge operation throws an exception.
+     */
+    @Test
+    @RequireAssertEnabled
+    public void testMergerRun_whenMergeOperationThrowsException_thenMergerFinishesNormally() {
+        TestMergeOperation operation = new TestMergeOperation(THROWS_EXCEPTION);
+        TestContainerMerger merger = new TestContainerMerger(collector, nodeEngine, operation);
+
+        merger.run();
+
+        assertTrue("Expected the merge operation to be invoked", operation.hasBeenInvoked);
+        assertTrue("Expected collected containers to be destroyed", collector.onDestroyHasBeenCalled);
+    }
+
+    /**
+     * Tests that the merger finishes eventually, when the merge operation blocks.
+     */
+    @Test
+    @RequireAssertEnabled
+    @Category(SlowTest.class)
+    public void testMergerRun_whenMergeOperationBlocks_thenMergerFinishesEventually() {
+        TestMergeOperation operation = new TestMergeOperation(BLOCKS);
+        TestContainerMerger merger = new TestContainerMerger(collector, nodeEngine, operation);
+
+        merger.run();
+        operation.unblock();
+
+        assertTrue("Expected the merge operation to be invoked", operation.hasBeenInvoked);
+        assertTrue("Expected collected containers to be destroyed", collector.onDestroyHasBeenCalled);
+    }
+
+    /**
+     * Tests that the merger finishes, when it's interrupted.
+     */
+    @Test
+    @RequireAssertEnabled
+    public void testMergerRun_whenMergerIsInterrupted_thenMergerFinishesEventually() {
+        TestMergeOperation operation = new TestMergeOperation(BLOCKS);
+        final TestContainerMerger merger = new TestContainerMerger(collector, nodeEngine, operation);
+
+        Thread thread = new Thread() {
+            @Override
+            public void run() {
+                merger.run();
+            }
+        };
+        thread.start();
+        thread.interrupt();
+        assertJoinable(thread);
+        operation.unblock();
+
+        // we cannot assert if the operation has been invoked, since the interruption could be faster
+        assertTrue("Expected collected containers to be destroyed", collector.onDestroyHasBeenCalled);
+    }
+
+    /**
+     * Tests that the merger finishes without invoking merge operations, if no containers have been collected.
+     */
+    @Test
+    @RequireAssertEnabled
+    public void testMergerRun_whenEmptyCollector_thenMergerDoesNotRun() {
+        TestMergeOperation operation = new TestMergeOperation();
+        TestContainerMerger merger = new TestContainerMerger(emptyCollector, nodeEngine, operation);
+
+        merger.run();
+
+        assertFalse("Expected the merge operation not to be invoked", operation.hasBeenInvoked);
+        assertFalse("Expected collected containers not to be destroyed", collector.onDestroyHasBeenCalled);
+    }
+
+    /**
+     * Tests that an assertion is triggered, if the merger implementation doesn't call
+     * {@link AbstractContainerMerger#invoke(String, Operation, int)}, when there are
+     * collected containers.
+     */
+    @Test(expected = AssertionError.class)
+    @RequireAssertEnabled
+    public void testMergerRun_whenMissingOperationInvocation_thenMergerThrowsAssertion() {
+        TestContainerMerger merger = new TestContainerMerger(collector, nodeEngine, null);
+
+        merger.run();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/AbstractNamedContainerCollectorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/AbstractNamedContainerCollectorTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractNamedContainerCollectorTest extends HazelcastTestSupport {
+
+    private NodeEngineImpl nodeEngine;
+
+    @Before
+    public void setUp() {
+        HazelcastInstance hazelcastInstance = createHazelcastInstance();
+        nodeEngine = getNodeEngineImpl(hazelcastInstance);
+        warmUpPartitions(hazelcastInstance);
+    }
+
+    @Test
+    public void testAbstractNamedContainerCollector() {
+        TestNamedContainerCollector collector = new TestNamedContainerCollector(nodeEngine, true, true);
+        assertEqualsStringFormat("Expected the to have %d containers, but found %d", 1, collector.containers.size());
+
+        collector.run();
+
+        assertEqualsStringFormat("Expected %d merging values, but found %d", 1, collector.getMergingValueCount());
+        assertEquals("Expected the collected containers to be removed from the container map", 0, collector.containers.size());
+    }
+
+    @Test
+    public void testNonPartitionedCollector_withoutContainers() {
+        TestNamedContainerCollector collector = new TestNamedContainerCollector(nodeEngine, false, true);
+        assertEqualsStringFormat("Expected the to have %d containers, but found %d", 0, collector.containers.size());
+
+        collector.run();
+
+        assertEqualsStringFormat("Expected %d merging values, but found %d", 0, collector.getMergingValueCount());
+        assertEquals("Expected the collected containers to be removed from the container map", 0, collector.containers.size());
+    }
+
+    @Test
+    public void testNonPartitionedCollector_withoutMergeableContainers() {
+        TestNamedContainerCollector collector = new TestNamedContainerCollector(nodeEngine, true, false);
+        assertEqualsStringFormat("Expected the to have %d containers, but found %d", 1, collector.containers.size());
+
+        collector.run();
+
+        assertEqualsStringFormat("Expected %d merging values, but found %d", 0, collector.getMergingValueCount());
+        assertEquals("Expected the collected containers to be removed from the container map", 0, collector.containers.size());
+    }
+
+    @Test
+    public void testContainerIterator() {
+        TestNamedContainerCollector collector = new TestNamedContainerCollector(nodeEngine, true, true);
+        assertEquals(1, collector.containers.size());
+
+        int partitionId = collector.getContainerPartitionId("myContainer");
+        Iterator<Object> iterator = collector.containerIterator(partitionId);
+
+        assertInstanceOf(AbstractNamedContainerCollector.ContainerIterator.class, iterator);
+        assertTrue("Expected next elements in iterator", iterator.hasNext());
+        assertNotNull("", iterator.next());
+        // iterator.remove() should remove the current container
+        iterator.remove();
+        assertEquals(0, collector.containers.size());
+    }
+
+    @Test
+    public void testContainerIterator_onEmptyPartition() {
+        TestNamedContainerCollector collector = new TestNamedContainerCollector(nodeEngine, true, true);
+        assertEquals(1, collector.containers.size());
+
+        int partitionId = collector.getContainerPartitionId("myContainer") + 1;
+        Iterator<Object> iterator = collector.containerIterator(partitionId);
+
+        assertInstanceOf(AbstractNamedContainerCollector.ContainerIterator.class, iterator);
+        assertFalse("Expected no next elements in iterator", iterator.hasNext());
+        try {
+            iterator.next();
+            fail("Expected ContainerIterator.next() to throw NoSuchElementException");
+        } catch (NoSuchElementException expected) {
+            ignore(expected);
+        }
+        // iterator.remove() should not remove anything, since the container belongs to another partition
+        iterator.remove();
+        assertEquals(1, collector.containers.size());
+    }
+
+    @Test
+    public void testContainerIterator_withoutContainers() {
+        TestNamedContainerCollector collector = new TestNamedContainerCollector(nodeEngine, false, false);
+        assertEquals(0, collector.containers.size());
+
+        int partitionId = collector.getContainerPartitionId("myContainer");
+        Iterator<Object> iterator = collector.containerIterator(partitionId);
+
+        assertInstanceOf(AbstractNamedContainerCollector.ContainerIterator.class, iterator);
+        assertFalse("Expected no next elements in iterator", iterator.hasNext());
+        try {
+            iterator.next();
+            fail("Expected ContainerIterator.next() to throw NoSuchElementException");
+        } catch (NoSuchElementException expected) {
+            ignore(expected);
+        }
+        // iterator.remove() should do nothing
+        iterator.remove();
+        assertEquals(0, collector.containers.size());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testContainerIterator_whenNextCalledBeforeHasNext() {
+        TestNamedContainerCollector collector = new TestNamedContainerCollector(nodeEngine, true, true);
+        assertEquals(1, collector.containers.size());
+
+        int partitionId = collector.getContainerPartitionId("myContainer");
+        Iterator<Object> iterator = collector.containerIterator(partitionId);
+
+        assertInstanceOf(AbstractNamedContainerCollector.ContainerIterator.class, iterator);
+        iterator.next();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/TestContainerCollector.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/TestContainerCollector.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.NodeEngine;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+class TestContainerCollector extends AbstractContainerCollector<Object> {
+
+    final Map<String, Object> containers = new HashMap<String, Object>();
+
+    private final boolean hasContainers;
+    private final boolean isMergeable;
+
+    boolean onDestroyHasBeenCalled;
+
+    TestContainerCollector(NodeEngine nodeEngine, boolean hasContainers, boolean isMergeable) {
+        super(nodeEngine);
+        this.hasContainers = hasContainers;
+        this.isMergeable = isMergeable;
+
+        if (hasContainers) {
+            containers.put("myContainer", new Object());
+        }
+    }
+
+    @Override
+    protected Iterator<Object> containerIterator(int partitionId) {
+        if (hasContainers && partitionId == 0) {
+            return containers.values().iterator();
+        }
+        return new EmptyIterator();
+    }
+
+    @Override
+    protected MergePolicyConfig getMergePolicyConfig(Object container) {
+        return new MergePolicyConfig();
+    }
+
+    @Override
+    protected void destroy(Object container) {
+    }
+
+    @Override
+    protected void destroyBackup(Object container) {
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        onDestroyHasBeenCalled = true;
+    }
+
+    @Override
+    protected int getMergingValueCount() {
+        return getCollectedContainers().size();
+    }
+
+    @Override
+    protected boolean isMergeable(Object container) {
+        return isMergeable && super.isMergeable(container);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/TestContainerMerger.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/TestContainerMerger.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.SplitBrainMergePolicy;
+
+import static org.junit.Assert.assertNotNull;
+
+class TestContainerMerger extends AbstractContainerMerger<Object> {
+
+    private final TestMergeOperation mergeOperation;
+
+    TestContainerMerger(TestContainerCollector collector, NodeEngine nodeEngine, TestMergeOperation mergeOperation) {
+        super(collector, nodeEngine);
+        this.mergeOperation = mergeOperation;
+    }
+
+    @Override
+    protected String getLabel() {
+        return null;
+    }
+
+    @Override
+    protected void runInternal() {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig();
+        SplitBrainMergePolicy mergePolicy = getMergePolicy(mergePolicyConfig);
+        assertNotNull("Expected to retrieve a merge policy, but was null", mergePolicy);
+
+        if (mergeOperation != null) {
+            invoke(MapService.SERVICE_NAME, mergeOperation, 1);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/TestMergeOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/TestMergeOperation.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.spi.Operation;
+
+import java.util.concurrent.CountDownLatch;
+
+class TestMergeOperation extends Operation {
+
+    enum OperationMode {
+        NORMAL,
+        THROWS_EXCEPTION,
+        BLOCKS
+    }
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    private final OperationMode operationMode;
+
+    boolean hasBeenInvoked;
+
+    TestMergeOperation() {
+        this.operationMode = OperationMode.NORMAL;
+    }
+
+    TestMergeOperation(OperationMode operationMode) {
+        this.operationMode = operationMode;
+    }
+
+    public void unblock() {
+        latch.countDown();
+    }
+
+    @Override
+    public void run() throws Exception {
+        hasBeenInvoked = true;
+        switch (operationMode) {
+            case THROWS_EXCEPTION:
+                throw new HazelcastException("Expected exception");
+            case BLOCKS:
+                try {
+                    latch.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                break;
+            default:
+                // NOP
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/TestNamedContainerCollector.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/merge/TestNamedContainerCollector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.spi.NodeEngine;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Collections.singletonMap;
+
+class TestNamedContainerCollector extends AbstractNamedContainerCollector<Object> {
+
+    private final boolean isMergeable;
+
+    TestNamedContainerCollector(NodeEngine nodeEngine, boolean hasContainer, boolean isMergeable) {
+        super(nodeEngine, hasContainer
+                ? new ConcurrentHashMap<String, Object>(singletonMap("myContainer", new Object()))
+                : new ConcurrentHashMap<String, Object>());
+        this.isMergeable = isMergeable;
+    }
+
+    @Override
+    protected MergePolicyConfig getMergePolicyConfig(Object container) {
+        return new MergePolicyConfig();
+    }
+
+    @Override
+    protected void destroy(Object container) {
+    }
+
+    @Override
+    protected void destroyBackup(Object container) {
+    }
+
+    @Override
+    protected boolean isMergeable(Object container) {
+        return isMergeable && super.isMergeable(container);
+    }
+
+    @Override
+    protected int getMergingValueCount() {
+        return getCollectedContainers().size();
+    }
+}


### PR DESCRIPTION
* added `AbstractContainerCollector` which collects non-threadsafe data structure containers via `PartitionSpecificRunnables`
* added `AbstractContainerMerger` which merges collected data containers
* added data structure specific merge helpers for `IQueue`, `ISet`, `IList`, `MultiMap`, `IAtomicLong`, `IAtomicReference`, `Ringbuffer`, `CardinalityEstimator` and `ScheduledExecutorService`
* added `clear()` method to `RingbufferContainer` and `Ringbuffer`
* added a minimal timeout of 5 seconds to wait for merge operations
* reduced memory footprint of `AtomicLong` and `AtomicReference` containers by removing name, config and `SerializationService` reference, which were formerly added by split-brain healing

<hr>

New classes in `com.hazelcast.spi.impl.merge`:
![screenshot from 2018-03-07 14-04-01](https://user-images.githubusercontent.com/4196298/37093670-70f4a1f0-2210-11e8-9f47-749ec1d6cef8.png)

Class hierarchy:
![container-collector](https://user-images.githubusercontent.com/4196298/37093632-5206994c-2210-11e8-8c02-f435115f9bf8.png)

The `AbstractNonPartitionedContainerCollector` has two groups of implementations:
* `CollectionContainerCollector` and `QueueContainerCollector`
* `AtomicLongContainerCollector`, `AtomicReferenceContainerCollector` and `CardinalityEstimatorContainerCollector`

The first group is fine as it is. For the second one I could add another abstract class to de-duplicate the lookup maps. But I think the small amount of duplicated code doesn't justify that additional layer of abstraction.

<hr>

The `ReplicatedMap` will be fixed in another PR, since it will be aligned with `IMap` and `ICache`, not the container based data structures of this PR.

<hr>

There is also no cleanup of any container maps in the `prepareMergeRunnable()` methods anymore. Just a simple:
```java
@Override
public Runnable prepareMergeRunnable() {
    MyContainerCollector collector = new MyContainerCollector(nodeEngine, containers);
    collector.run();
    return new Merger(collector);
}
```
**Note:** The collector will retain the collected containers for the merge runnable. So `ManagedService#reset()` is not allowed to clear or destroy those containers. To ensure this the collector removes the link between the data structure and a container via `Iterator#remove()` in `AbstractContainerCollector$CollectContainerRunnable.run()`.

The cleanup of the containers itself is done in `AbstractContainerCollector.destroy()` via `AbstractContainerCollector.destroy(container)` after the merge is done, or directly if the container is not collected. Containers from backup partitions are directly cleaned via `AbstractContainerCollector.destroyBackup(container)`.

This info has also been added to the JavaDoc of `AbstractContainerCollector`.