### PR TITLE
Cleanup of ConfigValidator tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorEvictionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorEvictionConfigTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.EvictionConfig;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.internal.eviction.EvictableEntryView;
+import com.hazelcast.internal.eviction.EvictionPolicyComparator;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.internal.config.ConfigValidator.checkEvictionConfig;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidatorEvictionConfigTest extends HazelcastTestSupport {
+
+    @Test
+    public void checkEvictionConfig_forMapAndCache() {
+        checkEvictionConfig(getEvictionConfig(false, false), false);
+    }
+
+    @Test
+    public void checkEvictionConfig_forNearCache() {
+        checkEvictionConfig(getEvictionConfig(false, false, EvictionPolicy.RANDOM), true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_withNull() {
+        checkEvictionConfig(null, false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_withNull_forNearCache() {
+        checkEvictionConfig(null, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenBothOfComparatorAndComparatorClassNameAreSet() {
+        checkEvictionConfig(getEvictionConfig(true, true), false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenBothOfComparatorAndComparatorClassNameAreSet_forNearCache() {
+        checkEvictionConfig(getEvictionConfig(true, true), true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsNone() {
+        checkEvictionConfig(getEvictionConfig(false, false, EvictionPolicy.NONE), false);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsNone() {
+        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.NONE), false);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsNone() {
+        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.NONE), false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsRandom() {
+        checkEvictionConfig(getEvictionConfig(false, false, EvictionPolicy.RANDOM), false);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsRandom() {
+        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.RANDOM), false);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsRandom() {
+        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.RANDOM), false);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsNotSet() {
+        checkEvictionConfig(getEvictionConfig(true, false), false);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsNotSet() {
+        checkEvictionConfig(getEvictionConfig(false, true), false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsAlsoSet() {
+        // default eviction policy is LRU (see EvictionConfig.DEFAULT_EVICTION_POLICY)
+        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.LFU), false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsAlsoSet() {
+        // default eviction policy is LRU (see EvictionConfig.DEFAULT_EVICTION_POLICY)
+        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.LFU), false);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsNone_forNearCache() {
+        checkEvictionConfig(getEvictionConfig(false, false, EvictionPolicy.NONE), true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsNone_forNearCache() {
+        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.NONE), true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsNone_forNearCache() {
+        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.NONE), true);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsRandom_forNearCache() {
+        checkEvictionConfig(getEvictionConfig(false, false, EvictionPolicy.RANDOM), true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsRandom_forNearCache() {
+        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.RANDOM), true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsRandom_forNearCache() {
+        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.RANDOM), true);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsNotSet_forNearCache() {
+        checkEvictionConfig(getEvictionConfig(true, false), true);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsNotSet_forNearCache() {
+        checkEvictionConfig(getEvictionConfig(false, true), true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsAlsoSet_forNearCache() {
+        // default eviction policy is LRU (see EvictionConfig.DEFAULT_EVICTION_POLICY)
+        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.LFU), true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsAlsoSet_forNearCache() {
+        // default eviction policy is LRU (see EvictionConfig.DEFAULT_EVICTION_POLICY)
+        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.LFU), true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsNull() {
+        checkEvictionConfig(null, null, null, false);
+    }
+
+    @Test
+    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsNull_forNearCache() {
+        checkEvictionConfig(null, null, null, true);
+    }
+
+    private EvictionConfig getEvictionConfig(boolean setComparatorClass, boolean setComparator) {
+        return getEvictionConfig(setComparatorClass, setComparator, EvictionConfig.DEFAULT_EVICTION_POLICY);
+    }
+
+    private EvictionConfig getEvictionConfig(boolean setComparatorClass, boolean setComparator, EvictionPolicy evictionPolicy) {
+        EvictionConfig evictionConfig = new EvictionConfig();
+        if (setComparatorClass) {
+            evictionConfig.setComparatorClassName("myComparatorClass");
+        }
+        if (setComparator) {
+            evictionConfig.setComparator(new EvictionPolicyComparator() {
+                @Override
+                public int compare(EvictableEntryView e1, EvictableEntryView e2) {
+                    return 0;
+                }
+
+                public int compare(Object o1, Object o2) {
+                    return 0;
+                }
+            });
+        }
+        evictionConfig.setEvictionPolicy(evictionPolicy);
+        return evictionConfig;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorNearCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorNearCacheConfigTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.config;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.config.InMemoryFormat.BINARY;
+import static com.hazelcast.config.InMemoryFormat.NATIVE;
+import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE;
+import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.INVALIDATE;
+import static com.hazelcast.internal.config.ConfigValidator.checkNearCacheConfig;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ConfigValidatorNearCacheConfigTest extends HazelcastTestSupport {
+
+    private static final String MAP_NAME = "default";
+
+    @Test
+    public void checkNearCacheConfig_BINARY() {
+        checkNearCacheConfig(MAP_NAME, getNearCacheConfig(BINARY), null, false);
+    }
+
+    @Test
+    public void checkNearCacheConfig_OBJECT() {
+        checkNearCacheConfig(MAP_NAME, getNearCacheConfig(OBJECT), null, false);
+    }
+
+    /**
+     * Not supported in open source version, so test is expected to throw exception.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void checkNearCacheConfig_NATIVE() {
+        checkNearCacheConfig(MAP_NAME, getNearCacheConfig(NATIVE), null, false);
+    }
+
+    /**
+     * Not supported client configuration, so test is expected to throw exception.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void checkNearCacheConfig_withUnsupportedClientConfig() {
+        checkNearCacheConfig(MAP_NAME, getNearCacheConfig(BINARY), null, true);
+    }
+
+    @Test
+    public void checkNearCacheConfig_withPreLoaderConfig_onClients() {
+        NearCacheConfig nearCacheConfig = getNearCacheConfig(BINARY)
+                .setCacheLocalEntries(false);
+        nearCacheConfig.getPreloaderConfig()
+                .setEnabled(true)
+                .setStoreInitialDelaySeconds(1)
+                .setStoreInitialDelaySeconds(1);
+
+        checkNearCacheConfig(MAP_NAME, nearCacheConfig, null, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkNearCacheConfig_withPreloaderConfig_onMembers() {
+        NearCacheConfig nearCacheConfig = getNearCacheConfig(BINARY);
+        nearCacheConfig.getPreloaderConfig()
+                .setEnabled(true)
+                .setStoreInitialDelaySeconds(1)
+                .setStoreInitialDelaySeconds(1);
+
+        checkNearCacheConfig(MAP_NAME, nearCacheConfig, null, false);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void checkNearCacheConfig_withLocalUpdatePolicy_CACHE_ON_UPDATE() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig()
+                .setLocalUpdatePolicy(CACHE_ON_UPDATE);
+
+        checkNearCacheConfig(MAP_NAME, nearCacheConfig, null, false);
+    }
+
+    @Test
+    public void checkNearCacheConfig_withLocalUpdatePolicy_INVALIDATE() {
+        NearCacheConfig nearCacheConfig = new NearCacheConfig()
+                .setLocalUpdatePolicy(INVALIDATE);
+
+        checkNearCacheConfig(MAP_NAME, nearCacheConfig, null, false);
+    }
+
+    private NearCacheConfig getNearCacheConfig(InMemoryFormat inMemoryFormat) {
+        return new NearCacheConfig()
+                .setInMemoryFormat(inMemoryFormat)
+                .setCacheLocalEntries(true);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/ConfigValidatorTest.java
@@ -19,14 +19,10 @@ package com.hazelcast.internal.config;
 import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionConfig;
-import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.NativeMemoryConfig;
-import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.internal.cluster.Versions;
-import com.hazelcast.internal.eviction.EvictableEntryView;
-import com.hazelcast.internal.eviction.EvictionPolicyComparator;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.merge.MergePolicyProvider;
@@ -47,13 +43,9 @@ import org.mockito.Mockito;
 import static com.hazelcast.config.InMemoryFormat.BINARY;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
-import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE;
-import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.INVALIDATE;
 import static com.hazelcast.internal.config.ConfigValidator.checkCacheConfig;
-import static com.hazelcast.internal.config.ConfigValidator.checkEvictionConfig;
 import static com.hazelcast.internal.config.ConfigValidator.checkMapConfig;
 import static com.hazelcast.internal.config.ConfigValidator.checkMergePolicySupportsInMemoryFormat;
-import static com.hazelcast.internal.config.ConfigValidator.checkNearCacheConfig;
 import static com.hazelcast.internal.config.ConfigValidator.checkNearCacheNativeMemoryConfig;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -64,8 +56,6 @@ import static org.mockito.Mockito.when;
 public class ConfigValidatorTest extends HazelcastTestSupport {
 
     private static final ILogger LOGGER = Logger.getLogger(ConfigValidatorTest.class);
-
-    private static final String MAP_NAME = "default";
 
     private MergePolicyProvider mapMergePolicyProvider;
 
@@ -120,180 +110,24 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
         checkMapConfig(mapConfig);
     }
 
-    @Test
-    public void checkNearCacheConfig_BINARY() {
-        checkNearCacheConfig(MAP_NAME, getNearCacheConfig(BINARY), null, false);
+    private MapConfig getMapConfig(InMemoryFormat inMemoryFormat) {
+        return new MapConfig()
+                .setInMemoryFormat(inMemoryFormat);
     }
 
     @Test
-    public void checkNearCacheConfig_OBJECT() {
-        checkNearCacheConfig(MAP_NAME, getNearCacheConfig(OBJECT), null, false);
-    }
+    public void checkCacheConfig_withEntryCountMaxSizePolicy_OBJECT() {
+        EvictionConfig evictionConfig = new EvictionConfig()
+                .setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT);
+        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig()
+                .setInMemoryFormat(OBJECT)
+                .setEvictionConfig(evictionConfig);
 
-    /**
-     * Not supported in open source version, so test is expected to throw exception.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void checkNearCacheConfig_NATIVE() {
-        checkNearCacheConfig(MAP_NAME, getNearCacheConfig(NATIVE), null, false);
-    }
-
-    /**
-     * Not supported client configuration, so test is expected to throw exception.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void checkNearCacheConfig_withUnsupportedClientConfig() {
-        checkNearCacheConfig(MAP_NAME, getNearCacheConfig(BINARY), null, true);
-    }
-
-    @Test
-    public void checkEvictionConfig_forMapAndCache() {
-        checkEvictionConfig(getEvictionConfig(false, false), false);
-    }
-
-    @Test
-    public void checkEvictionConfig_forNearCache() {
-        checkEvictionConfig(getEvictionConfig(false, false, EvictionPolicy.RANDOM), true);
-    }
-
-    @SuppressWarnings("ConstantConditions")
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_withNull() {
-        checkEvictionConfig(null, false);
-    }
-
-    @SuppressWarnings("ConstantConditions")
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_withNull_forNearCache() {
-        checkEvictionConfig(null, true);
+        checkCacheConfig(cacheSimpleConfig);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenBothOfComparatorAndComparatorClassNameAreSet() {
-        checkEvictionConfig(getEvictionConfig(true, true), false);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenBothOfComparatorAndComparatorClassNameAreSet_forNearCache() {
-        checkEvictionConfig(getEvictionConfig(true, true), true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsNone() {
-        checkEvictionConfig(getEvictionConfig(false, false, EvictionPolicy.NONE), false);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsNone() {
-        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.NONE), false);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsNone() {
-        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.NONE), false);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsRandom() {
-        checkEvictionConfig(getEvictionConfig(false, false, EvictionPolicy.RANDOM), false);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsRandom() {
-        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.RANDOM), false);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsRandom() {
-        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.RANDOM), false);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsNotSet() {
-        checkEvictionConfig(getEvictionConfig(true, false), false);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsNotSet() {
-        checkEvictionConfig(getEvictionConfig(false, true), false);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsAlsoSet() {
-        // default eviction policy is `LRU`. See `EvictionConfig.DEFAULT_EVICTION_POLICY`
-        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.LFU), false);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsAlsoSet() {
-        // default eviction policy is `LRU`. See `EvictionConfig.DEFAULT_EVICTION_POLICY`
-        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.LFU), false);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsNone_forNearCache() {
-        checkEvictionConfig(getEvictionConfig(false, false, EvictionPolicy.NONE), true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsNone_forNearCache() {
-        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.NONE), true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsNone_forNearCache() {
-        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.NONE), true);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsRandom_forNearCache() {
-        checkEvictionConfig(getEvictionConfig(false, false, EvictionPolicy.RANDOM), true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsRandom_forNearCache() {
-        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.RANDOM), true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsRandom_forNearCache() {
-        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.RANDOM), true);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsNotSet_forNearCache() {
-        checkEvictionConfig(getEvictionConfig(true, false), true);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsNotSet_forNearCache() {
-        checkEvictionConfig(getEvictionConfig(false, true), true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenComparatorClassNameIsSetIfEvictionPolicyIsAlsoSet_forNearCache() {
-        // default eviction policy is `LRU`. See `EvictionConfig.DEFAULT_EVICTION_POLICY`
-        checkEvictionConfig(getEvictionConfig(true, false, EvictionPolicy.LFU), true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenComparatorIsSetIfEvictionPolicyIsAlsoSet_forNearCache() {
-        // default eviction policy is `LRU`. See `EvictionConfig.DEFAULT_EVICTION_POLICY`
-        checkEvictionConfig(getEvictionConfig(false, true, EvictionPolicy.LFU), true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsNull() {
-        checkEvictionConfig(null, null, null, false);
-    }
-
-    @Test
-    public void checkEvictionConfig_whenNoneOfTheComparatorAndComparatorClassNameAreSetIfEvictionPolicyIsNull_forNearCache() {
-        checkEvictionConfig(null, null, null, true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkCacheConfig_whenNATIVEAndEntryCountMaxSizePolicy() {
+    public void checkCacheConfig_withEntryCountMaxSizePolicy_NATIVE() {
         EvictionConfig evictionConfig = new EvictionConfig()
                 .setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT);
         CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig()
@@ -304,119 +138,31 @@ public class ConfigValidatorTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void checkCacheConfig_whenOBJECTAndEntryCountMaxSizePolicy() {
-        EvictionConfig evictionConfig = new EvictionConfig()
-                .setMaximumSizePolicy(EvictionConfig.MaxSizePolicy.ENTRY_COUNT);
-        CacheSimpleConfig cacheSimpleConfig = new CacheSimpleConfig()
-                .setInMemoryFormat(OBJECT)
-                .setEvictionConfig(evictionConfig);
-
-        checkCacheConfig(cacheSimpleConfig);
+    public void checkNearCacheNativeMemoryConfig_shouldNotNeedNativeMemoryConfig_BINARY_onOS() {
+        checkNearCacheNativeMemoryConfig(BINARY, null, false);
     }
 
     @Test
-    public void checkNearCacheConfig_withPreLoaderConfig_onClients() {
-        NearCacheConfig nearCacheConfig = getNearCacheConfig(BINARY)
-                .setCacheLocalEntries(false);
-        nearCacheConfig.getPreloaderConfig()
-                .setEnabled(true)
-                .setStoreInitialDelaySeconds(1)
-                .setStoreInitialDelaySeconds(1);
-
-        checkNearCacheConfig(MAP_NAME, nearCacheConfig, null, true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkNearCacheConfig_withPreloaderConfig_onMembers() {
-        NearCacheConfig nearCacheConfig = getNearCacheConfig(BINARY);
-        nearCacheConfig.getPreloaderConfig()
-                .setEnabled(true)
-                .setStoreInitialDelaySeconds(1)
-                .setStoreInitialDelaySeconds(1);
-
-        checkNearCacheConfig(MAP_NAME, nearCacheConfig, null, false);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void checkNearCacheConfig_withLocalUpdatePolicy_CACHE_ON_UPDATE() {
-        NearCacheConfig nearCacheConfig = new NearCacheConfig()
-                .setLocalUpdatePolicy(CACHE_ON_UPDATE);
-
-        checkNearCacheConfig(MAP_NAME, nearCacheConfig, null, false);
+    public void checkNearCacheNativeMemoryConfig_shouldNotNeedNativeMemoryConfig_BINARY_onEE() {
+        checkNearCacheNativeMemoryConfig(BINARY, null, true);
     }
 
     @Test
-    public void checkNearCacheConfig_withLocalUpdatePolicy_INVALIDATE() {
-        NearCacheConfig nearCacheConfig = new NearCacheConfig()
-                .setLocalUpdatePolicy(INVALIDATE);
-
-        checkNearCacheConfig(MAP_NAME, nearCacheConfig, null, false);
+    public void checkNearCacheNativeMemoryConfig_shouldNotThrowExceptionWithoutNativeMemoryConfig_NATIVE_onOS() {
+        checkNearCacheNativeMemoryConfig(NATIVE, null, false);
     }
 
     @Test
-    public void should_not_need_native_memory_config_when_on_heap_memory_used_on_os() {
-        checkNearCacheNativeMemoryConfig(InMemoryFormat.BINARY, null, false);
-    }
-
-    @Test
-    public void should_not_need_native_memory_config_when_on_heap_memory_used_on_ee() {
-        checkNearCacheNativeMemoryConfig(InMemoryFormat.BINARY, null, true);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void should_throw_exception_without_native_memory_config_when_native_memory_used_on_ee() {
-        checkNearCacheNativeMemoryConfig(InMemoryFormat.NATIVE, null, true);
-    }
-
-    @Test
-    public void should_not_throw_exception_without_native_memory_config_when_native_memory_used_on_os() {
-        checkNearCacheNativeMemoryConfig(InMemoryFormat.NATIVE, null, false);
-    }
-
-    @Test
-    public void should_not_throw_exception_with_native_memory_config_when_native_memory_used_on_ee() {
+    public void checkNearCacheNativeMemoryConfig_shouldNotThrowExceptionWithNativeMemoryConfig_NATIVE_onEE() {
         NativeMemoryConfig nativeMemoryConfig = new NativeMemoryConfig()
                 .setEnabled(true);
 
-        checkNearCacheNativeMemoryConfig(InMemoryFormat.NATIVE, nativeMemoryConfig, true);
+        checkNearCacheNativeMemoryConfig(NATIVE, nativeMemoryConfig, true);
     }
 
-    private MapConfig getMapConfig(InMemoryFormat inMemoryFormat) {
-        return new MapConfig()
-                .setInMemoryFormat(inMemoryFormat);
-    }
-
-    private NearCacheConfig getNearCacheConfig(InMemoryFormat inMemoryFormat) {
-        return new NearCacheConfig()
-                .setInMemoryFormat(inMemoryFormat)
-                .setCacheLocalEntries(true);
-    }
-
-    private EvictionConfig getEvictionConfig(boolean setComparatorClass, boolean setComparator) {
-        return getEvictionConfig(setComparatorClass, setComparator, EvictionConfig.DEFAULT_EVICTION_POLICY);
-    }
-
-    private EvictionConfig getEvictionConfig(boolean setComparatorClass, boolean setComparator, EvictionPolicy evictionPolicy) {
-        EvictionConfig evictionConfig = new EvictionConfig();
-        if (setComparatorClass) {
-            evictionConfig.setComparatorClassName("myComparatorClass");
-        }
-        if (setComparator) {
-            evictionConfig.setComparator(new EvictionPolicyComparator() {
-                @Override
-                @SuppressWarnings("ComparatorMethodParameterNotUsed")
-                public int compare(EvictableEntryView e1, EvictableEntryView e2) {
-                    return 0;
-                }
-
-                @SuppressWarnings("ComparatorMethodParameterNotUsed")
-                public int compare(Object o1, Object o2) {
-                    return 0;
-                }
-            });
-        }
-        evictionConfig.setEvictionPolicy(evictionPolicy);
-        return evictionConfig;
+    @Test(expected = IllegalArgumentException.class)
+    public void checkNearCacheNativeMemoryConfig_shouldThrowExceptionWithoutNativeMemoryConfig_NATIVE_onEE() {
+        checkNearCacheNativeMemoryConfig(NATIVE, null, true);
     }
 
     @Test


### PR DESCRIPTION
* pulled out `ConfigValidatorEvictionConfigTest`
* pulled out `ConfigValidatorNearCacheConfigTest`
* fixed some tests names in `ConfigValidatorTest`

The `ConfigValidatorTest` was much too big, so I pulled out the tests for the `EvictionConfig` and `NearCacheConfig`. If I didn't mess up anything, there should be no changes in the test, just split-up, renaming and a little re-ordering. It's not nice to review though :(