### PR TITLE
Ignore NoHttpResponseException when shutting down a member via Rest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -216,7 +216,11 @@ public class RestClusterTest extends HazelcastTestSupport {
             assertEquals("{\"status\":\"success\"}", communicator.shutdownMember("dev", "dev-pass"));
         } catch (ConnectException ignored) {
             // if node shuts down before response is received, `java.net.ConnectException: Connection refused` is expected
+        } catch (NoHttpResponseException ignored) {
+            // `NoHttpResponseException` is also a possible outcome when a node shut down before it has a chance
+            // to send a response back to a client.
         }
+
 
         assertOpenEventually(shutdownLatch);
         assertFalse(instance.getLifecycleService().isRunning());


### PR DESCRIPTION
It's for the same reason as ignoring ConnectException - there is a race
between a member shutting down and sending a response back to a client.

I think eventually this should be improved to start the shutdown process
after responding to the client, but there is no infrastructure for this now.

Stacktrace from a test failure:
```
org.apache.http.NoHttpResponseException: The target server failed to respond
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:143)
	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:57)
	at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:260)
	at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:161)
	at sun.reflect.GeneratedMethodAccessor33.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.http.impl.conn.CPoolProxy.invoke(CPoolProxy.java:138)
	at com.sun.proxy.$Proxy56.receiveResponseHeader(Unknown Source)
	at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:271)
	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:123)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:253)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:194)
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:85)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:108)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:186)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:82)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:106)
	at com.hazelcast.internal.ascii.HTTPCommunicator.doPost(HTTPCommunicator.java:330)
	at com.hazelcast.internal.ascii.HTTPCommunicator.shutdownMember(HTTPCommunicator.java:163)
	at com.hazelcast.internal.ascii.RestClusterTest.testShutdownNode(RestClusterTest.java:216)
```