### PR TITLE
Make LockMBeanTest resilient against hiccups

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/LockMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/LockMBeanTest.java
@@ -62,8 +62,8 @@ public class LockMBeanTest extends HazelcastTestSupport {
 
     @Test
     public void testLockCountIsTwo_whenLockedTwice() throws Exception {
-        lock.lock(1000, TimeUnit.MILLISECONDS);
-        lock.lock(1000, TimeUnit.MILLISECONDS);
+        lock.lock(10000, TimeUnit.MILLISECONDS);
+        lock.lock(10000, TimeUnit.MILLISECONDS);
 
         // check number of times locked (locked twice now)
         int lockCount = getIntegerAttribute("lockCount");


### PR DESCRIPTION
In `LockMBeanTest#testLockCountIsTwo_whenLockedTwice` there is a chance that between the two lock requests the test experiences a >leaseTime(originally 1s) hiccup, which makes the first lock's ownership to expire, resulting lockCount=1 instead of the expected 2.
By inserting a `sleep(>1s)` between the two lock requests this failure is always reproducible.
Raising the lease time to 10000ms makes the test resilient against hiccups up to 10s.
    
Fixes #12530 
