### PR TITLE
Decrease resource usage on QueryBounceTest and other tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueTestsFrom2X.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueTestsFrom2X.java
@@ -58,9 +58,7 @@ public class QueueTestsFrom2X extends HazelcastTestSupport {
 
     @Override
     protected Config getConfig() {
-        final Config config = super.getConfig();
-        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "10");
-        return config;
+        return smallInstanceConfig();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/MapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapListenerTest.java
@@ -294,11 +294,7 @@ public class MapListenerTest extends HazelcastTestSupport {
 
     @Override
     protected Config getConfig() {
-        return super.getConfig()
-                    .setProperty(PARTITION_COUNT.getName(), "10")
-                    .setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "2")
-                    .setProperty(GENERIC_OPERATION_THREAD_COUNT.getName(), "2")
-                    .setProperty(EVENT_THREAD_COUNT.getName(), "1")
+        return smallInstanceConfig()
                     .setProperty(LISTENER_WITH_PREDICATE_PRODUCES_NATURAL_EVENT_TYPES.getName(), "true");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/QueryBounceTest.java
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith;
 import java.util.Collection;
 import java.util.Random;
 
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.Assert.assertEquals;
 
@@ -82,7 +83,7 @@ public class QueryBounceTest {
     }
 
     protected Config getConfig() {
-        return new Config();
+        return smallInstanceConfig();
     }
 
     private void prepareAndRunQueryTasks() {

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddAllReadManyStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddAllReadManyStressTest.java
@@ -104,12 +104,7 @@ public class RingbufferAddAllReadManyStressTest extends HazelcastTestSupport {
     }
 
     public void test(RingbufferConfig ringbufferConfig) {
-        // make the test instances consume less resources
-        Config config = new Config()
-                .setProperty(PARTITION_COUNT.getName(), "10")
-                .setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "2")
-                .setProperty(GENERIC_OPERATION_THREAD_COUNT.getName(), "2")
-                .setProperty(EVENT_THREAD_COUNT.getName(), "1");
+        Config config = smallInstanceConfig();
 
         config.addRingBufferConfig(ringbufferConfig);
         HazelcastInstance[] instances = createHazelcastInstanceFactory(2).newInstances(config);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -77,10 +77,7 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
         loggingService = new LoggingServiceImpl("foo", "jdk", new BuildInfo("1", "1", "1", 1, false, (byte) 1));
 
         serializationService = new DefaultSerializationServiceBuilder().build();
-        config = new Config();
-        config.setProperty(PARTITION_COUNT.getName(), "10");
-        config.setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "10");
-        config.setProperty(GENERIC_OPERATION_THREAD_COUNT.getName(), "10");
+        config = smallInstanceConfig();
         thisAddress = new Address("localhost", 5701);
         Node node = Mockito.mock(Node.class);
         when(node.getConfig()).thenReturn(config);

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -50,6 +50,7 @@ import com.hazelcast.spi.impl.operationparker.impl.OperationParkerImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.jitter.JitterRule;
@@ -135,8 +136,21 @@ public abstract class HazelcastTestSupport {
     // ########## configuration ##########
     // ###################################
 
-    protected Config getConfig() {
+    public static Config smallInstanceConfig() {
+        // make the test instances consume less resources per default
+        return new Config()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "11")
+                .setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "2")
+                .setProperty(GroupProperty.GENERIC_OPERATION_THREAD_COUNT.getName(), "2")
+                .setProperty(GroupProperty.EVENT_THREAD_COUNT.getName(), "1");
+    }
+
+    public static Config regularInstanceConfig() {
         return new Config();
+    }
+
+    protected Config getConfig() {
+        return regularInstanceConfig();
     }
 
     // ###############################################


### PR DESCRIPTION
Decreased the number of threads used since lots of threads may introduce
pressure on the scheduler and the environment may appear slow. Here we
assume that the number of partitions (and threads) will not have any
(significant) effect on the tests effectiveness.

Fixes: https://github.com/hazelcast/hazelcast/issues/9870