### PR TITLE
 Fixed merging of ISet/IList

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionDataSerializerHook.java
@@ -26,6 +26,7 @@ import com.hazelcast.collection.impl.collection.operations.CollectionCompareAndR
 import com.hazelcast.collection.impl.collection.operations.CollectionContainsOperation;
 import com.hazelcast.collection.impl.collection.operations.CollectionGetAllOperation;
 import com.hazelcast.collection.impl.collection.operations.CollectionIsEmptyOperation;
+import com.hazelcast.collection.impl.collection.operations.CollectionMergeBackupOperation;
 import com.hazelcast.collection.impl.collection.operations.CollectionMergeOperation;
 import com.hazelcast.collection.impl.collection.operations.CollectionRemoveBackupOperation;
 import com.hazelcast.collection.impl.collection.operations.CollectionRemoveOperation;
@@ -124,6 +125,7 @@ public class CollectionDataSerializerHook implements DataSerializerHook {
     public static final int QUEUE_TRANSACTION_LOG_RECORD = 44;
 
     public static final int COLLECTION_MERGE = 45;
+    public static final int COLLECTION_MERGE_BACKUP = 46;
 
     @Override
     public int getFactoryId() {
@@ -133,7 +135,7 @@ public class CollectionDataSerializerHook implements DataSerializerHook {
     @Override
     public DataSerializableFactory createFactory() {
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors
-                = new ConstructorFunction[COLLECTION_MERGE + 1];
+                = new ConstructorFunction[COLLECTION_MERGE_BACKUP + 1];
 
         constructors[COLLECTION_ADD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
@@ -360,6 +362,11 @@ public class CollectionDataSerializerHook implements DataSerializerHook {
         constructors[COLLECTION_MERGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new CollectionMergeOperation();
+            }
+        };
+        constructors[COLLECTION_MERGE_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CollectionMergeBackupOperation();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/CollectionService.java
@@ -46,11 +46,9 @@ import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.spi.serialization.SerializationService;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -90,7 +88,10 @@ public abstract class CollectionService implements ManagedService, RemoteService
 
     @Override
     public void destroyDistributedObject(String name) {
-        getContainerMap().remove(name);
+        CollectionContainer container = getContainerMap().remove(name);
+        if (container != null) {
+            container.destroy();
+        }
         nodeEngine.getEventService().deregisterAllListeners(getServiceName(), name);
     }
 
@@ -199,7 +200,7 @@ public abstract class CollectionService implements ManagedService, RemoteService
         return new Merger(collector);
     }
 
-    private class Merger extends AbstractContainerMerger<CollectionContainer, Data, CollectionMergeTypes> {
+    private class Merger extends AbstractContainerMerger<CollectionContainer, Collection<Object>, CollectionMergeTypes> {
 
         Merger(CollectionContainerCollector collector) {
             super(collector, nodeEngine);
@@ -212,39 +213,29 @@ public abstract class CollectionService implements ManagedService, RemoteService
 
         @Override
         public void runInternal() {
-            List<CollectionMergeTypes> mergingValues;
             for (Map.Entry<Integer, Collection<CollectionContainer>> entry : collector.getCollectedContainers().entrySet()) {
                 int partitionId = entry.getKey();
                 Collection<CollectionContainer> containerList = entry.getValue();
                 for (CollectionContainer container : containerList) {
-                    Collection<CollectionItem> itemList = container.getCollection();
+                    // TODO: add batching (which is a bit complex, since collections don't have a multi-name operation yet
+                    Collection<CollectionItem> items = container.getCollection();
 
                     String name = container.getName();
-                    int batchSize = container.getConfig().getMergePolicyConfig().getBatchSize();
-                    SplitBrainMergePolicy<Data, CollectionMergeTypes> mergePolicy
+                    SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes> mergePolicy
                             = getMergePolicy(container.getConfig().getMergePolicyConfig());
 
-                    mergingValues = new ArrayList<CollectionMergeTypes>();
-                    for (CollectionItem item : itemList) {
-                        CollectionMergeTypes mergingValue = createMergingValue(serializationService, item);
-                        mergingValues.add(mergingValue);
+                    CollectionMergeTypes mergingValue = createMergingValue(serializationService, items);
+                    sendBatch(partitionId, name, mergePolicy, mergingValue);
 
-                        if (mergingValues.size() == batchSize) {
-                            sendBatch(partitionId, name, mergePolicy, mergingValues);
-                            mergingValues = new ArrayList<CollectionMergeTypes>(batchSize);
-                        }
-                    }
-                    itemList.clear();
-                    if (mergingValues.size() > 0) {
-                        sendBatch(partitionId, name, mergePolicy, mergingValues);
-                    }
+                    items.clear();
                 }
             }
         }
 
-        private void sendBatch(int partitionId, String name, SplitBrainMergePolicy<Data, CollectionMergeTypes> mergePolicy,
-                               List<CollectionMergeTypes> mergingValues) {
-            CollectionOperation operation = new CollectionMergeOperation(name, mergePolicy, mergingValues);
+        private void sendBatch(int partitionId, String name,
+                               SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes> mergePolicy,
+                               CollectionMergeTypes mergingValue) {
+            CollectionOperation operation = new CollectionMergeOperation(name, mergePolicy, mergingValue);
             invoke(getServiceName(), operation, partitionId);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionClearOperation.java
@@ -48,8 +48,8 @@ public class CollectionClearOperation extends CollectionBackupAwareOperation imp
 
     @Override
     public void run() throws Exception {
-        CollectionContainer collectionContainer = getOrCreateContainer();
-        itemIdMap = collectionContainer.clear();
+        CollectionContainer container = getOrCreateContainer();
+        itemIdMap = container.clear(true);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionMergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionMergeBackupOperation.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.collection.operations;
+
+import com.hazelcast.collection.impl.collection.CollectionContainer;
+import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
+import com.hazelcast.collection.impl.collection.CollectionItem;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Creates backups for merged collection items after split-brain healing with a {@link SplitBrainMergePolicy}.
+ *
+ * @since 3.10
+ */
+public class CollectionMergeBackupOperation extends CollectionOperation implements BackupOperation {
+
+    private Collection<CollectionItem> backupItems;
+
+    public CollectionMergeBackupOperation() {
+    }
+
+    public CollectionMergeBackupOperation(String name, Collection<CollectionItem> backupItems) {
+        super(name);
+        this.backupItems = backupItems;
+    }
+
+    @Override
+    public void run() throws Exception {
+        CollectionContainer container = getOrCreateContainer();
+        if (backupItems.isEmpty()) {
+            RemoteService service = getService();
+            service.destroyDistributedObject(name);
+        } else {
+            Map<Long, CollectionItem> backupMap = container.getMap();
+            backupMap.clear();
+            for (CollectionItem backupItem : backupItems) {
+                backupMap.put(backupItem.getItemId(), backupItem);
+            }
+        }
+    }
+
+    @Override
+    public int getId() {
+        return CollectionDataSerializerHook.COLLECTION_MERGE_BACKUP;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(backupItems.size());
+        for (CollectionItem backupItem : backupItems) {
+            out.writeObject(backupItem);
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int size = in.readInt();
+        backupItems = new ArrayList<CollectionItem>(size);
+        for (int i = 0; i < size; i++) {
+            CollectionItem backupItem = in.readObject();
+            backupItems.add(backupItem);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionMergeOperation.java
@@ -21,86 +21,108 @@ import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.CollectionItem;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.CollectionMergeTypes;
+import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.Collection;
 
-import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingValue;
+import static com.hazelcast.util.CollectionUtil.isEmpty;
 
 /**
- * Contains multiple merge entries for split-brain healing with a {@link SplitBrainMergePolicy}.
+ * Merges a {@link CollectionMergeTypes} for split-brain healing with a {@link SplitBrainMergePolicy}.
  *
  * @since 3.10
  */
 public class CollectionMergeOperation extends CollectionBackupAwareOperation {
 
-    private SplitBrainMergePolicy<Data, CollectionMergeTypes> mergePolicy;
-    private List<CollectionMergeTypes> mergingValues;
+    private SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes> mergePolicy;
+    private CollectionMergeTypes mergingValue;
 
-    private transient Map<Long, Data> valueMap;
+    private transient Collection<CollectionItem> backupCollection;
+    private transient boolean shouldBackup;
 
-    public CollectionMergeOperation(String name, SplitBrainMergePolicy<Data, CollectionMergeTypes> mergePolicy,
-                                    List<CollectionMergeTypes> mergingValues) {
+    public CollectionMergeOperation(String name, SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes> mergePolicy,
+                                    CollectionMergeTypes mergingValue) {
         super(name);
         this.mergePolicy = mergePolicy;
-        this.mergingValues = mergingValues;
+        this.mergingValue = mergingValue;
     }
 
     public CollectionMergeOperation() {
     }
 
     @Override
-    public int getId() {
-        return CollectionDataSerializerHook.COLLECTION_MERGE;
+    public void run() throws Exception {
+        CollectionContainer container = getOrCreateContainer();
+        boolean currentCollectionIsEmpty = container.getCollection().isEmpty();
+        long currentItemId = container.getCurrentId();
+
+        backupCollection = merge(container, mergingValue, mergePolicy);
+        shouldBackup = currentCollectionIsEmpty != backupCollection.isEmpty() || currentItemId != container.getCurrentId();
+    }
+
+    private Collection<CollectionItem> merge(CollectionContainer container, CollectionMergeTypes mergingValue,
+                                             SplitBrainMergePolicy<Collection<Object>, CollectionMergeTypes> mergePolicy) {
+        SerializationService serializationService = getNodeEngine().getSerializationService();
+        serializationService.getManagedContext().initialize(mergingValue);
+        serializationService.getManagedContext().initialize(mergePolicy);
+
+        Collection<CollectionItem> existingItems = container.getCollection();
+
+        CollectionMergeTypes existingValue = createMergingValue(serializationService, existingItems);
+        Collection<Object> newValues = mergePolicy.merge(mergingValue, existingValue);
+
+        if (isEmpty(newValues)) {
+            RemoteService service = getService();
+            service.destroyDistributedObject(name);
+        } else if (existingValue == null) {
+            createNewCollectionItems(container, existingItems, newValues, serializationService);
+        } else if (!newValues.equals(existingValue.getValue())) {
+            container.clear(false);
+            createNewCollectionItems(container, existingItems, newValues, serializationService);
+        }
+        return existingItems;
+    }
+
+    private void createNewCollectionItems(CollectionContainer container, Collection<CollectionItem> items,
+                                          Collection<Object> values, SerializationService serializationService) {
+        for (Object value : values) {
+            CollectionItem item = new CollectionItem(container.nextId(), serializationService.toData(value));
+            items.add(item);
+        }
     }
 
     @Override
     public boolean shouldBackup() {
-        return valueMap != null && !valueMap.isEmpty();
+        return shouldBackup;
     }
 
     @Override
     public Operation getBackupOperation() {
-        return new CollectionAddAllBackupOperation(name, valueMap);
-    }
-
-    @Override
-    public void run() throws Exception {
-        CollectionContainer collectionContainer = getOrCreateContainer();
-        valueMap = createHashMap(mergingValues.size());
-        for (CollectionMergeTypes mergingValue : mergingValues) {
-            CollectionItem mergedItem = collectionContainer.merge(mergingValue, mergePolicy);
-            if (mergedItem != null) {
-                valueMap.put(mergedItem.getItemId(), mergedItem.getValue());
-            }
-        }
+        return new CollectionMergeBackupOperation(name, backupCollection);
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(mergePolicy);
-        out.writeInt(mergingValues.size());
-        for (CollectionMergeTypes mergingValue : mergingValues) {
-            out.writeObject(mergingValue);
-        }
+        out.writeObject(mergingValue);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         mergePolicy = in.readObject();
-        int size = in.readInt();
-        mergingValues = new ArrayList<CollectionMergeTypes>(size);
-        for (int i = 0; i < size; i++) {
-            CollectionMergeTypes mergingValue = in.readObject();
-            mergingValues.add(mergingValue);
-        }
+        mergingValue = in.readObject();
+    }
+
+    @Override
+    public int getId() {
+        return CollectionDataSerializerHook.COLLECTION_MERGE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListContainer.java
@@ -200,9 +200,6 @@ public class ListContainer extends CollectionContainer {
         if (itemList != null) {
             itemList.clear();
         }
-        if (itemMap != null) {
-            itemMap.clear();
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CollectionMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CollectionMergingValueImpl.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.spi.impl.merge;
 
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.CollectionMergeTypes;
 import com.hazelcast.spi.serialization.SerializationService;
+
+import java.util.Collection;
 
 /**
  * Implementation of {@link CollectionMergeTypes}.
@@ -27,7 +28,7 @@ import com.hazelcast.spi.serialization.SerializationService;
  */
 @SuppressWarnings("WeakerAccess")
 public class CollectionMergingValueImpl
-        extends AbstractMergingValueImpl<Data, CollectionMergingValueImpl>
+        extends AbstractCollectionMergingValueImpl<Collection<Object>, CollectionMergingValueImpl>
         implements CollectionMergeTypes {
 
     public CollectionMergingValueImpl() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
@@ -57,9 +57,17 @@ public final class MergingValueFactory {
     private MergingValueFactory() {
     }
 
-    public static CollectionMergeTypes createMergingValue(SerializationService serializationService, CollectionItem item) {
+    public static CollectionMergeTypes createMergingValue(SerializationService serializationService,
+                                                          Collection<CollectionItem> items) {
+        if (items.isEmpty()) {
+            return null;
+        }
+        Collection<Object> values = new ArrayList<Object>(items.size());
+        for (CollectionItem item : items) {
+            values.add(item.getValue());
+        }
         return new CollectionMergingValueImpl(serializationService)
-                .setValue(item.getValue());
+                .setValue(values);
     }
 
     public static QueueMergeTypes createMergingValue(SerializationService serializationService, QueueItem item) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
@@ -79,7 +79,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
-    public interface CollectionMergeTypes extends MergingValue<Data> {
+    public interface CollectionMergeTypes extends MergingValue<Collection<Object>> {
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/CollectionTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/CollectionTestUtil.java
@@ -40,6 +40,8 @@ import java.util.Queue;
 import java.util.Set;
 
 import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 
 public final class CollectionTestUtil {
 
@@ -59,6 +61,9 @@ public final class CollectionTestUtil {
     public static <E> List<E> getBackupList(HazelcastInstance backupInstance, String listName) {
         CollectionService service = getNodeEngineImpl(backupInstance).getService(ListService.SERVICE_NAME);
         CollectionContainer collectionContainer = service.getContainerMap().get(listName);
+        if (collectionContainer == null) {
+            return emptyList();
+        }
         // the replica items are retrieved via `getMap()`, the primary items via `getCollection()`
         Map<Long, CollectionItem> map = collectionContainer.getMap();
 
@@ -108,6 +113,9 @@ public final class CollectionTestUtil {
     public static <E> Set<E> getBackupSet(HazelcastInstance backupInstance, String setName) {
         CollectionService service = getNodeEngineImpl(backupInstance).getService(SetService.SERVICE_NAME);
         CollectionContainer collectionContainer = service.getContainerMap().get(setName);
+        if (collectionContainer == null) {
+            return emptySet();
+        }
         // the replica items are retrieved via `getMap()`, the primary items via `getCollection()`
         Map<Long, CollectionItem> map = collectionContainer.getMap();
 

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -41,8 +41,6 @@ import java.util.List;
 
 import static com.hazelcast.collection.impl.CollectionTestUtil.getBackupList;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -59,8 +57,7 @@ import static org.junit.Assert.fail;
 @Category({QuickTest.class, ParallelTest.class})
 public class ListSplitBrainTest extends SplitBrainTestSupport {
 
-    private static final int INITIAL_COUNT = 10;
-    private static final int NEW_ITEMS = 15;
+    private static final int ITEM_COUNT = 25;
 
     @Parameters(name = "mergePolicy:{0}")
     public static Collection<Object> parameters() {
@@ -68,7 +65,8 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
                 DiscardMergePolicy.class,
                 PassThroughMergePolicy.class,
                 PutIfAbsentMergePolicy.class,
-                MergeIntegerValuesMergePolicy.class,
+                RemoveValuesMergePolicy.class,
+                MergeCollectionOfIntegerValuesMergePolicy.class,
         });
     }
 
@@ -102,24 +100,6 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
         return config;
     }
 
-    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
-        IList<Object> list = instances[0].getList(listNameA);
-        for (int i = 0; i < INITIAL_COUNT; i++) {
-            list.add("item" + i);
-        }
-
-        waitAllForSafeState(instances);
-
-        int partitionId = ((AbstractCollectionProxyImpl) list).getPartitionId();
-        HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
-        List<Object> backupList = getBackupList(backupInstance, listNameA);
-
-        assertEquals("backupList should contain " + INITIAL_COUNT + " items", INITIAL_COUNT, backupList.size());
-        for (int i = 0; i < INITIAL_COUNT; i++) {
-            assertTrue("backupList should contain item" + i + " " + toString(backupList), backupList.contains("item" + i));
-        }
-    }
-
     @Override
     protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
         mergeLifecycleListener = new MergeLifecycleListener(secondBrain.length);
@@ -131,9 +111,6 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
         listA2 = secondBrain[0].getList(listNameA);
 
         listB2 = secondBrain[0].getList(listNameB);
-        for (int i = 0; i < INITIAL_COUNT; i++) {
-            listB2.add("item" + i);
-        }
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
@@ -141,7 +118,9 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
             afterSplitPassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
+            afterSplitRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == MergeCollectionOfIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
         } else {
             fail();
@@ -165,7 +144,9 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
             afterMergePassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
+            afterMergeRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == MergeCollectionOfIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
         } else {
             fail();
@@ -173,105 +154,104 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
     }
 
     private void afterSplitDiscardMergePolicy() {
-        // we should have these items in the merged listA, since they are added in both clusters
-        for (int i = INITIAL_COUNT; i < INITIAL_COUNT + NEW_ITEMS; i++) {
+        for (int i = 0; i < ITEM_COUNT; i++) {
             listA1.add("item" + i);
-            listA2.add("item" + i);
-        }
-
-        // we should not have these items in the merged lists, since they are in the smaller cluster only
-        for (int i = 0; i < NEW_ITEMS; i++) {
             listA2.add("lostItem" + i);
+
             listB2.add("lostItem" + i);
         }
     }
 
     private void afterMergeDiscardMergePolicy() {
-        assertListContent(listA1, false);
-        assertListContent(listA2, false);
-        assertListContent(backupList, false);
+        assertListContent(listA1);
+        assertListContent(listA2);
+        assertListContent(backupList);
 
-        assertTrue(listB1.isEmpty());
-        assertTrue(listB2.isEmpty());
+        assertListContent(listB1, 0);
+        assertListContent(listB2, 0);
     }
 
     private void afterSplitPassThroughMergePolicy() {
-        for (int i = INITIAL_COUNT; i < INITIAL_COUNT + NEW_ITEMS; i++) {
-            listA1.add("item" + i);
-        }
-
-        // we should not lose the additional items from listA2 or the new listB2
-        for (int i = INITIAL_COUNT; i < INITIAL_COUNT + NEW_ITEMS * 2; i++) {
+        for (int i = 0; i < ITEM_COUNT; i++) {
+            listA1.add("lostItem" + i);
             listA2.add("item" + i);
+
             listB2.add("item" + i);
         }
     }
 
     private void afterMergePassThroughMergePolicy() {
-        assertListContent(listA1, true);
-        assertListContent(listA2, true);
-        assertListContent(backupList, true);
+        assertListContent(listA1);
+        assertListContent(listA2);
+        assertListContent(backupList);
 
-        assertListContent(listB1, true);
-        assertListContent(listB2, true);
+        assertListContent(listB1);
+        assertListContent(listB2);
     }
 
     private void afterSplitPutIfAbsentMergePolicy() {
-        for (int i = INITIAL_COUNT; i < INITIAL_COUNT + NEW_ITEMS; i++) {
+        for (int i = 0; i < ITEM_COUNT; i++) {
             listA1.add("item" + i);
-        }
+            listA2.add("lostItem" + i);
 
-        // we should not lose the additional items from listA2 or the new listB2
-        for (int i = INITIAL_COUNT; i < INITIAL_COUNT + NEW_ITEMS * 2; i++) {
-            listA2.add("item" + i);
             listB2.add("item" + i);
         }
     }
 
     private void afterMergePutIfAbsentMergePolicy() {
-        assertListContent(listA1, true);
-        assertListContent(listA2, true);
-        assertListContent(backupList, true);
+        assertListContent(listA1);
+        assertListContent(listA2);
+        assertListContent(backupList);
 
-        assertListContent(listB1, true);
-        assertListContent(listB2, true);
+        assertListContent(listB1);
+        assertListContent(listB2);
+    }
+
+    private void afterSplitRemoveValuesMergePolicy() {
+        for (int i = 0; i < ITEM_COUNT; i++) {
+            listA1.add("lostItem" + i);
+            listA2.add("lostItem" + i);
+
+            listB2.add("lostItem" + i);
+        }
+    }
+
+    private void afterMergeRemoveValuesMergePolicy() {
+        assertListContent(listA1, 0);
+        assertListContent(listA2, 0);
+        assertListContent(backupList, 0);
+
+        assertListContent(listB1, 0);
+        assertListContent(listB2, 0);
     }
 
     private void afterSplitCustomMergePolicy() {
-        for (int i = 0; i < NEW_ITEMS; i++) {
+        for (int i = 0; i < ITEM_COUNT; i++) {
             listA2.add(i);
             listA2.add("lostItem" + i);
         }
     }
 
     private void afterMergeCustomMergePolicy() {
-        int expectedSize = INITIAL_COUNT + NEW_ITEMS;
-        assertEquals("listA1 should contain " + expectedSize + " items", expectedSize, listA1.size());
-        assertEquals("listA2 should contain " + expectedSize + " items", expectedSize, listA2.size());
-        assertEquals("backupList should contain " + expectedSize + " items " + backupList, expectedSize, backupList.size());
-
-        for (int i = 0; i < INITIAL_COUNT; i++) {
-            assertTrue("listA1 should contain 'item" + i + "' " + toString(listA1), listA1.contains("item" + i));
-            assertTrue("listA2 should contain 'item" + i + "' " + toString(listA2), listA2.contains("item" + i));
-            assertTrue("backupList should contain 'item" + i + "' " + backupList, backupList.contains("item" + i));
-        }
-        for (int i = 0; i < NEW_ITEMS; i++) {
-            assertTrue("listA1 should contain '" + i + "'", listA1.contains(i));
-            assertTrue("listA2 should contain '" + i + "'", listA2.contains(i));
-            assertTrue("backupList should contain '" + i + "'", backupList.contains(i));
-
-            assertFalse("listA1 should not contain 'lostItem" + i + "'", listA1.contains("lostItem" + i));
-            assertFalse("list2A should not contain 'lostItem" + i + "'", listA2.contains("lostItem" + i));
-            assertFalse("backupList should not contain 'lostItem" + i + "'", backupList.contains("lostItem" + i));
-        }
+        assertListContent(listA1, ITEM_COUNT);
+        assertListContent(listA2, ITEM_COUNT);
+        assertListContent(backupList, ITEM_COUNT);
     }
 
-    private static void assertListContent(List<Object> list, boolean hasMergedItems) {
-        int expectedSize = INITIAL_COUNT + NEW_ITEMS * (hasMergedItems ? 2 : 1);
-        assertEquals("list should contain " + expectedSize + " items " + toString(list), expectedSize, list.size());
+    private static void assertListContent(List<Object> list) {
+        assertListContent(list, ITEM_COUNT, "item");
+    }
 
-        for (int i = 0; i < INITIAL_COUNT + NEW_ITEMS * (hasMergedItems ? 2 : 1); i++) {
-            assertTrue("list should contain item" + i + " " + toString(list), list.contains("item" + i));
+    private static void assertListContent(List<Object> list, int expectedSize) {
+        assertListContent(list, expectedSize, null);
+    }
+
+    private static void assertListContent(List<Object> list, int expectedSize, String prefix) {
+        assertEqualsStringFormat("list " + toString(list) + " should contain %d items, but was %d ", expectedSize, list.size());
+
+        for (int i = 0; i < expectedSize; i++) {
+            Object expectedValue = prefix == null ? i : prefix + i;
+            assertTrue("list " + toString(list) + " should contain " + expectedValue, list.contains(expectedValue));
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetSplitBrainTest.java
@@ -41,8 +41,6 @@ import java.util.Set;
 
 import static com.hazelcast.collection.impl.CollectionTestUtil.getBackupSet;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -59,8 +57,7 @@ import static org.junit.Assert.fail;
 @Category({QuickTest.class, ParallelTest.class})
 public class SetSplitBrainTest extends SplitBrainTestSupport {
 
-    private static final int INITIAL_COUNT = 10;
-    private static final int NEW_ITEMS = 15;
+    private static final int ITEM_COUNT = 25;
 
     @Parameters(name = "mergePolicy:{0}")
     public static Collection<Object> parameters() {
@@ -68,7 +65,8 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
                 DiscardMergePolicy.class,
                 PassThroughMergePolicy.class,
                 PutIfAbsentMergePolicy.class,
-                MergeIntegerValuesMergePolicy.class,
+                RemoveValuesMergePolicy.class,
+                MergeCollectionOfIntegerValuesMergePolicy.class,
         });
     }
 
@@ -103,24 +101,6 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
     }
 
     @Override
-    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
-        ISet<Object> set = instances[0].getSet(setNameA);
-        for (int i = 0; i < INITIAL_COUNT; i++) {
-            set.add("item" + i);
-        }
-
-        waitAllForSafeState(instances);
-
-        int partitionId = ((AbstractCollectionProxyImpl) set).getPartitionId();
-        HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
-        backupSet = getBackupSet(backupInstance, setNameA);
-        assertEquals("backupSet should contain " + INITIAL_COUNT + " items", INITIAL_COUNT, backupSet.size());
-        for (int i = 0; i < INITIAL_COUNT; i++) {
-            assertTrue("backupSet should contain item" + i + " " + toString(backupSet), backupSet.contains("item" + i));
-        }
-    }
-
-    @Override
     protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
         mergeLifecycleListener = new MergeLifecycleListener(secondBrain.length);
         for (HazelcastInstance instance : secondBrain) {
@@ -131,9 +111,6 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
         setA2 = secondBrain[0].getSet(setNameA);
 
         setB2 = secondBrain[0].getSet(setNameB);
-        for (int i = 0; i < INITIAL_COUNT; i++) {
-            setB2.add("item" + i);
-        }
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             afterSplitDiscardMergePolicy();
@@ -141,7 +118,9 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
             afterSplitPassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
+            afterSplitRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == MergeCollectionOfIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
         } else {
             fail();
@@ -165,7 +144,9 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
             afterMergePassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
+        } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
+            afterMergeRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == MergeCollectionOfIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
         } else {
             fail();
@@ -173,105 +154,104 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
     }
 
     private void afterSplitDiscardMergePolicy() {
-        // we should have these items in the merged setA, since they are added in both clusters
-        for (int i = INITIAL_COUNT; i < INITIAL_COUNT + NEW_ITEMS; i++) {
+        for (int i = 0; i < ITEM_COUNT; i++) {
             setA1.add("item" + i);
-            setA2.add("item" + i);
-        }
-
-        // we should not have these items in the merged sets, since they are in the smaller cluster only
-        for (int i = 0; i < NEW_ITEMS; i++) {
             setA2.add("lostItem" + i);
+
             setB2.add("lostItem" + i);
         }
     }
 
     private void afterMergeDiscardMergePolicy() {
-        assertSetContent(setA1, false);
-        assertSetContent(setA2, false);
-        assertSetContent(backupSet, false);
+        assertSetContent(setA1);
+        assertSetContent(setA2);
+        assertSetContent(backupSet);
 
-        assertTrue(setB1.isEmpty());
-        assertTrue(setB2.isEmpty());
+        assertSetContent(setB1, 0);
+        assertSetContent(setB2, 0);
     }
 
     private void afterSplitPassThroughMergePolicy() {
-        for (int i = INITIAL_COUNT; i < INITIAL_COUNT + NEW_ITEMS; i++) {
-            setA1.add("item" + i);
-        }
-
-        // we should not lose the additional items from setA2 or the new setB2
-        for (int i = INITIAL_COUNT; i < INITIAL_COUNT + NEW_ITEMS * 2; i++) {
+        for (int i = 0; i < ITEM_COUNT; i++) {
+            setA1.add("lostItem" + i);
             setA2.add("item" + i);
+
             setB2.add("item" + i);
         }
     }
 
     private void afterMergePassThroughMergePolicy() {
-        assertSetContent(setA1, true);
-        assertSetContent(setA2, true);
-        assertSetContent(backupSet, true);
+        assertSetContent(setA1);
+        assertSetContent(setA2);
+        assertSetContent(backupSet);
 
-        assertSetContent(setB1, true);
-        assertSetContent(setB2, true);
+        assertSetContent(setB1);
+        assertSetContent(setB2);
     }
 
     private void afterSplitPutIfAbsentMergePolicy() {
-        for (int i = INITIAL_COUNT; i < INITIAL_COUNT + NEW_ITEMS; i++) {
+        for (int i = 0; i < ITEM_COUNT; i++) {
             setA1.add("item" + i);
-        }
+            setA2.add("lostItem" + i);
 
-        // we should not lose the additional items from setA2 or the new setB2
-        for (int i = INITIAL_COUNT; i < INITIAL_COUNT + NEW_ITEMS * 2; i++) {
-            setA2.add("item" + i);
             setB2.add("item" + i);
         }
     }
 
     private void afterMergePutIfAbsentMergePolicy() {
-        assertSetContent(setA1, true);
-        assertSetContent(setA2, true);
-        assertSetContent(backupSet, true);
+        assertSetContent(setA1);
+        assertSetContent(setA2);
+        assertSetContent(backupSet);
 
-        assertSetContent(setB1, true);
-        assertSetContent(setB2, true);
+        assertSetContent(setB1);
+        assertSetContent(setB2);
+    }
+
+    private void afterSplitRemoveValuesMergePolicy() {
+        for (int i = 0; i < ITEM_COUNT; i++) {
+            setA1.add("lostItem" + i);
+            setA2.add("lostItem" + i);
+
+            setB2.add("lostItem" + i);
+        }
+    }
+
+    private void afterMergeRemoveValuesMergePolicy() {
+        assertSetContent(setA1, 0);
+        assertSetContent(setA2, 0);
+        assertSetContent(backupSet, 0);
+
+        assertSetContent(setB1, 0);
+        assertSetContent(setB2, 0);
     }
 
     private void afterSplitCustomMergePolicy() {
-        for (int i = 0; i < NEW_ITEMS; i++) {
+        for (int i = 0; i < ITEM_COUNT; i++) {
             setA2.add(i);
             setA2.add("lostItem" + i);
         }
     }
 
     private void afterMergeCustomMergePolicy() {
-        int expectedSize = INITIAL_COUNT + NEW_ITEMS;
-        assertEquals("set1 should contain " + expectedSize + " items", expectedSize, setA1.size());
-        assertEquals("set2 should contain " + expectedSize + " items", expectedSize, setA2.size());
-        assertEquals("backupSet should contain " + expectedSize + " items " + backupSet, expectedSize, backupSet.size());
-
-        for (int i = 0; i < INITIAL_COUNT; i++) {
-            assertTrue("setA1 should contain 'item" + i + "'", setA1.contains("item" + i));
-            assertTrue("setA2 should contain 'item" + i + "'", setA2.contains("item" + i));
-            assertTrue("backupSet should contain 'item" + i + "' " + backupSet, backupSet.contains("item" + i));
-        }
-        for (int i = 0; i < NEW_ITEMS; i++) {
-            assertTrue("setA1 should contain '" + i + "'", setA1.contains(i));
-            assertTrue("setA2 should contain '" + i + "'", setA2.contains(i));
-            assertTrue("backupSet should contain '" + i + "' " + backupSet, backupSet.contains(i));
-
-            assertFalse("setA1 should not contain 'lostItem" + i + "'", setA1.contains("lostItem" + i));
-            assertFalse("setA2 should not contain 'lostItem" + i + "'", setA2.contains("lostItem" + i));
-            assertFalse("backupSet should not contain 'lostItem" + i + "'", backupSet.contains("lostItem" + i));
-        }
+        assertSetContent(setA1, ITEM_COUNT);
+        assertSetContent(setA2, ITEM_COUNT);
+        assertSetContent(backupSet, ITEM_COUNT);
     }
 
-    private static void assertSetContent(Set<Object> set, boolean hasMergedItems) {
-        int expectedSize = INITIAL_COUNT + NEW_ITEMS * (hasMergedItems ? 2 : 1);
-        assertEquals("set should contain " + expectedSize + " items " + toString(set), expectedSize, set.size());
+    private static void assertSetContent(Set<Object> set) {
+        assertSetContent(set, ITEM_COUNT, "item");
+    }
 
-        for (int i = 0; i < INITIAL_COUNT + NEW_ITEMS * (hasMergedItems ? 2 : 1); i++) {
-            assertTrue("set should contain item" + i + " " + toString(set), set.contains("item" + i));
+    private static void assertSetContent(Set<Object> set, int expectedSize) {
+        assertSetContent(set, expectedSize, null);
+    }
+
+    private static void assertSetContent(Set<Object> set, int expectedSize, String prefix) {
+        assertEqualsStringFormat("set " + toString(set) + " should contain %d items, but was %d", expectedSize, set.size());
+
+        for (int i = 0; i < expectedSize; i++) {
+            Object expectedValue = prefix == null ? i : prefix + i;
+            assertTrue("set " + toString(set) + " should contain " + expectedValue, set.contains(expectedValue));
         }
     }
 }


### PR DESCRIPTION
* fixed merging of `ISet`/`IList` with multiple values
* fixed when user returned new values, instead of `mergingEntry.getValue()` or `existingEntry.getValue()`
* destroyed the collection container if they are empty after the merging

Part of https://github.com/hazelcast/hazelcast/issues/12803
Part of https://github.com/hazelcast/hazelcast/issues/12804