### PR TITLE
Make ISemaphore.availablePermits() JUC Semaphore compatible

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/semaphore/ClientSemaphoreTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/semaphore/ClientSemaphoreTest.java
@@ -120,7 +120,7 @@ public class ClientSemaphoreTest {
         final ISemaphore semaphore = client.getSemaphore(randomString());
         semaphore.init(0);
         semaphore.reducePermits(1);
-        assertEquals(0, semaphore.availablePermits());
+        assertEquals(-1, semaphore.availablePermits());
     }
 
     @Test
@@ -138,6 +138,22 @@ public class ClientSemaphoreTest {
         semaphore.init(0);
         semaphore.increasePermits(1);
         assertEquals(1, semaphore.availablePermits());
+    }
+
+    @Test
+    public void testNegativePermitsJucCompatibility() throws Exception {
+        final ISemaphore semaphore = client.getSemaphore(randomString());
+        semaphore.init(0);
+        semaphore.reducePermits(100);
+        semaphore.release(10);
+
+        assertEquals(-90, semaphore.availablePermits());
+        assertEquals(-90, semaphore.drainPermits());
+
+        semaphore.release(10);
+
+        assertEquals(10, semaphore.availablePermits());
+        assertEquals(10, semaphore.drainPermits());
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreContainer.java
@@ -92,7 +92,7 @@ public class SemaphoreContainer implements IdentifiedDataSerializable {
     }
 
     public int getAvailable() {
-        return available < 0 ? 0 : available;
+        return available;
     }
 
     public boolean isAvailable(int permitCount) {

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/semaphore/SemaphoreBasicTest.java
@@ -107,17 +107,33 @@ public abstract class SemaphoreBasicTest extends HazelcastTestSupport {
     @Test(timeout = 30000)
     public void testAllowNegativePermits() {
         assertTrue(semaphore.init(10));
-        
+
         semaphore.reducePermits(15);
-        
-        assertEquals(0, semaphore.availablePermits());
-        
+
+        assertEquals(-5, semaphore.availablePermits());
+
         semaphore.release(10);
         
         assertEquals(5, semaphore.availablePermits());
-    }    
-    
-    
+    }
+
+    @Test(timeout = 30000)
+    public void testNegativePermitsJucCompatibility() {
+        assertTrue(semaphore.init(0));
+
+        semaphore.reducePermits(100);
+        semaphore.release(10);
+
+        assertEquals(-90, semaphore.availablePermits());
+        assertEquals(-90, semaphore.drainPermits());
+
+        semaphore.release(10);
+
+        assertEquals(10, semaphore.availablePermits());
+        assertEquals(10, semaphore.drainPermits());
+    }
+
+
     @Test(timeout = 30000)
     public void testIncreasePermits() {
         assertTrue(semaphore.init(10));


### PR DESCRIPTION
The below code produced different output with ISemaphore and JUC Semaphore:
```
semaphore = new MySemaphore(0);
semaphore.reducePermits(100);
semaphore.release(10);
System.out.println(semaphore.availablePermits());
System.out.println(semaphore.drainPermits());
```
ISemaphore output:
```
0
-90
```
JUC Semaphore output:
```
-90
-90
```
This commits make ISemaphore to produce the same output that JUC Semaphore does.