### PR TITLE
Revert "Minor NioThread selector.close cleanup"

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -39,7 +39,6 @@ import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT_NOW;
 import static com.hazelcast.internal.networking.nio.SelectorOptimizer.newSelector;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
-import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
@@ -392,7 +391,11 @@ public class NioThread extends Thread implements OperationHostileThread {
             logger.finest("Closing selector for:" + getName());
         }
 
-        closeResource(selector);
+        try {
+            selector.close();
+        } catch (Exception e) {
+            logger.finest("Failed to close selector", e);
+        }
     }
 
     public final void shutdown() {


### PR DESCRIPTION
#12707 Reverts hazelcast/hazelcast#12700

Closeable appearently was added in Java 7 on this class.