### PR TITLE
PartitionReplicaSyncResponse should be TargetAware

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
@@ -176,13 +176,15 @@ public final class PartitionReplicaSyncRequest extends AbstractPartitionOperatio
             logger.finest("Sending sync response to -> " + target + " for partitionId="
                     + getPartitionId() + ", replicaIndex=" + getReplicaIndex() + ", namespaces=" + ns);
         }
+
+        // PartitionReplicaSyncResponse is TargetAware and sent directly without invocation system.
+        syncResponse.setTarget(target);
+
         OperationService operationService = nodeEngine.getOperationService();
         operationService.send(syncResponse, target);
     }
 
-    private PartitionReplicaSyncResponse createResponse(Collection<Operation> operations, ServiceNamespace ns)
-            throws IOException {
-
+    private PartitionReplicaSyncResponse createResponse(Collection<Operation> operations, ServiceNamespace ns) {
         int partitionId = getPartitionId();
         int replicaIndex = getReplicaIndex();
         InternalPartitionService partitionService = getService();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
@@ -37,6 +37,7 @@ import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.exception.WrongTargetException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -61,7 +62,8 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createError
 // Version info is needed on 3.9 members while deserializing the operation.
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public class PartitionReplicaSyncResponse extends AbstractPartitionOperation
-        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation, AllowedDuringPassiveState, Versioned {
+        implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation,
+        AllowedDuringPassiveState, Versioned, TargetAware {
 
     private Collection<Operation> operations;
     private ServiceNamespace namespace;
@@ -237,6 +239,17 @@ public class PartitionReplicaSyncResponse extends AbstractPartitionOperation
     @Override
     public void logError(Throwable e) {
         ReplicaErrorLogger.log(e, getLogger());
+    }
+
+    @Override
+    public void setTarget(Address address) {
+        if (operations != null) {
+            for (Operation op : operations) {
+                if (op instanceof TargetAware) {
+                    ((TargetAware) op).setTarget(address);
+                }
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
PartitionReplicaSyncResponse, which carries replication operations created by
services similar to MigrationOperation, should be TargetAware
and inject the target to operations wrapped inside.

Follow up fix for https://github.com/hazelcast/hazelcast/pull/12534

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1986