### PR TITLE
Remove Versioned interface for classes no longer needing it

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
 
@@ -30,7 +29,7 @@ import java.util.Collection;
  * A {@code JoinMessage} issued by the master node of a subcluster to the master of another subcluster
  * while searching for other clusters for split brain recovery.
  */
-public class SplitBrainJoinMessage extends JoinMessage implements Versioned {
+public class SplitBrainJoinMessage extends JoinMessage {
 
     public enum SplitBrainMergeCheckResult {
         /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
@@ -22,12 +22,11 @@ import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.MembersViewMetadata;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 
 /** A heartbeat sent from one cluster member to another. The sent timestamp is the cluster clock time of the sending member */
-public final class HeartbeatOp extends AbstractClusterOperation implements Versioned {
+public final class HeartbeatOp extends AbstractClusterOperation {
 
     private MembersViewMetadata senderMembersViewMetadata;
     private String targetUuid;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
@@ -26,7 +26,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.Clock;
 
@@ -37,7 +36,7 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 
-public class MembersUpdateOp extends AbstractClusterOperation implements Versioned {
+public class MembersUpdateOp extends AbstractClusterOperation {
     /** The master cluster clock time. */
     long masterTime = Clock.currentTimeMillis();
     /** The updated member info collection. */

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.partition.impl.PartitionReplicaManager;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
@@ -39,7 +38,7 @@ import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.
 // should not be an urgent operation. required to be in order with backup operations on target node
 public final class PartitionBackupReplicaAntiEntropyOperation
         extends AbstractPartitionOperation
-        implements PartitionAwareOperation, AllowedDuringPassiveState, Versioned {
+        implements PartitionAwareOperation, AllowedDuringPassiveState {
 
     private Map<ServiceNamespace, Long> versions;
     private boolean returnResponse;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
@@ -30,7 +30,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
@@ -55,7 +54,7 @@ import java.util.Collections;
  * An empty response can be sent if the current replica version is 0.
  */
 public final class PartitionReplicaSyncRequest extends AbstractPartitionOperation
-        implements PartitionAwareOperation, MigrationCycleOperation, Versioned {
+        implements PartitionAwareOperation, MigrationCycleOperation {
 
     private Collection<ServiceNamespace> allNamespaces;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
@@ -27,7 +27,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -59,7 +58,7 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createError
  */
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public class PartitionReplicaSyncResponse extends AbstractPartitionOperation
-        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation, AllowedDuringPassiveState, Versioned {
+        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation, AllowedDuringPassiveState {
 
     private Collection<Operation> operations;
     private ServiceNamespace namespace;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRetryResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRetryResponse.java
@@ -25,7 +25,6 @@ import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.internal.partition.impl.PartitionReplicaManager;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ServiceNamespace;
@@ -41,7 +40,7 @@ import java.util.Collections;
  */
 public class PartitionReplicaSyncRetryResponse
         extends AbstractPartitionOperation
-        implements PartitionAwareOperation, BackupOperation, MigrationCycleOperation, Versioned {
+        implements PartitionAwareOperation, BackupOperation, MigrationCycleOperation {
 
     private Collection<ServiceNamespace> namespaces;
 


### PR DESCRIPTION
The rolling upgrade code has been removed with this commit:
https://github.com/hazelcast/hazelcast/commit/246b9d55525d43bccb5dcd6cff43a199235e4356

This PR removes the unnecessary Versioned marker interface.