### PR TITLE
Define MAX_JOIN_SECONDS on master config only to prevent join failures

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -240,13 +240,13 @@ public class MembershipManager {
         MemberMap memberMap = getMemberMap();
         MembersView membersView = memberMap.toMembersView();
 
+        if (logger.isFineEnabled()) {
+            logger.fine("Sending member list to the non-master nodes: " + memberListString());
+        }
+
         for (MemberImpl member : memberMap.getMembers()) {
             if (member.localMember()) {
                 continue;
-            }
-
-            if (logger.isFineEnabled()) {
-                logger.fine("Sending member list to the non-master nodes: " + memberListString());
             }
 
             MembersUpdateOp op = new MembersUpdateOp(member.getUuid(), membersView,

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -620,14 +620,16 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
     @Test
     public void memberListOrder_shouldBeSame_whenMemberRestartedWithSameIdentity() {
-        Config config = new Config();
-        config.setProperty(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
-        config.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "5");
+        Config configMaster = new Config();
+        configMaster.setProperty(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
+        // Needed only on master to prevent accepting stale join requests.
+        // See ClusterJoinManager#checkRecentlyJoinedMemberUuidBeforeJoin(target, uuid)
+        configMaster.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "5");
+        final HazelcastInstance hz1 = factory.newHazelcastInstance(configMaster);
 
-        final HazelcastInstance hz1 = factory.newHazelcastInstance(config);
-        final HazelcastInstance hz2 = factory.newHazelcastInstance(config);
-        HazelcastInstance hz3 = factory.newHazelcastInstance(config);
-        HazelcastInstance hz4 = factory.newHazelcastInstance(config);
+        final HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
+        HazelcastInstance hz4 = factory.newHazelcastInstance();
 
         assertClusterSizeEventually(4, hz2, hz3);
 
@@ -639,7 +641,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         assertClusterSizeEventually(3, hz1, hz4);
         assertClusterSize(4, hz2);
 
-        hz3 = newHazelcastInstance(config, "test-instance", new StaticMemberNodeContext(factory, member3));
+        hz3 = newHazelcastInstance(new Config(), "test-instance", new StaticMemberNodeContext(factory, member3));
 
         assertClusterSizeEventually(4, hz1, hz4);
 


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/12657