### PR TITLE
Do not break the text command loop on error

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -404,6 +404,8 @@ public class TextCommandServiceImpl implements TextCommandService {
                 } catch (OutOfMemoryError e) {
                     OutOfMemoryErrorDispatcher.onOutOfMemory(e);
                     throw e;
+                } catch (Throwable t) {
+                    logger.severe("Error while processing Memcache or Rest command.", t);
                 }
             }
         }


### PR DESCRIPTION
Fixes #11721

This is consistent with runners for regular operations.