### PR TITLE
Renamed OperationThread.operationRunner method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationRunner.java
@@ -23,14 +23,18 @@ import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
 /**
  * The OperationRunner is responsible for the actual running of operations.
  * <p>
- * So the {@link OperationExecutor} is responsible for 'executing' them (so finding a thread to run on), the actual work is done
- * by the {@link OperationRunner}. This separation of concerns makes the code a lot simpler and makes it possible to swap parts
- * of the system.
+ * So the {@link OperationExecutor} is responsible for 'executing' them
+ * (so finding a thread to run on), the actual work is done by the
+ * {@link OperationRunner}. This separation of concerns makes the code a
+ * lot simpler and makes it possible to swap parts of the system.
  * <p>
- * Since HZ 3.5 there are multiple OperationRunner instances; each partition will have its own OperationRunner, but also
- * generic threads will have their own OperationRunners. Each OperationRunner exposes the Operation it is currently working
- * on and this makes it possible to hook on all kinds of additional functionality like detecting slow operations, sampling which
- * operations are executed most frequently, check if an operation is still running, etc etc.
+ * Since HZ 3.5 there are multiple OperationRunner instances; each partition
+ * will have its own OperationRunner, but also generic threads will have their
+ * own OperationRunners. Each OperationRunner exposes the Operation it is
+ * currently working on and this makes it possible to hook on all kinds of
+ * additional functionality like detecting slow operations, sampling which
+ * operations are executed most frequently, check if an operation is still
+ * running, etc etc.
  */
 public abstract class OperationRunner {
 
@@ -52,12 +56,14 @@ public abstract class OperationRunner {
     public abstract void run(Operation task);
 
     /**
-     * Returns the current task that is executing. This value could be null if no operation is executing.
+     * Returns the current task that is executing. This value could be null
+     * if no operation is executing.
      * <p>
      * Value could be stale as soon as it is returned.
      * <p>
-     * This method is thread-safe; so the thread that executes a task will set/unset the current task,
-     * any other thread in the system is allowed to read it.
+     * This method is thread-safe; so the thread that executes a task will
+     * set/unset the current task, any other thread in the system is allowed
+     * to read it.
      *
      * @return the current running task.
      */
@@ -68,35 +74,44 @@ public abstract class OperationRunner {
     /**
      * Sets the thread that is running this OperationRunner instance.
      * <p>
-     * This method should only be called from the {@link OperationExecutor} since this component is responsible for
-     * executing operations on an OperationRunner.
+     * This method should only be called from the {@link OperationExecutor}
+     * since this component is responsible for executing operations on an
+     * OperationRunner.
      *
-     * @param currentThread the current Thread. Can be called with 'null', clearing the currentThread field.
+     * @param currentThread the current Thread. Can be called with 'null',
+     *                      clearing the currentThread field.
      */
     public final void setCurrentThread(Thread currentThread) {
         this.currentThread = currentThread;
     }
 
     /**
-     * Get the thread that is currently running this OperationRunner instance.
+     * Get the thread that is currently running this OperationRunner
+     * instance.
      * <p>
-     * This value only has meaning when an Operation is running. It depends on the implementation if the field is unset
-     * after an operation is executed or not. So it could be that a value is returned while no operation is running.
+     * This value only has meaning when an Operation is running. It depends on
+     * the implementation if the field is unset after an operation is executed
+     * or not. So it could be that a value is returned while no operation is
+     * running.
      * <p>
-     * For example, the {@link OperationExecutorImpl} will never unset
-     * this field since each OperationRunner is bound to a single OperationThread; so this field is initialized when the
-     * OperationRunner is created.
+     * For example, the {@link OperationExecutorImpl} will never unset this
+     * field since each OperationRunner is bound to a single OperationThread;
+     * so this field is initialized when the OperationRunner is created.
      * <p>
-     * The returned value could be null. When it is null, currently no thread is running this OperationRunner.
+     * The returned value could be null. When it is null, currently no thread
+     * is running this OperationRunner.
      * <p>
      * Recommended idiom for slow operation detection:
      * 1: First read the operation and store the reference.
      * 2: Then read the current thread and store the reference
-     * 3: Later read the operation again. If the operation-instance is the same, it means that you have captured the right thread.
+     * 3: Later read the operation again. If the operation-instance is the same,
+     * it means that you have captured the right thread.
      * <p>
-     * Then you use this Thread to create a stack trace. It can happen that the stracktrace doesn't reflect the call-state the
-     * thread had when the slow operation was detected. This could be solved by rechecking the currentTask after you have detected
-     * the slow operation. BUt don't create a stacktrace before you do the first recheck of the operation because otherwise it
+     * Then you use this Thread to create a stack trace. It can happen that the
+     * stracktrace doesn't reflect the call-state the thread had when the slow
+     * operation was detected. This could be solved by rechecking the currentTask
+     * after you have detected the slow operation. BUt don't create a stacktrace
+     * before you do the first recheck of the operation because otherwise it
      * will cause a lot of overhead.
      *
      * @return the Thread that currently is running this OperationRunner instance.
@@ -106,8 +121,9 @@ public abstract class OperationRunner {
     }
 
     /**
-     * Returns the partitionId this OperationRunner is responsible for. If the partition ID is smaller than 0,
-     * it is either a generic or ad hoc OperationRunner.
+     * Returns the partitionId this OperationRunner is responsible for. If
+     * the partition ID is smaller than 0, it is either a generic or ad hoc
+     * OperationRunner.
      * <p>
      * The value will never change for this OperationRunner instance.
      *

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/GenericOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/GenericOperationThread.java
@@ -35,7 +35,7 @@ public final class GenericOperationThread extends OperationThread {
     }
 
     @Override
-    public OperationRunner getOperationRunner(int partitionId) {
+    public OperationRunner operationRunner(int partitionId) {
         return operationRunner;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -86,7 +86,7 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
         return threadId;
     }
 
-    public abstract OperationRunner getOperationRunner(int partitionId);
+    public abstract OperationRunner operationRunner(int partitionId);
 
     @Override
     public final void run() {
@@ -136,19 +136,19 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
     }
 
     private void process(Operation operation) {
-        currentRunner = getOperationRunner(operation.getPartitionId());
+        currentRunner = operationRunner(operation.getPartitionId());
         currentRunner.run(operation);
         completedOperationCount.inc();
     }
 
     private void process(Packet packet) throws Exception {
-        currentRunner = getOperationRunner(packet.getPartitionId());
+        currentRunner = operationRunner(packet.getPartitionId());
         currentRunner.run(packet);
         completedPacketCount.inc();
     }
 
     private void process(PartitionSpecificRunnable runnable) {
-        currentRunner = getOperationRunner(runnable.getPartitionId());
+        currentRunner = operationRunner(runnable.getPartitionId());
         currentRunner.run(runnable);
         completedPartitionSpecificRunnableCount.inc();
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionOperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/PartitionOperationThread.java
@@ -42,7 +42,7 @@ public final class PartitionOperationThread extends OperationThread {
      * So we need to find the right one based on the partition ID.
      */
     @Override
-    public OperationRunner getOperationRunner(int partitionId) {
+    public OperationRunner operationRunner(int partitionId) {
         return partitionOperationRunners[partitionId];
     }
 


### PR DESCRIPTION
the rest of the 'getters' in this class are also
not prefixed with get.