### PR TITLE
Fixed merging of IQueue

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueDataSerializerHook.java
@@ -28,12 +28,13 @@ import com.hazelcast.collection.impl.queue.operations.DrainBackupOperation;
 import com.hazelcast.collection.impl.queue.operations.DrainOperation;
 import com.hazelcast.collection.impl.queue.operations.IsEmptyOperation;
 import com.hazelcast.collection.impl.queue.operations.IteratorOperation;
-import com.hazelcast.collection.impl.queue.operations.QueueMergeOperation;
 import com.hazelcast.collection.impl.queue.operations.OfferBackupOperation;
 import com.hazelcast.collection.impl.queue.operations.OfferOperation;
 import com.hazelcast.collection.impl.queue.operations.PeekOperation;
 import com.hazelcast.collection.impl.queue.operations.PollBackupOperation;
 import com.hazelcast.collection.impl.queue.operations.PollOperation;
+import com.hazelcast.collection.impl.queue.operations.QueueMergeBackupOperation;
+import com.hazelcast.collection.impl.queue.operations.QueueMergeOperation;
 import com.hazelcast.collection.impl.queue.operations.QueueReplicationOperation;
 import com.hazelcast.collection.impl.queue.operations.RemainingCapacityOperation;
 import com.hazelcast.collection.impl.queue.operations.RemoveBackupOperation;
@@ -124,6 +125,7 @@ public final class QueueDataSerializerHook implements DataSerializerHook {
     public static final int TXN_COMMIT_BACKUP = 43;
 
     public static final int MERGE = 44;
+    public static final int MERGE_BACKUP = 45;
 
     public int getFactoryId() {
         return F_ID;
@@ -131,7 +133,8 @@ public final class QueueDataSerializerHook implements DataSerializerHook {
 
     public DataSerializableFactory createFactory() {
 
-        ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[MERGE + 1];
+        //noinspection unchecked
+        ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[MERGE_BACKUP + 1];
         constructors[OFFER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new OfferOperation();
@@ -357,6 +360,12 @@ public final class QueueDataSerializerHook implements DataSerializerHook {
             @Override
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new QueueMergeOperation();
+            }
+        };
+        constructors[MERGE_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new QueueMergeBackupOperation();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueService.java
@@ -62,15 +62,13 @@ import com.hazelcast.util.ContextMutexFactory;
 import com.hazelcast.util.scheduler.EntryTaskScheduler;
 import com.hazelcast.util.scheduler.EntryTaskSchedulerFactory;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -266,7 +264,10 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
     @Override
     public void destroyDistributedObject(String name) {
-        containerMap.remove(name);
+        QueueContainer container = containerMap.remove(name);
+        if (container != null) {
+            container.destroy();
+        }
         nodeEngine.getEventService().deregisterAllListeners(SERVICE_NAME, name);
         quorumConfigCache.remove(name);
     }
@@ -393,7 +394,7 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
         return partitionService.getPartitionId(keyData);
     }
 
-    private class Merger extends AbstractContainerMerger<QueueContainer, Data, QueueMergeTypes> {
+    private class Merger extends AbstractContainerMerger<QueueContainer, Collection<Object>, QueueMergeTypes> {
 
         Merger(QueueContainerCollector collector) {
             super(collector, nodeEngine);
@@ -406,39 +407,27 @@ public class QueueService implements ManagedService, MigrationAwareService, Tran
 
         @Override
         public void runInternal() {
-            List<QueueMergeTypes> mergingValues;
             for (Entry<Integer, Collection<QueueContainer>> entry : collector.getCollectedContainers().entrySet()) {
                 int partitionId = entry.getKey();
                 Collection<QueueContainer> containerList = entry.getValue();
                 for (QueueContainer container : containerList) {
-                    Deque<QueueItem> itemList = container.getItemQueue();
+                    // TODO: add batching (which is a bit complex, since collections don't have a multi-name operation yet
+                    Queue<QueueItem> items = container.getItemQueue();
 
                     String name = container.getName();
-                    int batchSize = container.getConfig().getMergePolicyConfig().getBatchSize();
-                    SplitBrainMergePolicy<Data, QueueMergeTypes> mergePolicy
+                    SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes> mergePolicy
                             = getMergePolicy(container.getConfig().getMergePolicyConfig());
 
-                    mergingValues = new ArrayList<QueueMergeTypes>(batchSize);
-                    for (QueueItem item : itemList) {
-                        QueueMergeTypes mergingValue = createMergingValue(serializationService, item);
-                        mergingValues.add(mergingValue);
-
-                        if (mergingValues.size() == batchSize) {
-                            sendBatch(partitionId, name, mergePolicy, mergingValues);
-                            mergingValues = new ArrayList<QueueMergeTypes>(batchSize);
-                        }
-                    }
-                    itemList.clear();
-                    if (mergingValues.size() > 0) {
-                        sendBatch(partitionId, name, mergePolicy, mergingValues);
-                    }
+                    QueueMergeTypes mergingValue = createMergingValue(serializationService, items);
+                    sendBatch(partitionId, name, mergePolicy, mergingValue);
                 }
             }
         }
 
-        private void sendBatch(int partitionId, String name, SplitBrainMergePolicy<Data, QueueMergeTypes> mergePolicy,
-                               List<QueueMergeTypes> mergingValues) {
-            QueueMergeOperation operation = new QueueMergeOperation(name, mergePolicy, mergingValues);
+        private void sendBatch(int partitionId, String name,
+                               SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes> mergePolicy,
+                               QueueMergeTypes mergingValue) {
+            QueueMergeOperation operation = new QueueMergeOperation(name, mergePolicy, mergingValue);
             invoke(SERVICE_NAME, operation, partitionId);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueMergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueMergeBackupOperation.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.queue.operations;
+
+import com.hazelcast.collection.impl.queue.QueueContainer;
+import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
+import com.hazelcast.collection.impl.queue.QueueItem;
+import com.hazelcast.collection.impl.queue.QueueService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.MutatingOperation;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Creates backups for merged queue items after split-brain healing with a {@link SplitBrainMergePolicy}.
+ *
+ * @since 3.10
+ */
+public class QueueMergeBackupOperation extends QueueOperation implements MutatingOperation {
+
+    private Collection<QueueItem> backupItems;
+
+    public QueueMergeBackupOperation() {
+    }
+
+    public QueueMergeBackupOperation(String name, Collection<QueueItem> backupItems) {
+        super(name);
+        this.backupItems = backupItems;
+    }
+
+    @Override
+    public void run() {
+        if (backupItems.isEmpty()) {
+            QueueService service = getService();
+            service.destroyDistributedObject(name);
+            return;
+        }
+        QueueContainer container = getContainer();
+        container.clear();
+
+        Map<Long, QueueItem> backupMap = container.getBackupMap();
+        for (QueueItem backupItem : backupItems) {
+            backupMap.put(backupItem.getItemId(), backupItem);
+        }
+    }
+
+    @Override
+    public void afterRun() {
+        getQueueService().getLocalQueueStatsImpl(name).incrementOtherOperations();
+    }
+
+    @Override
+    public int getId() {
+        return QueueDataSerializerHook.MERGE_BACKUP;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(backupItems.size());
+        for (QueueItem backupItem : backupItems) {
+            out.writeObject(backupItem);
+        }
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int size = in.readInt();
+        backupItems = new ArrayList<QueueItem>(size);
+        for (int i = 0; i < size; i++) {
+            QueueItem backupItem = in.readObject();
+            backupItems.add(backupItem);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueMergeOperation.java
@@ -21,50 +21,80 @@ import com.hazelcast.collection.impl.queue.QueueDataSerializerHook;
 import com.hazelcast.collection.impl.queue.QueueItem;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.QueueMergeTypes;
+import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.Collection;
+import java.util.Queue;
 
-import static com.hazelcast.util.MapUtil.createHashMap;
+import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingValue;
+import static com.hazelcast.util.CollectionUtil.isEmpty;
 
 /**
- * Contains multiple merge entries for split-brain healing with a {@link SplitBrainMergePolicy}.
+ * Merges a {@link QueueMergeTypes} for split-brain healing with a {@link SplitBrainMergePolicy}.
  *
  * @since 3.10
  */
 public class QueueMergeOperation extends QueueBackupAwareOperation implements MutatingOperation {
 
-    private SplitBrainMergePolicy<Data, QueueMergeTypes> mergePolicy;
-    private List<QueueMergeTypes> mergingValues;
+    private SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes> mergePolicy;
+    private QueueMergeTypes mergingValue;
 
-    private transient Map<Long, Data> valueMap;
+    private transient Collection<QueueItem> backupCollection;
+    private transient boolean shouldBackup;
 
     public QueueMergeOperation() {
     }
 
-    public QueueMergeOperation(String name, SplitBrainMergePolicy<Data, QueueMergeTypes> mergePolicy,
-                               List<QueueMergeTypes> mergingValues) {
+    public QueueMergeOperation(String name, SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes> mergePolicy,
+                               QueueMergeTypes mergingValue) {
         super(name);
         this.mergePolicy = mergePolicy;
-        this.mergingValues = mergingValues;
+        this.mergingValue = mergingValue;
     }
 
     @Override
     public void run() {
-        QueueContainer queueContainer = getContainer();
-        valueMap = createHashMap(mergingValues.size());
-        for (QueueMergeTypes mergingValue : mergingValues) {
-            QueueItem mergedItem = queueContainer.merge(mergingValue, mergePolicy);
-            if (mergedItem != null) {
-                valueMap.put(mergedItem.getItemId(), mergedItem.getData());
+        QueueContainer container = getContainer();
+        boolean currentCollectionIsEmpty = container.getItemQueue().isEmpty();
+        long currentItemId = container.getCurrentId();
+
+        backupCollection = merge(container, mergingValue, mergePolicy);
+        shouldBackup = currentCollectionIsEmpty != backupCollection.isEmpty() || currentItemId != container.getCurrentId();
+    }
+
+    private Queue<QueueItem> merge(QueueContainer container, QueueMergeTypes mergingValue,
+                                   SplitBrainMergePolicy<Collection<Object>, QueueMergeTypes> mergePolicy) {
+        SerializationService serializationService = getNodeEngine().getSerializationService();
+        serializationService.getManagedContext().initialize(mergingValue);
+        serializationService.getManagedContext().initialize(mergePolicy);
+
+        Queue<QueueItem> existingItems = container.getItemQueue();
+        QueueMergeTypes existingValue = createMergingValue(serializationService, existingItems);
+        Collection<Object> newValues = mergePolicy.merge(mergingValue, existingValue);
+
+        if (isEmpty(newValues)) {
+            if (existingValue != null) {
+                container.clear();
             }
+            getQueueService().destroyDistributedObject(name);
+        } else if (existingValue == null) {
+            createNewQueueItems(container, newValues, serializationService);
+        } else if (!newValues.equals(existingValue.getValue())) {
+            container.clear();
+            createNewQueueItems(container, newValues, serializationService);
+        }
+        return existingItems;
+    }
+
+    private void createNewQueueItems(QueueContainer container, Collection<Object> values,
+                                     SerializationService serializationService) {
+        for (Object value : values) {
+            container.offer(serializationService.toData(value));
         }
     }
 
@@ -75,12 +105,12 @@ public class QueueMergeOperation extends QueueBackupAwareOperation implements Mu
 
     @Override
     public boolean shouldBackup() {
-        return valueMap != null && !valueMap.isEmpty();
+        return shouldBackup;
     }
 
     @Override
     public Operation getBackupOperation() {
-        return new AddAllBackupOperation(name, valueMap);
+        return new QueueMergeBackupOperation(name, backupCollection);
     }
 
     @Override
@@ -92,21 +122,13 @@ public class QueueMergeOperation extends QueueBackupAwareOperation implements Mu
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(mergePolicy);
-        out.writeInt(mergingValues.size());
-        for (QueueMergeTypes mergingValue : mergingValues) {
-            out.writeObject(mergingValue);
-        }
+        out.writeObject(mergingValue);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         mergePolicy = in.readObject();
-        int size = in.readInt();
-        mergingValues = new ArrayList<QueueMergeTypes>(size);
-        for (int i = 0; i < size; i++) {
-            QueueMergeTypes mergingValue = in.readObject();
-            mergingValues.add(mergingValue);
-        }
+        mergingValue = in.readObject();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
@@ -46,6 +46,7 @@ import com.hazelcast.spi.serialization.SerializationService;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Queue;
 
 /**
  * Provides static factory methods to create {@link MergingValue} and {@link MergingEntry} instances.
@@ -70,9 +71,16 @@ public final class MergingValueFactory {
                 .setValue(values);
     }
 
-    public static QueueMergeTypes createMergingValue(SerializationService serializationService, QueueItem item) {
+    public static QueueMergeTypes createMergingValue(SerializationService serializationService, Queue<QueueItem> items) {
+        if (items.isEmpty()) {
+            return null;
+        }
+        Collection<Object> values = new ArrayList<Object>(items.size());
+        for (QueueItem item : items) {
+            values.add(item.getData());
+        }
         return new QueueMergingValueImpl(serializationService)
-                .setValue(item.getData());
+                .setValue(values);
     }
 
     public static AtomicLongMergeTypes createMergingValue(SerializationService serializationService, Long value) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/QueueMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/QueueMergingValueImpl.java
@@ -16,9 +16,10 @@
 
 package com.hazelcast.spi.impl.merge;
 
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.QueueMergeTypes;
 import com.hazelcast.spi.serialization.SerializationService;
+
+import java.util.Collection;
 
 /**
  * Implementation of {@link QueueMergeTypes}.
@@ -26,7 +27,8 @@ import com.hazelcast.spi.serialization.SerializationService;
  * @since 3.10
  */
 @SuppressWarnings("WeakerAccess")
-public class QueueMergingValueImpl extends AbstractMergingValueImpl<Data, QueueMergingValueImpl> implements QueueMergeTypes {
+public class QueueMergingValueImpl extends AbstractCollectionMergingValueImpl<Collection<Object>, QueueMergingValueImpl>
+        implements QueueMergeTypes {
 
     public QueueMergingValueImpl() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
@@ -87,7 +87,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
-    public interface QueueMergeTypes extends MergingValue<Data> {
+    public interface QueueMergeTypes extends MergingValue<Collection<Object>> {
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -424,7 +424,10 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
     }
 
     public static void assertPiCollection(Collection<Object> collection) {
-        assertEquals("Expected the collection to be a PI collection", ReturnPiCollectionMergePolicy.PI_COLLECTION, collection);
+        assertEquals("Expected the collection to be a PI collection",
+                collection.size(), ReturnPiCollectionMergePolicy.PI_COLLECTION.size());
+        assertTrue("Expected the collection to be a PI collection",
+                collection.containsAll(ReturnPiCollectionMergePolicy.PI_COLLECTION));
     }
 
     public static void assertPiSet(Collection<Object> collection) {


### PR DESCRIPTION
* fixed merging of `IQueue` with multiple values
* fixed when user returned new values, instead of `mergingEntry.getValue()` or `existingEntry.getValue()`
* used correct methods for clear and destroy to consider the `QueueStore`

Part of https://github.com/hazelcast/hazelcast/issues/12803
Part of https://github.com/hazelcast/hazelcast/issues/12804