### PR TITLE
BACKPORT - Remove warmupPartitions() call from invokeOnStableClusterSerial()

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -21,13 +21,11 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IFunction;
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.util.futures.ChainingFuture;
 import com.hazelcast.internal.util.iterator.RestartingMemberIterator;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.SerializableByConvention;
-import com.hazelcast.partition.NoDataMemberInClusterException;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -71,8 +69,6 @@ public final class InvocationUtil {
             return new CompletedFuture<Object>(null, null, new CallerRunsExecutor());
         }
 
-        warmUpPartitions(nodeEngine);
-
         RestartingMemberIterator memberIterator = new RestartingMemberIterator(clusterService, maxRetries);
 
         // we are going to iterate over all members and invoke an operation on each of them
@@ -88,31 +84,6 @@ public final class InvocationUtil {
         // it invokes on another member only when the previous invocation is completed (so invocations are serial)
         // the future itself completes only when the last invocation completes (or if there is an error)
         return new ChainingFuture<Object>(invocationIterator, executor, memberIterator, logger);
-    }
-
-    private static void warmUpPartitions(NodeEngine nodeEngine) {
-        ClusterService clusterService = nodeEngine.getClusterService();
-        if (!clusterService.getClusterState().isMigrationAllowed()) {
-            return;
-        }
-
-        InternalPartitionService partitionService = (InternalPartitionService) nodeEngine.getPartitionService();
-        if (partitionService.getMemberGroupsSize() == 0) {
-            return;
-        }
-
-        for (int i = 0; i < partitionService.getPartitionCount(); i++) {
-            try {
-                partitionService.getPartitionOwnerOrWait(i);
-            } catch (IllegalStateException e) {
-                if (!clusterService.getClusterState().isMigrationAllowed()) {
-                    return;
-                }
-                throw e;
-            } catch (NoDataMemberInClusterException e) {
-                return;
-            }
-        }
     }
 
     // IFunction extends Serializable, but this function is only executed locally


### PR DESCRIPTION
`invokeOnStableClusterSerial()` should be an async invocation, because
it's called from Hazelcast internal threads too. But `warmupPartitions()`
is a blocking call, which waits until all partitions are assigned.

This can create a deadlock on generic operation threads when all generic threads
(including priority threads) are blocked on `warmupPartitions()`.
Because partition table update message is processed on priority generic operation thread
and if it's blocked then partition table won't be updated and blocked `invokeOnStableClusterSerial()`
will not be able to continue.

Currently client auth message tasks can cause deadlock described above. When this happens,
that member cannot process heartbeat messages and eventually split from cluster.
See https://github.com/hazelcast/hazelcast/issues/11615#issuecomment-380041887

(cherry picked from commit 42c9bd943c50b1ef47958ca8f5c1c7b10e2322af)

Backport of https://github.com/hazelcast/hazelcast/pull/12837