### PR TITLE
Fixes test failures when running with LITTLE_ENDIAN byte order override

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -73,7 +73,7 @@ public class AbstractSerializationServiceTest {
         String payload = "somepayload";
         int padding = 10;
 
-        byte[] unpadded = abstractSerializationService.toBytes(payload);
+        byte[] unpadded = abstractSerializationService.toBytes(payload, 0, true);
         byte[] padded = abstractSerializationService.toBytes(payload, 10, true);
 
         // make sure the size is expected

--- a/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapIndexLifecycleTest.java
@@ -324,7 +324,7 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
         public Map<Integer, Book> loadAll(Collection<Integer> keys) {
             Map<Integer, Book> map = new TreeMap<Integer, Book>();
             for (int key : keys) {
-                map.put(key, new Book(key, String.valueOf(key), String.valueOf(key % 7), 1800 + key % 200));
+                map.put(key, new Book(key, String.valueOf(key), getAuthorNameByKey(key), getYearByKey(key)));
             }
             return map;
         }
@@ -365,7 +365,7 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
                 break;
             }
         }
-        return String.valueOf(ownedKey % 7);
+        return getAuthorNameByKey(ownedKey);
     }
 
     private Integer findYearOwnedBy(HazelcastInstance hz) {
@@ -377,6 +377,14 @@ public class MapIndexLifecycleTest extends HazelcastTestSupport {
                 break;
             }
         }
-        return 1800 + ownedKey % 200;
+        return getYearByKey(ownedKey);
+    }
+
+    private static int getYearByKey(int key) {
+        return 1800 + key % 200;
+    }
+
+    private static String getAuthorNameByKey(int key) {
+        return String.valueOf(key % 7);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/StringSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/StringSerializationTest.java
@@ -36,6 +36,8 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 
+import static java.nio.ByteOrder.BIG_ENDIAN;
+import static java.nio.ByteOrder.LITTLE_ENDIAN;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -166,9 +168,32 @@ public class StringSerializationTest {
 
     private byte[] toDataByte(byte[] input, int length) {
         // the first 4 byte of type id, 4 byte string length and last 4 byte of partition hashCode
+        if (serializationService.getByteOrder() == BIG_ENDIAN) {
+            return toDataByteBigEndian(input, length);
+        } else {
+            return toDataByteLittleEndian(input, length);
+        }
+    }
+
+    private byte[] toDataByteBigEndian(byte[] input, int length) {
         ByteBuffer bf = ByteBuffer.allocate(input.length + 12);
         bf.putInt(0);
         bf.putInt(SerializationConstants.CONSTANT_TYPE_STRING);
+        bf.putInt(length);
+        bf.put(input);
+        return bf.array();
+    }
+
+    private byte[] toDataByteLittleEndian(byte[] input, int length) {
+        ByteBuffer bf = ByteBuffer.allocate(input.length + 12);
+        bf.order(LITTLE_ENDIAN);
+        bf.putInt(0);
+        // even when serialization service is configured with little endian byte order,
+        // the serializerTypeId (CONSTANT_TYPE_STRING) is still output in BIG_ENDIAN
+        bf.put((byte) 0xFF);
+        bf.put((byte) 0xFF);
+        bf.put((byte) 0xFF);
+        bf.put((byte) 0xF5);
         bf.putInt(length);
         bf.put(input);
         return bf.array();


### PR DESCRIPTION
- MapIndexLifecycleTest is updated to locate domain objects owned
by the member being asserted for index contents
- BinaryCompatibilityTest runs parametrically in both big & little
endian, so an assumption is added to ensure that the configured byte
order is indeed the expected one. When the byte order override is in
place the assumption is broken and tests are properly ignored.
- StringSerializationTest compares the output of
SerializationService.toBytes with a hand-crafted byte buffer which is
now adapted to match expected contents with LITTLE_ENDIAN byte order.
- AbstractSerializationServiceTest is updated to use the same method
(which takes into account configured byte order) when serializing
values to be compared.

Partial fix for #12932 