### PR TITLE
Fixed merging of MultiMap values

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/MergePolicyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MergePolicyConfig.java
@@ -42,10 +42,10 @@ public class MergePolicyConfig implements IdentifiedDataSerializable {
      */
     public static final int DEFAULT_BATCH_SIZE = 100;
 
-    protected String policy = DEFAULT_MERGE_POLICY;
-    protected int batchSize = DEFAULT_BATCH_SIZE;
+    private String policy = DEFAULT_MERGE_POLICY;
+    private int batchSize = DEFAULT_BATCH_SIZE;
 
-    protected MergePolicyConfig readOnly;
+    private MergePolicyConfig readOnly;
 
     public MergePolicyConfig() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -226,68 +226,74 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     /**
      * Merges the given {@link MultiMapMergeContainer} via the given {@link SplitBrainMergePolicy}.
      *
-     * @param key            the {@link Data} key to merge
      * @param mergeContainer the {@link MultiMapMergeContainer} instance to merge
      * @param mergePolicy    the {@link SplitBrainMergePolicy} instance to apply
      * @return the used {@link MultiMapValue} if merge is applied, otherwise {@code null}
      */
-    public MultiMapValue merge(Data key, MultiMapMergeContainer mergeContainer,
-                               SplitBrainMergePolicy<Object, MultiMapMergeTypes> mergePolicy) {
+    public MultiMapValue merge(MultiMapMergeContainer mergeContainer,
+                               SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy) {
         SerializationService serializationService = nodeEngine.getSerializationService();
         serializationService.getManagedContext().initialize(mergePolicy);
 
-        MultiMapValue existingValue = getMultiMapValueOrNull(key);
-
+        MultiMapMergeTypes mergingEntry = createMergingEntry(serializationService, mergeContainer);
+        MultiMapValue existingValue = getMultiMapValueOrNull(mergeContainer.getKey());
         if (existingValue == null) {
-            return mergeNewValue(mergePolicy, serializationService, key, mergeContainer);
+            return mergeNewValue(mergePolicy, mergingEntry);
         }
-        return mergeExistingValue(mergePolicy, serializationService, key, mergeContainer, existingValue);
+        return mergeExistingValue(mergePolicy, mergingEntry, existingValue, serializationService);
     }
 
-    private MultiMapValue mergeNewValue(SplitBrainMergePolicy<Object, MultiMapMergeTypes> mergePolicy,
-                                        SerializationService ss, Data key, MultiMapMergeContainer mergingContainer) {
-        boolean isBinary = getConfig().isBinary();
-
-        MultiMapValue mergedValue = null;
-        for (MultiMapRecord mergeRecord : mergingContainer.getRecords()) {
-            MultiMapMergeTypes mergingEntry = createMergingEntry(ss, mergingContainer, mergeRecord);
-            Object newValue = mergePolicy.merge(mergingEntry, null);
-            if (newValue != null) {
-                MultiMapRecord newRecord = new MultiMapRecord(nextId(), isBinary ? newValue : ss.toObject(newValue));
-                if (mergedValue == null) {
-                    mergedValue = getOrCreateMultiMapValue(key);
-                }
-                Collection<MultiMapRecord> collection = mergedValue.getCollection(false);
-                collection.add(newRecord);
+    private MultiMapValue mergeNewValue(SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy,
+                                        MultiMapMergeTypes mergingEntry) {
+        Collection<Object> newValues = mergePolicy.merge(mergingEntry, null);
+        if (newValues != null && !newValues.isEmpty()) {
+            MultiMapValue mergedValue = getOrCreateMultiMapValue(mergingEntry.getKey());
+            Collection<MultiMapRecord> records = mergedValue.getCollection(false);
+            createNewMultiMapRecords(records, newValues);
+            if (newValues.equals(mergingEntry.getValue())) {
+                setMergedStatistics(mergingEntry, mergedValue);
             }
+            return mergedValue;
         }
-        return mergedValue;
+        return null;
     }
 
-    private MultiMapValue mergeExistingValue(SplitBrainMergePolicy<Object, MultiMapMergeTypes> mergePolicy,
-                                             SerializationService ss, Data key, MultiMapMergeContainer mergeContainer,
-                                             MultiMapValue existingValue) {
-        boolean isBinary = getConfig().isBinary();
-
+    private MultiMapValue mergeExistingValue(SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy,
+                                             MultiMapMergeTypes mergingEntry, MultiMapValue existingValue,
+                                             SerializationService ss) {
         Collection<MultiMapRecord> existingRecords = existingValue.getCollection(false);
-        int existingHits = existingValue.getHits();
-        for (MultiMapRecord mergeRecord : mergeContainer.getRecords()) {
-            MultiMapMergeTypes mergingEntry = createMergingEntry(ss, mergeContainer, mergeRecord);
-            MultiMapMergeTypes existingEntry = null;
-            MultiMapRecord existingRecord = null;
-            for (MultiMapRecord record : existingRecords) {
-                if (record.getObject().equals(mergeRecord.getObject())) {
-                    existingEntry = createMergingEntry(ss, this, key, record, existingHits);
-                    existingRecord = record;
-                }
-            }
-            Object newValue = mergePolicy.merge(mergingEntry, existingEntry);
-            if (newValue != null && (existingRecord == null || !newValue.equals(existingRecord.getObject()))) {
-                MultiMapRecord newRecord = new MultiMapRecord(nextId(), isBinary ? newValue : ss.toObject(newValue));
-                existingRecords.remove(existingRecord);
-                existingRecords.add(newRecord);
+
+        Data dataKey = mergingEntry.getKey();
+        MultiMapMergeTypes existingEntry = createMergingEntry(ss, this, dataKey, existingRecords, existingValue.getHits());
+        Collection<Object> newValues = mergePolicy.merge(mergingEntry, existingEntry);
+        if (newValues == null || newValues.isEmpty()) {
+            existingRecords.clear();
+            multiMapValues.remove(dataKey);
+        } else if (!newValues.equals(existingRecords)) {
+            existingRecords.clear();
+            createNewMultiMapRecords(existingRecords, newValues);
+            if (newValues.equals(mergingEntry.getValue())) {
+                setMergedStatistics(mergingEntry, existingValue);
             }
         }
         return existingValue;
+    }
+
+    private void createNewMultiMapRecords(Collection<MultiMapRecord> records, Collection<Object> values) {
+        boolean isBinary = config.isBinary();
+        SerializationService serializationService = nodeEngine.getSerializationService();
+
+        for (Object value : values) {
+            long recordId = nextId();
+            MultiMapRecord record = new MultiMapRecord(recordId, isBinary ? serializationService.toData(value) : value);
+            records.add(record);
+        }
+    }
+
+    @SuppressWarnings("NonAtomicOperationOnVolatileField")
+    private void setMergedStatistics(MultiMapMergeTypes mergingEntry, MultiMapValue multiMapValue) {
+        multiMapValue.setHits(mergingEntry.getHits());
+        lastAccessTime = Math.max(lastAccessTime, mergingEntry.getLastAccessTime());
+        lastUpdateTime = Math.max(lastUpdateTime, mergingEntry.getLastUpdateTime());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapMergeContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapMergeContainer.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 
 /**
  * Container for the merge operation of a {@link com.hazelcast.core.MultiMap}.
+ *
+ * @since 3.10
  */
 public class MultiMapMergeContainer implements IdentifiedDataSerializable {
 
@@ -35,13 +37,13 @@ public class MultiMapMergeContainer implements IdentifiedDataSerializable {
     private long creationTime;
     private long lastAccessTime;
     private long lastUpdateTime;
-    private int hits;
+    private long hits;
 
     public MultiMapMergeContainer() {
     }
 
     public MultiMapMergeContainer(Data key, Collection<MultiMapRecord> records, long creationTime, long lastAccessTime,
-                                  long lastUpdateTime, int hits) {
+                                  long lastUpdateTime, long hits) {
         this.key = key;
         this.records = records;
         this.creationTime = creationTime;
@@ -70,7 +72,7 @@ public class MultiMapMergeContainer implements IdentifiedDataSerializable {
         return lastUpdateTime;
     }
 
-    public int getHits() {
+    public long getHits() {
         return hits;
     }
 
@@ -94,7 +96,7 @@ public class MultiMapMergeContainer implements IdentifiedDataSerializable {
         out.writeLong(creationTime);
         out.writeLong(lastAccessTime);
         out.writeLong(lastUpdateTime);
-        out.writeInt(hits);
+        out.writeLong(hits);
     }
 
     @Override
@@ -109,6 +111,6 @@ public class MultiMapMergeContainer implements IdentifiedDataSerializable {
         creationTime = in.readLong();
         lastAccessTime = in.readLong();
         lastUpdateTime = in.readLong();
-        hits = in.readInt();
+        hits = in.readLong();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -502,7 +502,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
         return new Merger(collector);
     }
 
-    private class Merger extends AbstractContainerMerger<MultiMapContainer, Object, MultiMapMergeTypes> {
+    private class Merger extends AbstractContainerMerger<MultiMapContainer, Collection<Object>, MultiMapMergeTypes> {
 
         Merger(MultiMapContainerCollector collector) {
             super(collector, nodeEngine);
@@ -521,7 +521,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
                 for (MultiMapContainer container : containers) {
                     String name = container.getObjectNamespace().getObjectName();
-                    SplitBrainMergePolicy<Object, MultiMapMergeTypes> mergePolicy
+                    SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy
                             = getMergePolicy(container.getConfig().getMergePolicyConfig());
                     int batchSize = container.getConfig().getMergePolicyConfig().getBatchSize();
 
@@ -548,7 +548,8 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
             }
         }
 
-        private void sendBatch(int partitionId, String name, SplitBrainMergePolicy<Object, MultiMapMergeTypes> mergePolicy,
+        private void sendBatch(int partitionId, String name,
+                               SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy,
                                List<MultiMapMergeContainer> mergeContainers) {
             MergeOperation operation = new MergeOperation(name, mergeContainers, mergePolicy);
             invoke(SERVICE_NAME, operation, partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -299,7 +299,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
             assert isKnownServiceNamespace(namespace) : namespace + " is not a MultiMapService namespace!";
 
             ObjectNamespace ns = (ObjectNamespace) namespace;
-            MultiMapContainer container = partitionContainer.getMultiMapContainer(ns.getObjectName());
+            MultiMapContainer container = partitionContainer.containerMap.get(ns.getObjectName());
             if (container == null) {
                 continue;
             }
@@ -315,7 +315,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
     public void insertMigratedData(int partitionId, Map<String, Map<Data, MultiMapValue>> map) {
         for (Map.Entry<String, Map<Data, MultiMapValue>> entry : map.entrySet()) {
             String name = entry.getKey();
-            MultiMapContainer container = getOrCreateCollectionContainer(partitionId, name);
+            MultiMapContainer container = getOrCreateCollectionContainerWithoutAccess(partitionId, name);
             Map<Data, MultiMapValue> collections = entry.getValue();
             long maxRecordId = -1;
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapValue.java
@@ -29,7 +29,7 @@ public class MultiMapValue {
 
     private final Collection<MultiMapRecord> collection;
 
-    private int hits;
+    private long hits;
 
     public MultiMapValue(Collection<MultiMapRecord> collection) {
         this.collection = collection;
@@ -55,8 +55,12 @@ public class MultiMapValue {
         hits++;
     }
 
-    public int getHits() {
+    public long getHits() {
         return hits;
+    }
+
+    public void setHits(long hits) {
+        this.hits = hits;
     }
 
     public boolean containsRecordId(long recordId) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/AbstractKeyBasedMultiMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/AbstractKeyBasedMultiMapOperation.java
@@ -16,19 +16,14 @@
 
 package com.hazelcast.multimap.impl.operations;
 
-import com.hazelcast.multimap.impl.MultiMapContainer;
-import com.hazelcast.multimap.impl.MultiMapRecord;
-import com.hazelcast.multimap.impl.MultiMapValue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.PartitionAwareOperation;
 
 import java.io.IOException;
-import java.util.Collection;
 
-public abstract class AbstractKeyBasedMultiMapOperation extends AbstractMultiMapOperation
-        implements PartitionAwareOperation {
+public abstract class AbstractKeyBasedMultiMapOperation extends AbstractMultiMapOperation implements PartitionAwareOperation {
 
     protected Data dataKey;
     protected long threadId;
@@ -49,23 +44,6 @@ public abstract class AbstractKeyBasedMultiMapOperation extends AbstractMultiMap
 
     public final void setThreadId(long threadId) {
         this.threadId = threadId;
-    }
-
-    public final MultiMapValue getOrCreateMultiMapValue() {
-        return getOrCreateContainer().getOrCreateMultiMapValue(dataKey);
-    }
-
-    public final MultiMapValue getMultiMapValueOrNull() {
-        MultiMapContainer container = getOrCreateContainer();
-        return container.getMultiMapValueOrNull(dataKey);
-    }
-
-    public final Collection<MultiMapRecord> remove(boolean copyOf) {
-        return getOrCreateContainer().remove(dataKey, copyOf);
-    }
-
-    public final boolean delete() {
-        return getOrCreateContainer().delete(dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/AbstractMultiMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/AbstractMultiMapOperation.java
@@ -116,7 +116,7 @@ public abstract class AbstractMultiMapOperation extends Operation
 
     @Override
     public ObjectNamespace getServiceNamespace() {
-        MultiMapContainer container = getOrCreateContainer();
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
         return container.getObjectNamespace();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ClearBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/ClearBackupOperation.java
@@ -31,7 +31,7 @@ public class ClearBackupOperation extends AbstractMultiMapOperation implements B
 
     @Override
     public void run() throws Exception {
-        MultiMapContainer container = getOrCreateContainer();
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
         container.clear();
         response = true;
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/DeleteBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/DeleteBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
@@ -31,7 +32,8 @@ public class DeleteBackupOperation extends AbstractKeyBasedMultiMapOperation imp
 
     @Override
     public void run() throws Exception {
-        delete();
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
+        container.delete(dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/DeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/DeleteOperation.java
@@ -35,8 +35,9 @@ public class DeleteOperation extends AbstractBackupAwareMultiMapOperation {
 
     @Override
     public void run() throws Exception {
-        if (delete()) {
-            getOrCreateContainer().update();
+        MultiMapContainer container = getOrCreateContainer();
+        if (container.delete(dataKey)) {
+            container.update();
         }
         shouldBackup = true;
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
@@ -34,7 +34,7 @@ import java.util.Map;
 import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
- * Contains multiple backup entries for split-brain healing with a {@link SplitBrainMergePolicy}.
+ * Creates backups for merged {@link MultiMapRecord} after split-brain healing with a {@link SplitBrainMergePolicy}.
  *
  * @since 3.10
  */
@@ -57,11 +57,15 @@ public class MergeBackupOperation extends AbstractMultiMapOperation implements B
         for (Map.Entry<Data, Collection<MultiMapRecord>> entry : backupEntries.entrySet()) {
             Data key = entry.getKey();
             Collection<MultiMapRecord> value = entry.getValue();
-            MultiMapValue containerValue = container.getOrCreateMultiMapValue(key);
-            Collection<MultiMapRecord> collection = containerValue.getCollection(false);
-            collection.clear();
-            if (!collection.addAll(value)) {
-                response = false;
+            if (value.isEmpty()) {
+                container.remove(key, false);
+            } else {
+                MultiMapValue containerValue = container.getOrCreateMultiMapValue(key);
+                Collection<MultiMapRecord> collection = containerValue.getCollection(false);
+                collection.clear();
+                if (!collection.addAll(value)) {
+                    response = false;
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
@@ -53,7 +53,7 @@ public class MergeBackupOperation extends AbstractMultiMapOperation implements B
     @Override
     public void run() throws Exception {
         response = true;
-        MultiMapContainer container = getOrCreateContainer();
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
         for (Map.Entry<Data, Collection<MultiMapRecord>> entry : backupEntries.entrySet()) {
             Data key = entry.getKey();
             Collection<MultiMapRecord> value = entry.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutBackupOperation.java
@@ -16,8 +16,10 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
+import com.hazelcast.multimap.impl.MultiMapValue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
@@ -45,13 +47,16 @@ public class PutBackupOperation extends AbstractKeyBasedMultiMapOperation implem
 
     @Override
     public void run() throws Exception {
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
+        MultiMapValue multiMapValue = container.getOrCreateMultiMapValue(dataKey);
+        Collection<MultiMapRecord> collection = multiMapValue.getCollection(false);
+
         MultiMapRecord record = new MultiMapRecord(recordId, isBinary() ? value : toObject(value));
-        Collection<MultiMapRecord> coll = getOrCreateMultiMapValue().getCollection(false);
         if (index == -1) {
-            response = coll.add(record);
+            response = collection.add(record);
         } else {
             try {
-                ((List<MultiMapRecord>) coll).add(index, record);
+                ((List<MultiMapRecord>) collection).add(index, record);
                 response = true;
             } catch (IndexOutOfBoundsException e) {
                 response = e;

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
@@ -31,7 +32,8 @@ public class RemoveAllBackupOperation extends AbstractKeyBasedMultiMapOperation 
 
     @Override
     public void run() throws Exception {
-        delete();
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
+        container.delete(dataKey);
         response = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveAllOperation.java
@@ -41,7 +41,7 @@ public class RemoveAllOperation extends AbstractBackupAwareMultiMapOperation imp
     @Override
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainer();
-        coll = remove(executedLocally());
+        coll = container.remove(dataKey, executedLocally());
         response = new MultiMapResponse(coll, getValueCollectionType(container));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
 import com.hazelcast.multimap.impl.MultiMapValue;
@@ -30,7 +31,7 @@ import java.util.Iterator;
 
 public class RemoveBackupOperation extends AbstractKeyBasedMultiMapOperation implements BackupOperation {
 
-    long recordId;
+    private long recordId;
 
     public RemoveBackupOperation() {
     }
@@ -42,8 +43,9 @@ public class RemoveBackupOperation extends AbstractKeyBasedMultiMapOperation imp
 
     @Override
     public void run() throws Exception {
-        MultiMapValue multiMapValue = getMultiMapValueOrNull();
         response = false;
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
+        MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
         if (multiMapValue == null) {
             return;
         }
@@ -54,7 +56,7 @@ public class RemoveBackupOperation extends AbstractKeyBasedMultiMapOperation imp
                 iterator.remove();
                 response = true;
                 if (coll.isEmpty()) {
-                    delete();
+                    container.delete(dataKey);
                 }
                 break;
             }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.multimap.impl.operations;
 
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
 import com.hazelcast.multimap.impl.MultiMapValue;
@@ -46,7 +47,8 @@ public class RemoveOperation extends AbstractBackupAwareMultiMapOperation implem
     @Override
     public void run() throws Exception {
         response = false;
-        MultiMapValue multiMapValue = getMultiMapValueOrNull();
+        MultiMapContainer container = getOrCreateContainer();
+        MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
         if (multiMapValue == null) {
             return;
         }
@@ -60,7 +62,7 @@ public class RemoveOperation extends AbstractBackupAwareMultiMapOperation implem
                 recordId = r.getRecordId();
                 response = true;
                 if (coll.isEmpty()) {
-                    delete();
+                    container.delete(dataKey);
                 }
                 break;
             }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnCommitBackupOperation.java
@@ -53,7 +53,7 @@ public class TxnCommitBackupOperation extends AbstractKeyBasedMultiMapOperation 
         }
         // changed to forceUnlock because replica-sync of lock causes problems, same as IMap
         // real solution is to make 'lock-and-get' backup-aware
-        getOrCreateContainer().forceUnlock(dataKey);
+        getOrCreateContainerWithoutAccess().forceUnlock(dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnLockAndGetOperation.java
@@ -58,7 +58,7 @@ public class TxnLockAndGetOperation extends AbstractKeyBasedMultiMapOperation im
         if (!container.txnLock(dataKey, getCallerUuid(), threadId, getCallId(), ttl, blockReads)) {
             throw new TransactionException("Transaction couldn't obtain lock!");
         }
-        MultiMapValue multiMapValue = getMultiMapValueOrNull();
+        MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
         boolean isLocal = executedLocally();
         Collection<MultiMapRecord> collection = multiMapValue == null ? null : multiMapValue.getCollection(isLocal);
         MultiMapResponse multiMapResponse = new MultiMapResponse(collection, getValueCollectionType(container));

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPrepareBackupOperation.java
@@ -45,7 +45,7 @@ public class TxnPrepareBackupOperation extends AbstractKeyBasedMultiMapOperation
 
     @Override
     public void run() throws Exception {
-        MultiMapContainer container = getOrCreateContainer();
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
         if (!container.txnLock(dataKey, caller, threadId, getCallId(), LOCK_EXTENSION_TIME_IN_MILLIS, true)) {
             throw new TransactionException(
                     "Lock is not owned by the transaction! -> " + container.getLockOwnerInfo(dataKey)

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
@@ -45,7 +45,7 @@ public class TxnPutBackupOperation extends AbstractKeyBasedMultiMapOperation imp
 
     @Override
     public void run() throws Exception {
-        MultiMapContainer container = getOrCreateContainer();
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
         MultiMapValue multiMapValue = container.getOrCreateMultiMapValue(dataKey);
         response = true;
         if (multiMapValue.containsRecordId(recordId)) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
@@ -54,11 +54,12 @@ public class TxnPutOperation extends AbstractKeyBasedMultiMapOperation implement
         startTimeNanos = System.nanoTime();
         MultiMapContainer container = getOrCreateContainer();
         MultiMapValue multiMapValue = container.getOrCreateMultiMapValue(dataKey);
-        response = true;
         if (multiMapValue.containsRecordId(recordId)) {
             response = false;
             return;
         }
+        response = true;
+        container.update();
         Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
         MultiMapRecord record = new MultiMapRecord(recordId, isBinary() ? value : toObject(value));
         coll.add(record);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllBackupOperation.java
@@ -45,9 +45,9 @@ public class TxnRemoveAllBackupOperation extends AbstractKeyBasedMultiMapOperati
 
     @Override
     public void run() throws Exception {
-        MultiMapContainer container = getOrCreateContainer();
-        MultiMapValue multiMapValue = container.getOrCreateMultiMapValue(dataKey);
         response = true;
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
+        MultiMapValue multiMapValue = container.getOrCreateMultiMapValue(dataKey);
         for (Long recordId : recordIds) {
             if (!multiMapValue.containsRecordId(recordId)) {
                 response = false;
@@ -66,7 +66,7 @@ public class TxnRemoveAllBackupOperation extends AbstractKeyBasedMultiMapOperati
             }
         }
         if (coll.isEmpty()) {
-            delete();
+            container.delete(dataKey);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllBackupOperation.java
@@ -45,7 +45,6 @@ public class TxnRemoveAllBackupOperation extends AbstractKeyBasedMultiMapOperati
 
     @Override
     public void run() throws Exception {
-        response = true;
         MultiMapContainer container = getOrCreateContainerWithoutAccess();
         MultiMapValue multiMapValue = container.getOrCreateMultiMapValue(dataKey);
         for (Long recordId : recordIds) {
@@ -54,6 +53,7 @@ public class TxnRemoveAllBackupOperation extends AbstractKeyBasedMultiMapOperati
                 return;
             }
         }
+        response = true;
         Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
         for (Long recordId : recordIds) {
             Iterator<MultiMapRecord> iterator = coll.iterator();

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllOperation.java
@@ -59,13 +59,14 @@ public class TxnRemoveAllOperation extends AbstractKeyBasedMultiMapOperation imp
         startTimeNanos = System.nanoTime();
         MultiMapContainer container = getOrCreateContainer();
         MultiMapValue multiMapValue = container.getOrCreateMultiMapValue(dataKey);
-        response = true;
         for (Long recordId : recordIds) {
             if (!multiMapValue.containsRecordId(recordId)) {
                 response = false;
                 return;
             }
         }
+        response = true;
+        container.update();
         Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
         removed = new LinkedList<MultiMapRecord>();
         for (Long recordId : recordIds) {
@@ -90,7 +91,6 @@ public class TxnRemoveAllOperation extends AbstractKeyBasedMultiMapOperation imp
         MultiMapService service = getService();
         service.getLocalMultiMapStatsImpl(name).incrementRemoveLatencyNanos(elapsed);
         if (removed != null) {
-            getOrCreateContainer().update();
             for (MultiMapRecord record : removed) {
                 publishEvent(EntryEventType.REMOVED, dataKey, null, record.getObject());
             }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllOperation.java
@@ -80,7 +80,7 @@ public class TxnRemoveAllOperation extends AbstractKeyBasedMultiMapOperation imp
             }
         }
         if (coll.isEmpty()) {
-            delete();
+            container.delete(dataKey);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
@@ -48,11 +48,11 @@ public class TxnRemoveBackupOperation extends AbstractKeyBasedMultiMapOperation 
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainerWithoutAccess();
         MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
-        response = true;
         if (multiMapValue == null || !multiMapValue.containsRecordId(recordId)) {
             response = false;
             return;
         }
+        response = true;
         Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
         Iterator<MultiMapRecord> iterator = coll.iterator();
         while (iterator.hasNext()) {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
@@ -46,7 +46,7 @@ public class TxnRemoveBackupOperation extends AbstractKeyBasedMultiMapOperation 
 
     @Override
     public void run() throws Exception {
-        MultiMapContainer container = getOrCreateContainer();
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
         MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
         response = true;
         if (multiMapValue == null || !multiMapValue.containsRecordId(recordId)) {
@@ -62,7 +62,7 @@ public class TxnRemoveBackupOperation extends AbstractKeyBasedMultiMapOperation 
             }
         }
         if (coll.isEmpty()) {
-            delete();
+            container.delete(dataKey);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
@@ -55,11 +55,12 @@ public class TxnRemoveOperation extends AbstractKeyBasedMultiMapOperation implem
         startTimeNanos = System.nanoTime();
         MultiMapContainer container = getOrCreateContainer();
         MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
-        response = true;
         if (multiMapValue == null || !multiMapValue.containsRecordId(recordId)) {
             response = false;
             return;
         }
+        response = true;
+        container.update();
         Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
         Iterator<MultiMapRecord> iter = coll.iterator();
         while (iter.hasNext()) {
@@ -79,7 +80,6 @@ public class TxnRemoveOperation extends AbstractKeyBasedMultiMapOperation implem
         MultiMapService service = getService();
         service.getLocalMultiMapStatsImpl(name).incrementRemoveLatencyNanos(elapsed);
         if (Boolean.TRUE.equals(response)) {
-            getOrCreateContainer().update();
             publishEvent(EntryEventType.REMOVED, dataKey, null, value);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
@@ -69,7 +69,7 @@ public class TxnRemoveOperation extends AbstractKeyBasedMultiMapOperation implem
             }
         }
         if (coll.isEmpty()) {
-            delete();
+            container.delete(dataKey);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRollbackBackupOperation.java
@@ -42,11 +42,9 @@ public class TxnRollbackBackupOperation extends AbstractKeyBasedMultiMapOperatio
 
     @Override
     public void run() throws Exception {
-        MultiMapContainer container = getOrCreateContainer();
+        MultiMapContainer container = getOrCreateContainerWithoutAccess();
         if (container.isLocked(dataKey) && !container.unlock(dataKey, caller, threadId, getCallId())) {
-            throw new TransactionException(
-                    "Lock is not owned by the transaction! -> " + container.getLockOwnerInfo(dataKey)
-            );
+            throw new TransactionException("Lock is not owned by the transaction! -> " + container.getLockOwnerInfo(dataKey));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractCollectionMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractCollectionMergingValueImpl.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.merge;
+
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.merge.MergingValue;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.spi.serialization.SerializationServiceAware;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Implementation of {@link MergingValue} for data structures with collections.
+ *
+ * @param <V> the type of value
+ * @since 3.10
+ */
+@SuppressWarnings("WeakerAccess")
+public abstract class AbstractCollectionMergingValueImpl<V extends Collection, T extends AbstractCollectionMergingValueImpl<V, T>>
+        implements MergingValue<V>, SerializationServiceAware, IdentifiedDataSerializable {
+
+    private V value;
+
+    private transient SerializationService serializationService;
+
+    public AbstractCollectionMergingValueImpl() {
+    }
+
+    public AbstractCollectionMergingValueImpl(SerializationService serializationService) {
+        this.serializationService = serializationService;
+    }
+
+    @Override
+    public V getValue() {
+        return value;
+    }
+
+    @Override
+    public <DV> DV getDeserializedValue() {
+        Collection<Object> deserializedValues = new ArrayList<Object>(value.size());
+        for (Object aValue : value) {
+            deserializedValues.add(serializationService.toObject(aValue));
+        }
+        //noinspection unchecked
+        return (DV) deserializedValues;
+    }
+
+    public T setValue(V value) {
+        this.value = value;
+        //noinspection unchecked
+        return (T) this;
+    }
+
+    @Override
+    public void setSerializationService(SerializationService serializationService) {
+        this.serializationService = serializationService;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeInt(value.size());
+        for (Object aValue : value) {
+            IOUtil.writeObject(out, aValue);
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        int size = in.readInt();
+        ArrayList<Object> list = new ArrayList<Object>(size);
+        for (int i = 0; i < size; i++) {
+            list.add(IOUtil.readObject(in));
+        }
+        //noinspection unchecked
+        value = (V) list;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SplitBrainDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AbstractCollectionMergingValueImpl)) {
+            return false;
+        }
+
+        AbstractCollectionMergingValueImpl<?, ?> that = (AbstractCollectionMergingValueImpl<?, ?>) o;
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "MergingValue{"
+                + "value=" + value
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
@@ -44,6 +44,9 @@ import com.hazelcast.spi.merge.SplitBrainMergeTypes.RingbufferMergeTypes;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.ScheduledExecutorMergeTypes;
 import com.hazelcast.spi.serialization.SerializationService;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 /**
  * Provides static factory methods to create {@link MergingValue} and {@link MergingEntry} instances.
  *
@@ -155,10 +158,15 @@ public final class MergingValueFactory {
     }
 
     public static MultiMapMergeTypes createMergingEntry(SerializationService serializationService,
-                                                        MultiMapMergeContainer container, MultiMapRecord record) {
+                                                        MultiMapMergeContainer container) {
+        Collection<Object> values = new ArrayList<Object>(container.getRecords().size());
+        for (MultiMapRecord record : container.getRecords()) {
+            values.add(record.getObject());
+        }
+
         return new MultiMapMergingEntryImpl(serializationService)
                 .setKey(container.getKey())
-                .setValue(record.getObject())
+                .setValues(values)
                 .setCreationTime(container.getCreationTime())
                 .setLastAccessTime(container.getLastAccessTime())
                 .setLastUpdateTime(container.getLastUpdateTime())
@@ -166,10 +174,15 @@ public final class MergingValueFactory {
     }
 
     public static MultiMapMergeTypes createMergingEntry(SerializationService serializationService, MultiMapContainer container,
-                                                        Data key, MultiMapRecord record, int hits) {
+                                                        Data dataKey, Collection<MultiMapRecord> records, long hits) {
+        Collection<Object> values = new ArrayList<Object>(records.size());
+        for (MultiMapRecord record : records) {
+            values.add(record.getObject());
+        }
+
         return new MultiMapMergingEntryImpl(serializationService)
-                .setKey(key)
-                .setValue(record.getObject())
+                .setKey(dataKey)
+                .setValues(values)
                 .setCreationTime(container.getCreationTime())
                 .setLastAccessTime(container.getLastAccessTime())
                 .setLastUpdateTime(container.getLastUpdateTime())

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingEntry.java
@@ -35,7 +35,8 @@ public interface MergingEntry<K, V> extends MergingValue<V> {
     /**
      * Returns the deserialized merging key.
      *
+     * @param <DK> the type of the deserialized key
      * @return the deserialized merging key
      */
-    Object getDeserializedKey();
+    <DK> DK getDeserializedKey();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
@@ -34,7 +34,8 @@ public interface MergingValue<V> {
     /**
      * Returns the deserialized merging value.
      *
+     * @param <DV> the type of the deserialized value
      * @return the deserialized merging value
      */
-    Object getDeserializedValue();
+    <DV> DV getDeserializedValue();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
@@ -20,6 +20,8 @@ import com.hazelcast.cardinality.impl.hyperloglog.HyperLogLog;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.scheduledexecutor.impl.ScheduledTaskDescriptor;
 
+import java.util.Collection;
+
 /**
  * Collection of interfaces which define the provided merge types for each data structure.
  * <p>
@@ -67,8 +69,9 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
-    public interface MultiMapMergeTypes extends MergingEntry<Data, Object>, MergingCreationTime<Object>, MergingHits<Object>,
-            MergingLastAccessTime<Object>, MergingLastUpdateTime<Object> {
+    public interface MultiMapMergeTypes extends MergingEntry<Data, Collection<Object>>, MergingCreationTime<Collection<Object>>,
+            MergingHits<Collection<Object>>, MergingLastAccessTime<Collection<Object>>,
+            MergingLastUpdateTime<Collection<Object>> {
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1707,7 +1707,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(2, cardinalityEstimatorConfig.getBackupCount());
         assertEquals(3, cardinalityEstimatorConfig.getAsyncBackupCount());
         assertEquals("com.hazelcast.spi.merge.HyperLogLogMergePolicy",
-                cardinalityEstimatorConfig.getMergePolicyConfig().policy);
+                cardinalityEstimatorConfig.getMergePolicyConfig().getPolicy());
         assertEquals("customQuorumRule", cardinalityEstimatorConfig.getQuorumName());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
@@ -243,19 +243,13 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
      */
     private void afterSplitLatestAccessMergePolicy() {
         multiMapA1.put("key", "value");
-        // access to record
-        multiMapA1.get("key");
 
         // prevent updating at the same time
         sleepAtLeastMillis(100);
 
         multiMapA2.put("key", "LatestAccessedValue");
-        // access to record
-        multiMapA2.get("key");
 
         multiMapB2.put("key", "LatestAccessedValue");
-        // access to record
-        multiMapB2.get("key");
     }
 
     private void afterMergeLatestAccessMergePolicy() {

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
@@ -55,7 +55,8 @@ import static org.junit.Assert.fail;
  * <p>
  * Most merge policies are tested with {@link MultiMapConfig#isBinary()} as {@code true} only, since they don't check the value.
  * <p>
- * The {@link MergeIntegerValuesMergePolicy} is tested with both in-memory formats, since it's using the value to merge.
+ * The {@link MergeCollectionOfIntegerValuesMergePolicy} is tested with both in-memory formats,
+ * since it's using the value to merge.
  * <p>
  * The {@link DiscardMergePolicy}, {@link PassThroughMergePolicy} and {@link PutIfAbsentMergePolicy} are also
  * tested with a data structure, which is only created in the smaller cluster.
@@ -75,8 +76,9 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
                 {true, PassThroughMergePolicy.class},
                 {true, PutIfAbsentMergePolicy.class},
 
-                {true, MergeIntegerValuesMergePolicy.class},
-                {false, MergeIntegerValuesMergePolicy.class},
+                {true, RemoveValuesMergePolicy.class},
+                {true, MergeCollectionOfIntegerValuesMergePolicy.class},
+                {false, MergeCollectionOfIntegerValuesMergePolicy.class},
         });
     }
 
@@ -149,7 +151,9 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
             afterSplitPassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
+            afterSplitRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == MergeCollectionOfIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
         } else {
             fail();
@@ -178,7 +182,9 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
             afterMergePassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
+            afterMergeRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == MergeCollectionOfIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
         } else {
             fail();
@@ -201,10 +207,15 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
     private void afterMergeDiscardMergePolicy() {
         assertMultiMapsA("key1", "value1", "value2");
         assertMultiMapsA("key2");
+        assertMultiMapsSizeA(2);
 
         assertMultiMapsB("key");
+        assertMultiMapsSizeB(0);
     }
 
+    /**
+     * The hits are measured per MultiMapValue, so we can test it with multiple keys on the same map.
+     */
     private void afterSplitHigherHitsMergePolicy() {
         multiMapA1.put("key1", "higherHitsValue1");
         multiMapA1.put("key2", "value2");
@@ -222,69 +233,58 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
     }
 
     private void afterMergeHigherHitsMergePolicy() {
-        assertMultiMapsA("key1", "value1", "higherHitsValue1");
-        assertMultiMapsA("key2", "value2", "higherHitsValue2");
-
-        assertEquals(4, multiMapA1.size());
-        assertEquals(4, multiMapA2.size());
-        assertEquals(2, backupMultiMapA.size());
+        assertMultiMapsA("key1", "higherHitsValue1");
+        assertMultiMapsA("key2", "higherHitsValue2");
+        assertMultiMapsSizeA(2);
     }
 
+    /**
+     * The lastAccessTime is measured per MultiMapContainer, so we cannot test it with multiple keys on the same map.
+     */
     private void afterSplitLatestAccessMergePolicy() {
-        multiMapA1.put("key1", "value1");
+        multiMapA1.put("key", "value");
         // access to record
-        multiMapA1.get("key1");
+        multiMapA1.get("key");
 
         // prevent updating at the same time
         sleepAtLeastMillis(100);
 
-        multiMapA2.put("key1", "LatestAccessedValue1");
+        multiMapA2.put("key", "LatestAccessedValue");
         // access to record
-        multiMapA2.get("key1");
+        multiMapA2.get("key");
 
-        multiMapA2.put("key2", "value2");
+        multiMapB2.put("key", "LatestAccessedValue");
         // access to record
-        multiMapA2.get("key2");
-
-        // prevent updating at the same time
-        sleepAtLeastMillis(100);
-
-        multiMapA1.put("key2", "LatestAccessedValue2");
-        // access to record
-        multiMapA1.get("key2");
+        multiMapB2.get("key");
     }
 
     private void afterMergeLatestAccessMergePolicy() {
-        assertMultiMapsA("key1", "value1", "LatestAccessedValue1");
-        assertMultiMapsA("key2", "value2", "LatestAccessedValue2");
+        assertMultiMapsA("key", "LatestAccessedValue");
+        assertMultiMapsSizeA(1);
 
-        assertEquals(4, multiMapA1.size());
-        assertEquals(4, multiMapA2.size());
-        assertEquals(2, backupMultiMapA.size());
+        assertMultiMapsB("key", "LatestAccessedValue");
+        assertMultiMapsSizeB(1);
     }
 
+    /**
+     * The lastUpdateTime is measured per MultiMapContainer, so we cannot test it with multiple keys on the same map.
+     */
     private void afterSplitLatestUpdateMergePolicy() {
-        multiMapA1.put("key1", "value1");
+        multiMapA1.put("key", "value");
 
         // prevent updating at the same time
         sleepAtLeastMillis(100);
 
-        multiMapA2.put("key1", "LatestUpdatedValue1");
-        multiMapA2.put("key2", "value2");
-
-        // prevent updating at the same time
-        sleepAtLeastMillis(100);
-
-        multiMapA1.put("key2", "LatestUpdatedValue2");
+        multiMapA2.put("key", "LatestUpdatedValue");
+        multiMapB2.put("key", "LatestUpdatedValue");
     }
 
     private void afterMergeLatestUpdateMergePolicy() {
-        assertMultiMapsA("key1", "value1", "LatestUpdatedValue1");
-        assertMultiMapsA("key2", "value2", "LatestUpdatedValue2");
+        assertMultiMapsA("key", "LatestUpdatedValue");
+        assertMultiMapsSizeA(1);
 
-        assertEquals(4, multiMapA1.size());
-        assertEquals(4, multiMapA2.size());
-        assertEquals(2, backupMultiMapA.size());
+        assertMultiMapsB("key", "LatestUpdatedValue");
+        assertMultiMapsSizeB(1);
     }
 
     private void afterSplitPassThroughMergePolicy() {
@@ -308,18 +308,12 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
         assertFalse("Expected lockedKey to be unlocked", multiMapA1.isLocked("lockedKey"));
 
         assertMultiMapsA("lockedKey", "lockedValue");
-        assertMultiMapsA("key1", "value1", "value2", "PassThroughValue1a", "PassThroughValue1b");
+        assertMultiMapsA("key1", "PassThroughValue1a", "PassThroughValue1b");
         assertMultiMapsA("key2", "PassThroughValue2a", "PassThroughValue2b");
-
-        assertEquals(7, multiMapA1.size());
-        assertEquals(7, multiMapA2.size());
-        assertEquals(3, backupMultiMapA.size());
+        assertMultiMapsSizeA(5);
 
         assertMultiMapsB("key", "PassThroughValue");
-
-        assertEquals(1, multiMapB1.size());
-        assertEquals(1, multiMapB2.size());
-        assertEquals(1, backupMultiMapB.size());
+        assertMultiMapsSizeB(1);
     }
 
     private void afterSplitPutIfAbsentMergePolicy() {
@@ -334,56 +328,85 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
     }
 
     private void afterMergePutIfAbsentMergePolicy() {
-        assertMultiMapsA("key1", "value", "PutIfAbsentValue1a", "PutIfAbsentValue1b");
+        assertMultiMapsA("key1", "PutIfAbsentValue1a", "PutIfAbsentValue1b");
         assertMultiMapsA("key2", "PutIfAbsentValue2a", "PutIfAbsentValue2b");
-
-        assertEquals(5, multiMapA1.size());
-        assertEquals(5, multiMapA2.size());
-        assertEquals(2, backupMultiMapA.size());
+        assertMultiMapsSizeA(4);
 
         assertMultiMapsB("key", "PutIfAbsentValue");
+        assertMultiMapsSizeB(1);
+    }
 
-        assertEquals(1, multiMapB1.size());
-        assertEquals(1, multiMapB2.size());
-        assertEquals(1, backupMultiMapB.size());
+    private void afterSplitRemoveValuesMergePolicy() {
+        multiMapA1.put("key1", "discardedValue1a");
+        multiMapA1.put("key1", "discardedValue1b");
+
+        multiMapA2.put("key1", "discardedValue2");
+        multiMapA2.put("key2", "discardedValue2a");
+        multiMapA2.put("key2", "discardedValue2b");
+
+        multiMapB2.put("key", "discardedValue");
+    }
+
+    private void afterMergeRemoveValuesMergePolicy() {
+        assertMultiMapsA("key1");
+        assertMultiMapsA("key2");
+        assertMultiMapsSizeA(0);
+
+        assertMultiMapsB("key");
+        assertMultiMapsSizeB(0);
     }
 
     private void afterSplitCustomMergePolicy() {
-        multiMapA1.put("key", 1);
-        multiMapA2.put("key", "value");
+        // for key1 just the Integer values survive
+        multiMapA1.put("key1", "value1");
+        multiMapA1.put("key1", 23);
+        multiMapA2.put("key1", "value2");
+        multiMapA2.put("key1", 42);
+
+        // key2 is completely removed
+        multiMapA1.put("key2", "value1");
+        multiMapA2.put("key2", "value2");
+
+        // key3 survives, since there is no mergingValue for it
+        multiMapA1.put("key3", "value");
+
+        multiMapB2.put("key1", 42);
+        multiMapB2.put("key2", "value");
     }
 
     private void afterMergeCustomMergePolicy() {
-        assertMultiMapsA("key", 1);
+        assertMultiMapsA("key1", 23, 42);
+        assertMultiMapsA("key2");
+        assertMultiMapsA("key3", "value");
+        assertMultiMapsSizeA(3);
 
-        assertEquals(1, multiMapA1.size());
-        assertEquals(1, multiMapA2.size());
-        assertEquals(1, backupMultiMapA.size());
+        assertMultiMapsB("key1", 42);
+        assertMultiMapsB("key2");
+        assertMultiMapsSizeB(1);
     }
 
-    private void assertMultiMapsA(String key, Object... objects) {
-        assertMultiMaps(multiMapA1, multiMapA2, backupMultiMapA, key, objects);
+    private void assertMultiMapsA(String key, Object... expectedValues) {
+        assertMultiMaps(multiMapA1, multiMapA2, backupMultiMapA, key, expectedValues);
     }
 
-    @SuppressWarnings("SameParameterValue")
-    private void assertMultiMapsB(String key, Object... objects) {
-        assertMultiMaps(multiMapB1, multiMapB2, backupMultiMapB, key, objects);
+    private void assertMultiMapsB(String key, Object... expectedValues) {
+        assertMultiMaps(multiMapB1, multiMapB2, backupMultiMapB, key, expectedValues);
     }
 
     private static void assertMultiMaps(MultiMap<Object, Object> multiMap1, MultiMap<Object, Object> multiMap2,
-                                        Map<Object, Collection<Object>> backupMultiMap, String key, Object... objects) {
+                                        Map<Object, Collection<Object>> backupMultiMap, String key, Object... expectedValues) {
         Collection<Object> collection1 = multiMap1.get(key);
         Collection<Object> collection2 = multiMap2.get(key);
         Collection<Object> backupCollection = backupMultiMap.get(key);
-        if (objects.length > 0) {
-            Collection<Object> expected = asList(objects);
+        if (expectedValues.length > 0) {
+            Collection<Object> expected = asList(expectedValues);
             assertContainsAll(collection1, expected);
             assertContainsAll(collection2, expected);
             assertContainsAll(backupCollection, expected);
 
-            assertEquals(objects.length, multiMap1.valueCount(key));
-            assertEquals(objects.length, multiMap2.valueCount(key));
-            assertEquals(objects.length, backupCollection.size());
+            assertEquals(expectedValues.length, multiMap1.valueCount(key));
+            assertEquals(expectedValues.length, multiMap2.valueCount(key));
+            assertEquals(expectedValues.length, backupCollection.size());
         } else {
             assertTrue("multiMap1 should be empty for " + key + ", but was " + collection1, collection1.isEmpty());
             assertTrue("multiMap2 should be empty for " + key + ", but was " + collection2, collection2.isEmpty());
@@ -392,5 +415,24 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
             assertEquals(0, multiMap1.valueCount(key));
             assertEquals(0, multiMap2.valueCount(key));
         }
+    }
+
+    private void assertMultiMapsSizeA(int expectedSize) {
+        assertMultiMapsSize(multiMapA1, multiMapA2, backupMultiMapA, expectedSize);
+    }
+
+    private void assertMultiMapsSizeB(int expectedSize) {
+        assertMultiMapsSize(multiMapB1, multiMapB2, backupMultiMapB, expectedSize);
+    }
+
+    private static void assertMultiMapsSize(MultiMap<?, ?> multiMap1, MultiMap<?, ?> multiMap2,
+                                            Map<?, ? extends Collection<?>> backupMultiMap, int expectedSize) {
+        assertEqualsStringFormat("multiMap1 should have size %d, but was %d", expectedSize, multiMap1.size());
+        assertEqualsStringFormat("multiMap2 should have size %d, but was %d", expectedSize, multiMap2.size());
+        int actualBackupSize = 0;
+        for (Collection<?> values : backupMultiMap.values()) {
+            actualBackupSize += values.size();
+        }
+        assertEqualsStringFormat("backupMultiMap should have size %d, but was %d", expectedSize, actualBackupSize);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -822,25 +822,27 @@ public abstract class HazelcastTestSupport {
 
     public static <E> void assertContains(Collection<E> collection, E expected) {
         if (!collection.contains(expected)) {
-            fail(format("Collection %s didn't contain expected '%s'", collection, expected));
+            fail(format("Collection %s (%d) didn't contain expected '%s'", collection, collection.size(), expected));
         }
     }
 
     public static <E> void assertNotContains(Collection<E> collection, E expected) {
         if (collection.contains(expected)) {
-            fail(format("Collection %s contained unexpected '%s'", collection, expected));
+            fail(format("Collection %s (%d) contained unexpected '%s'", collection, collection.size(), expected));
         }
     }
 
     public static <E> void assertContainsAll(Collection<E> collection, Collection<E> expected) {
         if (!collection.containsAll(expected)) {
-            fail(format("Collection %s didn't contain expected %s", collection, expected));
+            fail(format("Collection %s (%d) didn't contain expected %s (%d)",
+                    collection, collection.size(), expected, expected.size()));
         }
     }
 
     public static <E> void assertNotContainsAll(Collection<E> collection, Collection<E> expected) {
         if (collection.containsAll(expected)) {
-            fail(format("Collection %s contained unexpected %s", collection, expected));
+            fail(format("Collection %s (%d) contained unexpected %s (%d)",
+                    collection, collection.size(), expected, expected.size()));
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -474,4 +474,51 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
         public void readData(ObjectDataInput in) {
         }
     }
+
+    protected static class MergeCollectionOfIntegerValuesMergePolicy
+            implements SplitBrainMergePolicy<Collection<Object>, MergingValue<Collection<Object>>> {
+
+        @Override
+        public Collection<Object> merge(MergingValue<Collection<Object>> mergingValue,
+                                        MergingValue<Collection<Object>> existingValue) {
+            Collection<Object> result = new ArrayList<Object>();
+            for (Object value : mergingValue.<Collection<Object>>getDeserializedValue()) {
+                if (value instanceof Integer) {
+                    result.add(value);
+                }
+            }
+            if (existingValue != null) {
+                for (Object value : existingValue.<Collection<Object>>getDeserializedValue()) {
+                    if (value instanceof Integer) {
+                        result.add(value);
+                    }
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) {
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) {
+        }
+    }
+
+    protected static class RemoveValuesMergePolicy implements SplitBrainMergePolicy<Object, MergingValue<Object>> {
+
+        @Override
+        public Object merge(MergingValue<Object> mergingValue, MergingValue<Object> existingValue) {
+            return null;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) {
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) {
+        }
+    }
 }


### PR DESCRIPTION
* fixed merging of multiple values per key
* fixed setting of `MultiMap` statistics, if merged entries were chosen
* fixed when user returned new values, instead of `mergingEntry.getValue()` or `existingEntry.getValue()`
* fixed `lastAccessTime` updates for `MultiMap` on backups and migrations

Part of https://github.com/hazelcast/hazelcast/issues/12803
Part of https://github.com/hazelcast/hazelcast/issues/12804
Part of https://github.com/hazelcast/hazelcast/issues/12805