### PR TITLE
[BACKPORT 3.10.1] Use hardcoded value in testWrongVariables to prevent false positives

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>3.10-SNAPSHOT</version>
+        <version>3.10.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-build-utils/pom.xml
+++ b/hazelcast-build-utils/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>3.10-SNAPSHOT</version>
+        <version>3.10.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-client/pom.xml
+++ b/hazelcast-client/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>3.10-SNAPSHOT</version>
+        <version>3.10.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientResponseHandlerSupplier.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientResponseHandlerSupplier.java
@@ -31,6 +31,7 @@ import java.util.concurrent.BlockingQueue;
 import static com.hazelcast.client.spi.properties.ClientProperty.RESPONSE_THREAD_COUNT;
 import static com.hazelcast.instance.OutOfMemoryErrorDispatcher.onOutOfMemory;
 import static com.hazelcast.spi.impl.operationservice.impl.InboundResponseHandlerSupplier.getIdleStrategy;
+import static com.hazelcast.util.HashUtil.hashToIndex;
 
 /**
  * A {@link Supplier} for {@link ClientResponseHandler} instance.
@@ -186,7 +187,7 @@ public class ClientResponseHandlerSupplier implements Supplier<ClientResponseHan
     class AsyncMultiThreadedResponseHandler implements ClientResponseHandler {
         @Override
         public void handle(ClientMessage message, ClientConnection connection) {
-            int threadIndex = INT_HOLDER.get().getAndInc() % responseThreads.length;
+            int threadIndex = hashToIndex(INT_HOLDER.get().getAndInc(), responseThreads.length);
             responseThreads[threadIndex].responseQueue.add(new ClientPacket(connection, message));
         }
     }

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>3.10-SNAPSHOT</version>
+        <version>3.10.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast-root</artifactId>
-        <version>3.10-SNAPSHOT</version>
+        <version>3.10.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/hazelcast/src/test/java/com/hazelcast/config/replacer/AbstractPbeReplacerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/replacer/AbstractPbeReplacerTest.java
@@ -118,8 +118,9 @@ public class AbstractPbeReplacerTest {
         assertNull(replacer.getReplacement(null));
         assertNull(replacer.getReplacement("WronglyFormatted"));
         assertNull(replacer.getReplacement("aSalt:1:EncryptedValue"));
-        String encryptedStr = replacer.encrypt("test", 777);
-        assertNull(replacer.getReplacement(encryptedStr.replace(":777:", ":1:")));
+        // following incorrect value was generated using replacer.encrypt("test", 777).replace(":777:", ":1:");
+        assertNull("Null value expected as javax.crypto.BadPaddingException should be thrown in the AbstractPbeReplacer",
+                replacer.getReplacement("IVJXCMo0XBE=:1:NnZjBhX7sB/IT0sTFZ2eIA=="));
     }
 
     protected void assertReplacerWorks(AbstractPbeReplacer replacer) throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerStressTest.java
@@ -32,9 +32,11 @@ import com.hazelcast.nio.tcp.TcpIpConnectionManager;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.NightlyTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,6 +52,9 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(NightlyTest.class)
 public class IOBalancerStressTest extends HazelcastTestSupport {
+
+    @Rule
+    public final OverridePropertyRule overridePropertyRule = OverridePropertyRule.set("hazelcast.io.load", "0");
 
     @Before
     @After

--- a/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/CheckDependenciesIT.java
@@ -48,6 +48,7 @@ public class CheckDependenciesIT extends HazelcastTestSupport {
 
             // with the "javax" package we have to be more specific - do not use just "javax."
             // as it contains e.g. javax.servlet which is not part of the SE platform!
+            "javax.crypto",
             "javax.management",
             "javax.net.ssl",
             "javax.script",

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-root</artifactId>
     <packaging>pom</packaging>
-    <version>3.10-SNAPSHOT</version>
+    <version>3.10.1-SNAPSHOT</version>
     <name>Hazelcast Root</name>
     <description>Hazelcast In-Memory DataGrid</description>
     <url>http://www.hazelcast.com/</url>


### PR DESCRIPTION
Backports #12912.
Fixes #12910.