### PR TITLE
Close connections to members after they are removed from cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -320,6 +320,7 @@ public class MembershipManager {
         setMembers(MemberMap.createNew(membersView.getVersion(), members));
 
         for (MemberImpl member : removedMembers) {
+            closeConnection(member.getAddress(), "Member left event received from master");
             handleMemberRemove(memberMapRef.get(), member);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -31,6 +31,7 @@ import com.hazelcast.internal.cluster.impl.operations.MembersUpdateOp;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ConnectionManager;
 import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.tcp.FirewallingConnectionManager;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PostJoinAwareService;
@@ -64,6 +65,7 @@ import java.util.concurrent.locks.LockSupport;
 import static com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.FINALIZE_JOIN;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.F_ID;
+import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.HEARTBEAT;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMBER_INFO_UPDATE;
 import static com.hazelcast.spi.properties.GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS;
 import static com.hazelcast.test.PacketFiltersUtil.delayOperationsFrom;
@@ -79,6 +81,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -747,6 +750,55 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
             // expected
         }
         assertClusterSize(1, hz1);
+    }
+
+    @Test
+    public void connectionsToTerminatedMember_shouldBeClosed() {
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
+
+        assertClusterSizeEventually(3, hz1, hz2, hz3);
+
+        Address target = getAddress(hz2);
+        hz2.getLifecycleService().terminate();
+
+        assertClusterSizeEventually(2, hz1, hz3);
+
+        assertNull(getConnectionManager(hz1).getConnection(target));
+        assertNull(getConnectionManager(hz3).getConnection(target));
+    }
+
+    @Test
+    public void connectionsToRemovedMember_shouldBeClosed() {
+        Config config = new Config()
+            .setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName(), "10")
+            .setProperty(GroupProperty.HEARTBEAT_INTERVAL_SECONDS.getName(), "1");
+
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+        HazelcastInstance hz3 = factory.newHazelcastInstance(config);
+
+        assertClusterSizeEventually(3, hz1, hz2, hz3);
+
+        Address target = getAddress(hz2);
+
+        FirewallingConnectionManager cm2 = getFireWallingConnectionManager(hz2);
+        cm2.blockNewConnection(getAddress(hz1));
+        cm2.blockNewConnection(getAddress(hz3));
+
+        FirewallingConnectionManager cm3 = getFireWallingConnectionManager(hz3);
+        cm3.blockNewConnection(getAddress((hz2)));
+
+        dropOperationsBetween(hz2, hz1, F_ID, singletonList(HEARTBEAT));
+        assertClusterSizeEventually(2, hz1, hz3);
+
+        assertNull(getConnectionManager(hz1).getConnection(target));
+        assertNull(getConnectionManager(hz3).getConnection(target));
+    }
+
+    private static FirewallingConnectionManager getFireWallingConnectionManager(HazelcastInstance hz) {
+        return (FirewallingConnectionManager) getConnectionManager(hz);
     }
 
     private Config getConfigWithService(Object service, String serviceName) {


### PR DESCRIPTION
When a member is suspected, its connection is closed immediately and if suspecting
member is the master, it removes that member from cluster.
But if a slave member receives a member remove event without suspecting that member,
its connection remains open, unless connection fails with an IO exception.

Additionally, `Invocation` now keeps reference to the connection which operation is sent
through. This is just for logging purposes. Before, `Invocation` was logging
the current/latest connection to the remote target.

3.10.1 backport of https://github.com/hazelcast/hazelcast/pull/12924

Fixes https://github.com/hazelcast/hazelcast/issues/12868