### PR TITLE
Add more granularity to the "/health" REST endpoint.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -35,6 +35,12 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
 
     public static final String QUEUE_SIZE_COMMAND = "size";
 
+    private static final String HEALTH_PATH_PARAM_NODE_STATE = "/node-state";
+    private static final String HEALTH_PATH_PARAM_CLUSTER_STATE = "/cluster-state";
+    private static final String HEALTH_PATH_PARAM_CLUSTER_SAFE = "/cluster-safe";
+    private static final String HEALTH_PATH_PARAM_MIGRATION_QUEUE_SIZE = "/migration-queue-size";
+    private static final String HEALTH_PATH_PARAM_CLUSTER_SIZE = "/cluster-size";
+
     public HttpGetCommandProcessor(TextCommandService textCommandService) {
         super(textCommandService);
     }
@@ -48,8 +54,8 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
             handleQueue(command, uri);
         } else if (uri.startsWith(URI_CLUSTER)) {
             handleCluster(command);
-        } else if (uri.equals(URI_HEALTH_URL)) {
-            handleHealthcheck(command);
+        } else if (uri.startsWith(URI_HEALTH_URL)) {
+            handleHealthcheck(command, uri);
         } else if (uri.startsWith(URI_CLUSTER_VERSION_URL)) {
             handleGetClusterVersion(command);
         } else {
@@ -58,7 +64,7 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         textCommandService.sendResponse(command);
     }
 
-    private void handleHealthcheck(HttpGetCommand command) {
+    private void handleHealthcheck(HttpGetCommand command, String uri) {
         Node node = textCommandService.getNode();
         NodeState nodeState = node.getState();
 
@@ -71,14 +77,32 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         boolean clusterSafe = memberStateSafe && !partitionService.hasOnGoingMigration();
         long migrationQueueSize = partitionService.getMigrationQueueSize();
 
-        StringBuilder res = new StringBuilder();
-        res.append("Hazelcast::NodeState=").append(nodeState).append("\n");
-        res.append("Hazelcast::ClusterState=").append(clusterState).append("\n");
-        res.append("Hazelcast::ClusterSafe=").append(Boolean.toString(clusterSafe)
-                .toUpperCase(StringUtil.LOCALE_INTERNAL)).append("\n");
-        res.append("Hazelcast::MigrationQueueSize=").append(migrationQueueSize).append("\n");
-        res.append("Hazelcast::ClusterSize=").append(clusterSize).append("\n");
-        command.setResponse(MIME_TEXT_PLAIN, stringToBytes(res.toString()));
+        String healthParameter = uri.substring(URI_HEALTH_URL.length());
+        if (healthParameter.equals(HEALTH_PATH_PARAM_NODE_STATE)) {
+            command.setResponse(null, stringToBytes(nodeState.toString()));
+        } else if (healthParameter.equals(HEALTH_PATH_PARAM_CLUSTER_STATE)) {
+            command.setResponse(null, stringToBytes(clusterState.toString()));
+        } else if (healthParameter.equals(HEALTH_PATH_PARAM_CLUSTER_SAFE)) {
+            command.setResponse(null, stringToBytes(booleanToString(clusterSafe)));
+        } else if (healthParameter.equals(HEALTH_PATH_PARAM_MIGRATION_QUEUE_SIZE)) {
+            command.setResponse(null, stringToBytes(Long.toString(migrationQueueSize)));
+        } else if (healthParameter.equals(HEALTH_PATH_PARAM_CLUSTER_SIZE)) {
+            command.setResponse(null, stringToBytes(Integer.toString(clusterSize)));
+        } else if (healthParameter.isEmpty()) {
+            StringBuilder res = new StringBuilder();
+            res.append("Hazelcast::NodeState=").append(nodeState).append("\n");
+            res.append("Hazelcast::ClusterState=").append(clusterState).append("\n");
+            res.append("Hazelcast::ClusterSafe=").append(booleanToString(clusterSafe)).append("\n");
+            res.append("Hazelcast::MigrationQueueSize=").append(migrationQueueSize).append("\n");
+            res.append("Hazelcast::ClusterSize=").append(clusterSize).append("\n");
+            command.setResponse(MIME_TEXT_PLAIN, stringToBytes(res.toString()));
+        } else {
+            command.send400();
+        }
+    }
+
+    private static String booleanToString(boolean b) {
+        return Boolean.toString(b).toUpperCase(StringUtil.LOCALE_INTERNAL);
     }
 
     private void handleGetClusterVersion(HttpGetCommand command) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -79,11 +79,19 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
 
         String healthParameter = uri.substring(URI_HEALTH_URL.length());
         if (healthParameter.equals(HEALTH_PATH_PARAM_NODE_STATE)) {
-            command.setResponse(null, stringToBytes(nodeState.toString()));
+            if (NodeState.SHUT_DOWN.equals(nodeState)) {
+                command.setResponse(HttpCommand.RES_503);
+            } else {
+                command.setResponse(null, stringToBytes(nodeState.toString()));
+            }
         } else if (healthParameter.equals(HEALTH_PATH_PARAM_CLUSTER_STATE)) {
             command.setResponse(null, stringToBytes(clusterState.toString()));
         } else if (healthParameter.equals(HEALTH_PATH_PARAM_CLUSTER_SAFE)) {
-            command.setResponse(null, stringToBytes(booleanToString(clusterSafe)));
+            if (clusterSafe) {
+                command.send200();
+            } else {
+                command.setResponse(HttpCommand.RES_503);
+            }
         } else if (healthParameter.equals(HEALTH_PATH_PARAM_MIGRATION_QUEUE_SIZE)) {
             command.setResponse(null, stringToBytes(Long.toString(migrationQueueSize)));
         } else if (healthParameter.equals(HEALTH_PATH_PARAM_CLUSTER_SIZE)) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -133,9 +133,19 @@ public class HTTPCommunicator {
     }
 
     public String getClusterHealth() throws IOException {
+        return getClusterHealth("");
+    }
+
+    public String getClusterHealth(String pathParam) throws IOException {
         String baseAddress = instance.getCluster().getLocalMember().getSocketAddress().toString();
-        String url = "http:/" + baseAddress + HttpCommandProcessor.URI_HEALTH_URL;
+        String url = "http:/" + baseAddress + HttpCommandProcessor.URI_HEALTH_URL + pathParam;
         return doGet(url).response;
+    }
+
+    public int getClusterHealthResponseCode(String pathParam) throws IOException {
+        String baseAddress = instance.getCluster().getLocalMember().getSocketAddress().toString();
+        String url = "http:/" + baseAddress + HttpCommandProcessor.URI_HEALTH_URL + pathParam;
+        return doGet(url).responseCode;
     }
 
     public int mapPut(String mapName, String key, String value) throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -254,7 +254,7 @@ public class RestClusterTest extends HazelcastTestSupport {
 
         assertEquals("ACTIVE", communicator.getClusterHealth("/node-state"));
         assertEquals("ACTIVE", communicator.getClusterHealth("/cluster-state"));
-        assertEquals("TRUE", communicator.getClusterHealth("/cluster-safe"));
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.getClusterHealthResponseCode("/cluster-safe"));
         assertEquals("0", communicator.getClusterHealth("/migration-queue-size"));
         assertEquals("1", communicator.getClusterHealth("/cluster-size"));
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -247,6 +247,26 @@ public class RestClusterTest extends HazelcastTestSupport {
                 + "Hazelcast::ClusterSize=1\n", result);
     }
 
+    @Test
+    public void healthCheckWithPathParameters() throws Exception {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+
+        assertEquals("ACTIVE", communicator.getClusterHealth("/node-state"));
+        assertEquals("ACTIVE", communicator.getClusterHealth("/cluster-state"));
+        assertEquals("TRUE", communicator.getClusterHealth("/cluster-safe"));
+        assertEquals("0", communicator.getClusterHealth("/migration-queue-size"));
+        assertEquals("1", communicator.getClusterHealth("/cluster-size"));
+    }
+
+    @Test
+    public void healthCheckWithUnknownPathParameter() throws Exception {
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HTTPCommunicator communicator = new HTTPCommunicator(instance);
+
+        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, communicator.getClusterHealthResponseCode("/unknown-parameter"));
+    }
+
     @Test(expected = NoHttpResponseException.class)
     public void fail_with_deactivatedHealthCheck() throws Exception {
         // Healthcheck REST URL is deactivated by default - no passed config on purpose


### PR DESCRIPTION
Add REST enpoints:
- "hazelcast/health/node-state"
- "hazelcast/health/cluster-state"
- "hazelcast/health/cluster-safe"
- "hazelcast/health/migration-queue-size"
- "hazelcast/health/cluster-size"