### PR TITLE
 Publish oldValue after imap#set when map has a query cache

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheUpdateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheUpdateTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.querycache;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.QueryCache;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientQueryCacheUpdateTest extends HazelcastTestSupport {
+
+    private final String mapName = randomString();
+    private final String queryCacheName = randomString();
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    private HazelcastInstance client;
+
+    @Before
+    public void setUp() {
+        factory.newHazelcastInstance();
+
+        QueryCacheConfig queryCacheConfig = new QueryCacheConfig(queryCacheName);
+        queryCacheConfig.getPredicateConfig().setImplementation(new SqlPredicate("id=1"));
+
+        ClientConfig config = new ClientConfig();
+        config.addQueryCacheConfig(mapName, queryCacheConfig);
+
+        client = factory.newHazelcastClient(config);
+    }
+
+    @After
+    public void tearDown() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void query_cache_gets_latest_updated_value_when_map_is_updated_via_set_method() {
+        IMap<Integer, IdWrapper> clientMap = client.getMap(mapName);
+        final QueryCache<Integer, IdWrapper> queryCache = clientMap.getQueryCache(queryCacheName);
+
+        int id = 1;
+        for (int value = 0; value < 10; value++) {
+            clientMap.set(id, new IdWrapper(id, value));
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                IdWrapper idWrapper = queryCache.get(1);
+                assertEquals(9, idWrapper.value);
+            }
+        });
+    }
+
+
+    public static class IdWrapper implements Serializable {
+        public int id;
+        public int value;
+
+        public IdWrapper(int id, int value) {
+            this.id = id;
+            this.value = value;
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetOperation.java
@@ -35,15 +35,20 @@ public class SetOperation extends BasePutOperation implements MutatingOperation 
     }
 
     @Override
+    public void run() {
+        Object oldValue = recordStore.set(dataKey, dataValue, ttl);
+        newRecord = oldValue == null;
+
+        if (recordStore.hasQueryCache()) {
+            dataOldValue = mapServiceContext.toData(oldValue);
+        }
+    }
+
+    @Override
     public void afterRun() {
         eventType = newRecord ? ADDED : UPDATED;
 
         super.afterRun();
-    }
-
-    @Override
-    public void run() {
-        newRecord = recordStore.set(dataKey, dataValue, ttl);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -677,7 +677,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     /**
      * @return {@code true} if this IMap has any query-cache, otherwise return {@code false}
      */
-    private boolean hasQueryCache() {
+    public boolean hasQueryCache() {
         QueryCacheContext queryCacheContext = mapServiceContext.getQueryCacheContext();
         PublisherContext publisherContext = queryCacheContext.getPublisherContext();
         MapPublisherRegistry mapPublisherRegistry = publisherContext.getMapPublisherRegistry();
@@ -690,6 +690,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                 record.getKey(), mapServiceContext.toData(record.getValue()), null, null, ADDED.getType());
 
         mapEventPublisher.addEventToQueryCache(eventData);
+    }
+
+    @Override
+    public Object set(Data dataKey, Object value, long ttl) {
+        return putInternal(dataKey, value, ttl, false, true);
     }
 
     @Override
@@ -958,12 +963,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }
 
         return true;
-    }
-
-    @Override
-    public boolean set(Data dataKey, Object value, long ttl) {
-        Object oldValue = putInternal(dataKey, value, ttl, false, true);
-        return oldValue == null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -51,6 +51,16 @@ public interface RecordStore<R extends Record> {
 
     String getName();
 
+    /**
+     * @return oldValue only if it exists in memory, otherwise just returns
+     * null and doesn't try to load it from {@link com.hazelcast.core.MapLoader}
+     */
+    Object set(Data dataKey, Object value, long ttl);
+
+    /**
+     * @return oldValue if it exists in memory otherwise tries to load oldValue
+     * by using {@link com.hazelcast.core.MapLoader}
+     */
     Object put(Data dataKey, Object dataValue, long ttl);
 
     Object putIfAbsent(Data dataKey, Object value, long ttl);
@@ -65,17 +75,6 @@ public interface RecordStore<R extends Record> {
      * @return previous record if exists otherwise null.
      */
     R putBackup(Data key, Object value, long ttl, boolean putTransient);
-
-    /**
-     * Sets a value associated with the given {@code dataKey} to the new given {@code value}.
-     *
-     * @param dataKey the key to set the value of.
-     * @param value   the new value to store.
-     * @param ttl     the TTL for the new value.
-     * @return {@code true} if the key wasn't existent before the operation, {@code false} otherwise.
-     * @see com.hazelcast.core.IMap#set(Object, Object)
-     */
-    boolean set(Data dataKey, Object value, long ttl);
 
     /**
      * Does exactly the same thing as {@link #set(Data, Object, long)} except the invocation is not counted as
@@ -467,4 +466,10 @@ public interface RecordStore<R extends Record> {
      * @param exception an exception that occurred during key loading
      */
     void updateLoadStatus(boolean lastBatch, Throwable exception);
+
+    /**
+     * @return true if there is a {@link com.hazelcast.map.QueryCache} defined
+     * for this map.
+     */
+    boolean hasQueryCache();
 }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/10556

__Fix:__ imap#set was not setting oldValue even operation is an update-operation and this was breaking expectation of query-cache internal event handling. This pr just setting it if we have a query-cache.

- [ ] needs    EE and maintenance backports