### PR TITLE
Remove "mancenter" folder section from readme.html

### DIFF
--- a/hazelcast/src/main/resources/readme.html
+++ b/hazelcast/src/main/resources/readme.html
@@ -168,17 +168,6 @@
 					<li><strong>README.txt</strong> &mdash; License README.</li>
 				</ul>			
 			</li>
-			
-			<li><strong>/mancenter</strong>
-				<ul>
-					<li><strong>mancenter&ndash;<i>version</i>.war</strong> &mdash; Hazelcast Management Center. This WAR file is executable (double click on it) to start Management Center or can be deployed as a web application. Please see the <a href="docs/manual/html/managementcenter.html">Management Center chapter</a> for more information.</li>
-					<li><strong>startManCenter.bat</strong> &mdash; Starts the management center for Windows users.</li>
-					<li><strong>startManCenter.sh</strong> &mdash; Starts the management center for Linux users.</li>
-				</ul>
-			</li>
-			
-
-					
 		</ul>
 		
 		<h3 id="files">TXT Files</h3>


### PR DESCRIPTION
"mancenter" folder is removed from the archives. Only a README that
explains where users can download Management Center remains, so we
shouldn't mention this folder in the README.html anymore.