### PR TITLE
Destroy ringbuffer when client reliable topic is destroyed

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableTopicProxy.java
@@ -343,4 +343,10 @@ public class ClientReliableTopicProxy<E> extends ClientProxy implements ITopic<E
             }
         }
     }
+
+    @Override
+    protected void postDestroy() {
+        // this will trigger all listeners to destroy themselves.
+        ringbuffer.destroy();
+    }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicDestroyTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicDestroyTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.topic;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.impl.reliable.ReliableTopicDestroyTest;
+import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientReliableTopicDestroyTest extends ReliableTopicDestroyTest {
+
+    private TestHazelcastFactory factory;
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Override
+    protected void createInstances() {
+        this.factory = new TestHazelcastFactory();
+        this.member = factory.newHazelcastInstance();
+        this.client = factory.newHazelcastClient();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+
+    @Override
+    protected HazelcastInstance getMember() {
+        return member;
+    }
+
+    @After
+    public final void terminate() {
+        factory.terminateAll();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/ReliableTopicDestroyTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.topic.impl.reliable;
 
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.spi.ObjectNamespace;
@@ -32,22 +33,23 @@ import org.junit.runner.RunWith;
 
 import java.util.Map;
 
+import static com.hazelcast.ringbuffer.impl.RingbufferService.TOPIC_RB_PREFIX;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ReliableTopicDestroyTest extends HazelcastTestSupport {
 
-    private ReliableTopicProxy<String> topic;
-    private RingbufferService ringbufferService;
+    public static final String RELIABLE_TOPIC_NAME = "foo";
+    private ITopic<String> topic;
+    private HazelcastInstance member;
 
     @Before
     public void setup() {
-        HazelcastInstance hz = createHazelcastInstance();
-        topic = (ReliableTopicProxy<String>) hz.<String>getReliableTopic("foo");
-        ringbufferService = getNodeEngineImpl(hz).getService(RingbufferService.SERVICE_NAME);
+        createInstances();
+        this.topic = getDriver().getReliableTopic(RELIABLE_TOPIC_NAME);
     }
 
     @Test
@@ -69,7 +71,7 @@ public class ReliableTopicDestroyTest extends HazelcastTestSupport {
         // it should not receive any events.
         assertTrueDelayed5sec(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(0, listener.objects.size());
             }
         });
@@ -79,16 +81,30 @@ public class ReliableTopicDestroyTest extends HazelcastTestSupport {
     public void whenDestroyedThenRingbufferRemoved() {
         topic.publish("foo");
         topic.destroy();
+        final RingbufferService ringbufferService
+                = getNodeEngineImpl(getMember()).getService(RingbufferService.SERVICE_NAME);
 
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                final String name = topic.ringbuffer.getName();
+                final String name = TOPIC_RB_PREFIX + RELIABLE_TOPIC_NAME;
                 final Map<ObjectNamespace, RingbufferContainer> partitionContainers =
                         ringbufferService.getContainers().get(ringbufferService.getRingbufferPartitionId(name));
-                assertTrue(partitionContainers != null);
+                assertNotNull(partitionContainers);
                 assertFalse(partitionContainers.containsKey(RingbufferService.getRingbufferNamespace(name)));
             }
         });
+    }
+
+    protected void createInstances() {
+        this.member = createHazelcastInstance();
+    }
+
+    protected HazelcastInstance getDriver() {
+        return member;
+    }
+
+    protected HazelcastInstance getMember() {
+        return member;
     }
 }


### PR DESCRIPTION
This aligns the behaviour with the member side reliable topic. If the
topic is destroyed, that means that the ringbuffer must be destroyed as
well.

Fixes: https://github.com/hazelcast/hazelcast/issues/12808