### PR TITLE
Acquire WanReplicationService from NodeEngine while deleting cache

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -330,7 +330,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
             closeSegments(cacheNameWithPrefix);
         }
 
-        final WanReplicationService wanService = nodeEngine.getService(WanReplicationService.SERVICE_NAME);
+        WanReplicationService wanService = nodeEngine.getWanReplicationService();
         wanService.removeWanEventCounters(ICacheService.SERVICE_NAME, cacheNameWithPrefix);
         cacheContexts.remove(cacheNameWithPrefix);
         operationProviderCache.remove(cacheNameWithPrefix);


### PR DESCRIPTION
The same cache deletion mechanism is used during node shutdown too,
and acquiring `WanReplicationService` can fail in that case.

Fixes https://github.com/hazelcast/hazelcast/issues/12547