### PR TITLE
Correct usage of Runtime in RuntimeMetricSet

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSet.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.metrics.metricsets;
 
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
@@ -85,7 +84,7 @@ public final class RuntimeMetricSet {
                 new LongProbeFunction<Runtime>() {
                     @Override
                     public long get(Runtime runtime) {
-                        return RuntimeAvailableProcessors.get();
+                        return runtime.availableProcessors();
                     }
                 }
         );

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/RuntimeMetricSetTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.metrics.metricsets;
 import com.hazelcast.internal.metrics.LongGauge;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
-import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -107,7 +106,7 @@ public class RuntimeMetricSetTest extends HazelcastTestSupport {
     @Test
     public void availableProcessors() {
         LongGauge gauge = metricsRegistry.newLongGauge("runtime.availableProcessors");
-        assertEquals(RuntimeAvailableProcessors.get(), gauge.read());
+        assertEquals(runtime.availableProcessors(), gauge.read());
     }
 
     @Test


### PR DESCRIPTION
Revert usage of RuntimeAvailableProcessors from https://github.com/hazelcast/hazelcast/pull/12525 according to the comment of @pveentjer here: https://github.com/hazelcast/hazelcast/pull/12527