### PR TITLE
Fixed ScheduledExecutorContainer and enhanced split-brain test

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledExecutorContainer.java
@@ -28,7 +28,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.SplitBrainMergePolicy;
 import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
-import com.hazelcast.spi.merge.MergingValueHolder;
+import com.hazelcast.spi.merge.MergingEntryHolder;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.util.Collection;
@@ -234,48 +234,49 @@ public class ScheduledExecutorContainer {
     }
 
     /**
-     * Merges the given {@link MergingValueHolder} via the given {@link SplitBrainMergePolicy}.
+     * Merges the given {@link MergingEntryHolder} via the given {@link SplitBrainMergePolicy}.
      *
-     * @param mergingValue the {@link MergingValueHolder} instance to merge
+     * @param mergingEntry the {@link MergingEntryHolder} instance to merge
      * @param mergePolicy  the {@link SplitBrainMergePolicy} instance to apply
      * @return the used {@link ScheduledTaskDescriptor} if merge is applied, otherwise {@code null}
      */
-    public ScheduledTaskDescriptor merge(MergingValueHolder<ScheduledTaskDescriptor> mergingValue,
+    public ScheduledTaskDescriptor merge(MergingEntryHolder<String, ScheduledTaskDescriptor> mergingEntry,
                                          SplitBrainMergePolicy mergePolicy) {
         SerializationService serializationService = nodeEngine.getSerializationService();
-        serializationService.getManagedContext().initialize(mergingValue);
+        serializationService.getManagedContext().initialize(mergingEntry);
         serializationService.getManagedContext().initialize(mergePolicy);
 
-        // try to find an existing item with the same value
-        ScheduledTaskDescriptor match = null;
-        for (ScheduledTaskDescriptor item : tasks.values()) {
-            if (mergingValue.getValue().equals(item)) {
-                match = item;
+        // try to find an existing task with the same definition
+        ScheduledTaskDescriptor mergingTask = mergingEntry.getValue();
+        ScheduledTaskDescriptor existingTask = null;
+        for (ScheduledTaskDescriptor task : tasks.values()) {
+            if (mergingTask.equals(task)) {
+                existingTask = task;
                 break;
             }
         }
-
-        ScheduledTaskDescriptor merged;
-        if (match == null) {
-            // Missing incoming entry
-            merged = mergePolicy.merge(mergingValue, null);
-            if (merged != null) {
-                enqueueSuspended(merged, false);
+        if (existingTask == null) {
+            ScheduledTaskDescriptor newTask = mergePolicy.merge(mergingEntry, null);
+            if (newTask != null) {
+                enqueueSuspended(newTask, false);
+                return newTask;
             }
         } else {
-            // Found a match -> real merge
-            MergingValueHolder<ScheduledTaskDescriptor> existingValue = createMergeHolder(serializationService, match);
-            merged = mergePolicy.merge(mergingValue, existingValue);
-            if (merged != null && !merged.equals(match)) {
-                // Cancel matched one, before replacing it
-                match.cancel(true);
-                enqueueSuspended(merged, true);
-            } else {
-                merged = null;
+            MergingEntryHolder<String, ScheduledTaskDescriptor> existingEntry
+                    = createMergeHolder(serializationService, existingTask);
+            ScheduledTaskDescriptor newTask = mergePolicy.merge(mergingEntry, existingEntry);
+            // we are using == instead of equals() for the task comparison,
+            // since the descriptor may have the same fields for merging and existing entry,
+            // but we still want to be able to choose which one is merged (e.g. PassThroughMergePolicy)
+            if (newTask != null && newTask != existingTask) {
+                // cancel the existing task, before replacing it
+                existingTask.cancel(true);
+                enqueueSuspended(newTask, true);
+                return newTask;
             }
         }
-
-        return merged;
+        // the merging task was already suspended on the original node, so we don't have to cancel it here
+        return null;
     }
 
     ScheduledFuture createContextAndSchedule(TaskDefinition definition) {

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskResult.java
@@ -64,7 +64,6 @@ public class ScheduledTaskResult
     }
 
     void checkErroneousState() {
-
         if (wasCancelled()) {
             throw new CancellationException();
         } else if (exception != null) {

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -247,6 +247,10 @@ public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
 
         @Override
         public Double call() throws Exception {
+            return calculateResult(delta);
+        }
+
+        public static double calculateResult(int delta) {
             return 5 * 5.0 + delta;
         }
     }


### PR DESCRIPTION
* the `ScheduledExecutorSplitBrainTest` was missing different task result values to check if merge policies like `PassThroughMergePolicy` really overwrite an existing task
* the `ScheduledExecutorContainer` was using `MergingValueHolder` instead of `MergingEntryHolder`
* the naming in `ScheduledExecutorContainer` was still mixed with the original source of the code (item vs. task)
* fixed the task descriptor comparison in the `merge()` method, which didn't work properly in scenarios like `PassThroughMergePolicy`

<hr/>

The `PassThroughMergePolicy` didn't work as expected! It failed with:
```java
java.lang.AssertionError: 
Expected :42.0
Actual   :100.0
	at org.junit.Assert.fail(Assert.java:88)
	at org.junit.Assert.failNotEquals(Assert.java:834)
	at org.junit.Assert.assertEquals(Assert.java:553)
	at org.junit.Assert.assertEquals(Assert.java:683)
	at com.hazelcast.scheduledexecutor.ScheduledExecutorSplitBrainTest.assertContents(ScheduledExecutorSplitBrainTest.java:261)
	at com.hazelcast.scheduledexecutor.ScheduledExecutorSplitBrainTest.onAfterMergePassThroughMergePolicy(ScheduledExecutorSplitBrainTest.java:209)
	at com.hazelcast.scheduledexecutor.ScheduledExecutorSplitBrainTest.onAfterSplitBrainHealed(ScheduledExecutorSplitBrainTest.java:162)
```

With a reduced test set
```java
    private static final int INITIAL_COUNT = 5;
    private static final int AFTER_SPLIT_COMMON_COUNT = INITIAL_COUNT + 5;
    private static final int FINAL_COUNT = AFTER_SPLIT_COMMON_COUNT + 5;
```
and this debugging in `ScheduledExecutorContainer`
```java
public ScheduledTaskDescriptor merge(MergingEntryHolder<String, ScheduledTaskDescriptor> mergingEntry,
                                     SplitBrainMergePolicy mergePolicy) {
    SerializationService serializationService = nodeEngine.getSerializationService();
    serializationService.getManagedContext().initialize(mergingEntry);
    serializationService.getManagedContext().initialize(mergePolicy);

    // try to find an existing task with the same definition
    ScheduledTaskDescriptor existingTask = null;
    for (ScheduledTaskDescriptor task : tasks.values()) {
        if (mergingEntry.getValue().equals(task)) {
            existingTask = task;
            break;
        }
    }
    if (existingTask == null) {
        ScheduledTaskDescriptor newTask = mergePolicy.merge(mergingEntry, null);
        if (newTask != null) {
            enqueueSuspended(newTask, false);
        }
        System.out.println("(1) task name: " + mergingEntry.getValue().getDefinition().getName()
                + ", existingTask: null"
                + ", newTask: " + (newTask == null ? "null" : newTask.getTaskResult().getReturnValue()));
        return newTask;
    } else {
        MergingEntryHolder<String, ScheduledTaskDescriptor> existingEntry
                = createMergeHolder(serializationService, existingTask);
        ScheduledTaskDescriptor newTask = mergePolicy.merge(mergingEntry, existingEntry);
        if (newTask != null && !newTask.equals(existingTask)) {
            // cancel matched one, before replacing it
            existingTask.cancel(true);
            enqueueSuspended(newTask, true);
            System.out.println("(2) task name: " + mergingEntry.getValue().getDefinition().getName()
                    + ", existingTask: " + existingTask.getTaskResult().getReturnValue()
                    + ", newTask: " + newTask.getTaskResult().getReturnValue());
            return newTask;
        }
        System.out.println("(3) task name: " + mergingEntry.getValue().getDefinition().getName()
                + ", existingTask: " + existingTask.getTaskResult().getReturnValue()
                + ", newTask: " + (newTask == null ? "null" : newTask.getTaskResult().getReturnValue()));
    }
    return null;
}
```
I got this output:
```
(3) task name: 0, existingTask: 42.0, newTask: 42.0
(3) task name: 1, existingTask: 42.0, newTask: 42.0
(3) task name: 2, existingTask: 42.0, newTask: 42.0
(3) task name: 3, existingTask: 42.0, newTask: 42.0
(3) task name: 4, existingTask: 42.0, newTask: 42.0

(3) task name: 5, existingTask: 100.0, newTask: 42.0
(3) task name: 6, existingTask: 100.0, newTask: 42.0
(3) task name: 7, existingTask: 100.0, newTask: 42.0
(3) task name: 8, existingTask: 100.0, newTask: 42.0
(3) task name: 9, existingTask: 100.0, newTask: 42.0

(1) task name: 10, existingTask: null, newTask: 42.0
(1) task name: 11, existingTask: null, newTask: 42.0
(1) task name: 12, existingTask: null, newTask: 42.0
(1) task name: 13, existingTask: null, newTask: 42.0
(1) task name: 14, existingTask: null, newTask: 42.0
```
So despite the different task result, it was not replaced (jumped into branch `(3)` instead of the expected branch `(2)` for tasks 5 to 9). The reason is that the compared `ScheduledTaskDescriptor` is the same for both tasks, so the merging task could never win.

 ~~My solution is to check the `ScheduledTaskResult` as well for equality.~~ After some discussion it's clear that the task result is not a reliable source for the check. We switched from `equals()` to `==` check for now, which works fine. This might be improved further in 3.11 (see https://github.com/hazelcast/hazelcast/pull/12497#discussion_r172179423).
