### PR TITLE
Use query cache cacheId when registering a preconfigured user listener

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheConfigurator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheConfigurator.java
@@ -40,11 +40,11 @@ public class ClientQueryCacheConfigurator extends AbstractQueryCacheConfigurator
     }
 
     @Override
-    public QueryCacheConfig getOrCreateConfiguration(String mapName, String cacheName) {
+    public QueryCacheConfig getOrCreateConfiguration(String mapName, String cacheName, String cacheId) {
         QueryCacheConfig config = clientConfig.getOrCreateQueryCacheConfig(mapName, cacheName);
 
         setPredicateImpl(config);
-        setEntryListener(mapName, cacheName, config);
+        setEntryListener(mapName, cacheId, config);
 
         return config;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheConfigurator.java
@@ -31,7 +31,7 @@ public interface QueryCacheConfigurator {
      * @param cacheName query cache name.
      * @return {@link QueryCacheConfig} for the requested {@code cacheName}.
      */
-    QueryCacheConfig getOrCreateConfiguration(String mapName, String cacheName);
+    QueryCacheConfig getOrCreateConfiguration(String mapName, String cacheName, String cacheId);
 
     /**
      * Returns {@link QueryCacheConfig} for the requested {@code cacheName} or null

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -107,7 +107,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
 
     private QueryCacheConfig getQueryCacheConfig() {
         QueryCacheConfigurator queryCacheConfigurator = context.getQueryCacheConfigurator();
-        return queryCacheConfigurator.getOrCreateConfiguration(mapName, cacheName);
+        return queryCacheConfigurator.getOrCreateConfiguration(mapName, cacheName, cacheId);
     }
 
     private EvictionListener getEvictionListener() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
@@ -140,7 +140,7 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
         if (predicate == null) {
             queryCacheConfig = getOrNullQueryCacheConfig(mapName, request.getCacheName());
         } else {
-            queryCacheConfig = getOrCreateQueryCacheConfig(mapName, request.getCacheName());
+            queryCacheConfig = getOrCreateQueryCacheConfig(mapName, request.getCacheName(), request.getCacheId());
             queryCacheConfig.setIncludeValue(request.isIncludeValue());
             queryCacheConfig.getPredicateConfig().setImplementation(predicate);
         }
@@ -156,9 +156,9 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
         return queryCacheConfig;
     }
 
-    private QueryCacheConfig getOrCreateQueryCacheConfig(String mapName, String cacheName) {
+    private QueryCacheConfig getOrCreateQueryCacheConfig(String mapName, String cacheName, String cacheId) {
         QueryCacheConfigurator queryCacheConfigurator = subscriberContext.geQueryCacheConfigurator();
-        return queryCacheConfigurator.getOrCreateConfiguration(mapName, cacheName);
+        return queryCacheConfigurator.getOrCreateConfiguration(mapName, cacheName, cacheId);
     }
 
     private QueryCacheConfig getOrNullQueryCacheConfig(String mapName, String cacheName) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheConfigurator.java
@@ -44,14 +44,14 @@ public class NodeQueryCacheConfigurator extends AbstractQueryCacheConfigurator {
     }
 
     @Override
-    public QueryCacheConfig getOrCreateConfiguration(String mapName, String cacheName) {
+    public QueryCacheConfig getOrCreateConfiguration(String mapName, String cacheName, String cacheId) {
         MapConfig mapConfig = config.getMapConfig(mapName);
 
         QueryCacheConfig queryCacheConfig = findQueryCacheConfigFromMapConfig(mapConfig, cacheName);
 
         if (null != queryCacheConfig) {
             setPredicateImpl(queryCacheConfig);
-            setEntryListener(mapName, cacheName, queryCacheConfig);
+            setEntryListener(mapName, cacheId, queryCacheConfig);
             return queryCacheConfig;
         }
 


### PR DESCRIPTION
Previously the listener registration was done on the cacheName and
the listener would not receive any events, because events are published
with a topic formulated on the basis of cacheId. This fix is only
required for preconfigured user listeners, dynamically added listeners
(via queryCache.addEntryListener) are not affected.

Fixes #12825 