### PR TITLE
Revert "Cleanup of ConcurrencyUtil"

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
@@ -20,9 +20,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
-import static com.hazelcast.nio.IOUtil.closeResource;
-import static com.hazelcast.util.Preconditions.checkNotNull;
-
 /**
  * Utility methods to getOrPutSynchronized and getOrPutIfAbsent in a thread safe way
  * from a {@link ConcurrentMap} with a {@link ConstructorFunction}.
@@ -44,6 +41,7 @@ public final class ConcurrencyUtil {
             if (current >= value) {
                 return;
             }
+
             if (updater.compareAndSet(obj, current, value)) {
                 return;
             }
@@ -62,9 +60,11 @@ public final class ConcurrencyUtil {
         }
     }
 
-    @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
-    public static <K, V> V getOrPutSynchronized(ConcurrentMap<K, V> map, K key, Object mutex, ConstructorFunction<K, V> func) {
-        checkNotNull(mutex, "mutex cannot be null");
+    public static <K, V> V getOrPutSynchronized(ConcurrentMap<K, V> map, K key, final Object mutex,
+                                                ConstructorFunction<K, V> func) {
+        if (mutex == null) {
+            throw new NullPointerException();
+        }
         V value = map.get(key);
         if (value == null) {
             synchronized (mutex) {
@@ -80,13 +80,25 @@ public final class ConcurrencyUtil {
 
     public static <K, V> V getOrPutSynchronized(ConcurrentMap<K, V> map, K key, ContextMutexFactory contextMutexFactory,
                                                 ConstructorFunction<K, V> func) {
-        checkNotNull(contextMutexFactory, "contextMutexFactory cannot be null");
-        ContextMutexFactory.Mutex mutex = contextMutexFactory.mutexFor(key);
-        try {
-            return getOrPutSynchronized(map, key, mutex, func);
-        } finally {
-            closeResource(mutex);
+        if (contextMutexFactory == null) {
+            throw new NullPointerException();
         }
+        V value = map.get(key);
+        if (value == null) {
+            ContextMutexFactory.Mutex mutex = contextMutexFactory.mutexFor(key);
+            try {
+                synchronized (mutex) {
+                    value = map.get(key);
+                    if (value == null) {
+                        value = func.createNew(key);
+                        map.put(key, value);
+                    }
+                }
+            } finally {
+                mutex.close();
+            }
+        }
+        return value;
     }
 
     public static <K, V> V getOrPutIfAbsent(ConcurrentMap<K, V> map, K key, ConstructorFunction<K, V> func) {
@@ -98,4 +110,5 @@ public final class ConcurrencyUtil {
         }
         return value;
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/ConcurrencyUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ConcurrencyUtilTest.java
@@ -40,7 +40,7 @@ public class ConcurrencyUtilTest extends HazelcastTestSupport {
 
     private final IntIntConstructorFunction constructorFunction = new IntIntConstructorFunction();
 
-    private final ConcurrentMap<Integer, Integer> map = new ConcurrentHashMap<Integer, Integer>();
+    private ConcurrentMap<Integer, Integer> map = new ConcurrentHashMap<Integer, Integer>();
 
     @Test
     public void testConstructor() {
@@ -75,8 +75,7 @@ public class ConcurrencyUtilTest extends HazelcastTestSupport {
     @SuppressWarnings("ConstantConditions")
     @Test(expected = NullPointerException.class)
     public void testGetOrPutSynchronized_whenMutexIsNull_thenThrowException() {
-        Object mutex = null;
-        ConcurrencyUtil.getOrPutSynchronized(map, 5, mutex, constructorFunction);
+        ConcurrencyUtil.getOrPutSynchronized(map, 5, (Object) null, constructorFunction);
     }
 
     @Test
@@ -112,7 +111,7 @@ public class ConcurrencyUtilTest extends HazelcastTestSupport {
         volatile long value;
     }
 
-    private static final class IntIntConstructorFunction implements ConstructorFunction<Integer, Integer> {
+    private static class IntIntConstructorFunction implements ConstructorFunction<Integer, Integer> {
 
         private AtomicInteger constructions = new AtomicInteger();
 


### PR DESCRIPTION
Reverts hazelcast/hazelcast#11660

This causes a huge performance regression because the mutex factory is now always entered.

```

    public static <K, V> V getOrPutSynchronized(ConcurrentMap<K, V> map, K key, ContextMutexFactory contextMutexFactory,
                                                ConstructorFunction<K, V> func) {
        checkNotNull(contextMutexFactory, "contextMutexFactory cannot be null");
        ContextMutexFactory.Mutex mutex = contextMutexFactory.mutexFor(key);<---- happens always
        try {
            return getOrPutSynchronized(map, key, mutex, func);
        } finally {
            closeResource(mutex);
        }
    }
```

And in the old code it only happens when the value is null.

```
 public static <K, V> V getOrPutSynchronized(ConcurrentMap<K, V> map, K key, ContextMutexFactory contextMutexFactory,
                                                ConstructorFunction<K, V> func) {
        if (contextMutexFactory == null) {
            throw new NullPointerException();
        }
        V value = map.get(key);
        if (value == null) {
            ContextMutexFactory.Mutex mutex = contextMutexFactory.mutexFor(key);
            try {
                synchronized (mutex) {
                    value = map.get(key);
                    if (value == null) {
                        value = func.createNew(key);
                        map.put(key, value);
                    }
                }
            } finally {
                mutex.close();
            }
        }
        return value;
    }
```

@vbekiaris thanks for pinpointing it to the exact cause!!!

In my benchmark this change causes a performance degradation of 30+%.