### PR TITLE
Caches read-only copy of ReplicatedMapConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -78,6 +78,8 @@ public class ReplicatedMapConfig implements SplitBrainMergeTypeProvider, Identif
 
     private String quorumName;
 
+    private transient volatile ReplicatedMapConfigReadOnly readOnly;
+
     public ReplicatedMapConfig() {
     }
 
@@ -290,7 +292,10 @@ public class ReplicatedMapConfig implements SplitBrainMergeTypeProvider, Identif
      * @deprecated this method will be removed in 4.0; it is meant for internal usage only
      */
     public ReplicatedMapConfig getAsReadOnly() {
-        return new ReplicatedMapConfigReadOnly(this);
+        if (readOnly == null) {
+            readOnly = new ReplicatedMapConfigReadOnly(this);
+        }
+        return readOnly;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigReadOnlyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigReadOnlyTest.java
@@ -25,6 +25,9 @@ import org.junit.runner.RunWith;
 
 import java.util.Collections;
 
+import static com.hazelcast.test.HazelcastTestSupport.randomName;
+import static org.junit.Assert.assertSame;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapConfigReadOnlyTest {
@@ -86,5 +89,12 @@ public class ReplicatedMapConfigReadOnlyTest {
     @Test(expected = UnsupportedOperationException.class)
     public void testSetMergePolicyConfig() {
         getReadOnlyConfig().setMergePolicyConfig(new MergePolicyConfig());
+    }
+
+    @Test
+    public void testGetReadOnly_returnsSameInstance() {
+        ReplicatedMapConfig replicatedMapConfig = new ReplicatedMapConfig(randomName());
+        ReplicatedMapConfig readOnly = replicatedMapConfig.getAsReadOnly();
+        assertSame(readOnly, replicatedMapConfig.getAsReadOnly());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReplicatedMapConfigTest.java
@@ -23,12 +23,11 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -43,6 +42,9 @@ public class ReplicatedMapConfigTest {
                 .withPrefabValues(MergePolicyConfig.class,
                         new MergePolicyConfig(PutIfAbsentMergePolicy.class.getName(), 100),
                         new MergePolicyConfig(DiscardMergePolicy.class.getName(), 200))
+                .withPrefabValues(ReplicatedMapConfigReadOnly.class,
+                        new ReplicatedMapConfigReadOnly(new ReplicatedMapConfig("red")),
+                        new ReplicatedMapConfigReadOnly(new ReplicatedMapConfig("black")))
                 .verify();
     }
 }


### PR DESCRIPTION
Previously, each time a read-only copy of a `ReplicatedMapConfig`
was requested, a new instance was created, so each
`ReplicatedRecordStore` would obtain a separate instance as a copy
of the original `ReplicatedMapConfig` (via `Config.findReplicatedMapConfig`) ->
for a single `ReplicatedMap`, at least partition-count copies of the read-only
config instance would be created.

(Finding from a `ReplicatedMap` create-use-destroy test by @Danny-Hazelcast )