### PR TITLE
[BACKPORT] Fix proxy management on the client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/HazelcastClientInstanceImpl.java
@@ -643,7 +643,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
             }
 
             for (DistributedObjectInfo distributedObjectInfo : localDistributedObjects) {
-                proxyManager.removeProxy(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName());
+                proxyManager.destroyProxyLocally(distributedObjectInfo.getServiceName(), distributedObjectInfo.getName());
             }
             return (Collection<DistributedObject>) proxyManager.getDistributedObjects();
         } catch (Exception e) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
@@ -157,6 +157,26 @@ public abstract class ClientProxy implements DistributedObject {
     }
 
     /**
+     * Destroys this client proxy instance locally without issuing distributed
+     * object destroy request to the cluster as the {@link #destroy} method
+     * does.
+     * <p>
+     * The local destruction operation still may perform some communication
+     * with the cluster; for example, to unregister remote event subscriptions.
+     */
+    public final void destroyLocally() {
+        if (preDestroy()) {
+            try {
+                onDestroy();
+            } catch (Exception e) {
+                throw rethrow(e);
+            } finally {
+                postDestroy();
+            }
+        }
+    }
+
+    /**
      * Called when proxy is created.
      * Overriding implementations can add initialization specific logic into this method
      * like registering a listener, creating a cleanup task etc.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -316,6 +316,25 @@ public final class ProxyManager {
         }
     }
 
+    /**
+     * Locally destroys the proxy identified by the given service and object ID.
+     * <p>
+     * Upon successful completion the proxy is unregistered in this proxy
+     * manager and all local resources associated with the proxy are released.
+     * See {@link ClientProxy#destroyLocally} for more details.
+     *
+     * @param service the service associated with the proxy.
+     * @param id      the ID of the object.
+     */
+    public void destroyProxyLocally(String service, String id) {
+        ObjectNamespace objectNamespace = new DistributedObjectNamespace(service, id);
+        ClientProxyFuture clientProxyFuture = proxies.remove(objectNamespace);
+        if (clientProxyFuture != null) {
+            ClientProxy clientProxy = clientProxyFuture.get();
+            clientProxy.destroyLocally();
+        }
+    }
+
     private ClientProxy createClientProxy(String id, ClientProxyFactory factory) {
         if (factory instanceof ClientProxyFactoryWithContext) {
             return ((ClientProxyFactoryWithContext) factory).create(id, context);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -317,14 +317,52 @@ public final class ProxyManager {
     }
 
     /**
+     * Destroys the given proxy in a cluster-wide way.
+     * <p>
+     * Upon successful completion the proxy is unregistered in this proxy
+     * manager, all local resources associated with the proxy are released and
+     * a distributed object destruction operation is issued to the cluster.
+     * <p>
+     * If the given proxy instance is not registered in this proxy manager, the
+     * proxy instance is considered stale. In this case, this stale instance is
+     * a subject to a local-only destruction and its registered counterpart, if
+     * there is any, is a subject to a cluster-wide destruction.
+     *
+     * @param proxy the proxy to destroy.
+     */
+    public void destroyProxy(ClientProxy proxy) {
+        ObjectNamespace objectNamespace = new DistributedObjectNamespace(proxy.getServiceName(),
+                proxy.getDistributedObjectName());
+        ClientProxyFuture registeredProxyFuture = proxies.remove(objectNamespace);
+        ClientProxy registeredProxy = registeredProxyFuture == null ? null : registeredProxyFuture.get();
+
+        try {
+            if (registeredProxy != null) {
+                try {
+                    registeredProxy.destroyLocally();
+                } finally {
+                    registeredProxy.destroyRemotely();
+                }
+            }
+        } finally {
+            if (proxy != registeredProxy) {
+                // The given proxy is stale and was already destroyed, but the caller
+                // may have allocated local resources in the context of this stale proxy
+                // instance after it was destroyed, so we have to cleanup it locally one
+                // more time to make sure there are no leaking local resources.
+                proxy.destroyLocally();
+            }
+        }
+    }
+
+    /**
      * Locally destroys the proxy identified by the given service and object ID.
      * <p>
      * Upon successful completion the proxy is unregistered in this proxy
      * manager and all local resources associated with the proxy are released.
-     * See {@link ClientProxy#destroyLocally} for more details.
      *
      * @param service the service associated with the proxy.
-     * @param id      the ID of the object.
+     * @param id      the ID of the object to destroy the proxy of.
      */
     public void destroyProxyLocally(String service, String id) {
         ObjectNamespace objectNamespace = new DistributedObjectNamespace(service, id);
@@ -341,11 +379,6 @@ public final class ProxyManager {
         }
         return factory.create(id)
                 .setContext(context);
-    }
-
-    public void removeProxy(String service, String id) {
-        final ObjectNamespace ns = new DistributedObjectNamespace(service, id);
-        proxies.remove(ns);
     }
 
     private void initializeWithRetry(ClientProxy clientProxy) throws Exception {


### PR DESCRIPTION
A combo of the two cherry-picks from the fresh master:

> Fix a race condition while destroying proxies
> 
> Before this change there was a race condition while destroying proxies
> in a cluster-wide way. Multiple threads were performing destruction of
> the same proxy instance simultaneously and sometimes none of them
> were able to succeed at the local resources cleanup.
> 
> The idea of the fix is to unify the proxy destruction logic in
> ProxyManager to make sure the cluster-wide destruction for a certain
> proxy instance is done only once.
> 
> Fixes: https://github.com/hazelcast/hazelcast/issues/12679

and

> Fix resource leakage in getDistributedObjects
> 
> getDistributedObjects syncs the contents of the local and remote
> distributed object registries on each invocation. That involves the
> removal of the stale local proxies from the local registry, but the
> local resources associated with the proxies were not cleaned up
> properly.
> 
> Fixes: https://github.com/hazelcast/hazelcast/issues/12679
> Related: https://github.com/hazelcast/hazelcast/issues/9423