### PR TITLE
Added ID count to flake ID generators statistics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
@@ -195,7 +195,7 @@ public class FlakeIdGeneratorProxy
         long waitTime = Math.max(0, ((base + batchSize - now) >> BITS_SEQUENCE) - ALLOWED_FUTURE_MILLIS);
         base = base << BITS_NODE_ID | nodeId;
 
-        getService().incrementStatsForNewId(name);
+        getService().updateStatsForBatch(name, batchSize);
         return new IdBatchAndWaitTime(new IdBatch(base, INCREMENT, batchSize), waitTime);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorService.java
@@ -83,13 +83,14 @@ public class FlakeIdGeneratorService implements ManagedService, RemoteService,
     }
 
     /**
-     * Increments the usage count of the {@link FlakeIdGenerator} with the given
-     * name.
+     * Updated the statistics for the {@link FlakeIdGenerator} with the given
+     * name for a newly generated batch of the given size.
      *
      * @param name name of the generator, not null
+     * @param batchSize size of the batch created
      */
-    public void incrementStatsForNewId(String name) {
-        getLocalFlakeIdStats(name).incrementUsage();
+    public void updateStatsForBatch(String name, int batchSize) {
+        getLocalFlakeIdStats(name).update(batchSize);
     }
 
     private LocalFlakeIdGeneratorStatsImpl getLocalFlakeIdStats(String name) {

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalFlakeIdGeneratorStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalFlakeIdGeneratorStats.java
@@ -23,8 +23,20 @@ package com.hazelcast.monitor;
 public interface LocalFlakeIdGeneratorStats extends LocalInstanceStats {
 
     /**
+     * The average batch size can be calculated by dividing {@link #getIdCount()} by
+     * {@link #getBatchCount()}.
+     *
      * @return the total number of times the ID generator has been used to generate
      *         a new ID batch since its {@link #getCreationTime()}.
      */
-    long getUsageCount();
+    long getBatchCount();
+
+    /**
+     * Note that the ID count returned is the number of generated IDs not the number
+     * of consumed IDs.
+     *
+     * @return the total number of IDs generated (the sum of IDs for all batches)
+     *         since its {@link #getCreationTime()}.
+     */
+    long getIdCount();
 }

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_MemberIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_MemberIntegrationTest.java
@@ -94,5 +94,6 @@ public class FlakeIdGenerator_MemberIntegrationTest extends HazelcastTestSupport
         assertTrue(stats.containsKey("gen"));
         LocalFlakeIdGeneratorStats genStats = stats.get("gen");
         assertEquals(1L, genStats.getBatchCount());
+        assertTrue(genStats.getIdCount() > 0);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_MemberIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_MemberIntegrationTest.java
@@ -93,6 +93,6 @@ public class FlakeIdGenerator_MemberIntegrationTest extends HazelcastTestSupport
         assertTrue(!stats.isEmpty());
         assertTrue(stats.containsKey("gen"));
         LocalFlakeIdGeneratorStats genStats = stats.get("gen");
-        assertEquals(1L, genStats.getUsageCount());
+        assertEquals(1L, genStats.getBatchCount());
     }
 }


### PR DESCRIPTION
After discussions on the usefulness of statistics for the number of batch requests we (most likely) will show other statistics that require both the batch count and the number of generated IDs. So I added a metric for the `idCount` and changed the name form usage count to `batchCount`.

A small extra change is the default of `0` for the existing count instead `-1` that was not thought through.