### PR TITLE
Do not mutate ReplicatedMapConfig while constructing read-only variant

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -88,7 +88,8 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable {
         this.concurrencyLevel = replicatedMapConfig.concurrencyLevel;
         this.replicationDelayMillis = replicatedMapConfig.replicationDelayMillis;
         this.replicatorExecutorService = replicatedMapConfig.replicatorExecutorService;
-        this.listenerConfigs = new ArrayList<ListenerConfig>(replicatedMapConfig.getListenerConfigs());
+        this.listenerConfigs = replicatedMapConfig.listenerConfigs == null ? null
+                : new ArrayList<ListenerConfig>(replicatedMapConfig.getListenerConfigs());
         this.asyncFillup = replicatedMapConfig.asyncFillup;
         this.statisticsEnabled = replicatedMapConfig.statisticsEnabled;
         this.mergePolicy = replicatedMapConfig.mergePolicy;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -249,7 +249,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
 
 
     public ReplicatedMapConfig getReplicatedMapConfig(String name) {
-        return config.getReplicatedMapConfig(name).getAsReadOnly();
+        return config.findReplicatedMapConfig(name);
     }
 
     public ReplicatedRecordStore getReplicatedRecordStore(String name, boolean create, Object key) {
@@ -295,7 +295,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
     }
 
     public void initializeListeners(String name) {
-        List<ListenerConfig> listenerConfigs = config.getReplicatedMapConfig(name).getListenerConfigs();
+        List<ListenerConfig> listenerConfigs = getReplicatedMapConfig(name).getListenerConfigs();
         for (ListenerConfig listenerConfig : listenerConfigs) {
             EntryListener listener = null;
             if (listenerConfig.getImplementation() != null) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigTest.java
@@ -61,6 +61,7 @@ import com.hazelcast.core.ItemEvent;
 import com.hazelcast.core.ItemListener;
 import com.hazelcast.core.Message;
 import com.hazelcast.core.MessageListener;
+import com.hazelcast.core.ReplicatedMap;
 import com.hazelcast.core.RingbufferStore;
 import com.hazelcast.core.RingbufferStoreFactory;
 import com.hazelcast.internal.eviction.EvictableEntryView;
@@ -289,6 +290,15 @@ public class DynamicConfigTest extends HazelcastTestSupport {
     @Test
     public void testReplicatedMapDefaultConfig() {
         ReplicatedMapConfig config = new ReplicatedMapConfig(name);
+        driver.getConfig().addReplicatedMapConfig(config);
+        assertConfigurationsEqualsOnAllMembers(config);
+    }
+
+    @Test
+    public void testSameReplicatedMapConfig_canBeAddedTwice() {
+        ReplicatedMapConfig config = new ReplicatedMapConfig(name);
+        driver.getConfig().addReplicatedMapConfig(config);
+        ReplicatedMap map = driver.getReplicatedMap(name);
         driver.getConfig().addReplicatedMapConfig(config);
         assertConfigurationsEqualsOnAllMembers(config);
     }


### PR DESCRIPTION
Also, aligns `ReplicatedMapService` to use `findReplicatedMapConfig` to locate and obtain a read-only copy of the `ReplicatedMapConfig` instead of `getReplicatedMapConfig`, as other services do.

Fixes #12222 