### PR TITLE
[BACKPORT] Avoid full result set materialization for aggregations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/AggregationResultProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/AggregationResultProcessor.java
@@ -44,6 +44,6 @@ public class AggregationResultProcessor implements ResultProcessor<AggregationRe
     @Override
     public AggregationResult populateResult(Query query, long resultLimit) {
         Aggregator resultAggregator = serializationService.toObject(serializationService.toData(query.getAggregator()));
-        return new AggregationResult(resultAggregator);
+        return new AggregationResult(resultAggregator, serializationService);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/CallerRunsAccumulationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/CallerRunsAccumulationExecutor.java
@@ -46,7 +46,7 @@ public class CallerRunsAccumulationExecutor implements AccumulationExecutor {
             resultAggregator.onAccumulationFinished();
         }
 
-        AggregationResult result = new AggregationResult(resultAggregator);
+        AggregationResult result = new AggregationResult(resultAggregator, serializationService);
         result.setPartitionIds(partitionIds);
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/CallerRunsPartitionScanExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/CallerRunsPartitionScanExecutor.java
@@ -18,10 +18,8 @@ package com.hazelcast.map.impl.query;
 
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryableEntriesSegment;
-import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 
-import java.util.ArrayList;
 import java.util.Collection;
 
 /**
@@ -37,12 +35,11 @@ public class CallerRunsPartitionScanExecutor implements PartitionScanExecutor {
     }
 
     @Override
-    public Collection<QueryableEntry> execute(String mapName, Predicate predicate, Collection<Integer> partitions) {
+    public void execute(String mapName, Predicate predicate, Collection<Integer> partitions, Result result) {
         RetryableHazelcastException storedException = null;
-        Collection<QueryableEntry> result = new ArrayList<QueryableEntry>();
         for (Integer partitionId : partitions) {
             try {
-                result.addAll(partitionScanRunner.run(mapName, predicate, partitionId));
+                partitionScanRunner.run(mapName, predicate, partitionId, result);
             } catch (RetryableHazelcastException e) {
                 // RetryableHazelcastException are stored and re-thrown later. this is to ensure all partitions
                 // are touched as when the parallel execution was used.
@@ -55,7 +52,6 @@ public class CallerRunsPartitionScanExecutor implements PartitionScanExecutor {
         if (storedException != null) {
             throw storedException;
         }
-        return result;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/MapQueryEngineImpl.java
@@ -190,27 +190,30 @@ public class MapQueryEngineImpl implements MapQueryEngine {
     private void addResultsOfPredicate(List<Future<Result>> futures, Result result,
                                        BitSet finishedPartitionIds, boolean rethrowAll) {
         for (Future<Result> future : futures) {
+            Result queryResult = null;
+
             try {
-                Result queryResult = future.get();
-                if (queryResult == null) {
-                    continue;
-                }
-                Collection<Integer> queriedPartitionIds = queryResult.getPartitionIds();
-                if (queriedPartitionIds != null) {
-                    if (!hasAllBitsSet(finishedPartitionIds, queriedPartitionIds)) {
-                        // do not take into account results that contain partition IDs already removed from partitionIds
-                        // collection as this means that we will count results from a single partition twice
-                        // see also https://github.com/hazelcast/hazelcast/issues/6471
-                        continue;
-                    }
-                    BitSetUtils.unsetBits(finishedPartitionIds, queriedPartitionIds);
-                    result.combine(queryResult);
-                }
+                queryResult = future.get();
             } catch (Throwable t) {
                 if (t.getCause() instanceof QueryResultSizeExceededException || rethrowAll) {
                     throw rethrow(t);
                 }
                 logger.fine("Could not get query results", t);
+            }
+
+            if (queryResult == null) {
+                continue;
+            }
+            Collection<Integer> queriedPartitionIds = queryResult.getPartitionIds();
+            if (queriedPartitionIds != null) {
+                if (!hasAllBitsSet(finishedPartitionIds, queriedPartitionIds)) {
+                    // do not take into account results that contain partition IDs already removed from partitionIds
+                    // collection as this means that we will count results from a single partition twice
+                    // see also https://github.com/hazelcast/hazelcast/issues/6471
+                    continue;
+                }
+                BitSetUtils.unsetBits(finishedPartitionIds, queriedPartitionIds);
+                result.combine(queryResult);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelAccumulationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelAccumulationExecutor.java
@@ -65,7 +65,7 @@ public class ParallelAccumulationExecutor implements AccumulationExecutor {
             resultAggregator.onCombinationFinished();
         }
 
-        AggregationResult result = new AggregationResult(resultAggregator);
+        AggregationResult result = new AggregationResult(resultAggregator, serializationService);
         result.setPartitionIds(partitionIds);
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutor.java
@@ -19,11 +19,11 @@ package com.hazelcast.map.impl.query;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryableEntriesSegment;
-import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.util.executor.ManagedExecutorService;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -32,7 +32,6 @@ import java.util.concurrent.Future;
 import static com.hazelcast.query.PagingPredicateAccessor.getNearestAnchorEntry;
 import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
 import static com.hazelcast.util.FutureUtil.returnWithDeadline;
-import static com.hazelcast.util.SortingUtil.getSortedSubList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -45,21 +44,20 @@ public class ParallelPartitionScanExecutor implements PartitionScanExecutor {
     private final ManagedExecutorService executor;
     private final int timeoutInMillis;
 
-    public ParallelPartitionScanExecutor(
-            PartitionScanRunner partitionScanRunner, ManagedExecutorService executor, int timeoutInMillis) {
+    public ParallelPartitionScanExecutor(PartitionScanRunner partitionScanRunner, ManagedExecutorService executor,
+                                         int timeoutInMillis) {
         this.partitionScanRunner = partitionScanRunner;
         this.executor = executor;
         this.timeoutInMillis = timeoutInMillis;
     }
 
     @Override
-    public List<QueryableEntry> execute(String mapName, Predicate predicate, Collection<Integer> partitions) {
-        List<QueryableEntry> result = runUsingPartitionScanWithoutPaging(mapName, predicate, partitions);
+    public void execute(String mapName, Predicate predicate, Collection<Integer> partitions, Result result) {
+        runUsingPartitionScanWithoutPaging(mapName, predicate, partitions, result);
         if (predicate instanceof PagingPredicate) {
             Map.Entry<Integer, Map.Entry> nearestAnchorEntry = getNearestAnchorEntry((PagingPredicate) predicate);
-            result = getSortedSubList(result, (PagingPredicate) predicate, nearestAnchorEntry);
+            result.orderAndLimit((PagingPredicate) predicate, nearestAnchorEntry);
         }
-        return result;
     }
 
     /**
@@ -71,47 +69,48 @@ public class ParallelPartitionScanExecutor implements PartitionScanExecutor {
         return partitionScanRunner.run(mapName, predicate, partitionId, tableIndex, fetchSize);
     }
 
-    protected List<QueryableEntry> runUsingPartitionScanWithoutPaging(
-            String name, Predicate predicate, Collection<Integer> partitions) {
-
-        List<Future<Collection<QueryableEntry>>> futures = new ArrayList<Future<Collection<QueryableEntry>>>(partitions.size());
+    protected void runUsingPartitionScanWithoutPaging(String name, Predicate predicate, Collection<Integer> partitions,
+                                                      Result result) {
+        List<Future<Result>> futures = new ArrayList<Future<Result>>(partitions.size());
 
         for (Integer partitionId : partitions) {
-            Future<Collection<QueryableEntry>> future = runPartitionScanForPartition(name, predicate, partitionId);
+            Future<Result> future = runPartitionScanForPartition(name, predicate, partitionId, result.createSubResult());
             futures.add(future);
         }
 
-        Collection<Collection<QueryableEntry>> returnedResults = waitForResult(futures, timeoutInMillis);
-        List<QueryableEntry> result = new ArrayList<QueryableEntry>();
-        for (Collection<QueryableEntry> returnedResult : returnedResults) {
-            result.addAll(returnedResult);
+        Collection<Result> subResults = waitForResult(futures, timeoutInMillis);
+        for (Result subResult : subResults) {
+            result.combine(subResult);
         }
-        return result;
     }
 
-    protected Future<Collection<QueryableEntry>> runPartitionScanForPartition(String name, Predicate predicate, int partitionId) {
-        QueryPartitionCallable task = new QueryPartitionCallable(name, predicate, partitionId);
+    protected Future<Result> runPartitionScanForPartition(String name, Predicate predicate, int partitionId, Result result) {
+        QueryPartitionCallable task = new QueryPartitionCallable(name, predicate, partitionId, result);
         return executor.submit(task);
     }
 
-    private static <T> Collection<Collection<T>> waitForResult(List<Future<Collection<T>>> lsFutures, int timeoutInMillis) {
+    private static Collection<Result> waitForResult(List<Future<Result>> lsFutures, int timeoutInMillis) {
         return returnWithDeadline(lsFutures, timeoutInMillis, MILLISECONDS, RETHROW_EVERYTHING);
     }
 
-    private final class QueryPartitionCallable implements Callable<Collection<QueryableEntry>> {
+    private final class QueryPartitionCallable implements Callable<Result> {
         protected final int partition;
         protected final String name;
         protected final Predicate predicate;
+        protected final Result result;
 
-        private QueryPartitionCallable(String name, Predicate predicate, int partitionId) {
+        private QueryPartitionCallable(String name, Predicate predicate, int partitionId, Result result) {
             this.name = name;
             this.predicate = predicate;
             this.partition = partitionId;
+            this.result = result;
         }
 
         @Override
-        public Collection<QueryableEntry> call() throws Exception {
-            return partitionScanRunner.run(name, predicate, partition);
+        public Result call() {
+            partitionScanRunner.run(name, predicate, partition, result);
+            result.setPartitionIds(Collections.singletonList(partition));
+            return result;
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/PartitionScanExecutor.java
@@ -19,7 +19,6 @@ package com.hazelcast.map.impl.query;
 import com.hazelcast.core.IMap;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.QueryableEntriesSegment;
-import com.hazelcast.query.impl.QueryableEntry;
 
 import java.util.Collection;
 
@@ -29,7 +28,7 @@ import java.util.Collection;
  */
 public interface PartitionScanExecutor {
 
-    Collection<QueryableEntry> execute(String mapName, Predicate predicate, Collection<Integer> partitions);
+    void execute(String mapName, Predicate predicate, Collection<Integer> partitions, Result result);
 
     /**
      * Executes the predicate on a partition chunk. The offset in the partition is defined by the {@code tableIndex}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -29,7 +29,6 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.BinaryOperationFactory;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
-import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryOperation.java
@@ -29,6 +29,7 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.BinaryOperationFactory;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
+import com.hazelcast.util.ExceptionUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import java.util.List;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.spi.ExceptionAction.THROW_EXCEPTION;
 import static com.hazelcast.util.CollectionUtil.toIntArray;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 /**
  * Native handling only for RU compatibility purposes, can be deleted in 3.10 master
@@ -87,9 +89,9 @@ public class QueryOperation extends MapOperation implements ReadonlyOperation {
                        try {
                            modifiableResult = queryRunner.populateEmptyResult(query, initialPartitions);
                            populateResult((PartitionIteratingOperation.PartitionResponse) response, modifiableResult);
-                       } catch (Throwable throwable) {
-                           QueryOperation.this.sendResponse(throwable);
-                           return;
+                       } catch (Exception e) {
+                           QueryOperation.this.sendResponse(e);
+                           throw rethrow(e);
                        }
                        QueryOperation.this.sendResponse(modifiableResult);
                    } finally {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
@@ -23,9 +23,11 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.projection.Projection;
+import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.IterationType;
+import com.hazelcast.util.SortingUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,29 +35,77 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
 
 /**
- * Contains the result of a query or projection evaluation.
+ * Represents a result of the query execution in the form of an iterable
+ * collection of {@link QueryResultRow rows}.
  * <p>
- * A QueryResults is a collections of {@link QueryResultRow} instances.
+ * There are two modes of the result construction, the selection of the mode is
+ * controlled by the {@code orderAndLimitExpected} parameter:
+ * <ol>
+ * <li>When {@code orderAndLimitExpected} is {@code true}, this indicates that
+ * the call to the {@link #orderAndLimit} method is expected on behalf of the
+ * {@link PagingPredicate paging predicate} involved in the query. In this case,
+ * the intermediate result is represented as a collection of {@link
+ * QueryableEntry queryable entries} to allow the comparison of the items using
+ * the comparator of the paging predicate. After the call to {@link
+ * #completeConstruction}, all the queryable entries are converted to {@link
+ * QueryResultRow rows} and the result is ready to be provided to the client.
+ * <li>When {@code orderAndLimitExpected} is {@code false}, this indicates that
+ * no calls to the {@link #orderAndLimit} method are expected. In this case, the
+ * intermediate result is represented directly as a collection of {@link
+ * QueryResultRow rows} and no further conversion is performed.
+ * </ol>
  */
 public class QueryResult implements Result<QueryResult>, IdentifiedDataSerializable, Iterable<QueryResultRow> {
 
-    private final List<QueryResultRow> rows = new LinkedList<QueryResultRow>();
+    private List rows = new LinkedList();
 
     private Collection<Integer> partitionIds;
-
-    private transient long resultLimit;
-    private transient long resultSize;
     private IterationType iterationType;
 
+    private final transient SerializationService serializationService;
+    private final transient long resultLimit;
+    private final transient boolean orderAndLimitExpected;
+    private final transient Projection projection;
+
+    private transient long resultSize;
+
+    /**
+     * Constructs an empty result for the purposes of deserialization.
+     */
     public QueryResult() {
+        serializationService = null;
+        orderAndLimitExpected = false;
         resultLimit = Long.MAX_VALUE;
+        projection = null;
     }
 
-    public QueryResult(IterationType iterationType, long resultLimit) {
-        this.resultLimit = resultLimit;
+    /**
+     * Constructs an empty result.
+     *
+     * @param iterationType         the iteration type of the query for which
+     *                              this result is constructed for.
+     * @param projection            the projection of the query for which this
+     *                              result is constructed for.
+     * @param serializationService  the serialization service associated with
+     *                              the query for which this result is
+     *                              constructed for.
+     * @param resultLimit           the upper limit on the number of items that
+     *                              can be {@link #add added} to this result.
+     * @param orderAndLimitExpected the flag to signal that the call to the
+     *                              {@link #orderAndLimit} method is expected,
+     *                              see the class javadoc for more details.
+     */
+    public QueryResult(IterationType iterationType, Projection projection, SerializationService serializationService,
+                       long resultLimit, boolean orderAndLimitExpected) {
         this.iterationType = iterationType;
+        this.projection = projection;
+        this.serializationService = serializationService;
+        this.resultLimit = resultLimit;
+        this.orderAndLimitExpected = orderAndLimitExpected;
     }
 
     // for testing
@@ -68,49 +118,65 @@ public class QueryResult implements Result<QueryResult>, IdentifiedDataSerializa
         return rows.iterator();
     }
 
+    /**
+     * @return the size of this result.
+     */
     public int size() {
         return rows.size();
     }
 
+    /**
+     * @return {@code true} if this result is empty, {@code false} otherwise.
+     **/
     public boolean isEmpty() {
         return rows.isEmpty();
     }
 
-    // just for testing
-    long getResultLimit() {
-        return resultLimit;
-    }
-
+    /**
+     * Adds the given row into this result.
+     *
+     * @param row the row to add.
+     */
     public void addRow(QueryResultRow row) {
         rows.add(row);
     }
 
-    public void add(QueryableEntry entry, Projection projection, SerializationService serializationService) {
+    /**
+     * {@inheritDoc}
+     *
+     * @throws QueryResultSizeExceededException if the size of this result
+     *                                          exceeds the result size limit.
+     */
+    @Override
+    public void add(QueryableEntry entry) {
         if (++resultSize > resultLimit) {
             throw new QueryResultSizeExceededException();
         }
 
-        Data key = null;
-        Data value = null;
-        switch (iterationType) {
-            case KEY:
-                key = entry.getKeyData();
-                break;
-            case VALUE:
-                value = getValueData(entry, projection, serializationService);
-                break;
-            case ENTRY:
-                key = entry.getKeyData();
-                value = entry.getValueData();
-                break;
-            default:
-                throw new IllegalStateException("Unknown iterationtype:" + iterationType);
-        }
-
-        rows.add(new QueryResultRow(key, value));
+        rows.add(orderAndLimitExpected ? entry : convertEntryToRow(entry));
     }
 
-    private Data getValueData(QueryableEntry entry, Projection projection, SerializationService serializationService) {
+    @Override
+    public QueryResult createSubResult() {
+        return new QueryResult(iterationType, projection, serializationService, resultLimit, orderAndLimitExpected);
+    }
+
+    @Override
+    public void orderAndLimit(PagingPredicate pagingPredicate, Map.Entry<Integer, Map.Entry> nearestAnchorEntry) {
+        rows = SortingUtil.getSortedSubList(rows, pagingPredicate, nearestAnchorEntry);
+    }
+
+    @Override
+    public void completeConstruction(Collection<Integer> partitionIds) {
+        setPartitionIds(partitionIds);
+        if (orderAndLimitExpected) {
+            for (ListIterator iterator = rows.listIterator(); iterator.hasNext(); ) {
+                iterator.set(convertEntryToRow((QueryableEntry) iterator.next()));
+            }
+        }
+    }
+
+    private Data getValueData(QueryableEntry entry) {
         if (projection != null) {
             return serializationService.toData(projection.transform(entry));
         } else {
@@ -133,7 +199,7 @@ public class QueryResult implements Result<QueryResult>, IdentifiedDataSerializa
             partitionIds = new ArrayList<Integer>(otherPartitionIds.size());
         }
         partitionIds.addAll(otherPartitionIds);
-        rows.addAll(result.getRows());
+        rows.addAll(result.rows);
     }
 
     @Override
@@ -145,6 +211,9 @@ public class QueryResult implements Result<QueryResult>, IdentifiedDataSerializa
         this.partitionIds = new ArrayList<Integer>(partitionIds);
     }
 
+    /**
+     * @return the rows of this result.
+     */
     public List<QueryResultRow> getRows() {
         return rows;
     }
@@ -174,7 +243,7 @@ public class QueryResult implements Result<QueryResult>, IdentifiedDataSerializa
         int resultSize = rows.size();
         out.writeInt(resultSize);
         if (resultSize > 0) {
-            for (QueryResultRow row : rows) {
+            for (QueryResultRow row : (List<QueryResultRow>) rows) {
                 row.writeData(out);
             }
         }
@@ -200,5 +269,25 @@ public class QueryResult implements Result<QueryResult>, IdentifiedDataSerializa
                 rows.add(row);
             }
         }
+    }
+
+    private QueryResultRow convertEntryToRow(QueryableEntry entry) {
+        Data key = null;
+        Data value = null;
+        switch (iterationType) {
+            case KEY:
+                key = entry.getKeyData();
+                break;
+            case VALUE:
+                value = getValueData(entry);
+                break;
+            case ENTRY:
+                key = entry.getKeyData();
+                value = entry.getValueData();
+                break;
+            default:
+                throw new IllegalStateException("Unknown iterationType:" + iterationType);
+        }
+        return new QueryResultRow(key, value);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultProcessor.java
@@ -35,9 +35,10 @@ public class QueryResultProcessor implements ResultProcessor<QueryResult> {
     @Override
     public QueryResult populateResult(Query query, long resultLimit, Collection<QueryableEntry> entries,
                                       Collection<Integer> partitionIds) {
-        QueryResult result = new QueryResult(query.getIterationType(), resultLimit);
+        QueryResult result = new QueryResult(query.getIterationType(), query.getProjection(), serializationService, resultLimit,
+                false);
         for (QueryableEntry entry : entries) {
-            result.add(entry, query.getProjection(), serializationService);
+            result.add(entry);
         }
         result.setPartitionIds(partitionIds);
         return result;
@@ -45,6 +46,6 @@ public class QueryResultProcessor implements ResultProcessor<QueryResult> {
 
     @Override
     public QueryResult populateResult(Query query, long resultLimit) {
-        return new QueryResult(query.getIterationType(), resultLimit);
+        return new QueryResult(query.getIterationType(), query.getProjection(), serializationService, resultLimit, false);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Result.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Result.java
@@ -17,8 +17,11 @@
 package com.hazelcast.map.impl.query;
 
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.query.PagingPredicate;
+import com.hazelcast.query.impl.QueryableEntry;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Result of a Query. Each query type implements its own Result.
@@ -27,11 +30,76 @@ import java.util.Collection;
  */
 public interface Result<T extends Result> extends IdentifiedDataSerializable {
 
+    /**
+     * @return partition IDs of this result.
+     */
     Collection<Integer> getPartitionIds();
 
+    /**
+     * Sets the partition IDs of this result.
+     *
+     * @param partitionIds the partition IDs to set.
+     */
     void setPartitionIds(Collection<Integer> partitionIds);
 
+    /**
+     * Combines the given result with this result modifying this result.
+     *
+     * @param result the result to combine with.
+     * @see #onCombineFinished()
+     */
     void combine(T result);
 
+    /**
+     * Invoked when the result combining phase is finished.
+     * <p>
+     * Implementations may release intermediary resources associated with
+     * the combining. No further calls to {@link #combine} are expected after
+     * this method invocation.
+     *
+     * @see #combine(Result)
+     */
     void onCombineFinished();
+
+    /**
+     * Adds the given entry to this result.
+     *
+     * @param entry the entry to add.
+     */
+    void add(QueryableEntry entry);
+
+    /**
+     * Creates a new empty sub result of the same type as this result.
+     * <p>
+     * This method is used by the query execution engine while constructing the
+     * partial sub results. These sub results are combined with this result
+     * during the final stage of the result construction.
+     *
+     * @return the created sub result.
+     */
+    T createSubResult();
+
+    /**
+     * Performs the order-and-limit operation on this result for the given
+     * paging predicate.
+     *
+     * @param pagingPredicate    the paging predicate to perform the operation
+     *                           for.
+     * @param nearestAnchorEntry the anchor entry of the paging predicate.
+     */
+    void orderAndLimit(PagingPredicate pagingPredicate, Map.Entry<Integer, Map.Entry> nearestAnchorEntry);
+
+    /**
+     * Completes the construction of this result.
+     * <p>
+     * Implementations may release intermediary resources associated with the
+     * construction in this method. No further modifications of the result are
+     * expected after this method invocation except combining the result with
+     * other results.
+     *
+     * @param partitionIds the partition IDs to associate this result with.
+     * @see #combine(Result)
+     */
+    void completeConstruction(Collection<Integer> partitionIds);
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/CallerRunsPartitionScanExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/CallerRunsPartitionScanExecutorTest.java
@@ -19,11 +19,11 @@ package com.hazelcast.map.impl.query;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.QueryException;
-import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,8 +37,8 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -48,36 +48,40 @@ public class CallerRunsPartitionScanExecutorTest {
     public ExpectedException expected = ExpectedException.none();
 
     @Test
-    public void execute_success() throws Exception {
+    public void execute_success() {
         PartitionScanRunner runner = mock(PartitionScanRunner.class);
         CallerRunsPartitionScanExecutor executor = new CallerRunsPartitionScanExecutor(runner);
         Predicate predicate = Predicates.equal("attribute", 1);
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, null, null, Long.MAX_VALUE, false);
 
-        Collection<QueryableEntry> result = executor.execute("Map", predicate, asList(1, 2, 3));
+        executor.execute("Map", predicate, asList(1, 2, 3), queryResult);
+        Collection<QueryResultRow> result = queryResult.getRows();
         assertEquals(0, result.size());
     }
 
     @Test
-    public void execute_fail() throws Exception {
+    public void execute_fail() {
         PartitionScanRunner runner = mock(PartitionScanRunner.class);
         CallerRunsPartitionScanExecutor executor = new CallerRunsPartitionScanExecutor(runner);
         Predicate predicate = Predicates.equal("attribute", 1);
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, null, null, Long.MAX_VALUE, false);
 
-        when(runner.run(anyString(), eq(predicate), anyInt())).thenThrow(new QueryException());
+        doThrow(new QueryException()).when(runner).run(anyString(), eq(predicate), anyInt(), eq(queryResult));
 
         expected.expect(QueryException.class);
-        executor.execute("Map", predicate, asList(1, 2, 3));
+        executor.execute("Map", predicate, asList(1, 2, 3), queryResult);
     }
 
     @Test
-    public void execute_fail_retryable() throws Exception {
+    public void execute_fail_retryable() {
         PartitionScanRunner runner = mock(PartitionScanRunner.class);
         CallerRunsPartitionScanExecutor executor = new CallerRunsPartitionScanExecutor(runner);
         Predicate predicate = Predicates.equal("attribute", 1);
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, null, null, Long.MAX_VALUE, false);
 
-        when(runner.run(anyString(), eq(predicate), anyInt())).thenThrow(new RetryableHazelcastException());
+        doThrow(new RetryableHazelcastException()).when(runner).run(anyString(), eq(predicate), anyInt(), eq(queryResult));
 
         expected.expect(RetryableHazelcastException.class);
-        executor.execute("Map", predicate, asList(1, 2, 3));
+        executor.execute("Map", predicate, asList(1, 2, 3), queryResult);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/ParallelPartitionScanExecutorTest.java
@@ -19,11 +19,11 @@ package com.hazelcast.map.impl.query;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.QueryException;
-import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.IterationType;
 import com.hazelcast.util.executor.NamedThreadPoolExecutor;
 import com.hazelcast.util.executor.PoolExecutorThreadFactory;
 import org.junit.Rule;
@@ -43,8 +43,9 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -54,46 +55,48 @@ public class ParallelPartitionScanExecutorTest {
     public ExpectedException expected = ExpectedException.none();
 
     private ParallelPartitionScanExecutor executor(PartitionScanRunner runner) {
-        PoolExecutorThreadFactory threadFactory = new PoolExecutorThreadFactory(UUID.randomUUID().toString(), currentThread().getContextClassLoader());
-        NamedThreadPoolExecutor pool = new NamedThreadPoolExecutor(UUID.randomUUID().toString(), 1, 1,
-                100, TimeUnit.SECONDS,
-                new LinkedBlockingQueue<Runnable>(100),
-                threadFactory
-        );
+        PoolExecutorThreadFactory threadFactory = new PoolExecutorThreadFactory(UUID.randomUUID().toString(),
+                currentThread().getContextClassLoader());
+        NamedThreadPoolExecutor pool = new NamedThreadPoolExecutor(UUID.randomUUID().toString(), 1, 1, 100, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<Runnable>(100), threadFactory);
         return new ParallelPartitionScanExecutor(runner, pool, 60000);
     }
 
     @Test
-    public void execute_success() throws Exception {
+    public void execute_success() {
         PartitionScanRunner runner = mock(PartitionScanRunner.class);
         ParallelPartitionScanExecutor executor = executor(runner);
         Predicate predicate = Predicates.equal("attribute", 1);
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, null, null, Long.MAX_VALUE, false);
 
-        List<QueryableEntry> result = executor.execute("Map", predicate, asList(1, 2, 3));
+        executor.execute("Map", predicate, asList(1, 2, 3), queryResult);
+        List<QueryResultRow> result = queryResult.getRows();
         assertEquals(0, result.size());
     }
 
     @Test
-    public void execute_fail() throws Exception {
+    public void execute_fail() {
         PartitionScanRunner runner = mock(PartitionScanRunner.class);
         ParallelPartitionScanExecutor executor = executor(runner);
         Predicate predicate = Predicates.equal("attribute", 1);
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, null, null, Long.MAX_VALUE, false);
 
-        when(runner.run(anyString(), eq(predicate), anyInt())).thenThrow(new QueryException());
+        doThrow(new QueryException()).when(runner).run(anyString(), eq(predicate), anyInt(), isA(QueryResult.class));
 
         expected.expect(QueryException.class);
-        executor.execute("Map", predicate, asList(1, 2, 3));
+        executor.execute("Map", predicate, asList(1, 2, 3), queryResult);
     }
 
     @Test
-    public void execute_fail_retryable() throws Exception {
+    public void execute_fail_retryable() {
         PartitionScanRunner runner = mock(PartitionScanRunner.class);
         ParallelPartitionScanExecutor executor = executor(runner);
         Predicate predicate = Predicates.equal("attribute", 1);
+        QueryResult queryResult = new QueryResult(IterationType.ENTRY, null, null, Long.MAX_VALUE, false);
 
-        when(runner.run(anyString(), eq(predicate), anyInt())).thenThrow(new RetryableHazelcastException());
+        doThrow(new RetryableHazelcastException()).when(runner).run(anyString(), eq(predicate), anyInt(), isA(QueryResult.class));
 
         expected.expect(RetryableHazelcastException.class);
-        executor.execute("Map", predicate, asList(1, 2, 3));
+        executor.execute("Map", predicate, asList(1, 2, 3), queryResult);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryResultTest.java
@@ -46,7 +46,7 @@ public class QueryResultTest extends HazelcastTestSupport {
 
     @Test
     public void serialization() {
-        QueryResult expected = new QueryResult(IterationType.ENTRY, 100);
+        QueryResult expected = new QueryResult(IterationType.ENTRY, null, null, 100, false);
         QueryResultRow row = new QueryResultRow(serializationService.toData("1"), serializationService.toData("row"));
         expected.addRow(row);
 


### PR DESCRIPTION
The basic idea of the fix is to pass the result set to the full
scan iterators, so they push the entries into the result set,
instead of pulling the whole result set from them.

Aggregation result set then just invokes the aggregator for each
pushed entry without actual entry result set materialization.

Regular result set appends each pushed entry to the internal
entries collection, just as it was before the fix.

Fixes: https://github.com/hazelcast/hazelcast/issues/12623

EE part: https://github.com/hazelcast/hazelcast-enterprise/pull/2024
Backport of: https://github.com/hazelcast/hazelcast/pull/12684