### PR TITLE
Fixed ReplicatedMap with lite members and lite member promotion

### DIFF
--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/context/LiteMemberTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/context/LiteMemberTest.java
@@ -45,7 +45,8 @@ public class LiteMemberTest {
     private HazelcastInstance instance;
 
     @Test
-    public void shouldBeLiteMember() throws InterruptedException {
-        assertTrue(instance.getConfig().isLiteMember());
+    public void shouldBeLiteMember() {
+        assertTrue("Expected Config.isLiteMember() to be true", instance.getConfig().isLiteMember());
+        assertTrue("Expected Member.isLiteMember() to be true", instance.getCluster().getLocalMember().isLiteMember());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEventPublishingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapEventPublishingService.java
@@ -123,13 +123,13 @@ public class ReplicatedMapEventPublishingService implements EventPublishingServi
                     entryListener.mapCleared(mapEvent);
                     break;
                 default:
-                    throw new IllegalArgumentException("Unsupported EntryEventType " + type);
+                    throw new IllegalArgumentException("Unsupported EntryEventType: " + type);
             }
         }
     }
 
     public String addEventListener(EventListener entryListener, EventFilter eventFilter, String mapName) {
-        if (config.isLiteMember()) {
+        if (nodeEngine.getLocalMember().isLiteMember()) {
             throw new ReplicatedMapCantBeCreatedOnLiteMemberException(nodeEngine.getThisAddress());
         }
         EventRegistration registration = eventService.registerLocalListener(SERVICE_NAME, mapName, eventFilter,
@@ -138,7 +138,7 @@ public class ReplicatedMapEventPublishingService implements EventPublishingServi
     }
 
     public boolean removeEventListener(String mapName, String registrationId) {
-        if (config.isLiteMember()) {
+        if (nodeEngine.getLocalMember().isLiteMember()) {
             throw new ReplicatedMapCantBeCreatedOnLiteMemberException(nodeEngine.getThisAddress());
         }
         if (registrationId == null) {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -112,7 +112,7 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
         if (!config.isAsyncFillup()) {
             for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
                 ReplicatedRecordStore store = service.getReplicatedRecordStore(name, false, i);
-                while (!store.isLoaded()) {
+                while (store == null || !store.isLoaded()) {
                     if ((retryCount++) % RETRY_INTERVAL_COUNT == 0) {
                         requestDataForPartition(i);
                     }
@@ -199,7 +199,7 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
         isNotNull(key, "key");
         int partitionId = partitionService.getPartitionId(key);
         ReplicatedRecordStore store = service.getReplicatedRecordStore(name, false, partitionId);
-        return store.containsKey(key);
+        return store != null && store.containsKey(key);
     }
 
     @Override
@@ -221,6 +221,9 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
         isNotNull(key, "key");
         int partitionId = partitionService.getPartitionId(key);
         ReplicatedRecordStore store = service.getReplicatedRecordStore(getName(), false, partitionId);
+        if (store == null) {
+            return null;
+        }
         return (V) store.get(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -56,10 +56,8 @@ import com.hazelcast.spi.SplitBrainHandlerService;
 import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
 import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ContextMutexFactory;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,11 +68,15 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.cluster.memberselector.MemberSelectors.DATA_MEMBER_SELECTOR;
 import static com.hazelcast.internal.config.ConfigValidator.checkReplicatedMapConfig;
+import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutSynchronized;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static java.lang.Math.max;
 
 /**
  * This is the main service implementation to handle proxy creation, event publishing, migration, anti-entropy and
@@ -90,24 +92,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
 
     private static final Object NULL_OBJECT = new Object();
 
-    private final Config config;
-    private final NodeEngine nodeEngine;
-    private final PartitionContainer[] partitionContainers;
-    private final InternalPartitionServiceImpl partitionService;
-    private final ClusterService clusterService;
-    private final OperationService operationService;
-    private final QuorumService quorumService;
-    private final ReplicatedMapEventPublishingService eventPublishingService;
-    private final ReplicatedMapSplitBrainHandlerService splitBrainHandlerService;
-    private ConcurrentHashMap<String, LocalReplicatedMapStatsImpl> statsMap =
-            new ConcurrentHashMap<String, LocalReplicatedMapStatsImpl>();
-    private ConstructorFunction<String, LocalReplicatedMapStatsImpl> constructorFunction =
-            new ConstructorFunction<String, LocalReplicatedMapStatsImpl>() {
-                @Override
-                public LocalReplicatedMapStatsImpl createNew(String arg) {
-                    return new LocalReplicatedMapStatsImpl();
-                }
-            };
+    private final AntiEntropyTask antiEntropyTask = new AntiEntropyTask();
 
     private final ConcurrentMap<String, Object> quorumConfigCache = new ConcurrentHashMap<String, Object>();
     private final ContextMutexFactory quorumConfigCacheMutexFactory = new ContextMutexFactory();
@@ -119,6 +104,28 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
             return quorumName == null ? NULL_OBJECT : quorumName;
         }
     };
+
+    private final ConcurrentHashMap<String, LocalReplicatedMapStatsImpl> statsMap =
+            new ConcurrentHashMap<String, LocalReplicatedMapStatsImpl>();
+    private final ConstructorFunction<String, LocalReplicatedMapStatsImpl> statsConstructorFunction =
+            new ConstructorFunction<String, LocalReplicatedMapStatsImpl>() {
+                @Override
+                public LocalReplicatedMapStatsImpl createNew(String arg) {
+                    return new LocalReplicatedMapStatsImpl();
+                }
+            };
+
+    private final Config config;
+    private final NodeEngine nodeEngine;
+    private final PartitionContainer[] partitionContainers;
+    private final InternalPartitionServiceImpl partitionService;
+    private final ClusterService clusterService;
+    private final OperationService operationService;
+    private final QuorumService quorumService;
+    private final ReplicatedMapEventPublishingService eventPublishingService;
+    private final ReplicatedMapSplitBrainHandlerService splitBrainHandlerService;
+
+    private ScheduledFuture antiEntropyFuture;
 
     public ReplicatedMapService(NodeEngine nodeEngine) {
         this.nodeEngine = nodeEngine;
@@ -134,58 +141,15 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
 
     @Override
     public void init(NodeEngine nodeEngine, Properties properties) {
-        if (config.isLiteMember()) {
-            return;
-        }
-
         for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
             partitionContainers[i] = new PartitionContainer(this, i);
         }
-        nodeEngine.getExecutionService().getGlobalTaskScheduler().scheduleWithRepetition(new Runnable() {
-            @Override
-            public void run() {
-                triggerAntiEntropy();
-            }
-        }, 0, SYNC_INTERVAL_SECONDS, TimeUnit.SECONDS);
-    }
-
-    /**
-     * Send an operation to all replicas to check their replica versions for all partitions for which this node is the owner
-     */
-    public void triggerAntiEntropy() {
-        if (clusterService.getSize(DATA_MEMBER_SELECTOR) == 1) {
-            return;
-        }
-        Collection<Address> addresses = new ArrayList<Address>(getMemberAddresses(DATA_MEMBER_SELECTOR));
-        addresses.remove(nodeEngine.getThisAddress());
-        for (int i = 0; i < partitionContainers.length; i++) {
-            Address thisAddress = nodeEngine.getThisAddress();
-            InternalPartition partition = partitionService.getPartition(i, false);
-            Address ownerAddress = partition.getOwnerOrNull();
-            if (!thisAddress.equals(ownerAddress)) {
-                continue;
-            }
-            PartitionContainer partitionContainer = partitionContainers[i];
-            if (partitionContainer.isEmpty()) {
-                continue;
-            }
-            for (Address address : addresses) {
-                CheckReplicaVersionOperation checkReplicaVersionOperation = new CheckReplicaVersionOperation(partitionContainer);
-                checkReplicaVersionOperation.setPartitionId(i);
-                checkReplicaVersionOperation.setValidateTarget(false);
-                operationService.createInvocationBuilder(SERVICE_NAME, checkReplicaVersionOperation, address)
-                        .setTryCount(INVOCATION_TRY_COUNT)
-                        .invoke();
-            }
-        }
+        antiEntropyFuture = nodeEngine.getExecutionService().getGlobalTaskScheduler()
+                .scheduleWithRepetition(antiEntropyTask, 0, SYNC_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override
     public void reset() {
-        if (config.isLiteMember()) {
-            return;
-        }
-
         for (int i = 0; i < nodeEngine.getPartitionService().getPartitionCount(); i++) {
             ConcurrentMap<String, ReplicatedRecordStore> stores = partitionContainers[i].getStores();
             for (ReplicatedRecordStore store : stores.values()) {
@@ -196,17 +160,18 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
 
     @Override
     public void shutdown(boolean terminate) {
-        if (config.isLiteMember()) {
-            return;
-        }
-
         for (PartitionContainer container : partitionContainers) {
-            container.shutdown();
+            if (container != null) {
+                container.shutdown();
+            }
+        }
+        if (antiEntropyFuture != null) {
+            antiEntropyFuture.cancel(true);
         }
     }
 
     public LocalReplicatedMapStatsImpl getLocalMapStatsImpl(String name) {
-        return ConcurrencyUtil.getOrPutIfAbsent(statsMap, name, constructorFunction);
+        return getOrPutIfAbsent(statsMap, name, statsConstructorFunction);
     }
 
     public LocalReplicatedMapStatsImpl createReplicatedMapStats(String name) {
@@ -223,8 +188,8 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
             Iterator<ReplicatedRecord> iterator = store.recordIterator();
             while (iterator.hasNext()) {
                 ReplicatedRecord record = iterator.next();
-                stats.setLastAccessTime(Math.max(stats.getLastAccessTime(), record.getLastAccessTime()));
-                stats.setLastUpdateTime(Math.max(stats.getLastUpdateTime(), record.getUpdateTime()));
+                stats.setLastAccessTime(max(stats.getLastAccessTime(), record.getLastAccessTime()));
+                stats.setLastUpdateTime(max(stats.getLastUpdateTime(), record.getUpdateTime()));
                 hits += record.getHits();
                 if (isBinary) {
                     memoryUsage += ((HeapData) record.getValueInternal()).getHeapCost();
@@ -242,7 +207,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
     public DistributedObject createDistributedObject(String objectName) {
         ReplicatedMapConfig replicatedMapConfig = getReplicatedMapConfig(objectName);
         checkReplicatedMapConfig(replicatedMapConfig);
-        if (config.isLiteMember()) {
+        if (nodeEngine.getLocalMember().isLiteMember()) {
             throw new ReplicatedMapCantBeCreatedOnLiteMemberException(nodeEngine.getThisAddress());
         }
 
@@ -258,7 +223,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
 
     @Override
     public void destroyDistributedObject(String objectName) {
-        if (config.isLiteMember()) {
+        if (nodeEngine.getLocalMember().isLiteMember()) {
             return;
         }
 
@@ -273,7 +238,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
         eventPublishingService.dispatchEvent(event, listener);
     }
 
-
+    @SuppressWarnings("deprecation")
     public ReplicatedMapConfig getReplicatedMapConfig(String name) {
         return config.getReplicatedMapConfig(name).getAsReadOnly();
     }
@@ -283,7 +248,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
     }
 
     public ReplicatedRecordStore getReplicatedRecordStore(String name, boolean create, int partitionId) {
-        if (config.isLiteMember()) {
+        if (nodeEngine.getLocalMember().isLiteMember()) {
             throw new ReplicatedMapCantBeCreatedOnLiteMemberException(nodeEngine.getThisAddress());
         }
 
@@ -331,7 +296,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
                     listener = ClassLoaderUtil.newInstance(nodeEngine.getConfigClassLoader(),
                             listenerConfig.getClassName());
                 } catch (Exception e) {
-                    throw ExceptionUtil.rethrow(e);
+                    throw rethrow(e);
                 }
             }
             if (listener != null) {
@@ -357,10 +322,9 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
 
     @Override
     public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
-        if (config.isLiteMember()) {
+        if (nodeEngine.getLocalMember().isLiteMember()) {
             return null;
         }
-
         if (event.getReplicaIndex() > 0) {
             return null;
         }
@@ -409,12 +373,55 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
         if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
             return null;
         }
-        Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory,
-                quorumConfigConstructor);
+        Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory, quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;
     }
 
     public void ensureQuorumPresent(String distributedObjectName, QuorumType requiredQuorumPermissionType) {
         quorumService.ensureQuorumPresent(getQuorumName(distributedObjectName), requiredQuorumPermissionType);
+    }
+
+    // needed for a test
+    public void triggerAntiEntropy() {
+        antiEntropyTask.triggerAntiEntropy();
+    }
+
+    private class AntiEntropyTask implements Runnable {
+
+        @Override
+        public void run() {
+            triggerAntiEntropy();
+        }
+
+        /**
+         * Sends an operation to all replicas to check their replica versions for all partitions for which this node is the owner.
+         */
+        void triggerAntiEntropy() {
+            if (nodeEngine.getLocalMember().isLiteMember() || clusterService.getSize(DATA_MEMBER_SELECTOR) == 1) {
+                return;
+            }
+            Collection<Address> addresses = new ArrayList<Address>(getMemberAddresses(DATA_MEMBER_SELECTOR));
+            addresses.remove(nodeEngine.getThisAddress());
+            for (int i = 0; i < partitionContainers.length; i++) {
+                Address thisAddress = nodeEngine.getThisAddress();
+                InternalPartition partition = partitionService.getPartition(i, false);
+                Address ownerAddress = partition.getOwnerOrNull();
+                if (!thisAddress.equals(ownerAddress)) {
+                    continue;
+                }
+                PartitionContainer partitionContainer = partitionContainers[i];
+                if (partitionContainer.isEmpty()) {
+                    continue;
+                }
+                for (Address address : addresses) {
+                    Operation operation = new CheckReplicaVersionOperation(partitionContainer)
+                            .setPartitionId(i)
+                            .setValidateTarget(false);
+                    operationService.createInvocationBuilder(SERVICE_NAME, operation, address)
+                            .setTryCount(INVOCATION_TRY_COUNT)
+                            .invoke();
+                }
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperation.java
@@ -59,7 +59,7 @@ public class ClearOperation extends AbstractNamedSerializableOperation implement
 
     @Override
     public void run() throws Exception {
-        if (getNodeEngine().getConfig().isLiteMember()) {
+        if (getNodeEngine().getLocalMember().isLiteMember()) {
             return;
         }
         ReplicatedMapService service = getService();

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ContainsKeyOperation.java
@@ -43,7 +43,7 @@ public class ContainsKeyOperation extends AbstractNamedSerializableOperation imp
     public void run() throws Exception {
         ReplicatedMapService service = getService();
         ReplicatedRecordStore store = service.getReplicatedRecordStore(name, false, getPartitionId());
-        response = store.containsKey(key);
+        response = store != null && store.containsKey(key);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/GetOperation.java
@@ -44,9 +44,11 @@ public class GetOperation extends AbstractNamedSerializableOperation implements 
     public void run() throws Exception {
         ReplicatedMapService service = getService();
         ReplicatedRecordStore store = service.getReplicatedRecordStore(name, false, getPartitionId());
-        ReplicatedRecord record = store.getReplicatedRecord(key);
-        if (record != null) {
-            response = record.getValue();
+        if (store != null) {
+            ReplicatedRecord record = store.getReplicatedRecord(key);
+            if (record != null) {
+                response = record.getValue();
+            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/ManagedService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ManagedService.java
@@ -19,38 +19,36 @@ package com.hazelcast.spi;
 import java.util.Properties;
 
 /**
- * A interface that can be implemented by a SPI Service to receive lifecycle calls:
+ * An interface that can be implemented by an SPI Service to receive lifecycle calls:
  * <ol>
- *     <li>initialization</li>
- *     <li>shutdown</li>
- *     <li>reset</li>
+ * <li>initialization</li>
+ * <li>shutdown</li>
+ * <li>reset</li>
  * </ol>
- *
- * @author mdogan 7/23/12
  */
 public interface ManagedService {
 
     /**
-     * Initializes this ManagedService
+     * Initializes this service.
      *
-     * @param nodeEngine the NodeEngine that this ManagedService belongs to.
-     * @param properties the Properties. Can be used to pass settings to the service.
+     * @param nodeEngine the NodeEngine that this service belongs to
+     * @param properties the Properties (can be used to pass settings to the service)
      */
     void init(NodeEngine nodeEngine, Properties properties);
 
     /**
-     * reset this ManagedService back to initial state.
-     *
-     * todo: what is the purpose of reset
+     * Resets this service back to its initial state.
+     * <p>
+     * TODO: what is the purpose of reset
      */
     void reset();
 
     /**
-     * Shuts down this ManagedService.
+     * Shuts down this service.
+     * <p>
+     * TODO: what is the purpose of the terminate variable
      *
-     * todo: what is the purpose of the terminate variable.
-     *
-     * @param terminate true to shut down the ManagedService
+     * @param terminate {@code true} to shut down this service
      */
     void shutdown(boolean terminate);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -24,7 +24,6 @@ import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.util.Collection;
 import java.util.Map;
@@ -34,6 +33,7 @@ import java.util.concurrent.ConcurrentMap;
 import static com.hazelcast.core.DistributedObjectEvent.EventType.CREATED;
 import static com.hazelcast.core.DistributedObjectEvent.EventType.DESTROYED;
 import static com.hazelcast.util.EmptyStatement.ignore;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 /**
  * A ProxyRegistry contains all proxies for a given service. For example, it contains all proxies for the IMap.
@@ -204,7 +204,7 @@ public final class ProxyRegistry {
             // deregister future to avoid infinite hang on future.get()
             proxyFuture.setError(e);
             proxies.remove(name);
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
 
         InternalEventService eventService = proxyService.nodeEngine.getEventService();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/operations/PostJoinProxyOperation.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.CacheNotExistsException;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.replicatedmap.ReplicatedMapCantBeCreatedOnLiteMemberException;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -31,6 +32,8 @@ import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 public class PostJoinProxyOperation extends Operation implements IdentifiedDataSerializable {
 
@@ -128,11 +131,15 @@ public class PostJoinProxyOperation extends Operation implements IdentifiedDataS
             try {
                 registry.createProxy(proxyInfo.getObjectName(), false, true);
             } catch (CacheNotExistsException e) {
-                // This can happen when cache destroy event is received
-                // after cache config is replicated during join (pre-join)
-                // but before cache proxy is created (post-join).
-                getLogger().fine("Could not create Cache[" + proxyInfo.getObjectName()
-                        + "]. It is already destroyed.", e);
+                // this can happen when a cache destroy event is received
+                // after the cache config is replicated during join (pre-join)
+                // but before the cache proxy is created (post-join)
+                getLogger().fine("Could not create Cache[" + proxyInfo.getObjectName() + "]. It is already destroyed.", e);
+            } catch (ReplicatedMapCantBeCreatedOnLiteMemberException e) {
+                // this happens when there is a lite member in the cluster
+                // and a data member creates a ReplicatedMap proxy
+                // (this is totally expected and doesn't need logging)
+                ignore(e);
             } catch (Exception e) {
                 logProxyCreationFailure(proxyInfo, e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -26,8 +26,6 @@ import com.hazelcast.collection.impl.set.SetService;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.concurrent.countdownlatch.CountDownLatchService;
-import com.hazelcast.crdt.CRDTReplicationMigrationService;
-import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
@@ -35,9 +33,11 @@ import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.config.ServicesConfig;
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.crdt.CRDTReplicationMigrationService;
 import com.hazelcast.crdt.pncounter.PNCounterService;
 import com.hazelcast.durableexecutor.impl.DistributedDurableExecutorService;
 import com.hazelcast.executor.impl.DistributedExecutorService;
+import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
@@ -66,7 +66,7 @@ import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 import com.hazelcast.transaction.impl.TransactionManagerServiceImpl;
 import com.hazelcast.transaction.impl.xa.XAService;
-import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.ServiceLoader;
 import com.hazelcast.wan.WanReplicationService;
 
 import java.lang.reflect.Constructor;
@@ -82,10 +82,13 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.util.EmptyStatement.ignore;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 @SuppressWarnings("checkstyle:classfanoutcomplexity")
 public final class ServiceManagerImpl implements ServiceManager {
+
     private static final String PROVIDER_ID = "com.hazelcast.spi.impl.servicemanager.RemoteServiceDescriptorProvider";
+
     private final NodeEngineImpl nodeEngine;
     private final ILogger logger;
     private final ConcurrentMap<String, ServiceInfo> services = new ConcurrentHashMap<String, ServiceInfo>(20, .75f, 1);
@@ -177,12 +180,11 @@ public final class ServiceManagerImpl implements ServiceManager {
 
         try {
             ClassLoader classLoader = node.getConfigClassLoader();
-            Iterator<Class<RemoteServiceDescriptorProvider>> iter =
-                    com.hazelcast.util.ServiceLoader.classIterator(RemoteServiceDescriptorProvider.class, PROVIDER_ID,
-                            classLoader);
+            Iterator<Class<RemoteServiceDescriptorProvider>> iterator
+                    = ServiceLoader.classIterator(RemoteServiceDescriptorProvider.class, PROVIDER_ID, classLoader);
 
-            while (iter.hasNext()) {
-                Class<RemoteServiceDescriptorProvider> clazz = iter.next();
+            while (iterator.hasNext()) {
+                Class<RemoteServiceDescriptorProvider> clazz = iterator.next();
                 Constructor<RemoteServiceDescriptorProvider> constructor = clazz.getDeclaredConstructor();
                 RemoteServiceDescriptorProvider provider = constructor.newInstance();
                 RemoteServiceDescriptor[] services = provider.createRemoteServiceDescriptors();
@@ -192,7 +194,7 @@ public final class ServiceManagerImpl implements ServiceManager {
                 }
             }
         } catch (Exception e) {
-            throw ExceptionUtil.rethrow(e);
+            throw rethrow(e);
         }
     }
 
@@ -203,8 +205,7 @@ public final class ServiceManagerImpl implements ServiceManager {
     }
 
     private void registerCacheServiceIfAvailable() {
-        //CacheService Optional initialization
-        //search for jcache api jar on classpath
+        // optional initialization for CacheService when JCache API is on classpath
         if (JCacheDetector.isJCacheAvailable(nodeEngine.getConfigClassLoader(), logger)) {
             ICacheService service = createService(ICacheService.class);
             registerService(ICacheService.SERVICE_NAME, service);
@@ -295,7 +296,7 @@ public final class ServiceManagerImpl implements ServiceManager {
     public synchronized void shutdown(boolean terminate) {
         logger.finest("Stopping services...");
         final List<ManagedService> managedServices = getServices(ManagedService.class);
-        // reverse order to stop CoreServices last.
+        // reverse order to stop CoreServices last
         Collections.reverse(managedServices);
         services.clear();
         for (ManagedService service : managedServices) {
@@ -376,7 +377,7 @@ public final class ServiceManagerImpl implements ServiceManager {
 
     /**
      * Returns a list of services matching provided service class/interface.
-     * <br></br>
+     * <p>
      * <b>CoreServices will be placed at the beginning of the list.</b>
      */
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
@@ -43,7 +43,7 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(value = {QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapAntiEntropyTest extends ReplicatedMapAbstractTest {
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLiteMemberTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.replicatedmap.impl.ReplicatedMapService.SERVICE_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -38,33 +39,57 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapLiteMemberTest extends HazelcastTestSupport {
 
+    private Config dataMemberConfig = buildConfig(false);
+    private Config liteMemberConfig = buildConfig(true);
+
     @Test
     public void testLiteMembersWithReplicatedMap() {
-        Config config = buildConfig(false);
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
 
-        final HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(config);
-        final HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(config);
-        final HazelcastInstance lite = nodeFactory.newHazelcastInstance(buildConfig(true));
+        final HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(dataMemberConfig);
+        final HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(dataMemberConfig);
+        final HazelcastInstance lite = nodeFactory.newHazelcastInstance(liteMemberConfig);
 
-        ReplicatedMap<String, String> map1 = instance1.getReplicatedMap("default");
+        ReplicatedMap<String, String> replicatedMap = instance1.getReplicatedMap("default");
 
-        map1.put("key", "value");
+        replicatedMap.put("key", "value");
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
+                assertTrue(instance1.getReplicatedMap("default").containsKey("key"));
                 assertTrue(instance2.getReplicatedMap("default").containsKey("key"));
             }
         });
-
         assertTrueAllTheTime(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 ReplicatedMapService service = getReplicatedMapService(lite);
                 assertEquals(0, service.getAllReplicatedRecordStores("default").size());
             }
-        }, 5);
+        }, 3);
+    }
+
+    @Test
+    public void testPromoteLiteMember() {
+        String mapName = randomName();
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        HazelcastInstance instance1 = nodeFactory.newHazelcastInstance(dataMemberConfig);
+
+        ReplicatedMap<String, String> map = instance1.getReplicatedMap(mapName);
+        map.put("key", "value");
+
+        HazelcastInstance instance2 = nodeFactory.newHazelcastInstance(liteMemberConfig);
+        instance2.getCluster().promoteLocalLiteMember();
+
+        final ReplicatedMap<String, String> promotedMap = instance2.getReplicatedMap(mapName);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals("Expected the promoted lite member to retrieve a value from a ReplicatedMap",
+                        "value", promotedMap.get("key"));
+            }
+        });
     }
 
     @Test(expected = ReplicatedMapCantBeCreatedOnLiteMemberException.class)
@@ -87,20 +112,18 @@ public class ReplicatedMapLiteMemberTest extends HazelcastTestSupport {
         service.getReplicatedRecordStore("default", false, 1);
     }
 
-
     private HazelcastInstance createSingleLiteMember() {
         TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(1);
-        return nodeFactory.newHazelcastInstance(buildConfig(true));
+        return nodeFactory.newHazelcastInstance(liteMemberConfig);
     }
 
-    private ReplicatedMapService getReplicatedMapService(HazelcastInstance lite) {
-        NodeEngineImpl nodeEngine = getNodeEngineImpl(lite);
-        return nodeEngine.getService(ReplicatedMapService.SERVICE_NAME);
+    private ReplicatedMapService getReplicatedMapService(HazelcastInstance instance) {
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(instance);
+        return nodeEngine.getService(SERVICE_NAME);
     }
 
     private Config buildConfig(boolean liteMember) {
-        Config config = new Config();
-        config.setLiteMember(liteMember);
-        return config;
+        return smallInstanceConfig()
+                .setLiteMember(liteMember);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLoadingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapLoadingTest.java
@@ -33,7 +33,7 @@ import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(value = {QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapLoadingTest extends ReplicatedMapAbstractTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapPutSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapPutSerializationTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(value = {QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapPutSerializationTest extends HazelcastTestSupport {
 
     static AtomicInteger deSerializationCount = new AtomicInteger(0);

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReadYourWritesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapReadYourWritesTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(value = {QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapReadYourWritesTest extends ReplicatedMapAbstractTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/ReplicatedMapServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/ReplicatedMapServiceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.replicatedmap.impl;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ReplicatedMapServiceTest extends HazelcastTestSupport {
+
+    private NodeEngine nodeEngine;
+
+    @Before
+    public void setUp() {
+        HazelcastInstance hazelcastInstance = createHazelcastInstance();
+        nodeEngine = getNodeEngineImpl(hazelcastInstance);
+    }
+
+    @Test
+    public void testShutdown() {
+        ReplicatedMapService service = new ReplicatedMapService(nodeEngine);
+        service.init(nodeEngine, null);
+
+        service.shutdown(true);
+    }
+
+    @Test
+    public void testShutdown_withoutInit() {
+        ReplicatedMapService service = new ReplicatedMapService(nodeEngine);
+
+        service.shutdown(true);
+    }
+}


### PR DESCRIPTION
* fixed the `ReplicatedMapProxy` to create the partition containers and anti entropy task eagerly on a lite member to enable promotion
* fixed the `ReplicatedMap` classes from hard-coded `config.isLiteMember()` to `Member.isLiteMember()` checks to enable promotion
* removed the `ReplicatedRecordStore`s from the `PartitionContainer` during split-brain merge preparations (will be done by the unified code later and this caused NPEs due to the missing stores)
* added missing null checks for `getReplicatedRecordStore()` when the `create` flag is `false` (which might return `null` after a split-brain)
* suppressed logging of `ReplicatedMapCantBeCreatedOnLiteMemberException` when there is a lite member in the cluster and the `ReplicatedMap` is just used on the data members
* added missing tests for lite member promotion with `ReplicatedMap`

<hr/>

This fix approach will use a bit more memory, since the `PartitionContainer[] partitionContainers` is populated eagerly (even if the lite member will never be promoted). Also the anti entropy task is created right away (but checks for the lite member flag on its execution).

I think this is the simplest way to fix the promotion. I didn't see a listener or other notification mechanism to do it lazy after a promotion (I had a quick look if `PromotionAwareManagedService extends ManagedService` with a `promote(NodeEngine)` would be a solution, but it looked too complex to just fix the `ReplicatedMap`). I also didn't want to do it lazy on each method with a `ensureIsInitialized()` method, mainly because I wanted to prevent visibility issues on the partition container array and avoid to deal with concurrent initializations.

I see a tiny optimization potential in the `PartitionContainer` by moving the `ConstructorFunction<String, ReplicatedRecordStore> constructor` to the `ReplicatedMapService`, since it's the same in all instances. This could save a bit of memory in all scenarios, but also conflate the concerns of the classes.

Otherwise I think this fix is a fair compromise of memory usage vs. code complexity.

<hr/>

The log suppressions in `PostJoinProxyOperation` and `RemoteEventProcessor` are not super nice. But you can see that we just added a suppression for `ICache` there as well.

<hr/>

The changes in the `ReplicatedMapSplitBrainHandlerService` emulate what the split-brain healing for `ReplicatedMap` will do, once I use the unified code for it (`AbstractSplitBrainHandlerService` and `AbstractMergeRunnable`). It uses iterators and removes the stores from their partition containers. I just added this part here, to ensure that we'll catch all issues right away. This will make the unification PR much simpler.

<hr/>

Fixes: https://github.com/hazelcast/hazelcast/issues/12537