### PR TITLE
Cleanup of EmptyStatement usage

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClientManager.java
@@ -26,13 +26,14 @@ import com.hazelcast.core.DuplicateInstanceNameException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.OutOfMemoryHandler;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
-import com.hazelcast.util.EmptyStatement;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * Central manager for all Hazelcast clients of the JVM.
@@ -108,7 +109,7 @@ public final class HazelcastClientManager {
             try {
                 client.shutdown();
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
         OutOfMemoryErrorDispatcher.clearClients();
@@ -128,7 +129,7 @@ public final class HazelcastClientManager {
             try {
                 client.shutdown();
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             } finally {
                 OutOfMemoryErrorDispatcher.deregisterClient(client);
             }
@@ -148,7 +149,7 @@ public final class HazelcastClientManager {
         try {
             client.shutdown();
         } catch (Throwable ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         } finally {
             OutOfMemoryErrorDispatcher.deregisterClient(client);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientICMPManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientICMPManager.java
@@ -24,7 +24,6 @@ import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListener;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ICMPHelper;
 
 import java.io.IOException;
@@ -32,6 +31,7 @@ import java.net.ConnectException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -154,7 +154,7 @@ public class ClientICMPManager implements ConnectionListener {
                 }
             } catch (ConnectException ignored) {
                 // no route to host, means we cannot connect anymore
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
             return false;
         }
@@ -179,7 +179,7 @@ public class ClientICMPManager implements ConnectionListener {
                     heartbeatManager.fireHeartbeatStopped(connection);
                 }
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             } finally {
                 //because ping and connection removal runs concurrently,
                 //it could be the case that we created an entry for a dead connection.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -53,7 +53,6 @@ import com.hazelcast.mapreduce.impl.task.TransferableJobProcessInformation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.AbstractCompletableFuture;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.UuidUtil;
 
 import java.util.Collection;
@@ -65,6 +64,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * Proxy implementation of {@link JobTracker} for a client initiated map reduce job.
@@ -252,7 +252,7 @@ public class ClientMapReduceProxy
                 ClientMessage response = invoke(request, jobId);
                 cancelled = MapReduceCancelCodec.decodeResponse(response).response;
             } catch (Exception ignore) {
-                EmptyStatement.ignore(ignore);
+                ignore(ignore);
             }
             return cancelled;
         }
@@ -307,7 +307,7 @@ public class ClientMapReduceProxy
                 JobPartitionState[] partitionStates = responseParameters.jobPartitionStates.toArray(new JobPartitionState[0]);
                 return new TransferableJobProcessInformation(partitionStates, responseParameters.processRecords);
             } catch (Exception ignore) {
-                EmptyStatement.ignore(ignore);
+                ignore(ignore);
             }
             return null;
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -64,7 +64,6 @@ import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
@@ -80,6 +79,7 @@ import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.crdt.pncounter.PNCounterService;
 import com.hazelcast.durableexecutor.impl.DistributedDurableExecutorService;
 import com.hazelcast.executor.impl.DistributedExecutorService;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.mapreduce.impl.MapReduceService;
 import com.hazelcast.multimap.impl.MultiMapService;
@@ -93,7 +93,6 @@ import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 import com.hazelcast.transaction.impl.xa.XAService;
-import com.hazelcast.util.EmptyStatement;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -368,7 +367,6 @@ public final class ProxyManager {
             Thread.sleep(invocationRetryPauseMillis);
         } catch (InterruptedException ignored) {
             currentThread().interrupt();
-            EmptyStatement.ignore(ignored);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -35,7 +35,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.NoDataMemberInClusterException;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.HashUtil;
 
 import java.util.Collection;
@@ -44,6 +43,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * The {@link ClientPartitionService} implementation.
@@ -93,7 +94,7 @@ public final class ClientPartitionServiceImpl
             // use internal execution service for all partition refresh process (do not use the user executor thread)
             clientExecutionService.execute(new RefreshTask());
         } catch (RejectedExecutionException ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientUserCodeDeploymentService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientUserCodeDeploymentService.java
@@ -21,8 +21,6 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientDeployClassesCodec;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.IOUtil;
-import com.hazelcast.util.EmptyStatement;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -42,7 +40,9 @@ import java.util.jar.JarInputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.nio.IOUtil.toByteArray;
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 public class ClientUserCodeDeploymentService {
 
@@ -78,9 +78,9 @@ public class ClientUserCodeDeploymentService {
                 byte[] bytes = toByteArray(is);
                 classDefinitionList.add(new AbstractMap.SimpleEntry<String, byte[]>(className, bytes));
             } catch (IOException e) {
-                EmptyStatement.ignore(e);
+                ignore(e);
             } finally {
-                IOUtil.closeResource(is);
+                closeResource(is);
             }
         }
     }
@@ -92,7 +92,7 @@ public class ClientUserCodeDeploymentService {
                 loadClassesFromJar(os, jarPath);
             }
         } finally {
-            IOUtil.closeResource(os);
+            closeResource(os);
         }
     }
 
@@ -116,7 +116,7 @@ public class ClientUserCodeDeploymentService {
                 classDefinitionList.add(new AbstractMap.SimpleEntry<String, byte[]>(className, classDefinition));
             } while (true);
         } finally {
-            IOUtil.closeResource(inputStream);
+            closeResource(inputStream);
         }
     }
 
@@ -130,13 +130,12 @@ public class ClientUserCodeDeploymentService {
             URL url = new URL(jarPath);
             return new JarInputStream(url.openStream());
         } catch (MalformedURLException e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
 
         InputStream inputStream = configClassLoader.getResourceAsStream(jarPath);
         if (inputStream == null) {
-            throw new FileNotFoundException("File could not be found in " + jarPath
-                    + "  and resources/" + jarPath);
+            throw new FileNotFoundException("File could not be found in " + jarPath + "  and resources/" + jarPath);
         }
         return new JarInputStream(inputStream);
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -37,7 +37,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -248,7 +247,7 @@ public class ClientConnectionTest extends HazelcastTestSupport {
                 try {
                     countDownLatch.await();
                 } catch (InterruptedException e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 }
             }
             return super.getPassword();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientDisconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientDisconnectTest.java
@@ -31,7 +31,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -87,7 +86,7 @@ public class ClientDisconnectTest extends HazelcastTestSupport {
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 } catch (HazelcastInstanceNotActiveException e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 }
             }
         }).start();
@@ -142,7 +141,7 @@ public class ClientDisconnectTest extends HazelcastTestSupport {
                 try {
                     clientMap.lock(key);
                 } catch (Exception e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 }
 
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientSplitBrainTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -129,7 +128,7 @@ public class ClientSplitBrainTest extends ClientTestSupport {
                     try {
                         mapClient.put(1, 1);
                     } catch (Throwable t) {
-                        EmptyStatement.ignore(t);
+                        ignore(t);
                     }
                 }
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapUnboundReturnValuesTestSupport.java
@@ -28,7 +28,6 @@ import com.hazelcast.query.TruePredicate;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.transaction.TransactionContext;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import org.junit.After;
 
@@ -237,7 +236,7 @@ public abstract class ClientMapUnboundReturnValuesTestSupport extends HazelcastT
             queryMap.localKeySet();
             failExpectedException("IMap.localKeySet()");
         } catch (UnsupportedOperationException e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         } catch (QueryResultSizeExceededException e) {
             failUnwantedException("IMap.localKeySet()");
         }
@@ -246,7 +245,7 @@ public abstract class ClientMapUnboundReturnValuesTestSupport extends HazelcastT
             queryMap.localKeySet(TruePredicate.INSTANCE);
             failExpectedException("IMap.localKeySet(predicate)");
         } catch (UnsupportedOperationException e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         } catch (QueryResultSizeExceededException e) {
             failUnwantedException("IMap.localKeySet()");
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -50,7 +50,6 @@ import com.hazelcast.spi.merge.ExpirationTimeHolder;
 import com.hazelcast.spi.merge.MergingEntryHolder;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -80,6 +79,7 @@ import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLET
 import static com.hazelcast.cache.impl.record.CacheRecordFactory.isExpiredAt;
 import static com.hazelcast.internal.config.ConfigValidator.checkEvictionConfig;
 import static com.hazelcast.spi.impl.merge.MergingHolders.createMergeHolder;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkInstanceOf;
 import static com.hazelcast.util.SetUtil.createHashSet;
@@ -470,7 +470,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                 }
             }
         } catch (Exception e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
         return expiryTime;
     }
@@ -746,7 +746,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
                 expiryTime = getAdjustedExpireTime(expiryDuration, now);
             }
         } catch (Exception e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
         return updateRecordWithExpiry(key, value, record, expiryTime, now,
                 disableWriteThrough, completionId, source, origin);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -25,7 +25,6 @@ import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.LifecycleService;
-import com.hazelcast.util.EmptyStatement;
 
 import javax.cache.CacheException;
 import javax.cache.CacheManager;
@@ -45,6 +44,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateCacheConfig;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.SetUtil.createLinkedHashSet;
 
@@ -312,7 +312,7 @@ public abstract class AbstractHazelcastCacheManager
             // if hazelcastInstance is terminated already,
             // `lifecycleService.removeLifecycleListener` will throw HazelcastInstanceNotActiveException.
             // We can safely ignore this exception. See TerminatedLifecycleService.
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
@@ -19,13 +19,13 @@ package com.hazelcast.cache.impl;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.internal.config.ConfigValidator.checkCacheConfig;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -138,13 +138,13 @@ public final class CacheProxyUtil {
             containsNullKey = map.containsKey(null);
         } catch (NullPointerException e) {
             // ignore if null key is not allowed for this map
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
         try {
             containsNullValue = map.containsValue(null);
         } catch (NullPointerException e) {
             // ignore if null value is not allowed for this map
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
         if (containsNullKey) {
             throw new NullPointerException(NULL_KEY_IS_NOT_ALLOWED);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/MXBeanUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/MXBeanUtil.java
@@ -90,9 +90,8 @@ public final class MXBeanUtil {
                         // https://github.com/hazelcast/hazelcast/issues/11055
                         ignore(e);
                     } catch (Exception e) {
-                        throw new CacheException(
-                                "Error unregistering object instance " + registeredObjectName
-                                        + ". Error was " + e.getMessage(), e);
+                        throw new CacheException("Error unregistering object instance " + registeredObjectName
+                                + ". Error was " + e.getMessage(), e);
                     }
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/TcpIpJoiner.java
@@ -33,7 +33,6 @@ import com.hazelcast.util.AddressUtil;
 import com.hazelcast.util.AddressUtil.AddressMatcher;
 import com.hazelcast.util.AddressUtil.InvalidAddressException;
 import com.hazelcast.util.Clock;
-import com.hazelcast.util.EmptyStatement;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -46,6 +45,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.AddressUtil.AddressHolder;
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 public class TcpIpJoiner extends AbstractJoiner {
 
@@ -413,7 +413,7 @@ public class TcpIpJoiner extends AbstractJoiner {
                 try {
                     addressMatcher = AddressUtil.getAddressMatcher(addressHolder.getAddress());
                 } catch (InvalidAddressException ignore) {
-                    EmptyStatement.ignore(ignore);
+                    ignore(ignore);
                 }
                 if (addressMatcher != null) {
                     final Collection<String> matchedAddresses;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueStoreWrapper.java
@@ -27,7 +27,6 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.util.EmptyStatement;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,6 +34,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -121,10 +121,9 @@ public final class QueueStoreWrapper implements QueueStore<Data> {
         try {
             store = ClassLoaderUtil.newInstance(classLoader, storeConfig.getClassName());
         } catch (Exception ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
         return store;
-
     }
 
     private static QueueStore getQueueStoreFactory(String name, QueueStoreConfig storeConfig, ClassLoader classLoader) {
@@ -134,10 +133,9 @@ public final class QueueStoreWrapper implements QueueStore<Data> {
         QueueStoreFactory factory = storeConfig.getFactoryImplementation();
         if (factory == null) {
             try {
-                factory = ClassLoaderUtil.newInstance(classLoader,
-                        storeConfig.getFactoryClassName());
+                factory = ClassLoaderUtil.newInstance(classLoader, storeConfig.getFactoryClassName());
             } catch (Exception ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
         return factory == null ? null : factory.newQueueStore(name, storeConfig.getProperties());

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
@@ -20,7 +20,6 @@ import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.transaction.impl.Transaction;
-import com.hazelcast.util.EmptyStatement;
 
 import java.util.concurrent.TimeUnit;
 
@@ -44,7 +43,6 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E
             return offer(e, 0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException ignored) {
             currentThread().interrupt();
-            EmptyStatement.ignore(ignored);
         }
         return false;
     }
@@ -70,7 +68,6 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E
             return poll(0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException ignored) {
             currentThread().interrupt();
-            EmptyStatement.ignore(ignored);
         }
         return null;
     }
@@ -90,7 +87,6 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E
             return peek(0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException ignored) {
             currentThread().interrupt();
-            EmptyStatement.ignore(ignored);
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigLoader.java
@@ -16,12 +16,12 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.util.EmptyStatement;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * Provides loading service for a configuration.
@@ -75,7 +75,7 @@ public final class ConfigLoader {
             try {
                 return file.toURI().toURL();
             } catch (MalformedURLException ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
         return null;
@@ -85,7 +85,7 @@ public final class ConfigLoader {
         try {
             return new URL(path);
         } catch (MalformedURLException ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LoginModuleConfig.java
@@ -16,10 +16,12 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.StringUtil;
 
 import java.util.Properties;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
+
 /**
  * Configuration for Login Module
  */
@@ -63,7 +65,7 @@ public class LoginModuleConfig {
             try {
                 return LoginModuleUsage.valueOf(v.toUpperCase(StringUtil.LOCALE_INTERNAL));
             } catch (Exception ignore) {
-                EmptyStatement.ignore(ignore);
+                ignore(ignore);
             }
             return REQUIRED;
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -24,7 +24,6 @@ import com.hazelcast.core.Member;
 import com.hazelcast.internal.jmx.ManagementService;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Collections;
@@ -38,6 +37,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.STARTED;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.Preconditions.checkHasText;
 import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.lang.String.format;
@@ -213,7 +213,6 @@ public final class HazelcastInstanceFactory {
                     }
                 } catch (InterruptedException ignored) {
                     currentThread().interrupt();
-                    EmptyStatement.ignore(ignored);
                 }
             }
             awaitMinimalClusterSize(hazelcastInstance, node, firstMember);
@@ -243,7 +242,6 @@ public final class HazelcastInstanceFactory {
                 SECONDS.sleep(1);
             } catch (InterruptedException ignored) {
                 currentThread().interrupt();
-                EmptyStatement.ignore(ignored);
             }
         }
         if (initialMinClusterSize > 1) {
@@ -272,7 +270,7 @@ public final class HazelcastInstanceFactory {
                 HazelcastInstanceProxy instanceProxy = future.get();
                 instances.add(instanceProxy);
             } catch (RuntimeException ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -25,8 +25,6 @@ import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.flakeidgen.FlakeIdGenerator;
-import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
@@ -59,6 +57,8 @@ import com.hazelcast.crdt.pncounter.PNCounterService;
 import com.hazelcast.durableexecutor.DurableExecutorService;
 import com.hazelcast.durableexecutor.impl.DistributedDurableExecutorService;
 import com.hazelcast.executor.impl.DistributedExecutorService;
+import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.internal.jmx.ManagementService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
@@ -86,13 +86,13 @@ import com.hazelcast.transaction.TransactionManagerService;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalTask;
 import com.hazelcast.transaction.impl.xa.XAService;
-import com.hazelcast.util.EmptyStatement;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.util.EmptyStatement.ignore;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 @PrivateApi
@@ -154,9 +154,9 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
                 // connection manager, multicast service, operation threads, etc... if they exist
                 node.shutdown(true);
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -75,8 +75,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.Clock;
-import com.hazelcast.util.EmptyStatement;
-import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.PhoneHome;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
@@ -103,6 +101,8 @@ import static com.hazelcast.spi.properties.GroupProperty.LOGGING_TYPE;
 import static com.hazelcast.spi.properties.GroupProperty.MAX_JOIN_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_POLICY;
+import static com.hazelcast.util.EmptyStatement.ignore;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.StringUtil.isNullOrEmpty;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
 import static java.lang.Thread.currentThread;
@@ -187,7 +187,7 @@ public class Node {
         try {
             addressPicker.pickAddress();
         } catch (Throwable e) {
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
 
         final ServerSocketChannel serverSocketChannel = addressPicker.getServerSocketChannel();
@@ -230,9 +230,9 @@ public class Node {
             try {
                 serverSocketChannel.close();
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -441,13 +441,13 @@ public class Node {
                 Runtime.getRuntime().removeShutdownHook(shutdownHookThread);
             }
         } catch (Throwable ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
 
         try {
             discoveryService.destroy();
         } catch (Throwable ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
 
         try {
@@ -744,7 +744,7 @@ public class Node {
                     Constructor constructor = clazz.getConstructor(Node.class);
                     return (Joiner) constructor.newInstance(this);
                 } catch (Exception e) {
-                    throw ExceptionUtil.rethrow(e);
+                    throw rethrow(e);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryErrorDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryErrorDispatcher.java
@@ -19,11 +19,11 @@ package com.hazelcast.instance;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.OutOfMemoryHandler;
 import com.hazelcast.spi.annotation.PrivateApi;
-import com.hazelcast.util.EmptyStatement;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.Preconditions.isNotNull;
 import static java.lang.System.arraycopy;
 
@@ -178,7 +178,7 @@ public final class OutOfMemoryErrorDispatcher {
                 HazelcastInstance[] clients = removeRegisteredClients();
                 h.onOutOfMemory(outOfMemoryError, clients);
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
 
@@ -188,7 +188,7 @@ public final class OutOfMemoryErrorDispatcher {
                 HazelcastInstance[] instances = removeRegisteredServers();
                 h.onOutOfMemory(outOfMemoryError, instances);
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryHandlerHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/OutOfMemoryHandlerHelper.java
@@ -18,7 +18,8 @@ package com.hazelcast.instance;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.annotation.PrivateApi;
-import com.hazelcast.util.EmptyStatement;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * Helper class for OutOfMemoryHandlers to close sockets, stop threads, release allocated resources
@@ -46,7 +47,7 @@ public final class OutOfMemoryHandlerHelper {
             try {
                 factory.node.connectionManager.shutdown();
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
     }
@@ -60,7 +61,7 @@ public final class OutOfMemoryHandlerHelper {
         try {
             factory.node.shutdown(true);
         } catch (Throwable ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -41,7 +41,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ascii.TextEncoder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.util.Clock;
-import com.hazelcast.util.EmptyStatement;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.ByteBuffer;
@@ -76,6 +75,7 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.TOUCH;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.UNKNOWN;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.VERSION;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
 import static java.lang.Thread.currentThread;
 
@@ -427,7 +427,7 @@ public class TextCommandServiceImpl implements TextCommandService {
                     //noinspection WaitNotInLoop
                     stopObject.wait(WAIT_TIME);
                 } catch (Exception ignored) {
-                    EmptyStatement.ignore(ignored);
+                    ignore(ignored);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -35,7 +35,6 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.Clock;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.FutureUtil;
 
 import java.util.ArrayList;
@@ -202,7 +201,6 @@ public abstract class AbstractJoiner implements Joiner {
                     TimeUnit.SECONDS.sleep(1);
                 } catch (InterruptedException ignored) {
                     currentThread().interrupt();
-                    EmptyStatement.ignore(ignored);
                 }
             }
         }
@@ -251,7 +249,6 @@ public abstract class AbstractJoiner implements Joiner {
                 Thread.sleep(SPLIT_BRAIN_SLEEP_TIME_MILLIS);
             } catch (InterruptedException e) {
                 currentThread().interrupt();
-                EmptyStatement.ignore(e);
                 return null;
             }
             conn = node.connectionManager.getConnection(target);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -43,7 +43,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.Clock;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ICMPHelper;
 
 import java.io.IOException;
@@ -55,6 +54,7 @@ import java.util.logging.Level;
 
 import static com.hazelcast.internal.cluster.Versions.V3_9;
 import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.EXECUTOR_NAME;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.StringUtil.timeToString;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -753,7 +753,7 @@ public class ClusterHeartbeatManager {
                 logger.warning(reason);
                 clusterService.suspectMember(member, reason, true);
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
 
@@ -767,7 +767,7 @@ public class ClusterHeartbeatManager {
                 }
             } catch (ConnectException ignored) {
                 // no route to host, means we cannot connect anymore
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
             return false;
         }
@@ -804,9 +804,8 @@ public class ClusterHeartbeatManager {
                     clusterService.suspectMember(member, reason, true);
                 }
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
@@ -25,7 +25,6 @@ import com.hazelcast.nio.Disposable;
 import com.hazelcast.spi.CoreService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.SplitBrainHandlerService;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Collection;
@@ -35,6 +34,7 @@ import java.util.concurrent.Future;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.MERGED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.MERGE_FAILED;
 import static com.hazelcast.core.LifecycleEvent.LifecycleState.MERGING;
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * ClusterMergeTask prepares {@code Node}'s internal state and its services
@@ -188,7 +188,7 @@ class ClusterMergeTask implements Runnable {
             try {
                 waitOnFuture(f);
             } catch (HazelcastInstanceNotActiveException e) {
-                EmptyStatement.ignore(e);
+                ignore(e);
             } catch (Exception e) {
                 node.getLogger(getClass()).severe("While merging...", e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
@@ -22,7 +22,6 @@ import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.util.EmptyStatement;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -30,6 +29,7 @@ import java.util.Map;
 
 import static com.hazelcast.spi.properties.GroupProperty.APPLICATION_VALIDATION_TOKEN;
 import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
@@ -212,7 +212,7 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
             try {
                 memberGroupType = PartitionGroupConfig.MemberGroupType.valueOf(s);
             } catch (IllegalArgumentException ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
         int propSize = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -37,7 +37,6 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.util.EmptyStatement;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -66,6 +65,7 @@ import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.MEMBERSHIP_
 import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.SERVICE_NAME;
 import static com.hazelcast.spi.ExecutionService.SYSTEM_EXECUTOR;
 import static com.hazelcast.spi.properties.GroupProperty.MASTERSHIP_CLAIM_TIMEOUT_SECONDS;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static java.util.Collections.unmodifiableSet;
 
 /**
@@ -741,8 +741,8 @@ public class MembershipManager {
                     } catch (InterruptedException ignored) {
                         Thread.currentThread().interrupt();
                     } catch (ExecutionException ignored) {
-                        // we couldn't learn MembersView of 'address'. It will be removed from the cluster.
-                        EmptyStatement.ignore(ignored);
+                        // we couldn't learn MembersView of 'address'. It will be removed from the cluster
+                        ignore(ignored);
                     }
                 } else if (!isMemberSuspected(address) && latestMembersView.containsAddress(address)) {
                     // we don't suspect from 'address' and we need to learn its response

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -21,7 +21,6 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.Clock;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.RandomPicker;
 
 import java.util.concurrent.BlockingDeque;
@@ -99,7 +98,6 @@ public class MulticastJoiner extends AbstractJoiner {
                 Thread.sleep(JOIN_RETRY_INTERVAL);
             } catch (InterruptedException e) {
                 currentThread().interrupt();
-                EmptyStatement.ignore(e);
             }
 
             if (isBlacklisted(master)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -29,7 +29,6 @@ import com.hazelcast.nio.NodeIOService;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.util.ByteArrayProcessor;
-import com.hazelcast.util.EmptyStatement;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -43,6 +42,8 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 public final class MulticastService implements Runnable {
 
@@ -160,7 +161,7 @@ public final class MulticastService implements Runnable {
             try {
                 multicastSocket.close();
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
             running = false;
             if (!stopLatch.await(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
@@ -178,7 +179,7 @@ public final class MulticastService implements Runnable {
             datagramPacketReceive.setData(new byte[0]);
             datagramPacketSend.setData(new byte[0]);
         } catch (Throwable ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
         stopLatch.countDown();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
@@ -25,7 +25,6 @@ import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.memory.MemoryStats;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.util.EmptyStatement;
 
 import static com.hazelcast.internal.diagnostics.HealthMonitorLevel.OFF;
 import static com.hazelcast.internal.diagnostics.HealthMonitorLevel.valueOf;
@@ -116,7 +115,6 @@ public class HealthMonitor {
             monitorThread.join();
         } catch (InterruptedException e) {
             currentThread().interrupt();
-            EmptyStatement.ignore(e);
         }
         logger.finest("HealthMonitor stopped");
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -22,7 +22,6 @@ import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.util.counters.SwCounter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.impl.operationexecutor.OperationHostileThread;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.concurrent.IdleStrategy;
 
 import java.io.IOException;
@@ -40,6 +39,7 @@ import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT_NOW;
 import static com.hazelcast.internal.networking.nio.SelectorOptimizer.newSelector;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
 
@@ -424,7 +424,7 @@ public class NioThread extends Thread implements OperationHostileThread {
             } catch (CancelledKeyException e) {
                 // a CancelledKeyException may be thrown in key.interestOps
                 // in this case, since the key is already cancelled, just do nothing
-                EmptyStatement.ignore(e);
+                ignore(e);
             }
             key.cancel();
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerThread.java
@@ -17,10 +17,10 @@
 package com.hazelcast.internal.networking.nio.iobalancer;
 
 import com.hazelcast.logging.ILogger;
-import com.hazelcast.util.EmptyStatement;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
 
 class IOBalancerThread extends Thread {
@@ -55,7 +55,7 @@ class IOBalancerThread extends Thread {
         } catch (InterruptedException e) {
             log.finest("IOBalancer thread stopped");
             //this thread is about to exit, no reason restoring the interrupt flag
-            EmptyStatement.ignore(e);
+            ignore(e);
         } catch (Throwable e) {
             log.severe("IOBalancer failed", e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -62,7 +62,6 @@ import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.partition.IPartitionLostEvent;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.FutureUtil.ExceptionHandler;
 import com.hazelcast.util.HashUtil;
@@ -89,6 +88,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.returnWithDeadline;
 import static com.hazelcast.util.MapUtil.createHashMap;
@@ -1250,9 +1250,9 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                         allActiveMigrations.add(state.getActiveMigration());
                     }
                 } catch (TargetNotMemberException e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 } catch (MemberLeftException e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 } catch (InterruptedException e) {
                     currentThread().interrupt();
                     logger.fine("FetchMostRecentPartitionTableTask is interrupted.");

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProvider.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.usercodedeployment.impl;
 import com.hazelcast.config.UserCodeDeploymentConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.IOUtil;
-import com.hazelcast.util.EmptyStatement;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.nio.IOUtil.toByteArray;
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * Provides {@link ClassData} to remote members.
@@ -134,7 +134,7 @@ public final class ClassDataProvider {
                 innerClassDefinitions.put(innerClassName, innerByteCode);
             }
         } catch (ClassNotFoundException e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
         return innerClassDefinitions;
     }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceUtil.java
@@ -37,7 +37,6 @@ import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.Clock;
-import com.hazelcast.util.EmptyStatement;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -49,6 +48,7 @@ import static com.hazelcast.mapreduce.JobPartitionState.State.MAPPING;
 import static com.hazelcast.mapreduce.JobPartitionState.State.PROCESSED;
 import static com.hazelcast.mapreduce.JobPartitionState.State.REDUCING;
 import static com.hazelcast.mapreduce.JobPartitionState.State.WAITING;
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * This utility class contains a few basic operations that are needed in multiple places
@@ -265,7 +265,7 @@ public final class MapReduceUtil {
                 try {
                     Thread.sleep(RETRY_PARTITION_TABLE_MILLIS);
                 } catch (Exception ignore) {
-                    EmptyStatement.ignore(ignore);
+                    ignore(ignore);
                 }
 
                 if (Clock.currentTimeMillis() - startTime > PARTITION_READY_TIMEOUT) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
@@ -19,7 +19,6 @@ package com.hazelcast.query.impl.getters;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.impl.AttributeType;
 import com.hazelcast.query.impl.IndexImpl;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.lang.reflect.Field;
@@ -37,6 +36,7 @@ import static com.hazelcast.query.impl.getters.NullGetter.NULL_GETTER;
 import static com.hazelcast.query.impl.getters.NullMultiValueGetter.NULL_MULTIVALUE_GETTER;
 import static com.hazelcast.query.impl.getters.SuffixModifierUtils.getModifierSuffix;
 import static com.hazelcast.query.impl.getters.SuffixModifierUtils.removeModifierSuffix;
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * Scans your classpath, indexes the metadata, allows you to query it on runtime.
@@ -132,7 +132,7 @@ public final class ReflectionHelper {
                             clazz = method.getReturnType();
                             break;
                         } catch (NoSuchMethodException ignored) {
-                            EmptyStatement.ignore(ignored);
+                            ignore(ignored);
                         }
                     }
                     if (localGetter == null) {
@@ -144,7 +144,7 @@ public final class ReflectionHelper {
                             }
                             clazz = field.getType();
                         } catch (NoSuchFieldException ignored) {
-                            EmptyStatement.ignore(ignored);
+                            ignore(ignored);
                         }
                     }
                     if (localGetter == null) {

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferStoreWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferStoreWrapper.java
@@ -29,12 +29,12 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.util.EmptyStatement;
 
 import java.util.Arrays;
 
 import static com.hazelcast.config.InMemoryFormat.BINARY;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -135,7 +135,7 @@ public final class RingbufferStoreWrapper implements RingbufferStore<Data> {
         try {
             return ClassLoaderUtil.newInstance(classLoader, className);
         } catch (Exception ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.util.EmptyStatement;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.concurrent.CancellationException;
@@ -31,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
 import static com.hazelcast.util.Preconditions.isNotNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
@@ -192,11 +192,10 @@ public abstract class AbstractCompletableFuture<V> implements ICompletableFuture
             } catch (TimeoutException ignored) {
                 // A timeout here can only be a spurious artifact.
                 // It should never happen and even if it does, we must retry.
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
     }
-
 
     /**
      * PLEASE NOTE: It's legal to override this method, but please bear in mind that you should call super.get() or

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/UnmodifiableLazyList.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/UnmodifiableLazyList.java
@@ -21,7 +21,6 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.UnmodifiableListIterator;
 
 import java.io.IOException;
@@ -31,6 +30,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 public class UnmodifiableLazyList<E> extends AbstractList<E> implements IdentifiedDataSerializable {
 
@@ -79,7 +80,7 @@ public class UnmodifiableLazyList<E> extends AbstractList<E> implements Identifi
             try {
                 list.set(index, item);
             } catch (Exception e) {
-                EmptyStatement.ignore(e);
+                ignore(e);
             }
             return item;
         }
@@ -167,7 +168,7 @@ public class UnmodifiableLazyList<E> extends AbstractList<E> implements Identifi
                 try {
                     listIterator.set(item);
                 } catch (Exception e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 }
                 return item;
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -40,7 +40,6 @@ import com.hazelcast.spi.impl.eventservice.impl.operations.OnJoinRegistrationOpe
 import com.hazelcast.spi.impl.eventservice.impl.operations.RegistrationOperationSupplier;
 import com.hazelcast.spi.impl.eventservice.impl.operations.SendEventOperation;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.UuidUtil;
 import com.hazelcast.util.executor.StripedExecutor;
 import com.hazelcast.util.function.Supplier;
@@ -66,6 +65,7 @@ import static com.hazelcast.spi.properties.GroupProperty.EVENT_QUEUE_CAPACITY;
 import static com.hazelcast.spi.properties.GroupProperty.EVENT_QUEUE_TIMEOUT_MILLIS;
 import static com.hazelcast.spi.properties.GroupProperty.EVENT_SYNC_TIMEOUT_MILLIS;
 import static com.hazelcast.spi.properties.GroupProperty.EVENT_THREAD_COUNT;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -213,7 +213,7 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
         try {
             ((Closeable) listener).close();
         } catch (IOException e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFuture.java
@@ -18,7 +18,6 @@ package com.hazelcast.spi.impl.executionservice.impl;
 
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.AbstractCompletableFuture;
-import com.hazelcast.util.EmptyStatement;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -26,6 +25,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
 import static java.lang.Thread.currentThread;
 
@@ -81,9 +81,9 @@ class BasicCompletableFuture<V> extends AbstractCompletableFuture<V> {
             try {
                 ensureResultSet(Long.MAX_VALUE, TimeUnit.DAYS);
             } catch (ExecutionException ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             } catch (CancellationException ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
             return true;
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
@@ -22,7 +22,6 @@ import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.util.EmptyStatement;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.ArrayList;
@@ -35,6 +34,7 @@ import static com.hazelcast.spi.properties.GroupProperty.SLOW_OPERATION_DETECTOR
 import static com.hazelcast.spi.properties.GroupProperty.SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
 import static java.lang.String.format;
 
@@ -289,7 +289,7 @@ public final class SlowOperationDetector {
             try {
                 TimeUnit.NANOSECONDS.sleep(ONE_SECOND_IN_NANOS - (System.nanoTime() - nowNanos));
             } catch (Exception ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
 
@@ -300,7 +300,6 @@ public final class SlowOperationDetector {
                 detectorThread.join(SLOW_OPERATION_THREAD_MAX_WAIT_TIME_TO_FINISH);
             } catch (InterruptedException ignored) {
                 currentThread().interrupt();
-                EmptyStatement.ignore(ignored);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -49,7 +49,6 @@ import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
 import com.hazelcast.spi.impl.operationexecutor.slowoperationdetector.SlowOperationDetector;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.executor.ExecutorType;
 import com.hazelcast.util.executor.ManagedExecutorService;
 
@@ -481,10 +480,8 @@ public final class OperationServiceImpl implements InternalOperationService, Met
         try {
             invocationMonitor.awaitTermination(TERMINATION_TIMEOUT_MILLIS);
         } catch (InterruptedException e) {
-            //restore the interrupt.
-            //todo: we need a better mechanism for dealing with interruption and waiting for termination
+            // TODO: we need a better mechanism for dealing with interruption and waiting for termination
             Thread.currentThread().interrupt();
-            EmptyStatement.ignore(e);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -24,7 +24,6 @@ import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Collection;
@@ -34,6 +33,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.core.DistributedObjectEvent.EventType.CREATED;
 import static com.hazelcast.core.DistributedObjectEvent.EventType.DESTROYED;
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * A ProxyRegistry contains all proxies for a given service. For example, it contains all proxies for the IMap.
@@ -117,7 +117,7 @@ public final class ProxyRegistry {
                 result.add(object);
             } catch (Throwable ignored) {
                 // ignore if proxy creation failed
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyServiceImpl.java
@@ -37,7 +37,6 @@ import com.hazelcast.spi.impl.proxyservice.InternalProxyService;
 import com.hazelcast.spi.impl.proxyservice.impl.operations.DistributedObjectDestroyOperation;
 import com.hazelcast.spi.impl.proxyservice.impl.operations.PostJoinProxyOperation;
 import com.hazelcast.util.ConstructorFunction;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.FutureUtil.ExceptionHandler;
 import com.hazelcast.util.UuidUtil;
 
@@ -55,6 +54,7 @@ import static com.hazelcast.core.DistributedObjectEvent.EventType.CREATED;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ExceptionUtil.peel;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -241,7 +241,7 @@ public class ProxyServiceImpl
                     // listeners will be called if proxy is created here.
                 }
             } catch (HazelcastInstanceNotActiveException ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         } else {
             final ProxyRegistry registry = registries.get(serviceName);

--- a/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
@@ -32,6 +32,8 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Set;
 
+import static com.hazelcast.util.EmptyStatement.ignore;
+
 /**
  * AddressUtil contains Address helper methods.
  */
@@ -237,7 +239,7 @@ public final class AddressUtil {
                 addPossibleAddress(inet6Address, possibleAddresses, ni);
             }
         } catch (IOException ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
 
         if (possibleAddresses.isEmpty()) {

--- a/hazelcast/src/main/java/com/hazelcast/util/EmptyStatement.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/EmptyStatement.java
@@ -17,24 +17,19 @@
 package com.hazelcast.util;
 
 /**
- * This class does nothing!
- * <p/>
- * It is useful if you e.g. don't need to do anything with an exception; but checkstyle is complaining that
- * you need to have at least 1 statement.
+ * This class makes CheckStyle happy, if you have an ignored or expected exception,
+ * but need at least a single statement in the {@code catch} clause.
  */
 public final class EmptyStatement {
 
-    //we don't want instances.
     private EmptyStatement() {
     }
 
     /**
-     * Does totally nothing.
+     * Ignores the given exception.
      *
-     * @param t the exception to ignore.
+     * @param t the exception to ignore
      */
     public static void ignore(Throwable t) {
     }
-
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/MD5Util.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MD5Util.java
@@ -48,7 +48,6 @@ public final class MD5Util {
             }
             return sb.toString();
         } catch (NoSuchAlgorithmException ignored) {
-            EmptyStatement.ignore(ignored);
             return null;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/OperatingSystemMXBeanSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/OperatingSystemMXBeanSupport.java
@@ -21,6 +21,8 @@ import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+import static com.hazelcast.util.EmptyStatement.ignore;
+
 /**
  * Support class for reading attributes from OperatingSystemMXBean.
  */
@@ -70,7 +72,7 @@ public final class OperatingSystemMXBeanSupport {
         } catch (RuntimeException re) {
             throw re;
         } catch (Exception ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
         return defaultValue;
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -27,7 +27,6 @@ import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.management.ManagementCenterConnectionFactory;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.memory.MemoryUnit;
-import com.hazelcast.nio.IOUtil;
 import com.hazelcast.spi.properties.GroupProperty;
 
 import java.io.BufferedInputStream;
@@ -49,6 +48,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
+import static com.hazelcast.nio.IOUtil.closeResource;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static java.lang.System.getenv;
 
 /**
@@ -141,9 +142,9 @@ public final class PhoneHome {
                 downloadId = properties.getProperty("hazelcastDownloadId");
             }
         } catch (IOException ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         } finally {
-            IOUtil.closeResource(is);
+            closeResource(is);
         }
 
         //Calculate native memory usage from native memory config
@@ -201,9 +202,9 @@ public final class PhoneHome {
             conn.setReadTimeout(TIMEOUT * 2);
             in = new BufferedInputStream(conn.getInputStream());
         } catch (IOException ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         } finally {
-            IOUtil.closeResource(in);
+            closeResource(in);
         }
     }
 
@@ -261,13 +262,12 @@ public final class PhoneHome {
             version = JsonUtil.getString(mcPhoneHomeInfoJson, "mcVersion");
             license = JsonUtil.getString(mcPhoneHomeInfoJson, "mcLicense", null);
         } catch (Exception ignored) {
-            EmptyStatement.ignore(ignored);
             parameterCreator.addParam("mclicense", "MC_NOT_AVAILABLE");
             parameterCreator.addParam("mcver", "MC_NOT_AVAILABLE");
             return;
         } finally {
-            IOUtil.closeResource(reader);
-            IOUtil.closeResource(inputStream);
+            closeResource(reader);
+            closeResource(inputStream);
         }
 
         if (responseCode == HttpURLConnection.HTTP_OK) {

--- a/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
@@ -181,7 +181,6 @@ public final class ServiceLoader {
             if (clientClassLoader != classLoader && clientClassLoader != tccl && clientClassLoader != coreClassLoader) {
                 classLoaders.add(clientClassLoader);
             }
-
         } catch (ClassNotFoundException ignore) {
             // ignore since we does not have HazelcastClient in classpath
             ignore(ignore);

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CachedExecutorServiceDelegate.java
@@ -18,7 +18,6 @@ package com.hazelcast.util.executor;
 
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.util.EmptyStatement;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Collection;
@@ -40,6 +39,7 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
 
 public final class CachedExecutorServiceDelegate implements ExecutorService, ManagedExecutorService {
@@ -230,7 +230,7 @@ public final class CachedExecutorServiceDelegate implements ExecutorService, Man
                 }
                 while (r != null);
             } catch (InterruptedException ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             } finally {
                 exit();
             }

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/PoolExecutorThreadFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/PoolExecutorThreadFactory.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.util.executor;
 
-import com.hazelcast.util.EmptyStatement;
-
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 public final class PoolExecutorThreadFactory extends AbstractExecutorThreadFactory {
 
@@ -58,7 +58,7 @@ public final class PoolExecutorThreadFactory extends AbstractExecutorThreadFacto
             try {
                 idQ.offer(id);
             } catch (Throwable ignored) {
-                EmptyStatement.ignore(ignored);
+                ignore(ignored);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuil
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 import org.junit.Test;
@@ -823,7 +822,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
                     doRun(random);
                     LockSupport.parkNanos(1);
                 } catch (Exception e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 }
                 firstIterationDone.countDown();
 
@@ -832,7 +831,7 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
                         doRun(random);
                         LockSupport.parkNanos(1);
                     } catch (Exception e) {
-                        EmptyStatement.ignore(e);
+                        ignore(e);
                     }
                 }
             }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
@@ -25,7 +25,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
 import org.junit.Before;
 
@@ -143,7 +142,7 @@ public abstract class CacheTestSupport extends HazelcastTestSupport {
             assertEquals("there should be no evicted values", 0, cache.getLocalCacheStatistics().getCacheEvictions());
         } catch (UnsupportedOperationException e) {
             // cache statistics are not supported on clients yet
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueAdvancedTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.TestThread;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -128,7 +127,7 @@ public class QueueAdvancedTest extends HazelcastTestSupport {
                     String value = q2.take();
                     fail("Should not be able to take value from queue, but got: " + value);
                 } catch (HazelcastInstanceNotActiveException e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongAbstractTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -116,7 +115,7 @@ public abstract class AtomicLongAbstractTest extends HazelcastTestSupport {
             atomicLong.apply(new FailingFunction());
             fail();
         } catch (ExpectedRuntimeException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertEquals(1, atomicLong.get());
@@ -135,7 +134,7 @@ public abstract class AtomicLongAbstractTest extends HazelcastTestSupport {
             atomicLong.alter(new FailingFunction());
             fail();
         } catch (ExpectedRuntimeException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertEquals(10, atomicLong.get());
@@ -161,7 +160,7 @@ public abstract class AtomicLongAbstractTest extends HazelcastTestSupport {
             atomicLong.alterAndGet(new FailingFunction());
             fail();
         } catch (ExpectedRuntimeException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertEquals(10, atomicLong.get());
@@ -187,7 +186,7 @@ public abstract class AtomicLongAbstractTest extends HazelcastTestSupport {
             atomicLong.getAndAlter(new FailingFunction());
             fail();
         } catch (ExpectedRuntimeException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertEquals(10, atomicLong.get());

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceAbstractTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicReference;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -187,7 +186,7 @@ public abstract class AtomicReferenceAbstractTest extends HazelcastTestSupport {
             ref.apply(new FailingFunction());
             fail();
         } catch (HazelcastException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertEquals("foo", ref.get());
@@ -206,7 +205,7 @@ public abstract class AtomicReferenceAbstractTest extends HazelcastTestSupport {
             ref.alter(new FailingFunction());
             fail();
         } catch (HazelcastException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertEquals("foo", ref.get());
@@ -238,7 +237,7 @@ public abstract class AtomicReferenceAbstractTest extends HazelcastTestSupport {
             ref.alterAndGet(new FailingFunction());
             fail();
         } catch (HazelcastException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertEquals("foo", ref.get());
@@ -270,7 +269,7 @@ public abstract class AtomicReferenceAbstractTest extends HazelcastTestSupport {
             ref.getAndAlter(new FailingFunction());
             fail();
         } catch (HazelcastException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertEquals("foo", ref.get());

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -36,7 +36,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -506,7 +505,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
             cacheManager.createCache(cacheName, (Configuration<Object, Object>) null);
             fail("NullPointerException expected");
         } catch (NullPointerException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -47,7 +47,6 @@ import com.hazelcast.transaction.impl.Transaction;
 import com.hazelcast.transaction.impl.TransactionLogRecord;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 import com.hazelcast.util.Clock;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 import org.junit.Rule;
 import org.junit.Test;
@@ -683,7 +682,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
                 try {
                     cluster.changeClusterState(newState);
                 } catch (TransactionException e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 }
                 newState = flipState(newState);
                 sleepMillis(random.nextInt(5) + 1);

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/PortablePositionFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/PortablePositionFactoryTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -427,7 +426,7 @@ public class PortablePositionFactoryTest extends HazelcastTestSupport {
             portablePosition.asMultiPosition();
             fail("expected IllegalArgumentException");
         } catch (IllegalArgumentException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapCreationDelayWithMapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapCreationDelayWithMapStoreTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -63,7 +62,7 @@ public class MapCreationDelayWithMapStoreTest extends HazelcastTestSupport {
             try {
                 unreleasedLatch.await();
             } catch (InterruptedException e) {
-                EmptyStatement.ignore(e);
+                ignore(e);
             }
             return Collections.emptySet();
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreDataLoadingContinuesWhenNodeJoins.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreDataLoadingContinuesWhenNodeJoins.java
@@ -31,7 +31,6 @@ import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.SlowTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -100,7 +99,7 @@ public class MapStoreDataLoadingContinuesWhenNodeJoins extends HazelcastTestSupp
             try {
                 instances.get(i).getLifecycleService().terminate();
             } catch (Throwable t) {
-                EmptyStatement.ignore(t);
+                ignore(t);
             }
         }
     }
@@ -145,7 +144,7 @@ public class MapStoreDataLoadingContinuesWhenNodeJoins extends HazelcastTestSupp
                     node1FinishedLoading.await(loadTimeMillis, TimeUnit.MILLISECONDS);
                     thread2Finished.set(System.currentTimeMillis());
                 } catch (InterruptedException e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 }
             }
         }, "Thread 2");
@@ -200,7 +199,7 @@ public class MapStoreDataLoadingContinuesWhenNodeJoins extends HazelcastTestSupp
                     node1FinishedLoading.await(loadTimeMillis, TimeUnit.MILLISECONDS);
                     mapSizeOnNode2.set(map.size());
                 } catch (InterruptedException e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 }
             }
         }, "Thread 2");
@@ -268,7 +267,7 @@ public class MapStoreDataLoadingContinuesWhenNodeJoins extends HazelcastTestSupp
                     final int loadTimeMillis = MS_PER_LOAD * PRELOAD_SIZE;
                     node1FinishedLoading.await(loadTimeMillis, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 }
             }
         }, "Thread 2");

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
@@ -46,7 +46,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -1338,7 +1337,7 @@ public class MapStoreTest extends AbstractMapStoreTest {
                 try {
                     Thread.sleep(sleepStoreAllSeconds * 1000);
                 } catch (InterruptedException e) {
-                    EmptyStatement.ignore(e);
+                    ignore(e);
                 }
             }
             for (Object ignored : map.keySet()) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteThroughTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -248,21 +247,21 @@ public class MapStoreWriteThroughTest extends AbstractMapStoreTest {
             map.get("1");
             fail("should have thrown exception");
         } catch (Exception e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
         assertEquals(1, testMapStore.loads.get());
         try {
             map.get("1");
             fail("should have thrown exception");
         } catch (Exception e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
         assertEquals(2, testMapStore.loads.get());
         try {
             map.put("1", "value");
             fail("should have thrown exception");
         } catch (Exception e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
         assertEquals(0, testMapStore.stores.get());
         assertEquals(0, map.size());
@@ -282,7 +281,7 @@ public class MapStoreWriteThroughTest extends AbstractMapStoreTest {
             map.put("1", "value");
             fail("should have thrown exception");
         } catch (Exception e) {
-            EmptyStatement.ignore(e);
+            ignore(e);
         }
         assertEquals(0, map.size());
     }

--- a/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/IOUtilTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -436,14 +435,14 @@ public class IOUtilTest extends HazelcastTestSupport {
             copyFile(source, target, -1);
             fail();
         } catch (HazelcastException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         delete(source);
     }
 
     @Test
-    public void testCopyFailsWhenSourceCannotBeListed() throws IOException {
+    public void testCopyFailsWhenSourceCannotBeListed() {
         final File source = mock(File.class);
         when(source.exists()).thenReturn(true);
         when(source.isDirectory()).thenReturn(true);
@@ -458,7 +457,7 @@ public class IOUtilTest extends HazelcastTestSupport {
             copy(source, dest);
             fail();
         } catch (HazelcastException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         delete(dest);
@@ -478,7 +477,7 @@ public class IOUtilTest extends HazelcastTestSupport {
             copyFile(source, new File("target"), -1);
             fail();
         } catch (IllegalArgumentException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
         delete(source);
     }
@@ -494,14 +493,14 @@ public class IOUtilTest extends HazelcastTestSupport {
             copy(source, target);
             fail();
         } catch (IllegalArgumentException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
         delete(source);
         delete(target);
     }
 
     @Test
-    public void testCopyRecursiveDirectory() throws IOException {
+    public void testCopyRecursiveDirectory() {
         final File dir = new File("dir");
         final File subdir = new File(dir, "subdir");
         final File f1 = new File(dir, "f1");
@@ -562,12 +561,12 @@ public class IOUtilTest extends HazelcastTestSupport {
         deleteQuietly(file);
     }
 
-    private static File createDirectory(String dirName) throws IOException {
+    private static File createDirectory(String dirName) {
         File dir = new File(dirName);
         return createDirectory(dir);
     }
 
-    private static File createDirectory(File parent, String dirName) throws IOException {
+    private static File createDirectory(File parent, String dirName) {
         File dir = new File(parent, dirName);
         return createDirectory(dir);
     }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/cache/CacheQuorumListenerTest.java
@@ -32,7 +32,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -75,7 +74,7 @@ public class CacheQuorumListenerTest extends HazelcastTestSupport {
             cache.put(generateKeyOwnedBy(instance), 1);
             fail("Expected a QuorumException");
         } catch (QuorumException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertOpenEventually(countDownLatch, 15);
@@ -111,7 +110,7 @@ public class CacheQuorumListenerTest extends HazelcastTestSupport {
             cache.put(generateKeyOwnedBy(instance1), 1);
             fail("Expected a QuorumException");
         } catch (QuorumException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
         assertOpenEventually(belowLatch, 15);
 
@@ -167,13 +166,13 @@ public class CacheQuorumListenerTest extends HazelcastTestSupport {
             threeNode.put(generateKeyOwnedBy(h1), "bar");
             fail("Expected a QuorumException");
         } catch (QuorumException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
         try {
             fourNode.put(generateKeyOwnedBy(h1), "bar");
             fail("Expected a QuorumException");
         } catch (QuorumException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
         assertOpenEventually(quorumFailureLatch, 15);
     }
@@ -213,7 +212,7 @@ public class CacheQuorumListenerTest extends HazelcastTestSupport {
             cache.put(generateKeyOwnedBy(instance), 1);
             fail("Expected a QuorumException");
         } catch (QuorumException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertOpenEventually(countDownLatch, 15);
@@ -251,7 +250,7 @@ public class CacheQuorumListenerTest extends HazelcastTestSupport {
             cache.put(generateKeyOwnedBy(instance1), 1);
             fail("Expected a QuorumException");
         } catch (QuorumException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertOpenEventually(belowLatch, 15);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.util.EmptyStatement;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -268,7 +267,7 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
             try {
                 completedLatch.await();
             } catch (InterruptedException e) {
-                EmptyStatement.ignore(e);
+                ignore(e);
             }
         }
     }
@@ -285,7 +284,7 @@ abstract class SlowOperationDetectorAbstractTest extends HazelcastTestSupport {
             try {
                 latch.await();
             } catch (InterruptedException e) {
-                EmptyStatement.ignore(e);
+                ignore(e);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -37,7 +37,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -102,9 +101,8 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
         try {
             future.get(1, TimeUnit.MINUTES);
             fail("Future.get() should fail with a MemberLeftException!");
-        } catch (MemberLeftException e) {
-            // expected
-            EmptyStatement.ignore(e);
+        } catch (MemberLeftException expected) {
+            ignore(expected);
         } catch (Exception e) {
             fail(e.getClass().getName() + ": " + e.getMessage());
         }

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -21,7 +21,6 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.test.bounce.BounceMemberRule;
-import com.hazelcast.util.EmptyStatement;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.description.type.TypeDescription;
@@ -59,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.cache.jsr.JsrTestUtil.clearCachingProviderRegistry;
 import static com.hazelcast.cache.jsr.JsrTestUtil.getCachingProviderRegistrySize;
 import static com.hazelcast.test.TestEnvironment.isRunningCompatibilityTest;
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static java.lang.Integer.getInteger;
 
 /**
@@ -97,7 +97,7 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
                 threadMXBean.setThreadCpuTimeEnabled(true);
                 threadCPUTimeInfoAvailable = true;
             } catch (Throwable t) {
-                EmptyStatement.ignore(t);
+                ignore(t);
             }
         }
         THREAD_CPU_TIME_INFO_AVAILABLE = threadCPUTimeInfoAvailable;
@@ -108,7 +108,7 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
                 threadMXBean.setThreadContentionMonitoringEnabled(true);
                 threadContentionInfoAvailable = true;
             } catch (Throwable t) {
-                EmptyStatement.ignore(t);
+                ignore(t);
             }
         }
         THREAD_CONTENTION_INFO_AVAILABLE = threadContentionInfoAvailable;

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/TopicOverloadAbstractTest.java
@@ -25,7 +25,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadException;
-import com.hazelcast.util.EmptyStatement;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -80,7 +79,7 @@ public abstract class TopicOverloadAbstractTest extends HazelcastTestSupport {
             topic.publish("new");
             fail();
         } catch (TopicOverloadException expected) {
-            EmptyStatement.ignore(expected);
+            ignore(expected);
         }
 
         assertEquals(tail, ringbuffer.tailSequence());

--- a/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertTrue;
 public class FutureUtilTest extends HazelcastTestSupport {
 
     @Test
-    public void test_waitWithDeadline_first_wait_second_finished() throws Exception {
+    public void test_waitWithDeadline_first_wait_second_finished() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
@@ -69,7 +69,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_waitWithDeadline_first_finished_second_wait() throws Exception {
+    public void test_waitWithDeadline_first_finished_second_wait() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
@@ -82,7 +82,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_returnWithDeadline_first_wait_second_finished() throws Exception {
+    public void test_returnWithDeadline_first_wait_second_finished() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
@@ -100,7 +100,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_returnWithDeadline_first_finished_second_wait() throws Exception {
+    public void test_returnWithDeadline_first_finished_second_wait() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
@@ -118,7 +118,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
     }
 
     @Test(expected = TimeoutException.class)
-    public void test_returnWithDeadline_timeout_exception() throws Exception {
+    public void test_returnWithDeadline_timeout_exception() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
@@ -140,7 +140,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_waitWithDeadline_failing_second() throws Throwable {
+    public void test_waitWithDeadline_failing_second() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
@@ -159,7 +159,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_returnWithDeadline_failing_second() throws Throwable {
+    public void test_returnWithDeadline_failing_second() {
         AtomicBoolean waitLock = new AtomicBoolean(true);
         ExecutorService executorService = Executors.newFixedThreadPool(2);
 
@@ -178,7 +178,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
     }
 
     @Test(expected = TransactionTimedOutException.class)
-    public void testTransactionTimedOutExceptionHandler() throws Exception {
+    public void testTransactionTimedOutExceptionHandler() {
         final ExceptionHandler exceptionHandler = FutureUtil.RETHROW_TRANSACTION_EXCEPTION;
         final Throwable throwable = new TimeoutException();
 
@@ -232,11 +232,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
         @Override
         public void run() {
             if (waitLock.compareAndSet(true, false)) {
-                try {
-                    Thread.sleep(10000);
-                } catch (InterruptedException ignored) {
-                    EmptyStatement.ignore(ignored);
-                }
+                sleepSeconds(10);
             }
         }
     }
@@ -253,11 +249,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
         @Override
         public void run() {
             if (waitLock.compareAndSet(true, false)) {
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException ignored) {
-                    EmptyStatement.ignore(ignored);
-                }
+                sleepSeconds(1);
             }
         }
     }
@@ -274,14 +266,9 @@ public class FutureUtilTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Integer call()
-                throws Exception {
+        public Integer call() {
             if (waitLock.compareAndSet(true, false)) {
-                try {
-                    Thread.sleep(2000);
-                } catch (InterruptedException ignored) {
-                    EmptyStatement.ignore(ignored);
-                }
+                sleepSeconds(2);
             }
             return index;
         }
@@ -297,15 +284,10 @@ public class FutureUtilTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Integer call()
-                throws Exception {
+        public Integer call() {
             if (waitLock.compareAndSet(true, false)) {
-                try {
-                    Thread.sleep(1000);
-                    return 1;
-                } catch (InterruptedException ignored) {
-                    EmptyStatement.ignore(ignored);
-                }
+                sleepSeconds(1);
+                return 1;
             }
             throw new SpecialRuntimeException("foo");
         }
@@ -330,8 +312,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
         }
 
         @Override
-        public V get(long timeout, TimeUnit unit) throws InterruptedException,
-                ExecutionException, TimeoutException {
+        public V get(long timeout, TimeUnit unit) {
             return null;
         }
 


### PR DESCRIPTION
* improved JavaDoc of `EmptyStatement`
* removed unnecessary usage of `EmptyStatement.ignore()`
* used static imports for `EmptyStatement.ignore()`

Follow-up of https://github.com/hazelcast/hazelcast/pull/12451