### PR TITLE
Fixed brain sizes in some split-brain tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchSplitBrainTest.java
@@ -35,12 +35,6 @@ public class CountDownLatchSplitBrainTest extends SplitBrainTestSupport {
     private int count = 5;
 
     @Override
-    protected int[] brains() {
-        // 2nd merges to the 1st
-        return new int[]{2, 1};
-    }
-
-    @Override
     protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         warmUpPartitions(instances);
         name = generateKeyOwnedBy(instances[instances.length - 1]);

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
@@ -70,8 +70,6 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("WeakerAccess")
 public class MapSplitBrainTest extends SplitBrainTestSupport {
 
-    private static final int[] BRAINS = new int[]{3, 3};
-
     @Parameters(name = "format:{0}, mergePolicy:{1}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
@@ -103,11 +101,6 @@ public class MapSplitBrainTest extends SplitBrainTestSupport {
     private BackupAccessor<Object, Object> backupMapA;
     private BackupAccessor<Object, Object> backupMapB;
     private MergeLifecycleListener mergeLifecycleListener;
-
-    @Override
-    protected int[] brains() {
-        return BRAINS;
-    }
 
     @Override
     protected Config config() {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
@@ -51,11 +51,6 @@ public class IndexSplitBrainTest extends SplitBrainTestSupport {
     private ValueObject value;
 
     @Override
-    protected int[] brains() {
-        return new int[]{1, 1};
-    }
-
-    @Override
     protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
         warmUpPartitions(instances);
         key = generateKeyOwnedBy(instances[0]);


### PR DESCRIPTION
* reverted the brain sizes in `MapSplitBrainTest` to the default
* removed duplicated default brains in `CountDownLatchSplitBrainTest`
* changed `IgnoreMergingEntriesMapSplitBrainTest` to use default brains
* changed `IndexSplitBrainTest` to use default brains

Possible fix for https://github.com/hazelcast/hazelcast/issues/12263