### PR TITLE
[BACKPORT]IOBalancerStressTest counts events instead of number bytes

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
@@ -32,9 +32,11 @@ import com.hazelcast.nio.tcp.TcpIpConnectionManager;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,6 +52,9 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
 public class IOBalancerStressTest extends HazelcastTestSupport {
+
+    @Rule
+    public final OverridePropertyRule overridePropertyRule = OverridePropertyRule.set("hazelcast.io.load", "0");
 
     @Before
     @After


### PR DESCRIPTION
IOBalancerStressTest was using number of bytes received/sent to verify that handlers were balanced. Instead it should have used event counts. This has been resolved in maintenance branch before. Since it was not merged to master in a timely manner the issue appeared again.
Fixes #7662
Backport of #12886