### PR TITLE
Fixes compatibility issue in MapReplicationStateHolder

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -62,8 +62,8 @@ import java.util.concurrent.locks.Lock;
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.internal.cluster.impl.MemberMap.SINGLETON_MEMBER_LIST_VERSION;
 import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.CANNOT_MERGE;
-import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.REMOTE_NODE_SHOULD_MERGE;
 import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.LOCAL_NODE_SHOULD_MERGE;
+import static com.hazelcast.internal.cluster.impl.SplitBrainJoinMessage.SplitBrainMergeCheckResult.REMOTE_NODE_SHOULD_MERGE;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.lang.String.format;
 
@@ -656,7 +656,7 @@ public class ClusterJoinManager {
                         clusterClock.getClusterStartTime(), clusterStateManager.getState(),
                         clusterService.getClusterVersion(), partitionRuntimeState, false);
                 op.setCallerUuid(clusterService.getThisUuid());
-                nodeEngine.getOperationService().send(op, target);
+                invokeClusterOp(op, target);
             }
             return true;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
@@ -30,6 +30,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.version.Version;
 
@@ -41,7 +42,7 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createEmpty
 /**
  * Sent by the master to all members to finalize the join operation from a joining/returning node.
  */
-public class FinalizeJoinOp extends MembersUpdateOp {
+public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
     /**
      * Operations to be executed before node is marked as joined.
      * @see com.hazelcast.spi.PreJoinAwareService
@@ -203,6 +204,12 @@ public class FinalizeJoinOp extends MembersUpdateOp {
     @Override
     public int getId() {
         return ClusterDataSerializerHook.FINALIZE_JOIN;
+    }
+
+    @Override
+    public void setTarget(Address address) {
+        preJoinOp.setTarget(address);
+        postJoinOp.setTarget(address);
     }
 }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.NodeEngine;
@@ -24,6 +25,7 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.UrgentSystemOperation;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -33,7 +35,7 @@ import static com.hazelcast.util.Preconditions.checkNegative;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public class OnJoinOp
-        extends AbstractJoinOperation implements UrgentSystemOperation {
+        extends AbstractJoinOperation implements UrgentSystemOperation, TargetAware {
 
     private Operation[] operations;
 
@@ -134,5 +136,14 @@ public class OnJoinOp
     @Override
     public int getId() {
         return ClusterDataSerializerHook.POST_JOIN;
+    }
+
+    @Override
+    public void setTarget(Address address) {
+        for (Operation op : operations) {
+            if (op instanceof TargetAware) {
+                ((TargetAware) op).setTarget(address);
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ReplicaFragmentMigrationState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ReplicaFragmentMigrationState.java
@@ -17,11 +17,13 @@
 package com.hazelcast.internal.partition;
 
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ServiceNamespace;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,7 +36,7 @@ import java.util.Map;
  *
  * @since 3.9
  */
-public class ReplicaFragmentMigrationState implements IdentifiedDataSerializable {
+public class ReplicaFragmentMigrationState implements IdentifiedDataSerializable, TargetAware {
 
     private Map<ServiceNamespace, long[]> namespaces;
 
@@ -97,4 +99,12 @@ public class ReplicaFragmentMigrationState implements IdentifiedDataSerializable
         }
     }
 
+    @Override
+    public void setTarget(Address address) {
+        for (Operation op : migrationOperations) {
+            if (op instanceof TargetAware) {
+                ((TargetAware) op).setTarget(address);
+            }
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -22,11 +22,13 @@ import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.internal.partition.impl.PartitionReplicaManager;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ServiceNamespace;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -41,7 +43,7 @@ import java.util.Map.Entry;
  * Sent by the partition owner to the migration destination to start the migration process on the destination.
  * Contains the operations which will be executed on the destination node to migrate the data and the replica versions to be set.
  */
-public class MigrationOperation extends BaseMigrationDestinationOperation {
+public class MigrationOperation extends BaseMigrationDestinationOperation implements TargetAware {
 
     private ReplicaFragmentMigrationState fragmentMigrationState;
 
@@ -203,4 +205,8 @@ public class MigrationOperation extends BaseMigrationDestinationOperation {
         lastFragment = in.readBoolean();
     }
 
+    @Override
+    public void setTarget(Address address) {
+        fragmentMigrationState.setTarget(address);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/AbstractMapServiceFactory.java
@@ -191,6 +191,8 @@ abstract class AbstractMapServiceFactory implements MapServiceFactory {
         mapService.partitionAwareService = partitionAwareService;
         mapService.quorumAwareService = quorumAwareService;
         mapService.clientAwareService = clientAwareService;
+        // RU_COMPAT_3_9
+        mapService.mapIndexSynchronizer = new MapIndexSynchronizer(mapServiceContext, nodeEngine);
         mapServiceContext.setService(mapService);
         return mapService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapIndexSynchronizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapIndexSynchronizer.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.map.impl.operation.SynchronizeIndexesForPartitionTask;
+import com.hazelcast.query.impl.IndexInfo;
+import com.hazelcast.query.impl.MapIndexInfo;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.version.Version;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+// RU_COMPAT_V3_9
+
+/**
+ * This class is responsible for tracking cluster version changes and synchronizes indexes if needed.
+ * The synchronization will happen only on 3.9 to 3.10 cluster version change.
+ *
+ * It is a last-chance anti-entropy that guards the situation where the index definitions arrive after the map data.
+ * In this case the MapContainer.indexesToAdd indexes will be send to each partition and the indexes will be populated.
+ *
+ * IMPORTANT: The synchronization applies to runtime partitioned indexes only.
+ * It is impossible to apply this fix for global indexes due to the their global nature.
+ * It would require re-adding all data, since you don't know if the data from this partition has been added
+ * to the index just by checking if the index exists or not.
+ *
+ * @see com.hazelcast.map.impl.operation.SynchronizeIndexesForPartitionTask
+ * @see com.hazelcast.map.impl.operation.PostJoinMapOperation
+ * @see com.hazelcast.map.impl.operation.MapReplicationStateHolder
+ */
+class MapIndexSynchronizer {
+
+    protected MapServiceContext mapServiceContext;
+    protected OperationService operationService;
+    protected SerializationService serializationService;
+    protected NodeEngine nodeEngine;
+
+    private ILogger logger;
+    private Version currentVersion;
+
+    public MapIndexSynchronizer(MapServiceContext mapServiceContext, NodeEngine nodeEngine) {
+        this.mapServiceContext = mapServiceContext;
+        this.operationService = nodeEngine.getOperationService();
+        this.serializationService = nodeEngine.getSerializationService();
+        this.nodeEngine = nodeEngine;
+        this.logger = nodeEngine.getLogger(getClass());
+    }
+
+    public void onClusterVersionChange(Version newVersion) {
+        if (isV39toV310transition(newVersion)) {
+            synchronizeIndexes();
+        }
+        currentVersion = newVersion;
+    }
+
+    private void synchronizeIndexes() {
+        logger.info("Running MapIndexSynchronizer");
+        List<MapIndexInfo> mapIndexInfos = getIndexesToSynchronize();
+        if (!mapIndexInfos.isEmpty()) {
+            executeIndexSync(mapIndexInfos);
+        }
+    }
+
+    private List<MapIndexInfo> getIndexesToSynchronize() {
+        List<MapIndexInfo> mapIndexInfos = new ArrayList<MapIndexInfo>();
+        for (Map.Entry<String, MapContainer> entry : mapServiceContext.getMapContainers().entrySet()) {
+            MapContainer mapContainer = entry.getValue();
+            int indexesToSynchronize = mapContainer.getPartitionIndexesToAdd().size();
+            if (indexesToSynchronize > 0) {
+                String mapName = entry.getKey();
+                logger.info("Scheduling " + indexesToSynchronize + " indexes sync for map " + mapName);
+                MapIndexInfo mapIndexInfo = new MapIndexInfo(mapName);
+                for (IndexInfo indexInfo : mapContainer.getPartitionIndexesToAdd()) {
+                    mapIndexInfo.addIndexInfo(indexInfo.getAttributeName(), indexInfo.isOrdered());
+                }
+                mapIndexInfos.add(mapIndexInfo);
+            }
+            mapContainer.clearPartitionIndexesToAdd();
+        }
+        return mapIndexInfos;
+    }
+
+    private void executeIndexSync(List<MapIndexInfo> mapIndexInfos) {
+        OperationServiceImpl operationServiceImpl = (OperationServiceImpl) operationService;
+        for (int partitionId : mapServiceContext.getOwnedPartitions()) {
+            SynchronizeIndexesForPartitionTask task = new SynchronizeIndexesForPartitionTask(partitionId, mapIndexInfos,
+                    mapServiceContext.getService(), serializationService,
+                    (InternalPartitionService) nodeEngine.getPartitionService());
+            operationServiceImpl.execute(task);
+        }
+    }
+
+    private boolean isV39toV310transition(Version newVersion) {
+        return currentVersion != null && currentVersion.equals(Versions.V3_9) && newVersion.equals(Versions.V3_10);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapPostJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapPostJoinAwareService.java
@@ -40,14 +40,16 @@ class MapPostJoinAwareService implements PostJoinAwareService {
 
     @Override
     public Operation getPostJoinOperation() {
-        PostJoinMapOperation o = new PostJoinMapOperation();
+        PostJoinMapOperation postJoinOp = new PostJoinMapOperation();
         final Map<String, MapContainer> mapContainers = mapServiceContext.getMapContainers();
         for (MapContainer mapContainer : mapContainers.values()) {
-            o.addMapInterceptors(mapContainer);
+            postJoinOp.addMapIndex(mapServiceContext, mapContainer);
+            postJoinOp.addMapInterceptors(mapContainer);
         }
         List<AccumulatorInfo> infoList = getAccumulatorInfoList();
-        o.setInfoList(infoList);
-        return o;
+        postJoinOp.setInfoList(infoList);
+        postJoinOp.setNodeEngine(mapServiceContext.getNodeEngine());
+        return postJoinOp;
     }
 
     private List<AccumulatorInfo> getAccumulatorInfoList() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.internal.cluster.ClusterStateListener;
+import com.hazelcast.internal.cluster.ClusterVersionListener;
 import com.hazelcast.map.impl.event.MapEventPublishingService;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.spi.ClientAwareService;
@@ -47,6 +48,7 @@ import com.hazelcast.spi.impl.CountingMigrationAwareService;
 import com.hazelcast.spi.partition.IPartitionLostEvent;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.Transaction;
+import com.hazelcast.version.Version;
 import com.hazelcast.wan.WanReplicationEvent;
 
 import java.util.Collection;
@@ -75,7 +77,8 @@ import static com.hazelcast.core.EntryEventType.INVALIDATION;
 public class MapService implements ManagedService, FragmentedMigrationAwareService,
         TransactionalService, RemoteService, EventPublishingService<Object, ListenerAdapter>,
         PostJoinAwareService, SplitBrainHandlerService, ReplicationSupportingService, StatisticsAwareService<LocalMapStats>,
-        PartitionAwareService, ClientAwareService, QuorumAwareService, NotifiableEventListener, ClusterStateListener {
+        PartitionAwareService, ClientAwareService, QuorumAwareService, NotifiableEventListener, ClusterStateListener,
+        ClusterVersionListener {
 
     public static final String SERVICE_NAME = "hz:impl:mapService";
 
@@ -92,6 +95,8 @@ public class MapService implements ManagedService, FragmentedMigrationAwareServi
     protected ClientAwareService clientAwareService;
     protected MapQuorumAwareService quorumAwareService;
     protected MapServiceContext mapServiceContext;
+    // RU_COMPAT_V3_9
+    protected MapIndexSynchronizer mapIndexSynchronizer;
 
     public MapService() {
     }
@@ -245,6 +250,13 @@ public class MapService implements ManagedService, FragmentedMigrationAwareServi
     @Override
     public void onClusterStateChange(ClusterState newState) {
         mapServiceContext.onClusterStateChange(newState);
+    }
+
+    @Override
+    // RU_COMPAT_V3_9
+    // We wont need to sync the indexes in 3.10+ clusters.
+    public void onClusterVersionChange(Version newVersion) {
+        mapIndexSynchronizer.onClusterVersionChange(newVersion);
     }
 
     public static ObjectNamespace getObjectNamespace(String mapName) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -24,12 +24,15 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.map.impl.record.RecordReplicationInfo;
 import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ServiceNamespace;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
@@ -40,7 +43,7 @@ import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
 /**
  * Replicates all IMap-states of this partition to a replica partition.
  */
-public class MapReplicationOperation extends Operation implements IdentifiedDataSerializable {
+public class MapReplicationOperation extends Operation implements IdentifiedDataSerializable, Versioned, TargetAware {
 
     // keep these fields `protected`, extended in another context.
     protected final MapReplicationStateHolder mapReplicationStateHolder = new MapReplicationStateHolder(this);
@@ -115,5 +118,10 @@ public class MapReplicationOperation extends Operation implements IdentifiedData
     @Override
     public int getId() {
         return MapDataSerializerHook.MAP_REPLICATION;
+    }
+
+    @Override
+    public void setTarget(Address address) {
+        mapReplicationStateHolder.setTarget(address);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -17,12 +17,15 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.Member;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordReplicationInfo;
 import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -35,9 +38,11 @@ import com.hazelcast.query.impl.MapIndexInfo;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.ServiceNamespace;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ThreadUtil;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,6 +53,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.instance.BuildInfoProvider.getBuildInfo;
+import static com.hazelcast.internal.cluster.Versions.V3_10;
+import static com.hazelcast.internal.cluster.Versions.V3_9;
 import static com.hazelcast.map.impl.record.Records.applyRecordInfo;
 import static com.hazelcast.map.impl.record.Records.getValueOrCachedValue;
 import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
@@ -57,7 +65,19 @@ import static com.hazelcast.util.MapUtil.createHashMap;
  * Holder for raw IMap key-value pairs and their metadata.
  */
 // keep this `protected`, extended in another context.
-public class MapReplicationStateHolder implements IdentifiedDataSerializable, Versioned {
+public class MapReplicationStateHolder implements IdentifiedDataSerializable, Versioned, TargetAware {
+
+    // RU_COMPAT_3_9
+    // When cluster version is 3.9, 3.9 EE members:
+    //    Never write index info
+    //    Don't read index info when coming from 3.9 member
+    //    Read index info when coming from 3.10
+    // When cluster version is 3.9, 3.10 EE members:
+    //    Write index info when target is 3.9
+    //    Don't write index info when target member is 3.10
+    //    Never read index info
+    // When cluster version is 3.10:
+    //    Always read and write index info
 
     // holds recordStore-references of this partitions' maps
     protected transient Map<String, RecordStore<Record>> storesByMapName;
@@ -75,6 +95,8 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
     // on order of execution, so it was possible that the post-join operations were executed after some map-replication
     // operations, which meant that the index did not include some data.
     protected transient List<MapIndexInfo> mapIndexInfos;
+
+    private transient Address target;
 
     private MapReplicationOperation operation;
 
@@ -136,9 +158,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
     void applyState() {
         ThreadUtil.assertRunningOnPartitionThread();
 
-        for (MapIndexInfo mapIndexInfo : mapIndexInfos) {
-            addIndexes(mapIndexInfo.getMapName(), mapIndexInfo.getIndexInfos());
-        }
+        applyIndexesState();
 
         if (data != null) {
             for (Map.Entry<String, Collection<RecordReplicationInfo>> dataEntry : data.entrySet()) {
@@ -184,6 +204,24 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
                     recordStore.disposeDeferredBlocks();
                 }
             }
+        }
+    }
+
+    private void applyIndexesState() {
+        if (mapIndexInfos != null) {
+            for (MapIndexInfo mapIndexInfo : mapIndexInfos) {
+                addIndexes(mapIndexInfo.getMapName(), mapIndexInfo.getIndexInfos());
+            }
+        }
+
+        // RU_COMPAT_3_9
+        // Old nodes (3.9-) won't send mapIndexInfos to new nodes (3.9+) in the map-replication operation.
+        // This is the reason why we pick up the mapContainer.getIndexesToAdd() that were added by the PostJoinMapOperation
+        // and we add them to the map, before we add data
+        for (String mapName : data.keySet()) {
+            RecordStore recordStore = operation.getRecordStore(mapName);
+            MapContainer mapContainer = recordStore.getMapContainer();
+            addIndexes(mapName, mapContainer.getPartitionIndexesToAdd());
         }
     }
 
@@ -237,9 +275,12 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
             out.writeBoolean(loadedEntry.getValue());
         }
 
-        out.writeInt(mapIndexInfos.size());
-        for (MapIndexInfo mapIndexInfo : mapIndexInfos) {
-            out.writeObject(mapIndexInfo);
+        // RU_COMPAT_3_9
+        if (mustWriteIndexInfos(out.getVersion())) {
+            out.writeInt(mapIndexInfos.size());
+            for (MapIndexInfo mapIndexInfo : mapIndexInfos) {
+                out.writeObject(mapIndexInfo);
+            }
         }
     }
 
@@ -270,11 +311,14 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
             loaded.put(in.readUTF(), in.readBoolean());
         }
 
-        int mapIndexInfosSize = in.readInt();
-        mapIndexInfos = new ArrayList<MapIndexInfo>(mapIndexInfosSize);
-        for (int i = 0; i < mapIndexInfosSize; i++) {
-            MapIndexInfo mapIndexInfo = in.readObject();
-            mapIndexInfos.add(mapIndexInfo);
+        // RU_COMPAT_3_9
+        if (mustReadMapIndexInfos(in.getVersion())) {
+            int mapIndexInfosSize = in.readInt();
+            mapIndexInfos = new ArrayList<MapIndexInfo>(mapIndexInfosSize);
+            for (int i = 0; i < mapIndexInfosSize; i++) {
+                MapIndexInfo mapIndexInfo = in.readObject();
+                mapIndexInfos.add(mapIndexInfo);
+            }
         }
     }
 
@@ -286,6 +330,35 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
     @Override
     public int getId() {
         return MapDataSerializerHook.MAP_REPLICATION_STATE_HOLDER;
+    }
+
+    @Override
+    public void setTarget(Address address) {
+        this.target = address;
+    }
+
+    private boolean mustWriteIndexInfos(Version clusterVersion) {
+        // 3.10 OS always writes mapIndexInfos
+        // 3.10 EE on cluster version 3.10 must write index info
+        if (!getBuildInfo().isEnterprise() || clusterVersion.isGreaterOrEqual(V3_10)) {
+            return true;
+        }
+
+        ClusterService clusterService = operation.getNodeEngine().getClusterService();
+        Member targetMember = clusterService.getMember(target);
+        // When cluster version is 3.9, only write mapIndexInfo if target member is 3.9 EE. Reasoning:
+        // 3.9 EE expects to read mapIndexInfos when object data input comes with 3.9+ version. This is
+        // the case when the object stream originates from a versioned 3.10 member.
+        return targetMember.getVersion().asVersion().isEqualTo(V3_9) && clusterVersion.isEqualTo(V3_9);
+    }
+
+    private boolean mustReadMapIndexInfos(Version version) {
+        // 3.10 OS always reads mapIndexInfos
+        // 3.10 EE always read mapIndexInfos when cluster version >= 3.10
+        // When cluster version is 3.9:
+        //  - an object input from 3.9 EE does not contain mapIndexInfo and arrives with UNKNOWN version
+        //  - an object input from 3.10 EE comes with version 3.9 and contains mapIndexInfo
+        return !getBuildInfo().isEnterprise() || version.isGreaterOrEqual(V3_10);
     }
 
     private static boolean indexesMustBePopulated(Indexes indexes, MapReplicationOperation operation) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -17,6 +17,8 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.IMapEvent;
+import com.hazelcast.core.Member;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.impl.InterceptorRegistry;
 import com.hazelcast.map.impl.ListenerAdapter;
@@ -24,36 +26,59 @@ import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.PartitionContainer;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.impl.querycache.accumulator.AccumulatorInfo;
 import com.hazelcast.map.impl.querycache.accumulator.AccumulatorInfoSupplier;
 import com.hazelcast.map.impl.querycache.publisher.MapPublisherRegistry;
 import com.hazelcast.map.impl.querycache.publisher.PublisherContext;
 import com.hazelcast.map.impl.querycache.publisher.PublisherRegistry;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.impl.Versioned;
+import com.hazelcast.query.impl.Index;
+import com.hazelcast.query.impl.IndexInfo;
+import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.MapIndexInfo;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.hazelcast.instance.BuildInfoProvider.getBuildInfo;
+import static com.hazelcast.internal.cluster.Versions.V3_10;
 import static com.hazelcast.internal.cluster.Versions.V3_9;
 import static com.hazelcast.util.MapUtil.createHashMap;
 
-public class PostJoinMapOperation extends Operation implements IdentifiedDataSerializable, Versioned {
+public class PostJoinMapOperation extends Operation implements IdentifiedDataSerializable, Versioned, TargetAware {
 
+    // RU_COMPAT_3_9
+    // When cluster version is 3.9, 3.9 members:
+    //    Always write index info
+    //    Read index info when coming from 3.9 member
+    //    Don't read index info when coming from 3.10 member
+    // When cluster version is 3.9, 3.10 members:
+    //    Don't write index info when target member is 3.9
+    //    Write index info when target member is 3.10
+    //    Always read index info
+    // When cluster version is 3.10:
+    //    Never read or write index info
+    private List<MapIndexInfo> indexInfoList = new LinkedList<MapIndexInfo>();
     private List<InterceptorInfo> interceptorInfoList = new LinkedList<InterceptorInfo>();
     private List<AccumulatorInfo> infoList;
+    // used on sending side to determine member version of target
+    private transient Address target;
 
     @Override
     public String getServiceName() {
@@ -127,6 +152,32 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
     public void run() throws Exception {
         MapService mapService = getService();
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+
+        // RU_COMPAT_3_9
+        // Can be removed in 3.11, since the indexes will be populated in the MapReplicationOperation
+        if (indexInfoList != null) {
+            for (MapIndexInfo mapIndex : indexInfoList) {
+                MapContainer mapContainer = mapServiceContext.getMapContainer(mapIndex.getMapName());
+                for (IndexInfo indexInfo : mapIndex.getIndexInfos()) {
+                    if (mapContainer.isGlobalIndexEnabled()) {
+                        // GLOBAL-INDEX
+                        // we may add the index directly, since it's a global non-HD index, so adding it on a non-partition
+                        // thread is a no issue.
+                        Indexes indexes = mapContainer.getIndexes();
+                        indexes.addOrGetIndex(indexInfo.getAttributeName(), indexInfo.isOrdered());
+                    } else {
+                        // PARTITIONED-INDEX
+                        // Each partition thread is responsible for managing the lifecycle of a partitioned-index, thus
+                        // we can't add an index here directly (also partitioned-index is used in HD only for now, and
+                        // we are not allowed to touch HD memory on a non-partition thread).
+                        // That is the reason why we gather all the dynamic post-join index infos for a map in the
+                        // map-container. Later on they are picked up by the MapReplicationOperation which is spawned
+                        // for each migrated partition, and the index is added by it for each partition.
+                        mapContainer.addPartitionIndexToAdd(indexInfo);
+                    }
+                }
+            }
+        }
         for (InterceptorInfo interceptorInfo : interceptorInfoList) {
             final MapContainer mapContainer = mapServiceContext.getMapContainer(interceptorInfo.mapName);
             InterceptorRegistry interceptorRegistry = mapContainer.getInterceptorRegistry();
@@ -176,6 +227,13 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
+        if (mustWriteIndexInfos(out.getVersion())) {
+            out.writeInt(indexInfoList.size());
+            for (MapIndexInfo mapIndex : indexInfoList) {
+                mapIndex.writeData(out);
+            }
+        }
+
         out.writeInt(interceptorInfoList.size());
         for (InterceptorInfo interceptorInfo : interceptorInfoList) {
             interceptorInfo.writeData(out);
@@ -191,14 +249,15 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         // RU_COMPAT_39
-        // Version 3.9.x still sends index info's from EE because PostJoinMapOperation was not marked Versioned
         Version inputversion = in.getVersion();
-        if ((inputversion.isUnknown() || inputversion.isEqualTo(V3_9)) && getBuildInfo().isEnterprise()) {
-            // just consume the bytes
+        // read index info when object input comes from 3.9 EE (version UNKNOWN)
+        // or 3.10 EE on cluster version 3.9 (inputVersion < 3.10)
+        if ((inputversion.isUnknown() || inputversion.isLessThan(V3_10)) && getBuildInfo().isEnterprise()) {
             int indexesCount = in.readInt();
             for (int i = 0; i < indexesCount; i++) {
                 MapIndexInfo mapIndexInfo = new MapIndexInfo();
                 mapIndexInfo.readData(in);
+                indexInfoList.add(mapIndexInfo);
             }
         }
 
@@ -229,5 +288,55 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
     @Override
     public int getId() {
         return MapDataSerializerHook.POST_JOIN_MAP_OPERATION;
+    }
+
+    public void addMapIndex(MapServiceContext mapServiceContext, MapContainer mapContainer) {
+        // RU_COMPAT_3_9 can be removed in 3.11
+        if (mapContainer.isGlobalIndexEnabled()) {
+            // GLOBAL-INDEX
+            MapIndexInfo mapIndexInfo = new MapIndexInfo(mapContainer.getName());
+            for (Index index : mapContainer.getIndexes().getIndexes()) {
+                mapIndexInfo.addIndexInfo(index.getAttributeName(), index.isOrdered());
+            }
+            indexInfoList.add(mapIndexInfo);
+        } else {
+            // PARTITIONED-INDEX
+            // in case of partitioned-index we gather all index infos in a set, since all partition should have the
+            // same set of partitions. In theory it would be sufficient to gather data from only one partition, but
+            // gathering data from all of them does no harm.
+            Set<IndexInfo> indexInfos = new HashSet<IndexInfo>();
+            for (PartitionContainer partitionContainer : mapServiceContext.getPartitionContainers()) {
+                final Indexes indexes = mapContainer.getIndexes(partitionContainer.getPartitionId());
+                if (indexes != null && indexes.hasIndex()) {
+                    for (Index index : indexes.getIndexes()) {
+                        indexInfos.add(new IndexInfo(index.getAttributeName(), index.isOrdered()));
+                    }
+                }
+            }
+            indexInfos.addAll(mapContainer.getPartitionIndexesToAdd());
+            MapIndexInfo mapIndexInfo = new MapIndexInfo(mapContainer.getName());
+            mapIndexInfo.addIndexInfos(indexInfos);
+            indexInfoList.add(mapIndexInfo);
+        }
+    }
+
+    @Override
+    public void setTarget(Address address) {
+        this.target = address;
+    }
+
+    private boolean mustWriteIndexInfos(Version clusterVersion) {
+        // Do not write index info when OS or cluster version is 3.10+
+        if (!getBuildInfo().isEnterprise() || clusterVersion.isGreaterOrEqual(V3_10)) {
+            return false;
+        }
+
+        // 3.9 EE reads index definitions when object input version is UNKNOWN or <= 3.8
+        // --> it expects to read map index definitions from other 3.9 members but not from
+        // an input coming from 3.10 EE (as it will have version 3.9) --> do not send when target member is 3.9
+        // --> when target member is 3.10, do send index info so it behaves like 3.9-only cluster
+        ClusterService clusterService = getNodeEngine().getClusterService();
+        Member targetMember = clusterService.getMember(target);
+        return targetMember.getVersion().asVersion().isEqualTo(V3_10) && clusterVersion.isEqualTo(V3_9);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SynchronizeIndexesForPartitionTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SynchronizeIndexesForPartitionTask.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.internal.partition.InternalPartition;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.record.Records;
+import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.impl.IndexInfo;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.MapIndexInfo;
+import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.Clock;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+// RU_COMPAT_3_9
+
+/**
+ * A task that is sent to all local partitions in order to add the indexes that have been specified in the task.
+ * Each task is executed for a separate partition.
+ *
+ * It is a compatibility mode between 3.9 and 3.10 nodes. It is only necessary due to race between
+ * PostJoinMapOperations and MapReplicationOperations, so the map data may arrive before the index definitions.
+ *
+ * This task is responsible to put the index instances back in sync with the definitions.
+ *
+ * @see com.hazelcast.map.impl.MapIndexSynchronizer
+ * @see com.hazelcast.map.impl.operation.PostJoinMapOperation
+ * @see com.hazelcast.map.impl.operation.MapReplicationStateHolder
+ */
+public class SynchronizeIndexesForPartitionTask implements PartitionSpecificRunnable {
+
+    private final int partitionId;
+    // list is reused by multiple tasks, should not be modified.
+    private final List<MapIndexInfo> mapIndexInfos;
+
+    private final MapService mapService;
+    private final SerializationService serializationService;
+    private final InternalPartitionService partitionService;
+
+    public SynchronizeIndexesForPartitionTask(int partitionId, List<MapIndexInfo> mapIndexInfos, MapService mapService,
+                                              SerializationService serializationService,
+                                              InternalPartitionService partitionService) {
+        this.partitionId = partitionId;
+        this.mapIndexInfos = mapIndexInfos;
+        this.mapService = mapService;
+        this.serializationService = serializationService;
+        this.partitionService = partitionService;
+    }
+
+    @Override
+    public void run() {
+        InternalPartition partition = partitionService.getPartition(partitionId, false);
+        if (!partition.isLocal() || partition.isMigrating()) {
+            return;
+        }
+
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        long now = Clock.currentTimeMillis();
+
+        for (MapIndexInfo mapIndexInfo : mapIndexInfos) {
+            MapContainer mapContainer = mapServiceContext.getMapContainer(mapIndexInfo.getMapName());
+            Indexes indexes = mapContainer.getIndexes(partitionId);
+
+            // identify missing indexes
+            List<IndexInfo> missingIndexes = new ArrayList<IndexInfo>();
+            for (IndexInfo indexInfo : mapIndexInfo.getIndexInfos()) {
+                if (indexes.getIndex(indexInfo.getAttributeName()) == null) {
+                    indexes.addOrGetIndex(indexInfo.getAttributeName(), indexInfo.isOrdered());
+                    missingIndexes.add(indexInfo);
+                }
+            }
+
+            // recreate missing indexes
+            RecordStore recordStore = mapServiceContext.getRecordStore(getPartitionId(), mapIndexInfo.getMapName());
+            Iterator<Record> iterator = recordStore.iterator(now, false);
+            while (iterator.hasNext()) {
+                Record record = iterator.next();
+                Data key = record.getKey();
+                Object value = Records.getValueOrCachedValue(record, serializationService);
+                QueryableEntry queryEntry = mapContainer.newQueryEntry(key, value);
+                for (IndexInfo missingIndex : missingIndexes) {
+                    indexes.getIndex(missingIndex.getAttributeName()).saveEntryIndex(queryEntry, null);
+                }
+            }
+        }
+    }
+
+    @Override
+    public int getPartitionId() {
+        return partitionId;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/TargetAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/TargetAware.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice;
+
+import com.hazelcast.nio.Address;
+
+/**
+ * An {@link com.hazelcast.spi.Operation} that has to be aware of the remote
+ * target member address before being serialized and sent over the network
+ * can implement {@code TargetAware} interface so the target {@link Address}
+ * will be injected to it.
+ * <p>
+ * The target {@link Address} injection only happens when the
+ * {@link com.hazelcast.spi.Operation} is invoked using the invocation system.
+ * When a {@code TargetAware} operation is explicitly sent to a remote target
+ * or executed locally, {@link #setTarget(Address)} should be explicitly called
+ * before the operation is sent or executed.
+ */
+public interface TargetAware {
+
+    /**
+     * Provides the designated target member address to which the operation
+     * will be sent.
+     * <ul>
+     *     <li>
+     *         This method is invoked on the implementing object before the operation
+     *         is serialized and sent over the network
+     *     </li>
+     *     <li>
+     *         When an operation is retried, the target may be re-evaluated (eg a
+     *         partition operation may target a different member after a topology
+     *         change). {@code setTarget} will be invoked on each retry with the
+     *         current target member's {@code Address} as argument
+     *     </li>
+     *     <li>
+     *         When an operation is executed on the local member, the local member's
+     *         {@code address} is provided as target address
+     *     </li>
+     * </ul>
+     *
+     * @param address target member's address
+     */
+    void setTarget(Address address);
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -47,6 +47,7 @@ import com.hazelcast.spi.exception.WrongTargetException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
 import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 import com.hazelcast.spi.impl.operationservice.impl.responses.BackupAckResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.CallTimeoutResponse;
 import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
@@ -256,6 +257,10 @@ public abstract class Invocation implements OperationResponseHandler {
                 throw new TargetNotMemberException(
                         invTarget, op.getPartitionId(), op.getClass().getName(), op.getServiceName());
             }
+        }
+
+        if (op instanceof TargetAware) {
+            ((TargetAware) op).setTarget(invTarget);
         }
 
         remote = !context.thisAddress.equals(invTarget);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -25,9 +25,10 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.FragmentedMigrationAwareService;
 import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.ServiceNamespaceAware;
 import com.hazelcast.spi.ServiceNamespace;
+import com.hazelcast.spi.ServiceNamespaceAware;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
 
 import static com.hazelcast.internal.partition.InternalPartition.MAX_BACKUP_COUNT;
@@ -196,7 +197,49 @@ final class OperationBackupHandler {
     private int sendSingleBackup(BackupAwareOperation backupAwareOp, InternalPartition partition,
                                  long[] replicaVersions, int syncBackups) {
         // Since there is only one replica, replica index is `1`
-        Address target = partition.getReplicaAddress(1);
+        return sendSingleBackup(backupAwareOp, partition, replicaVersions, syncBackups, 1);
+    }
+
+    private int sendMultipleBackups(BackupAwareOperation backupAwareOp, InternalPartition partition,
+                                    long[] replicaVersions, int syncBackups, int totalBackups) {
+        int sendSyncBackups = 0;
+        Operation backupOp = getBackupOperation(backupAwareOp);
+        if (!(backupOp instanceof TargetAware)) {
+            // optimize common case: serialize operation once and send to multiple targets
+            Data backupOpData = nodeEngine.getSerializationService().toData(backupOp);
+
+            for (int replicaIndex = 1; replicaIndex <= totalBackups; replicaIndex++) {
+                Address target = partition.getReplicaAddress(replicaIndex);
+
+                if (target == null) {
+                    continue;
+                }
+
+                assertNoBackupOnPrimaryMember(partition, target);
+
+                boolean isSyncBackup = replicaIndex <= syncBackups;
+
+                Backup backup = newBackup(backupAwareOp, backupOpData, replicaVersions, replicaIndex, isSyncBackup);
+                outboundOperationHandler.send(backup, target);
+
+                if (isSyncBackup) {
+                    sendSyncBackups++;
+                }
+            }
+        } else {
+            for (int replicaIndex = 1; replicaIndex <= totalBackups; replicaIndex++) {
+                int syncBackupSent = sendSingleBackup(backupAwareOp, partition, replicaVersions,
+                        syncBackups, replicaIndex);
+                sendSyncBackups += syncBackupSent;
+            }
+        }
+        return sendSyncBackups;
+    }
+
+    private int sendSingleBackup(BackupAwareOperation backupAwareOp, InternalPartition partition,
+                                 long[] replicaVersions, int syncBackups, int replica) {
+        Operation backupOp = getBackupOperation(backupAwareOp);
+        Address target = partition.getReplicaAddress(replica);
         if (target != null) {
             // Since there is only one backup, backup operation is sent to only one node.
             // If backup operation is converted to `Data`, there will be these operations as below:
@@ -207,9 +250,10 @@ final class OperationBackupHandler {
             // So in this case (there is only one backup), we don't convert backup operation to `Data` as temporary
             // before `Backup` is serialized but backup operation is already serialized directly into output
             // without any unnecessary memory allocation and copy when it is used as object inside `Backup`.
-            Operation backupOp = getBackupOperation(backupAwareOp);
-
             assertNoBackupOnPrimaryMember(partition, target);
+            if (backupOp instanceof TargetAware) {
+                ((TargetAware) backupOp).setTarget(target);
+            }
 
             boolean isSyncBackup = syncBackups == 1;
 
@@ -221,34 +265,6 @@ final class OperationBackupHandler {
             }
         }
         return 0;
-    }
-
-    private int sendMultipleBackups(BackupAwareOperation backupAwareOp, InternalPartition partition,
-                                    long[] replicaVersions, int syncBackups, int totalBackups) {
-        int sendSyncBackups = 0;
-        Operation backupOp = getBackupOperation(backupAwareOp);
-        Data backupOpData = nodeEngine.getSerializationService().toData(backupOp);
-
-        for (int replicaIndex = 1; replicaIndex <= totalBackups; replicaIndex++) {
-            Address target = partition.getReplicaAddress(replicaIndex);
-
-            if (target == null) {
-                continue;
-            }
-
-            assertNoBackupOnPrimaryMember(partition, target);
-
-            boolean isSyncBackup = replicaIndex <= syncBackups;
-
-            Backup backup = newBackup(backupAwareOp, backupOpData, replicaVersions, replicaIndex, isSyncBackup);
-            outboundOperationHandler.send(backup, target);
-
-            if (isSyncBackup) {
-                sendSyncBackups++;
-            }
-        }
-
-        return sendSyncBackups;
     }
 
     private Operation getBackupOperation(BackupAwareOperation backupAwareOp) {

--- a/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
@@ -17,25 +17,39 @@
 package com.hazelcast.map;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapLoader;
 import com.hazelcast.instance.Node;
+import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.PartitionContainer;
+import com.hazelcast.map.impl.query.Query;
+import com.hazelcast.map.impl.query.QueryPartitionOperation;
+import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.query.Predicates;
 import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.spi.CoreService;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.PostJoinAwareService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -48,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static org.junit.Assert.assertEquals;
@@ -81,6 +96,103 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
         assertAllPartitionContainersAreInitialized(instance1);
     }
 
+    @Test
+    public void whenIndexConfigured_existsOnAllMembers() {
+        // GIVEN indexes are configured before Hazelcast starts
+        int clusterSize = 3;
+        TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(clusterSize);
+        HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
+
+        instances[0] = createNode(instanceFactory);
+        IMap<Integer, Book> bookMap = instances[0].getMap("default");
+        assertEquals(BOOK_COUNT, bookMap.size());
+
+        // THEN indexes are migrated and populated on all members
+        for (int i = 1; i < clusterSize; i++) {
+            instances[i] = createNode(instanceFactory);
+            bookMap = instances[i].getMap("default");
+            assertEquals(BOOK_COUNT, bookMap.keySet().size());
+            assertAllPartitionContainersAreInitialized(instances[i]);
+            assertGlobalIndexesAreInitialized(instances[i]);
+        }
+    }
+
+    @Test(timeout = 120000)
+    public void whenIndexAddedProgrammatically_existsOnAllMembers() {
+        // GIVEN indexes are configured before Hazelcast starts
+        int clusterSize = 3;
+        TestHazelcastInstanceFactory instanceFactory = createHazelcastInstanceFactory(clusterSize);
+        HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
+
+        Config config = getConfig().setProperty(GroupProperty.PARTITION_COUNT.getName(), "4");
+        config.getMapConfig("default")
+              .setMapStoreConfig(new MapStoreConfig().setImplementation(new BookMapLoader()));
+        config.getServicesConfig()
+              .addServiceConfig(
+                      new ServiceConfig()
+                              .setName("SlowPostJoinAwareService")
+                              .setEnabled(true)
+                              .setImplementation(new SlowPostJoinAwareService())
+              );
+
+        instances[0] = instanceFactory.newHazelcastInstance(config);
+        IMap<Integer, Book> bookMap = instances[0].getMap("default");
+        bookMap.addIndex("author", false);
+        bookMap.addIndex("year", true);
+        assertEquals(BOOK_COUNT, bookMap.size());
+
+        // THEN indexes are migrated and populated on all members
+        for (int i = 1; i < clusterSize; i++) {
+            instances[i] = instanceFactory.newHazelcastInstance(config);
+            bookMap = instances[i].getMap("default");
+            assertEquals(BOOK_COUNT, bookMap.keySet().size());
+            assertAllPartitionContainersAreInitialized(instances[i]);
+            assertGlobalIndexesAreInitialized(instances[i]);
+        }
+    }
+
+    private void assertGlobalIndexesAreInitialized(HazelcastInstance instance) {
+        MapServiceContext context = getMapServiceContext(instance);
+        final MapContainer mapContainer = context.getMapContainer("default");
+        if (mapContainer.getMapConfig().getInMemoryFormat().equals(NATIVE)) {
+            return;
+        }
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(2, mapContainer.getIndexes().getIndexes().length);
+            }
+        });
+        assertNotNull("There should be a global index for attribute 'author'",
+                mapContainer.getIndexes().getIndex("author"));
+        assertNotNull("There should be a global index for attribute 'year'",
+                mapContainer.getIndexes().getIndex("year"));
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertTrue("Author index should contain records.",
+                        mapContainer.getIndexes()
+                                    .getIndex("author")
+                                    .getRecords("1").size() > 0);
+            }
+        });
+
+
+        assertTrue("Year index should contain records",
+                mapContainer.getIndexes().getIndex("year").getRecords(1801).size() > 0);
+    }
+
+    private int numberOfPartitionQueryResults(OperationService operationService, int partitionId,
+                                              String attribute, Comparable value) {
+        QueryPartitionOperation queryOp = new QueryPartitionOperation(
+                Query.of().mapName("default")
+                     .iterationType(IterationType.KEY)
+                     .predicate(Predicates.equal(attribute, value)).build());
+        InternalCompletableFuture<QueryResult> future = operationService
+                .invokeOnPartition(MapService.SERVICE_NAME, queryOp, partitionId);
+        return future.join().size();
+    }
+
     private void assertAllPartitionContainersAreEmpty(HazelcastInstance instance) {
         MapServiceContext context = getMapServiceContext(instance);
         int partitionCount = getPartitionCount(instance);
@@ -99,19 +211,39 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
     private void assertAllPartitionContainersAreInitialized(HazelcastInstance instance) {
         MapServiceContext context = getMapServiceContext(instance);
         int partitionCount = getPartitionCount(instance);
+        final AtomicInteger authorRecordsCounter = new AtomicInteger();
+        final AtomicInteger yearRecordsCounter = new AtomicInteger();
+        final OperationService operationService = getOperationService(instance);
+        boolean isNativeMemoryFormat = context.getMapContainer("default").getMapConfig().getInMemoryFormat().equals(NATIVE);
 
         for (int i = 0; i < partitionCount; i++) {
+            if (!getNode(instance).getPartitionService().isPartitionOwner(i)) {
+                continue;
+            }
+
             PartitionContainer container = context.getPartitionContainer(i);
 
             ConcurrentMap<String, RecordStore> maps = container.getMaps();
             RecordStore recordStore = maps.get("default");
-            assertNotNull("record store is null", recordStore);
+            assertNotNull("record store is null: ", recordStore);
 
-            if (context.getMapContainer("default").getMapConfig().getInMemoryFormat().equals(NATIVE)) {
+            if (isNativeMemoryFormat) {
+                // also assert contents of partition indexes when NATIVE memory format
                 ConcurrentMap<String, Indexes> indexes = container.getIndexes();
-                Indexes index = indexes.get("default");
-                assertNotNull("indexes is null", index);
+                final Indexes index = indexes.get("default");
+                assertNotNull("indexes is null", indexes);
+                assertEquals(2, index.getIndexes().length);
+                assertNotNull("There should be a partition index for attribute 'author'", index.getIndex("author"));
+                assertNotNull("There should be a partition index for attribute 'year'", index.getIndex("year"));
+
+                authorRecordsCounter.getAndAdd(numberOfPartitionQueryResults(operationService, i, "author", "1"));
+                yearRecordsCounter.getAndAdd(numberOfPartitionQueryResults(operationService, i, "year", 1801));
             }
+        }
+
+        if (isNativeMemoryFormat) {
+            assertTrue("Author index should contain records", authorRecordsCounter.get() > 0);
+            assertTrue("Year index should contain records", yearRecordsCounter.get() > 0);
         }
     }
 
@@ -128,12 +260,12 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
 
 
     private HazelcastInstance createNode(TestHazelcastInstanceFactory instanceFactory) {
-        Config config = getConfig();
-        MapConfig mapConfig = config.getMapConfig("default");
-        mapConfig.addMapIndexConfig(new MapIndexConfig("author", false));
-        mapConfig.addMapIndexConfig(new MapIndexConfig("year", true));
-        mapConfig.setBackupCount(1);
-        mapConfig.setMapStoreConfig(new MapStoreConfig().setImplementation(new BookMapLoader()));
+        Config config = getConfig().setProperty(GroupProperty.PARTITION_COUNT.getName(), "4");
+        config.getMapConfig("default")
+              .addMapIndexConfig(new MapIndexConfig("author", false))
+              .addMapIndexConfig(new MapIndexConfig("year", true))
+              .setBackupCount(1)
+              .setMapStoreConfig(new MapStoreConfig().setImplementation(new BookMapLoader()));
         return instanceFactory.newHazelcastInstance(config);
     }
 
@@ -196,4 +328,20 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
         }
     }
 
+    // A CoreService with a slow post-join op. Its post-join operation will be executed before map's
+    // post-join operation so we can ensure indexes are created via MapReplicationOperation,
+    // even though PostJoinMapOperation has not yet been executed.
+    public static class SlowPostJoinAwareService implements CoreService, PostJoinAwareService {
+        @Override
+        public Operation getPostJoinOperation() {
+            return new SlowOperation();
+        }
+    }
+
+    public static class SlowOperation extends Operation {
+        @Override
+        public void run() {
+            sleepSeconds(60);
+        }
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapIndexSynchronizerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapIndexSynchronizerTest.java
@@ -1,0 +1,126 @@
+package com.hazelcast.map.impl;
+
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.query.impl.IndexInfo;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import static java.util.Arrays.asList;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapIndexSynchronizerTest extends HazelcastTestSupport {
+
+    private static String MAP_NAME = "MapIndexSynchronizerTest";
+
+    private HazelcastInstanceImpl hazelcastInstance;
+    private MapServiceContext mapServiceContext;
+    private NodeEngine nodeEngine;
+
+    private MapIndexSynchronizer synchronizer;
+
+    @Before
+    public void before() {
+        hazelcastInstance = ((HazelcastInstanceProxy) createHazelcastInstance(getConfig())).getOriginal();
+        nodeEngine = hazelcastInstance.node.getNodeEngine();
+        MapService mapService = nodeEngine.getService(MapService.SERVICE_NAME);
+        mapServiceContext = mapService.getMapServiceContext();
+
+        synchronizer = new MapIndexSynchronizer(mapServiceContext, nodeEngine);
+    }
+
+    @Test
+    public void noIndexes_properTransition_syncNotFired() throws Exception {
+        synchronizer.onClusterVersionChange(Versions.V3_9);
+        assertNoIndexesEventually();
+
+        synchronizer.onClusterVersionChange(Versions.V3_10);
+        assertNoIndexesEventually();
+
+    }
+
+    @Test
+    public void indexes_properTransition_syncFired() throws Exception {
+        synchronizer.onClusterVersionChange(Versions.V3_9);
+        assertNoIndexesEventually();
+
+        IndexInfo orderedIndex = index("age", true);
+        IndexInfo unorderedIndex = index("height", false);
+        add(orderedIndex, unorderedIndex);
+        assertNoIndexesEventually();
+
+        synchronizer.onClusterVersionChange(Versions.V3_10);
+        assertIndexesEqualEventually(orderedIndex, unorderedIndex);
+    }
+
+    @Test
+    public void indexes_improperTransition_syncNotFired() throws Exception {
+        synchronizer.onClusterVersionChange(Version.of(3, 8));
+        assertNoIndexesEventually();
+
+        IndexInfo orderedIndex = index("age", true);
+        IndexInfo unorderedIndex = index("height", false);
+        add(orderedIndex, unorderedIndex);
+        assertNoIndexesEventually();
+
+        synchronizer.onClusterVersionChange(Versions.V3_10);
+        assertNoIndexesEventually();
+    }
+
+    private void assertNoIndexesEventually() {
+        Callable assertion = new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                return getIndexDefinitions().size();
+            }
+        };
+        assertEqualsEventually(assertion, 0);
+        sleepMillis(500);
+        assertEqualsEventually(assertion, 0);
+
+    }
+
+    private void assertIndexesEqualEventually(IndexInfo... indexInfos) {
+        final Map<String, Boolean> indexes = indexes(indexInfos);
+        assertEqualsEventually(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return getIndexDefinitions().equals(indexes);
+            }
+        }, true);
+    }
+
+    private void add(IndexInfo... indexInfo) {
+        mapServiceContext.getMapContainer(MAP_NAME).getPartitionIndexesToAdd().addAll(asList(indexInfo));
+    }
+
+    private IndexInfo index(String path, boolean ordered) {
+        return new IndexInfo(path, ordered);
+    }
+
+    private Map<String, Boolean> indexes(IndexInfo... indexInfos) {
+        Map<String, Boolean> indexes = new HashMap<String, Boolean>();
+        for (IndexInfo indexInfo : indexInfos) {
+            indexes.put(indexInfo.getAttributeName(), indexInfo.isOrdered());
+        }
+        return indexes;
+    }
+
+    private Map<String, Boolean> getIndexDefinitions() {
+        return mapServiceContext.getMapContainer(MAP_NAME).getIndexDefinitions();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/MapReplicationStateHolderReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/MapReplicationStateHolderReadTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_ENTERPRISE;
+import static com.hazelcast.internal.cluster.Versions.V3_10;
+import static com.hazelcast.internal.cluster.Versions.V3_9;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapReplicationStateHolderReadTest {
+
+    @Parameters(name = "v:{0}, ee:{1}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {
+                // version, isEnterprise, shouldRead
+                {V3_9, false, true},
+                {V3_9, true, false},
+                {V3_10, false, true},
+                {V3_10, true, true},
+        });
+    }
+
+    @Parameter
+    public Version streamVersion;
+
+    @Parameter(1)
+    public boolean enterprise;
+
+    @Parameter(2)
+    public boolean shouldReadIndexInfo;
+
+    private ObjectDataInput input;
+    private MapReplicationStateHolder holder;
+
+    @Before
+    public void setup() throws IOException {
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_ENTERPRISE, Boolean.toString(enterprise));
+        holder = new MapReplicationStateHolder();
+
+        input = Mockito.mock(ObjectDataInput.class);
+        when(input.getVersion()).thenReturn(streamVersion);
+        when(input.readInt()).thenReturn(0, 0, 1);
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_ENTERPRISE);
+    }
+
+    @Test
+    public void test_readsMapIndexInfo() throws IOException {
+        holder.readData(input);
+        InOrder inOrder = inOrder(input);
+        inOrder.verify(input, times(2)).readInt();
+        inOrder.verify(input).getVersion();
+        if (shouldReadIndexInfo) {
+            inOrder.verify(input).readInt();
+            inOrder.verify(input).readObject();
+        }
+        inOrder.verifyNoMoreInteractions();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeTargetAwareOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeTargetAwareOperationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.partition.InternalPartition;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OperationServiceImpl_invokeTargetAwareOperationTest extends HazelcastTestSupport {
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private HazelcastInstance local;
+    private InternalOperationService operationService;
+    private HazelcastInstance remote;
+
+    @Before
+    public void setup() {
+        int clusterSize;
+        if (testName.getMethodName().equals("whenInvokedWithTargetAwareBackups_multipleBackupsHaveTargetInjected")) {
+            clusterSize = 5;
+        } else {
+            clusterSize = 2;
+        }
+        HazelcastInstance[] nodes = createHazelcastInstanceFactory(clusterSize).newInstances();
+        warmUpPartitions(nodes);
+
+        local = nodes[0];
+        remote = nodes[1];
+        operationService = getOperationService(local);
+        TargetAwareOperation.TARGETS.clear();
+    }
+
+    @Test
+    public void whenInvokedOnLocalPartition() {
+        Address expected = getAddress(local);
+        TargetAwareOperation operation = new TargetAwareOperation();
+
+        InternalCompletableFuture<String> invocation = operationService.invokeOnPartition(
+                null, operation, getPartitionId(local));
+        assertEquals(expected, invocation.join());
+    }
+
+    @Test
+    public void whenInvokedOnRemotePartition() {
+        Address expected = getAddress(remote);
+        TargetAwareOperation operation = new TargetAwareOperation();
+
+        InternalCompletableFuture<String> invocation = operationService.invokeOnPartition(
+                null, operation, getPartitionId(remote));
+        assertEquals(expected, invocation.join());
+    }
+
+    @Test
+    public void whenInvokedOnLocalTarget() {
+        Address expected = getAddress(local);
+        TargetAwareOperation operation = new TargetAwareOperation();
+
+        InternalCompletableFuture<String> invocation = operationService.invokeOnTarget(
+                null, operation, getAddress(local));
+        assertEquals(expected, invocation.join());
+    }
+
+    @Test
+    public void whenInvokedOnRemoteTarget() {
+        Address expected = getAddress(remote);
+        TargetAwareOperation operation = new TargetAwareOperation();
+
+        InternalCompletableFuture<String> invocation = operationService.invokeOnTarget(
+                null, operation, getAddress(remote));
+        assertEquals(expected, invocation.join());
+    }
+
+    @Test
+    public void whenInvokedWithTargetAwareBackup_singleBackupHasTargetInjected() {
+        TargetAwareOperation operation = new TargetAwareOperation(1, 0, getPartitionId(remote));
+
+        operationService.invokeOnPartition(null, operation, operation.getPartitionId()).join();
+
+        // primary operation targets remote, backup targets local
+        assertEquals(getAddress(remote), TargetAwareOperation.TARGETS.get(0));
+        assertEquals(getAddress(local), TargetAwareOperation.TARGETS.get(1));
+    }
+
+    @Test
+    public void whenInvokedWithTargetAwareBackups_multipleBackupsHaveTargetInjected() {
+        int backupCount = 4;
+        int partitionId = getPartitionId(local);
+        InternalPartitionService localPartitionService = getPartitionService(local);
+        InternalPartition partition = localPartitionService.getPartition(partitionId);
+
+        List<Address> expectedTargetAddresses = new ArrayList<Address>();
+        for (int i = 0; i < backupCount + 1; i++) {
+            expectedTargetAddresses.add(partition.getReplicaAddress(i));
+        }
+
+        TargetAwareOperation operation = new TargetAwareOperation(backupCount, 0, partitionId);
+
+        operationService.invokeOnPartition(null, operation, operation.getPartitionId()).join();
+        assertEquals(expectedTargetAddresses, TargetAwareOperation.TARGETS);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/TargetAwareOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/TargetAwareOperation.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.BackupAwareOperation;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class TargetAwareOperation extends Operation implements TargetAware, BackupAwareOperation, PartitionAwareOperation {
+
+    public static final List<Address> TARGETS = new CopyOnWriteArrayList<Address>();
+
+    private int syncBackupCount;
+    private int asyncBackupCount;
+    private TargetAwareOperation backupOp;
+    private Address targetAddress;
+
+    TargetAwareOperation() {
+        this(0, 0, -1);
+    }
+
+    TargetAwareOperation(int syncBackupCount, int asyncBackupCount, int partitionId) {
+        this.syncBackupCount = syncBackupCount;
+        this.asyncBackupCount = asyncBackupCount;
+        this.setPartitionId(partitionId);
+    }
+
+    @Override
+    public void run() throws Exception {
+        assert targetAddress != null;
+    }
+
+    @Override
+    public Object getResponse() {
+        return targetAddress;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(targetAddress);
+        out.writeInt(syncBackupCount);
+        out.writeInt(asyncBackupCount);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        targetAddress = in.readObject();
+        syncBackupCount = in.readInt();
+        asyncBackupCount = in.readInt();
+    }
+
+    @Override
+    public void setTarget(Address address) {
+        this.targetAddress = address;
+        TARGETS.add(targetAddress);
+    }
+
+    @Override
+    public boolean shouldBackup() {
+        return (syncBackupCount + asyncBackupCount) > 0;
+    }
+
+    @Override
+    public int getSyncBackupCount() {
+        return syncBackupCount;
+    }
+
+    @Override
+    public int getAsyncBackupCount() {
+        return asyncBackupCount;
+    }
+
+    @Override
+    public Operation getBackupOperation() {
+        if (backupOp == null) {
+            backupOp = new TargetAwareOperation();
+        }
+        return backupOp;
+    }
+
+    public Address getTargetAddress() {
+        return targetAddress;
+    }
+}


### PR DESCRIPTION
* Introduces `TargetAware` abstraction: operations that need to adjust serialization format depending on which the target member is, can implement `TargetAware` to get the target's `Address` injected before being serialized and sent to the remote member
* Fixes compatibility issues in `PostJoinMapOperation` and `MapReplicationStateHolder`
* Restores map index replication classes previously removed in df4bab8682cd658e94bb215a48183ac5a970b5d9

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/1967