### PR TITLE
Make OverloadedConnectionsPluginTest more resilient

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPluginTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.map.impl.operation.GetOperation;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.spi.impl.operationservice.impl.DummyOperation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.Backup;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
@@ -57,7 +58,8 @@ public class OverloadedConnectionsPluginTest extends AbstractDiagnosticsPluginTe
         Config config = new Config()
                 .setProperty(OverloadedConnectionsPlugin.PERIOD_SECONDS.getName(), "1")
                 .setProperty(OverloadedConnectionsPlugin.SAMPLES.getName(), "10")
-                .setProperty(OverloadedConnectionsPlugin.THRESHOLD.getName(), "10");
+                .setProperty(OverloadedConnectionsPlugin.THRESHOLD.getName(), "2")
+                .setProperty(GroupProperty.IO_OUTPUT_THREAD_COUNT.getName(), "1");
 
         local = Hazelcast.newHazelcastInstance(config);
         serializationService = getSerializationService(local);


### PR DESCRIPTION
OverloadedConnectionsPluginTest may fail if the outbound I/O threads can keep up the pace with the load that the only one load producer thread is generating with the async get operations in the test.
Currently, there is no reliable and clean way of throttling outbound connector or queue, therefore this commit attempts to decrease the possibility of test failures by decreasing both the number of I/O threads and the threshold.

Fixes #12713