### PR TITLE
Fix ManagementCenterService shutting down if MC is enabled on JDK 9

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
@@ -164,8 +164,6 @@ final class TimedMemberStateFactoryHelper {
                 return (Long) value;
             }
             return defaultValue;
-        } catch (RuntimeException re) {
-            throw re;
         } catch (Exception e) {
             return defaultValue;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactoryHelper.java
@@ -164,6 +164,8 @@ final class TimedMemberStateFactoryHelper {
                 return (Long) value;
             }
             return defaultValue;
+        } catch (RuntimeException e) {
+            return defaultValue;
         } catch (Exception e) {
             return defaultValue;
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ZuluExcludeRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ZuluExcludeRule.java
@@ -20,6 +20,7 @@ import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
+import static java.lang.Integer.parseInt;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -38,12 +39,7 @@ public class ZuluExcludeRule implements MethodRule {
         String vendor = System.getProperty(vendorPropertyName);
         assertNotNull(vendorPropertyName + " should be set!", vendor);
 
-        int version;
-        if (versionProperty.contains(".")) {
-            version = Integer.parseInt(versionProperty.split("\\.")[1]);
-        } else {
-            version = Integer.parseInt(versionProperty);
-        }
+        int version = parseInt(versionProperty.contains(".") ? versionProperty.split("\\.")[1] : versionProperty);
         EXCLUDED = version < 8 && vendor.startsWith("Azul");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ZuluExcludeRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ZuluExcludeRule.java
@@ -38,7 +38,12 @@ public class ZuluExcludeRule implements MethodRule {
         String vendor = System.getProperty(vendorPropertyName);
         assertNotNull(vendorPropertyName + " should be set!", vendor);
 
-        int version = Integer.parseInt(versionProperty.split("\\.")[1]);
+        int version;
+        if (versionProperty.contains(".")) {
+            version = Integer.parseInt(versionProperty.split("\\.")[1]);
+        } else {
+            version = Integer.parseInt(versionProperty);
+        }
         EXCLUDED = version < 8 && vendor.startsWith("Azul");
     }
 


### PR DESCRIPTION
* Some of the MXBeans' methods can't be made accessible under JDK 9, which
cause RuntimeExceptions and as we rethrow them it causes the
ManagementCenterService to shutdown. With this fix, we return the
default value for a stat in case any exception occurs. 
* Fix JDK version parsing logic for JDK 9 in ZuluExcludeRule
* The following tests are fixed on JDK with this PR (see [this temporary build](https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-3.x-OracleJDK9-emre/2/#showFailuresLink) with these results):
  * ExecuteScriptRequestTest
  * TimedMemberStateIntegrationTest
  * MemberStateImplTest

Fixes hazelcast/management-center#537