### PR TITLE
Set MC URL in XML config to /hazelcast-mancenter

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -30,7 +30,7 @@
         <name>dev</name>
         <password>dev-pass</password>
     </group>
-    <management-center enabled="false">http://localhost:8080/mancenter</management-center>
+    <management-center enabled="false">http://localhost:8080/hazelcast-mancenter</management-center>
     <network>
         <port auto-increment="true" port-count="100">5701</port>
         <outbound-ports>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -109,7 +109,7 @@ https://hazelcast.org/documentation/.
         at most 2 members in your cluster. To use it for more members, you need to have either a Management Center,
         Hazelcast Enterprise or Hazelcast Enterprise HD license.
     -->
-    <management-center enabled="true" update-interval="2">http://localhost:8080/mancenter</management-center>
+    <management-center enabled="true" update-interval="2">http://localhost:8080/hazelcast-mancenter</management-center>
     <!--
         The <properties> element lets you add properties to some of the Hazelcast elements used to configure some of
         the Hazelcast modules.


### PR DESCRIPTION
Management Center normally started under http://localhost:8080/mancenter
 by default. It's now being updated to start under
 http://localhost:8080/hazelcast-mancenter by default. With this change,
 we're updating the default XML configuration file and the full example
 XML configuration file to use the new URL structure by default.