### PR TITLE
Fix ICardinalityEstimator conversion from SPARSE to DENSE

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImpl.java
@@ -21,41 +21,36 @@ import com.hazelcast.cardinality.impl.hyperloglog.HyperLogLog;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 
 import static com.hazelcast.cardinality.impl.hyperloglog.impl.HyperLogLogEncoding.SPARSE;
 
-public class HyperLogLogImpl implements HyperLogLog {
+public class HyperLogLogImpl
+        implements HyperLogLog, Versioned {
 
     private static final int LOWER_P_BOUND = 4;
     private static final int UPPER_P_BOUND = 16;
-    private static final int UPPER_P_PRIME_BOUND = 25;
 
     // [1] shows good cardinality estimation
     private static final int DEFAULT_P = 14;
-    private static final int DEFAULT_P_PRIME = 25;
 
     private int m;
     private HyperLogLogEncoder encoder;
     private Long cachedEstimate;
 
     public HyperLogLogImpl() {
-        this(DEFAULT_P, DEFAULT_P_PRIME);
+        this(DEFAULT_P);
     }
 
-    public HyperLogLogImpl(final int p, final int pPrime) {
+    public HyperLogLogImpl(final int p) {
         if (p < LOWER_P_BOUND || p > UPPER_P_BOUND) {
             throw new IllegalArgumentException("Precision (p) outside valid range [4..16].");
         }
 
-        if (pPrime < p || pPrime > UPPER_P_PRIME_BOUND) {
-            throw new IllegalArgumentException("Prime precision (p') outside "
-                    + "valid range [" + p + ".." + UPPER_P_PRIME_BOUND + "].");
-        }
-
         this.m = 1 << p;
-        this.encoder = new SparseHyperLogLogEncoder(p, pPrime);
+        this.encoder = new SparseHyperLogLogEncoder(p);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/SparseHyperLogLogEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/SparseHyperLogLogEncoder.java
@@ -20,26 +20,32 @@ import com.hazelcast.cardinality.impl.CardinalityEstimatorDataSerializerHook;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 import java.util.Arrays;
 
+import static com.hazelcast.internal.cluster.Versions.V3_10;
+
 /**
  * 1. http://static.googleusercontent.com/media/research.google.com/en//pubs/archive/40671.pdf
+ * <p>The implementation is using a fixed p' = 25 which according to [1] provides very high accuracy
+ * for the range of cardinalities where the sparse representation is used.
  */
 @SuppressWarnings("checkstyle:magicnumber")
-public class SparseHyperLogLogEncoder implements HyperLogLogEncoder  {
+public class SparseHyperLogLogEncoder
+        implements HyperLogLogEncoder, Versioned {
 
-    private static final long P_PRIME_FENCE_MASK = 0x8000000000L;
+    private static final int P_PRIME = 25;
+    private static final int P_PRIME_MASK = 0x1ffffff;
+    private static final long P_PRIME_FENCE_MASK = 0x4000000000L;
+
     private static final int DEFAULT_TEMP_CAPACITY = 200;
 
     private int p;
     private int pMask;
     private int pFenseMask;
-    private int pPrime;
-    private int pPrimeMask;
     private long pDiffMask;
-
     private VariableLengthDiffArray register;
 
     private int[] temp;
@@ -49,19 +55,18 @@ public class SparseHyperLogLogEncoder implements HyperLogLogEncoder  {
     public SparseHyperLogLogEncoder() {
     }
 
-    SparseHyperLogLogEncoder(final int p, final int pPrime) {
-        init(p, pPrime, new VariableLengthDiffArray());
+    SparseHyperLogLogEncoder(final int p) {
+        init(p, new VariableLengthDiffArray());
     }
 
-    public void init(int p, int pPrime, VariableLengthDiffArray register) {
+    public void init(int p, VariableLengthDiffArray register) {
         this.p = p;
-        this.pFenseMask = 1 << (64 - p) - 1;
-        this.pPrime = pPrime;
-        this.pPrimeMask = (1 << pPrime) - 1;
-        this.mPrime = 1 << pPrime;
-        this.temp = new int[DEFAULT_TEMP_CAPACITY];
         this.pMask = ((1 << p) - 1);
-        this.pDiffMask = pPrimeMask ^ pMask;
+        this.pFenseMask = 1 << (64 - p) - 1;
+        this.pDiffMask = P_PRIME_MASK ^ pMask;
+
+        this.mPrime = 1 << P_PRIME;
+        this.temp = new int[DEFAULT_TEMP_CAPACITY];
         this.register = register;
     }
 
@@ -103,7 +108,10 @@ public class SparseHyperLogLogEncoder implements HyperLogLogEncoder  {
     public void writeData(ObjectDataOutput out) throws IOException {
         mergeAndResetTmp();
         out.writeInt(p);
-        out.writeInt(pPrime);
+        // RU_COMPAT_3_9
+        if (out.getVersion().isLessThan(V3_10)) {
+            out.writeInt(P_PRIME);
+        }
         out.writeInt(register.total);
         out.writeInt(register.mark);
         out.writeInt(register.prev);
@@ -113,12 +121,15 @@ public class SparseHyperLogLogEncoder implements HyperLogLogEncoder  {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int p = in.readInt();
-        int pPrime = in.readInt();
+        // RU_COMPAT_3_9
+        if (in.getVersion().isLessThan(V3_10)) {
+            in.readInt();
+        }
         int total = in.readInt();
         int mark = in.readInt();
         int prev = in.readInt();
         byte[] bytes = in.readByteArray();
-        init(p, pPrime, new VariableLengthDiffArray(bytes, total, mark, prev));
+        init(p, new VariableLengthDiffArray(bytes, total, mark, prev));
     }
 
     @Override
@@ -144,43 +155,46 @@ public class SparseHyperLogLogEncoder implements HyperLogLogEncoder  {
     }
 
     private int encodeHash(long hash) {
-        int index = (int) (hash & pPrimeMask) << (32 - pPrime);
         if ((hash & pDiffMask) == 0) {
-            return index | Long.numberOfTrailingZeros((hash >>> pPrime) | P_PRIME_FENCE_MASK) << 1 | 0x1;
+            int newHash = (int) (hash & P_PRIME_MASK) << (32 - P_PRIME);
+            return newHash | (Long.numberOfTrailingZeros((hash >>> P_PRIME) | P_PRIME_FENCE_MASK) + 1) << 1 | 0x1;
         }
 
-        return ((index >>> (32 - pPrime)) & pPrimeMask) << 1;
+        return (int) (hash & P_PRIME_MASK) << 1;
     }
 
     private int decodeHashPPrimeIndex(int hash) {
         if (!hasRunOfZerosEncoded(hash)) {
-            return ((hash >> 1) & pPrimeMask) & mPrime - 1;
+            return ((hash >> 1) & P_PRIME_MASK) & mPrime - 1;
         }
 
-        return (hash >> (32 - pPrime) & pPrimeMask) & mPrime - 1;
+        return (hash >> (32 - P_PRIME) & P_PRIME_MASK) & mPrime - 1;
     }
 
     private int decodeHashPIndex(long hash) {
         if (!hasRunOfZerosEncoded(hash)) {
-            return (int) ((hash >>> 1)) & pMask;
-        }
-
-        return (int) (hash >>> (32 - pPrime)) & pMask;
-    }
-
-    private byte decodeHashRunOfZeros(int hash) {
-        if (!hasRunOfZerosEncoded(hash)) {
             // |-25bits-||-1bit-
-            // (p - p') || 0
-            int stripFlag = hash >>> 1;
-            int pShifted = stripFlag >>> p;
-            return (byte) Integer.numberOfTrailingZeros(pShifted | pFenseMask);
+            return (int) ((hash >>> 1)) & pMask;
         }
 
         // |-25bits-||-6bits-||-1bit-|
         // (p - p') || p(w') || 1
-        int pW = (hash & ((1 << (32 - pPrime)) - 1)) >>> 1;
-        return (byte) (pW + (pPrime - p) + 1);
+        return (int) (hash >>> 7) & pMask;
+    }
+
+    private byte decodeHashRunOfZeros(int hash) {
+        int stripedZeroFlag = hash >>> 1;
+
+        if (!hasRunOfZerosEncoded(hash)) {
+            // |-25bits-||-1bit-
+            // (p - p') || 0
+            return (byte) (Long.numberOfTrailingZeros(stripedZeroFlag >>> p | pFenseMask) + 1);
+        }
+
+        // |-25bits-||-6bits-||-1bit-|
+        // (p - p') || p(w') || 1
+        int pW = stripedZeroFlag & ((1 << 6) - 1);
+        return (byte) (pW + (P_PRIME - p));
     }
 
     private boolean hasRunOfZerosEncoded(long hash) {

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/HyperLogLogImplTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.util.HashUtil;
 import com.hazelcast.util.collection.IntHashSet;
 import org.HdrHistogram.Histogram;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,7 +44,6 @@ import static org.junit.Assert.fail;
 @Category(SlowTest.class)
 public class HyperLogLogImplTest {
 
-    private static final int PRIME_PRECISION = 25;
     private static final int DEFAULT_RUN_LENGTH = 10000000;
 
     @Parameters(name = "precision:{0}, errorRange:{1}")
@@ -54,7 +52,7 @@ public class HyperLogLogImplTest {
                 {11, 6.5f},
                 {12, 5.5f},
                 {13, 3.5f},
-                {14, 3.5f},
+                {14, 3.0f},
                 {15, 2.5f},
                 {16, 2.0f},
         });
@@ -70,7 +68,7 @@ public class HyperLogLogImplTest {
 
     @Before
     public void setup() {
-        hyperLogLog = new HyperLogLogImpl(precision, PRIME_PRECISION);
+        hyperLogLog = new HyperLogLogImpl(precision);
     }
 
     @Test
@@ -96,7 +94,6 @@ public class HyperLogLogImplTest {
      * </ul>
      */
     @Test
-    @Ignore("https://github.com/hazelcast/hazelcast/issues/11433")
     public void testEstimateErrorRateForBigCardinalities() {
         double stdError = (1.04f / Math.sqrt(1 << precision)) * 100;
         double maxError = Math.ceil(stdError + errorRange);

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/SparseHyperLogLogEncoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/impl/hyperloglog/impl/SparseHyperLogLogEncoderTest.java
@@ -34,7 +34,7 @@ public class SparseHyperLogLogEncoderTest extends HyperLogLogEncoderAbstractTest
 
     @Override
     public HyperLogLogEncoder createStore() {
-        return new SparseHyperLogLogEncoder(14, precision());
+        return new SparseHyperLogLogEncoder(14);
     }
 
     @Override


### PR DESCRIPTION
The `encodeHash` in the SPARSE encoder was not correct for neither case of holding the number of trailing zeros in it or not. The result was small discrepancies on the number of trailing zeros, when converted back to DENSE, causing the big error rates. With the fixed approach, I reverted the initial error-rates that we put in place, and during testing, I noticed a significant decrease in the resulted error rates.

Fixes https://github.com/hazelcast/hazelcast/issues/11433
Re-enabled ignored failing test (https://github.com/hazelcast/hazelcast/pull/12465).

On other news, we removed support for different prime precisions on the SPARSE encoder, since we never did support them.