### PR TITLE
Remove clearMapOnly method on MapProxyImpl

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -590,29 +590,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         loadInternal(keys, null, replaceExistingValues);
     }
 
-    /**
-     * This method clears the map and calls deleteAll on MapStore which if connected to a database,
-     * will delete the records from that database.
-     * <p>
-     * If you wish to clear the map only without calling deleteAll, use #clearMapOnly.
-     *
-     * @see #clearMapOnly
-     */
     @Override
     public void clear() {
-        clearInternal();
-    }
-
-    /**
-     * This method clears the map. It does not invoke deleteAll on any associated MapStore.
-     *
-     * @see #clear
-     */
-    //TODO: why is this not tested?
-    //TODO: how come the implementation is the same as clear? I think this code is broken
-    //TODO: This method also isn't part of the IMap API
-    public void clearMapOnly() {
-        // TODO: need a different method here that does not call deleteAll()
         clearInternal();
     }
 


### PR DESCRIPTION
This method is not on public API and it has the same functionality as
clear() and clearInternal(). It was introduced with https://github.com/hazelcast/hazelcast/commit/d23ec867345bae5476d7a5743420816f59987f68#diff-ee7691c29f6e9b58d18ba1b5bf554776 and later the TODOs were added
with https://github.com/hazelcast/hazelcast/pull/2700/commits/8f706352ccb43698b7a679ee9dd8e03d56d0540c.

My presumption is that the method was introduced to have the same
behaviour as evictAll currently does.