### PR TITLE
Serialize WAN event collection size on unknown and 3.9 cluster version

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
@@ -49,7 +49,7 @@ abstract class AbstractMultipleEntryBackupOperation extends MapOperation impleme
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         // RU_COMPAT_3_9
-        if (!out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
+        if (out.getVersion().isUnknownOrLessThan(Versions.V3_10)) {
             out.writeInt(0);
         }
     }
@@ -58,12 +58,15 @@ abstract class AbstractMultipleEntryBackupOperation extends MapOperation impleme
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         // RU_COMPAT_3_9
-        if (!in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
+        if (in.getVersion().isUnknownOrLessThan(Versions.V3_10)) {
             final int size = in.readInt();
             for (int i = 0; i < size; i++) {
-                in.readData(); // key
-                in.readData(); // value
-                in.readInt(); // event type
+                // key
+                in.readData();
+                // value
+                in.readData();
+                // event type
+                in.readInt();
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
@@ -49,7 +49,7 @@ abstract class AbstractMultipleEntryBackupOperation extends MapOperation impleme
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         // RU_COMPAT_3_9
-        if (out.getVersion().isLessThan(Versions.V3_10)) {
+        if (!out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
             out.writeInt(0);
         }
     }
@@ -58,8 +58,13 @@ abstract class AbstractMultipleEntryBackupOperation extends MapOperation impleme
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         // RU_COMPAT_3_9
-        if (in.getVersion().isLessThan(Versions.V3_10)) {
-            in.readInt();
+        if (!in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
+            final int size = in.readInt();
+            for (int i = 0; i < size; i++) {
+                in.readData(); // key
+                in.readData(); // value
+                in.readInt(); // event type
+            }
         }
     }
 }


### PR DESCRIPTION
3.9 members may send the operation with the version UNKNOWN in which
case the collection wasn't read, causing further deserialisation to read
the collection data.
The fix reads the collection data if the input version is UNKNOWN or
less than 3.10.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/1996
EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/1999