### PR TITLE
Fixed merging of IAtomicLong/IAtomicReference

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongContainer.java
@@ -16,12 +16,6 @@
 
 package com.hazelcast.concurrent.atomiclong;
 
-import com.hazelcast.spi.merge.SplitBrainMergePolicy;
-import com.hazelcast.spi.merge.SplitBrainMergeTypes.AtomicLongMergeTypes;
-import com.hazelcast.spi.serialization.SerializationService;
-
-import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingValue;
-
 public class AtomicLongContainer {
 
     private long value;
@@ -60,34 +54,5 @@ public class AtomicLongContainer {
         long tempValue = this.value;
         this.value = value;
         return tempValue;
-    }
-
-    /**
-     * Merges the given {@link AtomicLongMergeTypes} via the given {@link SplitBrainMergePolicy}.
-     *
-     * @param mergingValue         the {@link AtomicLongMergeTypes} instance to merge
-     * @param mergePolicy          the {@link SplitBrainMergePolicy} instance to apply
-     * @param serializationService the {@link SerializationService} to inject dependencies
-     * @return the new value if merge is applied, otherwise {@code null}
-     */
-    public Long merge(AtomicLongMergeTypes mergingValue, SplitBrainMergePolicy<Long, AtomicLongMergeTypes> mergePolicy,
-                      boolean isExistingContainer, SerializationService serializationService) {
-        serializationService.getManagedContext().initialize(mergePolicy);
-
-        if (isExistingContainer) {
-            AtomicLongMergeTypes existingValue = createMergingValue(serializationService, value);
-            Long newValue = mergePolicy.merge(mergingValue, existingValue);
-            if (newValue != null && !newValue.equals(value)) {
-                value = newValue;
-                return newValue;
-            }
-        } else {
-            Long newValue = mergePolicy.merge(mergingValue, null);
-            if (newValue != null) {
-                value = newValue;
-                return newValue;
-            }
-        }
-        return null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongDataSerializerHook.java
@@ -27,6 +27,7 @@ import com.hazelcast.concurrent.atomiclong.operations.GetAndAddOperation;
 import com.hazelcast.concurrent.atomiclong.operations.GetAndAlterOperation;
 import com.hazelcast.concurrent.atomiclong.operations.GetAndSetOperation;
 import com.hazelcast.concurrent.atomiclong.operations.GetOperation;
+import com.hazelcast.concurrent.atomiclong.operations.MergeBackupOperation;
 import com.hazelcast.concurrent.atomiclong.operations.MergeOperation;
 import com.hazelcast.concurrent.atomiclong.operations.SetBackupOperation;
 import com.hazelcast.concurrent.atomiclong.operations.SetOperation;
@@ -56,6 +57,7 @@ public final class AtomicLongDataSerializerHook implements DataSerializerHook {
     public static final int SET_BACKUP = 11;
     public static final int REPLICATION = 12;
     public static final int MERGE = 13;
+    public static final int MERGE_BACKUP = 14;
 
     @Override
     public int getFactoryId() {
@@ -96,6 +98,8 @@ public final class AtomicLongDataSerializerHook implements DataSerializerHook {
                         return new AtomicLongReplicationOperation();
                     case MERGE:
                         return new MergeOperation();
+                    case MERGE_BACKUP:
+                        return new MergeBackupOperation();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/MergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/MergeBackupOperation.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.concurrent.atomiclong.operations;
+
+import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
+import com.hazelcast.concurrent.atomiclong.AtomicLongService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+
+import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.MERGE_BACKUP;
+
+/**
+ * Creates backups for merged atomic longs after split-brain healing with a {@link SplitBrainMergePolicy}.
+ */
+public class MergeBackupOperation extends AbstractAtomicLongOperation implements BackupOperation {
+
+    private Long newValue;
+
+    public MergeBackupOperation() {
+    }
+
+    public MergeBackupOperation(String name, Long newValue) {
+        super(name);
+        this.newValue = newValue;
+    }
+
+    @Override
+    public void run() throws Exception {
+        if (newValue == null) {
+            AtomicLongService service = getService();
+            service.destroyDistributedObject(name);
+        } else {
+            AtomicLongContainer container = getLongContainer();
+            container.set(newValue);
+        }
+    }
+
+    @Override
+    public int getId() {
+        return MERGE_BACKUP;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeObject(newValue);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        newValue = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/MergeOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.concurrent.atomiclong.operations;
 
+import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -30,7 +31,7 @@ import static com.hazelcast.concurrent.atomiclong.AtomicLongDataSerializerHook.M
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingValue;
 
 /**
- * Contains a merge value for split-brain healing with a {@link SplitBrainMergePolicy}.
+ * Merges a {@link AtomicLongMergeTypes} for split-brain healing with a {@link SplitBrainMergePolicy}.
  *
  * @since 3.10
  */
@@ -54,20 +55,38 @@ public class MergeOperation extends AtomicLongBackupAwareOperation {
     public void run() throws Exception {
         AtomicLongService service = getService();
         boolean isExistingContainer = service.containsAtomicLong(name);
+        AtomicLongContainer container = isExistingContainer ? getLongContainer() : null;
+        Long oldValue = isExistingContainer ? container.get() : null;
 
         SerializationService serializationService = getNodeEngine().getSerializationService();
+        serializationService.getManagedContext().initialize(mergePolicy);
+
         AtomicLongMergeTypes mergeValue = createMergingValue(serializationService, mergingValue);
-        backupValue = getLongContainer().merge(mergeValue, mergePolicy, isExistingContainer, serializationService);
+        AtomicLongMergeTypes existingValue = createMergingValue(serializationService, oldValue);
+        Long newValue = mergePolicy.merge(mergeValue, existingValue);
+
+        backupValue = setNewValue(service, container, oldValue, newValue);
+        shouldBackup = (backupValue == null && oldValue != null) || (backupValue != null && !backupValue.equals(oldValue));
     }
 
-    @Override
-    public boolean shouldBackup() {
-        return backupValue != null;
+    private Long setNewValue(AtomicLongService service, AtomicLongContainer container, Long oldValue, Long newValue) {
+        if (newValue == null) {
+            service.destroyDistributedObject(name);
+            return null;
+        } else if (container == null) {
+            container = getLongContainer();
+            container.set(newValue);
+            return newValue;
+        } else if (!newValue.equals(oldValue)) {
+            container.set(newValue);
+            return newValue;
+        }
+        return oldValue;
     }
 
     @Override
     public Operation getBackupOperation() {
-        return new SetBackupOperation(name, backupValue);
+        return new MergeBackupOperation(name, backupValue);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceContainer.java
@@ -17,11 +17,6 @@
 package com.hazelcast.concurrent.atomicreference;
 
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.merge.SplitBrainMergePolicy;
-import com.hazelcast.spi.merge.SplitBrainMergeTypes.AtomicReferenceMergeTypes;
-import com.hazelcast.spi.serialization.SerializationService;
-
-import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingValue;
 
 public class AtomicReferenceContainer {
 
@@ -61,34 +56,5 @@ public class AtomicReferenceContainer {
 
     public boolean isNull() {
         return value == null;
-    }
-
-    /**
-     * Merges the given {@link AtomicReferenceMergeTypes} via the given {@link SplitBrainMergePolicy}.
-     *
-     * @param mergingValue         the {@link AtomicReferenceMergeTypes} instance to merge
-     * @param mergePolicy          the {@link SplitBrainMergePolicy} instance to apply
-     * @param serializationService the {@link SerializationService} to inject dependencies
-     * @return the new value if merge is applied, otherwise {@code null}
-     */
-    public Data merge(AtomicReferenceMergeTypes mergingValue, SplitBrainMergePolicy<Data, AtomicReferenceMergeTypes> mergePolicy,
-                      boolean isExistingContainer, SerializationService serializationService) {
-        serializationService.getManagedContext().initialize(mergePolicy);
-
-        if (isExistingContainer) {
-            AtomicReferenceMergeTypes existingValue = createMergingValue(serializationService, value);
-            Data newValue = mergePolicy.merge(mergingValue, existingValue);
-            if (newValue != null && !newValue.equals(value)) {
-                value = newValue;
-                return newValue;
-            }
-        } else {
-            Data newValue = mergePolicy.merge(mergingValue, null);
-            if (newValue != null) {
-                value = newValue;
-                return newValue;
-            }
-        }
-        return null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceDataSerializerHook.java
@@ -26,6 +26,7 @@ import com.hazelcast.concurrent.atomicreference.operations.GetAndAlterOperation;
 import com.hazelcast.concurrent.atomicreference.operations.GetAndSetOperation;
 import com.hazelcast.concurrent.atomicreference.operations.GetOperation;
 import com.hazelcast.concurrent.atomicreference.operations.IsNullOperation;
+import com.hazelcast.concurrent.atomicreference.operations.MergeBackupOperation;
 import com.hazelcast.concurrent.atomicreference.operations.MergeOperation;
 import com.hazelcast.concurrent.atomicreference.operations.SetAndGetOperation;
 import com.hazelcast.concurrent.atomicreference.operations.SetBackupOperation;
@@ -56,6 +57,7 @@ public final class AtomicReferenceDataSerializerHook implements DataSerializerHo
     public static final int SET = 11;
     public static final int REPLICATION = 12;
     public static final int MERGE = 13;
+    public static final int MERGE_BACKUP = 14;
 
     @Override
     public int getFactoryId() {
@@ -96,6 +98,8 @@ public final class AtomicReferenceDataSerializerHook implements DataSerializerHo
                         return new AtomicReferenceReplicationOperation();
                     case MERGE:
                         return new MergeOperation();
+                    case MERGE_BACKUP:
+                        return new MergeBackupOperation();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
@@ -199,7 +199,7 @@ public class AtomicReferenceService
         return new Merger(collector);
     }
 
-    private class Merger extends AbstractContainerMerger<AtomicReferenceContainer, Data, AtomicReferenceMergeTypes> {
+    private class Merger extends AbstractContainerMerger<AtomicReferenceContainer, Object, AtomicReferenceMergeTypes> {
 
         Merger(AtomicReferenceContainerCollector collector) {
             super(collector, nodeEngine);
@@ -221,7 +221,7 @@ public class AtomicReferenceService
 
                 for (AtomicReferenceContainer container : containerList) {
                     String name = collector.getContainerName(container);
-                    SplitBrainMergePolicy<Data, AtomicReferenceMergeTypes> mergePolicy
+                    SplitBrainMergePolicy<Object, AtomicReferenceMergeTypes> mergePolicy
                             = getMergePolicy(collector.getMergePolicyConfig(container));
 
                     MergeOperation operation = new MergeOperation(name, mergePolicy, container.get());

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/MergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/MergeBackupOperation.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.concurrent.atomicreference.operations;
+
+import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
+import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+
+import java.io.IOException;
+
+import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerializerHook.MERGE_BACKUP;
+
+/**
+ * Creates backups for merged atomic references after split-brain healing with a {@link SplitBrainMergePolicy}.
+ */
+public class MergeBackupOperation extends AbstractAtomicReferenceOperation implements BackupOperation {
+
+    private Data newValue;
+
+    public MergeBackupOperation() {
+    }
+
+    public MergeBackupOperation(String name, Data newValue) {
+        super(name);
+        this.newValue = newValue;
+    }
+
+    @Override
+    public void run() throws Exception {
+        if (newValue == null) {
+            AtomicReferenceService service = getService();
+            service.destroyDistributedObject(name);
+        } else {
+            AtomicReferenceContainer container = getReferenceContainer();
+            container.set(newValue);
+        }
+    }
+
+    @Override
+    public int getId() {
+        return MERGE_BACKUP;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeData(newValue);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        newValue = in.readData();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/operations/MergeOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.concurrent.atomicreference.operations;
 
+import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -31,13 +32,13 @@ import static com.hazelcast.concurrent.atomicreference.AtomicReferenceDataSerial
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingValue;
 
 /**
- * Contains a merge value for split-brain healing with a {@link SplitBrainMergePolicy}.
+ * Merges a {@link AtomicReferenceMergeTypes} for split-brain healing with a {@link SplitBrainMergePolicy}.
  *
  * @since 3.10
  */
 public class MergeOperation extends AtomicReferenceBackupAwareOperation {
 
-    private SplitBrainMergePolicy<Data, AtomicReferenceMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<Object, AtomicReferenceMergeTypes> mergePolicy;
     private Data mergingValue;
 
     private transient Data backupValue;
@@ -45,7 +46,7 @@ public class MergeOperation extends AtomicReferenceBackupAwareOperation {
     public MergeOperation() {
     }
 
-    public MergeOperation(String name, SplitBrainMergePolicy<Data, AtomicReferenceMergeTypes> mergePolicy, Data mergingValue) {
+    public MergeOperation(String name, SplitBrainMergePolicy<Object, AtomicReferenceMergeTypes> mergePolicy, Data mergingValue) {
         super(name);
         this.mergePolicy = mergePolicy;
         this.mergingValue = mergingValue;
@@ -55,20 +56,38 @@ public class MergeOperation extends AtomicReferenceBackupAwareOperation {
     public void run() throws Exception {
         AtomicReferenceService service = getService();
         boolean isExistingContainer = service.containsReferenceContainer(name);
+        AtomicReferenceContainer container = isExistingContainer ? getReferenceContainer() : null;
+        Data oldValue = isExistingContainer ? container.get() : null;
 
         SerializationService serializationService = getNodeEngine().getSerializationService();
+        serializationService.getManagedContext().initialize(mergePolicy);
+
         AtomicReferenceMergeTypes mergeValue = createMergingValue(serializationService, mergingValue);
-        backupValue = getReferenceContainer().merge(mergeValue, mergePolicy, isExistingContainer, serializationService);
+        AtomicReferenceMergeTypes existingValue = isExistingContainer ? createMergingValue(serializationService, oldValue) : null;
+        Data newValue = serializationService.toData(mergePolicy.merge(mergeValue, existingValue));
+
+        backupValue = setNewValue(service, container, oldValue, newValue);
+        shouldBackup = (backupValue == null && oldValue != null) || (backupValue != null && !backupValue.equals(oldValue));
     }
 
-    @Override
-    public boolean shouldBackup() {
-        return backupValue != null;
+    private Data setNewValue(AtomicReferenceService service, AtomicReferenceContainer container, Data oldValue, Data newValue) {
+        if (newValue == null) {
+            service.destroyDistributedObject(name);
+            return null;
+        } else if (container == null) {
+            container = getReferenceContainer();
+            container.set(newValue);
+            return newValue;
+        } else if (!newValue.equals(oldValue)) {
+            container.set(newValue);
+            return newValue;
+        }
+        return oldValue;
     }
 
     @Override
     public Operation getBackupOperation() {
-        return new SetBackupOperation(name, backupValue);
+        return new MergeBackupOperation(name, backupValue);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AtomicReferenceMergingValueImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AtomicReferenceMergingValueImpl.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.impl.merge;
 
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.AtomicReferenceMergeTypes;
 import com.hazelcast.spi.serialization.SerializationService;
 
@@ -27,7 +26,7 @@ import com.hazelcast.spi.serialization.SerializationService;
  */
 @SuppressWarnings("WeakerAccess")
 public class AtomicReferenceMergingValueImpl
-        extends AbstractMergingValueImpl<Data, AtomicReferenceMergingValueImpl>
+        extends AbstractMergingValueImpl<Object, AtomicReferenceMergingValueImpl>
         implements AtomicReferenceMergeTypes {
 
     public AtomicReferenceMergingValueImpl() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
@@ -94,6 +94,9 @@ public final class MergingValueFactory {
     }
 
     public static AtomicReferenceMergeTypes createMergingValue(SerializationService serializationService, Data value) {
+        if (value == null) {
+            return null;
+        }
         return new AtomicReferenceMergingValueImpl(serializationService)
                 .setValue(value);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
@@ -86,6 +86,9 @@ public final class MergingValueFactory {
     }
 
     public static AtomicLongMergeTypes createMergingValue(SerializationService serializationService, Long value) {
+        if (value == null) {
+            return null;
+        }
         return new AtomicLongMergingValueImpl(serializationService)
                 .setValue(value);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
@@ -122,7 +122,7 @@ public class SplitBrainMergeTypes {
      * @since 3.10
      */
     @Beta
-    public interface AtomicReferenceMergeTypes extends MergingValue<Data> {
+    public interface AtomicReferenceMergeTypes extends MergingValue<Object> {
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomiclong/AtomicLongSplitBrainTest.java
@@ -60,6 +60,8 @@ public class AtomicLongSplitBrainTest extends SplitBrainTestSupport {
                 {DiscardMergePolicy.class},
                 {PassThroughMergePolicy.class},
                 {PutIfAbsentMergePolicy.class},
+                {RemoveValuesMergePolicy.class},
+                {ReturnLongPiMergePolicy.class},
                 {MergeGreaterValueMergePolicy.class},
         });
     }
@@ -113,6 +115,10 @@ public class AtomicLongSplitBrainTest extends SplitBrainTestSupport {
             afterSplitPassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
+        } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
+            afterSplitRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == ReturnLongPiMergePolicy.class) {
+            afterSplitReturnLongPiMergePolicy();
         } else if (mergePolicyClass == MergeGreaterValueMergePolicy.class) {
             afterSplitCustomMergePolicy();
         } else {
@@ -136,6 +142,10 @@ public class AtomicLongSplitBrainTest extends SplitBrainTestSupport {
             afterMergePassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
+        } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
+            afterMergeRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == ReturnLongPiMergePolicy.class) {
+            afterMergeReturnLongPiMergePolicy();
         } else if (mergePolicyClass == MergeGreaterValueMergePolicy.class) {
             afterMergeCustomMergePolicy();
         } else {
@@ -194,6 +204,40 @@ public class AtomicLongSplitBrainTest extends SplitBrainTestSupport {
         assertEquals(43, backupAtomicLongB.get());
     }
 
+    private void afterSplitRemoveValuesMergePolicy() {
+        atomicLongA1.set(23);
+
+        atomicLongA2.set(42);
+        atomicLongB2.set(43);
+    }
+
+    private void afterMergeRemoveValuesMergePolicy() {
+        assertEquals(0, atomicLongA1.get());
+        assertEquals(0, atomicLongA2.get());
+        assertEquals(0, backupAtomicLongA.get());
+
+        assertEquals(0, atomicLongB1.get());
+        assertEquals(0, atomicLongB2.get());
+        assertEquals(0, backupAtomicLongB.get());
+    }
+
+    private void afterSplitReturnLongPiMergePolicy() {
+        atomicLongA1.set(23);
+
+        atomicLongA2.set(42);
+        atomicLongB2.set(43);
+    }
+
+    private void afterMergeReturnLongPiMergePolicy() {
+        assertEquals(ReturnLongPiMergePolicy.LONG_PI, atomicLongA1.get());
+        assertEquals(ReturnLongPiMergePolicy.LONG_PI, atomicLongA2.get());
+        assertEquals(ReturnLongPiMergePolicy.LONG_PI, backupAtomicLongA.get());
+
+        assertEquals(ReturnLongPiMergePolicy.LONG_PI, atomicLongB1.get());
+        assertEquals(ReturnLongPiMergePolicy.LONG_PI, atomicLongB2.get());
+        assertEquals(ReturnLongPiMergePolicy.LONG_PI, backupAtomicLongB.get());
+    }
+
     private void afterSplitCustomMergePolicy() {
         atomicLongA1.set(23);
 
@@ -204,6 +248,24 @@ public class AtomicLongSplitBrainTest extends SplitBrainTestSupport {
         assertEquals(42, atomicLongA1.get());
         assertEquals(42, atomicLongA2.get());
         assertEquals(42, backupAtomicLongA.get());
+    }
+
+    private static class ReturnLongPiMergePolicy implements SplitBrainMergePolicy<Long, AtomicLongMergeTypes> {
+
+        private static long LONG_PI = 31415L;
+
+        @Override
+        public Long merge(AtomicLongMergeTypes mergingValue, AtomicLongMergeTypes existingValue) {
+            return LONG_PI;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) {
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) {
+        }
     }
 
     private static class MergeGreaterValueMergePolicy implements SplitBrainMergePolicy<Long, AtomicLongMergeTypes> {

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceSplitBrainTest.java
@@ -20,14 +20,10 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicReference;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.merge.DiscardMergePolicy;
 import com.hazelcast.spi.merge.PassThroughMergePolicy;
 import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
-import com.hazelcast.spi.merge.SplitBrainMergeTypes.AtomicReferenceMergeTypes;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -62,7 +58,9 @@ public class AtomicReferenceSplitBrainTest extends SplitBrainTestSupport {
                 {DiscardMergePolicy.class},
                 {PassThroughMergePolicy.class},
                 {PutIfAbsentMergePolicy.class},
-                {MergeInstanceOfIntegerMergePolicy.class},
+                {RemoveValuesMergePolicy.class},
+                {ReturnPiMergePolicy.class},
+                {MergeIntegerValuesMergePolicy.class},
         });
     }
 
@@ -115,7 +113,11 @@ public class AtomicReferenceSplitBrainTest extends SplitBrainTestSupport {
             afterSplitPassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterSplitPutIfAbsentMergePolicy();
-        } else if (mergePolicyClass == MergeInstanceOfIntegerMergePolicy.class) {
+        } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
+            afterSplitRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == ReturnPiMergePolicy.class) {
+            afterSplitReturnPiMergePolicy();
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
         } else {
             fail();
@@ -137,7 +139,11 @@ public class AtomicReferenceSplitBrainTest extends SplitBrainTestSupport {
             afterMergePassThroughMergePolicy();
         } else if (mergePolicyClass == PutIfAbsentMergePolicy.class) {
             afterMergePutIfAbsentMergePolicy();
-        } else if (mergePolicyClass == MergeInstanceOfIntegerMergePolicy.class) {
+        } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
+            afterMergeRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == ReturnPiMergePolicy.class) {
+            afterMergeReturnPiMergePolicy();
+        } else if (mergePolicyClass == MergeIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
         } else {
             fail();
@@ -195,34 +201,54 @@ public class AtomicReferenceSplitBrainTest extends SplitBrainTestSupport {
         assertEquals(43, backupAtomicReferenceB.get());
     }
 
+    private void afterSplitRemoveValuesMergePolicy() {
+        atomicReferenceA1.set(23);
+
+        atomicReferenceA2.set(42);
+        atomicReferenceB2.set(43);
+    }
+
+    private void afterMergeRemoveValuesMergePolicy() {
+        assertNull(atomicReferenceA1.get());
+        assertNull(atomicReferenceA2.get());
+        assertNull(backupAtomicReferenceA.get());
+
+        assertNull(atomicReferenceB1.get());
+        assertNull(atomicReferenceB2.get());
+        assertNull(backupAtomicReferenceB.get());
+    }
+
+    private void afterSplitReturnPiMergePolicy() {
+        atomicReferenceA1.set(23);
+
+        atomicReferenceA2.set(42);
+        atomicReferenceB2.set(43);
+    }
+
+    private void afterMergeReturnPiMergePolicy() {
+        assertPi(atomicReferenceA1.get());
+        assertPi(atomicReferenceA2.get());
+        assertPi(backupAtomicReferenceA.get());
+
+        assertPi(atomicReferenceB1.get());
+        assertPi(atomicReferenceB2.get());
+        assertPi(backupAtomicReferenceB.get());
+    }
+
     private void afterSplitCustomMergePolicy() {
         atomicReferenceA1.set(42);
 
         atomicReferenceA2.set("23");
+        atomicReferenceB2.set(43);
     }
 
     private void afterMergeCustomMergePolicy() {
         assertEquals(42, atomicReferenceA1.get());
         assertEquals(42, atomicReferenceA2.get());
         assertEquals(42, backupAtomicReferenceA.get());
-    }
 
-    private static class MergeInstanceOfIntegerMergePolicy implements SplitBrainMergePolicy<Data, AtomicReferenceMergeTypes> {
-
-        @Override
-        public Data merge(AtomicReferenceMergeTypes mergingValue, AtomicReferenceMergeTypes existingValue) {
-            if (mergingValue.getDeserializedValue() instanceof Integer) {
-                return mergingValue.getValue();
-            }
-            return existingValue.getValue();
-        }
-
-        @Override
-        public void writeData(ObjectDataOutput out) {
-        }
-
-        @Override
-        public void readData(ObjectDataInput in) {
-        }
+        assertEquals(43, atomicReferenceB1.get());
+        assertEquals(43, atomicReferenceB2.get());
+        assertEquals(43, backupAtomicReferenceB.get());
     }
 }


### PR DESCRIPTION
* fixed when user returned `null` or custom value (in OBJECT format), instead of `mergingEntry.getValue()` or `existingEntry.getValue()`
* prevented container to be created when user returned `null`

Part of https://github.com/hazelcast/hazelcast/issues/12804