### PR TITLE
Cleanup of LazySet and related test classes and fix of KeySetIteratorFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
@@ -48,8 +48,9 @@ class KeySetIteratorFactory<K, V> implements IteratorFactory<K, V, K> {
         @Override
         public boolean hasNext() {
             while (iterator.hasNext()) {
-                nextEntry = iterator.next();
-                if (testEntry(nextEntry)) {
+                Map.Entry<K, ReplicatedRecord<K, V>> entry = iterator.next();
+                if (testEntry(entry)) {
+                    nextEntry = entry;
                     return true;
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/KeySetIteratorFactory.java
@@ -35,12 +35,11 @@ class KeySetIteratorFactory<K, V> implements IteratorFactory<K, V, K> {
         return new KeySetIterator(iterator);
     }
 
-    private final class KeySetIterator
-            implements Iterator<K> {
+    private final class KeySetIterator implements Iterator<K> {
 
         private final Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator;
 
-        private Map.Entry<K, ReplicatedRecord<K, V>> entry;
+        private Map.Entry<K, ReplicatedRecord<K, V>> nextEntry;
 
         private KeySetIterator(Iterator<Map.Entry<K, ReplicatedRecord<K, V>>> iterator) {
             this.iterator = iterator;
@@ -49,8 +48,8 @@ class KeySetIteratorFactory<K, V> implements IteratorFactory<K, V, K> {
         @Override
         public boolean hasNext() {
             while (iterator.hasNext()) {
-                entry = iterator.next();
-                if (testEntry(entry)) {
+                nextEntry = iterator.next();
+                if (testEntry(nextEntry)) {
                     return true;
                 }
             }
@@ -59,26 +58,25 @@ class KeySetIteratorFactory<K, V> implements IteratorFactory<K, V, K> {
 
         @Override
         public K next() {
-            Map.Entry<K, ReplicatedRecord<K, V>> entry = this.entry;
+            Map.Entry<K, ReplicatedRecord<K, V>> entry = nextEntry;
             Object key = entry != null ? entry.getKey() : null;
 
             while (entry == null) {
                 entry = findNextEntry();
 
                 key = entry.getKey();
-
                 if (key != null) {
                     break;
                 }
             }
 
-            this.entry = null;
+            nextEntry = null;
             if (key == null) {
                 throw new NoSuchElementException();
             }
 
-            key = recordStore.unmarshall(key);
-            return (K) key;
+            //noinspection unchecked
+            return (K) recordStore.unmarshall(key);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazySet.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazySet.java
@@ -29,7 +29,7 @@ class LazySet<K, V, R> implements Set<R> {
     private final InternalReplicatedMapStorage<K, V> storage;
     private final IteratorFactory<K, V, R> iteratorFactory;
 
-    public LazySet(IteratorFactory<K, V, R> iteratorFactory, InternalReplicatedMapStorage<K, V> storage) {
+    LazySet(IteratorFactory<K, V, R> iteratorFactory, InternalReplicatedMapStorage<K, V> storage) {
         this.iteratorFactory = iteratorFactory;
         this.storage = storage;
     }
@@ -58,19 +58,22 @@ class LazySet<K, V, R> implements Set<R> {
     @Override
     public Object[] toArray() {
         List<Object> result = new ArrayList<Object>(storage.values().size());
-        Iterator<R> iterator = iterator();
-        while (iterator.hasNext()) {
-            result.add(iterator.next());
+        for (R r : this) {
+            // we cannot use addAll() here, since it results in StackOverflowError
+            //noinspection UseBulkOperation
+            result.add(r);
         }
         return result.toArray(new Object[0]);
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public <T> T[] toArray(T[] a) {
         List<Object> result = new ArrayList<Object>(storage.values().size());
-        Iterator<R> iterator = iterator();
-        while (iterator.hasNext()) {
-            result.add(iterator.next());
+        for (R r : this) {
+            // we cannot use addAll() here, since it results in StackOverflowError
+            //noinspection UseBulkOperation
+            result.add(r);
         }
         if (a.length != result.size()) {
             a = (T[]) Array.newInstance(a.getClass().getComponentType(), result.size());

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyCollectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyCollectionTest.java
@@ -44,42 +44,43 @@ public class LazyCollectionTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_add_throws_exception() {
-        collection.add(null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_add_all_throws_exception() {
-        collection.addAll(Collections.EMPTY_LIST);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_remove_throws_exception() {
-        collection.remove(null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_removeAll_throws_exception() {
-        collection.removeAll(Collections.EMPTY_LIST);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_contains_throws_exception() {
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void testContains_throwsException() {
         collection.contains(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_contains_all_throws_exception() {
+    public void testContainsAll_throwsException() {
         collection.containsAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_retain_all_throws_exception() {
+    public void testAdd_throwsException() {
+        collection.add(null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAddAll_throwsException() {
+        collection.addAll(Collections.EMPTY_LIST);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemove_throwsException() {
+        collection.remove(null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemoveAll_throwsException() {
+        collection.removeAll(Collections.EMPTY_LIST);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRetainAll_throwsException() {
         collection.retainAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_clear_throws_exception() {
+    public void testClear_throwsException() {
         collection.clear();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazyIteratorTest.java
@@ -16,30 +16,29 @@
 
 package com.hazelcast.replicatedmap.impl.record;
 
-import com.hazelcast.replicatedmap.merge.ReplicatedMapMergePolicy;
-import com.hazelcast.spi.merge.SplitBrainMergePolicy;
-import com.hazelcast.spi.merge.SplitBrainMergeTypes.ReplicatedMapMergeTypes;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.scheduler.ScheduledEntry;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
-import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -48,8 +47,6 @@ public class LazyIteratorTest extends HazelcastTestSupport {
 
     private static final InternalReplicatedMapStorage<String, Integer> TEST_DATA_SIMPLE;
     private static final InternalReplicatedMapStorage<String, Integer> TEST_DATA_TOMBS;
-
-    private static final ReplicatedRecordStore REPLICATED_RECORD_STORE = new NoOpReplicatedRecordStore();
 
     static {
         TEST_DATA_SIMPLE = new InternalReplicatedMapStorage<String, Integer>();
@@ -68,37 +65,35 @@ public class LazyIteratorTest extends HazelcastTestSupport {
         }
     }
 
-    @Test
-    public void test_lazy_set_size() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, String> set = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
-        assertEquals(100, set.size());
+    private ReplicatedRecordStore replicatedRecordStore;
+
+    @Before
+    public void setUp() {
+        // mocks a ReplicatedRecordStore, which does nothing beside returning the given key on (un)marshalling
+        replicatedRecordStore = mock(ReplicatedRecordStore.class);
+        when(replicatedRecordStore.marshall(anyObject())).thenAnswer(new ReturnFirstArgumentAnswer());
+        when(replicatedRecordStore.unmarshall(anyObject())).thenAnswer(new ReturnFirstArgumentAnswer());
     }
 
     @Test
-    public void test_lazy_set_empty() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, String> set = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
-        assertFalse(set.isEmpty());
-    }
-
-    @Test
-    public void test_lazy_collection_size() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_size() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_SIMPLE);
-        assertEquals(100, collection.size());
+
+        assertEqualsStringFormat("Expected %d items in LazyCollection, but was %d", 100, collection.size());
     }
 
     @Test
-    public void test_lazy_collection_empty() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_isEmpty() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_SIMPLE);
-        assertFalse(collection.isEmpty());
+
+        assertFalse("Expected LazyCollection to no be empty", collection.isEmpty());
     }
 
     @Test
-    public void test_lazy_values_no_tombs_with_has_next() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_withValuesIterator_hasNext() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_SIMPLE);
         Iterator<Integer> iterator = collection.iterator();
 
@@ -108,29 +103,31 @@ public class LazyIteratorTest extends HazelcastTestSupport {
             count++;
             values.add(iterator.next());
         }
-        assertEquals(100, count);
-        assertEquals(100, values.size());
+        assertEqualsStringFormat("Expected %d items in the LazyCollection.iterator(), but was %d", 100, count);
+        assertEqualsStringFormat("Expected %d unique items in the LazyCollection.iterator(), but was %d", 100, values.size());
+        assertFalse("Expected no more items in LazyCollection.iterator()", iterator.hasNext());
     }
 
     @Test
-    public void test_lazy_values_no_tombs_with_has_next_every_second_time() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_withValuesIterator_hasNext_everySecondTime() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_SIMPLE);
         Iterator<Integer> iterator = collection.iterator();
 
         Set<Integer> values = new HashSet<Integer>();
         for (int i = 0; i < 100; i++) {
             if (i % 2 == 0) {
-                iterator.hasNext();
+                assertTrue("Expected more items in LazyCollection.iterator()", iterator.hasNext());
             }
             values.add(iterator.next());
         }
-        assertEquals(100, values.size());
+        assertEqualsStringFormat("Expected %d unique items in the LazyCollection.iterator(), but was %d", 100, values.size());
+        assertFalse("Expected no more items in LazyCollection.iterator()", iterator.hasNext());
     }
 
     @Test
-    public void test_lazy_values_no_tombs_more_elements_possible() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_withValuesIterator_next_whenNoMoreElementsAreAvailable() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_SIMPLE);
         Iterator<Integer> iterator = collection.iterator();
 
@@ -138,20 +135,20 @@ public class LazyIteratorTest extends HazelcastTestSupport {
         for (int i = 0; i < 100; i++) {
             values.add(iterator.next());
         }
-        assertEquals(100, values.size());
-
+        assertEqualsStringFormat("Expected %d unique items in the LazyCollection.iterator(), but was %d", 100, values.size());
+        assertFalse("Expected no more items in LazyCollection.iterator()", iterator.hasNext());
         try {
             iterator.next();
-            fail("Shouldn't have further elements!");
-        } catch (NoSuchElementException e) {
+            fail("LazyCollection.iterator() shouldn't have further items");
+        } catch (NoSuchElementException expected) {
             // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_values_with_tombs_with_has_next() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_withValuesIterator_withTombs_hasNext() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
         Iterator<Integer> iterator = collection.iterator();
 
@@ -161,13 +158,14 @@ public class LazyIteratorTest extends HazelcastTestSupport {
             count++;
             values.add(iterator.next());
         }
-        assertEquals(50, count);
-        assertEquals(50, values.size());
+        assertEqualsStringFormat("Expected %d items in the LazyCollection.iterator(), but was %d", 50, count);
+        assertEqualsStringFormat("Expected %d unique items in the LazyCollection.iterator(), but was %d", 50, values.size());
+        assertFalse("Expected no more items in LazyCollection.iterator()", iterator.hasNext());
     }
 
     @Test
-    public void test_lazy_values_with_tombs_with_next() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_withValuesIterator_withTombs_next() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
         Iterator<Integer> iterator = collection.iterator();
 
@@ -175,20 +173,20 @@ public class LazyIteratorTest extends HazelcastTestSupport {
         for (int i = 0; i < 50; i++) {
             values.add(iterator.next());
         }
-        assertEquals(50, values.size());
-
+        assertEqualsStringFormat("Expected %d unique items in the LazyCollection.iterator(), but was %d", 50, values.size());
+        assertFalse("Expected no more items in LazyCollection.iterator()", iterator.hasNext());
         try {
             iterator.next();
-            fail("Shouldn't have further elements!");
-        } catch (NoSuchElementException e) {
+            fail("LazyCollection.iterator() shouldn't have further items");
+        } catch (NoSuchElementException expected) {
             // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_values_with_tombs_copy() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_withValuesIterator_withTombs_onSetCopy() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
 
         Set<Integer> copy = new HashSet<Integer>(collection);
@@ -198,47 +196,63 @@ public class LazyIteratorTest extends HazelcastTestSupport {
         for (int i = 0; i < 50; i++) {
             values.add(iterator.next());
         }
-        assertEquals(50, values.size());
-
+        assertEqualsStringFormat("Expected %d unique items in the LazyCollection.iterator(), but was %d", 50, values.size());
+        assertFalse("Expected no more items in LazyCollection.iterator()", iterator.hasNext());
         try {
             iterator.next();
-            fail("Shouldn't have further elements!");
-        } catch (NoSuchElementException e) {
+            fail("LazyCollection.iterator() shouldn't have further items");
+        } catch (NoSuchElementException expected) {
             // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_values_with_tombs_to_array_new_array() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_withValuesIterator_withTombs_toArray() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
 
         Object[] array = collection.toArray();
-        assertEquals(50, array.length);
+        assertEqualsStringFormat("Expected %d items in the LazyCollection.toArray(), but was %d", 50, array.length);
     }
 
     @Test
-    public void test_lazy_values_with_tombs_to_array_passed_array_too_small() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_withValuesIterator_withTombs_toArray_whenPassedArrayIsTooSmall() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
 
         Integer[] array = collection.toArray(new Integer[0]);
-        assertEquals(50, array.length);
+        assertEqualsStringFormat("Expected %d items in the LazyCollection.toArray(), but was %d", 50, array.length);
     }
 
     @Test
-    public void test_lazy_values_with_tombs_to_array_passed_array_matching_size() {
-        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazyCollection_withValuesIterator_withTombs_toArray_whenPassedArrayHasMatchingSize() {
+        ValuesIteratorFactory<String, Integer> factory = new ValuesIteratorFactory<String, Integer>(replicatedRecordStore);
         LazyCollection<String, Integer> collection = new LazyCollection<String, Integer>(factory, TEST_DATA_TOMBS);
 
         Integer[] array = collection.toArray(new Integer[50]);
-        assertEquals(50, array.length);
+        assertEqualsStringFormat("Expected %d items in the LazyCollection.toArray(), but was %d", 50, array.length);
     }
 
     @Test
-    public void test_lazy_keyset_no_tombs_with_has_next() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_size() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
+        LazySet<String, Integer, String> set = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
+
+        assertEqualsStringFormat("Expected %d items in LazySet, but was %d", 100, set.size());
+    }
+
+    @Test
+    public void testLazySet_isEmpty() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
+        LazySet<String, Integer, String> set = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
+
+        assertFalse("Expected LazySet to no be empty", set.isEmpty());
+    }
+
+    @Test
+    public void testLazySet_withKeySetIterator_hasNext() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
         Iterator<String> iterator = collection.iterator();
 
@@ -248,30 +262,31 @@ public class LazyIteratorTest extends HazelcastTestSupport {
             count++;
             values.add(iterator.next());
         }
-        assertEquals(100, count);
-        assertEquals(100, values.size());
+        assertEqualsStringFormat("Expected %d items in the LazySet.iterator(), but was %d", 100, count);
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 100, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
     }
 
     @Test
-    public void test_lazy_keyset_no_tombs_with_has_next_every_second_time() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withKeySetIterator_hasNext_everySecondTime() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
         Iterator<String> iterator = collection.iterator();
 
         Set<String> values = new HashSet<String>();
         for (int i = 0; i < 100; i++) {
             if (i % 2 == 0) {
-                iterator.hasNext();
+                assertTrue("Expected more items in LazySet.iterator()", iterator.hasNext());
             }
-
             values.add(iterator.next());
         }
-        assertEquals(100, values.size());
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 100, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
     }
 
     @Test
-    public void test_lazy_keyset_no_tombs_more_elements_possible() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withKeySetIterator_next_whenNoMoreElementsAreAvailable() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_SIMPLE);
         Iterator<String> iterator = collection.iterator();
 
@@ -279,20 +294,20 @@ public class LazyIteratorTest extends HazelcastTestSupport {
         for (int i = 0; i < 100; i++) {
             values.add(iterator.next());
         }
-        assertEquals(100, values.size());
-
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 100, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
         try {
             iterator.next();
-            fail("Shouldn't have further elements!");
-        } catch (NoSuchElementException e) {
+            fail("LazySet.iterator() shouldn't have further items");
+        } catch (NoSuchElementException expected) {
             // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_with_has_next() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withKeySetIterator_withTombs_hasNext() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
         Iterator<String> iterator = collection.iterator();
 
@@ -302,13 +317,14 @@ public class LazyIteratorTest extends HazelcastTestSupport {
             count++;
             values.add(iterator.next());
         }
-        assertEquals(50, count);
-        assertEquals(50, values.size());
+        assertEqualsStringFormat("Expected %d items in the LazySet.iterator(), but was %d", 50, count);
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 50, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_with_next() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withKeySetIterator_withTombs_next() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
         Iterator<String> iterator = collection.iterator();
 
@@ -316,20 +332,20 @@ public class LazyIteratorTest extends HazelcastTestSupport {
         for (int i = 0; i < 50; i++) {
             values.add(iterator.next());
         }
-        assertEquals(50, values.size());
-
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 50, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
         try {
             iterator.next();
-            fail("Shouldn't have further elements!");
-        } catch (NoSuchElementException e) {
+            fail("LazySet.iterator() shouldn't have further items");
+        } catch (NoSuchElementException expected) {
             // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_copy() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withKeySetIterator_withTombs_onSetCopy() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
 
         Set<String> copy = new HashSet<String>(collection);
@@ -339,49 +355,49 @@ public class LazyIteratorTest extends HazelcastTestSupport {
         for (int i = 0; i < 50; i++) {
             values.add(iterator.next());
         }
-        assertEquals(50, values.size());
-
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 50, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
         try {
             iterator.next();
-            fail("Shouldn't have further elements!");
-        } catch (NoSuchElementException e) {
+            fail("LazySet.iterator() shouldn't have further items");
+        } catch (NoSuchElementException expected) {
             // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_to_array_new_array() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withKeySetIterator_withTombs_toArray() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
 
         Object[] array = collection.toArray();
-        assertEquals(50, array.length);
+        assertEqualsStringFormat("Expected %d items in the LazySet.toArray(), but was %d", 50, array.length);
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_to_array_passed_array_too_small() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withKeySetIterator_withTombs_toArray_whenPassedArrayIsTooSmall() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
 
         String[] array = collection.toArray(new String[0]);
-        assertEquals(50, array.length);
+        assertEqualsStringFormat("Expected %d items in the LazySet.toArray(), but was %d", 50, array.length);
     }
 
     @Test
-    public void test_lazy_keyset_with_tombs_to_array_passed_array_matching_size() {
-        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withKeySetIterator_withTombs_toArray_whenPassedArrayHasMatchingSize() {
+        KeySetIteratorFactory<String, Integer> factory = new KeySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, String> collection = new LazySet<String, Integer, String>(factory, TEST_DATA_TOMBS);
 
         String[] array = collection.toArray(new String[50]);
-        assertEquals(50, array.length);
+        assertEqualsStringFormat("Expected %d items in the LazySet.toArray(), but was %d", 50, array.length);
     }
 
     @Test
-    public void test_lazy_entryset_no_tombs_with_has_next() {
-        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
-                new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_SIMPLE);
+    public void testLazySet_withEntrySetIterator_hasNext() {
+        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(replicatedRecordStore);
+        LazySet<String, Integer, Map.Entry<String, Integer>> collection
+                = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_SIMPLE);
         Iterator<Map.Entry<String, Integer>> iterator = collection.iterator();
 
         int count = 0;
@@ -390,53 +406,54 @@ public class LazyIteratorTest extends HazelcastTestSupport {
             count++;
             values.add(iterator.next().getValue());
         }
-        assertEquals(100, count);
-        assertEquals(100, values.size());
+        assertEqualsStringFormat("Expected %d items in the LazySet.iterator(), but was %d", 100, count);
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 100, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
     }
 
     @Test
-    public void test_lazy_entryset_no_tombs_with_has_next_every_second_time() {
-        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
-                new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_SIMPLE);
+    public void testLazySet_withEntrySetIterator_hasNext_everySecondTime() {
+        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(replicatedRecordStore);
+        LazySet<String, Integer, Map.Entry<String, Integer>> collection
+                = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_SIMPLE);
         Iterator<Map.Entry<String, Integer>> iterator = collection.iterator();
 
         Set<Integer> values = new HashSet<Integer>();
         for (int i = 0; i < 100; i++) {
             if (i % 2 == 0) {
-                iterator.hasNext();
+                assertTrue("Expected more items in LazySet.iterator()", iterator.hasNext());
             }
-
             values.add(iterator.next().getValue());
         }
-        assertEquals(100, values.size());
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 100, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
     }
 
     @Test
-    public void test_lazy_entryset_no_tombs_more_elements_possible() {
-        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
-        LazySet<String, Integer, Map.Entry<String, Integer>> collection = //
-                new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_SIMPLE);
+    public void testLazySet_withEntrySetIterator_next_whenNoMoreElementsAreAvailable() {
+        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(replicatedRecordStore);
+        LazySet<String, Integer, Map.Entry<String, Integer>> collection
+                = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_SIMPLE);
         Iterator<Map.Entry<String, Integer>> iterator = collection.iterator();
 
         Set<Integer> values = new HashSet<Integer>();
         for (int i = 0; i < 100; i++) {
             values.add(iterator.next().getValue());
         }
-        assertEquals(100, values.size());
-
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 100, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
         try {
             iterator.next();
-            fail("Shouldn't have further elements!");
-        } catch (NoSuchElementException e) {
+            fail("LazySet.iterator() shouldn't have further items");
+        } catch (NoSuchElementException expected) {
             // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_with_has_next() {
-        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withEntrySetIterator_withTombs_hasNext() {
+        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, Map.Entry<String, Integer>> collection
                 = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
         Iterator<Map.Entry<String, Integer>> iterator = collection.iterator();
@@ -447,13 +464,14 @@ public class LazyIteratorTest extends HazelcastTestSupport {
             count++;
             values.add(iterator.next().getValue());
         }
-        assertEquals(50, count);
-        assertEquals(50, values.size());
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 50, count);
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 50, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_with_next() {
-        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withEntrySetIterator_withTombs_next() {
+        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, Map.Entry<String, Integer>> collection
                 = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
         Iterator<Map.Entry<String, Integer>> iterator = collection.iterator();
@@ -462,20 +480,20 @@ public class LazyIteratorTest extends HazelcastTestSupport {
         for (int i = 0; i < 50; i++) {
             values.add(iterator.next().getValue());
         }
-        assertEquals(50, values.size());
-
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 50, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
         try {
             iterator.next();
-            fail("Shouldn't have further elements!");
-        } catch (NoSuchElementException e) {
+            fail("LazySet.iterator() shouldn't have further items");
+        } catch (NoSuchElementException expected) {
             // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_copy() {
-        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withEntrySetIterator_withTombs_onSetCopy() {
+        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, Map.Entry<String, Integer>> collection
                 = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
 
@@ -486,216 +504,51 @@ public class LazyIteratorTest extends HazelcastTestSupport {
         for (int i = 0; i < 50; i++) {
             values.add(iterator.next().getValue());
         }
-        assertEquals(50, values.size());
-
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.iterator(), but was %d", 50, values.size());
+        assertFalse("Expected no more items in LazySet.iterator()", iterator.hasNext());
         try {
             iterator.next();
-            fail("Shouldn't have further elements!");
-        } catch (NoSuchElementException e) {
+            fail("LazySet.iterator() shouldn't have further items");
+        } catch (NoSuchElementException expected) {
             // we need to catch it here since we won't have a successful test
             // if any of the prior calls would throw it!
         }
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_to_array_new_array() {
-        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withEntrySetIterator_withTombs_toArray() {
+        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, Map.Entry<String, Integer>> collection
                 = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
 
         Object[] array = collection.toArray();
-        assertEquals(50, array.length);
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.toArray(), but was %d", 50, array.length);
     }
 
     @Test
-    public void test_lazyEntrySet_with_tombs_to_array_passed_array_too_small() {
-        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withEntrySetIterator_withTombs_toArray_whenPassedArrayIsTooSmall() {
+        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, Map.Entry<String, Integer>> collection
                 = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
 
         Map.Entry[] array = collection.toArray(new Map.Entry[0]);
-        assertEquals(50, array.length);
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.toArray(), but was %d", 50, array.length);
     }
 
     @Test
-    public void test_lazy_entryset_with_tombs_to_array_passed_array_matching_size() {
-        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(REPLICATED_RECORD_STORE);
+    public void testLazySet_withEntrySetIterator_withTombs_toArray_whenPassedArrayHasMatchingSize() {
+        EntrySetIteratorFactory<String, Integer> factory = new EntrySetIteratorFactory<String, Integer>(replicatedRecordStore);
         LazySet<String, Integer, Map.Entry<String, Integer>> collection
                 = new LazySet<String, Integer, Map.Entry<String, Integer>>(factory, TEST_DATA_TOMBS);
 
         Map.Entry[] array = collection.toArray(new Map.Entry[50]);
-        assertEquals(50, array.length);
+        assertEqualsStringFormat("Expected %d unique items in the LazySet.toArray(), but was %d", 50, array.length);
     }
 
-    private static class NoOpReplicatedRecordStore implements ReplicatedRecordStore {
-
+    private static class ReturnFirstArgumentAnswer implements Answer<Object> {
         @Override
-        public String getName() {
-            return null;
-        }
-
-        @Override
-        public int getPartitionId() {
-            return 0;
-        }
-
-        @Override
-        public Object remove(Object key) {
-            return null;
-        }
-
-        @Override
-        public Object removeWithVersion(Object key, long version) {
-            return null;
-        }
-
-        @Override
-        public void evict(Object key) {
-        }
-
-        @Override
-        public Object get(Object key) {
-            return null;
-        }
-
-        @Override
-        public Object put(Object key, Object value) {
-            return null;
-        }
-
-        @Override
-        public Object put(Object key, Object value, long ttl, TimeUnit timeUnit, boolean incrementHits) {
-            return null;
-        }
-
-        @Override
-        public Object putWithVersion(Object key, Object value, long ttl, TimeUnit timeUnit, boolean incrementHits, long version) {
-            return null;
-        }
-
-        @Override
-        public boolean containsKey(Object key) {
-            return false;
-        }
-
-        @Override
-        public boolean containsValue(Object value) {
-            return false;
-        }
-
-        @Override
-        public ReplicatedRecord getReplicatedRecord(Object key) {
-            return null;
-        }
-
-        @Override
-        public Set keySet(boolean lazy) {
-            return null;
-        }
-
-        @Override
-        public Collection values(boolean lazy) {
-            return null;
-        }
-
-        @Override
-        public Collection values(Comparator comparator) {
-            return null;
-        }
-
-        @Override
-        public Set entrySet(boolean lazy) {
-            return null;
-        }
-
-        @Override
-        public int size() {
-            return 0;
-        }
-
-        @Override
-        public void clear() {
-        }
-
-        @Override
-        public void clearWithVersion(long version) {
-        }
-
-        @Override
-        public void reset() {
-        }
-
-        @Override
-        public boolean isEmpty() {
-            return false;
-        }
-
-        @Override
-        public Object unmarshall(Object key) {
-            return key;
-        }
-
-        @Override
-        public Object marshall(Object key) {
-            return key;
-        }
-
-        @Override
-        public void destroy() {
-        }
-
-        @Override
-        public long getVersion() {
-            return 0;
-        }
-
-        @Override
-        public boolean isStale(long version) {
-            return false;
-        }
-
-        @Override
-        public Iterator<ReplicatedRecord> recordIterator() {
-            return null;
-        }
-
-        @Override
-        public void putRecords(Collection<RecordMigrationInfo> records, long version) {
-        }
-
-        @Override
-        public InternalReplicatedMapStorage getStorage() {
-            return null;
-        }
-
-        @Override
-        public ScheduledEntry<Object, Object> cancelTtlEntry(Object key) {
-            return null;
-        }
-
-        @Override
-        public boolean scheduleTtlEntry(long delayMillis, Object key, Object object) {
-            return false;
-        }
-
-        @Override
-        public boolean isLoaded() {
-            return false;
-        }
-
-        @Override
-        public void setLoaded(boolean loaded) {
-        }
-
-        @Override
-        public boolean merge(Object key, ReplicatedMapEntryView entryView, ReplicatedMapMergePolicy mergePolicy) {
-            return false;
-        }
-
-        @Override
-        public boolean merge(ReplicatedMapMergeTypes mergingEntry,
-                             SplitBrainMergePolicy<Object, ReplicatedMapMergeTypes> mergePolicy) {
-            return false;
+        public Object answer(InvocationOnMock invocation) {
+            return invocation.getArguments()[0];
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazySetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/LazySetTest.java
@@ -44,42 +44,43 @@ public class LazySetTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_add_throws_exception() {
-        set.add(null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_add_all_throws_exception() {
-        set.addAll(Collections.EMPTY_LIST);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_remove_throws_exception() {
-        set.remove(null);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_removeAll_throws_exception() {
-        set.removeAll(Collections.EMPTY_LIST);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void test_contains_throws_exception() {
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    public void testContains_throwsException() {
         set.contains(null);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_contains_all_throws_exception() {
+    public void testContainsAll_throwsException() {
         set.containsAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_retain_all_throws_exception() {
+    public void testAdd_throwsException() {
+        set.add(null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testAddAll_throwsException() {
+        set.addAll(Collections.EMPTY_LIST);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemove_throwsException() {
+        set.remove(null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRemoveAll_throwsException() {
+        set.removeAll(Collections.EMPTY_LIST);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testRetainAll_throwsException() {
         set.retainAll(Collections.EMPTY_LIST);
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void test_clear_throws_exception() {
+    public void testClear_throwsException() {
         set.clear();
     }
 }


### PR DESCRIPTION
I had to adapt the `LazyIteratorTest` a couple of times now, just because it implements `ReplicatedRecordStore` (to have a NOP store). In fact we just need two methods overridden, everything else will work fine with a simple mock. So I refactored the test and also improved the test method names.

I also replaced the iterators in `LazySet` with a `for each` construct. The `addAll()` approach doesn't work due to a `StackOverflowException` (the method calls itself).

At last I've added a bunch of `assertFalse(iterator.hasNext());` checks to the iterator test and improved all assertion messages.

**EDIT:** There was actually a bug in `KeySetIteratorFactory`, which was triggered by the combination of JDK 6 (different order of map elements) and a new test assertion. Added the fix as separate commit to ease the review.