### PR TITLE
Renamed DefaultOperationQueue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -88,7 +88,7 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
     private final OperationRunner[] partitionOperationRunners;
 
     private final OperationQueue genericQueue
-            = new DefaultOperationQueue(new LinkedBlockingQueue<Object>(), new LinkedBlockingQueue<Object>());
+            = new OperationQueueImpl(new LinkedBlockingQueue<Object>(), new LinkedBlockingQueue<Object>());
 
     // all operations that are not specific for a partition will be executed here, e.g. heartbeat or map.size()
     private final GenericOperationThread[] genericThreads;
@@ -160,7 +160,7 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
             // the normalQueue will be a blocking queue. We don't want to idle, because there are many operation threads.
             MPSCQueue<Object> normalQueue = new MPSCQueue<Object>(idleStrategy);
 
-            OperationQueue operationQueue = new DefaultOperationQueue(normalQueue, new ConcurrentLinkedQueue<Object>());
+            OperationQueue operationQueue = new OperationQueueImpl(normalQueue, new ConcurrentLinkedQueue<Object>());
 
             PartitionOperationThread partitionThread = new PartitionOperationThread(threadName, threadId, operationQueue, logger,
                     nodeExtension, partitionOperationRunners, configClassLoader);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueueImpl.java
@@ -23,7 +23,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
-public final class DefaultOperationQueue implements OperationQueue {
+public final class OperationQueueImpl implements OperationQueue {
 
     static final Object TRIGGER_TASK = new Object() {
         public String toString() {
@@ -34,11 +34,11 @@ public final class DefaultOperationQueue implements OperationQueue {
     private final BlockingQueue<Object> normalQueue;
     private final Queue<Object> priorityQueue;
 
-    public DefaultOperationQueue() {
+    public OperationQueueImpl() {
         this(new LinkedBlockingQueue<Object>(), new ConcurrentLinkedQueue<Object>());
     }
 
-    public DefaultOperationQueue(BlockingQueue<Object> normalQueue, Queue<Object> priorityQueue) {
+    public OperationQueueImpl(BlockingQueue<Object> normalQueue, Queue<Object> priorityQueue) {
         this.normalQueue = checkNotNull(normalQueue, "normalQueue");
         this.priorityQueue = checkNotNull(priorityQueue, "priorityQueue");
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/InterceptorRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/InterceptorRegistryTest.java
@@ -21,7 +21,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
-import com.hazelcast.spi.impl.operationexecutor.impl.DefaultOperationQueue;
+import com.hazelcast.spi.impl.operationexecutor.impl.OperationQueueImpl;
 import com.hazelcast.spi.impl.operationexecutor.impl.OperationQueue;
 import com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -71,7 +71,7 @@ public class InterceptorRegistryTest extends HazelcastTestSupport {
     @Test
     @RequireAssertEnabled
     public void testRegister_fromPartitionOperationThread() throws Exception {
-        OperationQueue queue = new DefaultOperationQueue();
+        OperationQueue queue = new OperationQueueImpl();
         PartitionOperationThread thread = getPartitionOperationThread(queue);
         thread.start();
 
@@ -114,7 +114,7 @@ public class InterceptorRegistryTest extends HazelcastTestSupport {
     @Test
     @RequireAssertEnabled
     public void testDeregister_fromPartitionOperationThread() throws Exception {
-        OperationQueue queue = new DefaultOperationQueue();
+        OperationQueue queue = new OperationQueueImpl();
         PartitionOperationThread thread = getPartitionOperationThread(queue);
         thread.start();
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueueImplStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueueImplStressTest.java
@@ -31,11 +31,11 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
-public class DefaultOperationQueueStressTest extends HazelcastTestSupport {
+public class OperationQueueImplStressTest extends HazelcastTestSupport {
 
     private static final Object POISON_PILL = new Object();
 
-    private final DefaultOperationQueue queue = new DefaultOperationQueue();
+    private final OperationQueueImpl queue = new OperationQueueImpl();
     private final AtomicBoolean stop = new AtomicBoolean();
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueueImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueueImplTest.java
@@ -35,9 +35,9 @@ import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class DefaultOperationQueueTest extends HazelcastTestSupport {
+public class OperationQueueImplTest extends HazelcastTestSupport {
 
-    private DefaultOperationQueue operationQueue;
+    private OperationQueueImpl operationQueue;
     private ArrayBlockingQueue<Object> normalQueue;
     private ArrayBlockingQueue<Object> priorityQueue;
 
@@ -45,7 +45,7 @@ public class DefaultOperationQueueTest extends HazelcastTestSupport {
     public void setup() {
         normalQueue = new ArrayBlockingQueue<Object>(100);
         priorityQueue = new ArrayBlockingQueue<Object>(100);
-        operationQueue = new DefaultOperationQueue(normalQueue, priorityQueue);
+        operationQueue = new OperationQueueImpl(normalQueue, priorityQueue);
     }
 
     // ================== add =====================
@@ -67,7 +67,7 @@ public class DefaultOperationQueueTest extends HazelcastTestSupport {
         assertEquals(1, normalQueue.size());
 
         assertSame(task, priorityQueue.iterator().next());
-        assertSame(DefaultOperationQueue.TRIGGER_TASK, normalQueue.iterator().next());
+        assertSame(OperationQueueImpl.TRIGGER_TASK, normalQueue.iterator().next());
     }
 
     @Test
@@ -214,7 +214,7 @@ public class DefaultOperationQueueTest extends HazelcastTestSupport {
         assertSame(normalTask3, operationQueue.take(false));
 
         assertEmpty(priorityQueue);
-        //assertContent(normalQueue, DefaultOperationQueue.TRIGGER_TASK);
+        //assertContent(normalQueue, OperationQueueImpl.TRIGGER_TASK);
     }
 
     public void assertEmpty(Queue<Object> q) {


### PR DESCRIPTION
to OperationQueueImpl. Most of the other operation related classes
use the same naming pattern e.g. OperationExecutorImpl, OperationServiceImpl.