### PR TITLE
Implement idempotent retries for migration operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -71,16 +71,18 @@ import com.hazelcast.version.Version;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -88,7 +90,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
-import static com.hazelcast.util.EmptyStatement.ignore;
+import static com.hazelcast.cluster.memberselector.MemberSelectors.NON_LOCAL_MEMBER_SELECTOR;
 import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.returnWithDeadline;
 import static com.hazelcast.util.MapUtil.createHashMap;
@@ -109,6 +111,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     private static final String EXCEPTION_MSG_PARTITION_STATE_SYNC_TIMEOUT = "Partition state sync invocation timed out";
     private static final int PTABLE_SYNC_TIMEOUT_SECONDS = 10;
     private static final int SAFE_SHUTDOWN_MAX_AWAIT_STEP_MILLIS = 1000;
+    private static final long FETCH_PARTITION_STATE_SECONDS = 5;
 
     private final Node node;
     private final NodeEngineImpl nodeEngine;
@@ -1192,15 +1195,12 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
         public void run() {
             maxVersion = partitionStateManager.getVersion();
-
-            Collection<Future<PartitionRuntimeState>> futures = invokeFetchPartitionStateOps();
-
             logger.info("Fetching most recent partition table! my version: " + maxVersion);
 
             Collection<MigrationInfo> allCompletedMigrations = new HashSet<MigrationInfo>();
             Collection<MigrationInfo> allActiveMigrations = new HashSet<MigrationInfo>();
 
-            processResults(futures, allCompletedMigrations, allActiveMigrations);
+            collectAndProcessResults(allCompletedMigrations, allActiveMigrations);
 
             logger.info("Most recent partition table version: " + maxVersion);
 
@@ -1208,33 +1208,28 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             syncPartitionRuntimeState();
         }
 
-        /** Sends {@link FetchPartitionStateOperation} to all cluster members. */
-        private Collection<Future<PartitionRuntimeState>> invokeFetchPartitionStateOps() {
-            Collection<MemberImpl> members = node.clusterService.getMemberImpls();
-            Collection<Future<PartitionRuntimeState>> futures = new ArrayList<Future<PartitionRuntimeState>>(
-                    members.size());
-
-            for (MemberImpl m : members) {
-                if (m.localMember()) {
-                    continue;
-                }
-                Future<PartitionRuntimeState> future = nodeEngine.getOperationService()
-                        .createInvocationBuilder(SERVICE_NAME, new FetchPartitionStateOperation(),
-                                m.getAddress()).setTryCount(Integer.MAX_VALUE)
-                        .setCallTimeout(Long.MAX_VALUE).invoke();
-                futures.add(future);
-            }
-            return futures;
+        private Future<PartitionRuntimeState> fetchPartitionState(Member m) {
+            return nodeEngine.getOperationService()
+                    .invokeOnTarget(SERVICE_NAME, new FetchPartitionStateOperation(), m.getAddress());
         }
 
         /** Collects all completed and active migrations and sets the partition state to the latest version. */
-        private void processResults(Collection<Future<PartitionRuntimeState>> futures,
-                Collection<MigrationInfo> allCompletedMigrations, Collection<MigrationInfo> allActiveMigrations) {
-            for (Future<PartitionRuntimeState> future : futures) {
-                try {
-                    PartitionRuntimeState state = future.get();
+        private void collectAndProcessResults(Collection<MigrationInfo> allCompletedMigrations,
+                Collection<MigrationInfo> allActiveMigrations) {
+
+            Collection<Member> members = node.clusterService.getMembers(NON_LOCAL_MEMBER_SELECTOR);
+            Map<Member, Future<PartitionRuntimeState>> futures = new HashMap<Member, Future<PartitionRuntimeState>>();
+            for (Member member : members) {
+                Future<PartitionRuntimeState> future = fetchPartitionState(member);
+                futures.put(member, future);
+            }
+
+            while (!futures.isEmpty()) {
+                Iterator<Map.Entry<Member, Future<PartitionRuntimeState>>> iter = futures.entrySet().iterator();
+                while (iter.hasNext()) {
+                    PartitionRuntimeState state = collectNextPartitionState(iter);
                     if (state == null) {
-                        // state can be null, if not initialized
+                        // state can be null, if not initialized or operation is retried
                         continue;
                     }
 
@@ -1247,20 +1242,52 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                     if (state.getActiveMigration() != null) {
                         allActiveMigrations.add(state.getActiveMigration());
                     }
-                } catch (TargetNotMemberException e) {
-                    ignore(e);
-                } catch (MemberLeftException e) {
-                    ignore(e);
-                } catch (InterruptedException e) {
-                    currentThread().interrupt();
-                    logger.fine("FetchMostRecentPartitionTableTask is interrupted.");
-                } catch (ExecutionException e) {
-                    Throwable cause = e.getCause();
-                    if (!(cause instanceof TargetNotMemberException) && !(cause instanceof MemberLeftException))  {
-                        logger.warning("Failed to fetch partition table!", e);
-                    }
                 }
             }
+        }
+
+        /**
+         * Fetches known partition state from next member and returns null if target member is left
+         * and/or not a member of this cluster anymore.
+         * If future timeouts, then fetch operation is retried until we learn target member's partition state
+         * or it leaves the cluster.
+         */
+        private PartitionRuntimeState collectNextPartitionState(Iterator<Map.Entry<Member, Future<PartitionRuntimeState>>> iter) {
+            Map.Entry<Member, Future<PartitionRuntimeState>> next = iter.next();
+            Member member = next.getKey();
+            Future<PartitionRuntimeState> future = next.getValue();
+            boolean collectedState = true;
+
+            try {
+                PartitionRuntimeState state = future.get(FETCH_PARTITION_STATE_SECONDS, TimeUnit.SECONDS);
+                if (state == null) {
+                    logger.fine("Received NULL partition state from " + member);
+                } else {
+                    logger.fine("Received partition state version: " + state.getVersion() + " from " + member);
+                }
+                return state;
+            } catch (InterruptedException e) {
+                logger.fine("FetchMostRecentPartitionTableTask is interrupted.");
+                Thread.currentThread().interrupt();
+            } catch (TimeoutException e) {
+                collectedState = false;
+                // Fetch partition state operation is idempotent.
+                // We will retry it until it we learn the partition state or the member leaves the cluster.
+                // We can't just rely on invocation retries, because if connection is dropped while
+                // our operation is on the wire, invocation won't get any response and will eventually timeout.
+                next.setValue(fetchPartitionState(member));
+            } catch (Exception e) {
+                Level level = Level.SEVERE;
+                if ((e instanceof MemberLeftException) || (e.getCause() instanceof TargetNotMemberException)) {
+                    level = Level.FINE;
+                }
+                logger.log(level, "Failed to fetch partition table from " + member, e);
+            } finally {
+                if (collectedState) {
+                    iter.remove();
+                }
+            }
+            return null;
         }
 
         /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.core.MigrationEvent;
+import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.metrics.Probe;
@@ -112,6 +113,7 @@ public class MigrationManager {
     private final Lock partitionServiceLock;
     private final MigrationPlanner migrationPlanner;
     private final boolean fragmentedMigrationEnabled;
+    private final long memberHeartbeatTimeoutMillis;
 
     MigrationManager(Node node, InternalPartitionServiceImpl service, Lock partitionServiceLock) {
         this.node = node;
@@ -138,6 +140,7 @@ public class MigrationManager {
                 resumeMigration();
             }
         });
+        this.memberHeartbeatTimeoutMillis = properties.getMillis(GroupProperty.MAX_NO_HEARTBEAT_SECONDS);
     }
 
     @Probe(name = "migrationActive")
@@ -348,7 +351,7 @@ public class MigrationManager {
             Future<Boolean> future = nodeEngine.getOperationService()
                     .createInvocationBuilder(SERVICE_NAME, operation, destination)
                     .setTryCount(Integer.MAX_VALUE)
-                    .setCallTimeout(Long.MAX_VALUE).invoke();
+                    .setCallTimeout(memberHeartbeatTimeoutMillis).invoke();
 
             boolean result = future.get();
             if (logger.isFinestEnabled()) {
@@ -357,6 +360,10 @@ public class MigrationManager {
             return result;
         } catch (Throwable t) {
             logMigrationCommitFailure(destination, migration, t);
+
+            if (t.getCause() instanceof OperationTimeoutException) {
+                return commitMigrationToDestination(destination, migration);
+            }
         }
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateChecker.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 
+import static com.hazelcast.internal.partition.impl.PartitionServiceState.FETCHING_PARTITION_TABLE;
 import static com.hazelcast.internal.partition.impl.PartitionServiceState.MIGRATION_LOCAL;
 import static com.hazelcast.internal.partition.impl.PartitionServiceState.MIGRATION_ON_MASTER;
 import static com.hazelcast.internal.partition.impl.PartitionServiceState.REPLICA_NOT_OWNED;
@@ -75,6 +76,10 @@ public class PartitionReplicaStateChecker {
     }
 
     public PartitionServiceState getPartitionServiceState() {
+        if (partitionService.isFetchMostRecentPartitionTableTaskRequired()) {
+            return FETCHING_PARTITION_TABLE;
+        }
+
         if (hasMissingReplicaOwners()) {
             return REPLICA_NOT_OWNED;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionServiceState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionServiceState.java
@@ -43,8 +43,14 @@ public enum PartitionServiceState {
     REPLICA_NOT_SYNC,
 
     /**
-     * Indicates that there are some replicas are not owned.
+     * Indicates that there are some unowned replicas.
      */
-    REPLICA_NOT_OWNED
+    REPLICA_NOT_OWNED,
+
+    /**
+     * Indicates that new master still fetching partition tables from cluster members
+     * to determine the most recent partition table published by the previous master.
+     */
+    FETCHING_PARTITION_TABLE
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -50,6 +50,7 @@ public class PartitionStateManager {
 
     private final Node node;
     private final ILogger logger;
+    private final InternalPartitionServiceImpl partitionService;
 
     private final int partitionCount;
     private final InternalPartitionImpl[] partitions;
@@ -72,6 +73,7 @@ public class PartitionStateManager {
         this.node = node;
         this.logger = node.getLogger(getClass());
 
+        this.partitionService = partitionService;
         partitionCount = partitionService.getPartitionCount();
         this.partitions = new InternalPartitionImpl[partitionCount];
 
@@ -178,6 +180,10 @@ public class PartitionStateManager {
         ClusterState clusterState = node.getClusterService().getClusterState();
         if (!clusterState.isMigrationAllowed()) {
             logger.warning("Partitions can't be assigned since cluster-state= " + clusterState);
+            return false;
+        }
+        if (partitionService.isFetchMostRecentPartitionTableTaskRequired()) {
+            logger.warning("Partitions can't be assigned since most recent partition table is not decided yet.");
             return false;
         }
         return true;

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.impl.SpiDataSerializerHook;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.hazelcast.instance.TestUtil.terminateInstance;
+import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.FETCH_PARTITION_STATE;
+import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.F_ID;
+import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.PARTITION_STATE_OP;
+import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
+import static com.hazelcast.test.PacketFiltersUtil.resetPacketFiltersFrom;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MigrationInvocationsSafetyTest extends PartitionCorrectnessTestSupport {
+
+    @Before
+    public void setupParams() {
+        nodeCount = 4;
+        backupCount = nodeCount - 1;
+    }
+
+    @Test
+    public void members_shouldAgree_onPartitionTable_whenMasterChanges() {
+        final HazelcastInstance initialMaster = factory.newHazelcastInstance();
+        final HazelcastInstance nextMaster = factory.newHazelcastInstance();
+        final HazelcastInstance slave1 = factory.newHazelcastInstance();
+        final HazelcastInstance slave2 = factory.newHazelcastInstance();
+        final HazelcastInstance slave3 = factory.newHazelcastInstance();
+
+        assertClusterSizeEventually(5, nextMaster, slave1, slave2, slave3);
+
+        // nextMaster & slave1 won't receive partition table updates from initialMaster.
+        dropOperationsBetween(initialMaster, asList(slave1, nextMaster), F_ID, singletonList(PARTITION_STATE_OP));
+
+        warmUpPartitions(initialMaster, slave2, slave3);
+
+        final int initialPartitionStateVersion = getPartitionService(initialMaster).getPartitionStateVersion();
+        assertEquals(initialPartitionStateVersion, getPartitionService(slave2).getPartitionStateVersion());
+        assertEquals(initialPartitionStateVersion, getPartitionService(slave3).getPartitionStateVersion());
+        assertEquals(0, getPartitionService(nextMaster).getPartitionStateVersion());
+        assertEquals(0, getPartitionService(slave1).getPartitionStateVersion());
+
+        dropOperationsBetween(nextMaster, slave3, F_ID, singletonList(FETCH_PARTITION_STATE));
+
+        terminateInstance(initialMaster);
+
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                assertClusterSizeEventually(4, nextMaster, slave1, slave2, slave3);
+                sleepSeconds(10);
+                resetPacketFiltersFrom(nextMaster);
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                int nextPartitionStateVersion = getPartitionService(nextMaster).getPartitionStateVersion();
+                assertThat(nextPartitionStateVersion, greaterThan(initialPartitionStateVersion));
+
+                assertEquals(nextPartitionStateVersion, getPartitionService(slave1).getPartitionStateVersion());
+                assertEquals(nextPartitionStateVersion, getPartitionService(slave2).getPartitionStateVersion());
+                assertEquals(nextPartitionStateVersion, getPartitionService(slave3).getPartitionStateVersion());
+            }
+        });
+
+    }
+
+    @Test
+    public void members_shouldAgree_onPartitionTable_whenMasterChanges_and_anotherMemberCrashes() {
+        final HazelcastInstance initialMaster = factory.newHazelcastInstance();
+        final HazelcastInstance nextMaster = factory.newHazelcastInstance();
+        final HazelcastInstance slave1 = factory.newHazelcastInstance();
+        final HazelcastInstance slave2 = factory.newHazelcastInstance();
+        final HazelcastInstance slave3 = factory.newHazelcastInstance();
+
+        assertClusterSizeEventually(5, nextMaster, slave1, slave2, slave3);
+
+        // nextMaster & slave1 won't receive partition table updates from initialMaster.
+        dropOperationsBetween(initialMaster, asList(slave1, nextMaster), F_ID, singletonList(PARTITION_STATE_OP));
+
+        warmUpPartitions(initialMaster, slave2, slave3);
+
+        final int initialPartitionStateVersion = getPartitionService(initialMaster).getPartitionStateVersion();
+        assertEquals(initialPartitionStateVersion, getPartitionService(slave2).getPartitionStateVersion());
+        assertEquals(initialPartitionStateVersion, getPartitionService(slave3).getPartitionStateVersion());
+        assertEquals(0, getPartitionService(nextMaster).getPartitionStateVersion());
+        assertEquals(0, getPartitionService(slave1).getPartitionStateVersion());
+
+        dropOperationsBetween(nextMaster, slave3, F_ID, singletonList(FETCH_PARTITION_STATE));
+
+        terminateInstance(initialMaster);
+
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                assertClusterSizeEventually(4, nextMaster, slave1, slave2, slave3);
+                sleepSeconds(10);
+                terminateInstance(slave3);
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                int nextPartitionStateVersion = getPartitionService(nextMaster).getPartitionStateVersion();
+                assertThat(nextPartitionStateVersion, greaterThan(initialPartitionStateVersion));
+
+                assertEquals(nextPartitionStateVersion, getPartitionService(slave1).getPartitionStateVersion());
+                assertEquals(nextPartitionStateVersion, getPartitionService(slave2).getPartitionStateVersion());
+            }
+        });
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
@@ -18,7 +18,10 @@ package com.hazelcast.internal.partition;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.partition.service.TestMigrationAwareService;
+import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.impl.SpiDataSerializerHook;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -35,8 +38,10 @@ import java.util.Set;
 import static com.hazelcast.instance.TestUtil.terminateInstance;
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.FETCH_PARTITION_STATE;
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.F_ID;
+import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.MIGRATION_COMMIT;
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.PARTITION_STATE_OP;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
+import static com.hazelcast.test.PacketFiltersUtil.rejectOperationsFrom;
 import static com.hazelcast.test.PacketFiltersUtil.resetPacketFiltersFrom;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -193,4 +198,106 @@ public class MigrationInvocationsSafetyTest extends PartitionCorrectnessTestSupp
         });
     }
 
+    @Test
+    public void migrationCommit_shouldBeRetried_whenTargetNotResponds() throws Exception {
+        Config config = getConfig(true, true)
+                .setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName(), "5")
+                .setProperty(GroupProperty.HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                .setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "3000");
+
+        final HazelcastInstance master = factory.newHazelcastInstance(config);
+        final HazelcastInstance slave1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance slave2 = factory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, slave1, slave2);
+        warmUpPartitions(master, slave1, slave2);
+
+        fillData(master);
+        assertSizeAndDataEventually();
+
+        // reject migration commits from master to prevent migrations complete when slave3 joins the cluster
+        rejectOperationsFrom(master, F_ID, singletonList(MIGRATION_COMMIT));
+
+        final HazelcastInstance slave3 = factory.newHazelcastInstance(config);
+        assertClusterSizeEventually(4, slave1, slave2);
+
+        dropOperationsBetween(slave3, master, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.NORMAL_RESPONSE));
+        resetPacketFiltersFrom(master);
+
+        sleepSeconds(10);
+        resetPacketFiltersFrom(slave3);
+
+        waitAllForSafeState(master, slave1, slave2, slave3);
+
+        final PartitionTableView masterPartitionTable = getPartitionService(master).createPartitionTableView();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(masterPartitionTable, getPartitionService(slave1).createPartitionTableView());
+                assertEquals(masterPartitionTable, getPartitionService(slave2).createPartitionTableView());
+                assertEquals(masterPartitionTable, getPartitionService(slave3).createPartitionTableView());
+            }
+        });
+
+        assertSizeAndData();
+
+        assertNoDuplicateMigrations(master);
+        assertNoDuplicateMigrations(slave1);
+        assertNoDuplicateMigrations(slave2);
+        assertNoDuplicateMigrations(slave3);
+    }
+
+    @Test
+    public void migrationCommit_shouldRollback_whenTargetCrashes() throws Exception {
+        Config config = getConfig(true, true)
+                .setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName(), "5")
+                .setProperty(GroupProperty.HEARTBEAT_INTERVAL_SECONDS.getName(), "1")
+                .setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), "3000");
+
+        final HazelcastInstance master = factory.newHazelcastInstance(config);
+        final HazelcastInstance slave1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance slave2 = factory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, slave1, slave2);
+        warmUpPartitions(master, slave1, slave2);
+
+        fillData(master);
+        assertSizeAndDataEventually();
+
+        // reject migration commits from master to prevent migrations complete when slave3 joins the cluster
+        rejectOperationsFrom(master, F_ID, singletonList(MIGRATION_COMMIT));
+
+        final HazelcastInstance slave3 = factory.newHazelcastInstance(config);
+        assertClusterSizeEventually(4, slave1, slave2);
+
+        dropOperationsBetween(slave3, master, SpiDataSerializerHook.F_ID, singletonList(SpiDataSerializerHook.NORMAL_RESPONSE));
+        resetPacketFiltersFrom(master);
+
+        sleepSeconds(10);
+        terminateInstance(slave3);
+
+        waitAllForSafeState(master, slave1, slave2);
+
+        final PartitionTableView masterPartitionTable = getPartitionService(master).createPartitionTableView();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(masterPartitionTable, getPartitionService(slave1).createPartitionTableView());
+                assertEquals(masterPartitionTable, getPartitionService(slave2).createPartitionTableView());
+            }
+        });
+
+        assertSizeAndData();
+
+        assertNoDuplicateMigrations(master);
+        assertNoDuplicateMigrations(slave1);
+        assertNoDuplicateMigrations(slave2);
+    }
+
+    private static void assertNoDuplicateMigrations(HazelcastInstance hz) {
+        TestMigrationAwareService service = getNodeEngineImpl(hz).getService(TestMigrationAwareService.SERVICE_NAME);
+        List<PartitionMigrationEvent> events = service.getBeforeEvents();
+        Set<PartitionMigrationEvent> uniqueEvents = new HashSet<PartitionMigrationEvent>(events);
+        assertEquals(uniqueEvents.size(), events.size());
+    }
 }


### PR DESCRIPTION
- Retry fetching partition table during mastership change 
- Retry migration commit when commit operation timeouts
- Retry promotion commit when commit operation timeouts

See individual commits for additional details.