### PR TITLE
Increase latch timeout for ScheduledExecutorServiceBasicTest:scheduleOnKeyOwnerWithRepetition

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
@@ -874,7 +874,7 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
 
         assertEquals(expectedPartition, handler.getPartitionId());
 
-        latch.await(10, SECONDS);
+        latch.await(60, SECONDS);
         assertEquals(0, latch.getCount());
     }
 


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/12939
