### PR TITLE
fixes io balancer stress test counting bytes instead of events

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
@@ -32,9 +32,11 @@ import com.hazelcast.nio.tcp.TcpIpConnectionManager;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,6 +52,9 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
 public class IOBalancerStressTest extends HazelcastTestSupport {
+
+    @Rule
+    public final OverridePropertyRule overridePropertyRule = OverridePropertyRule.set("hazelcast.io.load", "0");
 
     @Before
     @After
@@ -86,9 +91,9 @@ public class IOBalancerStressTest extends HazelcastTestSupport {
         Map<NioThread, Set<MigratableHandler>> handlersPerSelector = getHandlersPerSelector(connectionManager);
 
         try {
-            for (Map.Entry<NioThread, Set<MigratableHandler>> entry : handlersPerSelector.entrySet()) {
-                NioThread selector = entry.getKey();
-                Set<MigratableHandler> handlers = entry.getValue();
+            for (Map.Entry<NioThread, Set<MigratableHandler>> selectorHandlersMap : handlersPerSelector.entrySet()) {
+                NioThread selector = selectorHandlersMap.getKey();
+                Set<MigratableHandler> handlers = selectorHandlersMap.getValue();
                 assertBalanced(selector, handlers);
             }
         } catch (AssertionError e) {


### PR DESCRIPTION
This test expects number of events seen on a dead connection to be lower than 3. However, IOBalancer counts number of bytes received, not events. This PR sets the load balancing selector to event count. Load balancing selectors are defined in [AbstractHandler](https://github.com/hazelcast/hazelcast/blob/maintenance-3.x/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/AbstractHandler.java#L36) and they are not public API.

Fixes https://github.com/hazelcast/hazelcast/issues/7662