### PR TITLE
Fix a race condition while destroying proxies

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.ClientDestroyProxyCodec;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 import com.hazelcast.core.DistributedObject;
@@ -160,6 +161,19 @@ public abstract class ClientProxy implements DistributedObject {
             } finally {
                 postDestroy();
             }
+        }
+    }
+
+    /**
+     * Destroys the remote distributed object counterpart of this proxy by
+     * issuing the destruction request to the cluster.
+     */
+    public final void destroyRemotely() {
+        ClientMessage clientMessage = ClientDestroyProxyCodec.encodeRequest(getDistributedObjectName(), getServiceName());
+        try {
+            new ClientInvocation(getClient(), clientMessage, getName()).invoke().get();
+        } catch (Exception e) {
+            throw rethrow(e);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
@@ -20,7 +20,6 @@ import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.codec.ClientDestroyProxyCodec;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 import com.hazelcast.core.DistributedObject;
@@ -147,37 +146,17 @@ public abstract class ClientProxy implements DistributedObject {
     }
 
     /**
-     * Destroys this proxy.
+     * Destroys this client proxy instance locally without issuing distributed
+     * object destroy request to the cluster as the {@link #destroy} method
+     * does.
      * <p>
-     * Optionally, the remote distributed object counterpart also can be
-     * destroyed by passing {@code true} for the {@code alsoRemotely} parameter.
-     * In this case, a distributed object destruction operation will be issued
-     * to the cluster.
-     * <p>
-     * However, even a pure local-only destruction still may involve some
-     * communication with the cluster; for example, to unregister remote event
-     * subscriptions.
-     *
-     * @param alsoRemotely {@code false} to perform the local destruction only,
-     *                     {@code true} to destroy the remote distributed
-     *                     counterpart in addition to the local destruction.
-     * @see ProxyManager#destroyProxyLocally(String, String)
-     * @see ProxyManager#destroyProxy(ClientProxy)
+     * The local destruction operation still may perform some communication
+     * with the cluster; for example, to unregister remote event subscriptions.
      */
-    public final void destroy(boolean alsoRemotely) {
+    public final void destroyLocally() {
         if (preDestroy()) {
             try {
-                try {
-                    onDestroy();
-                } finally {
-                    if (alsoRemotely) {
-                        ClientMessage clientMessage = ClientDestroyProxyCodec
-                                .encodeRequest(getDistributedObjectName(), getServiceName());
-                        new ClientInvocation(getClient(), clientMessage, getName()).invoke().get();
-                    }
-                }
-            } catch (Exception e) {
-                throw rethrow(e);
+                onDestroy();
             } finally {
                 postDestroy();
             }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -324,21 +324,56 @@ public final class ProxyManager {
     }
 
     /**
+     * Destroys the given proxy in a cluster-wide way.
+     * <p>
+     * Upon successful completion the proxy is unregistered in this proxy
+     * manager, all local resources associated with the proxy are released and
+     * a distributed object destruction operation is issued to the cluster.
+     * <p>
+     * If the given proxy instance is not registered in this proxy manager, the
+     * proxy instance is considered stale. In this case, this stale instance is
+     * a subject to a local-only destruction and its registered counterpart, if
+     * there is any, is a subject to a cluster-wide destruction.
+     *
+     * @param proxy the proxy to destroy.
+     * @see ClientProxy#destroy(boolean)
+     */
+    public void destroyProxy(ClientProxy proxy) {
+        ObjectNamespace objectNamespace = new DistributedObjectNamespace(proxy.getServiceName(),
+                proxy.getDistributedObjectName());
+        ClientProxyFuture registeredProxyFuture = proxies.remove(objectNamespace);
+        if (registeredProxyFuture != null) {
+            ClientProxy registeredProxy = registeredProxyFuture.get();
+            registeredProxy.destroy(true);
+            if (proxy == registeredProxy) {
+                return;
+            }
+        }
+
+        // The given proxy is stale and was already destroyed, but the caller
+        // may have allocated local resources in the context of this stale proxy
+        // instance after it was destroyed, so we have to cleanup it locally one
+        // more time to make sure there are no leaking local resources.
+        proxy.destroy(false);
+    }
+
+    /**
      * Locally destroys the proxy identified by the given service and object ID.
      * <p>
      * Upon successful completion the proxy is unregistered in this proxy
      * manager and all local resources associated with the proxy are released.
-     * See {@link ClientProxy#destroyLocally} for more details.
      *
-     * @param service the service associated with the proxy.
-     * @param id      the ID of the object.
+     * @param service      the service associated with the proxy.
+     * @param id           the ID of the object to destroy the proxy of.
+     *
+     * @see ClientProxy#destroy(boolean)
      */
     public void destroyProxyLocally(String service, String id) {
         ObjectNamespace objectNamespace = new DistributedObjectNamespace(service, id);
         ClientProxyFuture clientProxyFuture = proxies.remove(objectNamespace);
         if (clientProxyFuture != null) {
             ClientProxy clientProxy = clientProxyFuture.get();
-            clientProxy.destroyLocally();
+            clientProxy.destroy(false);
         }
     }
 
@@ -348,11 +383,6 @@ public final class ProxyManager {
         }
         return factory.create(id)
                 .setContext(context);
-    }
-
-    public void removeProxy(String service, String id) {
-        final ObjectNamespace ns = new DistributedObjectNamespace(service, id);
-        proxies.remove(ns);
     }
 
     private void initializeWithRetry(ClientProxy clientProxy) throws Exception {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -369,8 +369,8 @@ public final class ProxyManager {
      * Upon successful completion the proxy is unregistered in this proxy
      * manager and all local resources associated with the proxy are released.
      *
-     * @param service      the service associated with the proxy.
-     * @param id           the ID of the object to destroy the proxy of.
+     * @param service the service associated with the proxy.
+     * @param id      the ID of the object to destroy the proxy of.
      */
     public void destroyProxyLocally(String service, String id) {
         ObjectNamespace objectNamespace = new DistributedObjectNamespace(service, id);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -30,7 +30,6 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientAddDistributedObjectListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.ClientCreateProxiesCodec;
 import com.hazelcast.client.impl.protocol.codec.ClientCreateProxyCodec;
-import com.hazelcast.client.impl.protocol.codec.ClientDestroyProxyCodec;
 import com.hazelcast.client.impl.protocol.codec.ClientRemoveDistributedObjectListenerCodec;
 import com.hazelcast.client.proxy.ClientAtomicLongProxy;
 import com.hazelcast.client.proxy.ClientAtomicReferenceProxy;
@@ -349,7 +348,7 @@ public final class ProxyManager {
                 try {
                     registeredProxy.destroyLocally();
                 } finally {
-                    destroyRemoteDistributedObject(registeredProxy);
+                    registeredProxy.destroyRemotely();
                 }
             }
         } finally {
@@ -413,16 +412,6 @@ public final class ProxyManager {
         throw new OperationTimeoutException("Initializing  " + clientProxy.getServiceName() + ":"
                 + clientProxy.getName() + " is timed out after " + elapsedTime
                 + " ms. Configured invocation timeout is " + invocationTimeoutMillis + " ms");
-    }
-
-    private void destroyRemoteDistributedObject(ClientProxy proxy) {
-        try {
-            ClientMessage clientMessage = ClientDestroyProxyCodec
-                    .encodeRequest(proxy.getDistributedObjectName(), proxy.getServiceName());
-            new ClientInvocation(proxy.getClient(), clientMessage, proxy.getName()).invoke().get();
-        } catch (Exception e) {
-            throw rethrow(e);
-        }
     }
 
     private boolean isRetryable(final Throwable t) {


### PR DESCRIPTION
Before this change there was a race condition while destroying proxies
in a cluster-wide way. Multiple threads were performing destruction of
the same proxy instance simultaneously and none them were able to
succeed at the local resources cleanup.

The idea of the fix is to unify the proxy destruction logic in
ProxyManager to make sure the cluster-wide destruction for a certain
proxy instance is done only once.

Fixes: https://github.com/hazelcast/hazelcast/issues/12679