### PR TITLE
Remove WAN event list from EP operations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
@@ -16,28 +16,24 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.query.Predicate;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Provides common backup operation functionality for {@link com.hazelcast.map.EntryProcessor}
  * that can run on multiple entries.
  */
-abstract class AbstractMultipleEntryBackupOperation extends MapOperation {
+abstract class AbstractMultipleEntryBackupOperation extends MapOperation implements Versioned {
 
     protected MapEntries responses;
     protected EntryBackupProcessor backupProcessor;
-    protected List<WanEventHolder> wanEventList = Collections.emptyList();
 
     public AbstractMultipleEntryBackupOperation() {
     }
@@ -51,35 +47,21 @@ abstract class AbstractMultipleEntryBackupOperation extends MapOperation {
         return null;
     }
 
-    protected void setWanEventList(List<WanEventHolder> wanEventList) {
-        assert wanEventList != null;
-
-        this.wanEventList = wanEventList;
-    }
-
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeInt(wanEventList.size());
-        for (WanEventHolder wanEventHolder : wanEventList) {
-            out.writeData(wanEventHolder.getKey());
-            out.writeData(wanEventHolder.getValue());
-            out.writeInt(wanEventHolder.getEventType().getType());
+        // RU_COMPAT_3_9
+        if (out.getVersion().isLessThan(Versions.V3_10)) {
+            out.writeInt(0);
         }
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        int size = in.readInt();
-        if (size > 0) {
-            wanEventList = new ArrayList<WanEventHolder>(size);
-            for (int i = 0; i < size; i++) {
-                Data key = in.readData();
-                Data value = in.readData();
-                EntryEventType entryEventType = EntryEventType.getByType(in.readInt());
-                wanEventList.add(new WanEventHolder(key, value, entryEventType));
-            }
+        // RU_COMPAT_3_9
+        if (in.getVersion().isLessThan(Versions.V3_10)) {
+            in.readInt();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -44,9 +44,6 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.Clock;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
@@ -63,7 +60,6 @@ import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
  */
 public final class EntryOperator {
 
-    private final boolean collectWanEvents;
     private final boolean shouldClone;
     private final boolean backup;
     private final boolean readOnly;
@@ -82,7 +78,6 @@ public final class EntryOperator {
     private final MapServiceContext mapServiceContext;
     private final MapOperation mapOperation;
     private final Address callerAddress;
-    private final List<WanEventHolder> wanEventList;
     private final InMemoryFormat inMemoryFormat;
 
     private EntryProcessor entryProcessor;
@@ -102,9 +97,7 @@ public final class EntryOperator {
         this.mapOperation = mapOperation;
         this.predicate = predicate;
         this.recordStore = mapOperation.recordStore;
-        this.collectWanEvents = collectWanEvents;
         this.readOnly = entryProcessor instanceof ReadOnly;
-        this.wanEventList = collectWanEvents ? new ArrayList<WanEventHolder>() : Collections.<WanEventHolder>emptyList();
         this.mapContainer = recordStore.getMapContainer();
         this.inMemoryFormat = mapContainer.getMapConfig().getInMemoryFormat();
         this.mapName = mapContainer.getName();
@@ -143,11 +136,6 @@ public final class EntryOperator {
 
     public static EntryOperator operator(MapOperation mapOperation, Object processor, Predicate predicate) {
         return new EntryOperator(mapOperation, processor, predicate, false);
-    }
-
-    public static EntryOperator operator(MapOperation mapOperation, Object processor, Predicate predicate,
-                                         boolean collectWanEvents) {
-        return new EntryOperator(mapOperation, processor, predicate, collectWanEvents);
     }
 
     public EntryOperator init(Data dataKey, Object oldValue, Object newValue, Data result, EntryEventType eventType) {
@@ -207,10 +195,6 @@ public final class EntryOperator {
 
     public EntryEventType getEventType() {
         return eventType;
-    }
-
-    public List<WanEventHolder> getWanEventList() {
-        return wanEventList;
     }
 
     public Object getNewValue() {
@@ -352,9 +336,6 @@ public final class EntryOperator {
                 mapEventPublisher.publishWanReplicationRemoveBackup(mapName, dataKey, Clock.currentTimeMillis());
             } else {
                 mapEventPublisher.publishWanReplicationRemove(mapName, dataKey, Clock.currentTimeMillis());
-                if (collectWanEvents) {
-                    wanEventList.add(new WanEventHolder(dataKey, null, REMOVED));
-                }
             }
 
             return;
@@ -367,9 +348,6 @@ public final class EntryOperator {
             mapEventPublisher.publishWanReplicationUpdateBackup(mapName, entryView);
         } else {
             mapEventPublisher.publishWanReplicationUpdate(mapName, entryView);
-            if (collectWanEvents) {
-                wanEventList.add(new WanEventHolder(dataKey, dataNewValue, UPDATED));
-            }
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryBackupOperation.java
@@ -43,7 +43,7 @@ public class MultipleEntryBackupOperation extends AbstractMultipleEntryBackupOpe
 
     @Override
     public void run() throws Exception {
-        EntryOperator operator = operator(this, backupProcessor, getPredicate(), true);
+        EntryOperator operator = operator(this, backupProcessor, getPredicate());
         for (Data key : keys) {
             operator.operateOnKey(key).doPostOperateOps();
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MultipleEntryOperation.java
@@ -70,7 +70,7 @@ public class MultipleEntryOperation extends MapOperation
     public void run() throws Exception {
         responses = new MapEntries(keys.size());
 
-        operator = operator(this, entryProcessor, getPredicate(), true);
+        operator = operator(this, entryProcessor, getPredicate());
         for (Data key : keys) {
             Data response = operator.operateOnKey(key).doPostOperateOps().getResult();
             if (response != null) {
@@ -109,7 +109,6 @@ public class MultipleEntryOperation extends MapOperation
         MultipleEntryBackupOperation backupOperation = null;
         if (backupProcessor != null) {
             backupOperation = new MultipleEntryBackupOperation(name, keys, backupProcessor);
-            backupOperation.setWanEventList(operator.getWanEventList());
         }
         return backupOperation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -42,7 +42,7 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryBack
     @Override
     public void run() {
         responses = new MapEntries(recordStore.size());
-        EntryOperator operator = operator(this, backupProcessor, getPredicate(), true);
+        EntryOperator operator = operator(this, backupProcessor, getPredicate());
 
         Iterator<Record> iterator = recordStore.iterator(Clock.currentTimeMillis(), true);
         while (iterator.hasNext()) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -74,7 +74,7 @@ public class PartitionWideEntryOperation extends MapOperation
     @Override
     public void run() {
         responses = new MapEntries(recordStore.size());
-        operator = operator(this, entryProcessor, getPredicate(), true);
+        operator = operator(this, entryProcessor, getPredicate());
 
         Iterator<Record> iterator = recordStore.iterator(Clock.currentTimeMillis(), false);
         while (iterator.hasNext()) {
@@ -114,7 +114,6 @@ public class PartitionWideEntryOperation extends MapOperation
         PartitionWideEntryBackupOperation backupOperation = null;
         if (backupProcessor != null) {
             backupOperation = new PartitionWideEntryBackupOperation(name, backupProcessor);
-            backupOperation.setWanEventList(operator.getWanEventList());
         }
         return backupOperation;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperation.java
@@ -49,7 +49,6 @@ public class PartitionWideEntryWithPredicateOperation extends PartitionWideEntry
         PartitionWideEntryWithPredicateBackupOperation backupOperation = null;
         if (backupProcessor != null) {
             backupOperation = new PartitionWideEntryWithPredicateBackupOperation(name, backupProcessor, predicate);
-            backupOperation.setWanEventList(operator.getWanEventList());
         }
         return backupOperation;
     }


### PR DESCRIPTION
The list was sent from primary to backup replicas for all of the entries
updated or removed by the entry processor. This list is not used at all
and there is no reason why the entry events should be collected or sent.
The WAN events on the backup replica are generated by the
EntryOperator.doPostOperateOps method, just as on the primary and the
list sent from the primary is thrown away.
The change removes this list but keeps backwards compatibility for 3.9.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/1441
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/1971