### PR TITLE
add ISSUE_TEMPLATE and .github folder

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ It makes you feel good...
 
 ## Issue Reports
 Thanks for reporting your issue.  Please share with us the following information, to help us resolve your issue quickly and efficiently.
-*	Hazelcast version that you use (e.g. 3.4, also specify whether it is a minor release or the latest snapshot).
+1.	Hazelcast version that you use (e.g. 3.4, also specify whether it is a minor release or the latest snapshot).
 2.	Cluster size, i.e. the number of Hazelcast cluster members.
 3.	Number of the clients.
 4.	Version of Java. It is also helpful to mention the JVM parameters.
@@ -16,7 +16,7 @@ Thanks for reporting your issue.  Please share with us the following information
 
 ## Pull Requests
 Thanks for creating your pull request (PR).
-*	Contributions are submitted, reviewed, and accepted using the pull requests on GitHub.
+1.	Contributions are submitted, reviewed, and accepted using the pull requests on GitHub.
 2.	In order to merge your PR, please sign the [Contributor Agreement Form].
 3.	Try to make clean commits that are easily readable (including descriptive commit messages).
 4.	The latest changes are in the **master** branch.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,25 @@
+#### Expected Behaviour
+
+#### Actual Behaviour
+
+#### Steps to reproduce the issue
+1.
+2.
+3.
+
+***
+##### Hazelcast version that you use (e.g. 3.4, also specify whether it is a minor release or the latest snapshot):
+
+##### Cluster size, i.e. the number of Hazelcast cluster members:
+
+##### Number of the clients:
+
+##### Version of Java. It is also helpful to mention the JVM parameters:
+
+##### Operating system. If it is Linux, kernel version is helpful:
+
+##### Logs and stack traces, if available:
+
+##### Unit test with the `hazelcast.xml` file. If you could include a unit test which reproduces your issue, we would be grateful:
+
+#####If available, integration module versions (e.g. Tomcat, Jetty, Spring, Hibernate). Also, include their  detailed configuration information such as `web.xml`, Hibernate configuration and `context.xml` for Spring:


### PR DESCRIPTION
This pr adds `.github` folder and moves `CONTIBUTING.md` into the folder. `ISSUE_TEMPLATE.md` is also added so when someone creates an issue they will see what information is needed.