### PR TITLE
Fixes hopefully the MigrationInvocationSafetyTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,7 +52,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class})
 public class MigrationInvocationsSafetyTest extends PartitionCorrectnessTestSupport {
 
     @Before


### PR DESCRIPTION
The test was annotated with parallel test and due to
too many tests running in parallel, perhaps it didn't have sufficient
time to complete successfully.

I have run this test locally a few hundred times on JDK 6 without
any problem; but this was in isolation of other tests.

fix https://github.com/hazelcast/hazelcast/issues/12788