### PR TITLE
HttpPostCommandProcessor checks if group and pass have been given

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -567,6 +567,9 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
     private boolean checkCredentials(HttpPostCommand command) throws UnsupportedEncodingException {
         byte[] data = command.getData();
         final String[] strList = bytesToString(data).split("&");
+        if (strList.length < 2) {
+            return false;
+        }
         final String groupName = URLDecoder.decode(strList[0], "UTF-8");
         final String groupPass = URLDecoder.decode(strList[1], "UTF-8");
         final GroupConfig groupConfig = textCommandService.getNode().getConfig().getGroupConfig();


### PR DESCRIPTION
The `checkCredentials` would not check if at least 2 arguments have been supplied and could therefore cause an `ArrayIndexOutOfBoundsException`. 

This can actually happen by using MC when providing an empty password. 
Because `split("&")` has this _funny_ default behaviour: 

> Trailing empty strings are therefore not included in the resulting array.  

:roll_eyes: 

So in this situation what would would need to do is `split("&", -1)`. I guess this is news to most of us.
Still, the right fix is to simply check if we got at least two arguments since other callers might not even supply the credentials properly.