### PR TITLE
Increasing authentication timeout

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/HeartbeatManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/HeartbeatManager.java
@@ -70,6 +70,10 @@ public class HeartbeatManager implements Runnable {
         clientICMPManager.start();
     }
 
+    long getHeartbeatTimeout() {
+        return heartbeatTimeout;
+    }
+
     @Override
     public void run() {
         if (!clientConnectionManager.alive) {


### PR DESCRIPTION
With recent changes, due to having more stable authentication,
authentication takes longer.

We were failing an authentication invocation when connection
timeout duration passes.( default 5 seconds )

Since normally, our invocaitons fail when heartbeat timeout
expires, changing this timeout from connection timeout to
heartbeat timeout (60 seconds) seems more appropriate.

When heartbeat timeout is configured manually, this pr forces
authentication timeout as small as 2 * connection timeout.

fixes https://github.com/hazelcast/hazelcast/issues/12745