### PR TITLE
Move Memoizer to internal util package

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/crdt/pncounter/PNCounterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/crdt/pncounter/PNCounterService.java
@@ -18,7 +18,7 @@ package com.hazelcast.crdt.pncounter;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.PNCounterConfig;
-import com.hazelcast.core.Memoizer;
+import com.hazelcast.internal.util.Memoizer;
 import com.hazelcast.crdt.CRDTReplicationAwareService;
 import com.hazelcast.crdt.CRDTReplicationContainer;
 import com.hazelcast.crdt.MutationDisallowedException;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/Memoizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/Memoizer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.core;
+package com.hazelcast.internal.util;
 
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ContextMutexFactory;


### PR DESCRIPTION
The Memoizer is only for internal use and not public.