### PR TITLE
Make mastership claim idempotent and retry until timeouts or target leaves

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -248,8 +248,6 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
             checkTrue(isJoined(), candidateAddress + " claims mastership but this node is not joined!");
             checkFalse(isMaster(),
                     candidateAddress + " claims mastership but this node is master!");
-            checkFalse(candidateAddress.equals(getMasterAddress()),
-                    candidateAddress + " claims mastership but it is already the known master!");
 
             MemberImpl masterCandidate = membershipManager.getMember(candidateAddress, candidateUuid);
             checkTrue(masterCandidate != null,

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberListJoinVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberListJoinVersionTest.java
@@ -49,7 +49,7 @@ import static com.hazelcast.spi.properties.GroupProperty.MAX_NO_HEARTBEAT_SECOND
 import static com.hazelcast.spi.properties.GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS;
-import static com.hazelcast.test.PacketFiltersUtil.dropOperationsFrom;
+import static com.hazelcast.test.PacketFiltersUtil.rejectOperationsFrom;
 import static com.hazelcast.test.PacketFiltersUtil.resetPacketFiltersFrom;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -116,11 +116,11 @@ public class MemberListJoinVersionTest extends HazelcastTestSupport {
             }
         });
 
-        dropOperationsFrom(member3, F_ID, asList(HEARTBEAT, SPLIT_BRAIN_MERGE_VALIDATION));
+        rejectOperationsFrom(member3, F_ID, asList(HEARTBEAT, SPLIT_BRAIN_MERGE_VALIDATION));
 
         assertClusterSizeEventually(2, member1, member2);
 
-        dropOperationsFrom(member3, F_ID, singletonList(SPLIT_BRAIN_MERGE_VALIDATION));
+        rejectOperationsFrom(member3, F_ID, singletonList(SPLIT_BRAIN_MERGE_VALIDATION));
 
         assertClusterSizeEventually(1, member3);
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -61,6 +62,7 @@ import static com.hazelcast.spi.properties.GroupProperty.MERGE_FIRST_RUN_DELAY_S
 import static com.hazelcast.spi.properties.GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsFrom;
+import static com.hazelcast.test.PacketFiltersUtil.rejectOperationsBetween;
 import static com.hazelcast.test.PacketFiltersUtil.resetPacketFiltersFrom;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -72,7 +74,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
-@Category({QuickTest.class})
+@Category({QuickTest.class, ParallelTest.class})
 public class MembershipFailureTest extends HazelcastTestSupport {
 
     @Parameterized.Parameters(name = "fd:{0}")
@@ -391,7 +393,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(3, slave1);
         assertClusterSize(3, slave2);
 
-        dropOperationsBetween(master, slave1, F_ID, singletonList(MEMBER_INFO_UPDATE));
+        rejectOperationsBetween(master, slave1, F_ID, singletonList(MEMBER_INFO_UPDATE));
 
         HazelcastInstance slave3 = newHazelcastInstance(config);
 
@@ -418,7 +420,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(3, slave1);
         // master, slave1, slave2
 
-        dropOperationsBetween(master, slave1, F_ID, singletonList(MEMBER_INFO_UPDATE));
+        rejectOperationsBetween(master, slave1, F_ID, singletonList(MEMBER_INFO_UPDATE));
 
         HazelcastInstance slave3 = newHazelcastInstance(config);
         // master, slave1, slave2, slave3
@@ -426,7 +428,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(4, slave3, slave2);
         assertClusterSize(3, slave1);
 
-        dropOperationsBetween(master, asList(slave1, slave2), F_ID, singletonList(MEMBER_INFO_UPDATE));
+        rejectOperationsBetween(master, asList(slave1, slave2), F_ID, singletonList(MEMBER_INFO_UPDATE));
 
         HazelcastInstance slave4 = newHazelcastInstance(config);
         // master, slave1, slave2, slave3, slave4
@@ -435,7 +437,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
         assertClusterSizeEventually(4, slave2);
         assertClusterSize(3, slave1);
 
-        dropOperationsBetween(master, asList(slave1, slave2, slave3), F_ID, singletonList(MEMBER_INFO_UPDATE));
+        rejectOperationsBetween(master, asList(slave1, slave2, slave3), F_ID, singletonList(MEMBER_INFO_UPDATE));
 
         HazelcastInstance slave5 = newHazelcastInstance(config);
         // master, slave1, slave2, slave3, slave4, slave5
@@ -464,7 +466,7 @@ public class MembershipFailureTest extends HazelcastTestSupport {
 
         assertClusterSize(2, master, slave1);
 
-        dropOperationsBetween(master, slave1, F_ID, singletonList(MEMBER_INFO_UPDATE));
+        rejectOperationsBetween(master, slave1, F_ID, singletonList(MEMBER_INFO_UPDATE));
 
         HazelcastInstance slave2 = newHazelcastInstance(config);
         assertClusterSize(3, master);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -68,7 +68,8 @@ import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMB
 import static com.hazelcast.spi.properties.GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS;
 import static com.hazelcast.test.PacketFiltersUtil.delayOperationsFrom;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
-import static com.hazelcast.test.PacketFiltersUtil.dropOperationsFrom;
+import static com.hazelcast.test.PacketFiltersUtil.rejectOperationsBetween;
+import static com.hazelcast.test.PacketFiltersUtil.rejectOperationsFrom;
 import static com.hazelcast.test.PacketFiltersUtil.resetPacketFiltersFrom;
 import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
 import static java.lang.Thread.currentThread;
@@ -404,7 +405,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
         assertClusterSize(2, hz1, hz2);
 
-        dropOperationsFrom(hz1, F_ID, singletonList(MEMBER_INFO_UPDATE));
+        rejectOperationsFrom(hz1, F_ID, singletonList(MEMBER_INFO_UPDATE));
 
         HazelcastInstance hz3 = factory.newHazelcastInstance(config);
 
@@ -432,7 +433,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
         assertClusterSize(2, hz1, hz2);
 
-        dropOperationsFrom(hz1, F_ID, singletonList(MEMBER_INFO_UPDATE));
+        rejectOperationsFrom(hz1, F_ID, singletonList(MEMBER_INFO_UPDATE));
 
         HazelcastInstance hz3 = factory.newHazelcastInstance(config);
 
@@ -626,7 +627,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
         assertClusterSize(4, hz2, hz3);
 
-        dropOperationsBetween(hz1, hz2, F_ID, singletonList(MEMBER_INFO_UPDATE));
+        rejectOperationsBetween(hz1, hz2, F_ID, singletonList(MEMBER_INFO_UPDATE));
 
         final MemberImpl member3 = getNode(hz3).getLocalMember();
         hz3.getLifecycleService().terminate();

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -55,6 +55,7 @@ import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMB
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.PROMOTE_LITE_MEMBER;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsFrom;
+import static com.hazelcast.test.PacketFiltersUtil.rejectOperationsBetween;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.greaterThan;
@@ -296,7 +297,7 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
 
         assertClusterSizeEventually(3, hz2);
 
-        dropOperationsBetween(hz3, hz1, F_ID, asList(PROMOTE_LITE_MEMBER, EXPLICIT_SUSPICION));
+        rejectOperationsBetween(hz3, hz1, F_ID, asList(PROMOTE_LITE_MEMBER, EXPLICIT_SUSPICION));
         dropOperationsFrom(hz2, F_ID, asList(MEMBER_INFO_UPDATE, EXPLICIT_SUSPICION));
         dropOperationsFrom(hz1, F_ID, singletonList(HEARTBEAT));
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AntiEntropyCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AntiEntropyCorrectnessTest.java
@@ -74,7 +74,7 @@ public class AntiEntropyCorrectnessTest extends PartitionCorrectnessTestSupport 
     public static void setBackupPacketDropFilter(HazelcastInstance instance, float blockRatio) {
         Node node = getNode(instance);
         FirewallingConnectionManager cm = (FirewallingConnectionManager) node.getConnectionManager();
-        cm.setDroppingPacketFilter(new BackupPacketDropFilter(node.getSerializationService(), blockRatio));
+        cm.setPacketFilter(new BackupPacketDropFilter(node.getSerializationService(), blockRatio));
     }
 
     private static class BackupPacketDropFilter extends OperationPacketFilter implements PacketFilter {
@@ -86,9 +86,9 @@ public class AntiEntropyCorrectnessTest extends PartitionCorrectnessTestSupport 
         }
 
         @Override
-        protected boolean allowOperation(Address endpoint, int factory, int type) {
+        protected Action filterOperation(Address endpoint, int factory, int type) {
             boolean isBackup = factory == SpiDataSerializerHook.F_ID && type == SpiDataSerializerHook.BACKUP;
-            return !isBackup || Math.random() > blockRatio;
+            return !isBackup ? Action.ALLOW : (Math.random() > blockRatio ? Action.ALLOW : Action.DROP);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/DirtyBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/DirtyBackupTest.java
@@ -82,7 +82,8 @@ public class DirtyBackupTest extends PartitionCorrectnessTestSupport {
     private static void setBackupPacketReorderFilter(HazelcastInstance instance) {
         Node node = getNode(instance);
         FirewallingConnectionManager cm = (FirewallingConnectionManager) node.getConnectionManager();
-        cm.setDelayingPacketFilter(new BackupPacketReorderFilter(node.getSerializationService()), 100, 1000);
+        cm.setPacketFilter(new BackupPacketReorderFilter(node.getSerializationService()));
+        cm.setDelayMillis(100, 1000);
     }
 
     private static class BackupPacketReorderFilter extends OperationPacketFilter implements PacketFilter {
@@ -92,9 +93,9 @@ public class DirtyBackupTest extends PartitionCorrectnessTestSupport {
         }
 
         @Override
-        protected boolean allowOperation(Address enpoint, int factory, int type) {
+        protected Action filterOperation(Address endpoint, int factory, int type) {
             boolean isBackup = factory == SpiDataSerializerHook.F_ID && type == SpiDataSerializerHook.BACKUP;
-            return !isBackup;
+            return isBackup ? Action.DELAY : Action.ALLOW;
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingConnectionManager.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/FirewallingConnectionManager.java
@@ -44,8 +44,8 @@ public class FirewallingConnectionManager implements ConnectionManager, PacketHa
             = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryImpl("FirewallingConnectionManager"));
     private final PacketHandler packetHandler;
 
-    private volatile PacketFilter droppingPacketFilter;
-    private volatile DelayingPacketFilterWrapper delayingPacketFilter;
+    private volatile PacketFilter packetFilter;
+    private volatile PacketDelayProps delayProps = new PacketDelayProps(500, 5000);
 
     public FirewallingConnectionManager(ConnectionManager delegate, Set<Address> initiallyBlockedAddresses) {
         this.delegate = delegate;
@@ -92,57 +92,53 @@ public class FirewallingConnectionManager implements ConnectionManager, PacketHa
         }
     }
 
-    public void setDroppingPacketFilter(PacketFilter droppingPacketFilter) {
-        assert droppingPacketFilter != null;
-        this.droppingPacketFilter = droppingPacketFilter;
+    public void setPacketFilter(PacketFilter packetFilter) {
+        assert packetFilter != null;
+        this.packetFilter = packetFilter;
     }
 
-    public void removeDroppingPacketFilter() {
-        droppingPacketFilter = null;
+    public void removePacketFilter() {
+        packetFilter = null;
     }
 
-    public void setDelayingPacketFilter(PacketFilter delayingPacketFilter, long minDelayMs, long maxDelayMs) {
-        assert delayingPacketFilter != null;
-        this.delayingPacketFilter = new DelayingPacketFilterWrapper(delayingPacketFilter, minDelayMs, maxDelayMs);
+    public void setDelayMillis(long minDelayMs, long maxDelayMs) {
+        assert minDelayMs > 0 : "Min delay must be positive: " + minDelayMs;
+        assert maxDelayMs > 0 : "Max delay must be positive: " + minDelayMs;
+        assert maxDelayMs >= minDelayMs : "Max delay must not be smaller than min delay. Max: "
+                + maxDelayMs + ", min: " + minDelayMs;
+        this.delayProps = new PacketDelayProps(minDelayMs, maxDelayMs);
     }
 
-    public void removeDelayingPacketFilter() {
-        delayingPacketFilter = null;
-    }
-
-    private boolean isAllowed(Packet packet, Address target) {
+    private PacketFilter.Action applyFilter(Packet packet, Address target) {
         if (blockedAddresses.contains(target)) {
-            return false;
+            return PacketFilter.Action.REJECT;
         }
 
-        PacketFilter filter = droppingPacketFilter;
-        return filter == null || filter.allow(packet, target);
+        PacketFilter filter = packetFilter;
+        return filter == null ? PacketFilter.Action.ALLOW : filter.filter(packet, target);
     }
 
-    private long getDelayMs(Packet packet, Address target) {
-        DelayingPacketFilterWrapper delayingFilter = delayingPacketFilter;
-        if (delayingFilter != null) {
-            if (!delayingFilter.packetFilter.allow(packet, target)) {
-                return getRandomBetween(delayingFilter.maxDelayMs, delayingFilter.minDelayMs);
-            }
-        }
-        return 0;
+    private long getDelayMs() {
+        PacketDelayProps delay = delayProps;
+        return getRandomBetween(delay.maxDelayMs, delay.minDelayMs);
     }
 
-    private long getRandomBetween(long max, long min) {
+    private static long getRandomBetween(long max, long min) {
         return (long) ((max - min) * Math.random() + min);
     }
 
     @Override
     public boolean transmit(Packet packet, Connection connection) {
         if (connection != null) {
-            if (!isAllowed(packet, connection.getEndPoint())) {
-                return false;
-            }
-            long delayMs;
-            if ((delayMs = getDelayMs(packet, connection.getEndPoint())) > 0) {
-                scheduledExecutor.schedule(new DelayedPacketTask(packet, connection), delayMs, MILLISECONDS);
-                return true;
+            PacketFilter.Action action = applyFilter(packet, connection.getEndPoint());
+            switch (action) {
+                case DROP:
+                    return true;
+                case REJECT:
+                    return false;
+                case DELAY:
+                    scheduledExecutor.schedule(new DelayedPacketTask(packet, connection), getDelayMs(), MILLISECONDS);
+                    return true;
             }
         }
         return delegate.transmit(packet, connection);
@@ -150,13 +146,15 @@ public class FirewallingConnectionManager implements ConnectionManager, PacketHa
 
     @Override
     public boolean transmit(Packet packet, Address target) {
-        if (!isAllowed(packet, target)) {
-            return false;
-        }
-        long delayMs;
-        if ((delayMs = getDelayMs(packet, target)) > 0) {
-            scheduledExecutor.schedule(new DelayedPacketTask(packet, target), delayMs, MILLISECONDS);
-            return true;
+        PacketFilter.Action action = applyFilter(packet, target);
+        switch (action) {
+            case DROP:
+                return true;
+            case REJECT:
+                return false;
+            case DELAY:
+                scheduledExecutor.schedule(new DelayedPacketTask(packet, target), getDelayMs(), MILLISECONDS);
+                return true;
         }
         return delegate.transmit(packet, target);
     }
@@ -252,13 +250,11 @@ public class FirewallingConnectionManager implements ConnectionManager, PacketHa
         }
     }
 
-    private static class DelayingPacketFilterWrapper {
-        final PacketFilter packetFilter;
+    private static class PacketDelayProps {
         final long minDelayMs;
         final long maxDelayMs;
 
-        private DelayingPacketFilterWrapper(PacketFilter packetFilter, long minDelayMs, long maxDelayMs) {
-            this.packetFilter = packetFilter;
+        private PacketDelayProps(long minDelayMs, long maxDelayMs) {
             this.minDelayMs = minDelayMs;
             this.maxDelayMs = maxDelayMs;
         }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/OperationPacketFilter.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/OperationPacketFilter.java
@@ -35,11 +35,11 @@ public abstract class OperationPacketFilter implements PacketFilter {
     }
 
     @Override
-    public final boolean allow(Packet packet, Address endpoint) {
-        return packet.getPacketType() != Packet.Type.OPERATION || allowOperation(packet, endpoint);
+    public final Action filter(Packet packet, Address endpoint) {
+        return packet.getPacketType() != Packet.Type.OPERATION ? Action.ALLOW : filterOperation(packet, endpoint);
     }
 
-    private boolean allowOperation(Packet packet, Address endpoint) {
+    private Action filterOperation(Packet packet, Address endpoint) {
         try {
             ObjectDataInput input = serializationService.createObjectDataInput(packet);
             byte header = input.readByte();
@@ -48,13 +48,13 @@ public abstract class OperationPacketFilter implements PacketFilter {
                 boolean compressed = (header & 1 << 2) != 0;
                 int factory = compressed ? input.readByte() : input.readInt();
                 int type = compressed ? input.readByte() : input.readInt();
-                return allowOperation(endpoint, factory, type);
+                return filterOperation(endpoint, factory, type);
             }
         } catch (IOException e) {
             throw new HazelcastException(e);
         }
-        return true;
+        return Action.ALLOW;
     }
 
-    protected abstract boolean allowOperation(Address endpoint, int factory, int type);
+    protected abstract Action filterOperation(Address endpoint, int factory, int type);
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketFilter.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/PacketFilter.java
@@ -20,9 +20,31 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Packet;
 
 /**
- * A filter used by mock network system to allow, drop or delay {@code Packet}s
+ * A filter used by network system to allow, reject, drop or delay {@code Packet}s
  */
 public interface PacketFilter {
+
+    enum Action {
+        /**
+         * Allows the packet to pass through intact
+         */
+        ALLOW,
+
+        /**
+         * Rejects the packet. Sender will be aware of rejection.
+         */
+        REJECT,
+
+        /**
+         * Silently drops the packet as if sent to the destination.
+         */
+        DROP,
+
+        /**
+         * Delays sending packet to the destination.
+         */
+        DELAY
+    }
 
     /**
      * Filters a packet inspecting its content and/or endpoint and decides
@@ -30,8 +52,9 @@ public interface PacketFilter {
      *
      * @param packet   packet
      * @param endpoint target endpoint which packet is sent to
-     * @return returns true if packet should pass through intact, false otherwise
+     * @return returns An {@link Action} to denote whether packet should pass through intact,
+     * or should be rejected/dropped/delayed
      */
-    boolean allow(Packet packet, Address endpoint);
+    Action filter(Packet packet, Address endpoint);
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/PacketFiltersUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/PacketFiltersUtil.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.tcp.FirewallingConnectionManager;
 import com.hazelcast.nio.tcp.OperationPacketFilter;
 import com.hazelcast.nio.tcp.PacketFilter;
+import com.hazelcast.util.Preconditions;
 import com.hazelcast.util.collection.IntHashSet;
 
 import java.util.ArrayList;
@@ -33,7 +34,7 @@ import java.util.Set;
 
 import static com.hazelcast.test.HazelcastTestSupport.getAddress;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.singleton;
 
 @SuppressWarnings("unused")
 public final class PacketFiltersUtil {
@@ -44,54 +45,61 @@ public final class PacketFiltersUtil {
     public static void resetPacketFiltersFrom(HazelcastInstance instance) {
         Node node = getNode(instance);
         FirewallingConnectionManager cm = (FirewallingConnectionManager) node.getConnectionManager();
-        cm.removeDroppingPacketFilter();
-        cm.removeDelayingPacketFilter();
+        cm.removePacketFilter();
     }
 
     public static void delayOperationsFrom(HazelcastInstance instance, int factory, List<Integer> opTypes) {
-        Node node = getNode(instance);
-        FirewallingConnectionManager cm = (FirewallingConnectionManager) node.getConnectionManager();
-        PacketFilter packetFilter = new EndpointAgnosticPacketFilter(node.getSerializationService(), factory, opTypes);
-        cm.setDelayingPacketFilter(packetFilter, 500, 5000);
+       filterOperationsFrom(instance, factory, opTypes, PacketFilter.Action.DELAY);
     }
 
     public static void delayOperationsBetween(HazelcastInstance from, HazelcastInstance to, int factory, List<Integer> opTypes) {
-        Node node = getNode(from);
-        FirewallingConnectionManager cm = (FirewallingConnectionManager) node.getConnectionManager();
-        List<Address> blacklist = singletonList(getAddress(to));
-        PacketFilter packetFilter = new EndpointAwarePacketFilter(node.getSerializationService(), blacklist, factory, opTypes);
-        cm.setDelayingPacketFilter(packetFilter, 500, 5000);
+        filterOperationsBetween(from, singleton(to), factory, opTypes, PacketFilter.Action.DELAY);
     }
 
     public static void delayOperationsBetween(HazelcastInstance from, Collection<HazelcastInstance> to, int factory, List<Integer> opTypes) {
-        Node node = getNode(from);
-        FirewallingConnectionManager cm = (FirewallingConnectionManager) node.getConnectionManager();
-        Collection<Address> blacklist = getAddresses(to);
-        PacketFilter packetFilter = new EndpointAwarePacketFilter(node.getSerializationService(), blacklist, factory, opTypes);
-        cm.setDelayingPacketFilter(packetFilter, 500, 5000);
+        filterOperationsBetween(from, to, factory, opTypes, PacketFilter.Action.DELAY);
     }
 
     public static void dropOperationsFrom(HazelcastInstance instance, int factory, List<Integer> opTypes) {
-        Node node = getNode(instance);
-        FirewallingConnectionManager cm = (FirewallingConnectionManager) node.getConnectionManager();
-        PacketFilter packetFilter = new EndpointAgnosticPacketFilter(node.getSerializationService(), factory, opTypes);
-        cm.setDroppingPacketFilter(packetFilter);
+        filterOperationsFrom(instance, factory, opTypes, PacketFilter.Action.DROP);
     }
 
     public static void dropOperationsBetween(HazelcastInstance from, HazelcastInstance to, int factory, List<Integer> opTypes) {
-        Node node = getNode(from);
-        FirewallingConnectionManager cm = (FirewallingConnectionManager) node.getConnectionManager();
-        List<Address> blacklist = singletonList(getAddress(to));
-        PacketFilter packetFilter = new EndpointAwarePacketFilter(node.getSerializationService(), blacklist, factory, opTypes);
-        cm.setDroppingPacketFilter(packetFilter);
+        filterOperationsBetween(from, singleton(to), factory, opTypes, PacketFilter.Action.DROP);
     }
 
     public static void dropOperationsBetween(HazelcastInstance from, Collection<HazelcastInstance> to, int factory, List<Integer> opTypes) {
+        filterOperationsBetween(from, to, factory, opTypes, PacketFilter.Action.DROP);
+    }
+
+    public static void rejectOperationsFrom(HazelcastInstance instance, int factory, List<Integer> opTypes) {
+        filterOperationsFrom(instance, factory, opTypes, PacketFilter.Action.REJECT);
+    }
+
+    public static void rejectOperationsBetween(HazelcastInstance from, HazelcastInstance to, int factory, List<Integer> opTypes) {
+        filterOperationsBetween(from, singleton(to), factory, opTypes, PacketFilter.Action.REJECT);
+    }
+
+    public static void rejectOperationsBetween(HazelcastInstance from, Collection<HazelcastInstance> to, int factory, List<Integer> opTypes) {
+        filterOperationsBetween(from, to, factory, opTypes, PacketFilter.Action.REJECT);
+    }
+
+    private static void filterOperationsFrom(HazelcastInstance instance, int factory, List<Integer> opTypes,
+            PacketFilter.Action action) {
+        Node node = getNode(instance);
+        FirewallingConnectionManager cm = (FirewallingConnectionManager) node.getConnectionManager();
+        PacketFilter packetFilter = new EndpointAgnosticPacketFilter(node.getSerializationService(), factory, opTypes, action);
+        cm.setPacketFilter(packetFilter);
+    }
+
+    private static void filterOperationsBetween(HazelcastInstance from, Collection<HazelcastInstance> to, int factory,
+            List<Integer> opTypes, PacketFilter.Action action) {
         Node node = getNode(from);
         FirewallingConnectionManager cm = (FirewallingConnectionManager) node.getConnectionManager();
         Collection<Address> blacklist = getAddresses(to);
-        PacketFilter packetFilter = new EndpointAwarePacketFilter(node.getSerializationService(), blacklist, factory, opTypes);
-        cm.setDroppingPacketFilter(packetFilter);
+        PacketFilter packetFilter = new EndpointAwarePacketFilter(node.getSerializationService(), blacklist, factory,
+                opTypes, action);
+        cm.setPacketFilter(packetFilter);
     }
 
     private static Collection<Address> getAddresses(Collection<HazelcastInstance> instances) {
@@ -106,20 +114,23 @@ public final class PacketFiltersUtil {
     private static class EndpointAgnosticPacketFilter extends OperationPacketFilter {
 
         final int factory;
+        final Action action;
 
         // Integer.MIN_VALUE is used for missing value
         final IntHashSet types = new IntHashSet(1024, Integer.MIN_VALUE);
 
-        EndpointAgnosticPacketFilter(InternalSerializationService serializationService, int factory, List<Integer> typeIds) {
+        EndpointAgnosticPacketFilter(InternalSerializationService serializationService, int factory,
+                List<Integer> typeIds, Action action) {
             super(serializationService);
+            this.action = Preconditions.checkNotNull(action);
             assert typeIds.size() > 0 : "At least one operation type must be defined!";
             this.factory = factory;
             types.addAll(typeIds);
         }
 
         @Override
-        protected boolean allowOperation(Address endpoint, int factory, int type) {
-            return !(this.factory == factory && types.contains(type));
+        protected Action filterOperation(Address endpoint, int factory, int type) {
+            return (this.factory == factory && types.contains(type)) ? action : Action.ALLOW;
         }
     }
 
@@ -128,14 +139,17 @@ public final class PacketFiltersUtil {
         final Set<Address> blacklist = new HashSet<Address>();
 
         EndpointAwarePacketFilter(InternalSerializationService serializationService, Collection<Address> blacklist, int factory,
-                                  List<Integer> typeIds) {
-            super(serializationService, factory, typeIds);
+                                  List<Integer> typeIds, Action action) {
+            super(serializationService, factory, typeIds, action);
             this.blacklist.addAll(blacklist);
         }
 
         @Override
-        protected boolean allowOperation(Address endpoint, int factory, int type) {
-            return super.allowOperation(endpoint, factory, type) || !blacklist.contains(endpoint);
+        protected Action filterOperation(Address endpoint, int factory, int type) {
+            if (blacklist.contains(endpoint)) {
+                return super.filterOperation(endpoint, factory, type);
+            }
+            return Action.ALLOW;
         }
     }
 }


### PR DESCRIPTION
Mastership claim is expected to be finalized with one of the following:
- target member explicitly accepts the claim
- target member explicitly rejects the claim
- target member fails
- claim process timeouts

But in a rare case, if a network interruption occurs just around claim is being sent,
claim may be lost over the channel. In this case, sender will wait for an answer
to its claim but target never receives any claim. This leads to claim
process to timeout and eventually target splits from the main cluster.

To prevent this case, mastership claim is modified with a simple change
to make it idempotent, and new claims are sent periodically to target members
within timeout.

Additionally, packet filtering mechanism for testing is improved to distinguish
rejecting and dropping packets. And existing tests changed accordingly.

Fixes #10939