### PR TITLE
Add cluster safety assertions to SplitBrainHandlerTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/SplitBrainHandlerTest.java
@@ -536,6 +536,9 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         assertClusterSizeEventually(3, lite1, lite2, data1);
         assertClusterSizeEventually(2, data2, data3);
 
+        waitAllForSafeState(lite1, lite2, data1);
+        waitAllForSafeState(data2, data3);
+
         data1.getMap("default").put(1, "cluster1");
         data3.getMap("default").put(1, "cluster2");
 
@@ -547,9 +550,9 @@ public class SplitBrainHandlerTest extends HazelcastTestSupport {
         unblockCommunicationBetween(lite2, data3);
         unblockCommunicationBetween(data1, data3);
 
-        assertOpenEventually(mergeLatch, 120);
+        assertOpenEventually(mergeLatch);
         assertClusterSizeEventually(5, lite1, lite2, data1, data2, data3);
-
+        waitAllForSafeState(lite1, lite2, data1, data2, data3);
         assertEquals("cluster1", lite1.getMap("default").get(1));
     }
 


### PR DESCRIPTION
Logs of the failure #10656 are not available since they have not been uploaded to S3 for some reason. For now, just some cluster safety assertions are added to the failed test. Let's wait until the next failure to see more details.

Fixes #10656