### PR TITLE
Allow loss-tolerant reliable topic listener to tolerate ringbuffer loss

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
@@ -19,6 +19,8 @@ package com.hazelcast.topic.impl.reliable;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
+import com.hazelcast.instance.TestUtil;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -30,6 +32,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.ringbuffer.impl.RingbufferService.TOPIC_RB_PREFIX;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -37,18 +40,33 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class LossToleranceTest extends HazelcastTestSupport {
 
+    private static final String RELIABLE_TOPIC_NAME = "foo";
     private ReliableTopicProxy<String> topic;
     private Ringbuffer<ReliableTopicMessage> ringbuffer;
+    private HazelcastInstance topicOwnerInstance;
+    private HazelcastInstance topicBackupInstance;
 
     @Before
     public void setup() {
-        Config config = new Config();
-        config.addRingBufferConfig(new RingbufferConfig("foo")
-                .setCapacity(100)
-                .setTimeToLiveSeconds(0));
-        HazelcastInstance hz = createHazelcastInstance(config);
+        Config config = smallInstanceConfig().addRingBufferConfig(
+                new RingbufferConfig(RELIABLE_TOPIC_NAME)
+                        .setCapacity(100)
+                        .setTimeToLiveSeconds(0)
+                        .setBackupCount(0)
+                        .setAsyncBackupCount(0));
+        final HazelcastInstance[] instances = createHazelcastInstanceFactory(2).newInstances(config);
 
-        topic = (ReliableTopicProxy<String>) hz.<String>getReliableTopic("foo");
+        for (HazelcastInstance instance : instances) {
+            final Member owner = instance.getPartitionService().getPartition(TOPIC_RB_PREFIX + RELIABLE_TOPIC_NAME).getOwner();
+            final Member localMember = instance.getCluster().getLocalMember();
+            if (localMember.equals(owner)) {
+                topicOwnerInstance = instance;
+            } else {
+                topicBackupInstance = instance;
+            }
+        }
+
+        topic = (ReliableTopicProxy<String>) topicBackupInstance.<String>getReliableTopic(RELIABLE_TOPIC_NAME);
         ringbuffer = topic.ringbuffer;
     }
 
@@ -71,7 +89,7 @@ public class LossToleranceTest extends HazelcastTestSupport {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertTrue(topic.runnersMap.isEmpty());
             }
         });
@@ -96,7 +114,36 @@ public class LossToleranceTest extends HazelcastTestSupport {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
+                assertContains(listener.objects, "newItem");
+                assertFalse(topic.runnersMap.isEmpty());
+            }
+        });
+    }
+
+    @Test
+    public void whenLossTolerant_andOwnerCrashes_thenContinue() {
+        final ReliableMessageListenerMock listener = new ReliableMessageListenerMock();
+        listener.isLossTolerant = true;
+        topic.addMessageListener(listener);
+        topic.publish("item1");
+        topic.publish("item2");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertContains(listener.objects, "item1");
+                assertContains(listener.objects, "item2");
+            }
+        });
+        TestUtil.terminateInstance(topicOwnerInstance);
+
+        topic.publish("newItem");
+
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
                 assertContains(listener.objects, "newItem");
                 assertFalse(topic.runnersMap.isEmpty());
             }

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerMock.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableMessageListenerMock.java
@@ -17,6 +17,8 @@
 package com.hazelcast.topic.impl.reliable;
 
 import com.hazelcast.core.Message;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.topic.ReliableMessageListener;
 
 import java.util.List;
@@ -24,6 +26,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 public class ReliableMessageListenerMock implements ReliableMessageListener<String> {
 
+    private final ILogger logger = Logger.getLogger(ReliableMessageListenerMock.class);
     public final List<String> objects = new CopyOnWriteArrayList<String>();
     public final List<Message<String>> messages = new CopyOnWriteArrayList<Message<String>>();
     public volatile long storedSequence;
@@ -35,7 +38,7 @@ public class ReliableMessageListenerMock implements ReliableMessageListener<Stri
     public void onMessage(Message<String> message) {
         objects.add(message.getMessageObject());
         messages.add(message);
-        System.out.println(message.getMessageObject());
+        logger.info("Received: " + message.getMessageObject());
     }
 
     @Override


### PR DESCRIPTION
Previously an IllegalArgumentException was thrown indicating that the
requested sequence was too large. This means that a new ringbuffer was
created and the newest sequence is still less than the one requested by
the listener.
If the listener is loss-tolerant, it now tolerates loss of an entire
ringbuffer - logs a message and restarts to the oldest sequence.
It may still happen that the producers were fast enough to produce items
in the new ringbuffer so that the requested sequence is not too large.
In this case, the listener will not notice the ringbuffer was lost. This
will be fixed in a separate PR.

Fixes: https://github.com/hazelcast/hazelcast/issues/11857
Will be backported after merge.