### PR TITLE
[#11911] Decrease amount of resources used for parrallel tests

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/RuntimeAvailableProcessors.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/RuntimeAvailableProcessors.java
@@ -24,7 +24,10 @@ package com.hazelcast.internal.util;
  */
 public final class RuntimeAvailableProcessors {
 
-    private static volatile int availableProcessors = Runtime.getRuntime().availableProcessors();
+    // number of available processors currently configured
+    private static volatile int currentAvailableProcessors = Runtime.getRuntime().availableProcessors();
+    // number of processors to be used when reset
+    private static volatile int defaultAvailableProcessors = Runtime.getRuntime().availableProcessors();
 
     private RuntimeAvailableProcessors() {
     }
@@ -38,7 +41,7 @@ public final class RuntimeAvailableProcessors {
      * @return number of available processors
      */
     public static int get() {
-        return availableProcessors;
+        return currentAvailableProcessors;
     }
 
     /**
@@ -49,7 +52,18 @@ public final class RuntimeAvailableProcessors {
      * @param availableProcessors number of available processors
      */
     public static void override(int availableProcessors) {
-        RuntimeAvailableProcessors.availableProcessors = availableProcessors;
+        RuntimeAvailableProcessors.currentAvailableProcessors = availableProcessors;
+    }
+
+    /**
+     * Overrides the number of available processors that are set by the method {@link #override(int)}
+     * <p>
+     * This is to be used only for testing.
+     *
+     * @param availableProcessors
+     */
+    public static void overrideDefault(int availableProcessors) {
+        defaultAvailableProcessors = availableProcessors;
     }
 
     /**
@@ -58,6 +72,6 @@ public final class RuntimeAvailableProcessors {
      * This is to be used only for testing.
      */
     public static void resetOverride() {
-        RuntimeAvailableProcessors.availableProcessors = Runtime.getRuntime().availableProcessors();
+        RuntimeAvailableProcessors.currentAvailableProcessors = defaultAvailableProcessors;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.test;
 
+import com.hazelcast.internal.util.RuntimeAvailableProcessors;
 import com.hazelcast.test.annotation.ConfigureParallelRunnerWith;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.FrameworkMethod;
@@ -49,6 +50,14 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
 
     private static final boolean SPAWN_MULTIPLE_THREADS = TestEnvironment.isMockNetwork();
     private static final int DEFAULT_MAX_THREADS = getDefaultMaxThreads();
+
+    static {
+        boolean multipleJVM = Boolean.getBoolean("multipleJVM");
+        if (multipleJVM) {
+            // decrease the amount of resources used when running in multiple JVM
+            RuntimeAvailableProcessors.overrideDefault(min(getRuntime().availableProcessors(), 8));
+        }
+    }
 
     private static int getDefaultMaxThreads() {
         int cpuWorkers = max(getRuntime().availableProcessors(), 8);

--- a/pom.xml
+++ b/pom.xml
@@ -333,7 +333,7 @@
                                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                                     <useFile>false</useFile>
                                     <!-- 1C means 1 process per cpu core -->
-                                    <forkCount>1C</forkCount>
+                                    <forkCount>0.5C</forkCount>
                                     <reuseForks>true</reuseForks>
                                     <argLine>
                                         -Xms512m -Xmx2G -XX:MaxPermSize=1024M -ea


### PR DESCRIPTION
Based on @taburet 's review, experiment to decrease the resources needed for the PR builder to run. 
Please do not merge until we run PR builder several times to see the effect.

Should address https://github.com/hazelcast/hazelcast/issues/11991