### PR TITLE
Respect index config in query caches

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -86,15 +86,6 @@ import java.util.concurrent.TimeUnit;
  * <li>Be careful while using default interface method implementations from {@link ConcurrentMap} and {@link Map}. Under
  * the hood they are typically implemented as a sequence of more primitive map operations, therefore the operations won't
  * be executed atomically.</li>
- * <li>Currently, updates performed on the map having
- * {@link com.hazelcast.config.InMemoryFormat#OBJECT OBJECT} or
- * {@link com.hazelcast.config.InMemoryFormat#BINARY BINARY} in-memory format
- * are reflected in the indexes in a non-atomic way. Therefore, if there are
- * indexes configured for the map, their state may slightly lag behind the state
- * of the map. Use map listeners if you need to observe the state when the map
- * and its indexes are consistent about the state of a particular map entry, see
- * {@link #addEntryListener(MapListener, boolean) addEntryListener} for more
- * details.</li>
  * </ul>
  * <p>
  * This class does <em>not</em> allow {@code null} to be used as a key or value.

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -86,11 +86,13 @@ import java.util.concurrent.TimeUnit;
  * <li>Be careful while using default interface method implementations from {@link ConcurrentMap} and {@link Map}. Under
  * the hood they are typically implemented as a sequence of more primitive map operations, therefore the operations won't
  * be executed atomically.</li>
- * <li>Currently, updates performed on the map are reflected in the indexes in
- * a non-atomic way. Therefore, if there are indexes configured for the map,
- * their state may slightly lag behind the state of the map. Use map listeners
- * if you need to observe the state when the map and its indexes are consistent
- * about the state of a particular map entry, see
+ * <li>Currently, updates performed on the map having
+ * {@link com.hazelcast.config.InMemoryFormat#OBJECT OBJECT} or
+ * {@link com.hazelcast.config.InMemoryFormat#BINARY BINARY} in-memory format
+ * are reflected in the indexes in a non-atomic way. Therefore, if there are
+ * indexes configured for the map, their state may slightly lag behind the state
+ * of the map. Use map listeners if you need to observe the state when the map
+ * and its indexes are consistent about the state of a particular map entry, see
  * {@link #addEntryListener(MapListener, boolean) addEntryListener} for more
  * details.</li>
  * </ul>

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -86,6 +86,13 @@ import java.util.concurrent.TimeUnit;
  * <li>Be careful while using default interface method implementations from {@link ConcurrentMap} and {@link Map}. Under
  * the hood they are typically implemented as a sequence of more primitive map operations, therefore the operations won't
  * be executed atomically.</li>
+ * <li>Currently, updates performed on the map are reflected in the indexes in
+ * a non-atomic way. Therefore, if there are indexes configured for the map,
+ * their state may slightly lag behind the state of the map. Use map listeners
+ * if you need to observe the state when the map and its indexes are consistent
+ * about the state of a particular map entry, see
+ * {@link #addEntryListener(MapListener, boolean) addEntryListener} for more
+ * details.</li>
  * </ul>
  * <p>
  * This class does <em>not</em> allow {@code null} to be used as a key or value.

--- a/hazelcast/src/main/java/com/hazelcast/map/QueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/QueryCache.java
@@ -60,6 +60,15 @@ import java.util.Set;
  * event of that operation.
  * </li>
  * <li>
+ * Currently, updates performed on the entries are reflected in the indexes in a
+ * non-atomic way. Therefore, if there are indexes configured for the query
+ * cache, their state may slightly lag behind the state of the entries.
+ * Use map listeners if you need to observe the state when the entry store and
+ * its indexes are consistent about the state of a particular entry, see
+ * {@link IMap#addEntryListener(MapListener, boolean) addEntryListener} for more
+ * details.
+ * </li>
+ * <li>
  * There are some gotchas same with underlying {@link com.hazelcast.core.IMap IMap} implementation,
  * one should take care of them before using this {@code QueryCache}.
  * Please check gotchas section in {@link com.hazelcast.core.IMap IMap} class for them.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.querycache.subscriber;
 
+import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.PartitioningStrategy;
@@ -80,6 +81,10 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
         this.partitioningStrategy = getPartitioningStrategy();
         this.recordStore = new DefaultQueryCacheRecordStore(serializationService, indexes, getQueryCacheConfig(),
                 getEvictionListener());
+
+        for (MapIndexConfig indexConfig : getQueryCacheConfig().getIndexConfigs()) {
+            indexes.addOrGetIndex(indexConfig.getAttribute(), indexConfig.isOrdered());
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheIndexConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheIndexConfigTest.java
@@ -1,0 +1,47 @@
+package com.hazelcast.map.impl.querycache.subscriber;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.config.PredicateConfig;
+import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class QueryCacheIndexConfigTest extends HazelcastTestSupport {
+
+    @Test
+    public void testIndexConfigIsRespected() {
+        final Config config = new Config();
+        // @formatter:off
+        final MapConfig mapConfig = new MapConfig("map")
+                .addQueryCacheConfig(new QueryCacheConfig()
+                        .setName("query-cache")
+                        .setPredicateConfig(new PredicateConfig(TruePredicate.INSTANCE))
+                        .addIndexConfig(new MapIndexConfig("field", true))
+                );
+        // @formatter:on
+        config.addMapConfig(mapConfig);
+
+        final HazelcastInstance instance = createHazelcastInstance(config);
+        final IMap<Object, Object> map = instance.getMap("map");
+        final DefaultQueryCache<Object, Object> cache = (DefaultQueryCache<Object, Object>) map.getQueryCache("query-cache");
+
+        assertNotNull(cache.indexes.getIndex("field"));
+        assertTrue(cache.indexes.getIndex("field").isOrdered());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheIndexConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheIndexConfigTest.java
@@ -26,14 +26,9 @@ public class QueryCacheIndexConfigTest extends HazelcastTestSupport {
     @Test
     public void testIndexConfigIsRespected() {
         final Config config = new Config();
-        // @formatter:off
-        final MapConfig mapConfig = new MapConfig("map")
-                .addQueryCacheConfig(new QueryCacheConfig()
-                        .setName("query-cache")
-                        .setPredicateConfig(new PredicateConfig(TruePredicate.INSTANCE))
-                        .addIndexConfig(new MapIndexConfig("field", true))
-                );
-        // @formatter:on
+        final MapConfig mapConfig = new MapConfig("map").addQueryCacheConfig(
+                new QueryCacheConfig().setName("query-cache").setPredicateConfig(new PredicateConfig(TruePredicate.INSTANCE))
+                                      .addIndexConfig(new MapIndexConfig("field", true)));
         config.addMapConfig(mapConfig);
 
         final HazelcastInstance instance = createHazelcastInstance(config);


### PR DESCRIPTION
Also adds javadoc about the non-atomicity of index updates.

Fixes: https://github.com/hazelcast/hazelcast/issues/12358