### PR TITLE
Fixes uninitialized partition in LossToleranceTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/LossToleranceTest.java
@@ -56,6 +56,7 @@ public class LossToleranceTest extends HazelcastTestSupport {
                         .setAsyncBackupCount(0));
         final HazelcastInstance[] instances = createHazelcastInstanceFactory(2).newInstances(config);
 
+        warmUpPartitions(instances);
         for (HazelcastInstance instance : instances) {
             final Member owner = instance.getPartitionService().getPartition(TOPIC_RB_PREFIX + RELIABLE_TOPIC_NAME).getOwner();
             final Member localMember = instance.getCluster().getLocalMember();


### PR DESCRIPTION
whenLossTolerant_andOwnerCrashes_thenContinue test uses partition service to determine the owner of reliable topic's owner. The owner partition is killed during the test. However owner partition may be null because the partition table was not updated yet. This fix adds warmup stage so that partition owner is guaranteed to be non-null at the time of querying.
Fixes #12882