### PR TITLE
Increase connection-attempt-limit for ClientQueryCacheBasicTest

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheBasicTest.java
@@ -93,6 +93,8 @@ public class ClientQueryCacheBasicTest extends HazelcastTestSupport {
         clientConfig.addQueryCacheConfig(TEST_MAP_NAME, new QueryCacheConfig(QUERY_CACHE_NAME)
                 .setPredicateConfig(new PredicateConfig(predicate))
                 .setIncludeValue(includeValues));
+        clientConfig.getNetworkConfig()
+                    .setConnectionAttemptLimit(Integer.MAX_VALUE);
         if (useNearCache) {
             clientConfig.addNearCacheConfig(new NearCacheConfig()
                     .setName(TEST_MAP_NAME)

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnMapTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.txn;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
@@ -68,7 +69,9 @@ public class ClientTxnMapTest {
     @Before
     public void setup() {
         hazelcastFactory.newHazelcastInstance();
-        client = hazelcastFactory.newHazelcastClient();
+        final ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        client = hazelcastFactory.newHazelcastClient(clientConfig);
     }
 
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/TxnMapDeserializationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/TxnMapDeserializationTest.java
@@ -61,6 +61,7 @@ public class TxnMapDeserializationTest extends HazelcastTestSupport {
                         return new SampleIdentified();
                     }
                 });
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
 
         client.getMap("test").put(EXISTING_KEY, EXISTING_VALUE);
@@ -73,7 +74,9 @@ public class TxnMapDeserializationTest extends HazelcastTestSupport {
 
     @After
     public void tearDown() {
-        context.commitTransaction();
+        if (context != null) {
+            context.commitTransaction();
+        }
         hazelcastFactory.terminateAll();
     }
 


### PR DESCRIPTION
The test occasionally fails but the attempt limit is set to the default
number of 2. Since a lot of tests increase this limit, we are increasing
it here as well.

Fixes: https://github.com/hazelcast/hazelcast/issues/12602