### PR TITLE
Increase connection-attempt-limit for ClientToMemberDiscoveryTest

### DIFF
--- a/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
+++ b/hazelcast/src/test/resources/hazelcast-client-multicast-plugin.xml
@@ -28,5 +28,6 @@
             <discovery-strategy enabled="true" class="com.hazelcast.spi.discovery.multicast.MulticastDiscoveryStrategy">
             </discovery-strategy>
         </discovery-strategies>
+        <connection-attempt-limit>2147483647</connection-attempt-limit> <!-- Integer.MAX_VALUE -->
     </network>
 </hazelcast-client>


### PR DESCRIPTION
The test occasionally fails but the attempt limit is set to the default
number of 2. Since a lot of tests increase this limit, we are increasing
it here as well.

Fixes: #11304