### PR TITLE
Added capability to query objects by it's field of type Map for #8231

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/FieldGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/FieldGetter.java
@@ -39,6 +39,6 @@ public class FieldGetter extends AbstractMultiValueGetter {
 
     @Override
     public String toString() {
-        return "FieldGetter [parent=" + parent + ", field=" + field + ", modifier = " + getModifier() + "]";
+        return "FieldGetter [parent=" + parent + ", field=" + field + ", " + super.toString() + "]";
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/MethodGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/MethodGetter.java
@@ -40,6 +40,6 @@ final class MethodGetter extends AbstractMultiValueGetter {
 
     @Override
     public String toString() {
-        return "MethodGetter [parent=" + parent + ", method=" + method.getName() + ", modifier = " + getModifier() + "]";
+        return "MethodGetter [parent=" + parent + ", method=" + method.getName() + ", " + super.toString() + "]";
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionDataStructure.java
@@ -37,6 +37,7 @@ public class CollectionDataStructure {
         Limb[] limbs_array = null;
 
         private Map<String, Tatoo> tatoos = new HashMap<String, Tatoo>();
+        private Map<Short, Achievement> achievementsPerYear = new HashMap<Short, Achievement>();
 
         @Override
         public boolean equals(Object o) {
@@ -72,6 +73,13 @@ public class CollectionDataStructure {
         public Person withTatoos(Tatoo... tatoos) {
             for (Tatoo tatoo : tatoos) {
                 this.tatoos.put(tatoo.location, tatoo);
+            }
+            return this;
+        }
+
+        public Person withAchievements(Achievement... achievements) {
+            for (Achievement achievement : achievements) {
+                this.achievementsPerYear.put(achievement.year, achievement);
             }
             return this;
         }
@@ -156,11 +164,54 @@ public class CollectionDataStructure {
                     ", image='" + image + '\'' +
                     '}';
         }
+
     }
 
     public static Tatoo tatoo(String location, int size, String image) {
         return new Tatoo(location, size, image);
     }
+
+    public static class Achievement implements Serializable {
+
+        private final Short year;
+        private final String description;
+
+        public Achievement(Short year, String description) {
+            this.year = year;
+            this.description = description;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Achievement that = (Achievement) o;
+            return ObjectTestUtils.equals(year, that.year) &&
+                    ObjectTestUtils.equals(description, that.description);
+        }
+
+        @Override
+        public int hashCode() {
+            return ObjectTestUtils.hash(year, description);
+        }
+
+        @Override
+        public String toString() {
+            return "Achievement{" +
+                    "year=" + year +
+                    ", description='" + description + '\'' +
+                    '}';
+        }
+    }
+
+    public static Achievement achievement(Short year, String description) {
+        return new Achievement(year, description);
+    }
+
 
     public static Limb limb(String name, Integer power) {
         Limb limb = new Limb();

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionDataStructure.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/extractor/predicates/CollectionDataStructure.java
@@ -17,14 +17,15 @@
 package com.hazelcast.query.impl.extractor.predicates;
 
 import com.hazelcast.test.ObjectTestUtils;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Data structure used in the tests of extraction in multi-value attributes (in collections and arrays)
+ * Data structure used in the tests of extraction in multi-value attributes (in collections, arrays and maps)
  * Each multi-value attribute is present as both an array and as a collection, for example:
  * limbs_list & limbs_array, so that both extraction in arrays and in collections may be tested.
  */
@@ -35,22 +36,49 @@ public class CollectionDataStructure {
         List<Limb> limbs_list = new ArrayList<Limb>();
         Limb[] limbs_array = null;
 
+        private Map<String, Tatoo> tatoos = new HashMap<String, Tatoo>();
+
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof Person)) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
                 return false;
             }
-            final Person other = (Person) o;
-            return ObjectTestUtils.equals(this.limbs_list, other.limbs_list);
+            Person person = (Person) o;
+            return ObjectTestUtils.equals(limbs_list, person.limbs_list) &&
+                    Arrays.equals(limbs_array, person.limbs_array) &&
+                    ObjectTestUtils.equals(tatoos, person.tatoos);
         }
 
         @Override
         public int hashCode() {
-            return ObjectTestUtils.hashCode(limbs_list);
+
+            int result = ObjectTestUtils.hash(limbs_list, tatoos);
+            result = 31 * result + Arrays.hashCode(limbs_array);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Person{" +
+                    "limbs_list=" + limbs_list +
+                    ", limbs_array=" + Arrays.toString(limbs_array) +
+                    ", tatoos=" + tatoos +
+                    '}';
+        }
+
+        public Person withTatoos(Tatoo... tatoos) {
+            for (Tatoo tatoo : tatoos) {
+                this.tatoos.put(tatoo.location, tatoo);
+            }
+            return this;
         }
     }
 
     public static class Limb implements Serializable {
+
         String name;
         public Integer power;
 
@@ -67,6 +95,71 @@ public class CollectionDataStructure {
         public int hashCode() {
             return ObjectTestUtils.hash(name, power);
         }
+
+        @Override
+        public String toString() {
+            return "Limb{" +
+                    "name='" + name + '\'' +
+                    ", power=" + power +
+                    '}';
+        }
+    }
+
+    public static class Tatoo implements Serializable {
+
+        private final String location;
+        private final int size;
+        private final String image;
+
+        public Tatoo(String location, int size, String image) {
+            this.location = location;
+            this.size = size;
+            this.image = image;
+        }
+
+        public String getLocation() {
+            return location;
+        }
+
+        public int getSize() {
+            return size;
+        }
+
+        public String getImage() {
+            return image;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Tatoo tatoo = (Tatoo) o;
+            return size == tatoo.size &&
+                    ObjectTestUtils.equals(location, tatoo.location) &&
+                    ObjectTestUtils.equals(image, tatoo.image);
+        }
+
+        @Override
+        public int hashCode() {
+            return ObjectTestUtils.hash(location, size, image);
+        }
+
+        @Override
+        public String toString() {
+            return "Tatoo{" +
+                    "location='" + location + '\'' +
+                    ", size=" + size +
+                    ", image='" + image + '\'' +
+                    '}';
+        }
+    }
+
+    public static Tatoo tatoo(String location, int size, String image) {
+        return new Tatoo(location, size, image);
     }
 
     public static Limb limb(String name, Integer power) {
@@ -74,6 +167,10 @@ public class CollectionDataStructure {
         limb.name = name;
         limb.power = power;
         return limb;
+    }
+
+    public static Person person() {
+        return new Person();
     }
 
     public static Person person(Limb... limbs) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/GetterFactoryMapModifiersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/GetterFactoryMapModifiersTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+import static com.hazelcast.query.impl.getters.AbstractMultiValueGetter.WRONG_MODIFIER_SUFFIX_ERROR;
+import static com.hazelcast.query.impl.getters.GetterFactoryMapModifiersTest.Person.person;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.is;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class GetterFactoryMapModifiersTest {
+
+    private static final String WRONG_INPUT_ANY = "[any";
+    private static final String MODIFIER_SUFFIX = "[any]";
+    private static final String MATCHING_MODIFIER = "['Joe']";
+    private static final String MISMATCHING_MODIFIER = "['Jack']";
+
+    private final Field employeesField;
+    private final Method mapGetterMethod;
+
+    private Department department;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setUp() throws Exception {
+        department = Department.of(
+                person("Joe"),
+                person("Jan")
+        );
+    }
+
+    public GetterFactoryMapModifiersTest() throws NoSuchFieldException, NoSuchMethodException {
+        employeesField = Department.class.getDeclaredField("employees");
+        mapGetterMethod = Department.class.getDeclaredMethod("getEmployees");
+    }
+
+    @Test
+    public void newFieldGetterReturnsCorrectTypeForModifierAny() throws Exception {
+        // Act
+        Getter fieldGetter = GetterFactory.newFieldGetter(department, null, employeesField, MODIFIER_SUFFIX);
+
+        // Assert
+        Class returnType = fieldGetter.getReturnType();
+        Assert.assertThat(returnType, CoreMatchers.<Class>is(Person.class));
+    }
+
+    @Test
+    public void newFieldGetterReturnCorrectTypeForModifierMatchingElement() throws Exception {
+        // Act
+        Getter fieldGetter = GetterFactory.newFieldGetter(department, null, employeesField, MATCHING_MODIFIER);
+
+        // Assert
+        Class returnType = fieldGetter.getReturnType();
+        Assert.assertThat(returnType, CoreMatchers.<Class>is(Person.class));
+    }
+
+    @Test
+    public void newFieldGetterReturnCorrectTypeForModifierMismatchingElement() throws Exception {
+        // Act
+        Getter fieldGetter = GetterFactory.newFieldGetter(department, null, employeesField, MISMATCHING_MODIFIER);
+
+        // Assert
+        Class returnType = fieldGetter.getReturnType();
+        Assert.assertThat(returnType, CoreMatchers.<Class>is(Person.class));
+    }
+
+    @Test
+    public void newFieldGetterIcorrectMapModifierThrowsIllegalArgumentExcetpion() throws Exception {
+        // Arrange
+        Department department = Department.of();
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format(WRONG_MODIFIER_SUFFIX_ERROR, WRONG_INPUT_ANY));
+
+        // Act
+        Getter fieldGetter = GetterFactory.newFieldGetter(department, null, employeesField, WRONG_INPUT_ANY);
+
+        // Assert
+        Class returnType = fieldGetter.getReturnType();
+        Assert.assertThat(returnType, CoreMatchers.<Class>is(Person.class));
+    }
+
+    @Test
+    public void newFieldGetterCorrectMapModifierReturnsNullReturnTypeFroEmptyMap() throws Exception {
+        // Arrange
+        Department department = Department.of();
+
+        // Act
+        Getter fieldGetter = GetterFactory.newFieldGetter(department, null, employeesField, MODIFIER_SUFFIX);
+
+        // Assert
+        Class returnType = fieldGetter.getReturnType();
+        Assert.assertThat(returnType, is(nullValue()));
+    }
+
+    @Test
+    public void newMethodGetterReturnsCorrectTypeForModifierAny() throws Exception {
+        // Act
+        Getter fieldGetter = GetterFactory.newMethodGetter(department, null, mapGetterMethod, MODIFIER_SUFFIX);
+
+        // Assert
+        Class returnType = fieldGetter.getReturnType();
+        Assert.assertThat(returnType, CoreMatchers.<Class>is(Person.class));
+    }
+
+    @Test
+    public void newMethodGetterReturnCorrectTypeForModifierMatchingElement() throws Exception {
+        // Act
+        Getter fieldGetter = GetterFactory.newMethodGetter(department, null, mapGetterMethod, MATCHING_MODIFIER);
+
+        // Assert
+        Class returnType = fieldGetter.getReturnType();
+        Assert.assertThat(returnType, CoreMatchers.<Class>is(Person.class));
+    }
+
+    @Test
+    public void newMethodGetterReturnCorrectTypeForModifierMismatchingElement() throws Exception {
+        // Act
+        Getter fieldGetter = GetterFactory.newMethodGetter(department, null, mapGetterMethod, MISMATCHING_MODIFIER);
+
+        // Assert
+        Class returnType = fieldGetter.getReturnType();
+        Assert.assertThat(returnType, CoreMatchers.<Class>is(Person.class));
+    }
+
+
+    @Test
+    public void newMethodGetterIcorrectMapModifierThrowsIllegalArgumentExcetpion() throws Exception {
+        // Arrange
+        Department department = Department.of();
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format(WRONG_MODIFIER_SUFFIX_ERROR, WRONG_INPUT_ANY));
+
+        // Act
+        Getter fieldGetter = GetterFactory.newMethodGetter(department, null, mapGetterMethod, WRONG_INPUT_ANY);
+
+        // Assert
+        Class returnType = fieldGetter.getReturnType();
+        Assert.assertThat(returnType, CoreMatchers.<Class>is(Person.class));
+    }
+
+    @Test
+    public void newMethodGetterCorrectMapModifierReturnsNullReturnTypeFroEmptyMap() throws Exception {
+        // Arrange
+        Department department = Department.of();
+
+        // Act
+        Getter fieldGetter = GetterFactory.newMethodGetter(department, null, mapGetterMethod, MODIFIER_SUFFIX);
+
+        // Assert
+        Class returnType = fieldGetter.getReturnType();
+        Assert.assertThat(returnType, is(nullValue()));
+    }
+
+
+    static class Person {
+
+        private final String name;
+
+        private Person(String name) {
+            this.name = name;
+        }
+
+        static Person person(String name) {
+            return new Person(name);
+        }
+    }
+
+
+    static class Department {
+
+        Map<String, Person> employees = new HashMap<String, Person>();
+
+        Map<String, Person> getEmployees() {
+            return employees;
+        }
+
+        private static Department of(Person... employees) {
+            Department department = new Department();
+            for (Person employee : employees) {
+                department.employees.put(employee.name, employee);
+            }
+            return department;
+        }
+    }
+}


### PR DESCRIPTION
Added capability to query objects by it's field of type Map for #8231 
    - `AbstractMultiValueGetter` has new inner state to hold info about the reduceType, not depends on the `int modifier` value anymore, though the value is in sync for backward compatibility.
    - new constant `MODIFIER_NOT_USED` is introduced into `AbstractMultiValueGetter` to inform that the getter refers to the Map kind of reduce
    - `GetterFactory` refactored to avoid duplication of code
    - `GetterFactory` extended with the logic to define return type for non-empty map
    - added test cases for getting Map return type
    - added few basic cases to check query is working for the MapField

Fixes: 
https://github.com/hazelcast/hazelcast/issues/8231
https://github.com/hazelcast/hazelcast/issues/12801