### PR TITLE
Publish end-of-sequence event upon start of  migration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
@@ -26,6 +26,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
+import static com.hazelcast.map.impl.querycache.subscriber.EventPublisherHelper.hasListener;
 import static com.hazelcast.map.impl.querycache.subscriber.EventPublisherHelper.publishCacheWideEvent;
 import static java.lang.String.format;
 
@@ -43,8 +44,8 @@ class SubscriberAccumulatorHandler implements AccumulatorHandler<QueryCacheEvent
     private final boolean includeValue;
     private final InternalQueryCache queryCache;
     private final InternalSerializationService serializationService;
-    private final AtomicReferenceArray<Queue<Integer>> clearAllRemovedEntryCounts;
-    private final AtomicReferenceArray<Queue<Integer>> evictAllRemovedEntryCounts;
+    private final AtomicReferenceArray<Queue<Integer>> clearAllRemovedCountHolders;
+    private final AtomicReferenceArray<Queue<Integer>> evictAllRemovedCountHolders;
 
     public SubscriberAccumulatorHandler(boolean includeValue, InternalQueryCache queryCache,
                                         InternalSerializationService serializationService) {
@@ -52,19 +53,19 @@ class SubscriberAccumulatorHandler implements AccumulatorHandler<QueryCacheEvent
         this.queryCache = queryCache;
         this.serializationService = serializationService;
         this.partitionCount = ((DefaultQueryCache) queryCache).context.getPartitionCount();
-        this.clearAllRemovedEntryCounts = initRemovedEntryCounts(partitionCount);
-        this.evictAllRemovedEntryCounts = initRemovedEntryCounts(partitionCount);
+        this.clearAllRemovedCountHolders = initRemovedCountHolders(partitionCount);
+        this.evictAllRemovedCountHolders = initRemovedCountHolders(partitionCount);
     }
 
-    private static AtomicReferenceArray<Queue<Integer>> initRemovedEntryCounts(int partitionCount) {
-        AtomicReferenceArray<Queue<Integer>> removedEntryCounts
+    private static AtomicReferenceArray<Queue<Integer>> initRemovedCountHolders(int partitionCount) {
+        AtomicReferenceArray<Queue<Integer>> removedCountHolders
                 = new AtomicReferenceArray<Queue<Integer>>(partitionCount + 1);
         for (int i = 0; i < partitionCount; i++) {
-            removedEntryCounts.set(i, new ConcurrentLinkedQueue<Integer>());
+            removedCountHolders.set(i, new ConcurrentLinkedQueue<Integer>());
         }
-        removedEntryCounts.set(partitionCount, POLL_PERMIT);
+        removedCountHolders.set(partitionCount, POLL_PERMIT);
 
-        return removedEntryCounts;
+        return removedCountHolders;
     }
 
     @Override
@@ -91,10 +92,10 @@ class SubscriberAccumulatorHandler implements AccumulatorHandler<QueryCacheEvent
                 queryCache.deleteInternal(keyData, false, entryEventType);
                 break;
             case CLEAR_ALL:
-                handleMapWideEvent(eventData, entryEventType, clearAllRemovedEntryCounts);
+                handleMapWideEvent(eventData, entryEventType, clearAllRemovedCountHolders);
                 break;
             case EVICT_ALL:
-                handleMapWideEvent(eventData, entryEventType, evictAllRemovedEntryCounts);
+                handleMapWideEvent(eventData, entryEventType, evictAllRemovedCountHolders);
                 break;
             default:
                 throwException(format("Unexpected EntryEventType was found: `%s`", entryEventType));
@@ -102,50 +103,62 @@ class SubscriberAccumulatorHandler implements AccumulatorHandler<QueryCacheEvent
     }
 
     private void handleMapWideEvent(QueryCacheEventData eventData, EntryEventType eventType,
-                                    AtomicReferenceArray<Queue<Integer>> removedEntryCounts) {
+                                    AtomicReferenceArray<Queue<Integer>> removedCountHolders) {
 
         int partitionId = eventData.getPartitionId();
-        int removedEntryCount = queryCache.removeEntriesOf(partitionId);
+        int removedCount = queryCache.removeEntriesOf(partitionId);
+
+        tryPublishMapWideEvent(eventType, partitionId, removedCount, removedCountHolders);
+    }
+
+    private void tryPublishMapWideEvent(EntryEventType eventType, int partitionId, int removedEntryCount,
+                                        AtomicReferenceArray<Queue<Integer>> removedCountHolders) {
+        if (!hasListener(queryCache)) {
+            return;
+        }
 
         // add this `removedEntryCount` to partitions' removed-entry-count-holder queue
-        removedEntryCounts.get(partitionId).offer(removedEntryCount);
+        removedCountHolders.get(partitionId).offer(removedEntryCount);
 
-        if (!hasMissingCount(removedEntryCounts)) {
-            if (removedEntryCounts.compareAndSet(partitionCount, POLL_PERMIT, null)) {
-                try {
-                    int totalRemovedEntryCount = pollRemovedEntryCounts(removedEntryCounts);
-                    publishCacheWideEvent(((DefaultQueryCache) queryCache).context,
-                            ((DefaultQueryCache) queryCache).mapName,
-                            ((DefaultQueryCache) queryCache).cacheId,
-                            totalRemovedEntryCount,
-                            eventType);
-                } finally {
-                    removedEntryCounts.set(partitionCount, POLL_PERMIT);
+        if (noMissingMapWideEvent(removedCountHolders)
+                && removedCountHolders.compareAndSet(partitionCount, POLL_PERMIT, null)) {
+            try {
+                if (noMissingMapWideEvent(removedCountHolders)) {
+                    int totalRemovedCount = pollRemovedCountHolders(removedCountHolders);
+                    publishCacheWideEvent(queryCache, totalRemovedCount, eventType);
                 }
+            } finally {
+                removedCountHolders.set(partitionCount, POLL_PERMIT);
             }
         }
     }
 
     /**
-     * @return {@code true} if we have removed entries from all partitions,
-     * otherwise return {@code false} to indicate there is still
-     * not-received events for some partitions.
+     * Check if all map-wide events like {@link
+     * EntryEventType#CLEAR_ALL} or {@link EntryEventType#EVICT_ALL}
+     * were received. If an event is received, we populate its
+     * partitions' removed-entry-count-holder queue.
+     *
+     * @return {@code true} if we have received map-wide events from all
+     * partitions, otherwise return {@code false} to indicate there is
+     * still not-received map-wide events for some partitions.
      */
-    private boolean hasMissingCount(AtomicReferenceArray<Queue<Integer>> removedEntryCounts) {
+    private boolean noMissingMapWideEvent(AtomicReferenceArray<Queue<Integer>> removedCountHolders) {
         for (int i = 0; i < partitionCount; i++) {
-            if (removedEntryCounts.get(i).size() < 1) {
-                // we don't receive any map-wide event for this partition
-                return true;
+            if (removedCountHolders.get(i).size() < 1) {
+                // means we still have not-received map-wide event for this partition
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
-    // should be called when `hasMissingCount` `false`, otherwise polling can cause NPE
-    private int pollRemovedEntryCounts(AtomicReferenceArray<Queue<Integer>> removedEntryCounts) {
+    // should be called when `noMissingMapWideEvent` `false`, otherwise polling can cause NPE
+    private int pollRemovedCountHolders(AtomicReferenceArray<Queue<Integer>> removedCountHolders) {
         int count = 0;
         for (int i = 0; i < partitionCount; i++) {
-            count += removedEntryCounts.get(i).poll();
+            Queue<Integer> removalCounts = removedCountHolders.get(i);
+            count += removalCounts.poll();
         }
         return count;
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMapWideEventsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMapWideEventsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.querycache;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.PredicateConfig;
+import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.EventLostEvent;
+import com.hazelcast.map.QueryCache;
+import com.hazelcast.map.listener.EventLostListener;
+import com.hazelcast.query.TruePredicate;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class QueryCacheMapWideEventsTest extends HazelcastTestSupport {
+
+    private static final String MAP_NAME = "mapName";
+    private static final String QUERY_CACHE_NAME = "cacheName";
+    private static final String PARTITION_COUNT = "1999";
+    private static final int TEST_DURATION_SECONDS = 3;
+
+    private AtomicInteger eventLostCounter = new AtomicInteger();
+    private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+    @Test
+    public void no_event_lost_during_migrations() {
+        newQueryCacheOnNewNode();
+
+        // creates CLEAR_ALL events
+        Thread clearAllNode = new Thread() {
+            @Override
+            public void run() {
+                IMap map = newQueryCacheOnNewNode();
+
+                long endMillis = System.currentTimeMillis() + SECONDS.toMillis(TEST_DURATION_SECONDS);
+                while (System.currentTimeMillis() < endMillis) {
+                    map.clear();
+                }
+            }
+        };
+
+        clearAllNode.start();
+        assertJoinable(clearAllNode);
+
+        assertEquals(0, eventLostCounter.get());
+    }
+
+    private IMap newQueryCacheOnNewNode() {
+        HazelcastInstance node = factory.newHazelcastInstance(newConfig());
+        IMap map = node.getMap(MAP_NAME);
+        QueryCache queryCache = map.getQueryCache(QUERY_CACHE_NAME);
+        addEventLostListenerToQueryCache(queryCache);
+        return map;
+    }
+
+    private void addEventLostListenerToQueryCache(QueryCache queryCache) {
+        queryCache.addEntryListener(new EventLostListener() {
+            @Override
+            public void eventLost(EventLostEvent event) {
+                eventLostCounter.incrementAndGet();
+            }
+        }, false);
+    }
+
+    private Config newConfig() {
+        QueryCacheConfig queryCacheConfig = new QueryCacheConfig()
+                .setName(QUERY_CACHE_NAME)
+                .setPredicateConfig(new PredicateConfig(TruePredicate.INSTANCE));
+
+        MapConfig mapConfig = new MapConfig(MAP_NAME)
+                .addQueryCacheConfig(queryCacheConfig);
+
+        return getConfig()
+                .setProperty("hazelcast.partition.count", PARTITION_COUNT)
+                .addMapConfig(mapConfig);
+    }
+}


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/12572

- before, this publishing was being done in commit-migration-stage, now it will be done in before-migration-stage.
- also did some naming changes

backport: https://github.com/hazelcast/hazelcast/pull/12667