### PR TITLE
No type conversion in map browser

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/management/GetMapEntryRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/GetMapEntryRequestTest.java
@@ -46,7 +46,7 @@ public class GetMapEntryRequestTest extends HazelcastTestSupport {
 
     @Test
     public void testGetMapEntry() throws Exception {
-        GetMapEntryRequest request = new GetMapEntryRequest("string", "map", "key");
+        GetMapEntryRequest request = new GetMapEntryRequest("map", "key");
         IMap<String, String> map = hz.getMap("map");
         map.put("key", "value");
 


### PR DESCRIPTION
As a basic fix for https://github.com/hazelcast/management-center/issues/509 we do no longer pay attention to the key `type` hint but infer the type from the first key of the `keySet` and construct a key of the same class using reflection. This way any type is supported as long as it has a constructor accepting a `String`.