### PR TITLE
Fixed creation of null MergingValue on merging nodes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionMergeOperation.java
@@ -74,7 +74,7 @@ public class CollectionMergeOperation extends CollectionBackupAwareOperation {
 
         Collection<CollectionItem> existingItems = container.getCollection();
 
-        CollectionMergeTypes existingValue = createMergingValue(serializationService, existingItems);
+        CollectionMergeTypes existingValue = createMergingValueOrNull(serializationService, existingItems);
         Collection<Object> newValues = mergePolicy.merge(mergingValue, existingValue);
 
         if (isEmpty(newValues)) {
@@ -87,6 +87,11 @@ public class CollectionMergeOperation extends CollectionBackupAwareOperation {
             createNewCollectionItems(container, existingItems, newValues, serializationService);
         }
         return existingItems;
+    }
+
+    private CollectionMergeTypes createMergingValueOrNull(SerializationService serializationService,
+                                                          Collection<CollectionItem> existingItems) {
+        return existingItems.isEmpty() ? null : createMergingValue(serializationService, existingItems);
     }
 
     private void createNewCollectionItems(CollectionContainer container, Collection<CollectionItem> items,

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueMergeOperation.java
@@ -74,7 +74,7 @@ public class QueueMergeOperation extends QueueBackupAwareOperation implements Mu
         serializationService.getManagedContext().initialize(mergePolicy);
 
         Queue<QueueItem> existingItems = container.getItemQueue();
-        QueueMergeTypes existingValue = createMergingValue(serializationService, existingItems);
+        QueueMergeTypes existingValue = createMergingValueOrNull(serializationService, existingItems);
         Collection<Object> newValues = mergePolicy.merge(mergingValue, existingValue);
 
         if (isEmpty(newValues)) {
@@ -89,6 +89,10 @@ public class QueueMergeOperation extends QueueBackupAwareOperation implements Mu
             createNewQueueItems(container, newValues, serializationService);
         }
         return existingItems;
+    }
+
+    private QueueMergeTypes createMergingValueOrNull(SerializationService serializationService, Queue<QueueItem> existingItems) {
+        return existingItems.isEmpty() ? null : createMergingValue(serializationService, existingItems);
     }
 
     private void createNewQueueItems(QueueContainer container, Collection<Object> values,

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/operations/MergeOperation.java
@@ -62,7 +62,7 @@ public class MergeOperation extends AtomicLongBackupAwareOperation {
         serializationService.getManagedContext().initialize(mergePolicy);
 
         AtomicLongMergeTypes mergeValue = createMergingValue(serializationService, mergingValue);
-        AtomicLongMergeTypes existingValue = createMergingValue(serializationService, oldValue);
+        AtomicLongMergeTypes existingValue = isExistingContainer ? createMergingValue(serializationService, oldValue) : null;
         Long newValue = mergePolicy.merge(mergeValue, existingValue);
 
         backupValue = setNewValue(service, container, oldValue, newValue);

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/MergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/MergeOperation.java
@@ -106,11 +106,8 @@ public class MergeOperation extends Operation
      * @param mergingValue      the data to merge
      * @return the merged ringbuffer
      */
-    private Ringbuffer<Object> merge(RingbufferContainer<Object, Object> existingContainer,
-                                     RingbufferMergeTypes mergingValue) {
-        RingbufferMergeTypes existingValue = existingContainer != null
-                ? createMergingValue(serializationService, existingContainer.getRingbuffer())
-                : null;
+    private Ringbuffer<Object> merge(RingbufferContainer<Object, Object> existingContainer, RingbufferMergeTypes mergingValue) {
+        RingbufferMergeTypes existingValue = createMergingValueOrNull(existingContainer);
 
         RingbufferMergeData resultData = mergePolicy.merge(mergingValue, existingValue);
 
@@ -125,6 +122,12 @@ public class MergeOperation extends Operation
             setRingbufferData(resultData, existingContainer);
             return existingContainer.getRingbuffer();
         }
+    }
+
+    private RingbufferMergeTypes createMergingValueOrNull(RingbufferContainer<Object, Object> existingContainer) {
+        return existingContainer == null || existingContainer.getRingbuffer().isEmpty()
+                ? null
+                : createMergingValue(serializationService, existingContainer.getRingbuffer());
     }
 
     /**
@@ -152,7 +155,7 @@ public class MergeOperation extends Operation
         }
         if (storeEnabled) {
             toContainer.getStore()
-                       .storeAll(fromMergeData.getHeadSequence(), storeItems);
+                    .storeAll(fromMergeData.getHeadSequence(), storeItems);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
@@ -62,9 +62,6 @@ public final class MergingValueFactory {
 
     public static CollectionMergeTypes createMergingValue(SerializationService serializationService,
                                                           Collection<CollectionItem> items) {
-        if (items.isEmpty()) {
-            return null;
-        }
         Collection<Object> values = new ArrayList<Object>(items.size());
         for (CollectionItem item : items) {
             values.add(item.getValue());
@@ -74,9 +71,6 @@ public final class MergingValueFactory {
     }
 
     public static QueueMergeTypes createMergingValue(SerializationService serializationService, Queue<QueueItem> items) {
-        if (items.isEmpty()) {
-            return null;
-        }
         Collection<Object> values = new ArrayList<Object>(items.size());
         for (QueueItem item : items) {
             values.add(item.getData());
@@ -86,17 +80,11 @@ public final class MergingValueFactory {
     }
 
     public static AtomicLongMergeTypes createMergingValue(SerializationService serializationService, Long value) {
-        if (value == null) {
-            return null;
-        }
         return new AtomicLongMergingValueImpl(serializationService)
                 .setValue(value);
     }
 
     public static AtomicReferenceMergeTypes createMergingValue(SerializationService serializationService, Data value) {
-        if (value == null) {
-            return null;
-        }
         return new AtomicReferenceMergingValueImpl(serializationService)
                 .setValue(value);
     }
@@ -213,12 +201,8 @@ public final class MergingValueFactory {
                 .setHits(hits);
     }
 
-    public static RingbufferMergeTypes createMergingValue(SerializationService serializationService,
-                                                          Ringbuffer<Object> items) {
-        if (items.isEmpty()) {
-            return null;
-        }
-        final RingbufferMergeData mergingData = new RingbufferMergeData(items);
+    public static RingbufferMergeTypes createMergingValue(SerializationService serializationService, Ringbuffer<Object> items) {
+        RingbufferMergeData mergingData = new RingbufferMergeData(items);
         return new RingbufferMergingValueImpl(serializationService)
                 .setValues(mergingData);
     }


### PR DESCRIPTION
The `MergingValueFactory` had some shortcuts to create `null` `MergingValues` when a given parameter was `null` or an empty collection. This was meant to save some code in the merging operations, but could lead to a `null` `MergingValue` on the merging nodes as well. This should not happen, since our merging policies don't expect the `mergingValue` to be `null` (in this case no merging operation should have been created).

Kudos to @vbekiaris who found this issue!