### PR TITLE
Near-cache batch invalidation events should have sourceUuid set always

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheReadWriteThroughTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheReadWriteThroughTest.java
@@ -19,8 +19,11 @@ package com.hazelcast.client.cache;
 import com.hazelcast.cache.CacheReadWriteThroughTest;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.CacheConfiguration;
+import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.instance.HazelcastInstanceImpl;
@@ -51,22 +54,32 @@ import static org.junit.Assert.assertNotNull;
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientCacheReadWriteThroughTest extends CacheReadWriteThroughTest {
 
+    private static final String CACHE_WITH_NEARCACHE = randomName();
+    private static final int NEARCACHE_SIZE = 100;
+
     private CachingProvider serverCachingProvider;
 
+    @Override
     protected CachingProvider createCachingProvider(HazelcastInstance instance) {
         return HazelcastClientCachingProvider.createCachingProvider(instance);
     }
 
+    @Override
     protected TestHazelcastInstanceFactory createInstanceFactory(int instanceCount) {
         return new TestHazelcastFactory();
     }
 
+    @Override
     protected HazelcastInstance getInstance() {
         // Create server instance
         HazelcastInstance serverInstance = factory.newHazelcastInstance(createConfig());
         serverCachingProvider = HazelcastServerCachingProvider.createCachingProvider(serverInstance);
         // Create client instance
-        return ((TestHazelcastFactory) factory).newHazelcastClient();
+        ClientConfig clientConfig = new ClientConfig();
+        NearCacheConfig nearCacheConfig = new NearCacheConfig(CACHE_WITH_NEARCACHE);
+        nearCacheConfig.getEvictionConfig().setSize(NEARCACHE_SIZE);
+        clientConfig.addNearCacheConfig(nearCacheConfig);
+        return ((TestHazelcastFactory) factory).newHazelcastClient(clientConfig);
     }
 
     @Override
@@ -102,6 +115,23 @@ public class ClientCacheReadWriteThroughTest extends CacheReadWriteThroughTest {
         assertEquals(keys.size(), loaded.size());
         for (Map.Entry<Integer, String> entry : loaded.entrySet()) {
             assertEquals(ServerSideCacheLoader.valueOf(entry.getKey()), entry.getValue());
+        }
+    }
+
+    @Test
+    public void test_readThroughCacheLoader_withNearCache() {
+        String cacheName = CACHE_WITH_NEARCACHE;
+        CacheConfiguration<Integer, String> cacheConfig =
+                new CacheConfig<Integer, String>()
+                        .setReadThrough(true)
+                        .setCacheLoaderFactory(new ServerSideCacheLoaderFactory());
+
+        serverCachingProvider.getCacheManager().createCache(cacheName, cacheConfig);
+
+        Cache<Integer, String> cache = cachingProvider.getCacheManager().getCache(cacheName);
+
+        for (int i = 0; i < NEARCACHE_SIZE * 5; i++) {
+            assertNotNull(cache.get(i));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -588,12 +588,12 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
     protected R createRecordWithExpiry(Data key, Object value, long expiryTime,
                                        long now, boolean disableWriteThrough, int completionId) {
-        return createRecordWithExpiry(key, value, expiryTime, now, disableWriteThrough, completionId, null);
+        return createRecordWithExpiry(key, value, expiryTime, now, disableWriteThrough, completionId, SOURCE_NOT_AVAILABLE);
     }
 
     protected R createRecordWithExpiry(Data key, Object value, ExpiryPolicy expiryPolicy,
                                        long now, boolean disableWriteThrough, int completionId) {
-        return createRecordWithExpiry(key, value, expiryPolicy, now, disableWriteThrough, completionId, null);
+        return createRecordWithExpiry(key, value, expiryPolicy, now, disableWriteThrough, completionId, SOURCE_NOT_AVAILABLE);
     }
 
     protected R createRecordWithExpiry(Data key, Object value, ExpiryPolicy expiryPolicy,

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
@@ -29,6 +29,8 @@ import com.hazelcast.spi.partition.IPartitionService;
 import java.util.Collection;
 import java.util.UUID;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 /**
  * Contains shared functionality for Near Cache invalidation.
  */
@@ -63,9 +65,8 @@ public abstract class Invalidator {
      * @param dataStructureName name of the data structure to be invalidated
      */
     public final void invalidateKey(Data key, String dataStructureName, String sourceUuid) {
-        assert key != null;
-        assert dataStructureName != null;
-        assert sourceUuid != null;
+        checkNotNull(key, "key cannot be null");
+        checkNotNull(sourceUuid, "sourceUuid cannot be null");
 
         Invalidation invalidation = newKeyInvalidation(key, dataStructureName, sourceUuid);
         invalidateInternal(invalidation, getPartitionId(key));
@@ -77,8 +78,7 @@ public abstract class Invalidator {
      * @param dataStructureName name of the data structure to be cleared
      */
     public final void invalidateAllKeys(String dataStructureName, String sourceUuid) {
-        assert dataStructureName != null;
-        assert sourceUuid != null;
+        checkNotNull(sourceUuid, "sourceUuid cannot be null");
 
         int orderKey = getPartitionId(dataStructureName);
         Invalidation invalidation = newClearInvalidation(dataStructureName, sourceUuid);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/NonStopInvalidatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/invalidation/NonStopInvalidatorTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.RequireAssertEnabled;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
@@ -50,14 +49,12 @@ public class NonStopInvalidatorTest extends HazelcastTestSupport {
         invalidator = new NonStopInvalidator(MapService.SERVICE_NAME, TRUE_FILTER, nodeEngineImpl);
     }
 
-    @RequireAssertEnabled
-    @Test(expected = AssertionError.class)
+    @Test(expected = NullPointerException.class)
     public void testInvalidate_withInvalidMapName() {
         invalidator.invalidateKey(key, null, null);
     }
 
-    @RequireAssertEnabled
-    @Test(expected = AssertionError.class)
+    @Test(expected = NullPointerException.class)
     public void testClear_withInvalidMapName() {
         invalidator.invalidateAllKeys(null, null);
     }


### PR DESCRIPTION
Batch invalidation events contains list of sourceUuids. Client protocol
doesn't expect a null item while serializing collections. If that sourceUuid list
contains a null item, serialization fails with NPE.

When a cache record is created via read-through cache-loader, an invalidation event
with null source is published. Instead of null, used constant `SOURCE_NOT_AVAILABLE` source.

Fixes https://github.com/hazelcast/hazelcast/issues/10328

Backport of https://github.com/hazelcast/hazelcast/pull/12723