### PR TITLE
Enforces class filtering behavior consistently in FilteringClassLoader

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/UserCodeDeploymentConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/UserCodeDeploymentConfig.java
@@ -106,7 +106,7 @@ public class UserCodeDeploymentConfig {
      *     Config hazelcastConfig = new Config();
      *
      *     UserCodeDeploymentConfig userCodeDeploymentConfig = hazelcastConfig.getUserCodeDeploymentConfig();
-     *     userCodeDeploymentConfig.setProviderFilter(HAS_ATTRIBUTE:class-provider);
+     *     userCodeDeploymentConfig.setProviderFilter("HAS_ATTRIBUTE:class-provider");
      *
      *     HazecastInstance instance = Hazelcast.newHazelcastInstance(hazelcastConfig);
      * </pre>


### PR DESCRIPTION
Previously, the filtering only applied in `loadClass` method; now it is
enforced also on resource lookups (`getResource` etc).
Also applies filtering on previous Hazelcast versions used with
compatibility tests via `HazelcastStarter`, when the instance is started
with a `FilteringClassLoader` as config class loader.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1819