### PR TITLE
Fixed merge policy check in ConfigValidator

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.cache.impl;
 
-import com.hazelcast.cache.CacheUtil;
 import com.hazelcast.cache.HazelcastCacheManager;
 import com.hazelcast.cache.ICache;
 import com.hazelcast.config.CacheConfig;
@@ -43,7 +42,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.hazelcast.cache.impl.CacheProxyUtil.validateCacheConfig;
+import static com.hazelcast.cache.CacheUtil.getPrefix;
+import static com.hazelcast.internal.config.ConfigValidator.checkCacheConfig;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.SetUtil.createLinkedHashSet;
@@ -54,13 +54,14 @@ import static com.hazelcast.util.SetUtil.createLinkedHashSet;
  * provides shared functionality to server and client cache managers.
  * There are two cache managers which can be accessed via their providers.
  * <ul>
- *     <li>Client: HazelcastClientCacheManager.</li>
- *     <li>Server: HazelcastServerCacheManager.</li>
+ * <li>Client: HazelcastClientCacheManager.</li>
+ * <li>Server: HazelcastServerCacheManager.</li>
  * </ul>
  * </p>
  * <p>
- *    {@link AbstractHazelcastCacheManager} manages the lifecycle of the caches created or accessed through itself.
+ * {@link AbstractHazelcastCacheManager} manages the lifecycle of the caches created or accessed through itself.
  * </p>
+ *
  * @see HazelcastCacheManager
  * @see CacheManager
  */
@@ -106,14 +107,16 @@ public abstract class AbstractHazelcastCacheManager
         this.lifecycleListenerRegistrationId = registerLifecycleListener();
     }
 
-    private <K, V, C extends Configuration<K, V>> ICacheInternal<K, V> createCacheInternal(String cacheName,
-            C configuration) throws IllegalArgumentException {
+    private <K, V, C extends Configuration<K, V>> ICacheInternal<K, V> createCacheInternal(String cacheName, C configuration)
+            throws IllegalArgumentException {
         ensureOpen();
         checkNotNull(cacheName, "cacheName must not be null");
         checkNotNull(configuration, "configuration must not be null");
 
         CacheConfig<K, V> newCacheConfig = createCacheConfig(cacheName, configuration);
-        validateCacheConfig(newCacheConfig);
+        checkCacheConfig(newCacheConfig.getInMemoryFormat(), newCacheConfig.getEvictionConfig(),
+                newCacheConfig.isStatisticsEnabled(), newCacheConfig.getMergePolicy());
+
         if (caches.containsKey(newCacheConfig.getNameWithPrefix())) {
             throw new CacheException("A cache named '" + cacheName + "' already exists.");
         }
@@ -203,7 +206,7 @@ public abstract class AbstractHazelcastCacheManager
         return null;
     }
 
-    public <K, V>  ICache<K, V> getOrCreateCache(String cacheName, CacheConfig<K, V> cacheConfig) {
+    public <K, V> ICache<K, V> getOrCreateCache(String cacheName, CacheConfig<K, V> cacheConfig) {
         ensureOpen();
         String cacheNameWithPrefix = getCacheNameWithPrefix(cacheName);
         ICacheInternal<?, ?> cache = caches.get(cacheNameWithPrefix);
@@ -327,7 +330,7 @@ public abstract class AbstractHazelcastCacheManager
             cache.close();
         }
         postClose();
-        // TODO do we need to clear it as "caches.clear();"
+        // TODO: do we need to clear it as "caches.clear();"?
     }
 
     /**
@@ -372,10 +375,9 @@ public abstract class AbstractHazelcastCacheManager
      * @return the calculated cache prefix.
      */
     protected String cacheNamePrefix() {
-        String cacheNamePrefix =
-                CacheUtil.getPrefix(
-                        isDefaultURI ? null : uri,
-                        isDefaultClassLoader ? null : getClassLoader());
+        String cacheNamePrefix = getPrefix(
+                isDefaultURI ? null : uri,
+                isDefaultClassLoader ? null : getClassLoader());
         if (cacheNamePrefix == null) {
             return HazelcastCacheManager.CACHE_MANAGER_PREFIX;
         } else {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxyUtil.java
@@ -24,7 +24,6 @@ import com.hazelcast.util.ExceptionUtil;
 import java.util.Map;
 import java.util.Set;
 
-import static com.hazelcast.internal.config.ConfigValidator.checkCacheConfig;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -237,12 +236,4 @@ public final class CacheProxyUtil {
             }
         }
     }
-
-    public static <K, V> void validateCacheConfig(CacheConfig<K, V> cacheConfig) {
-        checkCacheConfig(cacheConfig.getInMemoryFormat(),
-                cacheConfig.getEvictionConfig(),
-                cacheConfig.isStatisticsEnabled(),
-                cacheConfig.getMergePolicy());
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheSplitBrainHandlerService.java
@@ -50,6 +50,10 @@ class CacheSplitBrainHandlerService extends AbstractSplitBrainHandlerService<ICa
         this.cacheService = nodeEngine.getService(SERVICE_NAME);
     }
 
+    public CacheMergePolicyProvider getMergePolicyProvider() {
+        return mergePolicyProvider;
+    }
+
     @Override
     protected Runnable newMergeRunnable(Map<String, Collection<ICacheRecordStore>> collectedStores,
                                         Map<String, Collection<ICacheRecordStore>> collectedStoresWithLegacyPolicies,

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergeRunnable.java
@@ -141,16 +141,14 @@ public abstract class AbstractMergeRunnable<Store, MergingItem> implements Runna
 
         for (Map.Entry<String, Collection<Store>> entry : collectedStoresWithLegacyPolicies.entrySet()) {
             String dataStructureName = entry.getKey();
+            if (!checkMergePolicySupportsInMemoryFormat(dataStructureName, getMergePolicy(dataStructureName),
+                    getInMemoryFormat(dataStructureName), clusterService.getClusterVersion(), false, logger)) {
+                continue;
+            }
 
-            if (checkMergePolicySupportsInMemoryFormat(dataStructureName,
-                    getMergePolicy(dataStructureName).getClass().getName(),
-                    getInMemoryFormat(dataStructureName),
-                    clusterService.getClusterVersion(), false, logger)) {
-
-                Collection<Store> recordStores = entry.getValue();
-                for (Store recordStore : recordStores) {
-                    consumeStoreLegacy(recordStore, consumer);
-                }
+            Collection<Store> recordStores = entry.getValue();
+            for (Store recordStore : recordStores) {
+                consumeStoreLegacy(recordStore, consumer);
             }
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -17,21 +17,32 @@
 package com.hazelcast.internal.config;
 
 import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.eviction.EvictableEntryView;
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.map.merge.MergePolicyProvider;
+import com.hazelcast.map.merge.PutIfAbsentMapMergePolicy;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
+import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 import static com.hazelcast.config.InMemoryFormat.BINARY;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
@@ -41,14 +52,34 @@ import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.INVALIDATE;
 import static com.hazelcast.internal.config.ConfigValidator.checkCacheConfig;
 import static com.hazelcast.internal.config.ConfigValidator.checkEvictionConfig;
 import static com.hazelcast.internal.config.ConfigValidator.checkMapConfig;
+import static com.hazelcast.internal.config.ConfigValidator.checkMergePolicySupportsInMemoryFormat;
 import static com.hazelcast.internal.config.ConfigValidator.checkNearCacheConfig;
 import static com.hazelcast.internal.config.ConfigValidator.checkNearCacheNativeMemoryConfig;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ConfigValidatorTest extends HazelcastTestSupport {
 
+    private static final ILogger LOGGER = Logger.getLogger(ConfigValidatorTest.class);
+
     private static final String MAP_NAME = "default";
+
+    private MergePolicyProvider mapMergePolicyProvider;
+
+    @Before
+    public void setUp() {
+        Config config = new Config();
+        NodeEngine nodeEngine = Mockito.mock(NodeEngine.class);
+        when(nodeEngine.getConfigClassLoader()).thenReturn(config.getClassLoader());
+
+        SplitBrainMergePolicyProvider splitBrainMergePolicyProvider = new SplitBrainMergePolicyProvider(nodeEngine);
+        when(nodeEngine.getSplitBrainMergePolicyProvider()).thenReturn(splitBrainMergePolicyProvider);
+
+        mapMergePolicyProvider = new MergePolicyProvider(nodeEngine);
+    }
 
     @Test
     public void testConstructor() {
@@ -386,5 +417,93 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
         }
         evictionConfig.setEvictionPolicy(evictionPolicy);
         return evictionConfig;
+    }
+
+    @Test
+    public void testCheckMergePolicySupportsInMemoryFormat_withMergePolicy_with310_OBJECT() {
+        Object mergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMergePolicy.class.getName());
+        assertTrue(checkMergePolicySupportsInMemoryFormat("myMap", mergePolicy, OBJECT, Versions.V3_10, false, LOGGER));
+    }
+
+    @Test
+    public void testCheckMergePolicySupportsInMemoryFormat_withLegacyMergePolicy_with310_OBJECT() {
+        Object legacyMergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMapMergePolicy.class.getName());
+        assertTrue(checkMergePolicySupportsInMemoryFormat("myMap", legacyMergePolicy, OBJECT, Versions.V3_10, false, LOGGER));
+    }
+
+    @Test
+    public void testCheckMergePolicySupportsInMemoryFormat_withMergePolicy_with310_NATIVE() {
+        Object mergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMergePolicy.class.getName());
+        assertTrue(checkMergePolicySupportsInMemoryFormat("myMap", mergePolicy, NATIVE, Versions.V3_10, false, LOGGER));
+    }
+
+    /**
+     * A legacy merge policy cannot merge NATIVE maps.
+     */
+    @Test
+    public void testCheckMergePolicySupportsInMemoryFormat_withLegacyMergePolicy_with310_NATIVE() {
+        Object legacyMergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMapMergePolicy.class.getName());
+        assertFalse(checkMergePolicySupportsInMemoryFormat("myMap", legacyMergePolicy, NATIVE, Versions.V3_10, false, LOGGER));
+    }
+
+    /**
+     * A legacy merge policy cannot merge NATIVE maps.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testCheckMergePolicySupportsInMemoryFormat_withLegacyMergePolicy_with310_NATIVE_failFast() {
+        Object legacyMergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMapMergePolicy.class.getName());
+        checkMergePolicySupportsInMemoryFormat("myMap", legacyMergePolicy, NATIVE, Versions.V3_10, true, LOGGER);
+    }
+
+    @Test
+    public void testCheckMergePolicySupportsInMemoryFormat_withMergePolicy_with39_OBJECT() {
+        Object mergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMergePolicy.class.getName());
+        assertTrue(checkMergePolicySupportsInMemoryFormat("myMap", mergePolicy, OBJECT, Versions.V3_9, false, LOGGER));
+    }
+
+    @Test
+    public void testCheckMergePolicySupportsInMemoryFormat_withLegacyMergePolicy_with39_OBJECT() {
+        Object legacyMergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMapMergePolicy.class.getName());
+        assertTrue(checkMergePolicySupportsInMemoryFormat("myMap", legacyMergePolicy, OBJECT, Versions.V3_9, false, LOGGER));
+    }
+
+    /**
+     * A 3.9 cluster cannot merge NATIVE maps.
+     */
+    @Test
+    public void testCheckMergePolicySupportsInMemoryFormat_withMergePolicy_with39_NATIVE() {
+        Object mergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMergePolicy.class.getName());
+        assertFalse(checkMergePolicySupportsInMemoryFormat("myMap", mergePolicy, NATIVE, Versions.V3_9, false, LOGGER));
+    }
+
+    /**
+     * A 3.9 cluster cannot merge NATIVE maps.
+     */
+    @Test
+    public void testCheckMergePolicySupportsInMemoryFormat_withLegacyMergePolicy_with39_NATIVE() {
+        Object legacyMergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMapMergePolicy.class.getName());
+        assertFalse(checkMergePolicySupportsInMemoryFormat("myMap", legacyMergePolicy, NATIVE, Versions.V3_9, false, LOGGER));
+    }
+
+    /**
+     * A 3.9 cluster cannot merge NATIVE maps, but will not throw an exception, even if fail-fast is configured.
+     * <p>
+     * This is for compatibility with existing setups.
+     */
+    @Test
+    public void testCheckMergePolicySupportsInMemoryFormat_withMergePolicy_with39_NATIVE_failFast() {
+        Object mergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMergePolicy.class.getName());
+        assertFalse(checkMergePolicySupportsInMemoryFormat("myMap", mergePolicy, NATIVE, Versions.V3_9, true, LOGGER));
+    }
+
+    /**
+     * A 3.9 cluster cannot merge NATIVE maps, but will not throw an exception, even if fail-fast is configured.
+     * <p>
+     * This is for compatibility with existing setups.
+     */
+    @Test
+    public void testCheckMergePolicySupportsInMemoryFormat_withLegacyMergePolicy_with39_NATIVE_failFast() {
+        Object legacyMergePolicy = mapMergePolicyProvider.getMergePolicy(PutIfAbsentMapMergePolicy.class.getName());
+        assertFalse(checkMergePolicySupportsInMemoryFormat("myMap", legacyMergePolicy, NATIVE, Versions.V3_9, true, LOGGER));
     }
 }


### PR DESCRIPTION
`ConfigValidator.checkMergePolicySupportsInMemoryFormat()` used a simple `Class.for()` to create a merge policy instance, which didn't work with simple class names (the default for 3.10 merge policies):

> java.lang.ClassNotFoundException: PutIfAbsentMergePolicy

This PR makes use of the existing merge policy providers to retrieve an instance of the configured merge policy.

It also replaced `CacheProxyUtil.validateCacheConfig()` calls with `ConfigValidator.checkCacheConfig()`, to prepare the upcoming changes.