### PR TITLE
Added @Beta annotation to split-brain SPI interfaces and classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/DiscardMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/DiscardMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
@@ -26,6 +27,7 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
+@Beta
 public class DiscardMergePolicy<V, T extends MergingValue<V>> extends AbstractSplitBrainMergePolicy<V, T> {
 
     public DiscardMergePolicy() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/ExpirationTimeMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/ExpirationTimeMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
@@ -29,6 +30,7 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
+@Beta
 public class ExpirationTimeMergePolicy<V, T extends MergingExpirationTime<V>>
         extends AbstractSplitBrainMergePolicy<V, T> {
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/HigherHitsMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/HigherHitsMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
@@ -27,6 +28,7 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
+@Beta
 public class HigherHitsMergePolicy<V, T extends MergingHits<V>> extends AbstractSplitBrainMergePolicy<V, T> {
 
     public HigherHitsMergePolicy() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/HyperLogLogMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/HyperLogLogMergePolicy.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.merge;
 
 import com.hazelcast.cardinality.impl.hyperloglog.HyperLogLog;
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.CardinalityEstimatorMergeTypes;
 
@@ -30,6 +31,7 @@ import static com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook.HYPER_LO
  *
  * @since 3.10
  */
+@Beta
 public class HyperLogLogMergePolicy extends AbstractSplitBrainMergePolicy<HyperLogLog, CardinalityEstimatorMergeTypes> {
 
     public HyperLogLogMergePolicy() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestAccessMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestAccessMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
@@ -29,6 +30,7 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
+@Beta
 public class LatestAccessMergePolicy<V, T extends MergingLastAccessTime<V>>
         extends AbstractSplitBrainMergePolicy<V, T> {
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestUpdateMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/LatestUpdateMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
@@ -29,6 +30,7 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
+@Beta
 public class LatestUpdateMergePolicy<V, T extends MergingLastUpdateTime<V>>
         extends AbstractSplitBrainMergePolicy<V, T> {
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingCosts.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingCosts.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view of memory costs for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingCosts<V> extends MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingCreationTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingCreationTime.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view a creation time for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingCreationTime<V> extends MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingEntry.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view of a data structure key/value-pair for the merging process after a split-brain.
  *
@@ -23,6 +25,7 @@ package com.hazelcast.spi.merge;
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingEntry<K, V> extends MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingExpirationTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingExpirationTime.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view of an expiration time for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingExpirationTime<V> extends MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingHits.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingHits.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view access hits for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingHits<V> extends MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastAccessTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastAccessTime.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view of a last access time for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingLastAccessTime<V> extends MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastStoredTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastStoredTime.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view of a last stored time for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingLastStoredTime<V> extends MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastUpdateTime.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingLastUpdateTime.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view of a last update time for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingLastUpdateTime<V> extends MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingTTL.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingTTL.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view of a TTL for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingTTL<V> extends MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingValue.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view of a data structure value for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingVersion.java
@@ -16,12 +16,15 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Represents a read-only view of a version for the merging process after a split-brain.
  *
  * @param <V> the type of the value
  * @since 3.10
  */
+@Beta
 public interface MergingVersion<V> extends MergingValue<V> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/PassThroughMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/PassThroughMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
@@ -26,6 +27,7 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
+@Beta
 public class PassThroughMergePolicy<V, T extends MergingValue<V>> extends AbstractSplitBrainMergePolicy<V, T> {
 
     public PassThroughMergePolicy() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/PutIfAbsentMergePolicy.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.impl.merge.AbstractSplitBrainMergePolicy;
 import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
 
@@ -26,6 +27,7 @@ import com.hazelcast.spi.impl.merge.SplitBrainDataSerializerHook;
  * @param <T> the type of the merging value
  * @since 3.10
  */
+@Beta
 public class PutIfAbsentMergePolicy<V, T extends MergingValue<V>> extends AbstractSplitBrainMergePolicy<V, T> {
 
     public PutIfAbsentMergePolicy() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/RingbufferMergeData.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/RingbufferMergeData.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.merge;
 
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.ringbuffer.impl.Ringbuffer;
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.spi.impl.merge.RingbufferMergingValueImpl;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -30,6 +31,7 @@ import java.util.Iterator;
  * @see RingbufferMergingValueImpl
  * @since 3.10
  */
+@Beta
 public class RingbufferMergeData implements Iterable<Object> {
 
     private Object[] items;

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/RingbufferMergeDataReadOnlyIterator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/RingbufferMergeDataReadOnlyIterator.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 import java.util.Iterator;
 
 /**
@@ -24,6 +26,7 @@ import java.util.Iterator;
  * @param <E> ringbuffer item types
  * @since 3.10
  */
+@Beta
 public class RingbufferMergeDataReadOnlyIterator<E> implements Iterator<E> {
 
     private final RingbufferMergeData ringbuffer;

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicy.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.spi.NodeAware;
+import com.hazelcast.spi.annotation.Beta;
 
 /**
  * Policy for merging data structure values after a split-brain has been healed.
@@ -50,6 +51,7 @@ import com.hazelcast.spi.NodeAware;
  *            or a composition like {@code MergingEntry<String, V> & MergingHits<V> & MergingLastAccessTime<V>}
  * @since 3.10
  */
+@Beta
 public interface SplitBrainMergePolicy<V, T extends MergingValue<V>> extends DataSerializable {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergePolicyProvider.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.merge;
 
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.annotation.Beta;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.HashMap;
@@ -35,6 +36,7 @@ import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
  *
  * @since 3.10
  */
+@Beta
 public final class SplitBrainMergePolicyProvider {
 
     private static final Map<String, SplitBrainMergePolicy> OUT_OF_THE_BOX_MERGE_POLICIES;

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypeProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypeProvider.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.spi.merge;
 
+import com.hazelcast.spi.annotation.Beta;
+
 /**
  * Returns a class with the provided merge value types.
  * <p>
@@ -29,6 +31,7 @@ package com.hazelcast.spi.merge;
  *            or a composition like {@code MergingEntry & MergingHits & MergingLastAccessTime}
  * @since 3.10
  */
+@Beta
 public interface SplitBrainMergeTypeProvider<T extends MergingValue> {
 
     Class<T> getProvidedMergeTypes();

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
@@ -19,6 +19,7 @@ package com.hazelcast.spi.merge;
 import com.hazelcast.cardinality.impl.hyperloglog.HyperLogLog;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.scheduledexecutor.impl.ScheduledTaskDescriptor;
+import com.hazelcast.spi.annotation.Beta;
 
 import java.util.Collection;
 
@@ -34,6 +35,7 @@ import java.util.Collection;
  *
  * @since 3.10
  */
+@Beta
 public class SplitBrainMergeTypes {
 
     /**
@@ -41,6 +43,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface MapMergeTypes extends MergingEntry<Data, Data>, MergingCreationTime<Data>, MergingHits<Data>,
             MergingLastAccessTime<Data>, MergingLastUpdateTime<Data>, MergingTTL<Data>, MergingCosts<Data>, MergingVersion<Data>,
             MergingExpirationTime<Data>, MergingLastStoredTime<Data> {
@@ -51,6 +54,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface CacheMergeTypes extends MergingEntry<Data, Data>, MergingCreationTime<Data>, MergingHits<Data>,
             MergingLastAccessTime<Data>, MergingExpirationTime<Data> {
     }
@@ -60,6 +64,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface ReplicatedMapMergeTypes extends MergingEntry<Object, Object>, MergingCreationTime<Object>,
             MergingHits<Object>, MergingLastAccessTime<Object>, MergingLastUpdateTime<Object>, MergingTTL<Object> {
     }
@@ -69,6 +74,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface MultiMapMergeTypes extends MergingEntry<Data, Collection<Object>>, MergingCreationTime<Collection<Object>>,
             MergingHits<Collection<Object>>, MergingLastAccessTime<Collection<Object>>,
             MergingLastUpdateTime<Collection<Object>> {
@@ -79,6 +85,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface CollectionMergeTypes extends MergingValue<Collection<Object>> {
     }
 
@@ -87,6 +94,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface QueueMergeTypes extends MergingValue<Collection<Object>> {
     }
 
@@ -95,6 +103,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface RingbufferMergeTypes extends MergingValue<RingbufferMergeData> {
     }
 
@@ -103,6 +112,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface AtomicLongMergeTypes extends MergingValue<Long> {
     }
 
@@ -111,6 +121,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface AtomicReferenceMergeTypes extends MergingValue<Data> {
     }
 
@@ -119,6 +130,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface ScheduledExecutorMergeTypes extends MergingEntry<String, ScheduledTaskDescriptor> {
     }
 
@@ -127,6 +139,7 @@ public class SplitBrainMergeTypes {
      *
      * @since 3.10
      */
+    @Beta
     public interface CardinalityEstimatorMergeTypes extends MergingEntry<String, HyperLogLog> {
     }
 }


### PR DESCRIPTION
As discussed, the split-brain SPI is released with `@Beta` annotations.

I've added the annotation to every class in `com.hazelcast.spi.merge` (also the sub interfaces in `SplitBrainMergeTypes`, since they are used individually).

Classes in `com.hazelcast.spi.impl.merge` are already private, no need to add the annotation there.