### PR TITLE
Fixed FindBugs issue in AbstractMultipleEntryBackupOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.map.EntryBackupProcessor;
-import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.impl.Versioned;
@@ -32,8 +31,7 @@ import java.io.IOException;
  */
 abstract class AbstractMultipleEntryBackupOperation extends MapOperation implements Versioned {
 
-    protected MapEntries responses;
-    protected EntryBackupProcessor backupProcessor;
+    EntryBackupProcessor backupProcessor;
 
     public AbstractMultipleEntryBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryBackupOperation.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -41,7 +40,6 @@ public class PartitionWideEntryBackupOperation extends AbstractMultipleEntryBack
 
     @Override
     public void run() {
-        responses = new MapEntries(recordStore.size());
         EntryOperator operator = operator(this, backupProcessor, getPredicate());
 
         Iterator<Record> iterator = recordStore.iterator(Clock.currentTimeMillis(), true);


### PR DESCRIPTION
Either we miss to do something with `responses` or it's really an unused field by now.