### PR TITLE
Fixed NodeThreadLeakTest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -164,7 +164,6 @@ public class NodeEngineImpl implements NodeEngine {
             }
             throw rethrow(e);
         }
-
     }
 
     private MetricsRegistryImpl newMetricRegistry(Node node) {

--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -55,7 +55,11 @@ public final class ThreadLeakTestUtils {
     }
 
     public static void assertHazelcastThreadShutdown(Set<Thread> oldThreads) {
-        Thread[] joinableThreads = getAndLogThreads("There are still Hazelcast threads running after shutdown!", oldThreads);
+        assertHazelcastThreadShutdown("There are still Hazelcast threads running after shutdown!", oldThreads);
+    }
+
+    public static void assertHazelcastThreadShutdown(String message, Set<Thread> oldThreads) {
+        Thread[] joinableThreads = getAndLogThreads(message, oldThreads);
         if (joinableThreads == null) {
             return;
         }


### PR DESCRIPTION
Hazelcast threads may need a little bit to shutdown, so we should use `assertJoinable()` to test them. The `ThreadLeakTestUtils` provide some convenient methods for that.

I checked that the test still fails if the `shutdown(true)` call in `NodeEngineImpl` is removed:
```java
        try {
            (...)
        } catch (Throwable e) {
            try {
                shutdown(true);
            } catch (Throwable ignored) {
                ignore(ignored);
            }
            throw rethrow(e);
        }
```

Fixes https://github.com/hazelcast/hazelcast/issues/12694