### PR TITLE
Assert index eventually has some data in MapIndexLifecycleTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
@@ -17,8 +17,6 @@
 package com.hazelcast.map;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.config.ServiceConfig;
@@ -177,9 +175,13 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
             }
         });
 
-
-        assertTrue("Year index should contain records",
-                mapContainer.getIndexes().getIndex("year").getRecords(1801).size() > 0);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertTrue("Year index should contain records",
+                        mapContainer.getIndexes().getIndex("year").getRecords(1801).size() > 0);
+            }
+        });
     }
 
     private int numberOfPartitionQueryResults(OperationService operationService, int partitionId,


### PR DESCRIPTION
Reasoning: the assertion may be executed before migrations
have been completed, so global indexes may be not yet populated
at the time they are queried.

Fixes #12597 