### PR TITLE
Fail fast only if cluster version is >= 3.10

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -67,6 +67,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.cache.impl.AbstractCacheRecordStore.SOURCE_NOT_AVAILABLE;
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateCacheConfig;
+import static com.hazelcast.internal.config.ConfigValidator.checkMergePolicySupportsInMemoryFormat;
 import static com.hazelcast.util.EmptyStatement.ignore;
 
 @SuppressWarnings("checkstyle:classdataabstractioncoupling")
@@ -75,16 +76,24 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
 
     private static final String SETUP_REF = "setupRef";
 
-    /** Map from full prefixed cache name to {@link CacheConfig} */
+    /**
+     * Map from full prefixed cache name to {@link CacheConfig}
+     */
     protected final ConcurrentMap<String, CacheConfig> configs = new ConcurrentHashMap<String, CacheConfig>();
 
-    /** Map from full prefixed cache name to {@link CacheContext} */
+    /**
+     * Map from full prefixed cache name to {@link CacheContext}
+     */
     protected final ConcurrentMap<String, CacheContext> cacheContexts = new ConcurrentHashMap<String, CacheContext>();
 
-    /** Map from full prefixed cache name to {@link CacheStatisticsImpl} */
+    /**
+     * Map from full prefixed cache name to {@link CacheStatisticsImpl}
+     */
     protected final ConcurrentMap<String, CacheStatisticsImpl> statistics = new ConcurrentHashMap<String, CacheStatisticsImpl>();
 
-    /** Map from full prefixed cache name to set of {@link Closeable} resources */
+    /**
+     * Map from full prefixed cache name to set of {@link Closeable} resources
+     */
     protected final ConcurrentMap<String, Set<Closeable>> resources = new ConcurrentHashMap<String, Set<Closeable>>();
     protected final ConcurrentMap<String, Closeable> closeableListeners = new ConcurrentHashMap<String, Closeable>();
     protected final ConcurrentMap<String, CacheOperationProvider> operationProviderCache =
@@ -218,6 +227,12 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
                 }
 
                 validateCacheConfig(cacheConfig);
+                checkMergePolicySupportsInMemoryFormat(cacheConfig.getName(),
+                        cacheConfig.getMergePolicy(),
+                        cacheConfig.getInMemoryFormat(),
+                        nodeEngine.getClusterService().getClusterVersion(),
+                        true, logger);
+
                 putCacheConfigIfAbsent(cacheConfig);
                 // ensure cache config becomes available on all members before the proxy is returned to the caller
                 createCacheConfigOnAllMembers(cacheConfig);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
@@ -239,8 +239,10 @@ public final class CacheProxyUtil {
     }
 
     public static <K, V> void validateCacheConfig(CacheConfig<K, V> cacheConfig) {
-        checkCacheConfig(cacheConfig.getName(), cacheConfig.getInMemoryFormat(),
-                cacheConfig.getEvictionConfig(), cacheConfig.isStatisticsEnabled(),
+        checkCacheConfig(cacheConfig.getInMemoryFormat(),
+                cacheConfig.getEvictionConfig(),
+                cacheConfig.isStatisticsEnabled(),
                 cacheConfig.getMergePolicy());
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -24,6 +24,7 @@ import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
 
+import static com.hazelcast.internal.config.ConfigValidator.checkMergePolicySupportsInMemoryFormat;
 import static com.hazelcast.internal.config.ConfigValidator.checkMapConfig;
 import static com.hazelcast.internal.config.ConfigValidator.checkNearCacheConfig;
 
@@ -47,6 +48,11 @@ class MapRemoteService implements RemoteService {
         Config config = nodeEngine.getConfig();
         MapConfig mapConfig = config.findMapConfig(name);
         checkMapConfig(mapConfig);
+        checkMergePolicySupportsInMemoryFormat(name,
+                mapConfig.getMergePolicyConfig().getPolicy(),
+                mapConfig.getInMemoryFormat(),
+                nodeEngine.getClusterService().getClusterVersion(),
+                true, nodeEngine.getLogger(getClass()));
 
         if (mapConfig.isNearCacheEnabled()) {
             checkNearCacheConfig(name, mapConfig.getNearCacheConfig(), config.getNativeMemoryConfig(), false);


### PR DESCRIPTION
otherwise print a warning log for an illegitimate merge policy

Fixes rolling upgrade issue caused by fail fast merge policy config check. With this PR, fail fast behavior will be active when cluster version >=3.10, previous versions will only print a warning log.

- Fail fast exceptions will only be thrown at proxy creation stage

ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/1958