### PR TITLE
Disable invalidation configs for expiration test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
@@ -804,13 +804,19 @@ public class NearCacheTest extends NearCacheTestSupport {
 
     @Test
     public void testNearCacheTTLRecordsExpired() {
-        NearCacheConfig nearCacheConfig = newNearCacheConfig().setTimeToLiveSeconds(MAX_TTL_SECONDS);
+        NearCacheConfig nearCacheConfig = newNearCacheConfig()
+                .setTimeToLiveSeconds(MAX_TTL_SECONDS)
+                .setInvalidateOnChange(false);
+
         testNearCacheExpiration(nearCacheConfig);
     }
 
     @Test
     public void testNearCacheMaxIdleRecordsExpired() {
-        NearCacheConfig nearCacheConfig = newNearCacheConfig().setMaxIdleSeconds(MAX_IDLE_SECONDS);
+        NearCacheConfig nearCacheConfig = newNearCacheConfig()
+                .setMaxIdleSeconds(MAX_IDLE_SECONDS)
+                .setInvalidateOnChange(false);
+
         testNearCacheExpiration(nearCacheConfig);
     }
 
@@ -821,8 +827,8 @@ public class NearCacheTest extends NearCacheTestSupport {
         Config config = getConfig();
         HazelcastInstance instance1 = factory.newHazelcastInstance(config);
 
-        IMap<Integer, Integer> noNearCachedMap = instance1.getMap(mapName);
-        populateMap(noNearCachedMap, MAX_CACHE_SIZE);
+        IMap<Integer, Integer> mapWithoutNearCache = instance1.getMap(mapName);
+        populateMap(mapWithoutNearCache, MAX_CACHE_SIZE);
 
         Config configWithNearCache = getConfig();
         nearCacheConfig.setCacheLocalEntries(true);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
@@ -131,17 +131,6 @@ public class NearCacheTestSupport extends HazelcastTestSupport {
         });
     }
 
-    private void populateNearCacheEventually(final IMap<Integer, Integer> map, final int size) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                populateNearCache(map, size);
-                long ownedEntryCount = getNearCacheStats(map).getOwnedEntryCount();
-                assertEquals("Near Cache has not reached expected size", size, ownedEntryCount);
-            }
-        });
-    }
-
     /**
      * Tests the Near Cache memory cost calculation.
      * <p>


### PR DESCRIPTION
fix attempt for https://github.com/hazelcast/hazelcast/issues/12566

This PR tries to eliminate one possible reason of failure by disabling invalidations for expiration tests.

