### PR TITLE
Fix partition assignment test by asserting cluster size before terminating nodes

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractPartitionAssignmentsCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractPartitionAssignmentsCorrectnessTest.java
@@ -41,8 +41,10 @@ public abstract class AbstractPartitionAssignmentsCorrectnessTest extends Partit
 
         int size = 1;
         while (size < (nodeCount + 1)) {
-            startNodes(config, backupCount + 1);
+            Collection<HazelcastInstance> instances = startNodes(config, backupCount + 1);
             size += (backupCount + 1);
+
+            assertClusterSizeEventually(size, instances);
 
             terminateNodes(backupCount);
             size -= backupCount;

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -963,6 +963,12 @@ public abstract class HazelcastTestSupport {
         }
     }
 
+    public static void assertClusterSizeEventually(int expectedSize, Collection<HazelcastInstance> instances) {
+        for (HazelcastInstance instance : instances) {
+            assertClusterSizeEventually(expectedSize, instance, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
+        }
+    }
+
     public static void assertClusterSizeEventually(final int expectedSize, final HazelcastInstance instance,
                                                    long timeoutSeconds) {
         assertTrueEventually(new AssertTask() {


### PR DESCRIPTION
Otherwise a missing/late membership update before terminating a node
can cause unexpected cluster splits and test fail.

Fixes https://github.com/hazelcast/hazelcast/issues/8062

Backport of https://github.com/hazelcast/hazelcast/pull/12560