### PR TITLE
Fix resource leakage in getDistributedObjects

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -660,7 +660,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             }
 
             for (DistributedObjectInfo distributedObjectInfo : localDistributedObjects) {
-                ClientProxy proxy = proxyManager.getProxy(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName());
+                String serviceName = distributedObjectInfo.getServiceName();
+                String objectName = distributedObjectInfo.getName();
+                ClientProxy proxy = proxyManager.getProxy(serviceName, objectName);
                 if (proxy != null) {
                     proxy.destroyLocally();
                 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -42,7 +42,6 @@ import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.client.spi.ClientInvocationService;
 import com.hazelcast.client.spi.ClientListenerService;
 import com.hazelcast.client.spi.ClientPartitionService;
-import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.ClientTransactionManagerService;
 import com.hazelcast.client.spi.ProxyManager;
 import com.hazelcast.client.spi.impl.AbstractClientInvocationService;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -660,12 +660,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             }
 
             for (DistributedObjectInfo distributedObjectInfo : localDistributedObjects) {
-                String serviceName = distributedObjectInfo.getServiceName();
-                String objectName = distributedObjectInfo.getName();
-                ClientProxy proxy = proxyManager.getProxy(serviceName, objectName);
-                if (proxy != null) {
-                    proxy.destroyLocally();
-                }
+                proxyManager.destroyProxyLocally(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName());
             }
             return (Collection<DistributedObject>) proxyManager.getDistributedObjects();
         } catch (Exception e) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -42,6 +42,7 @@ import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.client.spi.ClientInvocationService;
 import com.hazelcast.client.spi.ClientListenerService;
 import com.hazelcast.client.spi.ClientPartitionService;
+import com.hazelcast.client.spi.ClientProxy;
 import com.hazelcast.client.spi.ClientTransactionManagerService;
 import com.hazelcast.client.spi.ProxyManager;
 import com.hazelcast.client.spi.impl.AbstractClientInvocationService;
@@ -659,7 +660,10 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             }
 
             for (DistributedObjectInfo distributedObjectInfo : localDistributedObjects) {
-                proxyManager.removeProxy(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName());
+                ClientProxy proxy = proxyManager.getProxy(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName());
+                if (proxy != null) {
+                    proxy.destroyLocally();
+                }
             }
             return (Collection<DistributedObject>) proxyManager.getDistributedObjects();
         } catch (Exception e) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
@@ -162,7 +162,7 @@ public abstract class ClientProxy implements DistributedObject {
      * does.
      * <p>
      * This local destroy operation still may perform some communication with
-     * the cluster, for example, to unregister remote event subscriptions.
+     * the cluster; for example, to unregister remote event subscriptions.
      */
     public final void destroyLocally() {
         if (preDestroy()) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
@@ -161,17 +161,13 @@ public abstract class ClientProxy implements DistributedObject {
      * object destroy request to the cluster as the {@link #destroy} method
      * does.
      * <p>
-     * This local destroy operation still may perform some communication with
-     * the cluster; for example, to unregister remote event subscriptions.
+     * The local destruction operation still may perform some communication
+     * with the cluster; for example, to unregister remote event subscriptions.
      */
     public final void destroyLocally() {
         if (preDestroy()) {
             try {
-                try {
-                    onDestroy();
-                } finally {
-                    getContext().getProxyManager().removeProxy(getServiceName(), getDistributedObjectName());
-                }
+                onDestroy();
             } catch (Exception e) {
                 throw rethrow(e);
             } finally {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
@@ -157,6 +157,30 @@ public abstract class ClientProxy implements DistributedObject {
     }
 
     /**
+     * Destroys this client proxy instance locally without issuing distributed
+     * object destroy request to the cluster as the {@link #destroy} method
+     * does.
+     * <p>
+     * This local destroy operation still may perform some communication with
+     * the cluster, for example, to unregister remote event subscriptions.
+     */
+    public final void destroyLocally() {
+        if (preDestroy()) {
+            try {
+                try {
+                    onDestroy();
+                } finally {
+                    getContext().getProxyManager().removeProxy(getServiceName(), getDistributedObjectName());
+                }
+            } catch (Exception e) {
+                throw rethrow(e);
+            } finally {
+                postDestroy();
+            }
+        }
+    }
+
+    /**
      * Called when proxy is created.
      * Overriding implementations can add initialization specific logic into this method
      * like registering a listener, creating a cleanup task etc.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -324,19 +324,22 @@ public final class ProxyManager {
     }
 
     /**
-     * Returns the registered proxy instance for the given service and object
-     * ID. Unlike {@link #getOrCreateProxy} doesn't try to create a proxy
-     * instance if it's not registered in this proxy manager.
+     * Locally destroys the proxy identified by the given service and object ID.
+     * <p>
+     * Upon successful completion the proxy is unregistered in this proxy
+     * manager and all local resources associated with the proxy are released.
+     * See {@link ClientProxy#destroyLocally} for more details.
      *
-     * @param service the service associated with the object.
-     * @param id      the ID of the object to obtain the proxy of.
-     * @return the registered proxy or {@code null} if there is no proxy
-     * registered.
+     * @param service the service associated with the proxy.
+     * @param id      the ID of the object.
      */
-    public ClientProxy getProxy(String service, String id) {
-        final ObjectNamespace ns = new DistributedObjectNamespace(service, id);
-        ClientProxyFuture proxyFuture = proxies.get(ns);
-        return proxyFuture == null ? null : proxyFuture.get();
+    public void destroyProxyLocally(String service, String id) {
+        ObjectNamespace objectNamespace = new DistributedObjectNamespace(service, id);
+        ClientProxyFuture clientProxyFuture = proxies.remove(objectNamespace);
+        if (clientProxyFuture != null) {
+            ClientProxy clientProxy = clientProxyFuture.get();
+            clientProxy.destroyLocally();
+        }
     }
 
     private ClientProxy createClientProxy(String id, ClientProxyFactory factory) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -323,6 +323,22 @@ public final class ProxyManager {
         }
     }
 
+    /**
+     * Returns the registered proxy instance for the given service and object
+     * ID. Unlike {@link #getOrCreateProxy} doesn't try to create a proxy
+     * instance if it's not registered in this proxy manager.
+     *
+     * @param service the service associated with the object.
+     * @param id      the ID of the object to obtain the proxy of.
+     * @return the registered proxy or {@code null} if there are no proxy
+     * registered.
+     */
+    public ClientProxy getProxy(String service, String id) {
+        final ObjectNamespace ns = new DistributedObjectNamespace(service, id);
+        ClientProxyFuture proxyFuture = proxies.get(ns);
+        return proxyFuture == null ? null : proxyFuture.get();
+    }
+
     private ClientProxy createClientProxy(String id, ClientProxyFactory factory) {
         if (factory instanceof ClientProxyFactoryWithContext) {
             return ((ClientProxyFactoryWithContext) factory).create(id, context);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -330,7 +330,7 @@ public final class ProxyManager {
      *
      * @param service the service associated with the object.
      * @param id      the ID of the object to obtain the proxy of.
-     * @return the registered proxy or {@code null} if there are no proxy
+     * @return the registered proxy or {@code null} if there is no proxy
      * registered.
      */
     public ClientProxy getProxy(String service, String id) {


### PR DESCRIPTION
getDistributedObjects syncs the contents of the local and remote
distributed object registries on each invocation. That involves the
removal of the stale local proxies from the local registry, but the
local resources associated with the proxies were not cleaned up
properly.

Fixes: https://github.com/hazelcast/hazelcast/issues/12679
Related: https://github.com/hazelcast/hazelcast/issues/9423