### PR TITLE
Fixes version comparisons in conditional serialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/SparseHyperLogLogEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/hyperloglog/impl/SparseHyperLogLogEncoder.java
@@ -122,7 +122,7 @@ public class SparseHyperLogLogEncoder
     public void readData(ObjectDataInput in) throws IOException {
         int p = in.readInt();
         // RU_COMPAT_3_9
-        if (in.getVersion().isLessThan(V3_10)) {
+        if (in.getVersion().isUnknownOrLessThan(V3_10)) {
             in.readInt();
         }
         int total = in.readInt();

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -421,7 +421,7 @@ public class ReplicatedMapConfig implements IdentifiedDataSerializable, Versione
         asyncFillup = in.readBoolean();
         statisticsEnabled = in.readBoolean();
         // RU_COMPAT_3_9
-        if (in.getVersion().isLessThan(Versions.V3_10)) {
+        if (in.getVersion().isUnknownOrLessThan(Versions.V3_10)) {
             mergePolicyConfig.setPolicy(in.readUTF());
         }
         listenerConfigs = readNullableList(in);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -856,9 +856,6 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
      */
     public <R> Iterator<R> iterator(int fetchSize, int partitionId, Projection<Map.Entry<K, V>, R> projection,
                                     Predicate<K, V> predicate) {
-        if (getNodeEngine().getClusterService().getClusterVersion().isLessThan(Versions.V3_9)) {
-            throw new UnsupportedOperationException("Iterate map by query is available when cluster version is 3.9 or higher");
-        }
         if (predicate instanceof PagingPredicate) {
             throw new IllegalArgumentException("Paging predicate is not allowed when iterating map by query");
         }

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/helpers/Employee.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/helpers/Employee.java
@@ -21,6 +21,8 @@ import java.util.Random;
 
 public class Employee implements Serializable, Comparable<Employee> {
 
+    public static final long serialVersionUID = 5850489412220165243l;
+
     public static final int MAX_AGE = 75;
     public static final double MAX_SALARY = 1000.0;
 


### PR DESCRIPTION
- In `SparseHyperLogLogEncoder` & `ReplicatedMapConfig` the comparison `in.isLessThan(V3_10)` will return `false` for a stream coming from a 3.9 member, because in 3.9 these classes are not `Versioned` -> the stream will have `UNKNOWN` version. Kudos to @mmedenjak for identifying the issue!
- Removes a 3.8-specific condition in `MapProxyImpl`
- Introduces serial version UID for `Employee` test class so the current version's serialized form is compatible with the one present in 3.9 (otherwise `SerializedObjectsCompatibilityTest` fails). 