### PR TITLE
Ensures dynamic data structure configs can be added when proper version

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientDynamicConfigRollingUpgradeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientDynamicConfigRollingUpgradeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigRollingUpgradeTest;
+import com.hazelcast.version.Version;
+import org.junit.After;
+
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
+
+public class ClientDynamicConfigRollingUpgradeTest extends DynamicConfigRollingUpgradeTest {
+
+    private TestHazelcastFactory factory;
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance createHazelcastInstance(Version version) {
+        factory = new TestHazelcastFactory();
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, version.toString());
+        factory.newHazelcastInstance();
+        return factory.newHazelcastClient();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractBasicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractBasicConfig.java
@@ -24,6 +24,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * Provides a basic configuration for a split-brain aware data structure.
  *
  * @param <T> type of the config
+ * @since 3.10
  */
 @SuppressWarnings("WeakerAccess")
 public abstract class AbstractBasicConfig<T extends AbstractBasicConfig> implements IdentifiedDataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/config/AtomicLongConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AtomicLongConfig.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 
 /**
  * Contains the configuration for an {@link java.util.concurrent.atomic.AtomicLong}.
+ *
+ * @since 3.10
  */
 public class AtomicLongConfig extends AbstractBasicConfig<AtomicLongConfig> {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AtomicReferenceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AtomicReferenceConfig.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 
 /**
  * Contains the configuration for an {@link java.util.concurrent.atomic.AtomicReference}.
+ *
+ * @since 3.10
  */
 public class AtomicReferenceConfig extends AbstractBasicConfig<AtomicReferenceConfig> {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CountDownLatchConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CountDownLatchConfig.java
@@ -28,6 +28,8 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 
 /**
  * Contains the configuration for an {@link com.hazelcast.core.ICountDownLatch}.
+ *
+ * @since 3.10
  */
 public class CountDownLatchConfig implements IdentifiedDataSerializable, Versioned {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
@@ -32,6 +32,8 @@ import static com.hazelcast.util.Preconditions.checkTrue;
  * The {@code FlakeIdGeneratorConfig} contains the configuration for the member
  * regarding {@link com.hazelcast.core.HazelcastInstance#getFlakeIdGenerator(String)
  * Flake ID Generator}.
+ *
+ * @since 3.10
  */
 public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/PNCounterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PNCounterConfig.java
@@ -27,6 +27,8 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
  * Configuration for a {@link com.hazelcast.crdt.pncounter.PNCounter}
+ *
+ * @since 3.10
  */
 @Beta
 public class PNCounterConfig implements IdentifiedDataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -59,7 +59,6 @@ import com.hazelcast.config.UserCodeDeploymentConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.security.SecurityService;
 import com.hazelcast.util.StringUtil;
 
@@ -616,12 +615,6 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addAtomicLongConfig(AtomicLongConfig atomicLongConfig) {
-        // RU_COMPAT_3_9
-        if (clusterService.getClusterVersion().isLessThan(Versions.V3_10)) {
-            throw new ConfigurationException("Cannot add AtomicLongConfig while the cluster is not running version "
-                    + Versions.V3_10);
-        }
-
         checkStaticConfigurationDoesNotExist(staticConfig.getAtomicLongConfigs(), atomicLongConfig.getName(), atomicLongConfig);
         configurationService.broadcastConfig(atomicLongConfig);
         return this;
@@ -665,12 +658,6 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addAtomicReferenceConfig(AtomicReferenceConfig atomicReferenceConfig) {
-        // RU_COMPAT_3_9
-        if (clusterService.getClusterVersion().isLessThan(Versions.V3_10)) {
-            throw new ConfigurationException("Cannot add AtomicReferenceConfig while the cluster is not running version "
-                    + Versions.V3_10);
-        }
-
         checkStaticConfigurationDoesNotExist(staticConfig.getAtomicReferenceConfigs(), atomicReferenceConfig.getName(),
                 atomicReferenceConfig);
         configurationService.broadcastConfig(atomicReferenceConfig);
@@ -715,12 +702,6 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addCountDownLatchConfig(CountDownLatchConfig countDownLatchConfig) {
-        // RU_COMPAT_3_9
-        if (clusterService.getClusterVersion().isLessThan(Versions.V3_10)) {
-            throw new ConfigurationException("Cannot add CountDownLatchConfig while the cluster is not running version "
-                    + Versions.V3_10);
-        }
-
         checkStaticConfigurationDoesNotExist(staticConfig.getCountDownLatchConfigs(), countDownLatchConfig.getName(),
                 countDownLatchConfig);
         configurationService.broadcastConfig(countDownLatchConfig);

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigRollingUpgradeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigRollingUpgradeTest.java
@@ -18,20 +18,23 @@ package com.hazelcast.internal.dynamicconfig;
 
 import com.hazelcast.config.AtomicLongConfig;
 import com.hazelcast.config.AtomicReferenceConfig;
-import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.CountDownLatchConfig;
+import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.PNCounterConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
+import static com.hazelcast.internal.cluster.Versions.V3_8;
+import static com.hazelcast.internal.cluster.Versions.V3_9;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -39,38 +42,43 @@ public class DynamicConfigRollingUpgradeTest extends HazelcastTestSupport {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testThrowsExceptionWhenRunningInClusterVersion38() {
-        // system properties are cleared automatically by the Hazelcast Runner
-        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, Versions.V3_8.toString());
-        HazelcastInstance hazelcastInstance = createHazelcastInstance();
-
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(V3_8);
         hazelcastInstance.getConfig().addMapConfig(new MapConfig(randomName()));
     }
 
-    @Test(expected = ConfigurationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testThrowsExceptionWhenAddingAtomicLongConfigInClusterVersion39() {
-        // system properties are cleared automatically by the Hazelcast Runner
-        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, Versions.V3_9.toString());
-        HazelcastInstance hazelcastInstance = createHazelcastInstance();
-
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(V3_9);
         hazelcastInstance.getConfig().addAtomicLongConfig(new AtomicLongConfig(randomMapName()));
     }
 
-    @Test(expected = ConfigurationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testThrowsExceptionWhenAddingAtomicReferenceConfigInClusterVersion39() {
-        // system properties are cleared automatically by the Hazelcast Runner
-        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, Versions.V3_9.toString());
-        HazelcastInstance hazelcastInstance = createHazelcastInstance();
-
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(V3_9);
         hazelcastInstance.getConfig().addAtomicReferenceConfig(new AtomicReferenceConfig(randomMapName()));
     }
 
-    @Test(expected = ConfigurationException.class)
+    @Test(expected = UnsupportedOperationException.class)
     public void testThrowsExceptionWhenAddingCountDownLatchConfigInClusterVersion39() {
-        // system properties are cleared automatically by the Hazelcast Runner
-        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, Versions.V3_9.toString());
-        HazelcastInstance hazelcastInstance = createHazelcastInstance();
-
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(V3_9);
         hazelcastInstance.getConfig().addCountDownLatchConfig(new CountDownLatchConfig(randomMapName()));
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public void testThrowsExceptionWhenAddingFlakeIdConfigInClusterVersion39() {
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(V3_9);
+        hazelcastInstance.getConfig().addFlakeIdGeneratorConfig(new FlakeIdGeneratorConfig(randomName()));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testThrowsExceptionWhenAddingPNCounterConfigInClusterVersion39() {
+        HazelcastInstance hazelcastInstance = createHazelcastInstance(V3_9);
+        hazelcastInstance.getConfig().addPNCounterConfig(new PNCounterConfig(randomName()));
+    }
+
+    protected HazelcastInstance createHazelcastInstance(Version version) {
+        // system properties are cleared automatically by the Hazelcast Runner
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, version.toString());
+        return super.createHazelcastInstance();
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigVersionTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.dynamicconfig;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JobTrackerConfig;
+import com.hazelcast.config.ListenerConfig;
+import com.hazelcast.config.QuorumConfig;
+import com.hazelcast.config.WanReplicationConfig;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.hazelcast.internal.dynamicconfig.ClusterWideConfigurationService.CONFIG_TO_VERSION;
+import static java.lang.String.format;
+import static org.junit.Assert.assertTrue;
+
+public class DynamicConfigVersionTest {
+
+    // config classes not supported by dynamic data structure config
+    private static final Set<Class<?>> NON_DYNAMIC_CONFIG_CLASSES;
+
+    static {
+        Set<Class<?>> nonDynamicConfigClasses = new HashSet<Class<?>>();
+        nonDynamicConfigClasses.add(WanReplicationConfig.class);
+        nonDynamicConfigClasses.add(QuorumConfig.class);
+        nonDynamicConfigClasses.add(JobTrackerConfig.class);
+        nonDynamicConfigClasses.add(ListenerConfig.class);
+        NON_DYNAMIC_CONFIG_CLASSES = nonDynamicConfigClasses;
+    }
+
+    @Test
+    public void test_allConfigClasses_areAssignedToVersion() {
+        Class<Config> topLevelConfigClass = Config.class;
+        Method[] allConfigMethods = topLevelConfigClass.getDeclaredMethods();
+        for (Method method : allConfigMethods) {
+            String methodName = method.getName();
+            if (methodName.startsWith("add") && methodName.endsWith("Config")) {
+                assert method.getParameterTypes().length == 1;
+                Class klass = method.getParameterTypes()[0];
+                boolean isMappedToVersion = CONFIG_TO_VERSION.get(klass) != null
+                        || NON_DYNAMIC_CONFIG_CLASSES.contains(klass);
+                assertTrue(format("Config class %s does not have a minimum Version set", klass.getName()), isMappedToVersion);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Configuration for new data structures added in 3.10 should not be
allowed to be dynamically added while cluster version is 3.9.

Fixes #12151 