### PR TITLE
Client lock operations should use StringPartitioningStrategy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockForceUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockForceUnlockMessageTask.java
@@ -25,6 +25,7 @@ import com.hazelcast.concurrent.lock.operations.UnlockOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.LockPermission;
 import com.hazelcast.spi.Operation;
@@ -40,7 +41,7 @@ public class LockForceUnlockMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        final Data key = serializationService.toData(parameters.name);
+        final Data key = serializationService.toData(parameters.name, StringPartitioningStrategy.INSTANCE);
         return new UnlockOperation(new InternalLockNamespace(parameters.name), key, -1, true, parameters.referenceId);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockGetLockCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockGetLockCountMessageTask.java
@@ -25,6 +25,7 @@ import com.hazelcast.concurrent.lock.operations.GetLockCountOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.LockPermission;
 import com.hazelcast.spi.Operation;
@@ -40,7 +41,7 @@ public class LockGetLockCountMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        Data key = serializationService.toData(parameters.name);
+        Data key = serializationService.toData(parameters.name, StringPartitioningStrategy.INSTANCE);
         return new GetLockCountOperation(new InternalLockNamespace(parameters.name), key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockGetRemainingLeaseTimeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockGetRemainingLeaseTimeMessageTask.java
@@ -25,6 +25,7 @@ import com.hazelcast.concurrent.lock.operations.GetRemainingLeaseTimeOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.LockPermission;
 import com.hazelcast.spi.Operation;
@@ -40,7 +41,7 @@ public class LockGetRemainingLeaseTimeMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        final Data key = serializationService.toData(parameters.name);
+        final Data key = serializationService.toData(parameters.name, StringPartitioningStrategy.INSTANCE);
         return new GetRemainingLeaseTimeOperation(new InternalLockNamespace(parameters.name), key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockIsLockedByCurrentThreadMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockIsLockedByCurrentThreadMessageTask.java
@@ -25,6 +25,7 @@ import com.hazelcast.concurrent.lock.operations.IsLockedOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.LockPermission;
 import com.hazelcast.spi.Operation;
@@ -41,7 +42,7 @@ public class LockIsLockedByCurrentThreadMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        final Data key = serializationService.toData(parameters.name);
+        final Data key = serializationService.toData(parameters.name, StringPartitioningStrategy.INSTANCE);
         return new IsLockedOperation(new InternalLockNamespace(parameters.name), key, parameters.threadId);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockIsLockedMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockIsLockedMessageTask.java
@@ -25,6 +25,7 @@ import com.hazelcast.concurrent.lock.operations.IsLockedOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.LockPermission;
 import com.hazelcast.spi.Operation;
@@ -40,7 +41,7 @@ public class LockIsLockedMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        final Data key = serializationService.toData(parameters.name);
+        final Data key = serializationService.toData(parameters.name, StringPartitioningStrategy.INSTANCE);
         return new IsLockedOperation(new InternalLockNamespace(parameters.name), key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockLockMessageTask.java
@@ -25,6 +25,7 @@ import com.hazelcast.concurrent.lock.operations.LockOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.LockPermission;
 import com.hazelcast.spi.Operation;
@@ -41,7 +42,7 @@ public class LockLockMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        Data key = serializationService.toData(parameters.name);
+        Data key = serializationService.toData(parameters.name, StringPartitioningStrategy.INSTANCE);
         return new LockOperation(new InternalLockNamespace(parameters.name)
                 , key, parameters.threadId, parameters.leaseTime, -1, parameters.referenceId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockTryLockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockTryLockMessageTask.java
@@ -25,6 +25,7 @@ import com.hazelcast.concurrent.lock.operations.LockOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.LockPermission;
 import com.hazelcast.spi.Operation;
@@ -41,7 +42,7 @@ public class LockTryLockMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        Data key = serializationService.toData(parameters.name);
+        Data key = serializationService.toData(parameters.name, StringPartitioningStrategy.INSTANCE);
         return new LockOperation(new InternalLockNamespace(parameters.name)
                 , key, parameters.threadId, parameters.lease, parameters.timeout, parameters.referenceId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockUnlockMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/lock/LockUnlockMessageTask.java
@@ -25,6 +25,7 @@ import com.hazelcast.concurrent.lock.operations.UnlockOperation;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.LockPermission;
 import com.hazelcast.spi.Operation;
@@ -40,7 +41,7 @@ public class LockUnlockMessageTask
 
     @Override
     protected Operation prepareOperation() {
-        final Data key = serializationService.toData(parameters.name);
+        final Data key = serializationService.toData(parameters.name, StringPartitioningStrategy.INSTANCE);
         return new UnlockOperation(new InternalLockNamespace(parameters.name), key, parameters.threadId, false,
                 parameters.referenceId);
     }

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -447,6 +447,22 @@ public class LockAdvancedTest extends HazelcastTestSupport {
         }, 30);
     }
 
+    @Test
+    public void testLockLease_withStringPartitionAwareName() throws Exception {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz = factory.newHazelcastInstance();
+        final ILock lock = hz.getLock(randomName() + "@hazelcast");
+
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                lock.lock(5, TimeUnit.SECONDS);
+            }
+        }).get();
+
+        assertTrue("Lock should have been released after lease expires", lock.tryLock(2, TimeUnit.MINUTES));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testLockFail_whenGreaterThanMaxLeaseTimeUsed() {
         Config config = new Config();


### PR DESCRIPTION
Client lock messages are sent to correct partition by calculating `partitionId`
using `StringPartitioningStrategy` in `PartitionSpecificClientProxy`.
But lock operations created in specific `MessageTask`s serialize lock name
using default partitioning strategy. Default strategy creates serialized keys
without partitionHash.
`partitionId` calculated using that key will not be the correct one
when lock is created with a partition aware name (a name using `@` inside).

Fixes #12614

Backport of https://github.com/hazelcast/hazelcast/pull/12636