### PR TITLE
Added warnings to socket interceptors about TLS bypass

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/MemberSocketInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/MemberSocketInterceptor.java
@@ -22,12 +22,16 @@ import java.net.Socket;
 /**
  * Member Socket Interceptor can be registered via
  * see {@link com.hazelcast.config.SocketInterceptorConfig}
+ *
+ * Warning: a MemberSocketInterceptor provides access to the socket and will bypass
+ * any TLS encryption. So be warned that any data send using the SocketInterceptor
+ * could be visible as plain text and could therefor be a security risk.
  */
 public interface MemberSocketInterceptor extends SocketInterceptor {
 
     /**
-     * This method will be called when a connection to a member node is accepted meaning security requirements and
-     * clusters are matching.
+     * This method will be called when a connection to a member node is accepted
+     * meaning security requirements and clusters are matching.
      *
      * @param acceptedSocket accepted socket
      * @throws IOException

--- a/hazelcast/src/main/java/com/hazelcast/nio/SocketInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/SocketInterceptor.java
@@ -23,7 +23,13 @@ import java.util.Properties;
 /**
  * An interface that provides the ability to intercept the creation of sockets.
  * It can be registered from client via config.
+ *
  * For members see {@link com.hazelcast.nio.MemberSocketInterceptor}
+ *
+ * Warning: a SocketInterceptor provides access to the socket and will bypass
+ * any TLS encryption. So be warned that any data send using the SocketInterceptor
+ * could be visible as plain text and could therefor be a security risk.
+ *
  * see {@link com.hazelcast.config.SocketInterceptorConfig}
  */
 public interface SocketInterceptor {


### PR DESCRIPTION
Because TLS is bypassed, implementations could be at risk
if data is send unencrypted over the wire.