### PR TITLE
Skip tests which check for different hashCodes - they can give false negatives 

### DIFF
--- a/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/PackageDefinitionTest.java
+++ b/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/PackageDefinitionTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Set;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static java.lang.String.format;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
@@ -116,6 +117,7 @@ public class PackageDefinitionTest {
         assertEquals(packageDefinition.hashCode(), packageDefinitionOtherResolutionOptional.hashCode());
         assertEquals(packageDefinition.hashCode(), packageDefinitionOtherVersion.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(packageDefinition.hashCode(), packageDefinitionOtherPackageName.hashCode());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/AtomicLongConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AtomicLongConfigTest.java
@@ -48,6 +48,7 @@ public class AtomicLongConfigTest extends AbstractBasicConfigTest<AtomicLongConf
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(AtomicLongConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)

--- a/hazelcast/src/test/java/com/hazelcast/config/AtomicReferenceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AtomicReferenceConfigTest.java
@@ -48,6 +48,7 @@ public class AtomicReferenceConfigTest extends AbstractBasicConfigTest<AtomicRef
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(AtomicReferenceConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleConfigTest.java
@@ -76,6 +76,7 @@ public class CacheSimpleConfigTest extends HazelcastTestSupport {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         CacheSimpleEntryListenerConfig redEntryListenerConfig = new CacheSimpleEntryListenerConfig();
         redEntryListenerConfig.setCacheEntryListenerFactory("red");
         CacheSimpleEntryListenerConfig blackEntryListenerConfig = new CacheSimpleEntryListenerConfig();

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleEntryListenerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheSimpleEntryListenerConfigTest.java
@@ -21,6 +21,9 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -31,6 +34,7 @@ public class CacheSimpleEntryListenerConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         CacheSimpleEntryListenerConfig redEntryListenerConfig = new CacheSimpleEntryListenerConfig();
         redEntryListenerConfig.setCacheEntryListenerFactory("red");
         CacheSimpleEntryListenerConfig blackEntryListenerConfig = new CacheSimpleEntryListenerConfig();

--- a/hazelcast/src/test/java/com/hazelcast/config/CardinalityEstimatorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CardinalityEstimatorConfigTest.java
@@ -142,6 +142,7 @@ public class CardinalityEstimatorConfigTest extends HazelcastTestSupport {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(CardinalityEstimatorConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/CountDownLatchConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CountDownLatchConfigTest.java
@@ -78,6 +78,7 @@ public class CountDownLatchConfigTest extends HazelcastTestSupport {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(CountDownLatchConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)

--- a/hazelcast/src/test/java/com/hazelcast/config/DurableExecutorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/DurableExecutorConfigTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -60,6 +61,7 @@ public class DurableExecutorConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(DurableExecutorConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/EventJournalConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EventJournalConfigTest.java
@@ -22,6 +22,9 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -57,6 +60,7 @@ public class EventJournalConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(EventJournalConfig.class)
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();

--- a/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/EvictionConfigTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -37,6 +38,7 @@ public class EvictionConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(EvictionConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly", "sizeConfigured")
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/ExecutorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ExecutorConfigTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -55,6 +56,7 @@ public class ExecutorConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(ExecutorConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/GlobalSerializerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/GlobalSerializerConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class GlobalSerializerConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(GlobalSerializerConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/HotRestartConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/HotRestartConfigTest.java
@@ -21,6 +21,9 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -31,6 +34,7 @@ public class HotRestartConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(HotRestartConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/HotRestartPersistenceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/HotRestartPersistenceConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class HotRestartPersistenceConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(HotRestartPersistenceConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/IcmpFailureDetectorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/IcmpFailureDetectorConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class IcmpFailureDetectorConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(IcmpFailureDetectorConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/InterfacesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/InterfacesConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class InterfacesConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(InterfacesConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/ListConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ListConfigTest.java
@@ -23,6 +23,9 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -33,6 +36,7 @@ public class ListConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(ListConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/LockConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/LockConfigTest.java
@@ -26,6 +26,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertContains;
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -74,6 +75,7 @@ public class LockConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(LockConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapConfigTest.java
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith;
 import java.util.EventListener;
 import java.util.List;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -438,6 +439,7 @@ public class MapConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(MapConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/MapIndexConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapIndexConfigTest.java
@@ -26,6 +26,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.config.MapIndexConfig.validateIndexAttribute;
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -49,6 +50,7 @@ public class MapIndexConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(MapIndexConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/MapStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MapStoreConfigTest.java
@@ -264,6 +264,7 @@ public class MapStoreConfigTest extends HazelcastTestSupport {
 
     @Test
     public void testHashCode() {
+        assumeDifferentHashCodes();
         assertNotEquals(defaultCfg.hashCode(), cfgNotEnabled.hashCode());
         assertNotEquals(defaultCfg.hashCode(), cfgNotWriteCoalescing.hashCode());
         assertNotEquals(defaultCfg.hashCode(), cfgNonNullClassName.hashCode());
@@ -281,6 +282,7 @@ public class MapStoreConfigTest extends HazelcastTestSupport {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(MapStoreConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/MemberGroupConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MemberGroupConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class MemberGroupConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(MemberGroupConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/MergePolicyConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MergePolicyConfigTest.java
@@ -27,6 +27,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -127,6 +128,7 @@ public class MergePolicyConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(MergePolicyConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/MultiMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MultiMapConfigTest.java
@@ -31,6 +31,7 @@ import org.junit.runner.RunWith;
 
 import java.util.Locale;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertSame;
 
 /**
@@ -68,6 +69,7 @@ public class MultiMapConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(MultiMapConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/MulticastConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MulticastConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class MulticastConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(MulticastConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/NativeMemoryConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NativeMemoryConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class NativeMemoryConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(NativeMemoryConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/PartitionGroupConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/PartitionGroupConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class PartitionGroupConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(PartitionGroupConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/QueryCacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/QueryCacheConfigTest.java
@@ -115,6 +115,7 @@ public class QueryCacheConfigTest extends HazelcastTestSupport {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(QueryCacheConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/QueueConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/QueueConfigTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -85,6 +86,7 @@ public class QueueConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(QueueConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/QueueStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/QueueStoreConfigTest.java
@@ -21,6 +21,9 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -31,6 +34,7 @@ public class QueueStoreConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(QueueStoreConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executor;
 import static com.hazelcast.config.ReliableTopicConfig.DEFAULT_READ_BATCH_SIZE;
 import static com.hazelcast.config.ReliableTopicConfig.DEFAULT_STATISTICS_ENABLED;
 import static com.hazelcast.config.ReliableTopicConfig.DEFAULT_TOPIC_OVERLOAD_POLICY;
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static com.hazelcast.topic.TopicOverloadPolicy.DISCARD_NEWEST;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -228,6 +229,7 @@ public class ReliableTopicConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(ReliableTopicConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigTest.java
@@ -23,6 +23,9 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -33,6 +36,7 @@ public class ReplicatedMapConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(ReplicatedMapConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferConfigTest.java
@@ -33,6 +33,7 @@ import static com.hazelcast.config.RingbufferConfig.DEFAULT_ASYNC_BACKUP_COUNT;
 import static com.hazelcast.config.RingbufferConfig.DEFAULT_CAPACITY;
 import static com.hazelcast.config.RingbufferConfig.DEFAULT_SYNC_BACKUP_COUNT;
 import static com.hazelcast.internal.partition.InternalPartition.MAX_BACKUP_COUNT;
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -320,6 +321,7 @@ public class RingbufferConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(RingbufferConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/RingbufferStoreConfigTest.java
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith;
 import java.util.Properties;
 
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -110,6 +111,7 @@ public class RingbufferStoreConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(RingbufferStoreConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/ScheduledExecutorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ScheduledExecutorConfigTest.java
@@ -71,6 +71,7 @@ public class ScheduledExecutorConfigTest extends HazelcastTestSupport {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(ScheduledExecutorConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NULL_FIELDS, Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/SemaphoreConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SemaphoreConfigTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -51,6 +52,7 @@ public class SemaphoreConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(SemaphoreConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/SerializerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SerializerConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class SerializerConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(SerializerConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
@@ -68,6 +68,7 @@ public class ServiceConfigTest extends HazelcastTestSupport {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(ServiceConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/ServicesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ServicesConfigTest.java
@@ -18,11 +18,15 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class ServicesConfigTest {
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(ServicesConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/SetConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SetConfigTest.java
@@ -23,6 +23,9 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -33,6 +36,7 @@ public class SetConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(SetConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/SocketInterceptorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SocketInterceptorConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class SocketInterceptorConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(SocketInterceptorConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/TcpIpConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/TcpIpConfigTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.config;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class TcpIpConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(TcpIpConfig.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/config/TopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/TopicConfigTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -107,6 +108,7 @@ public class TopicConfigTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(TopicConfig.class)
                 .withPrefabValues(TopicConfigReadOnly.class,
                         new TopicConfigReadOnly(new TopicConfig("Topic1")),

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/impl/operations/DurableExecutorWaitNotifyKeyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/impl/operations/DurableExecutorWaitNotifyKeyTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -64,6 +65,7 @@ public class DurableExecutorWaitNotifyKeyTest {
         assertEquals(notifyKey.hashCode(), notifyKey.hashCode());
         assertEquals(notifyKey.hashCode(), notifyKeySameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(notifyKey.hashCode(), notifyKeyOtherUniqueId.hashCode());
         assertNotEquals(notifyKey.hashCode(), notifyKeyOtherName.hashCode());
     }

--- a/hazelcast/src/test/java/com/hazelcast/hotrestart/BackupTaskStatusTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/hotrestart/BackupTaskStatusTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -73,6 +74,7 @@ public class BackupTaskStatusTest {
         assertEquals(backupTaskStatus.hashCode(), backupTaskStatus.hashCode());
         assertEquals(backupTaskStatus.hashCode(), backupTaskStatusWithSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(backupTaskStatus.hashCode(), backupTaskStatusOtherState.hashCode());
         assertNotEquals(backupTaskStatus.hashCode(), backupTaskStatusOtherCompleted.hashCode());
         assertNotEquals(backupTaskStatus.hashCode(), backupTaskStatusOtherTotal.hashCode());

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateChangeTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -79,6 +80,7 @@ public class ClusterStateChangeTest {
         assertEquals(clusterStateChange.hashCode(), clusterStateChange.hashCode());
         assertEquals(clusterStateChange.hashCode(), clusterStateChangeSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(clusterStateChange.hashCode(), clusterStateChangeOtherType.hashCode());
         assertNotEquals(clusterStateChange.hashCode(), clusterStateChangeOtherNewState.hashCode());
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/ReplicaSyncInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/ReplicaSyncInfoTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -79,6 +80,7 @@ public class ReplicaSyncInfoTest {
         assertEquals(replicaSyncInfo.hashCode(), replicaSyncInfoSameAttributes.hashCode());
         assertEquals(replicaSyncInfo.hashCode(), replicaSyncInfoOtherTarget.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(replicaSyncInfo.hashCode(), replicaSyncInfoOtherPartitionId.hashCode());
         assertNotEquals(replicaSyncInfo.hashCode(), replicaSyncInfoOtherReplicaIndex.hashCode());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapMaxSizeConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapMaxSizeConfigTest.java
@@ -83,6 +83,7 @@ public class MapMaxSizeConfigTest extends HazelcastTestSupport {
 
     @Test
     public void testEquals() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(MaxSizeConfig.class)
                 .allFieldsShouldBeUsedExcept("readOnly")
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/BatchEventDataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/BatchEventDataTest.java
@@ -166,6 +166,7 @@ public class BatchEventDataTest extends HazelcastTestSupport {
 
         assertEquals(batchEventData.hashCode(), batchEventDataOtherSource.hashCode());
         assertEquals(batchEventData.hashCode(), batchEventDataOtherPartitionId.hashCode());
+        assumeDifferentHashCodes();
         assertNotEquals(batchEventData.hashCode(), batchEventDataOtherEvent.hashCode());
         assertNotEquals(batchEventData.hashCode(), batchEventDataNoEvent.hashCode());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventDataTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/event/DefaultQueryCacheEventDataTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -216,6 +217,7 @@ public class DefaultQueryCacheEventDataTest {
         assertEquals(queryCacheEventData.hashCode(), queryCacheEventData.hashCode());
         assertEquals(queryCacheEventData.hashCode(), queryCacheEventDataSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(queryCacheEventData.hashCode(), queryCacheEventDataOtherSequence.hashCode());
         assertNotEquals(queryCacheEventData.hashCode(), queryCacheEventDataOtherEventType.hashCode());
         assertNotEquals(queryCacheEventData.hashCode(), queryCacheEventDataOtherPartitionId.hashCode());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -115,6 +116,7 @@ public class AbstractRecordTest {
         assertEquals(record.hashCode(), record.hashCode());
         assertEquals(record.hashCode(), recordSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(record.hashCode(), recordOtherVersion.hashCode());
         assertNotEquals(record.hashCode(), recordOtherTtl.hashCode());
         assertNotEquals(record.hashCode(), recordOtherCreationTime.hashCode());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordWithStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/DataRecordWithStatsTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -93,6 +94,7 @@ public class DataRecordWithStatsTest {
         assertEquals(record.hashCode(), record.hashCode());
         assertEquals(record.hashCode(), recordSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(record.hashCode(), objectRecord.hashCode());
         assertNotEquals(record.hashCode(), recordOtherKeyAndValue.hashCode());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordWithStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordWithStatsTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
@@ -104,6 +105,7 @@ public class ObjectRecordWithStatsTest {
         assertEquals(record.hashCode(), record.hashCode());
         assertEquals(record.hashCode(), recordSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(record.hashCode(), dataRecord.hashCode());
         assertNotEquals(record.hashCode(), recordOtherLastStoredTime.hashCode());
         assertNotEquals(record.hashCode(), recordOtherExpirationTime.hashCode());

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/impl/task/JobPartitionStateImplTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 
 import static com.hazelcast.mapreduce.JobPartitionState.State.CANCELLED;
 import static com.hazelcast.mapreduce.JobPartitionState.State.WAITING;
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -90,6 +91,7 @@ public class JobPartitionStateImplTest {
         assertEquals(jobPartitionState.hashCode(), jobPartitionState.hashCode());
         assertEquals(jobPartitionState.hashCode(), jobPartitionStateSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(jobPartitionState.hashCode(), jobPartitionStateOtherAddress.hashCode());
         assertNotEquals(jobPartitionState.hashCode(), jobPartitionStateOtherState.hashCode());
     }

--- a/hazelcast/src/test/java/com/hazelcast/memory/MemorySizeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/memory/MemorySizeTest.java
@@ -18,12 +18,16 @@ package com.hazelcast.memory;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
+
 import org.junit.Test;
 
 public class MemorySizeTest {
 
     @Test
     public void testEqualsAndHashCode() {
+        assumeDifferentHashCodes();
         EqualsVerifier.forClass(MemorySize.class)
                 .allFieldsShouldBeUsed()
                 .suppress(Warning.NONFINAL_FIELDS)

--- a/hazelcast/src/test/java/com/hazelcast/multimap/impl/MultiMapEventFilterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/impl/MultiMapEventFilterTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -77,6 +78,7 @@ public class MultiMapEventFilterTest {
         assertEquals(multiMapEventFilter.hashCode(), multiMapEventFilter.hashCode());
         assertEquals(multiMapEventFilter.hashCode(), multiMapEventFilterSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(multiMapEventFilter.hashCode(), multiMapEventFilterOtherIncludeValue.hashCode());
         assertNotEquals(multiMapEventFilter.hashCode(), multiMapEventFilterOtherKey.hashCode());
         assertNotEquals(multiMapEventFilter.hashCode(), multiMapEventFilterDefaultParameters.hashCode());

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexInfoTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -66,6 +67,7 @@ public class IndexInfoTest {
         assertEquals(indexInfo.hashCode(), indexInfo.hashCode());
         assertEquals(indexInfo.hashCode(), indexInfoSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(indexInfo.hashCode(), indexInfoOtherIsOrdered.hashCode());
         assertNotEquals(indexInfo.hashCode(), indexInfoOtherAttributeName.hashCode());
         assertNotEquals(indexInfo.hashCode(), indexInfoNullAttributeName.hashCode());

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStoreTest.java
@@ -90,6 +90,7 @@ public class AbstractBaseReplicatedRecordStoreTest extends HazelcastTestSupport 
         assertEquals(recordStore.hashCode(), recordStore.hashCode());
         assertEquals(recordStoreSameAttributes.hashCode(), recordStore.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(recordStoreOtherStorage.hashCode(), recordStore.hashCode());
         assertNotEquals(recordStoreOtherName.hashCode(), recordStore.hashCode());
     }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/impl/record/ReplicatedRecordTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static com.hazelcast.test.HazelcastTestSupport.sleepAtLeastMillis;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -180,6 +181,7 @@ public class ReplicatedRecordTest {
         assertEquals(replicatedRecord.hashCode(), replicatedRecord.hashCode());
         assertEquals(replicatedRecord.hashCode(), replicatedRecordSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(replicatedRecord.hashCode(), replicatedRecordOtherKey.hashCode());
         assertNotEquals(replicatedRecord.hashCode(), replicatedRecordOtherValue.hashCode());
         assertNotEquals(replicatedRecord.hashCode(), replicatedRecordOtherTtl.hashCode());

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -97,6 +97,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * Base class for Hazelcast tests which provides a big number of convenient test methods.
@@ -108,6 +109,8 @@ import static org.junit.Assume.assumeFalse;
  */
 @SuppressWarnings({"unused", "SameParameterValue", "WeakerAccess"})
 public abstract class HazelcastTestSupport {
+
+    private static final boolean EXPECT_DIFFERENT_HASHCODES = (new Object().hashCode() != new Object().hashCode());
 
     public static final int ASSERT_TRUE_EVENTUALLY_TIMEOUT;
 
@@ -1451,5 +1454,13 @@ public abstract class HazelcastTestSupport {
     public static void assumeThatNoJDK6() {
         String javaVersion = System.getProperty("java.version");
         assumeFalse("Java 6 used", javaVersion.startsWith("1.6."));
+    }
+
+    /**
+     * Throws {@link org.junit.AssumptionViolatedException} if two new Objects have the same hashCode (e.g. when running tests
+     * with static hashCode ({@code -XX:hashCode=2}).
+     */
+    public static void assumeDifferentHashCodes() {
+        assumeTrue("Hash codes are equal for different objects", EXPECT_DIFFERENT_HASHCODES);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/LoggingScheduledExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/LoggingScheduledExecutorTest.java
@@ -233,6 +233,7 @@ public class LoggingScheduledExecutorTest extends HazelcastTestSupport {
         assertNotEquals(future1, null);
 
         assertEquals(future1.hashCode(), future1.hashCode());
+        assumeDifferentHashCodes();
         assertNotEquals(future1.hashCode(), future2.hashCode());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/version/MemberVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/MemberVersionTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static com.hazelcast.version.MemberVersion.MAJOR_MINOR_VERSION_COMPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -139,6 +140,7 @@ public class MemberVersionTest {
         assertEquals(version.hashCode(), version.hashCode());
         assertEquals(version.hashCode(), versionSameAttributes.hashCode());
 
+        assumeDifferentHashCodes();
         assertNotEquals(version.hashCode(), versionOtherMajor.hashCode());
         assertNotEquals(version.hashCode(), versionOtherMinor.hashCode());
         assertNotEquals(version.hashCode(), versionOtherPath.hashCode());


### PR DESCRIPTION
This PR adds assumptions to skip unequal hashCode checks when constant hashCode is used (`-XX:hashCode=2`).

The hashCodes should only be checked for equality. There is no guarantee, the hashCodes will differ for different objects in default Object implementation. This commit improves the behavior of the testsuite, but there can be still cases when it results in false negatives.

To run the testsuite with constant hashCode configured, one can use `mvn test -DextraVmArgs=-XX:hashCode=2`.