### PR TITLE
Add onSetup hook in CacheReadWriteThroughTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheReadWriteThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheReadWriteThroughTest.java
@@ -82,13 +82,23 @@ public class CacheReadWriteThroughTest extends HazelcastTestSupport {
         return instance;
     }
 
+    /**
+     * Hook for adding additional setup steps in child classes.
+     */
+    protected void onSetup() {
+    }
+
     @Before
     public void setup() {
+        onSetup();
         factory = createInstanceFactory(2);
         hz = getInstance();
         cachingProvider = createCachingProvider(hz);
     }
 
+    /**
+     * Hook for adding additional teardown steps in child classes.
+     */
     protected void onTearDown() {
     }
 


### PR DESCRIPTION
This is necessary for fix of HD tests in the lab. It also allows to add some custom configuration in the child tests.