### PR TITLE
Use default timeout for ClientMapLoadAllTest.testGetMap_issue_3031

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoadAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLoadAllTest.java
@@ -58,7 +58,7 @@ public class ClientMapLoadAllTest extends AbstractMapStoreTest {
         hazelcastFactory.terminateAll();
     }
 
-    @Test(timeout = 60000)
+    @Test
     public void testGetMap_issue_3031() throws Exception {
         final int itemCount = 1000;
         final String mapName = randomMapName();


### PR DESCRIPTION
Resets ClientMapLoadAllTest.testGetMap_issue_3031 timeout to the
default one, which should be 300 seconds (5 minutes).

Fixes: https://github.com/hazelcast/hazelcast/issues/12663