### PR TITLE
test fix possibleMemberAddressesAfterDisconnection

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/ConnectMemberListOrderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/ConnectMemberListOrderTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
@@ -67,17 +68,17 @@ public class ConnectMemberListOrderTest extends ClientTestSupport {
         HazelcastInstance instance = factory.newHazelcastInstance();
         ClientConfig config = new ClientConfig();
         config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), shuffleMemberList);
-        HazelcastInstance client = factory.newHazelcastClient(config);
-
-        final CountDownLatch connectedBack = new CountDownLatch(1);
-        client.getLifecycleService().addLifecycleListener(new LifecycleListener() {
+        final CountDownLatch connectedBack = new CountDownLatch(2);
+        config.addListenerConfig(new ListenerConfig(new LifecycleListener() {
             @Override
             public void stateChanged(LifecycleEvent event) {
                 if (LifecycleEvent.LifecycleState.CLIENT_CONNECTED.equals(event.getState())) {
                     connectedBack.countDown();
                 }
             }
-        });
+        }));
+
+        HazelcastInstance client = factory.newHazelcastClient(config);
 
         factory.newHazelcastInstance();
         factory.newHazelcastInstance();


### PR DESCRIPTION
Connected back latch was opening in first CLIENT_CONNECTED event
to cluster rather than second one after disconnection. And that
was causing test to fail. Fix makes sure latch opens in second
event.

fixes https://github.com/hazelcast/hazelcast/issues/12841