### PR TITLE
[FORWARD PORT] ExecuteScriptRequest/ThreadDumpRequest error reporting

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -29,6 +29,8 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 
+import static com.hazelcast.internal.cluster.Versions.V3_10;
+
 /**
  * Operation to execute script on the node.
  */
@@ -71,16 +73,18 @@ public class ScriptExecutorOperation extends AbstractManagementOperation {
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(engineName);
         out.writeUTF(script);
-        // kept for compatibility
-        out.writeInt(0);
+        if (out.getVersion().isLessThan(V3_10)) {
+            out.writeInt(0);
+        }
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         engineName = in.readUTF();
         script = in.readUTF();
-        // kept for compatibility
-        in.readInt();
+        if (in.getVersion().isLessThan(V3_10)) {
+            in.readInt();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.internal.management.ScriptEngineManagerContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
@@ -34,7 +35,7 @@ import static com.hazelcast.internal.cluster.Versions.V3_10;
 /**
  * Operation to execute script on the node.
  */
-public class ScriptExecutorOperation extends AbstractManagementOperation {
+public class ScriptExecutorOperation extends AbstractManagementOperation implements Versioned {
 
     private String engineName;
     private String script;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -74,7 +74,7 @@ public class ScriptExecutorOperation extends AbstractManagementOperation impleme
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(engineName);
         out.writeUTF(script);
-        if (out.getVersion().isLessThan(V3_10)) {
+        if (out.getVersion().isUnknownOrLessThan(V3_10)) {
             out.writeInt(0);
         }
     }
@@ -83,7 +83,7 @@ public class ScriptExecutorOperation extends AbstractManagementOperation impleme
     protected void readInternal(ObjectDataInput in) throws IOException {
         engineName = in.readUTF();
         script = in.readUTF();
-        if (in.getVersion().isLessThan(V3_10)) {
+        if (in.getVersion().isUnknownOrLessThan(V3_10)) {
             in.readInt();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -16,19 +16,18 @@
 
 package com.hazelcast.internal.management.operation;
 
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.internal.management.ScriptEngineManagerContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.io.IOException;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
-import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
-
-import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Operation to execute script on the node.
@@ -37,37 +36,29 @@ public class ScriptExecutorOperation extends AbstractManagementOperation {
 
     private String engineName;
     private String script;
-    private Map<String, Object> bindings;
     private Object result;
 
     @SuppressWarnings("unused")
     public ScriptExecutorOperation() {
     }
 
-    public ScriptExecutorOperation(String engineName, String script, Map<String, Object> bindings) {
+    public ScriptExecutorOperation(String engineName, String script) {
         this.engineName = engineName;
         this.script = script;
-        this.bindings = bindings;
     }
 
     @Override
-    public void run() throws Exception {
+    public void run() {
         ScriptEngineManager scriptEngineManager = ScriptEngineManagerContext.getScriptEngineManager();
         ScriptEngine engine = scriptEngineManager.getEngineByName(engineName);
         if (engine == null) {
             throw new IllegalArgumentException("Could not find ScriptEngine named '" + engineName + "'.");
         }
         engine.put("hazelcast", getNodeEngine().getHazelcastInstance());
-        if (bindings != null) {
-            Set<Map.Entry<String, Object>> entries = bindings.entrySet();
-            for (Map.Entry<String, Object> entry : entries) {
-                engine.put(entry.getKey(), entry.getValue());
-            }
-        }
         try {
             this.result = engine.eval(script);
         } catch (ScriptException e) {
-            this.result = e.getMessage();
+            throw new HazelcastException(ExceptionUtil.toString(e));
         }
     }
 
@@ -80,31 +71,16 @@ public class ScriptExecutorOperation extends AbstractManagementOperation {
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         out.writeUTF(engineName);
         out.writeUTF(script);
-        if (bindings != null) {
-            out.writeInt(bindings.size());
-            Set<Map.Entry<String, Object>> entries = bindings.entrySet();
-            for (Map.Entry<String, Object> entry : entries) {
-                out.writeUTF(entry.getKey());
-                out.writeObject(entry.getValue());
-            }
-        } else {
-            out.writeInt(0);
-        }
+        // kept for compatibility
+        out.writeInt(0);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         engineName = in.readUTF();
         script = in.readUTF();
-        int size = in.readInt();
-        if (size > 0) {
-            bindings = createHashMap(size);
-            for (int i = 0; i < size; i++) {
-                String key = in.readUTF();
-                Object value = in.readObject();
-                bindings.put(key, value);
-            }
-        }
+        // kept for compatibility
+        in.readInt();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
@@ -20,6 +20,7 @@ import com.eclipsesource.json.JsonObject;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ChangeWanStateOperation;
 
+import static com.hazelcast.internal.management.ManagementCenterService.resolveFuture;
 import static com.hazelcast.util.JsonUtil.getBoolean;
 import static com.hazelcast.util.JsonUtil.getString;
 
@@ -52,8 +53,9 @@ public class ChangeWanStateRequest implements ConsoleRequest {
     }
 
     @Override
-    public void writeResponse(ManagementCenterService mcs, JsonObject out) throws Exception {
-        Object operationResult = mcs.callOnThis(new ChangeWanStateOperation(schemeName, publisherName, start));
+    public void writeResponse(ManagementCenterService mcs, JsonObject out) {
+        Object operationResult = resolveFuture(
+                mcs.callOnThis(new ChangeWanStateOperation(schemeName, publisherName, start)));
         JsonObject result = new JsonObject();
         if (operationResult == null) {
             result.add("result", SUCCESS);

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ClearWanQueuesRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ClearWanQueuesRequest.java
@@ -20,6 +20,7 @@ import com.eclipsesource.json.JsonObject;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ClearWanQueuesOperation;
 
+import static com.hazelcast.internal.management.ManagementCenterService.resolveFuture;
 import static com.hazelcast.util.JsonUtil.getString;
 
 /**
@@ -49,9 +50,9 @@ public class ClearWanQueuesRequest implements ConsoleRequest {
     }
 
     @Override
-    public void writeResponse(ManagementCenterService mcs, JsonObject out) throws Exception {
+    public void writeResponse(ManagementCenterService mcs, JsonObject out) {
         ClearWanQueuesOperation operation = new ClearWanQueuesOperation(schemeName, publisherName);
-        Object operationResult = mcs.callOnThis(operation);
+        Object operationResult = resolveFuture(mcs.callOnThis(operation));
         JsonObject result = new JsonObject();
         if (operationResult == null) {
             result.add("result", SUCCESS);

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
@@ -26,7 +26,6 @@ import com.hazelcast.util.AddressUtil;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.MapUtil;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,22 +70,20 @@ public class ExecuteScriptRequest implements ConsoleRequest {
         }
 
         JsonObject responseJson = new JsonObject();
-        StringBuilder scriptResult = new StringBuilder();
         for (Map.Entry<Address, Future<Object>> entry : futures.entrySet()) {
             Address address = entry.getKey();
             Future<Object> future = entry.getValue();
 
             try {
-                addSuccessResponse(responseJson, scriptResult, address, prettyPrint(future.get()));
+                addSuccessResponse(responseJson, address, prettyPrint(future.get()));
             } catch (ExecutionException e) {
-                addErrorResponse(responseJson, scriptResult, address, e);
+                addErrorResponse(responseJson, address, e);
             } catch (InterruptedException e) {
-                addErrorResponse(responseJson, scriptResult, address, e);
+                addErrorResponse(responseJson, address, e);
                 Thread.currentThread().interrupt();
             }
         }
 
-        responseJson.add("scriptResult",  scriptResult.toString());
         root.add("result",  responseJson);
     }
 
@@ -123,25 +120,20 @@ public class ExecuteScriptRequest implements ConsoleRequest {
         }
     }
 
-    private static void addSuccessResponse(JsonObject root, StringBuilder scriptResult,
-                                           Address address, String result) {
+    private static void addSuccessResponse(JsonObject root, Address address, String result) {
 
-        addResponse(root, scriptResult, address, true, result);
+        addResponse(root, address, true, result);
     }
 
-    private static void addErrorResponse(JsonObject root, StringBuilder scriptResult,
-                                         Address address, Exception e) {
-        addResponse(root, scriptResult, address, false, ExceptionUtil.toString(e));
+    private static void addErrorResponse(JsonObject root, Address address, Exception e) {
+        addResponse(root, address, false, ExceptionUtil.toString(e));
     }
 
-    private static void addResponse(JsonObject root, StringBuilder scriptResult,
-                                    Address address, boolean success, String result) {
+    private static void addResponse(JsonObject root, Address address, boolean success, String result) {
 
         JsonObject json = new JsonObject();
         json.add("success", success);
         json.add("result", result);
         root.add(address.toString(), json);
-
-        scriptResult.append(result);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
@@ -19,21 +19,21 @@ package com.hazelcast.internal.management.request;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
-import com.hazelcast.core.Member;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ScriptExecutorOperation;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.AddressUtil;
+import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.MapUtil;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 
 import static com.hazelcast.util.JsonUtil.getArray;
-import static com.hazelcast.util.JsonUtil.getBoolean;
 import static com.hazelcast.util.JsonUtil.getString;
 import static com.hazelcast.util.SetUtil.createHashSet;
 
@@ -45,26 +45,14 @@ public class ExecuteScriptRequest implements ConsoleRequest {
     private String script;
     private String engine;
     private Set<String> targets;
-    private boolean targetAllMembers;
-    private Map<String, Object> bindings;
 
     public ExecuteScriptRequest() {
     }
 
-    public ExecuteScriptRequest(String script, String engine, boolean targetAllMembers, Map<String, Object> bindings) {
+    public ExecuteScriptRequest(String script, String engine, Set<String> targets) {
         this.script = script;
         this.engine = engine;
-        this.targets = new HashSet<String>(0);
-        this.targetAllMembers = targetAllMembers;
-        this.bindings = bindings;
-    }
-
-    public ExecuteScriptRequest(String script, String engine, Set<String> targets, Map<String, Object> bindings) {
-        this.script = script;
         this.targets = targets;
-        this.engine = engine;
-        this.targetAllMembers = false;
-        this.bindings = bindings;
     }
 
     @Override
@@ -74,47 +62,54 @@ public class ExecuteScriptRequest implements ConsoleRequest {
 
     @Override
     public void writeResponse(ManagementCenterService mcs, JsonObject root) throws Exception {
-        JsonObject jsonResult = new JsonObject();
-        ArrayList results;
-        if (targetAllMembers) {
-            Set<Member> members = mcs.getHazelcastInstance().getCluster().getMembers();
-            ArrayList<Object> list = new ArrayList<Object>(members.size());
-            for (Member member : members) {
-                list.add(mcs.callOnMember(member, new ScriptExecutorOperation(engine, script, bindings)));
-            }
-            results = list;
-        } else {
-            ArrayList<Object> list = new ArrayList<Object>(targets.size());
-            for (String address : targets) {
-                AddressUtil.AddressHolder addressHolder = AddressUtil.getAddressHolder(address);
-                Address targetAddress = new Address(addressHolder.getAddress(), addressHolder.getPort());
-                list.add(mcs.callOnAddress(targetAddress, new ScriptExecutorOperation(engine, script, bindings)));
-            }
-            results = list;
+        Map<Address, Future<Object>> futures = MapUtil.createHashMap(targets.size());
+
+        for (String address : targets) {
+            AddressUtil.AddressHolder addressHolder = AddressUtil.getAddressHolder(address);
+            Address targetAddress = new Address(addressHolder.getAddress(), addressHolder.getPort());
+            futures.put(targetAddress, mcs.callOnAddress(targetAddress, new ScriptExecutorOperation(engine, script)));
         }
 
-        StringBuilder sb = new StringBuilder();
-        for (Object result : results) {
-            if (result instanceof String) {
-                sb.append(result);
-            } else if (result instanceof List) {
-                List list = (List) result;
-                for (Object o : list) {
-                    sb.append(o).append("\n");
-                }
-            } else if (result instanceof Map) {
-                Map map = (Map) result;
-                for (Object o : map.entrySet()) {
-                    Map.Entry entry = (Map.Entry) o;
-                    sb.append(entry.getKey()).append("->").append(entry.getValue()).append("\n");
-                }
-            } else if (result == null) {
-                sb.append("error");
+        JsonObject responseJson = new JsonObject();
+        StringBuilder scriptResult = new StringBuilder();
+        for (Map.Entry<Address, Future<Object>> entry : futures.entrySet()) {
+            Address address = entry.getKey();
+            Future<Object> future = entry.getValue();
+
+            try {
+                addSuccessResponse(responseJson, scriptResult, address, prettyPrint(future.get()));
+            } catch (ExecutionException e) {
+                addErrorResponse(responseJson, scriptResult, address, e);
+            } catch (InterruptedException e) {
+                addErrorResponse(responseJson, scriptResult, address, e);
+                Thread.currentThread().interrupt();
             }
-            sb.append("\n");
         }
-        jsonResult.add("scriptResult", sb.toString());
-        root.add("result", jsonResult);
+
+        responseJson.add("scriptResult",  scriptResult.toString());
+        root.add("result",  responseJson);
+    }
+
+    private String prettyPrint(Object result) {
+        StringBuilder sb = new StringBuilder();
+        if (result instanceof String) {
+            sb.append(result);
+        } else if (result instanceof List) {
+            List list = (List) result;
+            for (Object o : list) {
+                sb.append(o).append("\n");
+            }
+        } else if (result instanceof Map) {
+            Map map = (Map) result;
+            for (Object o : map.entrySet()) {
+                Map.Entry e = (Map.Entry) o;
+                sb.append(e.getKey()).append("->").append(e.getValue()).append("\n");
+            }
+        } else if (result == null) {
+            sb.append("error");
+        }
+        sb.append("\n");
+        return sb.toString();
     }
 
     @Override
@@ -126,7 +121,27 @@ public class ExecuteScriptRequest implements ConsoleRequest {
         for (JsonValue target : array) {
             targets.add(target.asString());
         }
-        targetAllMembers = getBoolean(json, "targetAllMembers", false);
-        bindings = new HashMap<String, Object>();
+    }
+
+    private static void addSuccessResponse(JsonObject root, StringBuilder scriptResult,
+                                           Address address, String result) {
+
+        addResponse(root, scriptResult, address, true, result);
+    }
+
+    private static void addErrorResponse(JsonObject root, StringBuilder scriptResult,
+                                         Address address, Exception e) {
+        addResponse(root, scriptResult, address, false, ExceptionUtil.toString(e));
+    }
+
+    private static void addResponse(JsonObject root, StringBuilder scriptResult,
+                                    Address address, boolean success, String result) {
+
+        JsonObject json = new JsonObject();
+        json.add("success", success);
+        json.add("result", result);
+        root.add(address.toString(), json);
+
+        scriptResult.append(result);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/MapConfigRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/MapConfigRequest.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.management.operation.UpdateMapConfigOperation;
 
 import java.util.Set;
 
+import static com.hazelcast.internal.management.ManagementCenterService.resolveFuture;
 import static com.hazelcast.util.JsonUtil.getBoolean;
 import static com.hazelcast.util.JsonUtil.getObject;
 import static com.hazelcast.util.JsonUtil.getString;
@@ -60,11 +61,11 @@ public class MapConfigRequest implements ConsoleRequest {
         if (update) {
             final Set<Member> members = mcs.getHazelcastInstance().getCluster().getMembers();
             for (Member member : members) {
-                mcs.callOnMember(member, new UpdateMapConfigOperation(mapName, config.getMapConfig()));
+                resolveFuture(mcs.callOnMember(member, new UpdateMapConfigOperation(mapName, config.getMapConfig())));
             }
             result.add("updateResult", "success");
         } else {
-            MapConfig cfg = (MapConfig) mcs.callOnThis(new GetMapConfigOperation(mapName));
+            MapConfig cfg = (MapConfig) resolveFuture(mcs.callOnThis(new GetMapConfigOperation(mapName)));
             if (cfg != null) {
                 result.add("hasMapConfig", true);
                 result.add("mapConfig", new MapConfigDTO(cfg).toJson());

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ThreadDumpRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ThreadDumpRequest.java
@@ -19,6 +19,10 @@ package com.hazelcast.internal.management.request;
 import com.eclipsesource.json.JsonObject;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ThreadDumpOperation;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.util.JsonUtil.getBoolean;
 
@@ -44,18 +48,32 @@ public class ThreadDumpRequest implements ConsoleRequest {
     @Override
     public void writeResponse(ManagementCenterService mcs, JsonObject root) {
         final JsonObject result = new JsonObject();
-        String threadDump = (String) mcs.callOnThis(new ThreadDumpOperation(dumpDeadlocks));
-        if (threadDump != null) {
-            result.add("hasDump", true);
-            result.add("dump", threadDump);
-        } else {
-            result.add("hasDump", false);
+        InternalCompletableFuture<Object> future = mcs.callOnThis(new ThreadDumpOperation(dumpDeadlocks));
+        try {
+            String threadDump = (String) future.get();
+            if (threadDump != null) {
+                result.add("hasDump", true);
+                result.add("dump", threadDump);
+            } else {
+                result.add("hasDump", false);
+            }
+        } catch (ExecutionException e) {
+            addError(result, e);
+        } catch (InterruptedException e) {
+            addError(result, e);
+            Thread.currentThread().interrupt();
         }
+
         root.add("result", result);
     }
 
     @Override
     public void fromJson(JsonObject json) {
         dumpDeadlocks = getBoolean(json, "dumpDeadlocks", false);
+    }
+
+    private static void addError(JsonObject root, Exception e) {
+        root.add("hasDump", false);
+        root.add("error", ExceptionUtil.toString(e));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ExecuteScriptRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ExecuteScriptRequestTest.java
@@ -17,15 +17,15 @@
 package com.hazelcast.internal.management;
 
 import com.eclipsesource.json.JsonObject;
-import com.hazelcast.core.Cluster;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
 import com.hazelcast.internal.management.request.ExecuteScriptRequest;
-import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,21 +33,22 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
 
+import static com.hazelcast.util.JsonUtil.getBoolean;
+import static com.hazelcast.util.JsonUtil.getObject;
 import static com.hazelcast.util.JsonUtil.getString;
+import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ExecuteScriptRequestTest extends HazelcastTestSupport {
 
-    private Cluster cluster;
     private ManagementCenterService managementCenterService;
-    private Map<String, Object> bindings = new HashMap<String, Object>();
+    private String nodeAddressWithBrackets;
+    private String nodeAddressWithoutBrackets;
 
     /**
      * Zulu 6 and 7 doesn't have Rhino script engine, so this test should be excluded.
@@ -61,71 +62,68 @@ public class ExecuteScriptRequestTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         HazelcastInstance[] instances = factory.newInstances();
 
-        cluster = instances[0].getCluster();
-        managementCenterService = getNode(instances[0]).getManagementCenterService();
-
-        bindings.put("key", "value");
+        Node node = getNode(instances[0]);
+        nodeAddressWithBrackets = node.getThisAddress().toString();
+        nodeAddressWithoutBrackets = node.getThisAddress().getHost() + ":" + node.getThisAddress().getPort();
+        managementCenterService = node.getManagementCenterService();
     }
 
     @Test
     public void testExecuteScriptRequest() throws Exception {
-        ExecuteScriptRequest request = new ExecuteScriptRequest("print('test');", "JavaScript", false, bindings);
+        ExecuteScriptRequest request = new ExecuteScriptRequest("print('test');", "JavaScript",
+                singleton(nodeAddressWithoutBrackets));
 
         JsonObject jsonObject = new JsonObject();
         request.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        String response = getString(result, "scriptResult");
-        assertEquals("", response.trim());
+        JsonObject json = getObject(result, nodeAddressWithBrackets);
+        assertTrue(getBoolean(json, "success"));
+        assertEquals("error\n", getString(json, "result"));
+        assertEquals("error\n", getString(result, "scriptResult"));
     }
 
     @Test
-    public void testExecuteScriptRequest_whenTargetAllMembers() throws Exception {
-        ExecuteScriptRequest request = new ExecuteScriptRequest("print('test');", "JavaScript", true, null);
+    public void testExecuteScriptRequest_noTargets() throws Exception {
+        ExecuteScriptRequest request = new ExecuteScriptRequest("print('test');", "JavaScript",
+                Collections.<String>emptySet());
 
         JsonObject jsonObject = new JsonObject();
         request.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        String response = getString(result, "scriptResult");
-        assertEquals("error\nerror\n", response);
-    }
-
-    @Test
-    public void testExecuteScriptRequest_whenTargetAllMembers_withTarget() throws Exception {
-        Address address = cluster.getLocalMember().getAddress();
-        Set<String> targets = Collections.singleton(address.getHost() + ":" + address.getPort());
-        ExecuteScriptRequest request = new ExecuteScriptRequest("print('test');", "JavaScript", targets, bindings);
-
-        JsonObject jsonObject = new JsonObject();
-        request.writeResponse(managementCenterService, jsonObject);
-
-        JsonObject result = (JsonObject) jsonObject.get("result");
-        String response = getString(result, "scriptResult");
-        assertEquals("error", response.trim());
+        assertEquals("", getString(result, "scriptResult"));
     }
 
     @Test
     public void testExecuteScriptRequest_withIllegalScriptEngine() throws Exception {
-        ExecuteScriptRequest request = new ExecuteScriptRequest("script", "engine", true, bindings);
+        ExecuteScriptRequest request = new ExecuteScriptRequest("script", "engine",
+                singleton(nodeAddressWithoutBrackets));
 
         JsonObject jsonObject = new JsonObject();
         request.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        String response = getString(result, "scriptResult");
-        assertContains(response, "IllegalArgumentException");
+        JsonObject json = getObject(result, nodeAddressWithBrackets);
+        assertFalse(getBoolean(json, "success"));
+        assertContains(getString(json, "result"), "IllegalArgumentException");
+
+        assertContains(getString(result, "scriptResult"), "IllegalArgumentException");
     }
 
     @Test
     public void testExecuteScriptRequest_withScriptException() throws Exception {
-        ExecuteScriptRequest request = new ExecuteScriptRequest("print(;", "JavaScript", true, bindings);
+        ExecuteScriptRequest request = new ExecuteScriptRequest("print(;", "JavaScript",
+                singleton(nodeAddressWithoutBrackets));
 
         JsonObject jsonObject = new JsonObject();
         request.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        String response = getString(result, "scriptResult");
-        assertNotNull(response);
+        JsonObject json = getObject(result, nodeAddressWithBrackets);
+        assertFalse(getBoolean(json, "success"));
+        assertContains(getString(json, "result"), "ScriptException");
+
+        assertContains(getString(result, "scriptResult"), "ScriptException");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ExecuteScriptRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ExecuteScriptRequestTest.java
@@ -80,7 +80,6 @@ public class ExecuteScriptRequestTest extends HazelcastTestSupport {
         JsonObject json = getObject(result, nodeAddressWithBrackets);
         assertTrue(getBoolean(json, "success"));
         assertEquals("error\n", getString(json, "result"));
-        assertEquals("error\n", getString(result, "scriptResult"));
     }
 
     @Test
@@ -92,7 +91,7 @@ public class ExecuteScriptRequestTest extends HazelcastTestSupport {
         request.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        assertEquals("", getString(result, "scriptResult"));
+        assertTrue(result.isEmpty());
     }
 
     @Test
@@ -107,8 +106,6 @@ public class ExecuteScriptRequestTest extends HazelcastTestSupport {
         JsonObject json = getObject(result, nodeAddressWithBrackets);
         assertFalse(getBoolean(json, "success"));
         assertContains(getString(json, "result"), "IllegalArgumentException");
-
-        assertContains(getString(result, "scriptResult"), "IllegalArgumentException");
     }
 
     @Test
@@ -123,7 +120,5 @@ public class ExecuteScriptRequestTest extends HazelcastTestSupport {
         JsonObject json = getObject(result, nodeAddressWithBrackets);
         assertFalse(getBoolean(json, "success"));
         assertContains(getString(json, "result"), "ScriptException");
-
-        assertContains(getString(result, "scriptResult"), "ScriptException");
     }
 }


### PR DESCRIPTION
Forward port of https://github.com/hazelcast/hazelcast/pull/12437 

See the last three commits and their messages for the changes that were not in the original PR

These two types of requests are sent from MC to members. When they 
finish, they don't make any difference between an error result and
a success result. With this fix, a distinction is made so that MC can
log the error in its logs and show the success result on the UI.

`ExecuteScriptRequest` is changed so that it returns responses from each
member in a separate JSON field. MC can report error/success
from each member separately as a result.

Unused fields are removed from `ScriptExecutorOperation`, while
taking care to preserve its compatibility with previous member versions.

[PR on Management Center](https://github.com/hazelcast/management-center/pull/755)