### PR TITLE
Have MockJoiner consult the set targetAddress when picking join address

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -134,7 +134,7 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
      * @return the default Hazelcast configuration
      */
     protected Config config() {
-        return new Config()
+        return smallInstanceConfig()
                 .setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5")
                 .setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockJoiner.java
@@ -92,6 +92,10 @@ class MockJoiner extends AbstractJoiner {
     }
 
     private Address getJoinAddress() {
+        final Address targetAddress = getTargetAddress();
+        if (targetAddress != null) {
+            return targetAddress;
+        }
         Address joinAddress = node.getMasterAddress();
         logger.fine("Known master address is: " + joinAddress);
         if (joinAddress == null) {


### PR DESCRIPTION
MockJoiner did not consult the set targetAddress, causing it to search
for addresses to join, even when the target address was set by master on
cluster merging. The fix consults the targetAddress before searching for
other addresses to join to.

Also, changed all split brain tests to use small instance configs to use
less resources since they mostly use very little data and spawn many
instances.

Fixes: https://github.com/hazelcast/hazelcast/issues/12263