### PR TITLE
Added the Operation 'batch' functionality

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.impl.operationexecutor;
 
 import com.hazelcast.spi.LiveOperationsTracker;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.PartitionTaskFactory;
 import com.hazelcast.spi.impl.PacketHandler;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
@@ -94,6 +95,18 @@ public interface OperationExecutor extends PacketHandler, LiveOperationsTracker 
      * @throws java.lang.NullPointerException if op is null.
      */
     void execute(Operation op);
+
+    /**
+     * Executes a task from the taskFactory for each of the given partitions.
+     *
+     * For more detail see
+     * {@link com.hazelcast.spi.impl.operationservice.InternalOperationService#execute(PartitionTaskFactory, int[])}
+     *
+     * @param taskFactory the {@link PartitionTaskFactory} responsible for creating
+     *                    tasks.
+     * @param partitions the partitions to execute tasks on.
+     */
+    void execute(PartitionTaskFactory taskFactory, int[] partitions);
 
     /**
      * Executes the given {@link PartitionSpecificRunnable} at some point in the future.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -63,11 +63,14 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
     private final SwCounter completedRunnableCount = newSwCounter();
     @Probe
     private final SwCounter errorCount = newSwCounter();
+    @Probe
+    private final SwCounter completedOperationBatchCount = newSwCounter();
 
     private final boolean priority;
     private final NodeExtension nodeExtension;
     private final ILogger logger;
     private volatile boolean shutdown;
+
     public OperationThread(String name, int threadId, OperationQueue queue, ILogger logger,
                            NodeExtension nodeExtension, boolean priority, ClassLoader configClassLoader) {
         super(name);
@@ -110,34 +113,68 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
     private void process(Object task) {
         try {
             if (task.getClass() == Packet.class) {
-                Packet packet = (Packet) task;
-                currentRunner = getOperationRunner(packet.getPartitionId());
-                currentRunner.run(packet);
-                completedPacketCount.inc();
+                process((Packet) task);
             } else if (task instanceof Operation) {
-                Operation operation = (Operation) task;
-                currentRunner = getOperationRunner(operation.getPartitionId());
-                currentRunner.run(operation);
-                completedOperationCount.inc();
+                process((Operation) task);
             } else if (task instanceof PartitionSpecificRunnable) {
-                PartitionSpecificRunnable runnable = (PartitionSpecificRunnable) task;
-                currentRunner = getOperationRunner(runnable.getPartitionId());
-                currentRunner.run(runnable);
-                completedPartitionSpecificRunnableCount.inc();
+                process((PartitionSpecificRunnable) task);
             } else if (task instanceof Runnable) {
-                Runnable runnable = (Runnable) task;
-                runnable.run();
-                completedRunnableCount.inc();
+                process((Runnable) task);
+            } else if (task instanceof TaskBatch) {
+                process((TaskBatch) task);
             } else {
-                throw new IllegalStateException("Unhandled task type for task:" + task);
+                throw new IllegalStateException("Unhandled task:" + task);
             }
             completedTotalCount.inc();
         } catch (Throwable t) {
             errorCount.inc();
             inspectOutOfMemoryError(t);
-            logger.severe("Failed to process packet: " + task + " on " + getName(), t);
+            logger.severe("Failed to process: " + task + " on: " + getName(), t);
         } finally {
             currentRunner = null;
+        }
+    }
+
+    private void process(Operation operation) {
+        currentRunner = getOperationRunner(operation.getPartitionId());
+        currentRunner.run(operation);
+        completedOperationCount.inc();
+    }
+
+    private void process(Packet packet) throws Exception {
+        currentRunner = getOperationRunner(packet.getPartitionId());
+        currentRunner.run(packet);
+        completedPacketCount.inc();
+    }
+
+    private void process(PartitionSpecificRunnable runnable) {
+        currentRunner = getOperationRunner(runnable.getPartitionId());
+        currentRunner.run(runnable);
+        completedPartitionSpecificRunnableCount.inc();
+    }
+
+    private void process(Runnable runnable) {
+        runnable.run();
+        completedRunnableCount.inc();
+    }
+
+    private void process(TaskBatch batch) {
+        Object task = batch.next();
+        if (task == null) {
+            completedOperationBatchCount.inc();
+            return;
+        }
+
+        try {
+            if (task instanceof Operation) {
+                process((Operation) task);
+            } else if (task instanceof Runnable) {
+                process((Runnable) task);
+            } else {
+                throw new IllegalStateException("Unhandled task: " + task + " from " + batch.taskFactory());
+            }
+        } finally {
+            queue.add(batch, false);
         }
     }
 
@@ -152,7 +189,6 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
     }
 
     public final void awaitTermination(int timeout, TimeUnit unit) throws InterruptedException {
-        long timeoutMs = unit.toMillis(timeout);
-        join(timeoutMs);
+        join(unit.toMillis(timeout));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/TaskBatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/TaskBatch.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationexecutor.impl;
+
+import com.hazelcast.spi.impl.operationservice.PartitionTaskFactory;
+
+import static com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl.getPartitionThreadId;
+
+/**
+ * A 'batch' of tasks to be executed on a partition thread.
+ */
+public class TaskBatch {
+
+    private final PartitionTaskFactory taskFactory;
+    private final int[] partitions;
+    private final int threadId;
+    private final int partitionThreadCount;
+    private int partitionIndex;
+
+    public TaskBatch(PartitionTaskFactory taskFactory, int[] partitions, int threadId, int partitionThreadCount) {
+        this.taskFactory = taskFactory;
+        this.partitions = partitions;
+        this.threadId = threadId;
+        this.partitionThreadCount = partitionThreadCount;
+    }
+
+    public PartitionTaskFactory taskFactory() {
+        return taskFactory;
+    }
+
+    /**
+     * Gets the next task to execute.
+     *
+     * @return the task to execute, or null if the batch is complete.
+     */
+    public Object next() {
+        int partitionId = nextPartitionId();
+        return partitionId == -1 ? null : taskFactory.create(partitionId);
+    }
+
+    private int nextPartitionId() {
+        for (; ; ) {
+            if (partitionIndex == partitions.length) {
+                return -1;
+            }
+
+            int partitionId = partitions[partitionIndex];
+            partitionIndex++;
+
+            if (getPartitionThreadId(partitionId, partitionThreadCount) == threadId) {
+                // only selected partitions that belong to the right partition thread.
+                return partitionId;
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -123,6 +123,27 @@ public interface InternalOperationService extends OperationService {
     void execute(PartitionSpecificRunnable task);
 
     /**
+     * Executes for each of the partitions, a task created by the
+     * taskFactory.
+     *
+     * The reason this method exists is to prevent a bubble of operations/tasks
+     * to be created on the work-queue if the regular {@link #execute(Operation)}
+     * would be called in a loop.
+     *
+     * The consequence of this bubble is that no other operations can interleave
+     * and this can lead to very bad latency for the other operations.
+     *
+     * This method can be used to create Operations and Runnable's to be executed
+     * on a partition thread.
+     *
+     * @param taskFactory the PartitionTaskFactory used to create
+     *                         operations.
+     * @param partitions the partitions to execute an operation on.
+     * @throws NullPointerException if taskFactory or partitions is null.
+     */
+    void execute(PartitionTaskFactory taskFactory, int[] partitions);
+
+    /**
      * Returns information about long running operations.
      *
      * @return list of {@link SlowOperationDTO} instances.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/PartitionTaskFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/PartitionTaskFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice;
+
+/**
+ * An factory for creating partition specific tasks.
+ *
+ * A task can be:
+ * <ol>
+ * <li>Operation</li>
+ * <li>Runnable</li>
+ * </ol>
+ *
+ * See {@link InternalOperationService#execute(PartitionTaskFactory, int[])} for more detail.
+ */
+public interface PartitionTaskFactory<T> {
+
+    /**
+     * Creates the task.
+     *
+     * @param partitionId the partitionId of the partition this task is going to
+     *                    run on
+     * @return the created task. The returned task should not be null.
+     */
+    T create(int partitionId);
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -41,6 +41,7 @@ import com.hazelcast.spi.LiveOperationsTracker;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationFactory;
 import com.hazelcast.spi.OperationService;
+import com.hazelcast.spi.impl.operationservice.PartitionTaskFactory;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
@@ -258,6 +259,11 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     @Override
     public void execute(PartitionSpecificRunnable task) {
         operationExecutor.execute(task);
+    }
+
+    @Override
+    public void execute(PartitionTaskFactory taskFactory, int[] partitions) {
+        operationExecutor.execute(taskFactory, partitions);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecuteBatchTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_ExecuteBatchTest.java
@@ -1,0 +1,117 @@
+package com.hazelcast.spi.impl.operationexecutor.impl;
+
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.PartitionTaskFactory;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class OperationExecutorImpl_ExecuteBatchTest extends OperationExecutorImpl_AbstractTest {
+
+    @Test(expected = NullPointerException.class)
+    public void whenNullFactory() {
+        initExecutor();
+
+        executor.execute(null, new int[]{});
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void whenNullPartitions() {
+        initExecutor();
+
+        executor.execute(mock(PartitionTaskFactory.class), null);
+    }
+
+    @Test
+    public void executeOnEachPartition() {
+        config.setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "16");
+        initExecutor();
+
+        final int[] partitions = newPartitions();
+        final DummyPartitionTaskFactory taskFactory = new DummyPartitionTaskFactory();
+        executor.execute(taskFactory, partitions);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(partitions.length, taskFactory.completed.get());
+            }
+        });
+    }
+
+    @Test
+    public void noMoreBubble() {
+        config.setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
+        initExecutor();
+
+        final DummyPartitionTaskFactory taskFactory = new DummyPartitionTaskFactory();
+        taskFactory.delayMs = 1000;
+        executor.execute(taskFactory, newPartitions());
+
+        final DummyOperation op = new DummyOperation();
+        executor.execute(op);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertTrue(op.completed);
+            }
+        }, SECONDS.toMillis(5));
+    }
+
+    private int[] newPartitions() {
+        final int[] partitions = new int[props.getInteger(PARTITION_OPERATION_THREAD_COUNT)];
+        for (int k = 0; k < partitions.length; k++) {
+            partitions[k] = k;
+        }
+        return partitions;
+    }
+
+    class DummyOperation extends Operation {
+        private volatile boolean completed;
+
+        @Override
+        public void run() {
+            completed = true;
+        }
+    }
+
+    class DummyPartitionTaskFactory implements PartitionTaskFactory {
+        private final AtomicLong completed = new AtomicLong();
+        private int delayMs;
+
+        @Override
+        public Object create(int partitionId) {
+            return new DummyTask(completed, delayMs);
+        }
+    }
+
+    class DummyTask implements Runnable {
+        private final AtomicLong completed;
+        private final int delayMs;
+
+        DummyTask(AtomicLong completed, int delayMs) {
+            this.completed = completed;
+            this.delayMs = delayMs;
+        }
+
+        @Override
+        public void run() {
+            sleepMillis(delayMs);
+            completed.incrementAndGet();
+        }
+    }
+}


### PR DESCRIPTION
this will prevent causing bubbles.

Scheduling all operations for every partition in a short loop, leads to a large number of consecutive operations in the work-queue that can't be interleaved with other operations. So in an extreme case: if there would be 1 partition thread and a map.size call is done, there will be 271 map size operations on the work-queue. If every map.size operation takes 1ms, and e.g a map.get is done, in worst case this map.get needs to wait 271 ms. 

This pr fixes that by not scheduling the operations in 1 go. One operation gets picked from a batch, and then the batch gets added to the back of the work-queue so that other operations can flow through. With this fix, the maximum wait time for a map.get with 1 continuous executing map.size, would be 1ms. 

In this PR the underlying logic is added to the OperationService to execute a set of operations on a set of partitions and the PartitionIteratingOperation is fixed to make use of the new logic. But there are other parts in the system that should be refactored.
