### PR TITLE
Fix cluster lock lease time extension

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/LockGuard.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/LockGuard.java
@@ -98,6 +98,10 @@ public class LockGuard {
         return lockExpiryTime;
     }
 
+    public long getRemainingTime() {
+        return Math.max(0, getLockExpiryTime() - Clock.currentTimeMillis());
+    }
+
     @Override
     public String toString() {
         return "LockGuard{"

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -183,7 +183,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         final HazelcastInstance hz = instances[instances.length - 1];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
-        TransactionOptions options = TransactionOptions.getDefault().setTimeout(30, TimeUnit.SECONDS);
+        TransactionOptions options = TransactionOptions.getDefault().setTimeout(60, TimeUnit.SECONDS);
         when(transactionManagerService.newAllowedDuringPassiveStateTransaction(options)).thenAnswer(new TransactionAnswer() {
             @Override
             protected void beforePrepare() {
@@ -233,7 +233,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         final HazelcastInstance hz = instances[instances.length - 1];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
-        TransactionOptions options = new TransactionOptions().setDurability(0).setTimeout(30, TimeUnit.SECONDS);
+        TransactionOptions options = new TransactionOptions().setDurability(0).setTimeout(60, TimeUnit.SECONDS);
         when(transactionManagerService.newAllowedDuringPassiveStateTransaction(options)).thenAnswer(new TransactionAnswer() {
             @Override
             protected void beforePrepare() {
@@ -258,7 +258,7 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
         final HazelcastInstance hz = instances[instances.length - 1];
         TransactionManagerServiceImpl transactionManagerService = spyTransactionManagerService(hz);
 
-        TransactionOptions options = new TransactionOptions().setDurability(0).setTimeout(30, TimeUnit.SECONDS);
+        TransactionOptions options = new TransactionOptions().setDurability(0).setTimeout(60, TimeUnit.SECONDS);
         when(transactionManagerService.newAllowedDuringPassiveStateTransaction(options)).thenAnswer(new TransactionAnswer() {
             @Override
             protected void afterPrepare() {


### PR DESCRIPTION
Instead of calculating new lease time based on current time + lease duration, we should shift the current lease time by the given extension duration.

Fixes #6383