### PR TITLE
Fix single node hot restart cluster start bug

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -961,10 +961,10 @@ public class MembershipManager {
     void addMembersRemovedInNotJoinableState(Collection<MemberImpl> members) {
         clusterServiceLock.lock();
         try {
-            members.remove(clusterService.getLocalMember());
-            MemberMap membersRemovedInNotJoinableState = membersRemovedInNotJoinableStateRef.get();
-            membersRemovedInNotJoinableStateRef.set(MemberMap.cloneAdding(membersRemovedInNotJoinableState,
-                    members.toArray(new MemberImpl[0])));
+            MemberMap m = membersRemovedInNotJoinableStateRef.get();
+            m = MemberMap.cloneAdding(m, members.toArray(new MemberImpl[0]));
+            m = MemberMap.cloneExcluding(m, clusterService.getLocalMember());
+            membersRemovedInNotJoinableStateRef.set(m);
         } finally {
             clusterServiceLock.unlock();
         }


### PR DESCRIPTION
* The local member must be removed via uuid check from the "members removed while the cluster not active" set which is read from the disk during restart.
* Its test is available on the EE pr.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/2041