### PR TITLE
 Increase default value of hazelcast.client.endpoint.remove.delay.seconds

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -112,7 +112,7 @@ public final class GroupProperty {
      * With this property, client has a window to connect back and prevent cleaning up its resources.
      */
     public static final HazelcastProperty CLIENT_ENDPOINT_REMOVE_DELAY_SECONDS
-            = new HazelcastProperty("hazelcast.client.endpoint.remove.delay.seconds", 10);
+            = new HazelcastProperty("hazelcast.client.endpoint.remove.delay.seconds", 60);
     /**
      * Number of threads for the {@link com.hazelcast.spi.impl.eventservice.impl.EventServiceImpl} executor.
      * The executor is responsible for executing the events. If you process a lot of events and have many cores, setting


### PR DESCRIPTION
 Following scenario is likely to happen with current default(10 seconds)

1. lets say client is disconnected from owner and trying to find a new owner
2. (hazelcast.client.endpoint.remove.delay.seconds”, 10 ) has passed. Client resources are cleaned up.
3. we let the client a acquire a lock while searching for a new owner connection.
4. Client application shutdown.
5. In this scenario there will be a lock hanging forever, because there is no owner of the client .

By increasing default of “hazelcast.client.endpoint.remove.delay.seconds” to a minute,
we will reduce the possibility.