### PR TITLE
Cache config propagation fixes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheGetConfigOperation.java
@@ -16,24 +16,31 @@
 
 package com.hazelcast.cache.impl.operation;
 
+import com.hazelcast.cache.impl.AbstractCacheService;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.cache.impl.PreJoinCacheConfig;
 import com.hazelcast.config.CacheConfig;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ReadonlyOperation;
+import com.hazelcast.spi.impl.AbstractNamedOperation;
 
 import java.io.IOException;
 
 /**
- * Cache GetConfig Operation.
- * <p>Gets the already created cache configuration from the related partition.</p>
+ * Gets a cache configuration or creates one, if a matching cache config is found in this member's config.
+ *
  * @see CacheCreateConfigOperation
+ * @see AddCacheConfigOperation
  */
-public class CacheGetConfigOperation
-        extends PartitionWideCacheOperation
-        implements ReadonlyOperation {
+public class CacheGetConfigOperation extends AbstractNamedOperation implements IdentifiedDataSerializable, ReadonlyOperation {
 
+    private transient volatile Object response;
+    private transient ICompletableFuture createOnAllMembersFuture;
     private String simpleName;
 
     public CacheGetConfigOperation() {
@@ -47,7 +54,7 @@ public class CacheGetConfigOperation
     @Override
     public void run()
             throws Exception {
-        final ICacheService service = getService();
+        AbstractCacheService service = getService();
         CacheConfig cacheConfig = service.getCacheConfig(name);
         if (cacheConfig == null) {
             cacheConfig = service.findCacheConfig(simpleName);
@@ -56,10 +63,27 @@ public class CacheGetConfigOperation
                 CacheConfig existingCacheConfig = service.putCacheConfigIfAbsent(cacheConfig);
                 if (existingCacheConfig != null) {
                     cacheConfig = existingCacheConfig;
+                } else {
+                    // a new cache config was added on the local member, all members should become aware of it
+                    createOnAllMembersFuture = service.createCacheConfigOnAllMembersAsync(PreJoinCacheConfig.of(cacheConfig));
                 }
             }
         }
         response = cacheConfig;
+        if (createOnAllMembersFuture != null) {
+            createOnAllMembersFuture.andThen(new ExecutionCallback() {
+
+                @Override
+                public void onResponse(Object asyncResponse) {
+                    CacheGetConfigOperation.this.sendResponse(response);
+                }
+
+                @Override
+                public void onFailure(Throwable t) {
+                    CacheGetConfigOperation.this.sendResponse(t);
+                }
+            });
+        }
     }
 
     @Override
@@ -77,7 +101,27 @@ public class CacheGetConfigOperation
     }
 
     @Override
+    public boolean returnsResponse() {
+        return createOnAllMembersFuture == null;
+    }
+
+    @Override
     public int getId() {
         return CacheDataSerializerHook.GET_CONFIG;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public String getServiceName() {
+        return ICacheService.SERVICE_NAME;
+    }
+
+    @Override
+    public Object getResponse() {
+        return response;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PartitionWideCacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/PartitionWideCacheOperation.java
@@ -28,7 +28,6 @@ import com.hazelcast.spi.impl.AbstractNamedOperation;
  * @see com.hazelcast.cache.impl.operation.CacheSizeOperation
  * @see com.hazelcast.cache.impl.operation.CacheGetAllOperation
  * @see com.hazelcast.cache.impl.operation.CacheClearOperation
- * @see com.hazelcast.cache.impl.operation.CacheGetConfigOperation
  */
 abstract class PartitionWideCacheOperation
         extends AbstractNamedOperation

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheMessageTask.java
@@ -24,12 +24,8 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.task.AbstractPartitionMessageTask;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.LegacyCacheConfig;
-import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
-import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.properties.GroupProperty;
 
 import java.security.Permission;
 
@@ -72,20 +68,5 @@ public abstract class AbstractCacheMessageTask<P>
     @Override
     public Permission getRequiredPermission() {
         return null;
-    }
-
-    protected Data serializeCacheConfig(Object response) {
-        Data responseData = null;
-        if (BuildInfo.UNKNOWN_HAZELCAST_VERSION == getClientVersion()) {
-            boolean compatibilityEnabled = nodeEngine.getProperties().getBoolean(GroupProperty.COMPATIBILITY_3_6_CLIENT_ENABLED);
-            if (compatibilityEnabled) {
-                responseData = nodeEngine.toData(response == null ? null : new LegacyCacheConfig((CacheConfig) response));
-            }
-        }
-
-        if (null == responseData) {
-            responseData = nodeEngine.toData(response);
-        }
-        return responseData;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheGetConfigMessageTask.java
@@ -19,25 +19,61 @@ package com.hazelcast.client.impl.protocol.task.cache;
 import com.hazelcast.cache.impl.operation.CacheGetConfigOperation;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheGetConfigCodec;
+import com.hazelcast.client.impl.protocol.task.AbstractAddressMessageTask;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.LegacyCacheConfig;
+import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.properties.GroupProperty;
+
+import java.security.Permission;
+
+import static com.hazelcast.cache.impl.ICacheService.SERVICE_NAME;
 
 /**
- * This client request  specifically calls {@link CacheGetConfigOperation} on the server side.
+ * This client request specifically calls {@link CacheGetConfigOperation} on the server side.
  *
  * @see CacheGetConfigOperation
  */
 public class CacheGetConfigMessageTask
-        extends AbstractCacheMessageTask<CacheGetConfigCodec.RequestParameters> {
+        extends AbstractAddressMessageTask<CacheGetConfigCodec.RequestParameters> {
+
     public CacheGetConfigMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 
     @Override
+    protected Address getAddress() {
+        return nodeEngine.getThisAddress();
+    }
+
+    @Override
     protected Operation prepareOperation() {
         return new CacheGetConfigOperation(parameters.name, parameters.simpleName);
+    }
+
+    @Override
+    public String getServiceName() {
+        return SERVICE_NAME;
+    }
+
+    @Override
+    public String getMethodName() {
+        return null;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return null;
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return null;
     }
 
     @Override
@@ -55,5 +91,20 @@ public class CacheGetConfigMessageTask
     @Override
     public String getDistributedObjectName() {
         return parameters.name;
+    }
+
+    private Data serializeCacheConfig(Object response) {
+        Data responseData = null;
+        if (BuildInfo.UNKNOWN_HAZELCAST_VERSION == getClientVersion()) {
+            boolean compatibilityEnabled = nodeEngine.getProperties().getBoolean(GroupProperty.COMPATIBILITY_3_6_CLIENT_ENABLED);
+            if (compatibilityEnabled) {
+                responseData = nodeEngine.toData(response == null ? null : new LegacyCacheConfig((CacheConfig) response));
+            }
+        }
+
+        if (null == responseData) {
+            responseData = nodeEngine.toData(response);
+        }
+        return responseData;
     }
 }


### PR DESCRIPTION
- `CacheGetConfigOperation` shouldn't implement
`PartitionWideCacheOperation` as it is not used as a partition-wide
invocation. Instead, it can be executed on generic operation threads,
as all other cache config related operations.
- In case `CacheGetConfigOperation` results in registering a new
`CacheConfig` with the local `CacheService`, all members of the cluster
should become aware of that config. This is required to guarantee that
the `CacheConfig` will be available on all members of the cluster
immediately after a `Cache` has been created. This is implemented
asynchronously so the operation thread doesn't block until all members
have responded.
- `CacheGetConfigMessageTask` is no longer executed on a particular
partition
- `CacheCreateConfigMessageTask` now also propagates the cache config
to all members of the cluster asynchronously, while it was previously
blocking the thread it was executing on.

Fixes #12806 
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2054

Kudos @mdogan for identifying the root cause