### PR TITLE
Pluggable configuration replacers

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.10.xsd
@@ -25,6 +25,7 @@
         <xs:complexType>
             <xs:choice minOccurs="1" maxOccurs="unbounded">
                 <xs:element ref="import" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="config-replacers" type="config-replacers" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="group" type="cluster-group" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="license-key" type="xs:string" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
@@ -57,6 +58,28 @@
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
+    <xs:complexType name="config-replacers">
+        <xs:sequence>
+            <xs:element name="replacer" type="replacer" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="fail-if-value-missing" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Controls if missing replacement value should lead to stop the boot process.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:boolean"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="replacer">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="class-name" use="required"/>
+    </xs:complexType>
+
     <xs:complexType name="aws">
         <xs:all>
             <xs:element name="inside-aws" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -19,6 +19,19 @@
                   xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
+    <config-replacers fail-if-value-missing="false">
+        <replacer class-name="com.hazelcast.config.replacer.EncryptionReplacer">
+            <properties>
+                <property name="passwordFile">password.txt</property>
+                <property name="passwordUserProperties">false</property>
+                <property name="cipherAlgorithm">DES</property>
+                <property name="keyLengthBits">64</property>
+                <property name="secretKeyAlgorithm">DES</property>
+                <property name="secretKeyFactoryAlgorithm">PBKDF2WithHmacSHA1</property>
+            </properties>
+        </replacer>
+    </config-replacers>
+
     <group>
         <name>dev</name>
         <password>dev-pass</password>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -79,7 +79,7 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
     static final String HAZELCAST_CLIENT_START_TAG =
             "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n";
 
-    private static final String HAZELCAST_CLIENT_END_TAG = "</hazelcast-client>";
+    static final String HAZELCAST_CLIENT_END_TAG = "</hazelcast-client>";
 
     private ClientConfig fullClientConfig;
     private ClientConfig defaultClientConfig;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
@@ -16,21 +16,31 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.XmlConfigImportVariableReplacementTest.IdentityReplacer;
+import com.hazelcast.config.XmlConfigImportVariableReplacementTest.TestReplacer;
+import com.hazelcast.config.replacer.EncryptionReplacer;
+import com.hazelcast.nio.IOUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Properties;
 
+import static com.hazelcast.client.config.XmlClientConfigBuilderTest.HAZELCAST_CLIENT_END_TAG;
 import static com.hazelcast.client.config.XmlClientConfigBuilderTest.HAZELCAST_CLIENT_START_TAG;
 import static com.hazelcast.client.config.XmlClientConfigBuilderTest.buildConfig;
 import static com.hazelcast.nio.IOUtil.closeResource;
@@ -43,13 +53,16 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class XmlClientConfigImportVariableReplacementTest extends HazelcastTestSupport {
 
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
     @Test(expected = InvalidConfigurationException.class)
     public void testImportElementOnlyAppersInTopLevel() throws Exception {
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "   <network>\n"
                 + "        <import resource=\"\"/>\n"
                 + "   </network>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
 
         buildConfig(xml);
     }
@@ -59,7 +72,7 @@ public class XmlClientConfigImportVariableReplacementTest extends HazelcastTestS
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "   <hazelcast-client>"
                 + "   </hazelcast-client>"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
 
         buildConfig(xml);
     }
@@ -68,7 +81,7 @@ public class XmlClientConfigImportVariableReplacementTest extends HazelcastTestS
     public void readVariables() {
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "<executor-pool-size>${executor.pool.size}</executor-pool-size>"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
 
         ClientConfig config = buildConfig(xml, "executor.pool.size", "40");
         assertEquals(40, config.getExecutorPoolSize());
@@ -93,12 +106,12 @@ public class XmlClientConfigImportVariableReplacementTest extends HazelcastTestS
                 + "      </properties>"
                 + "    </socket-interceptor>"
                 + "  </network>"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
         writeStringToStreamAndClose(os, networkConfig);
 
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"${config.location}\"/>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
 
         ClientConfig config = buildConfig(xml, "config.location", file.getAbsolutePath());
         assertFalse(config.getNetworkConfig().isSmartRouting());
@@ -117,12 +130,12 @@ public class XmlClientConfigImportVariableReplacementTest extends HazelcastTestS
                 + "      <address>${ip.address}</address>"
                 + "    </cluster-members>"
                 + "  </network>"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
         writeStringToStreamAndClose(os, networkConfig);
 
         String xml = HAZELCAST_CLIENT_START_TAG +
                 "    <import resource=\"${config.location}\"/>\n" +
-                "</hazelcast-client>";
+                HAZELCAST_CLIENT_END_TAG;
 
         Properties properties = new Properties();
         properties.setProperty("config.location", file.getAbsolutePath());
@@ -139,10 +152,10 @@ public class XmlClientConfigImportVariableReplacementTest extends HazelcastTestS
         FileOutputStream os2 = new FileOutputStream(config2);
         String config1Xml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"file:///" + config2.getAbsolutePath() + "\"/>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
         String config2Xml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"file:///" + config1.getAbsolutePath() + "\"/>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
         writeStringToStreamAndClose(os1, config1Xml);
         writeStringToStreamAndClose(os2, config2Xml);
 
@@ -159,13 +172,13 @@ public class XmlClientConfigImportVariableReplacementTest extends HazelcastTestS
         FileOutputStream os3 = new FileOutputStream(config2);
         String config1Xml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"file:///" + config2.getAbsolutePath() + "\"/>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
         String config2Xml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"file:///" + config3.getAbsolutePath() + "\"/>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
         String config3Xml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"file:///" + config1.getAbsolutePath() + "\"/>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
         writeStringToStreamAndClose(os1, config1Xml);
         writeStringToStreamAndClose(os2, config2Xml);
         writeStringToStreamAndClose(os3, config3Xml);
@@ -178,7 +191,7 @@ public class XmlClientConfigImportVariableReplacementTest extends HazelcastTestS
         FileOutputStream os = new FileOutputStream(config);
         String configXml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"file:///" + config.getAbsolutePath() + "\"/>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
         writeStringToStreamAndClose(os, "");
         buildConfig(configXml);
     }
@@ -187,7 +200,7 @@ public class XmlClientConfigImportVariableReplacementTest extends HazelcastTestS
     public void testImportEmptyResourceThrowsException() throws Exception {
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"\"/>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
 
         buildConfig(xml);
     }
@@ -196,16 +209,102 @@ public class XmlClientConfigImportVariableReplacementTest extends HazelcastTestS
     public void testImportNotExistingResourceThrowsException() throws Exception {
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"notexisting.xml\"/>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
 
         buildConfig(xml);
+    }
+
+    @Test
+    public void testReplacers() throws Exception {
+        File passwordFile = tempFolder.newFile(getClass().getSimpleName() + ".pwd");
+        PrintWriter out = new PrintWriter(passwordFile);
+        try {
+            out.print("This is a password");
+        } finally {
+            IOUtil.closeResource(out);
+        }
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <config-replacers>\n"
+                + "        <replacer class-name='" + EncryptionReplacer.class.getName() + "'>\n"
+                + "            <properties>\n"
+                + "                <property name='passwordFile'>" + passwordFile.getAbsolutePath() + "</property>\n"
+                + "                <property name='passwordUserProperties'>false</property>\n"
+                + "                <property name='keyLengthBits'>64</property>\n"
+                + "                <property name='saltLengthBytes'>8</property>\n"
+                + "                <property name='cipherAlgorithm'>DES</property>\n"
+                + "                <property name='secretKeyFactoryAlgorithm'>PBKDF2WithHmacSHA1</property>\n"
+                + "                <property name='secretKeyAlgorithm'>DES</property>\n"
+                + "            </properties>\n"
+                + "        </replacer>\n"
+                + "        <replacer class-name='" + IdentityReplacer.class.getName() + "'/>\n"
+                + "    </config-replacers>\n"
+                + "    <group>\n"
+                + "        <name>${java.version} $ID{dev}</name>\n"
+                + "        <password>$ENC{7JX2r/8qVVw=:10000:Jk4IPtor5n/vCb+H8lYS6tPZOlCZMtZv}</password>\n"
+                + "    </group>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+        GroupConfig groupConfig = buildConfig(xml, System.getProperties()).getGroupConfig();
+        assertEquals(System.getProperty("java.version")+ " dev", groupConfig.getName());
+        assertEquals("My very secret secret", groupConfig.getPassword());
+    }
+
+    @Test(expected = ConfigurationException.class)
+    public void testMissingReplacement() throws Exception {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <config-replacers>\n"
+                + "        <replacer class-name='" + EncryptionReplacer.class.getName() + "'/>\n"
+                + "    </config-replacers>\n"
+                + "    <group>\n"
+                + "        <name>$ENC{7JX2r/8qVVw=:10000:Jk4IPtor5n/vCb+H8lYS6tPZOlCZMtZv}</name>\n"
+                + "    </group>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+        buildConfig(xml, System.getProperties());
+    }
+
+    @Test
+    public void testReplacerProperties() throws Exception {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <config-replacers fail-if-value-missing='false'>\n"
+                + "        <replacer class-name='" + TestReplacer.class.getName() + "'>\n"
+                + "            <properties>\n"
+                + "                <property name='p1'>a property</property>\n"
+                + "                <property name='p2'/>\n"
+                + "                <property name='p3'>another property</property>\n"
+                + "                <property name='p4'>&lt;test/&gt;</property>\n"
+                + "            </properties>\n"
+                + "        </replacer>\n"
+                + "    </config-replacers>\n"
+                + "    <group>\n"
+                + "        <name>$T{p1} $T{p2} $T{p3} $T{p4} $T{p5}</name>\n"
+                + "    </group>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+        GroupConfig groupConfig = buildConfig(xml, System.getProperties()).getGroupConfig();
+        assertEquals("a property  another property <test/> $T{p5}", groupConfig.getName());
+    }
+
+
+    /**
+     * Given: No replacer is used in the configuration file<br>
+     * When: A property variable is used within the file<br>
+     * Then: The configuration parsing doesn't fail and the variable string remains unchanged (i.e. backward compatible
+     * behavior, as if {@code fail-if-value-missing} attribute is {@code false}).
+     */
+    @Test
+    public void testNoConfigReplacersMissingProperties() throws Exception {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <group>\n"
+                + "        <name>${noSuchPropertyAvailable}</name>\n"
+                + "    </group>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+        GroupConfig groupConfig = buildConfig(xml, System.getProperties()).getGroupConfig();
+        assertEquals("${noSuchPropertyAvailable}", groupConfig.getName());
     }
 
     @Test
     public void testImportGroupConfigFromClassPath() throws Exception {
         String xml = HAZELCAST_CLIENT_START_TAG
                 + "    <import resource=\"classpath:hazelcast-client-c1.xml\"/>\n"
-                + "</hazelcast-client>";
+                + HAZELCAST_CLIENT_END_TAG;
 
         ClientConfig config = buildConfig(xml);
         GroupConfig groupConfig = config.getGroupConfig();

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigBuilder.java
@@ -16,27 +16,35 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
+import static com.hazelcast.config.XmlElements.CONFIG_REPLACERS;
+import static com.hazelcast.config.XmlElements.IMPORT;
+import static com.hazelcast.util.StringUtil.isNullOrEmpty;
+import static java.lang.String.format;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.xml.namespace.NamespaceContext;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.Properties;
-import java.util.Set;
-
-import static com.hazelcast.config.XmlElements.IMPORT;
-import static java.lang.String.format;
+import com.hazelcast.config.replacer.PropertyReplacer;
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 
 /**
  * Contains logic for replacing system variables in the XML file and importing XML files from different locations.
@@ -143,46 +151,101 @@ public abstract class AbstractConfigBuilder extends AbstractXmlConfigHelper {
     @Override
     protected abstract ConfigType getXmlType();
 
-    private void traverseChildrenAndReplaceVariables(Node root) {
+    private void traverseChildrenAndReplaceVariables(Node root) throws Exception {
+        // if no config-replacer is defined, use backward compatible default behavior for missing properties
+        boolean failFast = false;
+
+        List<ConfigReplacer> replacers = new ArrayList<ConfigReplacer>();
+
+        // Always use the Property replacer first.
+        PropertyReplacer propertyReplacer = new PropertyReplacer();
+        propertyReplacer.init(getProperties());
+        replacers.add(propertyReplacer);
+
+        // Add other replacers defined in the XML
+        Node node = (Node) xpath.evaluate(format("/hz:%s/hz:%s", getXmlType().name, CONFIG_REPLACERS.name), root,
+                XPathConstants.NODE);
+        if (node != null) {
+            String failFastAttr = getAttribute(node, "fail-if-value-missing");
+            failFast = isNullOrEmpty(failFastAttr) ? true : Boolean.parseBoolean(failFastAttr);
+            for (Node n : childElements(node)) {
+                String value = cleanNodeName(n);
+                if ("replacer".equals(value)) {
+                    replacers.add(createReplacer(n));
+                }
+            }
+        }
+
+        // Use all the replacers on the XML content
+        for (ConfigReplacer replacer : replacers) {
+            traverseChildrenAndReplaceVariables(root, replacer, failFast);
+        }
+    }
+
+    private ConfigReplacer createReplacer(Node node) throws Exception {
+        String replacerClass = getAttribute(node, "class-name");
+        Properties properties = new Properties();
+        for (Node n : childElements(node)) {
+            String value = cleanNodeName(n);
+            if ("properties".equals(value)) {
+                fillProperties(n, properties);
+            }
+        }
+        ConfigReplacer replacer = (ConfigReplacer) Class.forName(replacerClass).newInstance();
+        replacer.init(properties);
+        return replacer;
+    }
+
+    private void traverseChildrenAndReplaceVariables(Node root, ConfigReplacer replacer, boolean failFast) {
         NamedNodeMap attributes = root.getAttributes();
         if (attributes != null) {
             for (int k = 0; k < attributes.getLength(); k++) {
                 Node attribute = attributes.item(k);
-                replaceVariables(attribute);
+                replaceVariables(attribute, replacer, failFast);
             }
         }
         if (root.getNodeValue() != null) {
-            replaceVariables(root);
+            replaceVariables(root, replacer, failFast);
         }
         final NodeList childNodes = root.getChildNodes();
         for (int k = 0; k < childNodes.getLength(); k++) {
             Node child = childNodes.item(k);
-            traverseChildrenAndReplaceVariables(child);
+            traverseChildrenAndReplaceVariables(child, replacer, failFast);
         }
     }
 
-    private void replaceVariables(Node node) {
+    private void replaceVariables(Node node, ConfigReplacer replacer, boolean failFast) {
         String value = node.getNodeValue();
         StringBuilder sb = new StringBuilder(value);
+        String replacerPrefix = "$" + replacer.getPrefix() + "{";
         int endIndex = -1;
-        int startIndex = sb.indexOf("${");
+        int startIndex = sb.indexOf(replacerPrefix);
         while (startIndex > -1) {
             endIndex = sb.indexOf("}", startIndex);
             if (endIndex == -1) {
-                LOGGER.warning("Bad variable syntax. Could not find a closing curly bracket '}' on node: " + node.getLocalName());
+                LOGGER.warning("Bad variable syntax. Could not find a closing curly bracket '}' for prefix " + replacerPrefix
+                        + " on node: " + node.getLocalName());
                 break;
             }
 
-            String variable = sb.substring(startIndex + 2, endIndex);
-            String variableReplacement = getProperties().getProperty(variable);
+            String variable = sb.substring(startIndex + replacerPrefix.length(), endIndex);
+            String variableReplacement = replacer.getReplacement(variable);
             if (variableReplacement != null) {
                 sb.replace(startIndex, endIndex + 1, variableReplacement);
                 endIndex = startIndex + variableReplacement.length();
             } else {
-                LOGGER.warning("Could not find a value for property  '" + variable + "' on node: " + node.getLocalName());
+                handleMissingVariable(sb.substring(startIndex, endIndex + 1), node.getLocalName(), failFast);
             }
-            startIndex = sb.indexOf("${", endIndex);
+            startIndex = sb.indexOf(replacerPrefix, endIndex);
         }
         node.setNodeValue(sb.toString());
+    }
+
+    private void handleMissingVariable(String variable, String nodeName, boolean failFast) throws ConfigurationException {
+        String message = format("Could not find a replacement for '%s' on node '%s'", variable, nodeName);
+        if (failFast) {
+            throw new ConfigurationException(message);
+        }
+        LOGGER.warning(message);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -20,6 +20,7 @@ enum XmlElements {
     HAZELCAST("hazelcast", false),
     INSTANCE_NAME("instance-name", false),
     IMPORT("import", true),
+    CONFIG_REPLACERS("config-replacers", false),
     GROUP("group", false),
     LICENSE_KEY("license-key", false),
     MANAGEMENT_CENTER("management-center", false),

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/AbstractPbeReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/AbstractPbeReplacer.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.replacer;
+
+import static com.hazelcast.util.Preconditions.checkPositive;
+import static com.hazelcast.util.Preconditions.checkTrue;
+import static com.hazelcast.util.StringUtil.UTF8_CHARSET;
+
+import java.security.SecureRandom;
+import java.util.Properties;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.util.Base64;
+
+/**
+ * The common parent for {@link ConfigReplacer} implementations which allow to mask values by encrypting the value. This parent
+ * class contains shared methods responsible for encryption/decryption. The implementing classes have to provide
+ * {@link #getPassword()} implementation - the password will be used to generate a secret key.
+ */
+public abstract class AbstractPbeReplacer implements ConfigReplacer {
+
+    /**
+     * Replacer property name to configure {@link Cipher} algorithm name.
+     */
+    public static final String PROPERTY_CIPHER_ALGORITHM = "cipherAlgorithm";
+    /**
+     * Replacer property name to configure {@link SecretKeyFactory} algorithm name.
+     */
+    public static final String PROPERTY_SECRET_KEY_FACTORY_ALGORITHM = "secretKeyFactoryAlgorithm";
+    /**
+     * Replacer property name to configure {@link SecretKeySpec} algorithm name.
+     */
+    public static final String PROPERTY_SECRET_KEY_ALGORITHM = "secretKeyAlgorithm";
+    /**
+     * Replacer property name to configure key length (in bits).
+     */
+    public static final String PROPERTY_KEY_LENGTH_BITS = "keyLengthBits";
+    /**
+     * Replacer property name to configure salt length (in bytes).
+     */
+    public static final String PROPERTY_SALT_LENGTH_BYTES = "saltLengthBytes";
+    /**
+     * Replacer property name to configure Java Security provider name used for {@link Cipher} and {@link SecretKeyFactory}
+     * selection.
+     */
+    public static final String PROPERTY_SECURITY_PROVIDER = "securityProvider";
+
+    /**
+     * Default value for {@value #PROPERTY_CIPHER_ALGORITHM} property.
+     */
+    public static final String DEFAULT_CIPHER_ALGORITHM = "AES";
+    /**
+     * Default value for {@value #PROPERTY_SECRET_KEY_FACTORY_ALGORITHM} property.
+     */
+    public static final String DEFAULT_SECRET_KEY_FACTORY_ALGORITHM = "PBKDF2WithHmacSHA256";
+
+    private final ILogger logger = Logger.getLogger(AbstractPbeReplacer.class);
+
+    private String cipherAlgorithm;
+    private String secretKeyFactoryAlgorithm;
+    private String secretKeyAlgorithm;
+    private String securityProvider;
+    private int keyLengthBits;
+    private int saltLengthBytes;
+
+    @Override
+    public void init(Properties properties) {
+        securityProvider = properties.getProperty(PROPERTY_SECURITY_PROVIDER);
+        cipherAlgorithm = properties.getProperty(PROPERTY_CIPHER_ALGORITHM, DEFAULT_CIPHER_ALGORITHM);
+        secretKeyFactoryAlgorithm = properties.getProperty(PROPERTY_SECRET_KEY_FACTORY_ALGORITHM,
+                DEFAULT_SECRET_KEY_FACTORY_ALGORITHM);
+        secretKeyAlgorithm = properties.getProperty(PROPERTY_SECRET_KEY_ALGORITHM, DEFAULT_CIPHER_ALGORITHM);
+        keyLengthBits = Integer.parseInt(properties.getProperty(PROPERTY_KEY_LENGTH_BITS, "128"));
+        saltLengthBytes = Integer.parseInt(properties.getProperty(PROPERTY_SALT_LENGTH_BYTES, "8"));
+        checkPositive(keyLengthBits, "Key length has to be positive number");
+        checkPositive(saltLengthBytes, "Salt length has to be positive number");
+    }
+
+    /**
+     * Provides password for a chosen SecretKeyFactory.
+     *
+     * @return password must not be {@code null} or empty
+     */
+    protected abstract char[] getPassword();
+
+    @Override
+    public String getReplacement(String variable) {
+        try {
+            return decrypt(variable);
+        } catch (Exception e) {
+            logger.warning("Unable to decrypt variable " + variable, e);
+        }
+        return null;
+    }
+
+    /**
+     * Encrypts given string with key generated from {@link #getPassword()} with given iteration count and return the masked
+     * value (to be used as the variable).
+     *
+     * @param secretStr sensitive string to be protected by encryption
+     * @param iterations iteration count
+     * @return Encrypted value.
+     */
+    protected String encrypt(String secretStr, int iterations) throws Exception {
+        SecureRandom secureRandom = new SecureRandom();
+        byte[] salt = new byte[saltLengthBytes];
+        secureRandom.nextBytes(salt);
+        byte[] encryptedVal = transform(Cipher.ENCRYPT_MODE, secretStr.getBytes(UTF8_CHARSET), salt, iterations);
+        return new String(Base64.encode(salt), UTF8_CHARSET) + ":" + iterations + ":"
+                + new String(Base64.encode(encryptedVal), UTF8_CHARSET);
+    }
+
+    /**
+     * Decrypts given encrypted variable.
+     *
+     * @param encryptedStr
+     * @return
+     */
+    protected String decrypt(String encryptedStr) throws Exception {
+        String[] split = encryptedStr.split(":");
+        checkTrue(split.length == 3, "Wrong format of the encrypted variable (" + encryptedStr + ")");
+        byte[] salt = Base64.decode(split[0].getBytes(UTF8_CHARSET));
+        checkTrue(salt.length == saltLengthBytes, "Salt length doesn't match.");
+        int iterations = Integer.parseInt(split[1]);
+        byte[] encryptedVal = Base64.decode(split[2].getBytes(UTF8_CHARSET));
+        return new String(transform(Cipher.DECRYPT_MODE, encryptedVal, salt, iterations), UTF8_CHARSET);
+    }
+
+    /**
+     * Encrypt/decrypt given value by using the configured cipher algorithm with provided salt and iterations count.
+     *
+     * @param cryptMode mode (one of {@link Cipher#DECRYPT_MODE}, {@link Cipher#ENCRYPT_MODE})
+     * @param value value to encrypt/decrypt
+     * @param salt salt to be used
+     * @param iterations count of iterations
+     * @return encrypted or decrypted byte array (depending on cryptMode)
+     */
+    private byte[] transform(int cryptMode, byte[] value, byte[] salt, int iterations) throws Exception {
+        checkPositive(iterations, "Count of iterations has to be positive number.");
+        SecretKeyFactory factory = SecretKeyFactory.getInstance(secretKeyFactoryAlgorithm);
+        char[] password = getPassword();
+        checkTrue(password != null && password.length > 0, "Empty password is not supported");
+        PBEKeySpec pbeKeySpec = new PBEKeySpec(password, salt, iterations, keyLengthBits);
+        byte[] tmpKey = factory.generateSecret(pbeKeySpec).getEncoded();
+        SecretKeySpec secretKeySpec = new SecretKeySpec(tmpKey, secretKeyAlgorithm);
+        Cipher cipher = securityProvider == null ? Cipher.getInstance(cipherAlgorithm)
+                : Cipher.getInstance(cipherAlgorithm, securityProvider);
+        cipher.init(cryptMode, secretKeySpec);
+        return cipher.doFinal(value);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/EncryptionReplacer.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.replacer;
+
+import static com.hazelcast.config.AbstractXmlConfigHelper.childElements;
+import static com.hazelcast.config.AbstractXmlConfigHelper.cleanNodeName;
+import static com.hazelcast.nio.IOUtil.closeResource;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static com.hazelcast.util.Preconditions.checkFalse;
+import static com.hazelcast.util.Preconditions.checkPositive;
+import static com.hazelcast.util.StringUtil.UTF8_CHARSET;
+import static com.hazelcast.util.StringUtil.trim;
+import static java.lang.String.format;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.Properties;
+
+import javax.xml.namespace.NamespaceContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathException;
+import javax.xml.xpath.XPathFactory;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.util.Base64;
+
+/**
+ * Implementation of {@link AbstractPbeReplacer} which reads password from the provided file. The first line in the file is used
+ * as a password.
+ */
+public class EncryptionReplacer extends AbstractPbeReplacer {
+
+    /**
+     * Replacer property name to configure {@code true}/{@code false} flag contolling if users properties should be used as part
+     * of the encryption password.
+     */
+    public static final String PROPERTY_PASSWORD_USER_PROPERTIES = "passwordUserProperties";
+    /**
+     * Replacer property name to configure network interface name used to retrieve MAC address used as part of the encryption
+     * password.
+     */
+    public static final String PROPERTY_PASSWORD_NETWORK_INTERFACE = "passwordNetworkInterface";
+    /**
+     * Replacer property name to configure path to a password file which content should be used as part of the encryption
+     * password.
+     */
+    public static final String PROPERTY_PASSWORD_FILE = "passwordFile";
+
+    private static final String PREFIX = "ENC";
+    private static final int DEFAULT_ITERATIONS = 531;
+
+    private boolean passwordUserProperties;
+    private String passwordNetworkInterface;
+    private String passwordFile;
+
+    @Override
+    public void init(Properties properties) {
+        super.init(properties);
+        passwordFile = properties.getProperty(PROPERTY_PASSWORD_FILE);
+        passwordUserProperties = Boolean.parseBoolean(properties.getProperty(PROPERTY_PASSWORD_USER_PROPERTIES, "true"));
+        passwordNetworkInterface = properties.getProperty(PROPERTY_PASSWORD_NETWORK_INTERFACE);
+        checkFalse(passwordFile == null && passwordNetworkInterface == null && !passwordUserProperties,
+                "At least one of the properties used to generate encryption password has to be configured");
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    @Override
+    protected char[] getPassword() {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            if (passwordFile != null) {
+                FileInputStream fis = new FileInputStream(passwordFile);
+                try {
+                    baos.write(IOUtil.toByteArray(fis));
+                } finally {
+                    IOUtil.closeResource(fis);
+                }
+            }
+            if (passwordUserProperties) {
+                baos.write(System.getProperty("user.home").getBytes(UTF8_CHARSET));
+                baos.write(System.getProperty("user.name").getBytes(UTF8_CHARSET));
+            }
+            if (passwordNetworkInterface != null) {
+                try {
+                    NetworkInterface iface = NetworkInterface.getByName(passwordNetworkInterface);
+                    baos.write(iface.getHardwareAddress());
+                } catch (SocketException e) {
+                    throw rethrow(e);
+                }
+            }
+            return new String(Base64.encode(baos.toByteArray()), UTF8_CHARSET).toCharArray();
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
+    }
+
+    public static final void main(String... args) throws Exception {
+        if (args == null || args.length < 1 || args.length > 2) {
+            System.err.println("Usage:");
+            System.err.println("\tjava -D<propertyName>=<propertyValue>  " + EncryptionReplacer.class.getName()
+                    + " \"<String To Encrypt>\" [iterations]");
+            System.err.println();
+            System.err.println("The replacer configuration can be loaded either from hazelcast/hazelcast-client XML file:");
+            System.err.println("\t-Dhazelcast.config=/path/to/hazelcast.xml");
+            System.err.println();
+            System.err.println("or provided directly via following property names:");
+            System.err.println("\t" + PROPERTY_CIPHER_ALGORITHM);
+            System.err.println("\t" + PROPERTY_KEY_LENGTH_BITS);
+            System.err.println("\t" + PROPERTY_SALT_LENGTH_BYTES);
+            System.err.println("\t" + PROPERTY_SECRET_KEY_ALGORITHM);
+            System.err.println("\t" + PROPERTY_SECRET_KEY_FACTORY_ALGORITHM);
+            System.err.println("\t" + PROPERTY_SECURITY_PROVIDER);
+            System.err.println("\t" + PROPERTY_PASSWORD_FILE);
+            System.err.println("\t" + PROPERTY_PASSWORD_NETWORK_INTERFACE);
+            System.err.println("\t" + PROPERTY_PASSWORD_USER_PROPERTIES);
+            System.err.println();
+            System.err.println("Values available for property " + PROPERTY_PASSWORD_NETWORK_INTERFACE);
+            Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+            while (networkInterfaces.hasMoreElements()) {
+                NetworkInterface networkInterface = networkInterfaces.nextElement();
+                byte[] hardwareAddress = networkInterface.getHardwareAddress();
+                if (hardwareAddress != null) {
+                    System.err.println("\t" + networkInterface.getName());
+                }
+            }
+            System.err.println();
+            System.exit(1);
+        }
+        System.out.println(encrypt(args));
+    }
+
+    protected static String encrypt(String... args) throws Exception {
+        int iterations = args.length == 2 ? Integer.parseInt(args[1]) : DEFAULT_ITERATIONS;
+        EncryptionReplacer replacer = new EncryptionReplacer();
+        String xmlPath = System.getProperty("hazelcast.config");
+        Properties properties = xmlPath == null ? System.getProperties()
+                : loadPropertiesFromConfig(new FileInputStream(xmlPath));
+        replacer.init(properties);
+        String encrypted = replacer.encrypt(args[0], iterations);
+        String variable = "$" + replacer.getPrefix() + "{" + encrypted + "}";
+        return variable;
+    }
+
+    private static Properties loadPropertiesFromConfig(FileInputStream fileInputStream) throws Exception {
+        try {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(true);
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            DocumentBuilder builder = dbf.newDocumentBuilder();
+            Document doc = builder.parse(fileInputStream);
+            Element root = doc.getDocumentElement();
+            return loadProperties(findReplacerDefinition(root));
+        } finally {
+            closeResource(fileInputStream);
+        }
+    }
+
+    private static Node findReplacerDefinition(Element root) throws XPathException {
+        XPath xpath = XPathFactory.newInstance().newXPath();
+        xpath.setNamespaceContext(new HzNsContext());
+        String xpathExp = "//%s:config-replacers/%1$s:replacer[@class-name='%s']";
+        NodeList replaceTags = (NodeList) xpath.evaluate(format(xpathExp, "hz", EncryptionReplacer.class.getName()), root,
+                XPathConstants.NODESET);
+        if (replaceTags.getLength() < 1) {
+            replaceTags = (NodeList) xpath.evaluate(format(xpathExp, "hz-client", EncryptionReplacer.class.getName()), root,
+                    XPathConstants.NODESET);
+            checkPositive(replaceTags.getLength(), "No EncryptionReplacer definition found within the provided XML document.");
+        }
+
+        return replaceTags.item(0);
+    }
+
+    private static Properties loadProperties(Node node) {
+        Properties properties = new Properties();
+        for (Node n : childElements(node)) {
+            String value = cleanNodeName(n);
+            if ("properties".equals(value)) {
+                fillProperties(n, properties);
+            }
+        }
+        return properties;
+    }
+
+    private static void fillProperties(Node node, Properties properties) {
+        if (properties == null) {
+            return;
+        }
+        for (Node n : childElements(node)) {
+            String name = cleanNodeName(n);
+            if ("property".equals(name)) {
+                String propertyName = getTextContent(n.getAttributes().getNamedItem("name"));
+                String value = trim(getTextContent(n));
+                properties.setProperty(propertyName, value == null ? "" : value);
+            }
+        }
+    }
+
+    private static String getTextContent(Node node) {
+        try {
+            return node.getTextContent();
+        } catch (Exception e) {
+            return getTextContentOld(node);
+        }
+    }
+
+    private static String getTextContentOld(Node node) {
+        Node child = node.getFirstChild();
+        if (child != null) {
+            Node next = child.getNextSibling();
+            if (next == null) {
+                return hasTextContent(child) ? child.getNodeValue() : null;
+            }
+            StringBuilder buf = new StringBuilder();
+            appendTextContents(node, buf);
+            return buf.toString();
+        }
+        return null;
+    }
+
+    private static void appendTextContents(Node node, StringBuilder buf) {
+        Node child = node.getFirstChild();
+        while (child != null) {
+            if (hasTextContent(child)) {
+                buf.append(child.getNodeValue());
+            }
+            child = child.getNextSibling();
+        }
+    }
+
+    private static boolean hasTextContent(Node node) {
+        short nodeType = node.getNodeType();
+        return nodeType != Node.COMMENT_NODE && nodeType != Node.PROCESSING_INSTRUCTION_NODE;
+    }
+
+    private static class HzNsContext implements NamespaceContext {
+
+        @Override
+        public String getNamespaceURI(String prefix) {
+            if ("hz".equals(prefix)) {
+                return "http://www.hazelcast.com/schema/config";
+            } else if ("hz-client".equals(prefix)) {
+                return "http://www.hazelcast.com/schema/client-config";
+            }
+            return null;
+        }
+
+        @Override
+        public String getPrefix(String namespaceURI) {
+            return null;
+        }
+
+        @Override
+        @SuppressWarnings("rawtypes")
+        public Iterator getPrefixes(String namespaceURI) {
+            return null;
+        }
+
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/ExecReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/ExecReplacer.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.replacer;
+
+import static com.hazelcast.nio.IOUtil.closeResource;
+import static com.hazelcast.util.StringUtil.UTF8_CHARSET;
+import static com.hazelcast.util.StringUtil.isNullOrEmpty;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Properties;
+
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+/**
+ * The {@link ConfigReplacer} implementation which allows to replace variables with a standard output of an executed command.
+ * The prefix of this replacer is {@value #PREFIX} and the full format of variables is
+ * <code>$EXEC{executable arg1 arg2 ...}</code> (e.g. <code>$EXEC{echo Hello}</code>).
+ * <p>
+ * By default whitespaces are used as argument separators. If some argument value contains a whitespace, then configure another
+ * argument separator in {@value #PROPERTY_ARGUMENT_SEPARATOR} init property.
+ */
+public class ExecReplacer implements ConfigReplacer {
+
+    /**
+     * Replacer property name to configure argument separator regular expression.
+     */
+    public static final String PROPERTY_ARGUMENT_SEPARATOR = "argumentSeparator";
+    /**
+     * Replacer property name which controls if a {@code exitCode==0} is required to successfully finish the replacement.
+     */
+    public static final String PROPERTY_REQUIRES_ZERO_EXIT = "requiresZeroExitCode";
+    /**
+     * Default value for property {@link #PROPERTY_REQUIRES_ZERO_EXIT}.
+     */
+    public static final boolean DEFAULT_REQUIRES_ZERO_EXIT = true;
+
+    private static final String PREFIX = "EXEC";
+    private static final ILogger LOGGER = Logger.getLogger(ExecReplacer.class);
+
+    private String argumentSeparator;
+    private boolean requiresZeroExitCode;
+
+    public void init(Properties properties) {
+        argumentSeparator = properties.getProperty(PROPERTY_ARGUMENT_SEPARATOR, "\\s+");
+        String property = properties.getProperty(PROPERTY_REQUIRES_ZERO_EXIT);
+        requiresZeroExitCode = isNullOrEmpty(property) ? DEFAULT_REQUIRES_ZERO_EXIT : Boolean.parseBoolean(property);
+    }
+
+    @Override
+    public String getPrefix() {
+        return PREFIX;
+    }
+
+    @Override
+    public String getReplacement(String variable) {
+        try {
+            return processWaitAndGetOutput(variable);
+        } catch (Exception e) {
+            LOGGER.warning("Execution failed for variable " + variable, e);
+        }
+        return null;
+    }
+
+    /**
+     * Waits for termination of the given process and returns Standard output
+     */
+    private String processWaitAndGetOutput(String command) throws InterruptedException, IOException {
+        String[] cmdarray = command.split(argumentSeparator);
+        LOGGER.info("Executing command " + Arrays.toString(cmdarray));
+        Process process = Runtime.getRuntime().exec(cmdarray);
+        StdStreamReader outReader = new StdStreamReader(process.getInputStream(), true);
+        outReader.start();
+        StdStreamReader errReader = new StdStreamReader(process.getErrorStream(), false);
+        errReader.start();
+
+        process.waitFor();
+        outReader.join();
+        errReader.join();
+        int exitCode = process.exitValue();
+
+        if (exitCode != 0) {
+            LOGGER.warning("Command finished with non-zero exit code (" + exitCode + "): " + Arrays.toString(cmdarray));
+            if (requiresZeroExitCode) {
+                return null;
+            }
+        }
+
+        return outReader.getStreamContent();
+    }
+
+    /**
+     * Reader thread for process streams. It prevents SIGPIPE related process termination. It has 2 modes:<br>
+     * i) copy standard stream to a byte array and provide it as String<br>
+     * ii) just consume the bytes from the stream
+     */
+    private static class StdStreamReader extends Thread {
+
+        private static final int BUFFER_SIZE = 1024;
+
+        private final InputStream is;
+        private final boolean copy;
+        private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        public StdStreamReader(InputStream is, boolean copy) {
+            this.is = is;
+            this.copy = copy;
+        }
+
+        @Override
+        public void run() {
+            try {
+                byte[] buffer = new byte[BUFFER_SIZE];
+                int n;
+                while (-1 != (n = is.read(buffer))) {
+                    if (copy) {
+                        baos.write(buffer, 0, n);
+                    }
+                }
+            } catch (IOException e) {
+                LOGGER.warning("Reading a standard stream failed.", e);
+            } finally {
+                closeResource(is);
+            }
+        }
+
+        /**
+         * Returns all read bytes as String (with UTF-8 charset used).
+         */
+        public String getStreamContent() {
+            return new String(baos.toByteArray(), UTF8_CHARSET);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/PropertyReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/PropertyReplacer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.replacer;
+
+import java.util.Properties;
+
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+
+/**
+ * ConfigReplacer for replacing property names with property values for properties provided in {@link #init(Properties)} method.
+ * The implementation can be used for replacing System properties.
+ */
+public class PropertyReplacer implements ConfigReplacer {
+
+    private Properties properties;
+
+    public void init(Properties properties) {
+        this.properties = properties;
+    }
+
+    @Override
+    public String getPrefix() {
+        return "";
+    }
+
+    @Override
+    public String getReplacement(String variable) {
+        return properties.getProperty(variable);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains the public API and default implementation of variable replacers for configuration files.
+ */
+package com.hazelcast.config.replacer;

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/spi/ConfigReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/spi/ConfigReplacer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.replacer.spi;
+
+import java.util.Properties;
+
+/**
+ * Interface to be implemented by pluggable variable replacers for the configuration files. The replacers can be configured in
+ * XML configuration files and they are used to replace custom strings during loading the configuration.
+ * <p>
+ * A Variable to be replaced within the configuration file has following form:
+ *
+ * <pre>
+ * "$" PREFIX "{" MASKED_VALUE "}"
+ * </pre>
+ *
+ * where the {@code PREFIX} is the value returned by {@link #getPrefix()} method and {@code MASKED_VALUE} is a value provided to
+ * the {@link #getReplacement(String)} method. The result of {@link #getReplacement(String)} method call replaces the whole
+ * Variable String.
+ */
+public interface ConfigReplacer {
+
+    /**
+     * Initialization method called before first usage of the config replacer.
+     *
+     * @param properties properties configured (not {@code null})
+     */
+    void init(Properties properties);
+
+    /**
+     * Variable replacer prefix string. The value returned should be a constant unique short alphanumeric string without
+     * whitespaces.
+     *
+     * @return constant prefix of this replacer
+     */
+    String getPrefix();
+
+    /**
+     * Provides String which should be used as a variable replacement for given masked value.
+     *
+     * @param maskedValue the masked value
+     * @return either not {@code null} String to be used as a replacement for the variable; or null when this replacer is not
+     *         able to handle the masked value.
+     */
+    String getReplacement(String maskedValue);
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/replacer/spi/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/replacer/spi/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains the SPI for configuration files variable replacers.
+ */
+package com.hazelcast.config.replacer.spi;

--- a/hazelcast/src/main/java/com/hazelcast/util/ICMPHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ICMPHelper.java
@@ -24,13 +24,14 @@ import static com.hazelcast.nio.IOUtil.copy;
 import static com.hazelcast.nio.IOUtil.getFileFromResourcesAsStream;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.JVMUtil.is32bitJVM;
+import static com.hazelcast.util.OsHelper.OS;
+import static com.hazelcast.util.OsHelper.isUnixFamily;
 
 /**
  * Helper class that uses JNI to check whether the JVM process has enough permission to create raw-sockets.
  */
 public final class ICMPHelper {
 
-    private static final String OS = System.getProperty("os.name").toLowerCase();
     static {
         System.load(extractBundledLib());
     }
@@ -42,10 +43,6 @@ public final class ICMPHelper {
 
     public static boolean isRawSocketPermitted() {
         return isRawSocketPermitted0();
-    }
-
-    private static boolean isLinux() {
-        return (OS.contains("nix") || OS.contains("nux") || OS.contains("aix"));
     }
 
     private static String extractBundledLib() {
@@ -65,7 +62,7 @@ public final class ICMPHelper {
     }
 
     private static String getBundledLibraryPath() {
-        if (!isLinux()) {
+        if (!isUnixFamily()) {
             throw new IllegalStateException("ICMP not supported in this platform: " + OS);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/OsHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/OsHelper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+/**
+ * Helper methods related to operating system on which the code is actually running.
+ */
+public final class OsHelper {
+
+    /**
+     * OS name in lower case.
+     */
+    public static final String OS = StringUtil.lowerCaseInternal(System.getProperty("os.name"));
+
+    private OsHelper() {
+    }
+
+    /**
+     * Returns {@code true} if the system is from Unix family.
+     *
+     * @return {@code true} if the current system is Unix/Linux/AIX.
+     */
+    public static boolean isUnixFamily() {
+        return (OS.contains("nix") || OS.contains("nux") || OS.contains("aix"));
+    }
+}

--- a/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.10.xsd
@@ -25,6 +25,7 @@
         <xs:complexType>
             <xs:choice minOccurs="1" maxOccurs="unbounded">
                 <xs:element ref="import"/>
+                <xs:element name="config-replacers" type="config-replacers" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="group" type="cluster-group" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="license-key" type="xs:string" minOccurs="0" maxOccurs="1">
                     <xs:annotation>
@@ -87,6 +88,28 @@
             </xs:complexContent>
         </xs:complexType>
     </xs:element>
+
+    <xs:complexType name="config-replacers">
+        <xs:sequence>
+            <xs:element name="replacer" type="replacer" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="fail-if-value-missing" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Controls if missing replacement value should lead to stop the boot process.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:boolean"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="replacer">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="class-name" use="required"/>
+    </xs:complexType>
 
     <xs:complexType name="map">
         <xs:all>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -47,6 +47,32 @@ https://hazelcast.org/documentation/.
 
     -->
     <import resource="your-configuration-XML-file"/>
+
+    <!--
+        The <config-replacers> allow to use variables (placeholders) within the configuration file and use an external
+        class to retrieve correct values (replacements).
+
+        It can be used for masking sensitive strings such as passwords for instance.
+
+        Format of a variable is:
+        $ PREFIX { STRING_TO_BE_REPLACED }      e.g. $ENC{nnPgTqJCcCQ=:23000:B4y/nlp6M0t3q6YiKImW+w==}
+
+        The PREFIX value depends on the replacer implementation (e.g. "ENC" is used for the EncryptionReplacer)
+        The STRING_TO_BE_REPLACED is the value which is provided to replacer implementation.
+    -->
+    <config-replacers fail-if-value-missing="false">
+        <replacer class-name="com.hazelcast.config.replacer.EncryptionReplacer">
+            <properties>
+                <property name="passwordFile">password.txt</property>
+                <property name="passwordUserProperties">false</property>
+                <property name="cipherAlgorithm">DES</property>
+                <property name="keyLengthBits">64</property>
+                <property name="secretKeyAlgorithm">DES</property>
+                <property name="secretKeyFactoryAlgorithm">PBKDF2WithHmacSHA1</property>
+            </properties>
+        </replacer>
+    </config-replacers>
+
     <!--
         Specifies the name and password for a cluster group you create.
         Cluster groups allow you to create separate sub-clusters within your Hazelcast cluster to

--- a/hazelcast/src/test/java/com/hazelcast/config/replacer/AbstractPbeReplacerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/replacer/AbstractPbeReplacerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.replacer;
+
+import static com.hazelcast.config.replacer.AbstractPbeReplacer.DEFAULT_CIPHER_ALGORITHM;
+import static com.hazelcast.config.replacer.AbstractPbeReplacer.DEFAULT_SECRET_KEY_FACTORY_ALGORITHM;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.Properties;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKeyFactory;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Unit tests for {@link AbstractPbeReplacer}.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({ QuickTest.class, ParallelTest.class })
+public class AbstractPbeReplacerTest {
+
+    @Test
+    public void testDefaultEncryptDecrypt() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+        AbstractPbeReplacer replacer = createAndInitReplacer("test", new Properties());
+        assertReplacerWorks(replacer);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEncryptionFailWithEmptyPassword() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+        AbstractPbeReplacer replacer = createAndInitReplacer("", new Properties());
+        replacer.encrypt("test", 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEncryptionFailWithNullPassword() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+        AbstractPbeReplacer replacer = createAndInitReplacer(null, new Properties());
+        replacer.encrypt("test", 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDecryptionFailWithEmptyPassword() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+        AbstractPbeReplacer replacer = createAndInitReplacer("", new Properties());
+        replacer.decrypt("aSalt1xx:1:test");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDecryptionFailWithNullPassword() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+        AbstractPbeReplacer replacer = createAndInitReplacer(null, new Properties());
+        replacer.decrypt("aSalt1xx:1:test");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testEmptySalt() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(AbstractPbeReplacer.PROPERTY_SALT_LENGTH_BYTES, "0");
+        createAndInitReplacer(null, properties);
+    }
+
+    @Test
+    public void testMinimalSaltLength() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+        Properties properties = new Properties();
+        properties.setProperty(AbstractPbeReplacer.PROPERTY_SALT_LENGTH_BYTES, "1");
+        AbstractPbeReplacer replacer = createAndInitReplacer("test", properties);
+        assertReplacerWorks(replacer);
+    }
+
+    @Test
+    public void testLegacyCipher() throws Exception {
+        assumeAlgorithmsSupported("PBKDF2WithHmacSHA1", "DES");
+
+        Properties properties = new Properties();
+        properties.setProperty(AbstractPbeReplacer.PROPERTY_KEY_LENGTH_BITS, "64");
+        properties.setProperty(AbstractPbeReplacer.PROPERTY_SALT_LENGTH_BYTES, "8");
+        properties.setProperty(AbstractPbeReplacer.PROPERTY_CIPHER_ALGORITHM, "DES");
+        properties.setProperty(AbstractPbeReplacer.PROPERTY_SECRET_KEY_FACTORY_ALGORITHM, "PBKDF2WithHmacSHA1");
+        properties.setProperty(AbstractPbeReplacer.PROPERTY_SECRET_KEY_ALGORITHM, "DES");
+
+        AbstractPbeReplacer replacer = createAndInitReplacer("This is a password", properties);
+        assertReplacerWorks(replacer);
+    }
+
+    @Test
+    public void testWrongVariables() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+
+        AbstractPbeReplacer replacer = createAndInitReplacer("test", new Properties());
+
+        assertNull(replacer.getReplacement(null));
+        assertNull(replacer.getReplacement("WronglyFormatted"));
+        assertNull(replacer.getReplacement("aSalt:1:EncryptedValue"));
+        String encryptedStr = replacer.encrypt("test", 777);
+        assertNull(replacer.getReplacement(encryptedStr.replace(":777:", ":1:")));
+    }
+
+    protected void assertReplacerWorks(AbstractPbeReplacer replacer) throws Exception {
+        String encryptedStr = replacer.encrypt("aTestString", 77);
+        assertThat("Iteration count should be present in the encrypted string", encryptedStr, containsString("77"));
+        assertThat("Sensitive string has not to be part of the encrypted string", encryptedStr,
+                not(containsString("aTestString")));
+        assertEquals("aTestString", replacer.getReplacement(encryptedStr));
+    }
+
+    protected void assumeAlgorithmsSupported(String secretKeyFactory, String cipher) {
+        try {
+            SecretKeyFactory.getInstance(secretKeyFactory);
+            Cipher.getInstance(cipher);
+        } catch (Exception e) {
+            throw new AssumptionViolatedException("Skipping - Unsupported algorithm", e);
+        }
+    }
+
+    protected void assumeDefaultAlgorithmsSupported() {
+        assumeAlgorithmsSupported(DEFAULT_SECRET_KEY_FACTORY_ALGORITHM, DEFAULT_CIPHER_ALGORITHM);
+    }
+
+    protected AbstractPbeReplacer createAndInitReplacer(String password, Properties properties) throws Exception {
+        TestReplacer replacer = new TestReplacer(password == null ? null : password.toCharArray());
+        replacer.init(properties);
+        return replacer;
+    }
+
+    private static class TestReplacer extends AbstractPbeReplacer {
+
+        private final char[] password;
+
+        private TestReplacer(char[] password) {
+            this.password = password;
+        }
+
+        public String getPrefix() {
+            return "TEST";
+        }
+
+        @Override
+        protected char[] getPassword() {
+            return password;
+        }
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/replacer/EncryptionReplacerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/replacer/EncryptionReplacerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.replacer;
+
+import static com.hazelcast.config.replacer.EncryptionReplacer.encrypt;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.NetworkInterface;
+import java.util.Enumeration;
+import java.util.Properties;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Unit tests for {@link EncryptionReplacer}.
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({ QuickTest.class })
+public class EncryptionReplacerTest extends AbstractPbeReplacerTest {
+
+    private static final ILogger LOGGER = Logger.getLogger(EncryptionReplacerTest.class);
+    private static final String interfaceName;
+
+    private static final String XML_LEGACY_CONFIG = "    <config-replacers>\n"
+            + "        <replacer class-name='" + EncryptionReplacer.class.getName() + "'>\n"
+            + "            <properties>\n"
+            + "                <property name='keyLengthBits'>64</property>\n"
+            + "                <property name='saltLengthBytes'>8</property>\n"
+            + "                <property name='cipherAlgorithm'>DES</property>\n"
+            + "                <property name='secretKeyFactoryAlgorithm'>PBKDF2WithHmacSHA1</property>\n"
+            + "                <property name='secretKeyAlgorithm'>DES</property>\n"
+            + "            </properties>\n"
+            + "        </replacer>\n"
+            + "    </config-replacers>\n";
+
+    private static final String XML_DEFAULT_CONFIG = "    <config-replacers>\n"
+            + "        <replacer class-name='"+ EncryptionReplacer.class.getName() + "'/>\n"
+            + "    </config-replacers>\n";
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Rule
+    public OverridePropertyRule userNameProperty = OverridePropertyRule.set("user.name", "test");
+
+    @Rule
+    public OverridePropertyRule hazelcastConfigProperty = OverridePropertyRule.clear("hazelcast.config");
+
+    @Test
+    public void testGetPrefix() {
+        assertEquals("ENC", new EncryptionReplacer().getPrefix());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoPasswordInputProvided() throws Exception {
+        EncryptionReplacer replacer = new EncryptionReplacer();
+        Properties properties = new Properties();
+        properties.setProperty(EncryptionReplacer.PROPERTY_PASSWORD_USER_PROPERTIES, "false");
+        replacer.init(properties);
+    }
+
+    @Test(expected = HazelcastException.class)
+    public void testMissingFileWithPassword() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+        EncryptionReplacer replacer = new EncryptionReplacer();
+        Properties properties = new Properties();
+        properties.setProperty(EncryptionReplacer.PROPERTY_PASSWORD_USER_PROPERTIES, "false");
+        properties.setProperty(EncryptionReplacer.PROPERTY_PASSWORD_FILE, "/path/to/nonExistingFile");
+        replacer.init(properties);
+        replacer.encrypt("test", 1);
+    }
+
+    @Test
+    public void testNetworkInterfaceUsed() throws Exception {
+        assumeNotNull(interfaceName);
+        assumeDefaultAlgorithmsSupported();
+
+        Properties properties = new Properties();
+        properties.setProperty(EncryptionReplacer.PROPERTY_PASSWORD_NETWORK_INTERFACE, interfaceName);
+        properties.setProperty(EncryptionReplacer.PROPERTY_PASSWORD_USER_PROPERTIES, "false");
+        assertReplacerWorks(createAndInitReplacer(properties));
+    }
+
+    @Test
+    public void testUserChanged() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+        AbstractPbeReplacer replacer = createAndInitReplacer(new Properties());
+        String encryptedStr = replacer.encrypt("aTestString", 77);
+        userNameProperty.setOrClearProperty("somebodyElse");
+        assertNull(replacer.getReplacement(encryptedStr));
+    }
+
+    @Test
+    public void testGenerateEncrypted() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+        String xml = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n" + XML_DEFAULT_CONFIG + "</hazelcast>";
+        File configFile = createFileWithString(xml);
+        hazelcastConfigProperty.setOrClearProperty(configFile.getAbsolutePath());
+        String encrypted = encrypt("test");
+        assertThat(encrypted, allOf(startsWith("$ENC{"), endsWith("}")));
+    }
+
+    @Test
+    public void testGenerateEncryptedLegacy() throws Exception {
+        assumeAlgorithmsSupported("PBKDF2WithHmacSHA1", "DES");
+        String xml = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n" + XML_LEGACY_CONFIG + "</hazelcast>";
+        File configFile = createFileWithString(xml);
+        hazelcastConfigProperty.setOrClearProperty(configFile.getAbsolutePath());
+        String encrypted = encrypt("test");
+        assertThat(encrypted, allOf(startsWith("$ENC{"), endsWith("}")));
+    }
+
+    @Test
+    public void testClientGenerateEncrypted() throws Exception {
+        assumeDefaultAlgorithmsSupported();
+        String xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" + XML_DEFAULT_CONFIG + "</hazelcast-client>";
+        File configFile = createFileWithString(xml);
+        hazelcastConfigProperty.setOrClearProperty(configFile.getAbsolutePath());
+        String encrypted = encrypt("test");
+        assertThat(encrypted, allOf(startsWith("$ENC{"), endsWith("}")));
+    }
+
+    @Test
+    public void testClientGenerateEncryptedLegacy() throws Exception {
+        assumeAlgorithmsSupported("PBKDF2WithHmacSHA1", "DES");
+        String xml = "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n" + XML_LEGACY_CONFIG + "</hazelcast-client>";
+        File configFile = createFileWithString(xml);
+        hazelcastConfigProperty.setOrClearProperty(configFile.getAbsolutePath());
+        String encrypted = encrypt("test");
+        assertThat(encrypted, allOf(startsWith("$ENC{"), endsWith("}")));
+    }
+
+    @Override
+    protected AbstractPbeReplacer createAndInitReplacer(String password, Properties properties) throws Exception {
+        File file = createFileWithString(password);
+        properties.setProperty(EncryptionReplacer.PROPERTY_PASSWORD_USER_PROPERTIES, "false");
+        properties.setProperty(EncryptionReplacer.PROPERTY_PASSWORD_FILE, file.getAbsolutePath());
+        return createAndInitReplacer(properties);
+    }
+
+    private AbstractPbeReplacer createAndInitReplacer(Properties properties) {
+        AbstractPbeReplacer replacer = new EncryptionReplacer();
+        replacer.init(properties);
+        return replacer;
+    }
+
+    private File createFileWithString(String string) throws IOException {
+        File file = tempFolder.newFile();
+        if (string != null && string.length() > 0) {
+            PrintWriter out = new PrintWriter(file);
+            try {
+                out.print(string);
+            } finally {
+                IOUtil.closeResource(out);
+            }
+        }
+        return file;
+    }
+
+    static {
+        String name = null;
+        try {
+            Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+            while (networkInterfaces.hasMoreElements()) {
+                NetworkInterface networkInterface = networkInterfaces.nextElement();
+                byte[] hardwareAddress = networkInterface.getHardwareAddress();
+                if (hardwareAddress != null) {
+                    name = networkInterface.getName();
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.severe(e);
+        }
+        interfaceName = name;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/replacer/ExecReplacerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/replacer/ExecReplacerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.replacer;
+
+import static com.hazelcast.util.OsHelper.isUnixFamily;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Properties;
+
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Unit tests for {@link ExecReplacer}.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({ QuickTest.class, ParallelTest.class })
+public class ExecReplacerTest {
+
+    @Test
+    public void testGetPrefix() {
+        assertEquals("EXEC", new ExecReplacer().getPrefix());
+    }
+
+    @Test
+    public void testReplacementDefaultSeparator() {
+        Assume.assumeTrue(isUnixFamily());
+        ExecReplacer execReplacer = new ExecReplacer();
+        execReplacer.init(new Properties());
+        assertEquals("Hi", execReplacer.getReplacement("echo -n Hi"));
+    }
+
+    @Test
+    public void testReplacementCustomSeparator() {
+        Assume.assumeTrue(isUnixFamily());
+        ExecReplacer execReplacer = new ExecReplacer();
+        Properties properties = new Properties();
+        properties.setProperty(ExecReplacer.PROPERTY_ARGUMENT_SEPARATOR, "#");
+        execReplacer.init(properties);
+        assertEquals("Hi, world!", execReplacer.getReplacement("echo#-n#Hi, world!"));
+    }
+
+    @Test
+    public void testMissingExecutable() {
+        ExecReplacer execReplacer = new ExecReplacer();
+        execReplacer.init(new Properties());
+        assertNull(execReplacer.getReplacement("aCommandWhichIsHardToFind"));
+    }
+
+    @Test
+    public void testNonZeroExitCode() {
+        Assume.assumeTrue(isUnixFamily());
+        ExecReplacer execReplacer = new ExecReplacer();
+        execReplacer.init(new Properties());
+        assertNull(execReplacer.getReplacement("test -f /usr/bin/aCommandWhichIsHardToFind"));
+    }
+
+    @Test
+    public void testNonZeroExitCodeAllowed() {
+        Assume.assumeTrue(isUnixFamily());
+        ExecReplacer execReplacer = new ExecReplacer();
+        Properties properties = new Properties();
+        properties.setProperty(ExecReplacer.PROPERTY_REQUIRES_ZERO_EXIT, "false");
+        execReplacer.init(properties);
+        assertEquals("", execReplacer.getReplacement("test -f /usr/bin/aCommandWhichIsHardToFind"));
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/OverridePropertyRule.java
@@ -61,22 +61,17 @@ public final class OverridePropertyRule implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                String oldValue = System.getProperty(propertyName);
-                setOrClearProperty(propertyName, value);
+                String oldValue = setOrClearProperty(value);
                 try {
                     base.evaluate();
                 } finally {
-                    setOrClearProperty(propertyName, oldValue);
+                    setOrClearProperty(oldValue);
                 }
             }
         };
     }
 
-    private static void setOrClearProperty(String propertyName, String value) {
-        if (value == null) {
-            System.clearProperty(propertyName);
-        } else {
-            System.setProperty(propertyName, value);
-        }
+    public String setOrClearProperty(String value) {
+        return value == null ? System.clearProperty(propertyName) : System.setProperty(propertyName, value);
     }
 }


### PR DESCRIPTION
# Variable replacers

Main goal of introducing variable replacers for `hazelcast.xml` and `hazelcast-client.xml` is to allow masking sensitive strings (e.g. usernames, passwords) in the configuration files. Nevertheless the usage of replacers is not limited to security related values.

## Configuration

Replacers are define within `config-replacers` element under the configuration XML root element.

```xml
<hazelcast>
    <config-replacers fail-if-value-missing="false">
        <replacer class-name="com.acme.MyReplacer">
            <properties>
                <property name="propName">value</property>
                <!-- ... -->
            </properties>
        </replacer>
        <replacer class-name="example.AnotherReplacer"/>
    </config-replacers>
    <!-- ... -->
</hazelcast>
```

## Replacers provided by Hazelcast

### EncryptionReplacer
|     |     |
| --- | --- |
|**Full class name** | `com.hazelcast.config.replacer.EncryptionReplacer`|
|**Replacer prefix** | `ENC`|

The `EncryptionReplacer` replaces encrypted variables by its plain form. The Secret key for encryption/decryption is generated from a password which can be a value in a file or/and environment specific values (MAC address, actual user data).

#### Options

| Option              | Mandatory | Default value |Description  |
| ---                 | ---       | ---           | ---  |
| `cipherAlgorithm` | no | `AES` | Cipher algorithm used for the encryption/decryption. |
| `keyLengthBits` | no | `128` | Length (in bits) of the secret key to be generated. |
| `passwordFile` | no | `(null)` | Path to a file which content should be used as a part of the encryption password. When the property is not provided no file is used as a part of the password.  |
| `passwordNetworkInterface` | no | `(null)` | Name of network interface which MAC address should be used be used as a part of the encryption password. When the property is not provided no network interface property is used as a part of the password. |
| `passwordUserProperties` | no | `true` | A `true`/`false` flag which controls if current user properties (`user.name` and `user.home`) should be used as a part of the encryption password. |
| `saltLengthBytes` | no | `8` | Length (in bytes) of a random password salt. |
| `secretKeyAlgorithm` | no | `AES` | Name of the secret-key algorithm to be associated with the generated secret key. |
| `secretKeyFactoryAlgorithm` | no | `PBKDF2WithHmacSHA256` | Algorithm used to generate a secret key from a password. |
| `securityProvider` | no | `(null)` | Name of a Java Security Provider to be used for retrieving the configured secret key factory and the cipher. |

Older Java versions may not support all the algorithms used as defaults. Use the parameter values your Java version supports. Example:

```
cipherAlgorithm=DES
keyLengthBits=64
secretKeyAlgorithm=DES
secretKeyFactoryAlgorithm=PBKDF2WithHmacSHA1
```

#### Example

Create the password file and Generate the encrypted strings:
```bash
# create a password file
echo '/Za-uG3dDfpd,5.-' > /opt/master-password

# running EncryptionReplacer without arguments prints help
java -cp hazelcast-*.jar com.hazelcast.config.replacer.EncryptionReplacer
Usage:
	java -D<propertyName>=<propertyValue>  com.hazelcast.config.replacer.EncryptionReplacer "<String To Encrypt>" [iterations]

The replacer configuration can be loaded either from hazelcast/hazelcast-client XML file:
	-Dhazelcast.config=/path/to/hazelcast.xml

or provided directly via following property names:
	cipherAlgorithm
	keyLengthBits
	saltLengthBytes
	secretKeyAlgorithm
	secretKeyFactoryAlgorithm
	securityProvider
	passwordFile
	passwordNetworkInterface
	passwordUserProperties

Values available for property passwordNetworkInterface
	br-dbf2437a48db
	docker0

# lets generate an encrypted variables
java -cp hazelcast-*.jar \
    -DpasswordFile=/opt/master-password \
    -DpasswordUserProperties=false \
    com.hazelcast.config.replacer.EncryptionReplacer \
    "aGroup"
$ENC{Gw45stIlan0=:531:yVN9/xQpJ/Ww3EYkAPvHdA==}

java -cp hazelcast-*.jar \
    -DpasswordFile=/opt/master-password \
    -DpasswordUserProperties=false \
    com.hazelcast.config.replacer.EncryptionReplacer \
    "aPasswordToEncrypt"
$ENC{wJxe1vfHTgg=:531:WkAEdSi//YWEbwvVNoU9mUyZ0DE49acJeaJmGalHHfA=}
```

Put the Replacer configuration and encrypted variables into the configuration
```xml
<hazelcast>
    <config-replacers>
        <replacer class-name="com.hazelcast.config.replacer.EncryptionReplacer">
            <properties>
                <property name="passwordFile">/opt/master-password</property>
                <property name="passwordUserProperties">false</property>
            </properties>
        </replacer>
    </config-replacers>
    <group>
        <name>$ENC{Gw45stIlan0=:531:yVN9/xQpJ/Ww3EYkAPvHdA==}</name>
        <password>$ENC{wJxe1vfHTgg=:531:WkAEdSi//YWEbwvVNoU9mUyZ0DE49acJeaJmGalHHfA=}</password>
    </group>
</hazelcast>
```

Check if the decryption works:
```bash
java -jar hazelcast-*.jar
Apr 06, 2018 10:15:43 AM com.hazelcast.config.XmlConfigLocator
INFO: Loading 'hazelcast.xml' from working directory.
Apr 06, 2018 10:15:44 AM com.hazelcast.instance.AddressPicker
INFO: [LOCAL] [aGroup] [3.10-SNAPSHOT] Prefer IPv4 stack is true.
```
As you can see in the logs the correctly decrypted group name value (`"aGroup"`) is used.

### ExecReplacer
|     |     |
| --- | --- |
|**Full class name** | `com.hazelcast.config.replacer.ExecReplacer`|
|**Replacer prefix** | `EXEC`|

The `ExecReplacer` runs external command and uses its standard output as the value for the variable.

#### Options

| Option              | Mandatory | Default value |Description  |
| ---                 | ---       | ---           | ---  |
| `argumentSeparator` | no        |  `"\s+"` *(whitespaces)* | A regular expression used as a separator betwen arguments. It can be used when command path or argument contains whitespaces. |
| `requiresZeroExitCode` | no        |  `true` | A `true`/`false` flag which controls if a non-zero exit code is allowed to continue with the replacement. |

#### Example

```xml
<hazelcast>
    <config-replacers>
        <replacer class-name="com.hazelcast.config.replacer.ExecReplacer">
            <properties>
                <property name="argumentSeparator">#</property>
            </properties>
        </replacer>
    </config-replacers>
    <group>
        <!-- read group name from "hazelcast group.txt" file -->
        <name>$EXEC{cat#/opt/hazelcast group.txt}</name>
    </group>
</hazelcast>
```
### PropertyReplacer
|     |     |
| --- | --- |
|**Full class name** | `com.hazelcast.config.replacer.PropertyReplacer`|
|**Replacer prefix** | `""` *(empty string)*|

The `PropertyReplacer` is an implementation which is used always (i.e there is no need to define it in the config file). It replaces variables by properties with given name. Usually the System properties are used (e.g. `${user.name}`).

## Using custom replacers
Users can provide their own replacer implementations. All Replacers has to implement `com.hazelcast.config.replacer.spi.ConfigReplacer` interface.

```java
public interface ConfigReplacer {
    void init(Properties properties);
    String getPrefix();
    String getReplacement(String maskedValue);
}
```
