### PR TITLE
Cleanup on TimedMemberState

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -72,7 +72,6 @@ import com.hazelcast.wan.WanReplicationService;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -126,7 +125,7 @@ public class TimedMemberStateFactory {
         Collection<StatisticsAwareService> services = instance.node.nodeEngine.getServices(StatisticsAwareService.class);
 
         TimedMemberState timedMemberState = new TimedMemberState();
-        createMemberState(timedMemberState, memberState, services);
+        createMemberState(memberState, services);
         timedMemberState.setMaster(instance.node.isMaster());
         timedMemberState.setMemberList(new ArrayList<String>());
         if (timedMemberState.isMaster()) {
@@ -158,7 +157,7 @@ public class TimedMemberStateFactory {
         return new LocalOperationStatsImpl(instance.node);
     }
 
-    private void createMemberState(TimedMemberState timedMemberState, MemberStateImpl memberState,
+    private void createMemberState(MemberStateImpl memberState,
                                    Collection<StatisticsAwareService> services) {
         Node node = instance.node;
 
@@ -189,7 +188,7 @@ public class TimedMemberStateFactory {
         memberState.setLocalMemoryStats(getMemoryStats());
         memberState.setOperationStats(getOperationStats());
         TimedMemberStateFactoryHelper.createRuntimeProps(memberState);
-        createMemState(timedMemberState, memberState, services);
+        createMemState(memberState, services);
 
         createNodeState(memberState);
         createHotRestartState(memberState);
@@ -229,36 +228,33 @@ public class TimedMemberStateFactory {
         }
     }
 
-    private void createMemState(TimedMemberState timedMemberState, MemberStateImpl memberState,
+    private void createMemState(MemberStateImpl memberState,
                                 Collection<StatisticsAwareService> services) {
         int count = 0;
         Config config = instance.getConfig();
-        LinkedList<String> longInstanceNames = new LinkedList<String>();
         for (StatisticsAwareService service : services) {
             if (count < maxVisibleInstanceCount) {
                 if (service instanceof MapService) {
-                    count = handleMap(memberState, count, config, ((MapService) service).getStats(), longInstanceNames);
+                    count = handleMap(memberState, count, config, ((MapService) service).getStats());
                 } else if (service instanceof MultiMapService) {
-                    count = handleMultimap(memberState, count, config, ((MultiMapService) service).getStats(), longInstanceNames);
+                    count = handleMultimap(memberState, count, config, ((MultiMapService) service).getStats());
                 } else if (service instanceof QueueService) {
-                    count = handleQueue(memberState, count, config, ((QueueService) service).getStats(), longInstanceNames);
+                    count = handleQueue(memberState, count, config, ((QueueService) service).getStats());
                 } else if (service instanceof TopicService) {
-                    count = handleTopic(memberState, count, config, ((TopicService) service).getStats(), longInstanceNames);
+                    count = handleTopic(memberState, count, config, ((TopicService) service).getStats());
                 } else if (service instanceof ReliableTopicService) {
                     count = handleReliableTopic(memberState, count, config,
-                            ((ReliableTopicService) service).getStats(), longInstanceNames);
+                            ((ReliableTopicService) service).getStats());
                 } else if (service instanceof DistributedExecutorService) {
                     count = handleExecutorService(memberState, count, config,
-                            ((DistributedExecutorService) service).getStats(), longInstanceNames);
+                            ((DistributedExecutorService) service).getStats());
                 } else if (service instanceof ReplicatedMapService) {
-                    count = handleReplicatedMap(memberState, count, config, ((ReplicatedMapService) service).getStats(),
-                            longInstanceNames);
+                    count = handleReplicatedMap(memberState, count, config, ((ReplicatedMapService) service).getStats());
                 } else if (service instanceof PNCounterService) {
-                    count = handlePNCounter(memberState, count, config, ((PNCounterService) service).getStats(),
-                            longInstanceNames);
+                    count = handlePNCounter(memberState, count, config, ((PNCounterService) service).getStats());
                 } else if (service instanceof FlakeIdGeneratorService) {
                     count = handleFlakeIdGenerator(memberState, count, config,
-                            ((FlakeIdGeneratorService) service).getStats(), longInstanceNames);
+                            ((FlakeIdGeneratorService) service).getStats());
                 }
             }
         }
@@ -266,7 +262,7 @@ public class TimedMemberStateFactory {
         WanReplicationService wanReplicationService = instance.node.nodeEngine.getWanReplicationService();
         Map<String, LocalWanStats> wanStats = wanReplicationService.getStats();
         if (wanStats != null) {
-            count = handleWan(memberState, count, wanStats, longInstanceNames);
+            count = handleWan(memberState, count, wanStats);
         }
 
         if (cacheServiceEnabled) {
@@ -277,16 +273,15 @@ public class TimedMemberStateFactory {
                     //Statistics can be null for a short period of time since config is created at first then stats map
                     //is filled.git
                     if (statistics != null) {
-                        count = handleCache(memberState, count, cacheConfig, statistics, longInstanceNames);
+                        count = handleCache(memberState, count, cacheConfig, statistics);
                     }
                 }
             }
         }
-        timedMemberState.setInstanceNames(longInstanceNames);
     }
 
     private int handleFlakeIdGenerator(MemberStateImpl memberState, int count, Config config,
-            Map<String, LocalFlakeIdGeneratorStats> flakeIdstats, List<String> longInstanceNames) {
+            Map<String, LocalFlakeIdGeneratorStats> flakeIdstats) {
         for (Map.Entry<String, LocalFlakeIdGeneratorStats> entry : flakeIdstats.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -294,7 +289,6 @@ public class TimedMemberStateFactory {
             } else if (config.findFlakeIdGeneratorConfig(name).isStatisticsEnabled()) {
                 LocalFlakeIdGeneratorStats stats = entry.getValue();
                 memberState.putLocalFlakeIdStats(name, stats);
-                longInstanceNames.add("f:" + name);
                 ++count;
             }
         }
@@ -302,8 +296,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handleExecutorService(MemberStateImpl memberState, int count, Config config,
-                                      Map<String, LocalExecutorStats> executorServices,
-                                      List<String> longInstanceNames) {
+                                      Map<String, LocalExecutorStats> executorServices) {
 
         for (Map.Entry<String, LocalExecutorStats> entry : executorServices.entrySet()) {
             String name = entry.getKey();
@@ -312,15 +305,13 @@ public class TimedMemberStateFactory {
             } else if (config.findExecutorConfig(name).isStatisticsEnabled()) {
                 LocalExecutorStats stats = entry.getValue();
                 memberState.putLocalExecutorStats(name, stats);
-                longInstanceNames.add("e:" + name);
                 ++count;
             }
         }
         return count;
     }
 
-    private int handleMultimap(MemberStateImpl memberState, int count, Config config, Map<String, LocalMultiMapStats> multiMaps,
-                               List<String> longInstanceNames) {
+    private int handleMultimap(MemberStateImpl memberState, int count, Config config, Map<String, LocalMultiMapStats> multiMaps) {
         for (Map.Entry<String, LocalMultiMapStats> entry : multiMaps.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -328,7 +319,6 @@ public class TimedMemberStateFactory {
             } else if (config.findMultiMapConfig(name).isStatisticsEnabled()) {
                 LocalMultiMapStats stats = entry.getValue();
                 memberState.putLocalMultiMapStats(name, stats);
-                longInstanceNames.add("m:" + name);
                 ++count;
             }
         }
@@ -336,7 +326,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handleReplicatedMap(MemberStateImpl memberState, int count, Config
-            config, Map<String, LocalReplicatedMapStats> replicatedMaps, List<String> longInstanceNames) {
+            config, Map<String, LocalReplicatedMapStats> replicatedMaps) {
         for (Map.Entry<String, LocalReplicatedMapStats> entry : replicatedMaps.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -344,7 +334,6 @@ public class TimedMemberStateFactory {
             } else if (config.findReplicatedMapConfig(name).isStatisticsEnabled()) {
                 LocalReplicatedMapStats stats = entry.getValue();
                 memberState.putLocalReplicatedMapStats(name, stats);
-                longInstanceNames.add("r:" + name);
                 ++count;
             }
         }
@@ -352,8 +341,7 @@ public class TimedMemberStateFactory {
     }
 
     private int handlePNCounter(MemberStateImpl memberState, int count, Config config,
-                                Map<String, LocalPNCounterStats> counters,
-                                List<String> longInstanceNames) {
+                                Map<String, LocalPNCounterStats> counters) {
         for (Map.Entry<String, LocalPNCounterStats> entry : counters.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -361,15 +349,13 @@ public class TimedMemberStateFactory {
             } else if (config.findPNCounterConfig(name).isStatisticsEnabled()) {
                 LocalPNCounterStats stats = entry.getValue();
                 memberState.putLocalPNCounterStats(name, stats);
-                longInstanceNames.add("pnc:" + name);
                 ++count;
             }
         }
         return count;
     }
 
-    private int handleReliableTopic(MemberStateImpl memberState, int count, Config config, Map<String, LocalTopicStats> topics,
-                                    List<String> longInstanceNames) {
+    private int handleReliableTopic(MemberStateImpl memberState, int count, Config config, Map<String, LocalTopicStats> topics) {
         for (Map.Entry<String, LocalTopicStats> entry : topics.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -377,15 +363,13 @@ public class TimedMemberStateFactory {
             } else if (config.findReliableTopicConfig(name).isStatisticsEnabled()) {
                 LocalTopicStats stats = entry.getValue();
                 memberState.putLocalReliableTopicStats(name, stats);
-                longInstanceNames.add("rt:" + name);
                 ++count;
             }
         }
         return count;
     }
 
-    private int handleTopic(MemberStateImpl memberState, int count, Config config, Map<String, LocalTopicStats> topics,
-                            List<String> longInstanceNames) {
+    private int handleTopic(MemberStateImpl memberState, int count, Config config, Map<String, LocalTopicStats> topics) {
         for (Map.Entry<String, LocalTopicStats> entry : topics.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -393,15 +377,13 @@ public class TimedMemberStateFactory {
             } else if (config.findTopicConfig(name).isStatisticsEnabled()) {
                 LocalTopicStats stats = entry.getValue();
                 memberState.putLocalTopicStats(name, stats);
-                longInstanceNames.add("t:" + name);
                 ++count;
             }
         }
         return count;
     }
 
-    private int handleQueue(MemberStateImpl memberState, int count, Config config, Map<String, LocalQueueStats> queues,
-                            List<String> longInstanceNames) {
+    private int handleQueue(MemberStateImpl memberState, int count, Config config, Map<String, LocalQueueStats> queues) {
         for (Map.Entry<String, LocalQueueStats> entry : queues.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -409,15 +391,13 @@ public class TimedMemberStateFactory {
             } else if (config.findQueueConfig(name).isStatisticsEnabled()) {
                 LocalQueueStats stats = entry.getValue();
                 memberState.putLocalQueueStats(name, stats);
-                longInstanceNames.add("q:" + name);
                 ++count;
             }
         }
         return count;
     }
 
-    private int handleMap(MemberStateImpl memberState, int count, Config config, Map<String, LocalMapStats> maps,
-                          List<String> longInstanceNames) {
+    private int handleMap(MemberStateImpl memberState, int count, Config config, Map<String, LocalMapStats> maps) {
         for (Map.Entry<String, LocalMapStats> entry : maps.entrySet()) {
             String name = entry.getKey();
             if (count >= maxVisibleInstanceCount) {
@@ -425,29 +405,24 @@ public class TimedMemberStateFactory {
             } else if (config.findMapConfig(name).isStatisticsEnabled()) {
                 LocalMapStats stats = entry.getValue();
                 memberState.putLocalMapStats(name, stats);
-                longInstanceNames.add("c:" + name);
                 ++count;
             }
         }
         return count;
     }
 
-    private int handleWan(MemberStateImpl memberState, int count, Map<String, LocalWanStats> wans,
-                          List<String> longInstanceNames) {
+    private int handleWan(MemberStateImpl memberState, int count, Map<String, LocalWanStats> wans) {
         for (Map.Entry<String, LocalWanStats> entry : wans.entrySet()) {
             String schemeName = entry.getKey();
             LocalWanStats stats = entry.getValue();
             memberState.putLocalWanStats(schemeName, stats);
-            longInstanceNames.add("w:" + schemeName);
             count++;
         }
         return count;
     }
 
-    private int handleCache(MemberStateImpl memberState, int count, CacheConfig config, CacheStatistics cacheStatistics,
-                            List<String> longInstanceNames) {
+    private int handleCache(MemberStateImpl memberState, int count, CacheConfig config, CacheStatistics cacheStatistics) {
         memberState.putLocalCacheStats(config.getNameWithPrefix(), new LocalCacheStatsImpl(cacheStatistics));
-        longInstanceNames.add("j:" + config.getNameWithPrefix());
         return ++count;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/TimedMemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/TimedMemberState.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.management.JsonSerializable;
 import com.hazelcast.monitor.impl.MemberStateImpl;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 
 import static com.hazelcast.util.JsonUtil.getArray;
@@ -37,7 +36,6 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
 
     long time;
     MemberStateImpl memberState;
-    List<String> instanceNames;
     List<String> memberList;
     boolean master;
     String clusterName;
@@ -77,14 +75,6 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         return time;
     }
 
-    public List<String> getInstanceNames() {
-        return instanceNames;
-    }
-
-    public void setInstanceNames(List<String> longInstanceNames) {
-        this.instanceNames = longInstanceNames;
-    }
-
     public MemberStateImpl getMemberState() {
         return memberState;
     }
@@ -122,7 +112,6 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         TimedMemberState state = (TimedMemberState) super.clone();
         state.setTime(time);
         state.setMemberState(memberState);
-        state.setInstanceNames(instanceNames);
         state.setMemberList(memberList);
         state.setMaster(master);
         state.setClusterName(clusterName);
@@ -138,11 +127,6 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         root.add("master", master);
         root.add("time", time);
         root.add("clusterName", clusterName);
-        JsonArray instanceNames = new JsonArray();
-        for (String instanceName : this.instanceNames) {
-            instanceNames.add(instanceName);
-        }
-        root.add("instanceNames", instanceNames);
         if (memberList != null) {
             JsonArray members = new JsonArray();
             for (String member : memberList) {
@@ -162,11 +146,6 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         time = getLong(json, "time");
         master = getBoolean(json, "master");
         clusterName = getString(json, "clusterName");
-        instanceNames = new LinkedList<String>();
-        final JsonArray jsonInstanceNames = getArray(json, "instanceNames");
-        for (JsonValue instanceName : jsonInstanceNames.values()) {
-            instanceNames.add(instanceName.asString());
-        }
         final JsonArray jsonMemberList = getArray(json, "memberList");
         memberList = new ArrayList<String>(jsonMemberList.size());
         for (JsonValue member : jsonMemberList.values()) {
@@ -182,8 +161,6 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
 
     @Override
     public String toString() {
-        return "TimedMemberState{"
-                + LINE_SEPARATOR + '\t' + memberState
-                + LINE_SEPARATOR + "} Instances: " + instanceNames;
+        return "TimedMemberState{" + LINE_SEPARATOR + '\t' + memberState + LINE_SEPARATOR + "}";
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateIntegrationTest.java
@@ -25,11 +25,10 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.List;
 
 import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static org.junit.Assert.assertEquals;
@@ -53,16 +52,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
         hz.getExecutorService("trial");
 
         TimedMemberState timedMemberState = factory.createTimedMemberState();
-        List<String> instanceNames = timedMemberState.getInstanceNames();
-
         assertEquals("dev", timedMemberState.clusterName);
-        assertContains(instanceNames, "c:trial");
-        assertContains(instanceNames, "m:trial");
-        assertContains(instanceNames, "q:trial");
-        assertContains(instanceNames, "t:trial");
-        assertContains(instanceNames, "rt:trial");
-        assertContains(instanceNames, "r:trial");
-        assertContains(instanceNames, "e:trial");
     }
 
     @Test
@@ -79,10 +69,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
         hz.getReliableTopic("trial").publish("Hello");
 
         TimedMemberState timedMemberState = factory.createTimedMemberState();
-        List<String> instanceNames = timedMemberState.getInstanceNames();
-
         assertEquals("dev", timedMemberState.clusterName);
-        assertEquals(3, instanceNames.size());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateTest.java
@@ -25,13 +25,11 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.LinkedList;
-import java.util.List;
 
 import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static org.junit.Assert.assertEquals;
@@ -47,30 +45,23 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
-        List<String> instanceNames = new LinkedList<String>();
-        instanceNames.add("topicStats");
-
         hz = createHazelcastInstance();
         TimedMemberStateFactory timedMemberStateFactory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
 
         timedMemberState = timedMemberStateFactory.createTimedMemberState();
         timedMemberState.setClusterName("ClusterName");
         timedMemberState.setTime(1827731);
-        timedMemberState.setInstanceNames(instanceNames);
         timedMemberState.setSslEnabled(true);
         timedMemberState.setLite(true);
     }
 
     @Test
-    public void testClone() throws InterruptedException, CloneNotSupportedException {
+    public void testClone() throws CloneNotSupportedException {
         TimedMemberState cloned = timedMemberState.clone();
 
         assertNotNull(cloned);
         assertEquals("ClusterName", cloned.getClusterName());
         assertEquals(1827731, cloned.getTime());
-        assertNotNull(cloned.getInstanceNames());
-        assertEquals(1, cloned.getInstanceNames().size());
-        assertContains(cloned.getInstanceNames(), "topicStats");
         assertNotNull(cloned.getMemberState());
         assertTrue(cloned.isSslEnabled());
         assertTrue(cloned.isLite());
@@ -78,7 +69,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testSerialization() throws InterruptedException, CloneNotSupportedException {
+    public void testSerialization() {
         JsonObject serialized = timedMemberState.toJson();
         TimedMemberState deserialized = new TimedMemberState();
         deserialized.fromJson(serialized);
@@ -86,9 +77,6 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         assertNotNull(deserialized);
         assertEquals("ClusterName", deserialized.getClusterName());
         assertEquals(1827731, deserialized.getTime());
-        assertNotNull(deserialized.getInstanceNames());
-        assertEquals(1, deserialized.getInstanceNames().size());
-        assertContains(deserialized.getInstanceNames(), "topicStats");
         assertNotNull(deserialized.getMemberState());
         assertTrue(deserialized.isSslEnabled());
         assertTrue(deserialized.isLite());


### PR DESCRIPTION
`instanceNames` on TimedMemberState is no longer used by MC, so it's
removed.