### PR TITLE
Fix testAsyncConnectionCreationInAsyncMethods

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -198,12 +197,20 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         ClientConfig config = new ClientConfig();
         WaitingCredentials credentials = new WaitingCredentials("dev", "dev-pass", countDownLatch);
         config.setCredentials(credentials);
-        HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
         final IExecutorService executorService = client.getExecutorService(randomString());
 
         credentials.waitFlag.set(true);
 
         final HazelcastInstance secondInstance = hazelcastFactory.newHazelcastInstance();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(2, client.getCluster().getMembers().size());
+            }
+        });
+
         final AtomicReference<Future> atomicReference = new AtomicReference<Future>();
         Thread thread = new Thread(new Runnable() {
             @Override


### PR DESCRIPTION
Fix makes client wait for memberlist size to become 2 before
proceeding to test so that submitToMember would not fail.

fixes https://github.com/hazelcast/hazelcast/issues/12502