### PR TITLE
IMap/ICache: Skip replicating records when eviction is required

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -109,6 +109,12 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
 
             Iterator<Map.Entry<Data, CacheRecord>> iterator = map.entrySet().iterator();
             while (iterator.hasNext()) {
+                if (cache.evictIfRequired()) {
+                    // No need to continue replicating records anymore.
+                    // We are already over eviction threshold, each put record will cause another eviction.
+                    break;
+                }
+
                 Map.Entry<Data, CacheRecord> next = iterator.next();
                 Data key = next.getKey();
                 CacheRecord record = next.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -200,7 +200,12 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
                         }
                     }
 
-                    recordStore.evictEntries(key);
+                    if (recordStore.shouldEvict()) {
+                        // No need to continue replicating records anymore.
+                        // We are already over eviction threshold, each put record will cause another eviction.
+                        recordStore.evictEntries(key);
+                        break;
+                    }
                     recordStore.disposeDeferredBlocks();
                 }
             }


### PR DESCRIPTION
Normally, we trigger eviction (if needed) after inserting a record. This adds
a small latency (a few ms) to the invocation.

But during migration, many records are inserted (thousands, tens of thousands etc).
If system is close to the eviction threshold and we trigger eviction on each insertion,
this adds a significant latency (a few ms * ten thousand = many seconds) to the migration operation.

Instead of inserting one record and evicting another, we can skip inserting new records
when eviction threshold is reached.

Fixes https://github.com/hazelcast/hazelcast/issues/11615

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2053