### PR TITLE
Added missing @RunWith and @Category annotations to tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheConfigPropagationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/impl/ClientCacheConfigPropagationTest.java
@@ -19,11 +19,18 @@ package com.hazelcast.client.cache.impl;
 import com.hazelcast.cache.impl.CacheConfigPropagationTest;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import javax.cache.CacheManager;
 
 import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ClientCacheConfigPropagationTest extends CacheConfigPropagationTest {
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientDynamicConfigRollingUpgradeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/impl/ClientDynamicConfigRollingUpgradeTest.java
@@ -19,11 +19,19 @@ package com.hazelcast.client.impl;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.dynamicconfig.DynamicConfigRollingUpgradeTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SerializationSamplesExcluded;
 import com.hazelcast.version.Version;
 import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class, SerializationSamplesExcluded.class})
 public class ClientDynamicConfigRollingUpgradeTest extends DynamicConfigRollingUpgradeTest {
 
     private TestHazelcastFactory factory;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/pncounter/ClientPNCounterBasicIntegrationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/pncounter/ClientPNCounterBasicIntegrationTest.java
@@ -5,7 +5,7 @@ import com.hazelcast.config.CRDTReplicationConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.PNCounterConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.crdt.pncounter.BasePNCounterBasicIntegrationTest;
+import com.hazelcast.crdt.pncounter.AbstractPNCounterBasicIntegrationTest;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -30,7 +30,7 @@ import static java.util.Arrays.asList;
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientPNCounterBasicIntegrationTest extends BasePNCounterBasicIntegrationTest {
+public class ClientPNCounterBasicIntegrationTest extends AbstractPNCounterBasicIntegrationTest {
 
     @Parameters(name = "replicaCount:{0}")
     public static Collection<Object[]> parameters() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/pncounter/ClientPNCounterConsistencyLostTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/pncounter/ClientPNCounterConsistencyLostTest.java
@@ -6,7 +6,7 @@ import com.hazelcast.config.CRDTReplicationConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ConsistencyLostException;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.crdt.pncounter.BasePNCounterConsistencyLostTest;
+import com.hazelcast.crdt.pncounter.AbstractPNCounterConsistencyLostTest;
 import com.hazelcast.crdt.pncounter.PNCounter;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.properties.GroupProperty;
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientPNCounterConsistencyLostTest extends BasePNCounterConsistencyLostTest {
+public class ClientPNCounterConsistencyLostTest extends AbstractPNCounterConsistencyLostTest {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/pncounter/ClientPNCounterNoDataMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/pncounter/ClientPNCounterNoDataMemberTest.java
@@ -4,7 +4,7 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.ConsistencyLostException;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.crdt.pncounter.BasePNCounterNoDataMemberTest;
+import com.hazelcast.crdt.pncounter.AbstractPNCounterNoDataMemberTest;
 import com.hazelcast.crdt.pncounter.PNCounter;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ClientPNCounterNoDataMemberTest extends BasePNCounterNoDataMemberTest {
+public class ClientPNCounterNoDataMemberTest extends AbstractPNCounterNoDataMemberTest {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
 

--- a/hazelcast/src/test/java/com/hazelcast/config/GlobalSerializerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/GlobalSerializerConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class GlobalSerializerConfigTest {
 
     @Test
@@ -32,5 +39,4 @@ public class GlobalSerializerConfigTest {
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/HotRestartPersistenceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/HotRestartPersistenceConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class HotRestartPersistenceConfigTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/IcmpFailureDetectorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/IcmpFailureDetectorConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class IcmpFailureDetectorConfigTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/InterfacesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/InterfacesConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class InterfacesConfigTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/MemberGroupConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MemberGroupConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MemberGroupConfigTest {
 
     @Test
@@ -32,5 +39,4 @@ public class MemberGroupConfigTest {
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
                 .verify();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/MergePolicyConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MergePolicyConfigTest.java
@@ -23,15 +23,22 @@ import com.hazelcast.spi.merge.HigherHitsMergePolicy;
 import com.hazelcast.spi.merge.PassThroughMergePolicy;
 import com.hazelcast.spi.merge.PutIfAbsentMergePolicy;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MergePolicyConfigTest {
 
     private MergePolicyConfig config = new MergePolicyConfig();

--- a/hazelcast/src/test/java/com/hazelcast/config/MergePolicyReadOnlyConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MergePolicyReadOnlyConfigTest.java
@@ -17,8 +17,15 @@
 package com.hazelcast.config;
 
 import com.hazelcast.spi.merge.DiscardMergePolicy;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MergePolicyReadOnlyConfigTest {
 
     private MergePolicyConfig getReadOnlyConfig() {

--- a/hazelcast/src/test/java/com/hazelcast/config/MulticastConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MulticastConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MulticastConfigTest {
 
     @Test
@@ -32,5 +39,4 @@ public class MulticastConfigTest {
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
                 .verify();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/NativeMemoryConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/NativeMemoryConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class NativeMemoryConfigTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/PartitionGroupConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/PartitionGroupConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class PartitionGroupConfigTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/SerializerConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SerializerConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class SerializerConfigTest {
 
     @Test
@@ -32,5 +39,4 @@ public class SerializerConfigTest {
                 .suppress(Warning.NONFINAL_FIELDS)
                 .verify();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ServicesConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ServicesConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ServicesConfigTest {
     @Test
     public void testEqualsAndHashCode() {
@@ -31,5 +38,4 @@ public class ServicesConfigTest {
                 .suppress(Warning.NONFINAL_FIELDS, Warning.NULL_FIELDS)
                 .verify();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/SocketInterceptorConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/SocketInterceptorConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class SocketInterceptorConfigTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/TcpIpConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/TcpIpConfigTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class TcpIpConfigTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/crdt/AbstractCRDTPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/crdt/AbstractCRDTPropertyTest.java
@@ -27,7 +27,8 @@ import java.util.Random;
 
 import static org.junit.Assert.assertArrayEquals;
 
-public abstract class BaseCRDTPropertyTest<C extends CRDT<C>, H, S> {
+public abstract class AbstractCRDTPropertyTest<C extends CRDT<C>, H, S> {
+
     private final Random random = new Random();
     private int numCounters;
 

--- a/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/AbstractPNCounterBasicIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/AbstractPNCounterBasicIntegrationTest.java
@@ -34,7 +34,7 @@ import static org.junit.Assert.assertEquals;
  * Concrete implementations must provide the two {@link HazelcastInstance}s
  * which will be used to perform the tests.
  */
-public abstract class BasePNCounterBasicIntegrationTest extends HazelcastTestSupport {
+public abstract class AbstractPNCounterBasicIntegrationTest extends HazelcastTestSupport {
 
     @Test
     public void testSimpleReplication() {

--- a/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/AbstractPNCounterConsistencyLostTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/AbstractPNCounterConsistencyLostTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 /**
  * Base test for testing behaviour of {@link ConsistencyLostException} in the case of CRDTs.
  */
-public abstract class BasePNCounterConsistencyLostTest extends HazelcastTestSupport {
+public abstract class AbstractPNCounterConsistencyLostTest extends HazelcastTestSupport {
 
     @Test(expected = ConsistencyLostException.class)
     public void consistencyLostExceptionIsThrownWhenTargetReplicaDisappears() {

--- a/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/AbstractPNCounterNoDataMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/AbstractPNCounterNoDataMemberTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 /**
  * Base test for testing behaviour of PN counter behaviour when there are no data members in the cluster
  */
-public abstract class BasePNCounterNoDataMemberTest extends HazelcastTestSupport {
+public abstract class AbstractPNCounterNoDataMemberTest extends HazelcastTestSupport {
 
     @Test(expected = NoDataMemberInClusterException.class)
     public void noDataMemberExceptionIsThrown() {

--- a/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/PNCounterBasicIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/PNCounterBasicIntegrationTest.java
@@ -44,7 +44,7 @@ import static java.util.Arrays.asList;
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class PNCounterBasicIntegrationTest extends BasePNCounterBasicIntegrationTest {
+public class PNCounterBasicIntegrationTest extends AbstractPNCounterBasicIntegrationTest {
 
     private HazelcastInstance[] instances;
 

--- a/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/PNCounterConsistencyLostTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/PNCounterConsistencyLostTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class PNCounterConsistencyLostTest extends BasePNCounterConsistencyLostTest {
+public class PNCounterConsistencyLostTest extends AbstractPNCounterConsistencyLostTest {
 
     private HazelcastInstance[] members;
     private HazelcastInstance liteMember;

--- a/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/PNCounterImplPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/PNCounterImplPropertyTest.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.crdt.pncounter;
 
-import com.hazelcast.crdt.BaseCRDTPropertyTest;
+import com.hazelcast.crdt.AbstractCRDTPropertyTest;
 import com.hazelcast.crdt.Operation;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -31,7 +31,7 @@ import java.util.Random;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class PNCounterImplPropertyTest extends BaseCRDTPropertyTest<PNCounterImpl, MutableLong, Long> {
+public class PNCounterImplPropertyTest extends AbstractCRDTPropertyTest<PNCounterImpl, MutableLong, Long> {
 
     @Override
     protected MutableLong getStateHolder() {

--- a/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/PNCounterNoDataMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/PNCounterNoDataMemberTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class PNCounterNoDataMemberTest extends BasePNCounterNoDataMemberTest {
+public class PNCounterNoDataMemberTest extends AbstractPNCounterNoDataMemberTest {
 
     private HazelcastInstance liteMember;
     private String counterName = randomMapName("counter-");

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigVersionTest.java
@@ -21,7 +21,12 @@ import com.hazelcast.config.JobTrackerConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.lang.reflect.Method;
 import java.util.HashSet;
@@ -31,6 +36,8 @@ import static com.hazelcast.internal.dynamicconfig.ClusterWideConfigurationServi
 import static java.lang.String.format;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class DynamicConfigVersionTest {
 
     // config classes not supported by dynamic data structure config
@@ -59,6 +66,5 @@ public class DynamicConfigVersionTest {
                 assertTrue(format("Config class %s does not have a minimum Version set", klass.getName()), isMappedToVersion);
             }
         }
-
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/memory/MemorySizeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/memory/MemorySizeTest.java
@@ -16,12 +16,19 @@
 
 package com.hazelcast.memory;
 
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeDifferentHashCodes;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MemorySizeTest {
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/impl/RecentlyActiveQuorumFunctionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/impl/RecentlyActiveQuorumFunctionTest.java
@@ -17,7 +17,11 @@
 package com.hazelcast.quorum.impl;
 
 import com.hazelcast.quorum.QuorumFunction;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.lang.reflect.Constructor;
 import java.util.Arrays;
@@ -26,6 +30,8 @@ import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyObjectForSta
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class})
 public class RecentlyActiveQuorumFunctionTest extends AbstractQuorumFunctionTest {
 
     @Test


### PR DESCRIPTION
There were a lot of tests which were never executed.

Had to rename some `abstract` test classes from `Base...Test` to `Abstract...Test`. The name `Base...Test` is ambiguous, since we have some non-abstract `Base...Test` classes as well.

Test script:
```bash
#!/bin/bash

echo "Missing @Run or @RunWith annotation:"
find . -name "*Test.java" -exec grep -L "@Run" {} \; | grep -vi abstract | egrep -v "/(annotation|standalone|generated-test-sources)/"

echo

echo "Missing @Category annotation:"
find . -name "*Test.java" -exec grep -L "@Category" {} \; | grep -vi abstract | egrep -v "/(annotation|standalone|generated-test-sources)/"
```