### PR TITLE
Fix behaviour when addressProvider.loadAddress throws excepion

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -911,7 +911,13 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
 
         LinkedHashSet<Address> providerAddresses = new LinkedHashSet<Address>();
         for (AddressProvider addressProvider : addressProviders) {
-            providerAddresses.addAll(addressProvider.loadAddresses());
+            try {
+                providerAddresses.addAll(addressProvider.loadAddresses());
+            } catch (NullPointerException e) {
+                throw e;
+            } catch (Exception e) {
+                logger.warning("Exception from AddressProvider: " + addressProvider, e);
+            }
         }
 
         if (shuffleMemberList) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -67,6 +67,7 @@ import javax.xml.validation.Validator;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -74,6 +75,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -234,6 +236,22 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         //Then
         assertOpenEventually(startLatch);
         assertOpenEventually(stopLatch);
+    }
+
+    @Test
+    public void testClientCanConnect_afterDiscoveryStrategyThrowsException() {
+        Config config = new Config();
+        config.getNetworkConfig().setPort(50001);
+        Hazelcast.newHazelcastInstance(config);
+        ClientConfig clientConfig = new ClientConfig();
+
+        clientConfig.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
+        DiscoveryConfig discoveryConfig = clientConfig.getNetworkConfig().getDiscoveryConfig();
+        DiscoveryStrategyFactory factory = new ExceptionThrowingDiscoveryStrategyFactory();
+        DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig(factory, Collections.<String, Comparable>emptyMap());
+        discoveryConfig.addDiscoveryStrategyConfig(strategyConfig);
+
+        HazelcastClient.newHazelcastClient(clientConfig);
     }
 
     @Test
@@ -491,6 +509,66 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         @Override
         public Collection<PropertyDefinition> getConfigurationProperties() {
             return propertyDefinitions;
+        }
+    }
+
+    private static class FirstCallExceptionThrowingDiscoveryStrategy implements DiscoveryStrategy {
+
+        AtomicBoolean firstCall = new AtomicBoolean(true);
+
+        @Override
+        public void start() {
+        }
+
+        @Override
+        public Collection<DiscoveryNode> discoverNodes() {
+            if (firstCall.compareAndSet(true, false)) {
+                throw new RuntimeException();
+            }
+            try {
+                List<DiscoveryNode> discoveryNodes = new ArrayList<DiscoveryNode>(1);
+                Address privateAddress = new Address("127.0.0.1", 50001);
+                discoveryNodes.add(new SimpleDiscoveryNode(privateAddress));
+                return discoveryNodes;
+            } catch (UnknownHostException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void destroy() {
+        }
+
+        @Override
+        public PartitionGroupStrategy getPartitionGroupStrategy() {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> discoverLocalMetadata() {
+            return Collections.emptyMap();
+        }
+    }
+
+    public static class ExceptionThrowingDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
+
+        public ExceptionThrowingDiscoveryStrategyFactory() {
+        }
+
+        @Override
+        public Class<? extends DiscoveryStrategy> getDiscoveryStrategyType() {
+            return FirstCallExceptionThrowingDiscoveryStrategy.class;
+        }
+
+        @Override
+        public DiscoveryStrategy newDiscoveryStrategy(DiscoveryNode discoveryNode, ILogger logger,
+                                                      Map<String, Comparable> properties) {
+            return new FirstCallExceptionThrowingDiscoveryStrategy();
+        }
+
+        @Override
+        public Collection<PropertyDefinition> getConfigurationProperties() {
+            return Collections.EMPTY_LIST;
         }
     }
 


### PR DESCRIPTION
Client needs to expect and handle exceptions from `loadAdress`
method. Expceptions will be caught, logged and client will continue to
attempt to connect to cluster.

fixes https://github.com/hazelcast/hazelcast/issues/12457
fixes https://github.com/hazelcast/hazelcast-aws/issues/57