### PR TITLE
[DONT MERGE] Fixed merging of IMap and ICache

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -47,6 +47,7 @@ import com.hazelcast.cache.impl.operation.CacheListenerRegistrationOperation;
 import com.hazelcast.cache.impl.operation.CacheLoadAllOperation;
 import com.hazelcast.cache.impl.operation.CacheLoadAllOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheManagementConfigOperation;
+import com.hazelcast.cache.impl.operation.CacheMergeBackupOperation;
 import com.hazelcast.cache.impl.operation.CacheMergeOperation;
 import com.hazelcast.cache.impl.operation.CacheMergeOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheNearCacheStateHolder;
@@ -157,7 +158,8 @@ public final class CacheDataSerializerHook
 
     public static final int MERGE_FACTORY = 64;
     public static final int MERGE = 65;
-    public static final int ADD_CACHE_CONFIG_OPERATION = 66;
+    public static final int MERGE_BACKUP = 66;
+    public static final int ADD_CACHE_CONFIG_OPERATION = 67;
 
     private static final int LEN = ADD_CACHE_CONFIG_OPERATION + 1;
 
@@ -493,6 +495,13 @@ public final class CacheDataSerializerHook
                     @Override
                     public IdentifiedDataSerializable createNew(Integer arg) {
                         return new CacheMergeOperation();
+                    }
+                };
+        constructors[MERGE_BACKUP] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new CacheMergeBackupOperation();
                     }
                 };
         constructors[ADD_CACHE_CONFIG_OPERATION] =

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
@@ -41,7 +41,7 @@ import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
 import static com.hazelcast.config.MergePolicyConfig.DEFAULT_BATCH_SIZE;
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 
-class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordStore, CacheMergeTypes> {
+class CacheMergeRunnable extends AbstractMergeRunnable<Data, Object, ICacheRecordStore, CacheMergeTypes> {
 
     private final CacheService cacheService;
 
@@ -63,11 +63,12 @@ class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordS
         int partitionId = store.getPartitionId();
 
         for (Map.Entry<Data, CacheRecord> entry : store.getReadOnlyRecords().entrySet()) {
-            Data key = toHeapData(entry.getKey());
             CacheRecord record = entry.getValue();
+
+            Data dataKey = toHeapData(entry.getKey());
             Data dataValue = toHeapData(record.getValue());
 
-            consumer.accept(partitionId, createMergingEntry(getSerializationService(), key, dataValue, record));
+            consumer.accept(partitionId, createMergingEntry(getSerializationService(), dataKey, dataValue, record));
         }
     }
 
@@ -122,7 +123,7 @@ class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordS
 
     @Override
     protected OperationFactory createMergeOperationFactory(String dataStructureName,
-                                                           SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy,
+                                                           SplitBrainMergePolicy<Object, CacheMergeTypes> mergePolicy,
                                                            int[] partitions, List<CacheMergeTypes>[] entries) {
         CacheConfig cacheConfig = cacheService.getCacheConfig(dataStructureName);
         CacheOperationProvider operationProvider

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
@@ -58,11 +58,11 @@ public interface CacheOperationProvider {
     Operation createEntryIteratorOperation(int lastTableIndex, int fetchSize);
 
     Operation createMergeOperation(String name, List<CacheMergeTypes> mergingEntries,
-                                   SplitBrainMergePolicy<Data, CacheMergeTypes> policy);
+                                   SplitBrainMergePolicy<Object, CacheMergeTypes> policy);
 
     OperationFactory createMergeOperationFactory(String name, int[] partitions,
                                                  List<CacheMergeTypes>[] mergingEntries,
-                                                 SplitBrainMergePolicy<Data, CacheMergeTypes> policy);
+                                                 SplitBrainMergePolicy<Object, CacheMergeTypes> policy);
 
     OperationFactory createGetAllOperationFactory(Set<Data> keySet, ExpiryPolicy policy);
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
@@ -122,14 +122,14 @@ public class DefaultOperationProvider implements CacheOperationProvider {
 
     @Override
     public Operation createMergeOperation(String name, List<CacheMergeTypes> mergingEntries,
-                                          SplitBrainMergePolicy<Data, CacheMergeTypes> policy) {
+                                          SplitBrainMergePolicy<Object, CacheMergeTypes> policy) {
         return new CacheMergeOperation(name, mergingEntries, policy);
     }
 
     @Override
     public OperationFactory createMergeOperationFactory(String name, int[] partitions,
                                                         List<CacheMergeTypes>[] mergingEntries,
-                                                        SplitBrainMergePolicy<Data, CacheMergeTypes> policy) {
+                                                        SplitBrainMergePolicy<Object, CacheMergeTypes> policy) {
         return new CacheMergeOperationFactory(name, partitions, mergingEntries, policy);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -494,9 +494,9 @@ public interface ICacheRecordStore {
      *
      * @param mergingEntry the {@link CacheMergeTypes} instance to merge
      * @param mergePolicy  the {@link SplitBrainMergePolicy} instance to apply
-     * @return the used {@link CacheRecord} if merge is applied, otherwise {@code null}
+     * @return {@code true} if the merge is applied, {@code false} otherwise
      */
-    CacheRecord merge(CacheMergeTypes mergingEntry, SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy);
+    boolean merge(CacheMergeTypes mergingEntry, SplitBrainMergePolicy<Object, CacheMergeTypes> mergePolicy);
 
     /**
      * Merges the given {@link CacheEntryView} via the given {@link CacheMergePolicy}.
@@ -507,7 +507,7 @@ public interface ICacheRecordStore {
      * @param completionId   User generated id which shall be received as a field of the cache event upon completion of
      *                       the request in the cluster.
      * @param origin         source of the call
-     * @return the used {@link CacheRecord} if merge is applied, otherwise {@code null}
+     * @return the used {@link CacheRecord} if merge is applied, {@code null} otherwise
      */
     CacheRecord merge(CacheEntryView<Data, Data> cacheEntryView, CacheMergePolicy mergePolicy,
                       String caller, String origin, int completionId);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperationFactory.java
@@ -19,7 +19,6 @@ package com.hazelcast.cache.impl.operation;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
@@ -40,14 +39,14 @@ public class CacheMergeOperationFactory extends PartitionAwareOperationFactory {
 
     private String name;
     private List<CacheMergeTypes>[] mergingEntries;
-    private SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<Object, CacheMergeTypes> mergePolicy;
 
     public CacheMergeOperationFactory() {
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public CacheMergeOperationFactory(String name, int[] partitions, List<CacheMergeTypes>[] mergingEntries,
-                                      SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy) {
+                                      SplitBrainMergePolicy<Object, CacheMergeTypes> mergePolicy) {
         this.name = name;
         this.partitions = partitions;
         this.mergingEntries = mergingEntries;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapDataSerializerHook.java
@@ -79,6 +79,7 @@ import com.hazelcast.map.impl.operation.MapNearCacheStateHolder;
 import com.hazelcast.map.impl.operation.MapReplicationOperation;
 import com.hazelcast.map.impl.operation.MapReplicationStateHolder;
 import com.hazelcast.map.impl.operation.MapSizeOperation;
+import com.hazelcast.map.impl.operation.MergeBackupOperation;
 import com.hazelcast.map.impl.operation.MergeOperation;
 import com.hazelcast.map.impl.operation.MergeOperationFactory;
 import com.hazelcast.map.impl.operation.MultipleEntryBackupOperation;
@@ -308,8 +309,9 @@ public final class MapDataSerializerHook implements DataSerializerHook {
     public static final int EVENT_JOURNAL_READ_RESULT_SET = 145;
     public static final int MERGE_FACTORY = 146;
     public static final int MERGE = 147;
+    public static final int MERGE_BACKUP = 148;
 
-    private static final int LEN = MERGE + 1;
+    private static final int LEN = MERGE_BACKUP + 1;
 
     @Override
     public int getFactoryId() {
@@ -1038,6 +1040,11 @@ public final class MapDataSerializerHook implements DataSerializerHook {
         constructors[MERGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new MergeOperation();
+            }
+        };
+        constructors[MERGE_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new MergeBackupOperation();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMergeRunnable.java
@@ -40,7 +40,7 @@ import java.util.List;
 import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
 
-class MapMergeRunnable extends AbstractMergeRunnable<Data, Data, RecordStore, MapMergeTypes> {
+class MapMergeRunnable extends AbstractMergeRunnable<Data, Object, RecordStore, MapMergeTypes> {
 
     private final MapServiceContext mapServiceContext;
 
@@ -121,7 +121,7 @@ class MapMergeRunnable extends AbstractMergeRunnable<Data, Data, RecordStore, Ma
 
     @Override
     protected OperationFactory createMergeOperationFactory(String dataStructureName,
-                                                           SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy,
+                                                           SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy,
                                                            int[] partitions, List<MapMergeTypes>[] entries) {
         MapOperationProvider operationProvider = mapServiceContext.getMapOperationProvider(dataStructureName);
         return operationProvider.createMergeOperationFactory(dataStructureName, partitions, entries, mergePolicy);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapReplicationSupportingService.java
@@ -86,7 +86,7 @@ class MapReplicationSupportingService implements ReplicationSupportingService {
             MapMergeTypes mergingEntry = createMergingEntry(serializationService, replicationUpdate.getEntryView());
             //noinspection unchecked
             operation = operationProvider.createMergeOperation(mapName, mergingEntry,
-                    (SplitBrainMergePolicy<Data, MapMergeTypes>) mergePolicy, true);
+                    (SplitBrainMergePolicy<Object, MapMergeTypes>) mergePolicy, true);
         } else {
             EntryView<Data, Data> entryView = replicationUpdate.getEntryView();
             operation = operationProvider.createLegacyMergeOperation(mapName, entryView, (MapMergePolicy) mergePolicy, true);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -195,7 +195,7 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
 
     @Override
     public MapOperation createMergeOperation(String name, MapMergeTypes mergingValue,
-                                             SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy,
+                                             SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy,
                                              boolean disableWanReplicationEvent) {
         return new MergeOperation(name, singletonList(mergingValue), mergePolicy, disableWanReplicationEvent);
     }
@@ -255,7 +255,7 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
 
     @Override
     public OperationFactory createMergeOperationFactory(String name, int[] partitions, List<MapMergeTypes>[] mergingEntries,
-                                                        SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy) {
+                                                        SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy) {
         return new MergeOperationFactory(name, partitions, mergingEntries, mergePolicy);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -111,7 +111,8 @@ public interface MapOperationProvider {
                                             boolean disableWanReplicationEvent);
 
     MapOperation createMergeOperation(String name, MapMergeTypes mergingValue,
-                                      SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy, boolean disableWanReplicationEvent);
+                                      SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy,
+                                      boolean disableWanReplicationEvent);
 
     MapOperation createMapFlushOperation(String name);
 
@@ -154,5 +155,5 @@ public interface MapOperationProvider {
     OperationFactory createPutAllOperationFactory(String name, int[] partitions, MapEntries[] mapEntries);
 
     OperationFactory createMergeOperationFactory(String name, int[] partitions, List<MapMergeTypes>[] mergingEntries,
-                                                 SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy);
+                                                 SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -147,7 +147,7 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
 
     @Override
     public OperationFactory createMergeOperationFactory(String name, int[] partitions, List<MapMergeTypes>[] mergingEntries,
-                                                        SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy) {
+                                                        SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy) {
         return getDelegate().createMergeOperationFactory(name, partitions, mergingEntries, mergePolicy);
     }
 
@@ -180,7 +180,7 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
 
     @Override
     public MapOperation createMergeOperation(String name, MapMergeTypes mergingValue,
-                                             SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy,
+                                             SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy,
                                              boolean disableWanReplicationEvent) {
         return getDelegate().createMergeOperation(name, mergingValue, mergePolicy, disableWanReplicationEvent);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeBackupOperation.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.core.EntryView;
+import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.MapEntries;
+import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.record.RecordInfo;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+import com.hazelcast.util.Clock;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.map.impl.EntryViews.createSimpleEntryView;
+import static com.hazelcast.map.impl.record.Records.applyRecordInfo;
+
+/**
+ * Creates backups for merged {@link MapEntries} after split-brain healing with a {@link SplitBrainMergePolicy}.
+ *
+ * @since 3.10
+ */
+public class MergeBackupOperation extends MapOperation implements PartitionAwareOperation, BackupOperation {
+
+    private MapEntries entries;
+    private List<RecordInfo> recordInfos;
+    private boolean hasWanReplication;
+
+    public MergeBackupOperation(String name, MapEntries entries, List<RecordInfo> recordInfos, boolean hasWanReplication) {
+        super(name);
+        this.entries = entries;
+        this.recordInfos = recordInfos;
+        this.hasWanReplication = hasWanReplication;
+    }
+
+    public MergeBackupOperation() {
+    }
+
+    @Override
+    public void run() {
+        for (int i = 0; i < entries.size(); i++) {
+            Data dataKey = entries.getKey(i);
+            Data dataValue = entries.getValue(i);
+            if (dataValue == null) {
+                recordStore.removeBackup(dataKey);
+                if (hasWanReplication) {
+                    mapEventPublisher.publishWanReplicationRemoveBackup(name, dataKey, Clock.currentTimeMillis());
+                }
+            } else if (!recordStore.shouldEvict()) {
+                Record record = recordStore.putBackup(dataKey, dataValue);
+                applyRecordInfo(record, recordInfos.get(i));
+                if (hasWanReplication) {
+                    Data dataValueAsData = mapServiceContext.toData(dataValue);
+                    EntryView entryView = createSimpleEntryView(dataKey, dataValueAsData, record);
+                    mapEventPublisher.publishWanReplicationUpdateBackup(name, entryView);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void afterRun() {
+        evict(null);
+        recordStore.disposeDeferredBlocks();
+    }
+
+    @Override
+    public Object getResponse() {
+        return entries;
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        entries.writeData(out);
+        for (RecordInfo recordInfo : recordInfos) {
+            recordInfo.writeData(out);
+        }
+        out.writeBoolean(hasWanReplication);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        entries = new MapEntries();
+        entries.readData(in);
+        int size = entries.size();
+        recordInfos = new ArrayList<RecordInfo>(size);
+        for (int i = 0; i < size; i++) {
+            RecordInfo recordInfo = new RecordInfo();
+            recordInfo.readData(in);
+            recordInfos.add(recordInfo);
+        }
+        hasWanReplication = in.readBoolean();
+    }
+
+    @Override
+    public int getId() {
+        return MapDataSerializerHook.MERGE_BACKUP;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MergeOperationFactory.java
@@ -19,7 +19,6 @@ package com.hazelcast.map.impl.operation;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
@@ -41,14 +40,14 @@ public class MergeOperationFactory extends PartitionAwareOperationFactory {
 
     protected String name;
     protected List<MapMergeTypes>[] mergingEntries;
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    protected SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy;
 
     public MergeOperationFactory() {
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public MergeOperationFactory(String name, int[] partitions, List<MapMergeTypes>[] mergingEntries,
-                                 SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy) {
+                                 SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy) {
         this.name = name;
         this.partitions = partitions;
         this.mergingEntries = mergingEntries;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
@@ -175,7 +175,7 @@ public class WANAwareOperationProvider extends MapOperationProviderDelegator {
 
     @Override
     public MapOperation createMergeOperation(String name, MapMergeTypes mergingValue,
-                                             SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy,
+                                             SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy,
                                              boolean disableWanReplicationEvent) {
         checkWanReplicationQueues(name);
         return getDelegate().createMergeOperation(name, mergingValue, mergePolicy, disableWanReplicationEvent);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -43,7 +43,6 @@ import java.util.Collection;
 
 import static com.hazelcast.map.impl.ExpirationTimeSetter.setTTLAndUpdateExpiryTime;
 
-
 /**
  * Contains record store common parts.
  */
@@ -150,7 +149,6 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
             indexes.saveEntryIndex(queryableEntry, oldValue);
         }
     }
-
 
     protected void removeIndex(Record record) {
         Indexes indexes = mapContainer.getIndexes(partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -174,7 +174,7 @@ public interface RecordStore<R extends Record> {
      * @param mergePolicy  the {@link SplitBrainMergePolicy} instance to apply
      * @return {@code true} if merge is applied, otherwise {@code false}
      */
-    boolean merge(MapMergeTypes mergingEntry, SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy);
+    boolean merge(MapMergeTypes mergingEntry, SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy);
 
     /**
      * Merges the given {@link EntryView} via the given {@link MapMergePolicy}.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CacheMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/CacheMergingEntryImpl.java
@@ -35,7 +35,7 @@ import java.io.IOException;
 @SuppressWarnings("WeakerAccess")
 public class CacheMergingEntryImpl implements CacheMergeTypes, SerializationServiceAware, IdentifiedDataSerializable {
 
-    private Data value;
+    private Object value;
     private Data key;
     private long creationTime = -1;
     private long expirationTime = -1;
@@ -52,16 +52,16 @@ public class CacheMergingEntryImpl implements CacheMergeTypes, SerializationServ
     }
 
     @Override
-    public Data getValue() {
+    public Object getValue() {
         return value;
     }
 
     @Override
-    public Object getDeserializedValue() {
+    public <DV> DV getDeserializedValue() {
         return serializationService.toObject(value);
     }
 
-    public CacheMergingEntryImpl setValue(Data value) {
+    public CacheMergingEntryImpl setValue(Object value) {
         this.value = value;
         return this;
     }
@@ -72,7 +72,7 @@ public class CacheMergingEntryImpl implements CacheMergeTypes, SerializationServ
     }
 
     @Override
-    public Object getDeserializedKey() {
+    public <DV> DV getDeserializedKey() {
         return serializationService.toObject(key);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
@@ -55,8 +55,8 @@ public class SplitBrainMergeTypes {
      * @since 3.10
      */
     @Beta
-    public interface CacheMergeTypes extends MergingEntry<Data, Data>, MergingCreationTime<Data>, MergingHits<Data>,
-            MergingLastAccessTime<Data>, MergingExpirationTime<Data> {
+    public interface CacheMergeTypes extends MergingEntry<Data, Object>, MergingCreationTime<Object>, MergingHits<Object>,
+            MergingLastAccessTime<Object>, MergingExpirationTime<Object> {
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
@@ -44,9 +44,9 @@ public class SplitBrainMergeTypes {
      * @since 3.10
      */
     @Beta
-    public interface MapMergeTypes extends MergingEntry<Data, Data>, MergingCreationTime<Data>, MergingHits<Data>,
-            MergingLastAccessTime<Data>, MergingLastUpdateTime<Data>, MergingTTL<Data>, MergingCosts<Data>, MergingVersion<Data>,
-            MergingExpirationTime<Data>, MergingLastStoredTime<Data> {
+    public interface MapMergeTypes extends MergingEntry<Data, Object>, MergingCreationTime<Object>, MergingHits<Object>,
+            MergingLastAccessTime<Object>, MergingLastUpdateTime<Object>, MergingTTL<Object>, MergingCosts<Object>,
+            MergingVersion<Object>, MergingExpirationTime<Object>, MergingLastStoredTime<Object> {
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/CustomMapMergePolicy.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/CustomMapMergePolicy.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  *
  * @see SplitBrainMergeTypes
  */
-public class CustomMapMergePolicy<T extends SplitBrainMergeTypes.MapMergeTypes> implements SplitBrainMergePolicy<Data, T> {
+public class CustomMapMergePolicy<T extends SplitBrainMergeTypes.MapMergeTypes> implements SplitBrainMergePolicy<Object, T> {
 
     @Override
     public Data merge(T mergingValue, T existingValue) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/CustomMapMergePolicyNoTypeVariable.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/config/mergepolicies/CustomMapMergePolicyNoTypeVariable.java
@@ -32,7 +32,7 @@ import java.io.IOException;
  *
  * @see SplitBrainMergeTypes
  */
-public class CustomMapMergePolicyNoTypeVariable implements SplitBrainMergePolicy<Data, SplitBrainMergeTypes.MapMergeTypes> {
+public class CustomMapMergePolicyNoTypeVariable implements SplitBrainMergePolicy<Object, SplitBrainMergeTypes.MapMergeTypes> {
 
     @Override
     public Data merge(SplitBrainMergeTypes.MapMergeTypes mergingValue, SplitBrainMergeTypes.MapMergeTypes existingValue) {

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/LegacyMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/LegacyMapSplitBrainTest.java
@@ -67,28 +67,29 @@ import static org.junit.Assert.fail;
 @SuppressWarnings("WeakerAccess")
 public class LegacyMapSplitBrainTest extends SplitBrainTestSupport {
 
-    @Parameters(name = "format:{0}, mergePolicy:{1}")
+    @Parameters(name = "mergePolicy:{0}, format:{1}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {BINARY, IgnoreMergingEntryMapMergePolicy.class},
-                {BINARY, HigherHitsMapMergePolicy.class},
-                {BINARY, LatestUpdateMapMergePolicy.class},
-                {BINARY, PassThroughMergePolicy.class},
-                {BINARY, PutIfAbsentMapMergePolicy.class},
+                {IgnoreMergingEntryMapMergePolicy.class, BINARY},
+                {HigherHitsMapMergePolicy.class, BINARY},
+                {LatestUpdateMapMergePolicy.class, BINARY},
+                {PassThroughMergePolicy.class, BINARY},
+                {PutIfAbsentMapMergePolicy.class, BINARY},
 
-                {BINARY, CustomLegacyMergePolicy.class},
-                {OBJECT, CustomLegacyMergePolicy.class},
+                {CustomLegacyMergePolicy.class, BINARY},
+                {CustomLegacyMergePolicy.class, OBJECT},
         });
     }
 
     @Parameter
-    public InMemoryFormat inMemoryFormat;
+    public Class<? extends MapMergePolicy> mergePolicyClass;
 
     @Parameter(value = 1)
-    public Class<? extends MapMergePolicy> mergePolicyClass;
+    public InMemoryFormat inMemoryFormat;
 
     protected String mapNameA = randomMapName("mapA-");
     protected String mapNameB = randomMapName("mapB-");
+
     private IMap<Object, Object> mapA1;
     private IMap<Object, Object> mapA2;
     private IMap<Object, Object> mapB1;

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/AbstractSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/AbstractSplitBrainMergePolicyTest.java
@@ -34,14 +34,14 @@ public abstract class AbstractSplitBrainMergePolicyTest {
     private static final Data EXISTING = SERIALIZATION_SERVICE.toData("EXISTING");
     private static final Data MERGING = SERIALIZATION_SERVICE.toData("MERGING");
 
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    protected SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy;
 
     @Before
     public void setup() {
         mergePolicy = createMergePolicy();
     }
 
-    protected abstract SplitBrainMergePolicy<Data, MapMergeTypes> createMergePolicy();
+    protected abstract SplitBrainMergePolicy<Object, MapMergeTypes> createMergePolicy();
 
     @Test
     public void merge_mergingWins() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/DiscardMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/DiscardMergePolicyTest.java
@@ -41,11 +41,11 @@ public class DiscardMergePolicyTest {
     private static final Data EXISTING = SERIALIZATION_SERVICE.toData("EXISTING");
     private static final Data MERGING = SERIALIZATION_SERVICE.toData("MERGING");
 
-    private SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy;
 
     @Before
     public void setup() {
-        mergePolicy = new DiscardMergePolicy<Data, MapMergeTypes>();
+        mergePolicy = new DiscardMergePolicy<Object, MapMergeTypes>();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/ExpirationTimeSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/ExpirationTimeSplitBrainMergePolicyTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -29,7 +28,7 @@ import org.junit.runner.RunWith;
 public class ExpirationTimeSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
 
     @Override
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> createMergePolicy() {
-        return new ExpirationTimeMergePolicy<Data, MapMergeTypes>();
+    protected SplitBrainMergePolicy<Object, MapMergeTypes> createMergePolicy() {
+        return new ExpirationTimeMergePolicy<Object, MapMergeTypes>();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/HigherHitsSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/HigherHitsSplitBrainMergePolicyTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -29,7 +28,7 @@ import org.junit.runner.RunWith;
 public class HigherHitsSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
 
     @Override
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> createMergePolicy() {
-        return new HigherHitsMergePolicy<Data, MapMergeTypes>();
+    protected SplitBrainMergePolicy<Object, MapMergeTypes> createMergePolicy() {
+        return new HigherHitsMergePolicy<Object, MapMergeTypes>();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestAccessSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestAccessSplitBrainMergePolicyTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -29,7 +28,7 @@ import org.junit.runner.RunWith;
 public class LatestAccessSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
 
     @Override
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> createMergePolicy() {
-        return new LatestAccessMergePolicy<Data, MapMergeTypes>();
+    protected SplitBrainMergePolicy<Object, MapMergeTypes> createMergePolicy() {
+        return new LatestAccessMergePolicy<Object, MapMergeTypes>();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestUpdateSplitBrainMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/LatestUpdateSplitBrainMergePolicyTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spi.merge;
 
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -29,7 +28,7 @@ import org.junit.runner.RunWith;
 public class LatestUpdateSplitBrainMergePolicyTest extends AbstractSplitBrainMergePolicyTest {
 
     @Override
-    protected SplitBrainMergePolicy<Data, MapMergeTypes> createMergePolicy() {
-        return new LatestUpdateMergePolicy<Data, MapMergeTypes>();
+    protected SplitBrainMergePolicy<Object, MapMergeTypes> createMergePolicy() {
+        return new LatestUpdateMergePolicy<Object, MapMergeTypes>();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/PassThroughMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/PassThroughMergePolicyTest.java
@@ -40,11 +40,11 @@ public class PassThroughMergePolicyTest {
     private static final Data EXISTING = SERIALIZATION_SERVICE.toData("EXISTING");
     private static final Data MERGING = SERIALIZATION_SERVICE.toData("MERGING");
 
-    private SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy;
 
     @Before
     public void setup() {
-        mergePolicy = new PassThroughMergePolicy<Data, MapMergeTypes>();
+        mergePolicy = new PassThroughMergePolicy<Object, MapMergeTypes>();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicyTest.java
@@ -41,11 +41,11 @@ public class PutIfAbsentMergePolicyTest {
     private static final Data EXISTING = SERIALIZATION_SERVICE.toData("EXISTING");
     private static final Data MERGING = SERIALIZATION_SERVICE.toData("MERGING");
 
-    private SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy;
+    private SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy;
 
     @Before
     public void setup() {
-        mergePolicy = new PutIfAbsentMergePolicy<Data, MapMergeTypes>();
+        mergePolicy = new PutIfAbsentMergePolicy<Object, MapMergeTypes>();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/impl/WanReplicationTest.java
@@ -284,8 +284,8 @@ public class WanReplicationTest extends HazelcastTestSupport {
                     !enableWANReplicationEvent);
         } else {
             MapMergeTypes mergingEntry = createMergingEntry(serializationService, entryView);
-            SplitBrainMergePolicy<Data, MapMergeTypes> mergePolicy
-                    = new com.hazelcast.spi.merge.PassThroughMergePolicy<Data, MapMergeTypes>();
+            SplitBrainMergePolicy<Object, MapMergeTypes> mergePolicy
+                    = new com.hazelcast.spi.merge.PassThroughMergePolicy<Object, MapMergeTypes>();
             op = operationProvider.createMergeOperation(mapName, mergingEntry, mergePolicy, !enableWANReplicationEvent);
         }
         operationService.createInvocationBuilder(MapService.SERVICE_NAME, op, partitionService.getPartitionId(data)).invoke();


### PR DESCRIPTION
`IMap` couldn't handle a `null` value from a merge policy properly, even though this is the data structure which started the whole API change regarding this point (the legacy merge policy supports `null` as return value and then removes the entry). Same with `ICache`. Both data structures didn't handle backups and WAN replication correctly in that case.

The added `RemoveValuesMergePolicy` and `ReturnPiMergePolicy` check that the merging of `null` and custom values work properly. The `MergeIntegerValueMergePolicy` also checks, that the lazy deserialization still works.

I had to add new backup operations, since they need to support batched removal or updating of backups, depending on the value.

The return type of the merge policies had to be changed from `Data` to `Object`, so the user can return a custom value easily, without knowing about the in-memory format of the backing data structure. The used record store methods handle the serialization part for us (same like a normal put operation). So there is no manual check and serialization needed. The NATIVE in-memory format is also handled transparently by the record stores.

Part of https://github.com/hazelcast/hazelcast/issues/12804
Part of https://github.com/hazelcast/hazelcast/issues/12805

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/2055