### PR TITLE
Added additional merge policies to test user created values

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -66,6 +66,7 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
                 PassThroughMergePolicy.class,
                 PutIfAbsentMergePolicy.class,
                 RemoveValuesMergePolicy.class,
+                ReturnPiCollectionMergePolicy.class,
                 MergeCollectionOfIntegerValuesMergePolicy.class,
         });
     }
@@ -120,6 +121,8 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
             afterSplitPutIfAbsentMergePolicy();
         } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
             afterSplitRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == ReturnPiCollectionMergePolicy.class) {
+            afterSplitReturnPiCollectionMergePolicy();
         } else if (mergePolicyClass == MergeCollectionOfIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
         } else {
@@ -146,6 +149,8 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
             afterMergePutIfAbsentMergePolicy();
         } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
             afterMergeRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == ReturnPiCollectionMergePolicy.class) {
+            afterMergeReturnPiCollectionMergePolicy();
         } else if (mergePolicyClass == MergeCollectionOfIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
         } else {
@@ -223,6 +228,24 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
 
         assertListContent(listB1, 0);
         assertListContent(listB2, 0);
+    }
+
+    private void afterSplitReturnPiCollectionMergePolicy() {
+        for (int i = 0; i < ITEM_COUNT; i++) {
+            listA1.add("lostItem" + i);
+            listA2.add("lostItem" + i);
+
+            listB2.add("lostItem" + i);
+        }
+    }
+
+    private void afterMergeReturnPiCollectionMergePolicy() {
+        assertPiCollection(listA1);
+        assertPiCollection(listA2);
+        assertPiCollection(backupList);
+
+        assertPiCollection(listB1);
+        assertPiCollection(listB2);
     }
 
     private void afterSplitCustomMergePolicy() {

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetSplitBrainTest.java
@@ -66,6 +66,7 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
                 PassThroughMergePolicy.class,
                 PutIfAbsentMergePolicy.class,
                 RemoveValuesMergePolicy.class,
+                ReturnPiCollectionMergePolicy.class,
                 MergeCollectionOfIntegerValuesMergePolicy.class,
         });
     }
@@ -120,6 +121,8 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
             afterSplitPutIfAbsentMergePolicy();
         } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
             afterSplitRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == ReturnPiCollectionMergePolicy.class) {
+            afterSplitReturnPiCollectionMergePolicy();
         } else if (mergePolicyClass == MergeCollectionOfIntegerValuesMergePolicy.class) {
             afterSplitCustomMergePolicy();
         } else {
@@ -146,6 +149,8 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
             afterMergePutIfAbsentMergePolicy();
         } else if (mergePolicyClass == RemoveValuesMergePolicy.class) {
             afterMergeRemoveValuesMergePolicy();
+        } else if (mergePolicyClass == ReturnPiCollectionMergePolicy.class) {
+            afterMergeReturnPiCollectionMergePolicy();
         } else if (mergePolicyClass == MergeCollectionOfIntegerValuesMergePolicy.class) {
             afterMergeCustomMergePolicy();
         } else {
@@ -223,6 +228,24 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
 
         assertSetContent(setB1, 0);
         assertSetContent(setB2, 0);
+    }
+
+    private void afterSplitReturnPiCollectionMergePolicy() {
+        for (int i = 0; i < ITEM_COUNT; i++) {
+            setA1.add("lostItem" + i);
+            setA2.add("lostItem" + i);
+
+            setB2.add("lostItem" + i);
+        }
+    }
+
+    private void afterMergeReturnPiCollectionMergePolicy() {
+        assertPiSet(setA1);
+        assertPiSet(setA2);
+        assertPiSet(backupSet);
+
+        assertPiSet(setB1);
+        assertPiSet(setB2);
     }
 
     private void afterSplitCustomMergePolicy() {


### PR DESCRIPTION
* `RemoveValuesMergePolicy`
  * Always returns `null` as merged value.
  * Used to test the removal of all values from a data structure.
* `ReturnPiMergePolicy`
  * Always returns `Math.PI` as merged value.
  * Used to test that data structures can deal with user created data in `OBJECT` format.
* `ReturnPiCollectionMergePolicy`
  * Always returns a collection of `Math.PI` digits as merged value.
  * Used to test that data structures can deal with user created data in `OBJECT` format.
* `MergeIntegerValuesMergePolicy`
  * Merges only `Integer` values of the given values (preferring the merging value).
  * Used to test the deserialization of values.
* `MergeCollectionOfIntegerValuesMergePolicy`
  * Merges only `Integer` values of the given collections.
  * Used to test the deserialization of values.

The `MergeIntegerValuesMergePolicy` just tests the proper deserialization, it still returns one of the given values. Only the `ReturnPiMergePolicy` and `ReturnPiCollectionMergePolicy` create completely new merge values (and does not rely on correct deserialization of the merging values, so we have an independent test case).