### PR TITLE
Improve logging around cluster joining

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -192,13 +192,19 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         try {
             MemberImpl member = getMember(address);
             if (member == null) {
-                logger.fine("Cannot suspect " + address + ", since it's not a member.");
+                if (logger.isFineEnabled()) {
+                    logger.fine("Cannot suspect " + address + ", since it's not a member.");
+                }
+
                 return;
             }
 
             Connection conn = node.getConnectionManager().getConnection(address);
             if (conn != null && conn.isAlive()) {
-                logger.fine("Cannot suspect " + member + ", since there's a live connection -> " + conn);
+                if (logger.isFineEnabled()) {
+                    logger.fine("Cannot suspect " + member + ", since there's a live connection -> " + conn);
+                }
+
                 return;
             }
             suspectMember(member, "No connection", false);
@@ -215,7 +221,10 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         }
 
         if (!isJoined()) {
-            logger.fine("Cannot send explicit suspicion, not joined yet!");
+            if (logger.isFineEnabled()) {
+                logger.fine("Cannot send explicit suspicion, not joined yet!");
+            }
+
             return;
         }
 
@@ -284,8 +293,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
         for (MemberImpl member : memberMap.headMemberSet(candidate, false)) {
             if (!membershipManager.isMemberSuspected(member.getAddress())) {
-                logger.fine("Should not accept mastership claim of " + candidate + ", because " + member
-                        + " is not suspected at the moment and is before than " + candidate + " in the member list.");
+                if (logger.isFineEnabled()) {
+                    logger.fine("Should not accept mastership claim of " + candidate + ", because " + member
+                            + " is not suspected at the moment and is before than " + candidate + " in the member list.");
+                }
+
                 return false;
             }
         }
@@ -490,8 +502,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     private boolean shouldProcessMemberUpdate(MembersView membersView) {
         int memberListVersion = membershipManager.getMemberListVersion();
         if (memberListVersion > membersView.getVersion()) {
-            logger.fine("Received an older member update, ignoring... Current version: "
-                    + memberListVersion + ", Received version: " + membersView.getVersion());
+            if (logger.isFineEnabled()) {
+                logger.fine("Received an older member update, ignoring... Current version: "
+                        + memberListVersion + ", Received version: " + membersView.getVersion());
+            }
+
             return false;
         }
 
@@ -507,7 +522,10 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                         + " Current: " + memberMap.toMembersView() + ", New: " + membersView;
             }
 
-            logger.fine("Received a periodic member update, ignoring... Version: " + memberListVersion);
+            if (logger.isFineEnabled()) {
+                logger.fine("Received a periodic member update, ignoring... Version: " + memberListVersion);
+            }
+
             return false;
         }
 
@@ -658,7 +676,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
                 if (!currentMasterAddress.equals(master)) {
                     logger.warning("Cannot set master address to " + master
                             + " because node is already joined! Current master: " + currentMasterAddress);
-                } else {
+                } else if (logger.isFineEnabled()) {
                     logger.fine("Master address is already set to " + master);
                 }
                 return false;
@@ -821,23 +839,8 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         return sb.toString();
     }
 
-    private String memberListString() {
-        MemberMap memberMap = membershipManager.getMemberMap();
-        Collection<MemberImpl> members = memberMap.getMembers();
-        StringBuilder sb = new StringBuilder("\n\nMembers {")
-                .append("size:").append(members.size()).append(", ")
-                .append("ver:").append(memberMap.getVersion())
-                .append("} [");
-
-        for (Member member : members) {
-            sb.append("\n\t").append(member);
-        }
-        sb.append("\n]\n");
-        return sb.toString();
-    }
-
     public String getMemberListString() {
-        return useLegacyMemberListFormat ? legacyMemberListString() : memberListString();
+        return useLegacyMemberListFormat ? legacyMemberListString() : membershipManager.memberListString();
     }
 
     void printMemberList() {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/JoinStressTest.java
@@ -26,6 +26,9 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.internal.util.RuntimeAvailableProcessors;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -65,6 +68,7 @@ import static org.junit.Assert.assertNotNull;
 public class JoinStressTest extends HazelcastTestSupport {
 
     private static final long TEN_MINUTES_IN_MILLIS = 10 * 60 * 1000L;
+    private ILogger logger = Logger.getLogger(JoinStressTest.class);
 
     @Before
     @After
@@ -138,6 +142,7 @@ public class JoinStressTest extends HazelcastTestSupport {
         for (int i = 0; i < nodeCount; i++) {
             HazelcastInstance hz = instances.get(i);
             assertNotNull(hz);
+            logEvaluatedMember(hz);
             assertClusterSizeEventually(nodeCount, hz);
         }
     }
@@ -206,6 +211,7 @@ public class JoinStressTest extends HazelcastTestSupport {
         for (int i = 0; i < nodeCount; i++) {
             HazelcastInstance hz = instances.get(i);
             assertNotNull(hz);
+            logEvaluatedMember(hz);
 
             final int clusterSize = hz.getCluster().getMembers().size();
             final String groupName = hz.getConfig().getGroupConfig().getName();
@@ -218,6 +224,12 @@ public class JoinStressTest extends HazelcastTestSupport {
                 }
             });
         }
+    }
+
+    private void logEvaluatedMember(HazelcastInstance hz) {
+        ClusterServiceImpl instanceClusterService = getNode(hz).getClusterService();
+        logger.info("Evaluating member: " + hz + " " + hz.getLocalEndpoint().getSocketAddress() + " with memberList "
+                + instanceClusterService.getMemberListString());
     }
 
     private void initNetworkConfig(NetworkConfig networkConfig, int basePort, int portSeed, boolean multicast, int nodeCount) {


### PR DESCRIPTION
Prod code logging changes:
- Log at fine level when master sends member list to non-master nodes
- Guard fine level logging in the touched classes with isFineEnabled() checks

Test code logging change:
- Log the evaluated member and its member view in JoinStressTest to ease test-failure investigations.

Related issue: #3888