### PR TITLE
CacheConfig propagation fixes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheHelper.java
@@ -105,23 +105,14 @@ final class ClientCacheHelper {
      * Creates a new cache configuration on Hazelcast members.
      *
      * @param client             the client instance which will send the operation to server
-     * @param existingConfig     an existing {@link CacheConfig}, already known to the client
      * @param newCacheConfig     the cache configuration to be sent to server
-     * @param createAlsoOnOthers when {@code true} the {@code newCacheConfig}
-     *                           will be sent to all cluster members by the target member that receives the
-     *                           invocation
-     * @param syncCreate         when {@code true}, this call will block until response is received from the member. This does not
-     *                           imply that when this method exits the {@code CacheConfig} is already created on all members.
      * @param <K>                type of the key of the cache
      * @param <V>                type of the value of the cache
      * @return the created cache configuration
      * @see com.hazelcast.cache.impl.operation.CacheCreateConfigOperation
      */
     static <K, V> CacheConfig<K, V> createCacheConfig(HazelcastClientInstanceImpl client,
-                                                      CacheConfig<K, V> existingConfig,
-                                                      CacheConfig<K, V> newCacheConfig,
-                                                      boolean createAlsoOnOthers,
-                                                      boolean syncCreate) {
+                                                      CacheConfig<K, V> newCacheConfig) {
         try {
             String nameWithPrefix = newCacheConfig.getNameWithPrefix();
             int partitionId = client.getClientPartitionService().getPartitionId(nameWithPrefix);
@@ -129,16 +120,12 @@ final class ClientCacheHelper {
             Object resolvedConfig = resolveCacheConfigWithRetry(client, newCacheConfig, partitionId);
 
             Data configData = client.getSerializationService().toData(resolvedConfig);
-            ClientMessage request = CacheCreateConfigCodec.encodeRequest(configData, createAlsoOnOthers);
+            ClientMessage request = CacheCreateConfigCodec.encodeRequest(configData, true);
             ClientInvocation clientInvocation = new ClientInvocation(client, request, nameWithPrefix, partitionId);
             Future<ClientMessage> future = clientInvocation.invoke();
-            if (syncCreate) {
-                final ClientMessage response = future.get();
-                final Data data = CacheCreateConfigCodec.decodeResponse(response).response;
-                return resolveCacheConfig(client, clientInvocation, data);
-            } else {
-                return existingConfig;
-            }
+            final ClientMessage response = future.get();
+            final Data data = CacheCreateConfigCodec.decodeResponse(response).response;
+            return resolveCacheConfig(client, clientInvocation, data);
         } catch (Exception e) {
             throw rethrow(e);
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -133,9 +133,9 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
     }
 
     @Override
-    protected <K, V> CacheConfig<K, V> createCacheConfig(String cacheName, CacheConfig<K, V> config,
+    protected <K, V> void createCacheConfig(String cacheName, CacheConfig<K, V> config,
                                                          boolean createAlsoOnOthers, boolean syncCreate) {
-        return ClientCacheHelper.createCacheConfig(client, clientCacheProxyFactory.getCacheConfig(cacheName), config,
+        ClientCacheHelper.createCacheConfig(client, clientCacheProxyFactory.getCacheConfig(cacheName), config,
                 createAlsoOnOthers, syncCreate);
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -118,25 +118,22 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
     }
 
     @Override
-    protected <K, V> CacheConfig<K, V> findCacheConfig(String cacheName, String simpleCacheName, boolean createAlsoOnOthers,
-                                                       boolean syncCreate) {
+    protected <K, V> CacheConfig<K, V> findCacheConfig(String cacheName, String simpleCacheName) {
         CacheConfig<K, V> config = clientCacheProxyFactory.getCacheConfig(cacheName);
         if (config == null) {
             // if cache config not found, try to find it from partition
             config = getCacheConfig(cacheName, simpleCacheName);
             if (config != null) {
                 // cache config possibly is not exist on other nodes, so create also on them if absent
-                createCacheConfig(cacheName, config, createAlsoOnOthers, syncCreate);
+                createCacheConfig(cacheName, config);
             }
         }
         return config;
     }
 
     @Override
-    protected <K, V> void createCacheConfig(String cacheName, CacheConfig<K, V> config,
-                                                         boolean createAlsoOnOthers, boolean syncCreate) {
-        ClientCacheHelper.createCacheConfig(client, clientCacheProxyFactory.getCacheConfig(cacheName), config,
-                createAlsoOnOthers, syncCreate);
+    protected <K, V> void createCacheConfig(String cacheName, CacheConfig<K, V> config) {
+        ClientCacheHelper.createCacheConfig(client, config);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheConfigPropagationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheConfigPropagationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cache.impl;
+
+import com.hazelcast.cache.impl.CacheConfigPropagationTest;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+
+import javax.cache.CacheManager;
+
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
+
+public class ClientCacheConfigPropagationTest extends CacheConfigPropagationTest {
+
+    @Override
+    protected void setupFactory() {
+        factory = new TestHazelcastFactory();
+    }
+
+    @Override
+    protected CacheManager createCacheManagerTestDriver() {
+        return HazelcastClientCachingProvider.createCachingProvider(driver).getCacheManager(null, null,
+                propertiesByInstanceItself(driver));
+    }
+
+    @Override
+    protected HazelcastInstance createTestDriver() {
+        return ((TestHazelcastFactory) factory).newHazelcastClient();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheHelperTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheHelperTest.java
@@ -119,21 +119,14 @@ public class ClientCacheHelperTest extends HazelcastTestSupport {
 
     @Test
     public void testCreateCacheConfig_whenSyncCreate_thenReturnNewConfig() {
-        CacheConfig<String, String> actualConfig = createCacheConfig(client, cacheConfig, newCacheConfig, false, true);
+        CacheConfig<String, String> actualConfig = createCacheConfig(client, newCacheConfig);
 
         assertNotEquals(cacheConfig, actualConfig);
     }
 
-    @Test
-    public void testCreateCacheConfig_whenNotSyncCreate_thenReturnCurrentConfig() {
-        CacheConfig<String, String> actualConfig = createCacheConfig(client, cacheConfig, newCacheConfig, false, false);
-
-        assertEquals(cacheConfig, actualConfig);
-    }
-
     @Test(expected = IllegalArgumentException.class)
     public void testCreateCacheConfig_rethrowsExceptions() {
-        createCacheConfig(exceptionThrowingClient, cacheConfig, newCacheConfig, false, false);
+        createCacheConfig(exceptionThrowingClient, newCacheConfig);
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -431,10 +431,10 @@ public abstract class AbstractHazelcastCacheManager
                                                                 boolean createAlsoOnOthers,
                                                                 boolean syncCreate);
 
-    protected abstract <K, V> CacheConfig<K, V> createCacheConfig(String cacheName,
-                                                                  CacheConfig<K, V> config,
-                                                                  boolean createAlsoOnOthers,
-                                                                  boolean syncCreate);
+    protected abstract <K, V> void createCacheConfig(String cacheName,
+                                                     CacheConfig<K, V> config,
+                                                     boolean createAlsoOnOthers,
+                                                     boolean syncCreate);
 
     protected abstract <K, V> CacheConfig<K, V> getCacheConfig(String cacheName,
                                                                String simpleCacheName);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -121,7 +121,7 @@ public abstract class AbstractHazelcastCacheManager
             throw new CacheException("A cache named '" + cacheName + "' already exists.");
         }
         // Create cache config on all nodes as sync
-        createCacheConfig(cacheName, newCacheConfig, true, true);
+        createCacheConfig(cacheName, newCacheConfig);
         // Create cache proxy object with cache config
         ICacheInternal<K, V> cacheProxy = createCacheProxy(newCacheConfig);
         // Add created cache config to local configurations map
@@ -237,7 +237,7 @@ public abstract class AbstractHazelcastCacheManager
         String cacheNameWithPrefix = getCacheNameWithPrefix(cacheName);
         ICacheInternal<?, ?> cache = caches.get(cacheNameWithPrefix);
         if (cache == null) {
-            CacheConfig<K, V> cacheConfig = findCacheConfig(cacheNameWithPrefix, cacheName, true, true);
+            CacheConfig<K, V> cacheConfig = findCacheConfig(cacheNameWithPrefix, cacheName);
             if (cacheConfig == null) {
                 // No cache found
                 return null;
@@ -427,14 +427,10 @@ public abstract class AbstractHazelcastCacheManager
     protected abstract <K, V> ICacheInternal<K, V> createCacheProxy(CacheConfig<K, V> cacheConfig);
 
     protected abstract <K, V> CacheConfig<K, V> findCacheConfig(String cacheName,
-                                                                String simpleCacheName,
-                                                                boolean createAlsoOnOthers,
-                                                                boolean syncCreate);
+                                                                String simpleCacheName);
 
     protected abstract <K, V> void createCacheConfig(String cacheName,
-                                                     CacheConfig<K, V> config,
-                                                     boolean createAlsoOnOthers,
-                                                     boolean syncCreate);
+                                                     CacheConfig<K, V> config);
 
     protected abstract <K, V> CacheConfig<K, V> getCacheConfig(String cacheName,
                                                                String simpleCacheName);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -24,6 +24,7 @@ import com.hazelcast.cache.impl.journal.CacheEventJournalSubscribeOperation;
 import com.hazelcast.cache.impl.journal.DeserializingEventJournalCacheEvent;
 import com.hazelcast.cache.impl.journal.InternalEventJournalCacheEvent;
 import com.hazelcast.cache.impl.merge.entry.DefaultCacheEntryView;
+import com.hazelcast.cache.impl.operation.AddCacheConfigOperation;
 import com.hazelcast.cache.impl.operation.CacheBackupEntryProcessorOperation;
 import com.hazelcast.cache.impl.operation.CacheClearBackupOperation;
 import com.hazelcast.cache.impl.operation.CacheClearOperation;
@@ -156,8 +157,9 @@ public final class CacheDataSerializerHook
 
     public static final int MERGE_FACTORY = 64;
     public static final int MERGE = 65;
+    public static final int ADD_CACHE_CONFIG_OPERATION = 66;
 
-    private static final int LEN = MERGE + 1;
+    private static final int LEN = ADD_CACHE_CONFIG_OPERATION + 1;
 
     public int getFactoryId() {
         return F_ID;
@@ -491,6 +493,13 @@ public final class CacheDataSerializerHook
                     @Override
                     public IdentifiedDataSerializable createNew(Integer arg) {
                         return new CacheMergeOperation();
+                    }
+                };
+        constructors[ADD_CACHE_CONFIG_OPERATION] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new AddCacheConfigOperation();
                     }
                 };
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DeferredValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DeferredValue.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Thread-safe holder of value and/or its serialized form.
+ *
+ * @param <V> the type of value
+ */
+public final class DeferredValue<V> {
+
+    private static final DeferredValue NULL_VALUE;
+
+    private volatile Data serializedValue;
+    private volatile V value;
+    private volatile boolean valueExists;
+    private volatile boolean serializedValueExists;
+
+    static {
+        DeferredValue nullValue = new DeferredValue();
+        nullValue.valueExists = true;
+        nullValue.serializedValueExists = true;
+        NULL_VALUE = nullValue;
+    }
+
+    private DeferredValue() {
+    }
+
+    // get-or-deserialize-and-get
+    public V get(SerializationService serializationService) {
+        if (!valueExists) {
+            // it's ok to deserialize twice in case of race
+            assert serializationService != null;
+            value = serializationService.toObject(serializedValue);
+            valueExists = true;
+        }
+        return value;
+    }
+
+    public Data getSerializedValue(SerializationService serializationService) {
+        if (!serializedValueExists) {
+            assert serializationService != null;
+            serializedValue = serializationService.toData(value);
+            serializedValueExists = true;
+        }
+        return serializedValue;
+    }
+
+    // returns a new DeferredValue representing the same value as this
+    public DeferredValue<V> shallowCopy() {
+        if (this == NULL_VALUE) {
+            return NULL_VALUE;
+        }
+        DeferredValue<V> copy = new DeferredValue<V>();
+        if (serializedValueExists) {
+            copy.serializedValueExists = true;
+            copy.serializedValue = serializedValue;
+        }
+        if (valueExists) {
+            copy.valueExists = true;
+            copy.value = value;
+        }
+        return copy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DeferredValue<?> deferredValue = (DeferredValue<?>) o;
+
+        if (valueExists && deferredValue.valueExists) {
+            return value != null ? value.equals(deferredValue.value) : deferredValue.value == null;
+        }
+        if (serializedValueExists && deferredValue.serializedValueExists) {
+            return serializedValue != null ? serializedValue.equals(deferredValue.serializedValue)
+                    : deferredValue.serializedValue == null;
+        }
+        throw new IllegalArgumentException("Cannot compare serialized vs deserialized value");
+    }
+
+    @Override
+    public int hashCode() {
+        int result = serializedValue != null ? serializedValue.hashCode() : 0;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + (valueExists ? 1 : 0);
+        result = 31 * result + (serializedValueExists ? 1 : 0);
+        return result;
+    }
+
+    public static <V> DeferredValue<V> withSerializedValue(Data serializedValue) {
+        if (serializedValue == null) {
+            return NULL_VALUE;
+        }
+        DeferredValue<V> deferredValue = new DeferredValue<V>();
+        deferredValue.serializedValue = serializedValue;
+        deferredValue.serializedValueExists = true;
+        return deferredValue;
+    }
+
+    public static <V> DeferredValue<V> withValue(V value) {
+        if (value == null) {
+            return NULL_VALUE;
+        }
+        DeferredValue<V> deferredValue = new DeferredValue<V>();
+        deferredValue.value = value;
+        deferredValue.valueExists = true;
+        return deferredValue;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <V> DeferredValue<V> withNullValue() {
+        return (DeferredValue<V>) NULL_VALUE;
+    }
+
+    public static <V> Set<DeferredValue<V>> concurrentSetOfValues(Set<V> values) {
+        Set<DeferredValue<V>> result = Collections.newSetFromMap(new ConcurrentHashMap<DeferredValue<V>, Boolean>());
+        for (V value : values) {
+            result.add(DeferredValue.withValue(value));
+        }
+        return result;
+    }
+
+    /**
+     * Adapts a {@code Set<DeferredValue<V>>} as a {@code Set<V>}. Operations on the returned set pass through to
+     * the original {@code deferredValues} set.
+     *
+     * @param deferredValues        original set of deferred values to be adapted
+     * @param serializationService  reference to {@link SerializationService}
+     * @param <V>                   the value type
+     * @return                      a {@code Set<V>} that wraps the {@code deferredValues} set.
+     */
+    public static <V> Set<V> asPassThroughSet(Set<DeferredValue<V>> deferredValues, SerializationService serializationService) {
+        return new DeferredValueSet<V>(serializationService, deferredValues);
+    }
+
+    private static class DeferredValueSet<V> extends AbstractSet<V> {
+        private final SerializationService serializationService;
+        private final Set<DeferredValue<V>> delegate;
+
+        public DeferredValueSet(SerializationService serializationService, Set<DeferredValue<V>> delegate) {
+            this.serializationService = serializationService;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int size() {
+            return delegate.size();
+        }
+
+        @Override
+        public Iterator<V> iterator() {
+            return new DeferredValueIterator<V>(serializationService, delegate.iterator());
+        }
+
+        public boolean add(V v) {
+            return delegate.add(DeferredValue.withValue(v));
+        }
+
+        @Override
+        public boolean remove(Object o) {
+            return delegate.remove(DeferredValue.withValue(o));
+        }
+
+        @Override
+        public void clear() {
+            delegate.clear();
+        }
+
+        private Collection<DeferredValue<?>> asDeferredValues(Collection<?> collection) {
+            Collection<DeferredValue<?>> deferredValues = new ArrayList<DeferredValue<?>>();
+            for (Object object : collection) {
+                deferredValues.add(DeferredValue.withValue(object));
+            }
+            return deferredValues;
+        }
+    }
+
+    private static class DeferredValueIterator<V> implements Iterator<V> {
+        private final SerializationService serializationService;
+        private final Iterator<DeferredValue<V>> iterator;
+
+        public DeferredValueIterator(SerializationService serializationService, Iterator<DeferredValue<V>> iterator) {
+            this.serializationService = serializationService;
+            this.iterator = iterator;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public V next() {
+            DeferredValue<V> next = iterator.next();
+            return next.get(serializationService);
+        }
+
+        @Override
+        public void remove() {
+            iterator.remove();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/HazelcastServerCacheManager.java
@@ -17,20 +17,15 @@
 package com.hazelcast.cache.impl;
 
 import com.hazelcast.cache.HazelcastCachingProvider;
-import com.hazelcast.cache.impl.operation.AddCacheConfigOperationSupplier;
-import com.hazelcast.cache.impl.operation.CacheCreateConfigOperation;
 import com.hazelcast.cache.impl.operation.CacheGetConfigOperation;
 import com.hazelcast.cache.impl.operation.CacheManagementConfigOperation;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.HazelcastInstanceProxy;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.OperationService;
-import com.hazelcast.version.Version;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -39,13 +34,8 @@ import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.internal.cluster.Versions.V3_10;
-import static com.hazelcast.internal.util.InvocationUtil.invokeOnStableClusterSerial;
-import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
-import static com.hazelcast.util.FutureUtil.waitForever;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static java.util.Collections.singleton;
 
 /**
  * <p>
@@ -131,9 +121,7 @@ public class HazelcastServerCacheManager
 
     @Override
     protected <K, V> CacheConfig<K, V> findCacheConfig(String cacheName,
-                                                       String simpleCacheName,
-                                                       boolean createAlsoOnOthers,
-                                                       boolean syncCreate) {
+                                                       String simpleCacheName) {
         CacheConfig<K, V> config = cacheService.getCacheConfig(cacheName);
         if (config == null) {
             config = cacheService.findCacheConfig(simpleCacheName);
@@ -149,39 +137,15 @@ public class HazelcastServerCacheManager
             // This is needed because even though cache config is exist on this node
             // (for example added by an in-flight cache config creation operation)
             // it still might not exist on other nodes yet (but will created eventually).
-            createCacheConfig(cacheName, config, createAlsoOnOthers, syncCreate);
+            createCacheConfig(cacheName, config);
         }
         return config;
     }
 
     @Override
     protected <K, V> void createCacheConfig(String cacheName,
-                                            CacheConfig<K, V> config,
-                                            boolean createAlsoOnOthers,
-                                            boolean syncCreate) {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
-        if (clusterVersion.isGreaterOrEqual(V3_10)) {
-            AddCacheConfigOperationSupplier operationSupplier = new AddCacheConfigOperationSupplier(
-                    PreJoinCacheConfig.of(config, false));
-            ICompletableFuture future = invokeOnStableClusterSerial(nodeEngine,
-                    operationSupplier, cacheService.MAX_ADD_CACHE_CONFIG_RETRIES);
-            if (syncCreate) {
-                waitForever(singleton(future), RETHROW_EVERYTHING);
-            }
-        } else {
-            // RU_COMPAT_3_9
-            OperationService operationService = nodeEngine.getOperationService();
-            // Create cache config on all nodes.
-            CacheCreateConfigOperation op = new CacheCreateConfigOperation(config, createAlsoOnOthers);
-            // Run "CacheCreateConfigOperation" on this node. Its itself handles interaction with other nodes.
-            // This operation doesn't block operation thread even "syncCreate" is specified.
-            // In that case, scheduled thread is used, not operation thread.
-            InternalCompletableFuture future =
-                    operationService.invokeOnTarget(CacheService.SERVICE_NAME, op, nodeEngine.getThisAddress());
-            if (syncCreate) {
-                future.join();
-            }
-        }
+                                            CacheConfig<K, V> config) {
+        cacheService.createCacheConfigOnAllMembers(PreJoinCacheConfig.of(config));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -43,6 +43,11 @@ public interface ICacheService
     String SERVICE_NAME = "hz:impl:cacheService";
 
     /**
+     * Maximum retries for adding cache config cluster-wide on stable cluster
+     */
+    int MAX_ADD_CACHE_CONFIG_RETRIES = 100;
+
+    /**
      * Gets or creates a cache record store with the prefixed {@code cacheNameWithPrefix}
      * and partition ID.
      *

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheService.java
@@ -133,4 +133,16 @@ public interface ICacheService
      * Returns an interface for interacting with the cache event journals.
      */
     CacheEventJournal getEventJournal();
+
+    /**
+     * Creates the given CacheConfig on all members of the cluster synchronously. When used with
+     * cluster version 3.10 or greater, the cluster-wide invocation ensures that all members of
+     * the cluster will receive the cache config even in the face of cluster membership changes.
+     *
+     * @param cacheConfig   the cache config to create on all members of the cluster
+     * @param <K>           key type parameter
+     * @param <V>           value type parameter
+     * @since 3.10
+     */
+    <K, V> void createCacheConfigOnAllMembers(PreJoinCacheConfig<K, V> cacheConfig);
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/JCacheDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/JCacheDetector.java
@@ -18,6 +18,8 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ClassLoaderUtil;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 
 /**
  * Utility class to detect existence of JCache 1.0.0 in the classpath.
@@ -55,6 +57,18 @@ public final class JCacheDetector {
      * @return {@code true} if JCache 1.0.0 is located in the classpath, otherwise {@code false}.
      */
     public static boolean isJCacheAvailable(ClassLoader classLoader, ILogger logger) {
+        ClassLoader backupClassLoader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+            @Override
+            public ClassLoader run() {
+                return JCacheDetector.class.getClassLoader();
+            }
+        });
+        // try the class loader that loaded Hazelcast/JCacheDetector class
+        // if the thread-context class loader is too narrowly defined and doesn't contain JCache
+        return isJCacheAvailableInternal(classLoader, null) || isJCacheAvailableInternal(backupClassLoader, null);
+    }
+
+    private static boolean isJCacheAvailableInternal(ClassLoader classLoader, ILogger logger) {
         if (!ClassLoaderUtil.isClassAvailable(classLoader, JCACHE_CACHING_CLASSNAME)) {
             // no cache-api jar in the classpath
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/JCacheDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/JCacheDetector.java
@@ -65,7 +65,7 @@ public final class JCacheDetector {
         });
         // try the class loader that loaded Hazelcast/JCacheDetector class
         // if the thread-context class loader is too narrowly defined and doesn't contain JCache
-        return isJCacheAvailableInternal(classLoader, null) || isJCacheAvailableInternal(backupClassLoader, null);
+        return isJCacheAvailableInternal(classLoader, logger) || isJCacheAvailableInternal(backupClassLoader, logger);
     }
 
     private static boolean isJCacheAvailableInternal(ClassLoader classLoader, ILogger logger) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/PreJoinCacheConfig.java
@@ -99,4 +99,23 @@ public class PreJoinCacheConfig<K, V> extends CacheConfig<K, V> implements Ident
 
         return true;
     }
+
+    /**
+     * @return an instance of {@code CacheConfig} that is not a {@code PreJoinCacheConfig}
+     */
+    public static CacheConfig asCacheConfig(CacheConfig cacheConfig) {
+        if (!(cacheConfig instanceof PreJoinCacheConfig)) {
+            return cacheConfig;
+        } else {
+            return ((PreJoinCacheConfig) cacheConfig).asCacheConfig();
+        }
+    }
+
+    public static PreJoinCacheConfig of(CacheConfig cacheConfig, boolean resolved) {
+        if (cacheConfig instanceof PreJoinCacheConfig) {
+            return (PreJoinCacheConfig) cacheConfig;
+        } else {
+            return new PreJoinCacheConfig(cacheConfig, resolved);
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AddCacheConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AddCacheConfigOperation.java
@@ -40,7 +40,7 @@ public class AddCacheConfigOperation extends Operation implements IdentifiedData
     @Override
     public void run() {
         ICacheService cacheService = getService();
-        cacheService.putCacheConfigIfAbsent(cacheConfig.asCacheConfig());
+        cacheService.putCacheConfigIfAbsent(cacheConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AddCacheConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AddCacheConfigOperation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.operation;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.impl.PreJoinCacheConfig;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.Operation;
+
+import java.io.IOException;
+
+public class AddCacheConfigOperation extends Operation implements IdentifiedDataSerializable {
+
+    private PreJoinCacheConfig cacheConfig;
+
+    public AddCacheConfigOperation() {
+    }
+
+    public AddCacheConfigOperation(PreJoinCacheConfig cacheConfig) {
+        this.cacheConfig = cacheConfig;
+    }
+
+    @Override
+    public void run() {
+        ICacheService cacheService = getService();
+        cacheService.putCacheConfigIfAbsent(cacheConfig.asCacheConfig());
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        out.writeObject(cacheConfig);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        cacheConfig = in.readObject();
+    }
+
+    @Override
+    public String getServiceName() {
+        return ICacheService.SERVICE_NAME;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.ADD_CACHE_CONFIG_OPERATION;
+    }
+
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AddCacheConfigOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/AddCacheConfigOperationSupplier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.operation;
+
+import com.hazelcast.cache.impl.PreJoinCacheConfig;
+import com.hazelcast.util.function.Supplier;
+
+public class AddCacheConfigOperationSupplier implements Supplier<AddCacheConfigOperation> {
+
+    private final PreJoinCacheConfig cacheConfig;
+
+    public AddCacheConfigOperationSupplier(PreJoinCacheConfig cacheConfig) {
+        this.cacheConfig = cacheConfig;
+    }
+
+    @Override
+    public AddCacheConfigOperation get() {
+        return new AddCacheConfigOperation(cacheConfig);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -18,7 +18,6 @@ package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheService;
-import com.hazelcast.cache.impl.PreJoinCacheConfig;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.Member;
@@ -92,9 +91,7 @@ public class CacheCreateConfigOperation
     public void run() throws Exception {
         ICacheService service = getService();
         if (!ignoreLocal) {
-            CacheConfig cacheConfig =
-                    config instanceof PreJoinCacheConfig ? ((PreJoinCacheConfig) config).asCacheConfig() : config;
-            response = service.putCacheConfigIfAbsent(cacheConfig);
+            response = service.putCacheConfigIfAbsent(config);
         }
         if (createAlsoOnOthers) {
             NodeEngine nodeEngine = getNodeEngine();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -52,7 +52,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  * remote members on which the new {@code CacheConfig} needs to be created. When this operation returns {@code null} with {@code
  * createAlsoOnOthers == true}, it is impossible to tell whether it is because the {@code CacheConfig} was not already registered
  * or due to sending out the operation to other remote members.
+ *
+ * @deprecated as of 3.10 replaced by {@link AddCacheConfigOperation}, which is used in conjunction with
+ * {@link com.hazelcast.internal.util.InvocationUtil#invokeOnStableClusterSerial(NodeEngine,
+ * com.hazelcast.util.function.Supplier, int)} to reliably broadcast the {@code CacheConfig} to all members of the cluster.
  */
+@Deprecated
 public class CacheCreateConfigOperation
         extends AbstractNamedOperation
         implements IdentifiedDataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/OnJoinCacheOperation.java
@@ -19,7 +19,6 @@ package com.hazelcast.cache.impl.operation;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheService;
 import com.hazelcast.config.CacheConfig;
-import com.hazelcast.cache.impl.PreJoinCacheConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -60,14 +59,7 @@ public class OnJoinCacheOperation extends Operation implements IdentifiedDataSer
         if (isJCacheAvailable(getNodeEngine().getConfigClassLoader())) {
             ICacheService cacheService = getService();
             for (CacheConfig cacheConfig : configs) {
-                // RU_COMPAT_38 since 3.9, configs are instances of PreJoinCacheConfig
-                CacheConfig cacheConfigToAdd;
-                if (cacheConfig instanceof PreJoinCacheConfig) {
-                    cacheConfigToAdd = ((PreJoinCacheConfig) cacheConfig).asCacheConfig();
-                } else {
-                    cacheConfigToAdd = cacheConfig;
-                }
-                cacheService.putCacheConfigIfAbsent(cacheConfigToAdd);
+                cacheService.putCacheConfigIfAbsent(cacheConfig);
             }
         } else {
             // if JCache is not in classpath and no Cache configurations need to be processed, do not fail the operation

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheCreateConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheCreateConfigMessageTask.java
@@ -17,37 +17,39 @@
 package com.hazelcast.client.impl.protocol.task.cache;
 
 import com.hazelcast.cache.impl.CacheService;
-import com.hazelcast.cache.impl.operation.CacheCreateConfigOperation;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.impl.PreJoinCacheConfig;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheCreateConfigCodec;
+import com.hazelcast.client.impl.protocol.task.AbstractCallableMessageTask;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.LegacyCacheConfig;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.properties.GroupProperty;
 
 import java.security.Permission;
 
 /**
- * This client request  specifically calls {@link CacheCreateConfigOperation} on the server side.
+ * Creates the given CacheConfig on all members of the cluster.
  *
- * @see CacheCreateConfigOperation
+ * @see ICacheService#createCacheConfigOnAllMembers(PreJoinCacheConfig)
  */
 public class CacheCreateConfigMessageTask
-        extends AbstractCacheMessageTask<CacheCreateConfigCodec.RequestParameters> {
+        extends AbstractCallableMessageTask<CacheCreateConfigCodec.RequestParameters> {
 
     public CacheCreateConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
-    protected Operation prepareOperation() {
-        // todo THIS MUST MIGRATE FROM PARTITION TO GENERIC OPERATION
+    protected Object call() throws Exception {
         CacheConfig cacheConfig = extractCacheConfigFromMessage();
-        return new CacheCreateConfigOperation(cacheConfig, parameters.createAlsoOnOthers);
+        ICacheService cacheService = getService(CacheService.SERVICE_NAME);
+        cacheService.createCacheConfigOnAllMembers(PreJoinCacheConfig.of(cacheConfig));
+        return null;
     }
 
     private CacheConfig extractCacheConfigFromMessage() {
@@ -101,5 +103,20 @@ public class CacheCreateConfigMessageTask
     @Override
     public Object[] getParameters() {
         return null;
+    }
+
+    private Data serializeCacheConfig(Object response) {
+        Data responseData = null;
+        if (BuildInfo.UNKNOWN_HAZELCAST_VERSION == getClientVersion()) {
+            boolean compatibilityEnabled = nodeEngine.getProperties().getBoolean(GroupProperty.COMPATIBILITY_3_6_CLIENT_ENABLED);
+            if (compatibilityEnabled) {
+                responseData = nodeEngine.toData(response == null ? null : new LegacyCacheConfig((CacheConfig) response));
+            }
+        }
+
+        if (null == responseData) {
+            responseData = nodeEngine.toData(response);
+        }
+        return responseData;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheCreateConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheCreateConfigMessageTask.java
@@ -45,8 +45,8 @@ public class CacheCreateConfigMessageTask
 
     @Override
     protected Operation prepareOperation() {
+        // todo THIS MUST MIGRATE FROM PARTITION TO GENERIC OPERATION
         CacheConfig cacheConfig = extractCacheConfigFromMessage();
-
         return new CacheCreateConfigOperation(cacheConfig, parameters.createAlsoOnOthers);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheConfig.java
@@ -47,6 +47,10 @@ import static com.hazelcast.config.CacheSimpleConfig.MIN_BACKUP_COUNT;
 import static com.hazelcast.util.Preconditions.checkAsyncBackupCount;
 import static com.hazelcast.util.Preconditions.checkBackupCount;
 import static com.hazelcast.util.Preconditions.isNotNull;
+import java.util.Set;
+import javax.cache.expiry.ExpiryPolicy;
+import javax.cache.integration.CacheLoader;
+import javax.cache.integration.CacheWriter;
 
 /**
  * Contains all the configuration for the {@link com.hazelcast.cache.ICache}.
@@ -79,6 +83,7 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
      * Full-flush invalidation means the invalidation of events for all entries when clear is called.
      */
     private boolean disablePerEntryInvalidationEvents;
+
 
     public CacheConfig() {
     }
@@ -129,16 +134,16 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
         this.isReadThrough = simpleConfig.isReadThrough();
         this.isWriteThrough = simpleConfig.isWriteThrough();
         if (simpleConfig.getCacheLoaderFactory() != null) {
-            this.cacheLoaderFactory = ClassLoaderUtil.newInstance(null, simpleConfig.getCacheLoaderFactory());
+            setCacheLoaderFactory(ClassLoaderUtil.<Factory<? extends CacheLoader<K,V>>>newInstance(null, simpleConfig.getCacheLoaderFactory()));
         }
         if (simpleConfig.getCacheLoader() != null) {
-            this.cacheLoaderFactory = FactoryBuilder.factoryOf(simpleConfig.getCacheLoader());
+            setCacheLoaderFactory(FactoryBuilder.<CacheLoader<K,V>>factoryOf(simpleConfig.getCacheLoader()));
         }
         if (simpleConfig.getCacheWriterFactory() != null) {
-            this.cacheWriterFactory = ClassLoaderUtil.newInstance(null, simpleConfig.getCacheWriterFactory());
+            setCacheWriterFactory(ClassLoaderUtil.<Factory<? extends CacheWriter<K,V>>>newInstance(null, simpleConfig.getCacheWriterFactory()));
         }
         if (simpleConfig.getCacheWriter() != null) {
-            this.cacheWriterFactory = FactoryBuilder.factoryOf(simpleConfig.getCacheWriter());
+            setCacheWriterFactory(FactoryBuilder.<CacheWriter<K,V>>factoryOf(simpleConfig.getCacheWriter()));
         }
         initExpiryPolicyFactoryConfig(simpleConfig);
         this.asyncBackupCount = simpleConfig.getAsyncBackupCount();
@@ -181,8 +186,7 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
                 simpleConfig.getExpiryPolicyFactoryConfig();
         if (expiryPolicyFactoryConfig != null) {
             if (expiryPolicyFactoryConfig.getClassName() != null) {
-                this.expiryPolicyFactory =
-                        ClassLoaderUtil.newInstance(null, expiryPolicyFactoryConfig.getClassName());
+                setExpiryPolicyFactory(ClassLoaderUtil.<Factory<? extends ExpiryPolicy>>newInstance(null, expiryPolicyFactoryConfig.getClassName()));
             } else {
                 TimedExpiryPolicyFactoryConfig timedExpiryPolicyConfig =
                         expiryPolicyFactoryConfig.getTimedExpiryPolicyFactoryConfig();
@@ -191,31 +195,31 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
                     ExpiryPolicyType expiryPolicyType = timedExpiryPolicyConfig.getExpiryPolicyType();
                     switch (expiryPolicyType) {
                         case CREATED:
-                            this.expiryPolicyFactory =
+                            setExpiryPolicyFactory(
                                     CreatedExpiryPolicy.factoryOf(
                                             new Duration(durationConfig.getTimeUnit(),
-                                                    durationConfig.getDurationAmount()));
+                                                    durationConfig.getDurationAmount())));
                             break;
                         case MODIFIED:
-                            this.expiryPolicyFactory =
+                            setExpiryPolicyFactory(
                                     ModifiedExpiryPolicy.factoryOf(
                                             new Duration(durationConfig.getTimeUnit(),
-                                                    durationConfig.getDurationAmount()));
+                                                    durationConfig.getDurationAmount())));
                             break;
                         case ACCESSED:
-                            this.expiryPolicyFactory =
+                            setExpiryPolicyFactory(
                                     AccessedExpiryPolicy.factoryOf(
                                             new Duration(durationConfig.getTimeUnit(),
-                                                    durationConfig.getDurationAmount()));
+                                                    durationConfig.getDurationAmount())));
                             break;
                         case TOUCHED:
-                            this.expiryPolicyFactory =
+                            setExpiryPolicyFactory(
                                     TouchedExpiryPolicy.factoryOf(
                                             new Duration(durationConfig.getTimeUnit(),
-                                                    durationConfig.getDurationAmount()));
+                                                    durationConfig.getDurationAmount())));
                             break;
                         case ETERNAL:
-                            this.expiryPolicyFactory = EternalExpiryPolicy.factoryOf();
+                            setExpiryPolicyFactory(EternalExpiryPolicy.factoryOf());
                             break;
                         default:
                             throw new IllegalArgumentException("Unsupported expiry policy type: " + expiryPolicyType);
@@ -527,9 +531,7 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
         out.writeObject(wanReplicationRef);
         // SUPER
         writeKeyValueTypes(out);
-        out.writeObject(cacheLoaderFactory);
-        out.writeObject(cacheWriterFactory);
-        out.writeObject(expiryPolicyFactory);
+        writeFactories(out);
 
         out.writeBoolean(isReadThrough);
         out.writeBoolean(isWriteThrough);
@@ -541,13 +543,9 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
 
         out.writeUTF(quorumName);
 
-        final boolean listNotEmpty = listenerConfigurations != null && !listenerConfigurations.isEmpty();
-        out.writeBoolean(listNotEmpty);
-        if (listNotEmpty) {
-            out.writeInt(listenerConfigurations.size());
-            for (CacheEntryListenerConfiguration<K, V> cc : listenerConfigurations) {
-                out.writeObject(cc);
-            }
+        out.writeBoolean(hasListenerConfiguration());
+        if (hasListenerConfiguration()) {
+            writeListenerConfigurations(out);
         }
 
         out.writeUTF(mergePolicy);
@@ -570,9 +568,7 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
 
         // SUPER
         readKeyValueTypes(in);
-        cacheLoaderFactory = in.readObject();
-        cacheWriterFactory = in.readObject();
-        expiryPolicyFactory = in.readObject();
+        readFactories(in);
 
         isReadThrough = in.readBoolean();
         isWriteThrough = in.readBoolean();
@@ -586,17 +582,14 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
 
         final boolean listNotEmpty = in.readBoolean();
         if (listNotEmpty) {
-            final int size = in.readInt();
-            listenerConfigurations = createConcurrentSet();
-            for (int i = 0; i < size; i++) {
-                listenerConfigurations.add((CacheEntryListenerConfiguration<K, V>) in.readObject());
-            }
+            readListenerConfigurations(in);
         }
 
         mergePolicy = in.readUTF();
         disablePerEntryInvalidationEvents = in.readBoolean();
 
         setClassLoader(in.getClassLoader());
+        this.serializationService = in.getSerializationService();
     }
 
     @Override
@@ -653,6 +646,45 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
         setValueType((Class<V>) in.readObject());
     }
 
+    protected void writeFactories(ObjectDataOutput out) throws IOException {
+        out.writeObject(getCacheLoaderFactory());
+        out.writeObject(getCacheWriterFactory());
+        out.writeObject(getExpiryPolicyFactory());
+    }
+
+    protected void readFactories(ObjectDataInput in) throws IOException {
+        doReadFactories(in);
+    }
+
+    @Override
+    protected void doReadFactories(ObjectDataInput in) throws IOException {
+        setCacheLoaderFactory(in.<Factory<? extends CacheLoader<K,V>>>readObject());
+        setCacheWriterFactory(in.<Factory<? extends CacheWriter<? super K,? super V>>>readObject());
+        setExpiryPolicyFactory(in.<Factory<? extends ExpiryPolicy>>readObject());
+    }
+
+    protected void writeListenerConfigurations(ObjectDataOutput out) throws IOException {
+        out.writeInt(getListenerConfigurations().size());
+        for (CacheEntryListenerConfiguration<K, V> cc : getListenerConfigurations()) {
+            out.writeObject(cc);
+        }
+    }
+
+    protected void readListenerConfigurations(ObjectDataInput in) throws IOException {
+        doReadListenerConfigurations(in);
+    }
+
+    @Override
+    protected void doReadListenerConfigurations(ObjectDataInput in) throws IOException {
+        final int size = in.readInt();
+        Set<CacheEntryListenerConfiguration<K,V>> lc = createConcurrentSet();
+        for (int i = 0; i < size; i++) {
+            lc.add((CacheEntryListenerConfiguration<K, V>) in.readObject());
+        }
+        setListenerConfigurations(lc);
+    }
+
+
     /**
      * Copy this CacheConfig to given {@code target} object whose type extends CacheConfig.
      *
@@ -666,19 +698,27 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
     public <T extends CacheConfig<K, V>> T copy(T target, boolean resolved) {
         target.setAsyncBackupCount(getAsyncBackupCount());
         target.setBackupCount(getBackupCount());
-        target.setCacheLoaderFactory(getCacheLoaderFactory());
-        target.setCacheWriterFactory(getCacheWriterFactory());
         target.setDisablePerEntryInvalidationEvents(isDisablePerEntryInvalidationEvents());
         target.setEvictionConfig(getEvictionConfig());
-        target.setExpiryPolicyFactory(getExpiryPolicyFactory());
         target.setHotRestartConfig(getHotRestartConfig());
         target.setInMemoryFormat(getInMemoryFormat());
         if (resolved) {
             target.setKeyType(getKeyType());
             target.setValueType(getValueType());
+
+            target.setCacheLoaderFactory(getCacheLoaderFactory());
+            target.setCacheWriterFactory(getCacheWriterFactory());
+            target.setExpiryPolicyFactory(getExpiryPolicyFactory());
+            Iterable<CacheEntryListenerConfiguration<K, V>> entryListenerConfigs = getCacheEntryListenerConfigurations();
+            for (CacheEntryListenerConfiguration<K, V> entryListenerConfig : entryListenerConfigs) {
+                target.addCacheEntryListenerConfiguration(entryListenerConfig);
+            }
         } else {
             target.setKeyClassName(getKeyClassName());
             target.setValueClassName(getValueClassName());
+
+            target.serializedFactories = serializedFactories;
+            target.serializedListenerConfigurations = serializedListenerConfigurations;
         }
         target.setManagementEnabled(isManagementEnabled());
         target.setManagerPrefix(getManagerPrefix());
@@ -692,10 +732,8 @@ public class CacheConfig<K, V> extends AbstractCacheConfig<K, V> {
         target.setUriString(getUriString());
         target.setWanReplicationRef(getWanReplicationRef());
         target.setWriteThrough(isWriteThrough());
-        Iterable<CacheEntryListenerConfiguration<K, V>> entryListenerConfigs = getCacheEntryListenerConfigurations();
-        for (CacheEntryListenerConfiguration<K, V> entryListenerConfig : entryListenerConfigs) {
-            target.addCacheEntryListenerConfiguration(entryListenerConfig);
-        }
+        target.setClassLoader(classLoader);
+        target.serializationService = serializationService;
         return target;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInput.java
@@ -674,6 +674,11 @@ class ByteArrayObjectDataInput extends VersionedObjectDataInput implements Buffe
         return service.getClassLoader();
     }
 
+    @Override
+    public InternalSerializationService getSerializationService() {
+        return service;
+    }
+
     public ByteOrder getByteOrder() {
         return bigEndian ? ByteOrder.BIG_ENDIAN : ByteOrder.LITTLE_ENDIAN;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -444,6 +444,11 @@ class ByteArrayObjectDataOutput extends VersionedObjectDataOutput implements Buf
     }
 
     @Override
+    public InternalSerializationService getSerializationService() {
+        return service;
+    }
+
+    @Override
     public String toString() {
         return "ByteArrayObjectDataOutput{"
                 + "size=" + (buffer != null ? buffer.length : 0)

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 
@@ -143,4 +144,8 @@ final class EmptyObjectDataOutput extends VersionedObjectDataOutput implements O
         return ByteOrder.BIG_ENDIAN;
     }
 
+    @Override
+    public InternalSerializationService getSerializationService() {
+        return null;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -356,6 +356,10 @@ public class ObjectDataInputStream extends VersionedObjectDataInput implements C
         return serializationService.getClassLoader();
     }
 
+    public InternalSerializationService getSerializationService() {
+        return serializationService;
+    }
+
     @Override
     public ByteOrder getByteOrder() {
         return byteOrder;
@@ -364,5 +368,4 @@ public class ObjectDataInputStream extends VersionedObjectDataInput implements C
     private boolean bigEndian() {
         return byteOrder == ByteOrder.BIG_ENDIAN;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -282,8 +282,12 @@ public class ObjectDataOutputStream extends VersionedObjectDataOutput implements
         return byteOrder;
     }
 
+    @Override
+    public InternalSerializationService getSerializationService() {
+        return serializationService;
+    }
+
     private boolean bigEndian() {
         return byteOrder == ByteOrder.BIG_ENDIAN;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -63,7 +63,7 @@ public final class InvocationUtil {
      * is interrupted and the exception is propagated to the caller.
      */
     public static ICompletableFuture<Object> invokeOnStableClusterSerial(NodeEngine nodeEngine,
-                                                                         Supplier<Operation> operationSupplier,
+                                                                         Supplier<? extends Operation> operationSupplier,
                                                                          int maxRetries) {
 
         ClusterService clusterService = nodeEngine.getClusterService();
@@ -120,13 +120,13 @@ public final class InvocationUtil {
     private static class InvokeOnMemberFunction implements IFunction<Member, ICompletableFuture<Object>> {
         private static final long serialVersionUID = 2903680336421872278L;
 
-        private final transient Supplier<Operation> operationSupplier;
+        private final transient Supplier<? extends Operation> operationSupplier;
         private final transient NodeEngine nodeEngine;
         private final transient RestartingMemberIterator memberIterator;
         private final long retryDelayMillis;
         private volatile int lastRetryCount;
 
-        InvokeOnMemberFunction(Supplier<Operation> operationSupplier, NodeEngine nodeEngine,
+        InvokeOnMemberFunction(Supplier<? extends Operation> operationSupplier, NodeEngine nodeEngine,
                 RestartingMemberIterator memberIterator) {
             this.operationSupplier = operationSupplier;
             this.nodeEngine = nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataInput.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.serialization.Data;
 
 import java.io.DataInput;
@@ -127,4 +128,9 @@ public interface ObjectDataInput extends DataInput, VersionAware {
      * @return ByteOrder BIG_ENDIAN or LITTLE_ENDIAN
      */
     ByteOrder getByteOrder();
+
+    /**
+     * @return serialization service for this object
+     */
+    InternalSerializationService getSerializationService();
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.serialization.Data;
 
 import java.io.DataOutput;
@@ -109,4 +110,8 @@ public interface ObjectDataOutput extends DataOutput, VersionAware {
      */
     ByteOrder getByteOrder();
 
+    /**
+     * @return serialization service for this object
+     */
+    InternalSerializationService getSerializationService();
 }

--- a/hazelcast/src/test/java/classloading/domain/PersonCacheEntryListenerConfiguration.java
+++ b/hazelcast/src/test/java/classloading/domain/PersonCacheEntryListenerConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Hazelcast, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package classloading.domain;
+
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import javax.cache.configuration.Factory;
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryEventFilter;
+import javax.cache.event.CacheEntryListener;
+import javax.cache.event.CacheEntryListenerException;
+
+/**
+ *
+ * @author lprimak
+ */
+public class PersonCacheEntryListenerConfiguration implements CacheEntryListenerConfiguration<String, Person> {
+
+    @Override
+    public Factory<CacheEntryListener<? super String, ? super Person>> getCacheEntryListenerFactory() {
+        return new Factory<CacheEntryListener<? super String, ? super Person>>() {
+            @Override
+            public CacheEntryListener<? super String, ? super Person> create() {
+                return new CacheEntryListener<String, Person>() {
+                };
+            }
+            private static final long serialVersionUID = 1L;
+        };
+    }
+
+    @Override
+    public boolean isOldValueRequired() {
+        return false;
+    }
+
+    @Override
+    public Factory<CacheEntryEventFilter<? super String, ? super Person>> getCacheEntryEventFilterFactory() {
+        return new Factory<CacheEntryEventFilter<? super String, ? super Person>>() {
+            @Override
+            public CacheEntryEventFilter<? super String, ? super Person> create() {
+                return new CacheEntryEventFilter<String, Person>() {
+                    @Override
+                    public boolean evaluate(CacheEntryEvent<? extends String, ? extends Person> cee) throws CacheEntryListenerException {
+                        throw new UnsupportedOperationException("Not supported yet.");
+                    }
+                };
+            }
+            private static final long serialVersionUID = 1L;
+        };
+    }
+
+    @Override
+    public boolean isSynchronous() {
+        return false;
+    }
+    private static final long serialVersionUID = 1L;
+
+}

--- a/hazelcast/src/test/java/classloading/domain/PersonCacheEntryListenerConfiguration.java
+++ b/hazelcast/src/test/java/classloading/domain/PersonCacheEntryListenerConfiguration.java
@@ -22,11 +22,9 @@ import javax.cache.event.CacheEntryEventFilter;
 import javax.cache.event.CacheEntryListener;
 import javax.cache.event.CacheEntryListenerException;
 
-/**
- *
- * @author lprimak
- */
 public class PersonCacheEntryListenerConfiguration implements CacheEntryListenerConfiguration<String, Person> {
+
+    private static final long serialVersionUID = 1L;
 
     @Override
     public Factory<CacheEntryListener<? super String, ? super Person>> getCacheEntryListenerFactory() {
@@ -52,8 +50,9 @@ public class PersonCacheEntryListenerConfiguration implements CacheEntryListener
             public CacheEntryEventFilter<? super String, ? super Person> create() {
                 return new CacheEntryEventFilter<String, Person>() {
                     @Override
-                    public boolean evaluate(CacheEntryEvent<? extends String, ? extends Person> cee) throws CacheEntryListenerException {
-                        throw new UnsupportedOperationException("Not supported yet.");
+                    public boolean evaluate(CacheEntryEvent<? extends String, ? extends Person> cee)
+                            throws CacheEntryListenerException {
+                        return true;
                     }
                 };
             }
@@ -65,6 +64,9 @@ public class PersonCacheEntryListenerConfiguration implements CacheEntryListener
     public boolean isSynchronous() {
         return false;
     }
-    private static final long serialVersionUID = 1L;
 
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof PersonCacheEntryListenerConfiguration;
+    }
 }

--- a/hazelcast/src/test/java/classloading/domain/PersonCacheLoaderFactory.java
+++ b/hazelcast/src/test/java/classloading/domain/PersonCacheLoaderFactory.java
@@ -15,17 +15,15 @@
  */
 package classloading.domain;
 
-import java.util.HashMap;
-import java.util.Map;
 import javax.cache.configuration.Factory;
 import javax.cache.integration.CacheLoader;
 import javax.cache.integration.CacheLoaderException;
+import java.util.HashMap;
+import java.util.Map;
 
-/**
- *
- * @author lprimak
- */
 public class PersonCacheLoaderFactory implements Factory<CacheLoader<String, Person>> {
+    private static final long serialVersionUID = 1L;
+
     @Override
     public CacheLoader<String, Person> create() {
         return new CacheLoader<String, Person>() {
@@ -45,5 +43,8 @@ public class PersonCacheLoaderFactory implements Factory<CacheLoader<String, Per
         };
     }
 
-    private static final long serialVersionUID = 1L;
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof PersonCacheLoaderFactory;
+    }
 }

--- a/hazelcast/src/test/java/classloading/domain/PersonCacheLoaderFactory.java
+++ b/hazelcast/src/test/java/classloading/domain/PersonCacheLoaderFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Hazelcast, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package classloading.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.cache.configuration.Factory;
+import javax.cache.integration.CacheLoader;
+import javax.cache.integration.CacheLoaderException;
+
+/**
+ *
+ * @author lprimak
+ */
+public class PersonCacheLoaderFactory implements Factory<CacheLoader<String, Person>> {
+    @Override
+    public CacheLoader<String, Person> create() {
+        return new CacheLoader<String, Person>() {
+            @Override
+            public Person load(String k) throws CacheLoaderException {
+                return new Person();
+            }
+
+            @Override
+            public Map<String, Person> loadAll(Iterable<? extends String> itrbl) throws CacheLoaderException {
+                Map<String, Person> rv = new HashMap<String, Person>();
+                for(String it : itrbl) {
+                    rv.put(it, load(it));
+                }
+                return rv;
+            }
+        };
+    }
+
+    private static final long serialVersionUID = 1L;
+}

--- a/hazelcast/src/test/java/classloading/domain/PersonCacheWriterFactory.java
+++ b/hazelcast/src/test/java/classloading/domain/PersonCacheWriterFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Hazelcast, Inc..
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package classloading.domain;
+
+import java.util.Collection;
+import javax.cache.Cache;
+import javax.cache.configuration.Factory;
+import javax.cache.integration.CacheWriter;
+import javax.cache.integration.CacheWriterException;
+
+/**
+ *
+ * @author lprimak
+ */
+public class PersonCacheWriterFactory implements Factory<CacheWriter<String, Person>> {
+    @Override
+    public CacheWriter<String, Person> create() {
+        return new CacheWriter<String, Person>() {
+            @Override
+            public void write(Cache.Entry<? extends String, ? extends Person> entry) throws CacheWriterException {
+                throw new UnsupportedOperationException("Not supported");
+            }
+
+            @Override
+            public void writeAll(Collection<Cache.Entry<? extends String, ? extends Person>> clctn) throws CacheWriterException {
+                throw new UnsupportedOperationException("Not supported");
+            }
+
+            @Override
+            public void delete(Object o) throws CacheWriterException {
+                throw new UnsupportedOperationException("Not supported");
+            }
+
+            @Override
+            public void deleteAll(Collection<?> clctn) throws CacheWriterException {
+                throw new UnsupportedOperationException("Not supported");
+            }
+        };
+    }
+
+    private static final long serialVersionUID = 1L;
+}

--- a/hazelcast/src/test/java/classloading/domain/PersonCacheWriterFactory.java
+++ b/hazelcast/src/test/java/classloading/domain/PersonCacheWriterFactory.java
@@ -15,17 +15,15 @@
  */
 package classloading.domain;
 
-import java.util.Collection;
 import javax.cache.Cache;
 import javax.cache.configuration.Factory;
 import javax.cache.integration.CacheWriter;
 import javax.cache.integration.CacheWriterException;
+import java.util.Collection;
 
-/**
- *
- * @author lprimak
- */
 public class PersonCacheWriterFactory implements Factory<CacheWriter<String, Person>> {
+    private static final long serialVersionUID = 1L;
+
     @Override
     public CacheWriter<String, Person> create() {
         return new CacheWriter<String, Person>() {
@@ -51,5 +49,8 @@ public class PersonCacheWriterFactory implements Factory<CacheWriter<String, Per
         };
     }
 
-    private static final long serialVersionUID = 1L;
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof PersonCacheWriterFactory;
+    }
 }

--- a/hazelcast/src/test/java/classloading/domain/PersonExpiryPolicyFactory.java
+++ b/hazelcast/src/test/java/classloading/domain/PersonExpiryPolicyFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package classloading.domain;
+
+import javax.cache.configuration.Factory;
+import javax.cache.expiry.EternalExpiryPolicy;
+import javax.cache.expiry.ExpiryPolicy;
+
+public class PersonExpiryPolicyFactory implements Factory<ExpiryPolicy> {
+
+    @Override
+    public ExpiryPolicy create() {
+        return new EternalExpiryPolicy();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof PersonExpiryPolicyFactory;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTypesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTypesConfigTest.java
@@ -17,6 +17,8 @@
 package com.hazelcast.cache;
 
 import classloading.domain.Person;
+import classloading.domain.PersonCacheEntryListenerConfiguration;
+import classloading.domain.PersonCacheLoaderFactory;
 import classloading.domain.PersonEntryProcessor;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.CacheConfig;
@@ -42,6 +44,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.hazelcast.config.UserCodeDeploymentConfig.ClassCacheMode.OFF;
+import java.util.Set;
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import org.junit.Assert;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -71,7 +76,6 @@ public class CacheTypesConfigTest extends HazelcastTestSupport {
         HazelcastInstance hz1 = factory.newHazelcastInstance(getConfig());
         CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(hz1);
         cachingProvider.getCacheManager().createCache(cacheName, createCacheConfig());
-        sleepSeconds(5);
 
         // joining member cannot resolve Person class
         List<String> excludes = Arrays.asList("classloading");
@@ -122,11 +126,53 @@ public class CacheTypesConfigTest extends HazelcastTestSupport {
         assertNotNull(testCache.get(key));
     }
 
+    // tests deferred resolution of factories
+    @Test
+    public void cacheConfigShouldBeAddedOnJoiningMember_whenFactoryNotResolvable() throws InterruptedException {
+        HazelcastInstance hz1 = factory.newHazelcastInstance(getConfig());
+        CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(hz1);
+        cachingProvider.getCacheManager().createCache(cacheName, createCacheConfig().setCacheLoaderFactory(new PersonCacheLoaderFactory()));
+
+        // joining member cannot resolve PersonCacheLoaderFactory class
+        List<String> excludes = Arrays.asList("classloading");
+        ClassLoader classLoader = new FilteringClassLoader(excludes, null);
+        Config hz2Config = getConfig();
+        hz2Config.setClassLoader(classLoader);
+        HazelcastInstance hz2 = factory.newHazelcastInstance(hz2Config);
+        assertClusterSize(2, hz1, hz2);
+
+        expect.expectCause(new RootCauseMatcher(ClassNotFoundException.class, "classloading.domain.PersonCacheLoaderFactory - "
+                + "Package excluded explicitly"));
+        ICache<String, Person> cache = hz2.getCacheManager().getCache(cacheName);
+        @SuppressWarnings("unchecked")
+        CacheConfig<String, Person> cacheConfig = cache.getConfiguration(CacheConfig.class);
+    }
+
+    // tests deferred resolution of config listeners
+    @Test
+    public void cacheConfigShouldBeAddedOnJoiningMember_deferredConfigListeners() throws InterruptedException {
+        HazelcastInstance hz1 = factory.newHazelcastInstance(getConfig());
+        CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(hz1);
+        cachingProvider.getCacheManager().createCache(cacheName, createCacheConfig()
+                .addCacheEntryListenerConfiguration(new PersonCacheEntryListenerConfiguration()));
+
+        HazelcastInstance hz2 = factory.newHazelcastInstance(getConfig());
+        assertClusterSize(2, hz1, hz2);
+
+        ICache<String, Person> cache = hz2.getCacheManager().getCache(cacheName);
+        @SuppressWarnings("unchecked")
+        CacheConfig<String, Person> cacheConfig = cache.getConfiguration(CacheConfig.class);
+        Set<CacheEntryListenerConfiguration<String, Person>> listeners = cacheConfig.getListenerConfigurations();
+        Assert.assertEquals(1, listeners.size());
+        expect.expect(UnsupportedOperationException.class);
+        expect.expectMessage("Not supported yet.");
+        listeners.iterator().next().getCacheEntryEventFilterFactory().create().evaluate(null);
+    }
+
     // overridden in another context
-    CacheConfig createCacheConfig() {
-        CacheConfig cacheConfig = new CacheConfig();
+    CacheConfig<String, Person> createCacheConfig() {
+        CacheConfig<String, Person> cacheConfig = new CacheConfig<String, Person>();
         cacheConfig.setTypes(String.class, Person.class).setManagementEnabled(true);
         return cacheConfig;
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/CacheConfigPropagationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/CacheConfigPropagationTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.cache.impl;
 
-import com.hazelcast.cache.HazelcastCachingProvider;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/CacheConfigPropagationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/CacheConfigPropagationTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.cache.HazelcastCachingProvider;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.CacheManager;
+
+import static com.hazelcast.cache.CacheUtil.getDistributedObjectName;
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
+import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+// asserts contents of AbstractCacheService.configs
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheConfigPropagationTest extends HazelcastTestSupport {
+
+    private static final String DYNAMIC_CACHE_NAME = "dynamic-cache";
+    private static final String DECLARED_CACHE_NAME = "declared-cache-1";
+
+    protected int clusterSize = 2;
+    protected HazelcastInstance driver;
+    protected TestHazelcastInstanceFactory factory;
+
+    private CacheManager cacheManagerDriver;
+    private HazelcastInstance[] members;
+
+    @Before
+    public void setup() {
+        setupFactory();
+        members = createMembers();
+        driver = createTestDriver();
+        cacheManagerDriver = createCacheManagerTestDriver();
+    }
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void noPreJoinCacheConfig_whenCacheCreatedDynamically_viaCacheManager() {
+        cacheManagerDriver.createCache(DYNAMIC_CACHE_NAME, new CacheConfig<String, String>());
+        CacheService cacheService = getCacheService(members[0]);
+        assertNoPreJoinCacheConfig(cacheService);
+    }
+
+    @Test
+    public void noPreJoinCacheConfig_whenCacheGet_viaCacheManager() {
+        cacheManagerDriver.getCache(DECLARED_CACHE_NAME);
+        CacheService cacheService = getCacheService(members[0]);
+        assertNoPreJoinCacheConfig(cacheService);
+        assertNotNull("Cache config 'declared-cache-1' should exist in registered cache configs",
+                cacheService.getCacheConfig(getDistributedObjectName(DECLARED_CACHE_NAME, null, null)));
+    }
+
+    @Test
+    public void noPreJoinCacheConfig_whenCacheGet_viaHazelcastInstance() {
+        driver.getCacheManager().getCache(DECLARED_CACHE_NAME);
+        CacheService cacheService = getCacheService(members[0]);
+        assertNoPreJoinCacheConfig(cacheService);
+    }
+
+    @Test
+    public void noPreJoinCacheConfig_onNewMember() {
+        cacheManagerDriver.createCache(DYNAMIC_CACHE_NAME, new CacheConfig<String, String>());
+        HazelcastInstance newMember = factory.newHazelcastInstance(getConfig());
+        CacheService cacheService = getCacheService(newMember);
+        assertNoPreJoinCacheConfig(cacheService);
+    }
+
+    @Test
+    public void cacheConfig_existsOnRemoteMember_immediatelyAfterCacheGet() {
+        CacheService cacheServiceOnRemote = getCacheService(members[1]);
+        String distributedObjectName = getDistributedObjectName(DECLARED_CACHE_NAME);
+        assertNull(cacheServiceOnRemote.getCacheConfig(distributedObjectName));
+        driver.getCacheManager().getCache(DECLARED_CACHE_NAME);
+        assertNotNull(cacheServiceOnRemote.getCacheConfig(distributedObjectName));
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = super.getConfig();
+        config.addCacheConfig(new CacheSimpleConfig()
+                                .setName("declared-cache*"));
+        return config;
+    }
+
+    protected void setupFactory() {
+        factory = createHazelcastInstanceFactory();
+    }
+
+    protected HazelcastInstance createTestDriver() {
+        return factory.newHazelcastInstance(getConfig());
+    }
+
+    protected CacheManager createCacheManagerTestDriver() {
+        return HazelcastServerCachingProvider.createCachingProvider(driver).getCacheManager(null, null,
+                propertiesByInstanceItself(driver));
+    }
+
+    protected HazelcastInstance[] createMembers() {
+        return factory.newInstances(getConfig(), clusterSize);
+    }
+
+    protected HazelcastInstance newMember() {
+        return factory.newHazelcastInstance(getConfig());
+    }
+
+    protected CacheService getCacheService(HazelcastInstance member) {
+        CacheService cacheService = getNodeEngineImpl(member).getService(SERVICE_NAME);
+        return cacheService;
+    }
+
+    private void assertNoPreJoinCacheConfig(CacheService cacheService) {
+        for (CacheConfig cacheConfig : cacheService.getCacheConfigs()) {
+            Assert.assertFalse("No PreJoinCacheConfig should exist in CacheService configs",
+                    cacheConfig instanceof PreJoinCacheConfig);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/DeferredValueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/DeferredValueTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl;
+
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static com.hazelcast.cache.impl.DeferredValue.concurrentSetOfValues;
+import static com.hazelcast.cache.impl.DeferredValue.asPassThroughSet;
+import static com.hazelcast.cache.impl.DeferredValue.withSerializedValue;
+import static com.hazelcast.cache.impl.DeferredValue.withValue;
+import static com.hazelcast.test.HazelcastTestSupport.randomString;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DeferredValueTest {
+
+    private SerializationService serializationService;
+    private String expected;
+    private Data serializedValue;
+
+    // for deferred value sets tests
+    private Set<String> valueSet;
+    private Set<DeferredValue<String>> deferredSet;
+    // adaptedSet is backed by deferredSet
+    private Set<String> adaptedSet;
+
+    @Before
+    public void setup() {
+        serializationService = new DefaultSerializationServiceBuilder().build();
+        expected = randomString();
+        serializedValue = serializationService.toData(expected);
+
+        valueSet = new HashSet<String>();
+        valueSet.add("1");
+        valueSet.add("2");
+        valueSet.add("3");
+
+        deferredSet = concurrentSetOfValues(valueSet);
+        adaptedSet = asPassThroughSet(deferredSet, serializationService);
+    }
+
+    @Test
+    public void testValue_isSame_whenConstructedWithValue() {
+        DeferredValue<String> deferredValue = withValue(expected);
+        assertSame(expected, deferredValue.get(serializationService));
+    }
+
+    @Test
+    public void testValue_whenConstructedWithSerializedValue() {
+        DeferredValue<String> deferredValue = DeferredValue.withSerializedValue(serializedValue);
+        assertEquals(expected, deferredValue.get(serializationService));
+    }
+
+    @Test
+    public void testSerializedValue_isSame_whenConstructedWithSerializedValue() {
+        DeferredValue<String> deferredValue = DeferredValue.withSerializedValue(serializedValue);
+        assertSame(serializedValue, deferredValue.getSerializedValue(serializationService));
+    }
+
+    @Test
+    public void testSerializedValue_whenConstructedWithValue() {
+        DeferredValue<String> deferredValue = withValue(expected);
+        assertEquals(serializedValue, deferredValue.getSerializedValue(serializationService));
+    }
+
+    @Test
+    public void testEquals_WithValue() {
+        DeferredValue<String> v1 = withValue(expected);
+        DeferredValue<String> v2 = withValue(expected);
+        assertEquals(v1, v2);
+    }
+
+    @Test
+    public void testEquals_WithSerializedValue() {
+        DeferredValue<String> v1 = DeferredValue.withSerializedValue(serializedValue);
+        DeferredValue<String> v2 = DeferredValue.withSerializedValue(serializedValue);
+        assertEquals(v1, v2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEquals_WithValueAndSerializedValue() {
+        DeferredValue<String> v1 = withValue(expected);
+        DeferredValue<String> v2 = DeferredValue.withSerializedValue(serializedValue);
+        assertEquals(v1, v2);
+    }
+
+    @Test
+    public void testNullValue_returnsNull() {
+        DeferredValue deferredValue = DeferredValue.withNullValue();
+        assertNull(deferredValue.getSerializedValue(serializationService));
+        assertNull(deferredValue.get(serializationService));
+    }
+
+    @Test
+    public void testCopy_whenNullValue() {
+        DeferredValue nullValue = DeferredValue.withNullValue();
+        DeferredValue copy = nullValue.shallowCopy();
+        assertNull(copy.getSerializedValue(serializationService));
+        assertNull(copy.get(serializationService));
+    }
+
+    @Test
+    public void testCopy_whenSerializedValue() {
+        DeferredValue<String> v1 = withSerializedValue(serializedValue);
+        DeferredValue<String> v2 = v1.shallowCopy();
+        assertEquals(v1, v2);
+    }
+
+    @Test
+    public void testCopy_whenValue() {
+        DeferredValue<String> v1 = withValue(expected);
+        DeferredValue<String> v2 = v1.shallowCopy();
+        assertEquals(v1, v2);
+    }
+
+    @Test
+    public void test_setOfValues() {
+        assertTrue(deferredSet.contains(DeferredValue.withValue("1")));
+        assertTrue(deferredSet.contains(DeferredValue.withValue("2")));
+        assertTrue(deferredSet.contains(DeferredValue.withValue("3")));
+        assertFalse(deferredSet.contains(DeferredValue.withValue("4")));
+    }
+
+    @Test
+    public void test_adaptedSet() {
+        assertTrue(adaptedSet.containsAll(valueSet));
+        assertFalse(adaptedSet.isEmpty());
+        assertEquals(3, adaptedSet.size());
+
+        // add "4" -> "1", "2", "3", "4"
+        adaptedSet.add("4");
+        assertTrue(deferredSet.contains(DeferredValue.withValue("4")));
+
+        // remove "1" -> "2", "3", "4"
+        adaptedSet.remove("1");
+        assertFalse(deferredSet.contains(DeferredValue.withValue("1")));
+
+        // retain just "2" & "3"
+        adaptedSet.retainAll(valueSet);
+        assertEquals(2, adaptedSet.size());
+        List<String> currentContents = Arrays.asList("2", "3");
+        assertTrue(adaptedSet.containsAll(currentContents));
+        assertTrue(adaptedSet.contains("2"));
+
+        // toArray
+        Object[] valuesAsArray = adaptedSet.toArray();
+        assertEquals(2, valuesAsArray.length);
+        assertArrayEquals(new Object[] {"2", "3"}, valuesAsArray);
+        String[] stringArray = adaptedSet.toArray(new String[0]);
+        assertEquals(2, stringArray.length);
+        assertArrayEquals(new Object[] {"2", "3"}, stringArray);
+
+        // iterator
+        Iterator<String> iterator = adaptedSet.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals("2", iterator.next());
+        // iterator.remove -> just "3" left in set
+        iterator.remove();
+        assertEquals(1, adaptedSet.size());
+        assertEquals("3", deferredSet.iterator().next().get(serializationService));
+
+        // removeAll
+        adaptedSet.removeAll(valueSet);
+        assertTrue(adaptedSet.isEmpty());
+
+        // addAll
+        adaptedSet.addAll(valueSet);
+        assertEquals(3, adaptedSet.size());
+        assertTrue(adaptedSet.containsAll(valueSet));
+
+        // clear
+        adaptedSet.clear();
+        assertTrue(adaptedSet.isEmpty());
+        assertTrue(deferredSet.isEmpty());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/PreJoinCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/PreJoinCacheConfigTest.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.cache.impl;
 
+import classloading.domain.Person;
+import classloading.domain.PersonCacheEntryListenerConfiguration;
+import classloading.domain.PersonCacheLoaderFactory;
+import classloading.domain.PersonCacheWriterFactory;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheConfigTest;
 import com.hazelcast.core.HazelcastException;
@@ -35,7 +39,11 @@ import static com.hazelcast.config.helpers.CacheConfigHelper.getEvictionConfigBy
 import static com.hazelcast.config.helpers.CacheConfigHelper.getEvictionConfigByPolicy;
 import static com.hazelcast.config.helpers.CacheConfigHelper.newCompleteCacheConfig;
 import static com.hazelcast.config.helpers.CacheConfigHelper.newDefaultCacheConfig;
+import javax.cache.configuration.Factory;
+import javax.cache.expiry.ExpiryPolicy;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -168,4 +176,67 @@ public class PreJoinCacheConfigTest {
         }
     }
 
+    @Test
+    public void serializationSucceeds_cacheLoaderFactory() {
+        CacheConfig<String, Person> cacheConfig = newDefaultCacheConfig("test");
+        cacheConfig.setCacheLoaderFactory(new PersonCacheLoaderFactory());
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        Data data  = serializationService.toData(preJoinCacheConfig);
+        PreJoinCacheConfig deserialized = serializationService.toObject(data);
+        assertTrue("Serialization Not Delayed", deserialized.isFactorySerializationDelayed());
+        assertEquals(preJoinCacheConfig, deserialized);
+        assertEquals(cacheConfig, deserialized.asCacheConfig());
+        assertTrue("Invalid Factory Class", deserialized.getCacheLoaderFactory() instanceof PersonCacheLoaderFactory);
+    }
+
+    @Test
+    public void serializationSucceeds_cacheWriterFactory() {
+        CacheConfig<String, Person> cacheConfig = newDefaultCacheConfig("test");
+        cacheConfig.setCacheWriterFactory(new PersonCacheWriterFactory());
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        Data data  = serializationService.toData(preJoinCacheConfig);
+        PreJoinCacheConfig deserialized = serializationService.toObject(data);
+        assertTrue("Serialization Not Delayed", deserialized.isFactorySerializationDelayed());
+        assertEquals(preJoinCacheConfig, deserialized);
+        assertEquals(cacheConfig, deserialized.asCacheConfig());
+        assertNull(deserialized.getCacheLoaderFactory());
+        assertTrue("Invalid Factory Class", deserialized.getCacheWriterFactory() instanceof PersonCacheWriterFactory);
+    }
+
+    @Test
+    public void serializationSucceeds_cacheExpiryFactory() {
+        CacheConfig<String, Person> cacheConfig = newDefaultCacheConfig("test");
+        cacheConfig.setExpiryPolicyFactory(new ExpiryFactoryImpl());
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        Data data  = serializationService.toData(preJoinCacheConfig);
+        PreJoinCacheConfig deserialized = serializationService.toObject(data);
+        assertTrue("Serialization Not Delayed", deserialized.isFactorySerializationDelayed());
+        assertEquals(preJoinCacheConfig, deserialized);
+        assertEquals(cacheConfig, deserialized.asCacheConfig());
+        assertNull(deserialized.getCacheWriterFactory());
+        assertTrue("Invalid Factory Class", deserialized.getExpiryPolicyFactory() instanceof ExpiryFactoryImpl);
+    }
+
+    @Test
+    public void serializationSucceeds_cacheListeners() {
+        CacheConfig<String, Person> cacheConfig = newDefaultCacheConfig("test");
+        cacheConfig.getListenerConfigurations().add(new PersonCacheEntryListenerConfiguration());
+        PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
+        Data data  = serializationService.toData(preJoinCacheConfig);
+        PreJoinCacheConfig deserialized = serializationService.toObject(data);
+        assertTrue("Serialization Not Delayed", deserialized.isFactorySerializationDelayed());
+        assertEquals(preJoinCacheConfig, deserialized);
+        assertEquals(cacheConfig, deserialized.asCacheConfig());
+        assertNull(deserialized.getCacheWriterFactory());
+        assertEquals(1, deserialized.getListenerConfigurations().size());
+        assertTrue("Invalid Factory Class", deserialized.getCacheEntryListenerConfigurations().iterator().next() instanceof PersonCacheEntryListenerConfiguration);
+    }
+
+    private static class ExpiryFactoryImpl implements Factory<ExpiryPolicy> {
+        @Override
+        public ExpiryPolicy create() {
+            return null;
+        }
+        private static final long serialVersionUID = 1L;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/PreJoinCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/PreJoinCacheConfigTest.java
@@ -20,6 +20,7 @@ import classloading.domain.Person;
 import classloading.domain.PersonCacheEntryListenerConfiguration;
 import classloading.domain.PersonCacheLoaderFactory;
 import classloading.domain.PersonCacheWriterFactory;
+import classloading.domain.PersonExpiryPolicyFactory;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.CacheConfigTest;
 import com.hazelcast.core.HazelcastException;
@@ -39,8 +40,6 @@ import static com.hazelcast.config.helpers.CacheConfigHelper.getEvictionConfigBy
 import static com.hazelcast.config.helpers.CacheConfigHelper.getEvictionConfigByPolicy;
 import static com.hazelcast.config.helpers.CacheConfigHelper.newCompleteCacheConfig;
 import static com.hazelcast.config.helpers.CacheConfigHelper.newDefaultCacheConfig;
-import javax.cache.configuration.Factory;
-import javax.cache.expiry.ExpiryPolicy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -183,7 +182,6 @@ public class PreJoinCacheConfigTest {
         PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
         Data data  = serializationService.toData(preJoinCacheConfig);
         PreJoinCacheConfig deserialized = serializationService.toObject(data);
-        assertTrue("Serialization Not Delayed", deserialized.isFactorySerializationDelayed());
         assertEquals(preJoinCacheConfig, deserialized);
         assertEquals(cacheConfig, deserialized.asCacheConfig());
         assertTrue("Invalid Factory Class", deserialized.getCacheLoaderFactory() instanceof PersonCacheLoaderFactory);
@@ -196,7 +194,6 @@ public class PreJoinCacheConfigTest {
         PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
         Data data  = serializationService.toData(preJoinCacheConfig);
         PreJoinCacheConfig deserialized = serializationService.toObject(data);
-        assertTrue("Serialization Not Delayed", deserialized.isFactorySerializationDelayed());
         assertEquals(preJoinCacheConfig, deserialized);
         assertEquals(cacheConfig, deserialized.asCacheConfig());
         assertNull(deserialized.getCacheLoaderFactory());
@@ -206,15 +203,14 @@ public class PreJoinCacheConfigTest {
     @Test
     public void serializationSucceeds_cacheExpiryFactory() {
         CacheConfig<String, Person> cacheConfig = newDefaultCacheConfig("test");
-        cacheConfig.setExpiryPolicyFactory(new ExpiryFactoryImpl());
+        cacheConfig.setExpiryPolicyFactory(new PersonExpiryPolicyFactory());
         PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
         Data data  = serializationService.toData(preJoinCacheConfig);
         PreJoinCacheConfig deserialized = serializationService.toObject(data);
-        assertTrue("Serialization Not Delayed", deserialized.isFactorySerializationDelayed());
         assertEquals(preJoinCacheConfig, deserialized);
         assertEquals(cacheConfig, deserialized.asCacheConfig());
         assertNull(deserialized.getCacheWriterFactory());
-        assertTrue("Invalid Factory Class", deserialized.getExpiryPolicyFactory() instanceof ExpiryFactoryImpl);
+        assertTrue("Invalid Factory Class", deserialized.getExpiryPolicyFactory() instanceof PersonExpiryPolicyFactory);
     }
 
     @Test
@@ -224,19 +220,10 @@ public class PreJoinCacheConfigTest {
         PreJoinCacheConfig preJoinCacheConfig = new PreJoinCacheConfig(cacheConfig);
         Data data  = serializationService.toData(preJoinCacheConfig);
         PreJoinCacheConfig deserialized = serializationService.toObject(data);
-        assertTrue("Serialization Not Delayed", deserialized.isFactorySerializationDelayed());
         assertEquals(preJoinCacheConfig, deserialized);
         assertEquals(cacheConfig, deserialized.asCacheConfig());
         assertNull(deserialized.getCacheWriterFactory());
         assertEquals(1, deserialized.getListenerConfigurations().size());
         assertTrue("Invalid Factory Class", deserialized.getCacheEntryListenerConfigurations().iterator().next() instanceof PersonCacheEntryListenerConfiguration);
-    }
-
-    private static class ExpiryFactoryImpl implements Factory<ExpiryPolicy> {
-        @Override
-        public ExpiryPolicy create() {
-            return null;
-        }
-        private static final long serialVersionUID = 1L;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableImplementsVersionedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableImplementsVersionedTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.serialization.impl;
 
 import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.VersionAware;
@@ -53,6 +54,7 @@ import static org.mockito.Mockito.when;
 @SuppressWarnings("WeakerAccess")
 public class DataSerializableImplementsVersionedTest {
 
+    private InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
     private Set<Class<? extends IdentifiedDataSerializable>> idsClasses;
     private Set<Class<? extends DataSerializable>> dsClasses;
 
@@ -170,7 +172,9 @@ public class DataSerializableImplementsVersionedTest {
 
     // overridden in EE
     protected ObjectDataOutput getObjectDataOutput() {
-        return spy(ObjectDataOutput.class);
+        ObjectDataOutput output = spy(ObjectDataOutput.class);
+        when(output.getSerializationService()).thenReturn(serializationService);
+        return output;
     }
 
     // overridden in EE


### PR DESCRIPTION
- Deprecates CacheCreateConfigOperation due to unclear semantics; replaced by `AddCacheConfigOperation`, invoked cluster-wide with `invokeOnStableClusterSerial` to ensure all members become aware of new cache config's.
- Removes unused return value from `AbstractHazelcastCacheManager#createCacheConfig`
- Incorporates #12225 so that deferred resolution of classes is extended to cache loader/writer factories, expiry policy factory and cache entry listener configurations (previously it only applied to cache's KV types).

Supersedes #12225 
Fixes #11905 
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/2016