### PR TITLE
Ignore SemaphoreAdvancedTest.testSemaphoreWithFailuresAndJoin #11935

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreAdvancedTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -78,6 +79,7 @@ public class SemaphoreAdvancedTest extends HazelcastTestSupport {
     }
 
     @Test(timeout = 300000)
+    @Ignore(value = "Known issue in operation system. See: https://github.com/hazelcast/hazelcast/issues/11839")
     public void testSemaphoreWithFailuresAndJoin() {
         final String semaphoreName = randomString();
         final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);


### PR DESCRIPTION
Ignores frequently failing test because of a known complex root cause in
the operation system.
See: #11839
Related: #11818