### PR TITLE
Move long running parameterized near cache tests to slow test category

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicSlowTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.nearcache;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(SlowTest.class)
+public class ClientCacheNearCacheBasicSlowTest extends ClientCacheNearCacheBasicTest {
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameter(value = 1)
+    public boolean serializeKeys;
+
+    @Parameterized.Parameter(value = 2)
+    public NearCacheConfig.LocalUpdatePolicy localUpdatePolicy;
+
+    @Parameterized.Parameters(name = "format:{0} serializeKeys:{1} localUpdatePolicy:{2}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, true, NearCacheConfig.LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.BINARY, true, NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE},
+                {InMemoryFormat.BINARY, false, NearCacheConfig.LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.BINARY, false, NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE},
+                {InMemoryFormat.OBJECT, true, NearCacheConfig.LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.OBJECT, true, NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE},
+                {InMemoryFormat.OBJECT, false, NearCacheConfig.LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.OBJECT, false, NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys)
+                .setLocalUpdatePolicy(localUpdatePolicy);
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicTest.java
@@ -26,9 +26,7 @@ import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
-import com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.adapter.DataStructureAdapterMethod;
 import com.hazelcast.internal.adapter.ICacheCacheLoader;
@@ -41,66 +39,39 @@ import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import javax.cache.configuration.FactoryBuilder;
 import javax.cache.spi.CachingProvider;
-import java.util.Collection;
 
 import static com.hazelcast.client.cache.nearcache.ClientCacheInvalidationListener.createInvalidationEventHandler;
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_LOCAL_UPDATE_POLICY;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_MEMORY_FORMAT;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_SERIALIZE_KEYS;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
-import static java.util.Arrays.asList;
 
 /**
  * Basic Near Cache tests for {@link ICache} on Hazelcast clients.
  */
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientCacheNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, String> {
 
-    @Parameter
-    public InMemoryFormat inMemoryFormat;
-
-    @Parameter(value = 1)
-    public boolean serializeKeys;
-
-    @Parameter(value = 2)
-    public LocalUpdatePolicy localUpdatePolicy;
-
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-
-    @Parameters(name = "format:{0} serializeKeys:{1} localUpdatePolicy:{2}")
-    public static Collection<Object[]> parameters() {
-        return asList(new Object[][]{
-                {InMemoryFormat.BINARY, true, LocalUpdatePolicy.INVALIDATE},
-                {InMemoryFormat.BINARY, true, LocalUpdatePolicy.CACHE_ON_UPDATE},
-                {InMemoryFormat.BINARY, false, LocalUpdatePolicy.INVALIDATE},
-                {InMemoryFormat.BINARY, false, LocalUpdatePolicy.CACHE_ON_UPDATE},
-                {InMemoryFormat.OBJECT, true, LocalUpdatePolicy.INVALIDATE},
-                {InMemoryFormat.OBJECT, true, LocalUpdatePolicy.CACHE_ON_UPDATE},
-                {InMemoryFormat.OBJECT, false, LocalUpdatePolicy.INVALIDATE},
-                {InMemoryFormat.OBJECT, false, LocalUpdatePolicy.CACHE_ON_UPDATE},
-        });
-    }
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys)
-                .setLocalUpdatePolicy(localUpdatePolicy);
+        nearCacheConfig = createNearCacheConfig(DEFAULT_MEMORY_FORMAT, DEFAULT_SERIALIZE_KEYS)
+                .setLocalUpdatePolicy(DEFAULT_LOCAL_UPDATE_POLICY);
     }
 
     @After

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderSlowTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.nearcache;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(SlowTest.class)
+public class ClientCacheNearCachePreloaderSlowTest extends ClientCacheNearCachePreloaderTest {
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameter(value = 1)
+    public boolean invalidationOnChange;
+
+    @Parameterized.Parameter(value = 2)
+    public boolean serializeKeys;
+
+    @Parameterized.Parameters(name = "format:{0} invalidationOnChange:{1} serializeKeys:{2}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, false, true},
+                {InMemoryFormat.BINARY, false, false},
+                {InMemoryFormat.BINARY, true, true},
+                {InMemoryFormat.BINARY, true, false},
+
+                {InMemoryFormat.OBJECT, false, true},
+                {InMemoryFormat.OBJECT, false, false},
+                {InMemoryFormat.OBJECT, true, true},
+                {InMemoryFormat.OBJECT, true, false},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = getNearCacheConfig(inMemoryFormat, serializeKeys, invalidationOnChange, KEY_COUNT,
+                storeFile.getParent());
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderTest.java
@@ -25,7 +25,6 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
@@ -36,70 +35,42 @@ import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import javax.cache.Cache;
 import javax.cache.spi.CachingProvider;
 import java.io.File;
-import java.util.Collection;
 
 import static com.hazelcast.cache.CacheUtil.getDistributedObjectName;
 import static com.hazelcast.client.cache.nearcache.ClientCacheInvalidationListener.createInvalidationEventHandler;
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_INVALIDATE_ON_CHANGE;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_MEMORY_FORMAT;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_SERIALIZE_KEYS;
 import static com.hazelcast.nio.IOUtil.toFileName;
-import static java.util.Arrays.asList;
 
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientCacheNearCachePreloaderTest extends AbstractNearCachePreloaderTest<Data, String> {
 
-    private final String cacheFileName = toFileName(getDistributedObjectName(defaultNearCache));
-    private final File storeFile = new File("nearCache-" + cacheFileName + ".store").getAbsoluteFile();
-    private final File storeLockFile = new File(storeFile.getName() + ".lock").getAbsoluteFile();
-
-    @Parameters(name = "format:{0} invalidationOnChange:{1} serializeKeys:{2}")
-    public static Collection<Object[]> parameters() {
-        return asList(new Object[][]{
-                {InMemoryFormat.BINARY, false, true},
-                {InMemoryFormat.BINARY, false, false},
-                {InMemoryFormat.BINARY, true, true},
-                {InMemoryFormat.BINARY, true, false},
-
-                {InMemoryFormat.OBJECT, false, true},
-                {InMemoryFormat.OBJECT, false, false},
-                {InMemoryFormat.OBJECT, true, true},
-                {InMemoryFormat.OBJECT, true, false},
-        });
-    }
-
-    @Parameter
-    public InMemoryFormat inMemoryFormat;
-
-    @Parameter(value = 1)
-    public boolean invalidationOnChange;
-
-    @Parameter(value = 2)
-    public boolean serializeKeys;
+    protected final String cacheFileName = toFileName(getDistributedObjectName(defaultNearCache));
+    protected final File storeFile = new File("nearCache-" + cacheFileName + ".store").getAbsoluteFile();
+    protected final File storeLockFile = new File(storeFile.getName() + ".lock").getAbsoluteFile();
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
     @Before
     public void setUp() {
-        nearCacheConfig = getNearCacheConfig(inMemoryFormat, serializeKeys, invalidationOnChange, KEY_COUNT,
-                storeFile.getParent());
+        nearCacheConfig = getNearCacheConfig(DEFAULT_MEMORY_FORMAT, DEFAULT_SERIALIZE_KEYS,
+                DEFAULT_INVALIDATE_ON_CHANGE, KEY_COUNT, storeFile.getParent());
     }
 
     @After

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/AbstractClientMapTest.java
@@ -21,22 +21,22 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastTestSupport;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 @SuppressWarnings("WeakerAccess")
 public abstract class AbstractClientMapTest extends HazelcastTestSupport {
 
-    protected final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    protected static TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
-    protected HazelcastInstance client;
+    protected static HazelcastInstance client;
 
-    protected HazelcastInstance member1;
-    protected HazelcastInstance member2;
+    protected static HazelcastInstance member1;
+    protected static HazelcastInstance member2;
 
-    @Before
-    public final void startHazelcastInstances() {
-        Config config = getConfig();
+    @BeforeClass
+    public static final void startHazelcastInstances() {
+        Config config = regularInstanceConfig();
         ClientConfig clientConfig = getClientConfig();
 
         member1 = hazelcastFactory.newHazelcastInstance(config);
@@ -45,12 +45,12 @@ public abstract class AbstractClientMapTest extends HazelcastTestSupport {
         client = hazelcastFactory.newHazelcastClient(clientConfig);
     }
 
-    @After
-    public final void stopHazelcastInstances() {
+    @AfterClass
+    public static final void stopHazelcastInstances() {
         hazelcastFactory.terminateAll();
     }
 
-    protected ClientConfig getClientConfig() {
+    protected static ClientConfig getClientConfig() {
         return new ClientConfig();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryProcessorTest.java
@@ -35,6 +35,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
@@ -44,39 +45,58 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientEntryProcessorTest extends AbstractClientMapTest {
 
-    private static final String MAP_NAME = "default";
-
     @Test
     public void test_executeOnEntries_updatesValue_onOwnerAndBackupPartition() {
+        String mapName = "test_executeOnEntries_updatesValue_onOwnerAndBackupPartition";
+
         String member1Key = generateKeyOwnedBy(member1);
 
-        IMap<String, String> clientMap = client.getMap(MAP_NAME);
+        IMap<String, String> clientMap = client.getMap(mapName);
         clientMap.put(member1Key, "value");
 
         clientMap.executeOnEntries(new ValueUpdater("newValue"));
 
-        IMap<String, String> member1Map = member1.getMap(MAP_NAME);
-        String member1Value = member1Map.get(member1Key);
+        IMap<String, String> member1Map = member1.getMap(mapName);
 
-        member1.shutdown();
+        OwnerBackupValueCollector ep = new OwnerBackupValueCollector();
+        member1Map.executeOnKey(member1Key, ep);
 
-        IMap<String, String> member2Map = member2.getMap(MAP_NAME);
-        String member2Value = member2Map.get(member1Key);
+        ConcurrentLinkedQueue<String> values = OwnerBackupValueCollector.getValues();
+        assertEquals(2, values.size());
 
-        assertEquals("newValue", member1Value);
-        assertEquals("newValue", member2Value);
+        String value1 = values.poll();
+        String value2 = values.poll();
+
+        assertEquals(value1, value2);
+    }
+
+    public static class OwnerBackupValueCollector extends AbstractEntryProcessor<String, String> {
+
+        private static final ConcurrentLinkedQueue<String> values = new ConcurrentLinkedQueue<String>();
+
+        @Override
+        public Object process(Map.Entry<String, String> entry) {
+            values.add(entry.getValue());
+            return null;
+        }
+
+        public static ConcurrentLinkedQueue<String> getValues() {
+            return values;
+        }
     }
 
     @Test
     public void test_executeOnEntries_notUpdatesValue_with_FalsePredicate() {
+        String mapName = "test_executeOnEntries_notUpdatesValue_with_FalsePredicate";
+
         String member1Key = generateKeyOwnedBy(member1);
 
-        IMap<String, String> clientMap = client.getMap(MAP_NAME);
+        IMap<String, String> clientMap = client.getMap(mapName);
         clientMap.put(member1Key, "value");
 
         clientMap.executeOnEntries(new ValueUpdater("newValue"), FalsePredicate.INSTANCE);
 
-        IMap<String, String> member1Map = member1.getMap(MAP_NAME);
+        IMap<String, String> member1Map = member1.getMap(mapName);
         String member1Value = member1Map.get(member1Key);
 
         assertEquals("value", member1Value);
@@ -84,14 +104,16 @@ public class ClientEntryProcessorTest extends AbstractClientMapTest {
 
     @Test
     public void test_executeOnEntries_updatesValue_with_TruePredicate() {
+        String mapName = "test_executeOnEntries_updatesValue_with_TruePredicate";
+
         String member1Key = generateKeyOwnedBy(member1);
 
-        IMap<String, String> clientMap = client.getMap(MAP_NAME);
+        IMap<String, String> clientMap = client.getMap(mapName);
         clientMap.put(member1Key, "value");
 
         clientMap.executeOnEntries(new ValueUpdater("newValue"), TruePredicate.INSTANCE);
 
-        IMap<String, String> member1Map = member1.getMap(MAP_NAME);
+        IMap<String, String> member1Map = member1.getMap(mapName);
         String member1Value = member1Map.get(member1Key);
 
         assertEquals("newValue", member1Value);
@@ -99,7 +121,9 @@ public class ClientEntryProcessorTest extends AbstractClientMapTest {
 
     @Test
     public void test_executeOnEntriesWithPredicate_usesIndexes_whenIndexesAvailable() {
-        IMap<Integer, Integer> map = client.getMap("test");
+        String mapName = "test_executeOnEntriesWithPredicate_usesIndexes_whenIndexesAvailable";
+
+        IMap<Integer, Integer> map = client.getMap(mapName);
         map.addIndex("__key", true);
 
         for (int i = 0; i < 10; i++) {
@@ -114,9 +138,11 @@ public class ClientEntryProcessorTest extends AbstractClientMapTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void test_executeOnKey_readOnly_setValue() {
+        String mapName = "test_executeOnKey_readOnly_setValue";
+
         String member1Key = generateKeyOwnedBy(member1);
 
-        IMap<String, String> clientMap = client.getMap(MAP_NAME);
+        IMap<String, String> clientMap = client.getMap(mapName);
         clientMap.put(member1Key, "value");
 
         clientMap.executeOnKey(member1Key, new ValueUpdaterReadOnly("newValue"));

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicSlowTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(SlowTest.class)
+public class ClientMapNearCacheBasicSlowTest extends ClientMapNearCacheBasicTest {
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameter(value = 1)
+    public boolean serializeKeys;
+
+    @Parameterized.Parameters(name = "format:{0} serializeKeys:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, true},
+                {InMemoryFormat.BINARY, false},
+                {InMemoryFormat.OBJECT, true},
+                {InMemoryFormat.OBJECT, false},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys);
+    }
+
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.adapter.DataStructureAdapterMethod;
@@ -34,54 +33,32 @@ import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
-
-import java.util.Collection;
 
 import static com.hazelcast.client.map.impl.nearcache.ClientMapInvalidationListener.createInvalidationEventHandler;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_MEMORY_FORMAT;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_SERIALIZE_KEYS;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.map.impl.nearcache.MapNearCacheBasicTest.addMapStoreConfig;
-import static java.util.Arrays.asList;
 
 /**
  * Basic Near Cache tests for {@link IMap} on Hazelcast clients.
  */
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, String> {
 
-    @Parameter
-    public InMemoryFormat inMemoryFormat;
-
-    @Parameter(value = 1)
-    public boolean serializeKeys;
-
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-
-    @Parameters(name = "format:{0} serializeKeys:{1}")
-    public static Collection<Object[]> parameters() {
-        return asList(new Object[][]{
-                {InMemoryFormat.BINARY, true},
-                {InMemoryFormat.BINARY, false},
-                {InMemoryFormat.OBJECT, true},
-                {InMemoryFormat.OBJECT, false},
-        });
-    }
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys);
+        nearCacheConfig = createNearCacheConfig(DEFAULT_MEMORY_FORMAT, DEFAULT_SERIALIZE_KEYS);
     }
 
     @After

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderSlowTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(SlowTest.class)
+public class ClientMapNearCachePreloaderSlowTest extends ClientMapNearCachePreloaderTest {
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameter(value = 1)
+    public boolean invalidationOnChange;
+
+    @Parameterized.Parameter(value = 2)
+    public boolean serializeKeys;
+
+    @Parameterized.Parameters(name = "format:{0} invalidationOnChange:{1} serializeKeys:{2}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, false, true},
+                {InMemoryFormat.BINARY, false, false},
+                {InMemoryFormat.BINARY, true, true},
+                {InMemoryFormat.BINARY, true, false},
+
+                {InMemoryFormat.OBJECT, false, true},
+                {InMemoryFormat.OBJECT, false, false},
+                {InMemoryFormat.OBJECT, true, true},
+                {InMemoryFormat.OBJECT, true, false},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = getNearCacheConfig(inMemoryFormat, serializeKeys,
+                invalidationOnChange, KEY_COUNT, storeFile.getParent());
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.map.impl.nearcache;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
@@ -30,62 +29,34 @@ import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.File;
-import java.util.Collection;
 
 import static com.hazelcast.client.map.impl.nearcache.ClientMapInvalidationListener.createInvalidationEventHandler;
-import static java.util.Arrays.asList;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_INVALIDATE_ON_CHANGE;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_MEMORY_FORMAT;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_SERIALIZE_KEYS;
 
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientMapNearCachePreloaderTest extends AbstractNearCachePreloaderTest<Data, String> {
 
-    private final File storeFile = new File("nearCache-" + defaultNearCache + ".store").getAbsoluteFile();
-    private final File storeLockFile = new File(storeFile.getName() + ".lock").getAbsoluteFile();
-
-    @Parameters(name = "format:{0} invalidationOnChange:{1} serializeKeys:{2}")
-    public static Collection<Object[]> parameters() {
-        return asList(new Object[][]{
-                {InMemoryFormat.BINARY, false, true},
-                {InMemoryFormat.BINARY, false, false},
-                {InMemoryFormat.BINARY, true, true},
-                {InMemoryFormat.BINARY, true, false},
-
-                {InMemoryFormat.OBJECT, false, true},
-                {InMemoryFormat.OBJECT, false, false},
-                {InMemoryFormat.OBJECT, true, true},
-                {InMemoryFormat.OBJECT, true, false},
-        });
-    }
-
-    @Parameter
-    public InMemoryFormat inMemoryFormat;
-
-    @Parameter(value = 1)
-    public boolean invalidationOnChange;
-
-    @Parameter(value = 2)
-    public boolean serializeKeys;
+    protected final File storeFile = new File("nearCache-" + defaultNearCache + ".store").getAbsoluteFile();
+    protected final File storeLockFile = new File(storeFile.getName() + ".lock").getAbsoluteFile();
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
     @Before
     public void setUp() {
-        nearCacheConfig = getNearCacheConfig(inMemoryFormat, serializeKeys, invalidationOnChange, KEY_COUNT,
-                storeFile.getParent());
+        nearCacheConfig = getNearCacheConfig(DEFAULT_MEMORY_FORMAT, DEFAULT_SERIALIZE_KEYS,
+                DEFAULT_INVALIDATE_ON_CHANGE, KEY_COUNT, storeFile.getParent());
     }
 
     @After

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSlowTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED;
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(SlowTest.class)
+@SuppressWarnings("WeakerAccess")
+public class ClientMapNearCacheSlowTest extends ClientMapNearCacheTest {
+
+    @Parameterized.Parameter
+    public boolean batchInvalidationEnabled;
+
+    @Parameterized.Parameters(name = "batchInvalidationEnabled:{0}")
+    public static Iterable<Object[]> parameters() {
+        return asList(new Object[]{TRUE}, new Object[]{FALSE});
+    }
+
+    @Override
+    protected Config newConfig() {
+        return getConfig()
+                .setProperty(MAP_INVALIDATION_MESSAGE_BATCH_ENABLED.getName(), String.valueOf(batchInvalidationEnabled));
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheTest.java
@@ -37,7 +37,7 @@ import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -45,10 +45,6 @@ import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -60,30 +56,16 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED;
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-@SuppressWarnings("WeakerAccess")
 public class ClientMapNearCacheTest extends NearCacheTestSupport {
-
-    @Parameter
-    public boolean batchInvalidationEnabled;
-
-    @Parameters(name = "batchInvalidationEnabled:{0}")
-    public static Iterable<Object[]> parameters() {
-        return asList(new Object[]{TRUE}, new Object[]{FALSE});
-    }
 
     protected final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 
@@ -1277,8 +1259,7 @@ public class ClientMapNearCacheTest extends NearCacheTestSupport {
     }
 
     protected Config newConfig() {
-        return getConfig()
-                .setProperty(MAP_INVALIDATION_MESSAGE_BATCH_ENABLED.getName(), String.valueOf(batchInvalidationEnabled));
+        return getConfig();
     }
 
     protected NearCacheConfig newNoInvalidationNearCacheConfig() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/LiteMemberClientMapNearCacheBasicSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/LiteMemberClientMapNearCacheBasicSlowTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.nearcache;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(SlowTest.class)
+public class LiteMemberClientMapNearCacheBasicSlowTest extends LiteMemberClientMapNearCacheBasicTest {
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameter(value = 1)
+    public boolean serializeKeys;
+
+    @Parameterized.Parameters(name = "format:{0} serializeKeys:{1}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY, true},
+                {InMemoryFormat.BINARY, false},
+                {InMemoryFormat.OBJECT, true},
+                {InMemoryFormat.OBJECT, false},
+        });
+    }
+
+    @Before
+    public void setUp() {
+        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys);
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/LiteMemberClientMapNearCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/LiteMemberClientMapNearCacheBasicTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
@@ -35,56 +34,34 @@ import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
-import java.util.Collection;
-
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_MEMORY_FORMAT;
+import static com.hazelcast.config.NearCacheConfig.DEFAULT_SERIALIZE_KEYS;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
 import static com.hazelcast.map.impl.nearcache.MapInvalidationListener.createInvalidationEventHandler;
 import static com.hazelcast.map.impl.nearcache.MapNearCacheBasicTest.addMapStoreConfig;
-import static java.util.Arrays.asList;
 
 /**
  * Basic Near Cache tests for {@link IMap} on Hazelcast Lite members
  * with a Hazelcast client as {@link NearCacheTestContext#dataInstance}.
  */
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class LiteMemberClientMapNearCacheBasicTest extends AbstractNearCacheBasicTest<Data, String> {
 
-    @Parameter
-    public InMemoryFormat inMemoryFormat;
-
-    @Parameter(value = 1)
-    public boolean serializeKeys;
-
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
-
-    @Parameters(name = "format:{0} serializeKeys:{1}")
-    public static Collection<Object[]> parameters() {
-        return asList(new Object[][]{
-                {InMemoryFormat.BINARY, true},
-                {InMemoryFormat.BINARY, false},
-                {InMemoryFormat.OBJECT, true},
-                {InMemoryFormat.OBJECT, false},
-        });
-    }
 
     @Before
     public void setUp() {
-        nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys);
+        nearCacheConfig = createNearCacheConfig(DEFAULT_MEMORY_FORMAT, DEFAULT_SERIALIZE_KEYS);
     }
 
     @After

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -40,6 +40,21 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
     public static final InMemoryFormat DEFAULT_MEMORY_FORMAT = InMemoryFormat.BINARY;
 
     /**
+     * Do not serialize by default
+     */
+    public static final boolean DEFAULT_SERIALIZE_KEYS = false;
+
+    /**
+     * @see LocalUpdatePolicy#INVALIDATE
+     */
+    public static final boolean DEFAULT_INVALIDATE_ON_CHANGE = true;
+
+    /**
+     * @see LocalUpdatePolicy#INVALIDATE
+     */
+    public static final LocalUpdatePolicy DEFAULT_LOCAL_UPDATE_POLICY = LocalUpdatePolicy.INVALIDATE;
+
+    /**
      * Default value of the time to live in seconds.
      */
     public static final int DEFAULT_TTL_SECONDS = 0;
@@ -92,15 +107,15 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
 
     private String name = "default";
     private InMemoryFormat inMemoryFormat = DEFAULT_MEMORY_FORMAT;
-    private boolean serializeKeys;
-    private boolean invalidateOnChange = true;
+    private boolean serializeKeys = DEFAULT_SERIALIZE_KEYS;
+    private boolean invalidateOnChange = DEFAULT_INVALIDATE_ON_CHANGE;
     private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
     private int maxIdleSeconds = DEFAULT_MAX_IDLE_SECONDS;
     private int maxSize = EvictionConfig.DEFAULT_MAX_ENTRY_COUNT_FOR_ON_HEAP_MAP;
     private String evictionPolicy = EvictionConfig.DEFAULT_EVICTION_POLICY.name();
     private EvictionConfig evictionConfig = new EvictionConfig();
     private boolean cacheLocalEntries;
-    private LocalUpdatePolicy localUpdatePolicy = LocalUpdatePolicy.INVALIDATE;
+    private LocalUpdatePolicy localUpdatePolicy = DEFAULT_LOCAL_UPDATE_POLICY;
     private NearCachePreloaderConfig preloaderConfig = new NearCachePreloaderConfig();
 
     private NearCacheConfigReadOnly readOnly;
@@ -264,7 +279,7 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
 
     /**
      * Checks if the Near Cache key is stored in serialized format or by-reference.
-     * <p>
+     *
      * <b>NOTE:</b> When the in-memory-format is {@code NATIVE}, this method will always return {@code true}.
      *
      * @return {@code true} if the key is stored in serialized format or in-memory-format is {@code NATIVE},
@@ -276,7 +291,7 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
 
     /**
      * Sets if the Near Cache key is stored in serialized format or by-reference.
-     * <p>
+     *
      * <b>NOTE:</b> It's not supported to disable the key serialization when the in-memory-format is {@code NATIVE}.
      * You can still set this value to {@code false}, but it will have no effect.
      *
@@ -430,7 +445,7 @@ public class NearCacheConfig implements IdentifiedDataSerializable, Serializable
      * <li>{@code NONE} (no extra eviction, time-to-live-seconds or max-idle-seconds may still apply)</li>
      * <li>{@code RANDOM} (random entry)</li>
      * </ul>
-     *
+     * <p>
      * {@code LRU} is the default.
      * Regardless of the eviction policy used, time-to-live-seconds and max-idle-seconds will still apply.
      *


### PR DESCRIPTION
run quick near-cache tests with default config, move other parameterized ones to nightly category.
some speedups can be expected on ee and os builders with these changes

ee counterpart https://github.com/hazelcast/hazelcast-enterprise/pull/1962