### PR TITLE
Increase validity for flakeIds concurrent smoke test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/AutoBatcherTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/AutoBatcherTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class AutoBatcherTest {
 
-    private static final int VALIDITY = 1000;
+    private static final int VALIDITY = 10000;
 
     private AutoBatcher batcher = new AutoBatcher(3, VALIDITY, new AutoBatcher.IdBatchSupplier() {
         int base;


### PR DESCRIPTION
Current test validity of 1 sec, is too strict for the build environment, given the number of parallel jobs and spawned threads, we could easily end up with validity expirations, therefore creating gaps in the result (generated ids). 

I can easily reproduce a similar failure by introducing random delays in the threads. 
Increasing the validity to 10 secs should make the test more failure resistant, however, it might slightly affect the concurrent nature of this test. 

Fixes https://github.com/hazelcast/hazelcast/issues/12479