### PR TITLE
Fix CustomLoggerFactorySingularityTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/logging/CustomLoggerFactorySingularityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/CustomLoggerFactorySingularityTest.java
@@ -46,18 +46,19 @@ public class CustomLoggerFactorySingularityTest extends HazelcastTestSupport {
     private static final Field FACTORY_LOCK_FIELD = getField("FACTORY_LOCK");
 
     private String originalLoggingClass;
-    private LoggerFactory originLoggerFactory;
+    private LoggerFactory originalLoggerFactory;
 
     @Before
     public void setUp() throws Exception {
         originalLoggingClass = System.getProperty(LOGGING_CLASS_PROP_NAME);
-        originLoggerFactory = (LoggerFactory) LOGGER_FACTORY_FIELD.get(null);
+        originalLoggerFactory = (LoggerFactory) LOGGER_FACTORY_FIELD.get(null);
+        LOGGER_FACTORY_FIELD.set(null, null);
     }
 
     @After
     public void tearDown() throws Exception {
         restoreProperty(LOGGING_CLASS_PROP_NAME, originalLoggingClass);
-        LOGGER_FACTORY_FIELD.set(null, originLoggerFactory);
+        LOGGER_FACTORY_FIELD.set(null, originalLoggerFactory);
     }
 
     @Test


### PR DESCRIPTION
Seems like the test was picking up the logger factory from a test performed before it and this was producing random failures.

Fixes: https://github.com/hazelcast/hazelcast/issues/12668