### PR TITLE
Do not rethrow exceptions cached in futures in ProxyRegistry.destroy()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
+import com.hazelcast.util.EmptyStatement;
 
 import java.util.Collection;
 import java.util.Map;
@@ -262,11 +263,26 @@ public final class ProxyRegistry {
             if (!future.isSetAndInitialized()) {
                 continue;
             }
-            DistributedObject distributedObject = future.get();
-            if (distributedObject instanceof AbstractDistributedObject) {
-                ((AbstractDistributedObject) distributedObject).invalidate();
-            }
+
+            DistributedObject distributedObject = extractDistributedObject(future);
+            invalidate(distributedObject);
         }
         proxies.clear();
+    }
+
+    private DistributedObject extractDistributedObject(DistributedObjectFuture future) {
+        try {
+            return future.get();
+        } catch (Throwable ex) {
+            EmptyStatement.ignore(ex);
+        }
+        return null;
+    }
+
+    private void invalidate(DistributedObject distributedObject) {
+        if (distributedObject != null
+                && distributedObject instanceof AbstractDistributedObject) {
+            ((AbstractDistributedObject) distributedObject).invalidate();
+        }
     }
 }


### PR DESCRIPTION
Exceptions cached in `DistributedObjectFuture`s are rethrown on the shutdown thread from `ProxyRegistry.destroy()`, which aborts shutdown procedure abruptly, potentially leading to resource leaking. These exceptions should not be rethrown to ensure proper shutdown.

Fixes #12480 #12516 https://github.com/hazelcast/hazelcast/issues/12589