### PR TITLE
Removed OperationExecutor.interruptOperationThreads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -165,11 +165,6 @@ public interface OperationExecutor extends PacketHandler, LiveOperationsTracker 
     int getPartitionThreadId(int partitionId);
 
     /**
-     * Interrupts the partition threads.
-     */
-    void interruptPartitionThreads();
-
-    /**
      * Starts this OperationExecutor
      */
     void start();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -387,13 +387,6 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
     }
 
     @Override
-    public void interruptPartitionThreads() {
-        for (PartitionOperationThread partitionThread : partitionThreads) {
-            partitionThread.interrupt();
-        }
-    }
-
-    @Override
     public void run(Operation operation) {
         checkNotNull(operation, "operation can't be null");
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_BasicTest.java
@@ -157,36 +157,6 @@ public class OperationExecutorImpl_BasicTest extends OperationExecutorImpl_Abstr
     }
 
     @Test
-    public void test_interruptAllPartitionThreads() throws Exception {
-        initExecutor();
-
-        int threadCount = executor.getPartitionThreadCount();
-        final CyclicBarrier barrier = new CyclicBarrier(threadCount + 1);
-
-        executor.executeOnPartitionThreads(new Runnable() {
-            @Override
-            public void run() {
-                // current thread must be a PartitionOperationThread
-                if (Thread.currentThread() instanceof PartitionOperationThread) {
-                    try {
-                        Thread.sleep(Long.MAX_VALUE);
-                    } catch (InterruptedException ignored) {
-                    } finally {
-                        try {
-                            awaitBarrier(barrier);
-                        } catch (Exception ex) {
-                            ex.printStackTrace();
-                        }
-                    }
-                }
-            }
-        });
-
-        executor.interruptPartitionThreads();
-        awaitBarrier(barrier);
-    }
-
-    @Test
     public void genericPriorityTaskIsPickedUpEvenWhenAllGenericThreadsBusy() {
         initExecutor();
 


### PR DESCRIPTION
method isn't used by EE and JET.