### PR TITLE
Decrease schedule_withMapChanges_durable loop count

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -39,6 +39,8 @@ import static java.lang.Thread.sleep;
  */
 public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
 
+    public static final int MAP_INCREMENT_TASK_MAX_ENTRIES = 10000;
+
     public IScheduledExecutorService getScheduledExecutor(HazelcastInstance[] instances, String name) {
         return instances[0].getScheduledExecutorService(name);
     }
@@ -141,30 +143,34 @@ public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
 
     static class ICountdownLatchMapIncrementCallableTask implements Runnable, Serializable, HazelcastInstanceAware {
 
-        final String runLatchName;
+        final String startedLatch;
+        final String finishedLatch;
         final String runEntryCounterName;
         final String mapName;
 
         transient HazelcastInstance instance;
 
-        ICountdownLatchMapIncrementCallableTask(String mapName, String runEntryCounterName, String runLatchName) {
+        ICountdownLatchMapIncrementCallableTask(String mapName, String runEntryCounterName,
+                                                String startedLatch, String finishedLatch) {
             this.mapName = mapName;
             this.runEntryCounterName = runEntryCounterName;
-            this.runLatchName = runLatchName;
+            this.startedLatch = startedLatch;
+            this.finishedLatch = finishedLatch;
         }
 
         @Override
         public void run() {
             instance.getAtomicLong(runEntryCounterName).incrementAndGet();
+            instance.getCountDownLatch(startedLatch).countDown();
 
             IMap<String, Integer> map = instance.getMap(mapName);
-            for (int i = 0; i < 100000; i++) {
+            for (int i = 0; i < MAP_INCREMENT_TASK_MAX_ENTRIES; i++) {
                 if (map.get(String.valueOf(i)) == i) {
                     map.put(String.valueOf(i), i + 1);
                 }
             }
 
-            instance.getCountDownLatch(runLatchName).countDown();
+            instance.getCountDownLatch(finishedLatch).countDown();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -22,6 +22,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Cluster;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICountDownLatch;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.core.PartitionService;
@@ -1026,15 +1027,27 @@ public abstract class HazelcastTestSupport {
         assertOpenEventually(latch, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }
 
+    public static void assertOpenEventually(ICountDownLatch latch) {
+        assertOpenEventually(latch, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
+    }
+
     public static void assertOpenEventually(String message, CountDownLatch latch) {
-        assertOpenEventually(message, latch, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
+        assertOpenEventually(message, new CountdownLatchAdapter(latch), ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }
 
     public static void assertOpenEventually(CountDownLatch latch, long timeoutSeconds) {
-        assertOpenEventually(null, latch, timeoutSeconds);
+        assertOpenEventually(null, new CountdownLatchAdapter(latch), timeoutSeconds);
+    }
+
+    public static void assertOpenEventually(ICountDownLatch latch, long timeoutSeconds) {
+        assertOpenEventually(null, new ICountdownLatchAdapter(latch), timeoutSeconds);
     }
 
     public static void assertOpenEventually(String message, CountDownLatch latch, long timeoutSeconds) {
+        assertOpenEventually(message, new CountdownLatchAdapter(latch), timeoutSeconds);
+    }
+
+    public static void assertOpenEventually(String message, Latch latch, long timeoutSeconds) {
         try {
             boolean completed = latch.await(timeoutSeconds, TimeUnit.SECONDS);
             if (message == null) {
@@ -1327,6 +1340,54 @@ public abstract class HazelcastTestSupport {
         @Override
         public Object call() throws Exception {
             return null;
+        }
+    }
+
+    private interface Latch {
+        boolean await(long timeout, TimeUnit unit)
+                throws InterruptedException;
+        long getCount();
+    }
+
+    private static class ICountdownLatchAdapter
+            implements Latch {
+
+        private final ICountDownLatch latch;
+
+        ICountdownLatchAdapter(ICountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public boolean await(long timeout, TimeUnit unit)
+                throws InterruptedException {
+            return latch.await(timeout, unit);
+        }
+
+        @Override
+        public long getCount() {
+            return latch.getCount();
+        }
+    }
+
+    private static class CountdownLatchAdapter
+            implements Latch {
+
+        private final CountDownLatch latch;
+
+        CountdownLatchAdapter(CountDownLatch latch) {
+            this.latch = latch;
+        }
+
+        @Override
+        public boolean await(long timeout, TimeUnit unit)
+                throws InterruptedException {
+            return latch.await(timeout, unit);
+        }
+
+        @Override
+        public long getCount() {
+            return latch.getCount();
         }
     }
 


### PR DESCRIPTION
- Decreased loop count to make test faster, shouldn't be needing 2 mins
- Assert that the latch was actually zero-ed instead of time running out
- Removed the need for `sleep`

Fixes https://github.com/hazelcast/hazelcast/issues/12423