### PR TITLE
Fixes LoggingScheduledExecutor removeOnCancel problems

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/executor/LoggingScheduledExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/LoggingScheduledExecutor.java
@@ -18,6 +18,7 @@ package com.hazelcast.util.executor;
 
 import com.hazelcast.logging.ILogger;
 
+import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Delayed;
@@ -42,18 +43,39 @@ import static java.util.logging.Level.SEVERE;
  * Logs execution exceptions by overriding {@link ScheduledThreadPoolExecutor#afterExecute}
  * and {@link ScheduledThreadPoolExecutor#decorateTask} methods.
  *
- * Reasoning is given tasks to {@link ScheduledThreadPoolExecutor} stops silently if there is an execution exception.
+ * Reasoning is given tasks to {@link ScheduledThreadPoolExecutor} stops silently if there is an
+ * execution exception.
  *
  * Note: Task decoration is only needed to call given tasks {@code toString} methods.
  *
  * {@link java.util.concurrent.ScheduledExecutorService#scheduleWithFixedDelay}
+ *
+ * Remove on cancel:
+ * To prevent running into an accumulation of cancelled task which can cause gc related problems
+ * (e.g. transactions in combination with LockResource eviction), it is best that tasks are
+ * removed from the scheduler on cancellation.
+ *
+ * In Java 7+ the there is a method {@code ScheduledThreadPoolExecutor#setRemoveOnCancelPolicy(boolean)}
+ * which removes the runnable on cancellation. Removal of tasks is done in logarithmic time
+ * (see ScheduledThreadPoolExecutor.DelayedWorkQueue.indexOf where there is a direct lookup
+ * instead of a linear scan over the queue). So in Java 7 we try to set this method using
+ * reflection. In Java 7+ the manualRemoveOnCancel is ignored, since it has an efficient removal
+ * of cancelled tasks and therefore it will always apply it. If we would wrap the task with the
+ * RemoveOnCancelFuture, it would even prevent constant time removal.
+ *
+ * In Java 6 there is no such method setRemoveOnCancelPolicy and therefore the task is
+ * wrapped in a RemoveOnCancelFuture which will remove itself from the work-queue
+ * on cancellation. However this removal isn't done in constant time, but in linear time
+ * because Java 6 ScheduledThreadPoolExecutor doesn't support a constant time removal.
+ *
+ * By default in Java 6, the removal of this task is done based on the 'removeOnCancel'
+ * property which gets its value from the
+ * {@link com.hazelcast.spi.properties.GroupProperty#TASK_SCHEDULER_REMOVE_ON_CANCEL}
  */
 public class LoggingScheduledExecutor extends ScheduledThreadPoolExecutor {
 
-    /**
-     * Default {@link ScheduledThreadPoolExecutor#removeOnCancel} policy is not working when tasks are decorated.
-     */
-    private final boolean removeOnCancel;
+    // this property is accessible for for testing purposes.
+    boolean manualRemoveOnCancel;
     private final ILogger logger;
     private volatile boolean shutdownInitiated;
 
@@ -65,7 +87,7 @@ public class LoggingScheduledExecutor extends ScheduledThreadPoolExecutor {
                                     boolean removeOnCancel) {
         super(corePoolSize, threadFactory);
         this.logger = checkNotNull(logger, "logger cannot be null");
-        this.removeOnCancel = removeOnCancel;
+        this.manualRemoveOnCancel = manualRemoveOnCancel(removeOnCancel);
     }
 
     public LoggingScheduledExecutor(ILogger logger, int corePoolSize, ThreadFactory threadFactory,
@@ -78,17 +100,43 @@ public class LoggingScheduledExecutor extends ScheduledThreadPoolExecutor {
                                     RejectedExecutionHandler handler) {
         super(corePoolSize, threadFactory, handler);
         this.logger = checkNotNull(logger, "logger cannot be null");
-        this.removeOnCancel = removeOnCancel;
+        this.manualRemoveOnCancel = manualRemoveOnCancel(removeOnCancel);
+    }
+
+    private boolean manualRemoveOnCancel(boolean removeOnCancel) {
+        if (trySetRemoveOnCancelPolicy()) {
+            return false;
+        } else {
+            return removeOnCancel;
+        }
+    }
+
+    private boolean trySetRemoveOnCancelPolicy() {
+        try {
+            Method method = ScheduledThreadPoolExecutor.class.getMethod("setRemoveOnCancelPolicy", Boolean.TYPE);
+            method.invoke(this, true);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
     }
 
     @Override
     protected <V> RunnableScheduledFuture<V> decorateTask(Runnable runnable, RunnableScheduledFuture<V> task) {
-        return new LoggingDelegatingFuture<V>(runnable, task, this, removeOnCancel);
+        if (!manualRemoveOnCancel) {
+            return super.decorateTask(runnable, task);
+        }
+
+        return new RemoveOnCancelFuture<V>(runnable, task, this);
     }
 
     @Override
     protected <V> RunnableScheduledFuture<V> decorateTask(Callable<V> callable, RunnableScheduledFuture<V> task) {
-        return new LoggingDelegatingFuture<V>(callable, task, this, removeOnCancel);
+        if (!manualRemoveOnCancel) {
+            return super.decorateTask(callable, task);
+        }
+
+        return new RemoveOnCancelFuture<V>(callable, task, this);
     }
 
     @Override
@@ -124,25 +172,19 @@ public class LoggingScheduledExecutor extends ScheduledThreadPoolExecutor {
     }
 
     /**
-     * Only goal of this wrapping is to call given tasks {@code toString} method. Because
-     * there is no straightforward way to reach it due to the internal wrapping done by
-     * {@link ScheduledThreadPoolExecutor}
-     *
-     * {@link ScheduledThreadPoolExecutor#scheduleWithFixedDelay}
+     * The only goal of this task is to enable removal of the task from the executor
+     * when the future is cancelled.
      */
-    static class LoggingDelegatingFuture<V> implements RunnableScheduledFuture<V> {
+    static class RemoveOnCancelFuture<V> implements RunnableScheduledFuture<V> {
 
         private final Object task;
         private final RunnableScheduledFuture<V> delegate;
         private final LoggingScheduledExecutor executor;
-        private final boolean removeOnCancel;
 
-        LoggingDelegatingFuture(Object task, RunnableScheduledFuture<V> delegate, LoggingScheduledExecutor executor,
-                                boolean removeOnCancel) {
+        RemoveOnCancelFuture(Object task, RunnableScheduledFuture<V> delegate, LoggingScheduledExecutor executor) {
             this.task = task;
             this.delegate = delegate;
             this.executor = executor;
-            this.removeOnCancel = removeOnCancel;
         }
 
         @Override
@@ -170,10 +212,10 @@ public class LoggingScheduledExecutor extends ScheduledThreadPoolExecutor {
             if (this == o) {
                 return true;
             }
-            if (!(o instanceof LoggingDelegatingFuture)) {
+            if (!(o instanceof RemoveOnCancelFuture)) {
                 return false;
             }
-            LoggingDelegatingFuture<?> that = (LoggingDelegatingFuture<?>) o;
+            RemoveOnCancelFuture<?> that = (RemoveOnCancelFuture<?>) o;
             return delegate.equals(that.delegate);
         }
 
@@ -184,7 +226,7 @@ public class LoggingScheduledExecutor extends ScheduledThreadPoolExecutor {
 
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
-            boolean removeOnCancel = !executor.isShutdown() && this.removeOnCancel;
+            boolean removeOnCancel = !executor.isShutdown();
             boolean cancelled = delegate.cancel(mayInterruptIfRunning);
             if (cancelled && removeOnCancel) {
                 executor.remove(this);
@@ -215,7 +257,7 @@ public class LoggingScheduledExecutor extends ScheduledThreadPoolExecutor {
 
         @Override
         public String toString() {
-            return "LoggingDelegatingFuture{task=" + task + '}';
+            return "RemoveOnCancelFuture{task=" + task + '}';
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -96,6 +96,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * Base class for Hazelcast tests which provides a big number of convenient test methods.
@@ -1445,5 +1446,10 @@ public abstract class HazelcastTestSupport {
 
     protected MapOperationProvider getMapOperationProvider() {
         return new DefaultMapOperationProvider();
+    }
+
+    public static void assumeThatNoJDK6() {
+        String javaVersion = System.getProperty("java.version");
+        assumeFalse("Java 6 used", javaVersion.startsWith("1.6."));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/LoggingScheduledExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/LoggingScheduledExecutorTest.java
@@ -25,7 +25,7 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.util.RootCauseMatcher;
-import com.hazelcast.util.executor.LoggingScheduledExecutor.LoggingDelegatingFuture;
+import com.hazelcast.util.executor.LoggingScheduledExecutor.RemoveOnCancelFuture;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,14 +33,15 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
+import java.lang.reflect.Method;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionHandler;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -62,7 +63,7 @@ public class LoggingScheduledExecutorTest extends HazelcastTestSupport {
     private TestLogger logger = new TestLogger();
     private TestThreadFactory factory = new TestThreadFactory();
 
-    private ScheduledExecutorService executor;
+    private LoggingScheduledExecutor executor;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -73,6 +74,17 @@ public class LoggingScheduledExecutorTest extends HazelcastTestSupport {
             executor.shutdownNow();
             executor.awaitTermination(5, SECONDS);
         }
+    }
+
+    @Test
+    public void test_setRemoveOnCancelPolicy_isCalledOnJava7() throws Exception {
+        assumeThatNoJDK6();
+
+        executor = new LoggingScheduledExecutor(logger, 1, factory);
+
+        Method method = ScheduledThreadPoolExecutor.class.getMethod("getRemoveOnCancelPolicy");
+        // will only return true when the setRemoveOnCancelPolicy was called with true.
+        assertEquals(Boolean.TRUE, method.invoke(executor));
     }
 
     @Test
@@ -144,6 +156,7 @@ public class LoggingScheduledExecutorTest extends HazelcastTestSupport {
     @Test
     public void logsExecutionException_withRunnable() {
         executor = new LoggingScheduledExecutor(logger, 1, factory);
+        executor.manualRemoveOnCancel = true;
         executor.submit(new FailedRunnable());
 
         assertTrueEventually(new AssertTask() {
@@ -196,19 +209,21 @@ public class LoggingScheduledExecutorTest extends HazelcastTestSupport {
         future.get();
     }
 
+
     @Test
-    public void testLoggingDelegatingFuture() {
+    public void testWhenManualRemoveOnCancel() {
         executor = new LoggingScheduledExecutor(logger, 1, factory);
+        executor.manualRemoveOnCancel = true;
         Runnable task = new FailedRunnable();
 
         ScheduledFuture<?> scheduledFuture1 = executor.schedule(task, 0, SECONDS);
         ScheduledFuture<?> scheduledFuture2 = executor.scheduleAtFixedRate(task, 0, 1, SECONDS);
 
-        assertInstanceOf(LoggingDelegatingFuture.class, scheduledFuture1);
-        assertInstanceOf(LoggingDelegatingFuture.class, scheduledFuture2);
+        assertInstanceOf(LoggingScheduledExecutor.RemoveOnCancelFuture.class, scheduledFuture1);
+        assertInstanceOf(RemoveOnCancelFuture.class, scheduledFuture2);
 
-        LoggingDelegatingFuture future1 = (LoggingDelegatingFuture) scheduledFuture1;
-        LoggingDelegatingFuture future2 = (LoggingDelegatingFuture) scheduledFuture2;
+        LoggingScheduledExecutor.RemoveOnCancelFuture future1 = (LoggingScheduledExecutor.RemoveOnCancelFuture) scheduledFuture1;
+        LoggingScheduledExecutor.RemoveOnCancelFuture future2 = (RemoveOnCancelFuture) scheduledFuture2;
 
         assertFalse(future1.isPeriodic());
         assertTrue(future2.isPeriodic());


### PR DESCRIPTION
In Java 7 there is an efficient removal of canceled tasks,
so this is enabled regardless of any system property. Enabling the wrapping of the task could even aversely effect the performance because the constant time removal isn't possible!

In Java 6, there is no efficient removal of canceled tasks.
So using the group property hazelcast.executionservice.taskscheduler.remove.oncancel
this behavior can be enabled/disabled. This property is now set
to true; even though there can be performance implications due
to the non efficient removal in Java 6. However the disabling
of the property can also cause severe performance problems due
to retention of cancelled tasks.