### PR TITLE
[Backport 3.10] Whitelist javax.crypto in CheckDependenciesIT test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
@@ -48,6 +48,7 @@ public class CheckDependenciesIT extends HazelcastTestSupport {
 
             // with the "javax" package we have to be more specific - do not use just "javax."
             // as it contains e.g. javax.servlet which is not part of the SE platform!
+            "javax.crypto",
             "javax.management",
             "javax.net.ssl",
             "javax.script",


### PR DESCRIPTION
Backports #12895 to 3.10.
Fixes #12894.