### PR TITLE
Increasing authentication timeout

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -134,7 +134,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
     private volatile Address ownerConnectionAddress;
     private volatile Address previousOwnerConnectionAddress;
 
-    private HeartbeatManager heartbeat;
+    private final HeartbeatManager heartbeat;
+    private final long authenticationTimeout;
     private volatile ClientPrincipal principal;
     private final ClientConnectionStrategy connectionStrategy;
     private final ExecutorService clusterConnectionExecutor;
@@ -173,7 +174,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         this.clusterConnectionExecutor = createSingleThreadExecutorService(client);
         this.shuffleMemberList = client.getProperties().getBoolean(SHUFFLE_MEMBER_LIST);
         this.addressProviders = addressProviders;
-        connectionAttemptPeriod = networkConfig.getConnectionAttemptPeriod();
+        this.connectionAttemptPeriod = networkConfig.getConnectionAttemptPeriod();
 
         int connAttemptLimit = networkConfig.getConnectionAttemptLimit();
         boolean isAsync = client.getClientConfig().getConnectionStrategyConfig().isAsyncStart();
@@ -187,7 +188,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
 
         this.outboundPorts.addAll(getOutboundPorts(networkConfig));
         this.outboundPortCount = outboundPorts.size();
-
+        this.heartbeat = new HeartbeatManager(this, client);
+        this.authenticationTimeout = heartbeat.getHeartbeatTimeout();
         checkSslAllowed();
     }
 
@@ -286,7 +288,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         }
         alive = true;
         startEventLoopGroup();
-        heartbeat = new HeartbeatManager(this, client);
+
         heartbeat.start();
         addConnectionHeartbeatListener(this);
         connectionStrategy.init(clientContext);
@@ -629,8 +631,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
         ClientMessage clientMessage = encodeAuthenticationRequest(asOwner, client.getSerializationService(), principal);
         ClientInvocation clientInvocation = new ClientInvocation(client, clientMessage, null, connection);
         ClientInvocationFuture invocationFuture = clientInvocation.invokeUrgent();
-        ScheduledFuture timeoutTaskFuture = executionService.schedule(new TimeoutAuthenticationTask(invocationFuture),
-                connectionTimeoutMillis, MILLISECONDS);
+
+        ScheduledFuture timeoutTaskFuture = executionService.schedule(
+                new TimeoutAuthenticationTask(invocationFuture), authenticationTimeout, MILLISECONDS);
         invocationFuture.andThen(new AuthCallback(connection, asOwner, target, future, timeoutTaskFuture));
     }
 
@@ -722,7 +725,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
                 return;
             }
             future.complete(new TimeoutException("Authentication response did not come back in "
-                    + connectionTimeoutMillis + " millis"));
+                    + authenticationTimeout + " millis"));
         }
 
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/HeartbeatManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/HeartbeatManager.java
@@ -71,6 +71,10 @@ public class HeartbeatManager implements Runnable {
         clientICMPManager.start();
     }
 
+    long getHeartbeatTimeout() {
+        return heartbeatTimeout;
+    }
+
     @Override
     public void run() {
         if (!clientConnectionManager.alive) {


### PR DESCRIPTION
With recent changes, due to having more stable authentication,
authentication takes longer.

We were failing an authentication invocation when connection
timeout duration passes.( default 5 seconds )

Since normally, our invocaitons fail when heartbeat timeout
expires, changing this timeout from connection timeout to
heartbeat timeout (60 seconds) seems more appropriate.

fixes https://github.com/hazelcast/hazelcast/issues/12745