### PR TITLE
Adds explicit serialVersionUID to test domain class Employee

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/helpers/Employee.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/helpers/Employee.java
@@ -21,6 +21,8 @@ import java.util.Random;
 
 public class Employee implements Serializable, Comparable<Employee> {
 
+    public static final long serialVersionUID = 5850489412220165243l;
+
     public static final int MAX_AGE = 75;
     public static final double MAX_SALARY = 1000.0;
 


### PR DESCRIPTION
Employee class implementation was changed in bdd0bb5c94664d6ddc1c3fdf45a7cba5d0ac7eda resulting in a change of serial version UID as it now overrides `equals` & `hashCode`.

Fixes test failure in `SerializedObjectsCompatibilityTest`