### PR TITLE
Add serialVersionUID to ComplexValue, maintain backwards compatibility when serializing

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/multimap/ComplexValue.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/ComplexValue.java
@@ -20,6 +20,8 @@ import java.io.Serializable;
 
 class ComplexValue implements Serializable {
 
+    private static final long serialVersionUID = -6926569333412274188L;
+
     private String name;
     private int time;
 


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2035

The class was slightly refactored ([here](https://github.com/hazelcast/hazelcast/pull/12738/files#diff-4ac40b86d87d145c30755ab39e553669)) without changing its properties. 
Added a `serialVersionUID`.