### PR TITLE
Drop heartbeat messages before suspicion to correctly split cluster

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipFailureTest.java
@@ -52,6 +52,7 @@ import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.HEAR
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.HEARTBEAT_COMPLAINT;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MASTER_CONFIRM;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMBER_INFO_UPDATE;
+import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.SPLIT_BRAIN_MERGE_VALIDATION;
 import static com.hazelcast.internal.cluster.impl.MembershipUpdateTest.assertMemberViewsAreSame;
 import static com.hazelcast.internal.cluster.impl.MembershipUpdateTest.getMemberMap;
 import static com.hazelcast.spi.properties.GroupProperty.HEARTBEAT_INTERVAL_SECONDS;
@@ -555,8 +556,8 @@ public class MembershipFailureTest extends HazelcastTestSupport {
     @Test
     public void slave_splits_and_eventually_merges_back() {
         Config config = new Config();
-        config.setProperty(MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "15")
-              .setProperty(MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
+        config.setProperty(MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5")
+                .setProperty(MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
         final HazelcastInstance member1 = newHazelcastInstance(config);
         final HazelcastInstance member2 = newHazelcastInstance(config);
         final HazelcastInstance member3 = newHazelcastInstance(config);
@@ -574,13 +575,27 @@ public class MembershipFailureTest extends HazelcastTestSupport {
             }
         });
 
+        // prevent heartbeats to member3 to prevent suspicion to be removed
+        dropOperationsBetween(member1, member3, F_ID, singletonList(HEARTBEAT));
+        dropOperationsBetween(member2, member3, F_ID, singletonList(HEARTBEAT));
+        dropOperationsFrom(member3, F_ID, singletonList(SPLIT_BRAIN_MERGE_VALIDATION));
         suspectMember(member3, member1);
         suspectMember(member3, member2);
         assertClusterSizeEventually(1, member3);
 
+        resetPacketFiltersFrom(member1);
+        resetPacketFiltersFrom(member2);
+        resetPacketFiltersFrom(member3);
         assertOpenEventually(mergeLatch);
-        assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member2));
+
         assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member3));
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertMemberViewsAreSame(getMemberMap(member1), getMemberMap(member2));
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/12619

Backport of https://github.com/hazelcast/hazelcast/pull/12647