### PR TITLE
Use RuntimeAvailableProcessors instead of pure Runtime.availableProce…

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -41,8 +41,8 @@ import com.hazelcast.core.Message;
 import com.hazelcast.core.MessageListener;
 import com.hazelcast.core.MultiMap;
 import com.hazelcast.core.Partition;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.util.Clock;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.BufferedReader;
@@ -560,7 +560,7 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
         long total = runtime.totalMemory();
         long free = runtime.freeMemory();
         println("Used Memory:" + ((total - free) / ONE_KB / ONE_KB) + "MB");
-        println("# procs: " + runtime.availableProcessors());
+        println("# procs: " + RuntimeAvailableProcessors.get());
         println("OS info: " + ManagementFactory.getOperatingSystemMXBean().getArch()
                 + ' ' + ManagementFactory.getOperatingSystemMXBean().getName() + ' '
                 + ManagementFactory.getOperatingSystemMXBean().getVersion());

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
@@ -25,6 +25,7 @@ import com.hazelcast.internal.management.dto.OperationServiceDTO;
 import com.hazelcast.internal.management.dto.PartitionServiceBeanDTO;
 import com.hazelcast.internal.management.dto.ProxyServiceDTO;
 import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.monitor.impl.MemberStateImpl;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.spi.EventService;
@@ -110,7 +111,7 @@ final class TimedMemberStateFactoryHelper {
         MemoryUsage nonHeapMemory = memoryMxBean.getNonHeapMemoryUsage();
         final int propertyCount = 29;
         Map<String, Long> map = createHashMap(propertyCount);
-        map.put("runtime.availableProcessors", Integer.valueOf(runtime.availableProcessors()).longValue());
+        map.put("runtime.availableProcessors", Integer.valueOf(RuntimeAvailableProcessors.get()).longValue());
         map.put("date.startTime", runtimeMxBean.getStartTime());
         map.put("seconds.upTime", runtimeMxBean.getUptime());
         map.put("memory.maxMemory", runtime.maxMemory());

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSet.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.metrics.metricsets;
 
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
@@ -84,7 +85,7 @@ public final class RuntimeMetricSet {
                 new LongProbeFunction<Runtime>() {
                     @Override
                     public long get(Runtime runtime) {
-                        return runtime.availableProcessors();
+                        return RuntimeAvailableProcessors.get();
                     }
                 }
         );

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheDestroyTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.core.DistributedObjectListener;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.internal.nearcache.impl.invalidation.Invalidation;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.test.AssertTask;
@@ -188,7 +189,7 @@ public class CacheDestroyTest extends CacheTestSupport {
         final Cache<Integer, Integer> cache = cacheManager.createCache(cacheName, cacheConfig);
 
         final CountDownLatch latch = new CountDownLatch(1);
-        int concurrency = Runtime.getRuntime().availableProcessors();
+        int concurrency = RuntimeAvailableProcessors.get();
         Future[] destroyFutures = new Future[concurrency];
 
         DestroyCacheTask destroyCacheTask = new DestroyCacheTask(cacheName, cacheManager, latch, cache);
@@ -212,7 +213,7 @@ public class CacheDestroyTest extends CacheTestSupport {
         final CacheConfig<Integer, Integer> cacheConfig = createCacheConfig();
 
         final CountDownLatch latch = new CountDownLatch(1);
-        int concurrency = Runtime.getRuntime().availableProcessors() * 4;
+        int concurrency = RuntimeAvailableProcessors.get() * 4;
         Future[] futures = new Future[concurrency];
 
         DestroyCacheTask destroyCacheTask = new DestroyCacheTask(cacheName, cacheManager, latch, null);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -111,7 +112,7 @@ public class JoinStressTest extends HazelcastTestSupport {
         final CountDownLatch latch = new CountDownLatch(nodeCount);
         final AtomicReferenceArray<HazelcastInstance> instances = new AtomicReferenceArray<HazelcastInstance>(nodeCount);
 
-        ExecutorService ex = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2);
+        ExecutorService ex = Executors.newFixedThreadPool(RuntimeAvailableProcessors.get() * 2);
         for (int i = 0; i < nodeCount; i++) {
             final int portSeed = i;
             ex.execute(new Runnable() {
@@ -175,7 +176,7 @@ public class JoinStressTest extends HazelcastTestSupport {
             groups.put("group-" + i, new AtomicInteger(0));
         }
 
-        ExecutorService ex = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() * 2);
+        ExecutorService ex = Executors.newFixedThreadPool(RuntimeAvailableProcessors.get() * 2);
         for (int i = 0; i < nodeCount; i++) {
             final int portSeed = i;
             ex.execute(new Runnable() {

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.util.CollectionUtil;
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -566,7 +567,7 @@ class ConfigCompatibilityChecker {
             }
             int max1 = c1.getMaxThreadSize();
             int max2 = c2.getMaxThreadSize();
-            int availableProcessors = Runtime.getRuntime().availableProcessors();
+            int availableProcessors = RuntimeAvailableProcessors.get();
             return nullSafeEqual(c1.getName(), c2.getName())
                     && (nullSafeEqual(max1, max2) || (Math.min(max1, max2) == 0 && Math.max(max1, max2) == availableProcessors))
                     && nullSafeEqual(c1.getRetryCount(), c2.getRetryCount())

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.metrics.metricsets;
 import com.hazelcast.internal.metrics.LongGauge;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -106,7 +107,7 @@ public class RuntimeMetricSetTest extends HazelcastTestSupport {
     @Test
     public void availableProcessors() {
         LongGauge gauge = metricsRegistry.newLongGauge("runtime.availableProcessors");
-        assertEquals(runtime.availableProcessors(), gauge.read());
+        assertEquals(RuntimeAvailableProcessors.get(), gauge.read());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableBouncingNodesTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.Offloadable;
 import com.hazelcast.core.ReadOnly;
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
@@ -43,7 +44,7 @@ public class EntryProcessorOffloadableBouncingNodesTest extends HazelcastTestSup
 
     public static final String MAP_NAME = "EntryProcessorOffloadableTest";
     public static final int COUNT_ENTRIES = 1000;
-    private static final int CONCURRENCY = Runtime.getRuntime().availableProcessors();
+    private static final int CONCURRENCY = RuntimeAvailableProcessors.get();
 
     @Rule
     public BounceMemberRule bounceMemberRule = BounceMemberRule.with(getBouncingTestConfig()).build();

--- a/hazelcast/src/test/java/com/hazelcast/util/ContextMutexFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ContextMutexFactoryTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.util;
 
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -52,7 +53,7 @@ public class ContextMutexFactoryTest {
         final String[] keys = new String[]{"a", "b", "c"};
         final Map<String, Integer> timesAcquired = new HashMap<String, Integer>();
 
-        int concurrency = Runtime.getRuntime().availableProcessors() * 3;
+        int concurrency = RuntimeAvailableProcessors.get() * 3;
         final CyclicBarrier cyc = new CyclicBarrier(concurrency + 1);
 
         for (int i = 0; i < concurrency; i++) {


### PR DESCRIPTION
…ssors()

Direct access to available processors makes it impossible to test being stable when switching environments that have different number of cores. We should (almost) always use indirect approach via RuntimeAvailableProcessors.

This PR replaces all the occurrences of pure Runtime.availableProcessors with 4 exceptions, where I think it makes sense:
* RuntimeAvailableProcessors and RuntimeAvailableProcessorsTest - trivially
* MapReduceParallelRunnerOptions and HazelcastParallelClassRunner - I believe that we want to base the number of parallel threads running the tests to reflect the real number of cores.

This change is a prerequisite for fixing some test failures in EE, but I also believe it will fix enable to fix the https://github.com/hazelcast/hazelcast/issues/3888 . 