### PR TITLE
Send the exception to caller when response of an callable not serializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.monitor.impl.LocalExecutorStatsImpl;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.LiveOperations;
 import com.hazelcast.spi.LiveOperationsTracker;
@@ -309,7 +310,11 @@ public class DistributedExecutorService implements ManagedService, RemoteService
 
         private boolean sendResponse(Object result) {
             if (RESPONSE_FLAG.compareAndSet(this, Boolean.FALSE, Boolean.TRUE)) {
-                op.sendResponse(result);
+                try {
+                    op.sendResponse(result);
+                } catch (HazelcastSerializationException e) {
+                    op.sendResponse(e);
+                }
                 return true;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/OperationResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/OperationResponseHandler.java
@@ -29,6 +29,9 @@ public interface OperationResponseHandler<O extends Operation> {
      *
      * @param op       the operation that got executed.
      * @param response the response of the operation that got executed.
+     * @throws com.hazelcast.nio.serialization.HazelcastSerializationException if response is not serializable or
+     *                                                                         contains non serializable object
+     *                                                                         inside NormalResponse
      */
     void sendResponse(O op, Object response);
 }

--- a/hazelcast/src/test/java/com/hazelcast/executor/SmallClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SmallClusterTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MultiExecutionCallback;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -43,6 +44,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -308,5 +310,48 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
         public Integer call() throws Exception {
             return ++state;
         }
+    }
+
+    @Test
+    public void submitToAllMembers_NonSerializableResponse() {
+        IExecutorService executorService = instances[0].getExecutorService(randomString());
+        NonSerializableResponseCallable nonSerializableResponseCallable = new NonSerializableResponseCallable();
+
+        final AtomicLong exceptionCount = new AtomicLong();
+        final AtomicLong responseCount = new AtomicLong();
+        final CountDownLatch completedLatch = new CountDownLatch(1);
+        executorService.submitToAllMembers(nonSerializableResponseCallable, new MultiExecutionCallback() {
+            @Override
+            public void onResponse(Member member, Object value) {
+                if (value instanceof HazelcastSerializationException) {
+                    exceptionCount.incrementAndGet();
+                } else {
+                    responseCount.incrementAndGet();
+                }
+            }
+
+            @Override
+            public void onComplete(Map<Member, Object> values) {
+                completedLatch.countDown();
+            }
+        });
+
+        assertOpenEventually(completedLatch);
+        // two exceptions from remote nodes
+        assertEquals(2, exceptionCount.get());
+        // one response from local node since, it does not need to serialize/deserialize the response
+        assertEquals(1, responseCount.get());
+    }
+
+    private static class NonSerializableResponseCallable implements Callable, Serializable {
+
+        @Override
+        public Object call() throws Exception {
+            return new NonSerializableResponse();
+        }
+    }
+
+    private static class NonSerializableResponse {
+
     }
 }


### PR DESCRIPTION
    
    When response is not serializable, it was logged on the side that
    callable is running.
    And the caller was waiting until operation call timeout.
    
    In this pr, we are sending the HazelcastSerializationException to caller.
    And exception is not logged on the running side.
    
    Fix is related to executor service. Added a test on operation service
    to show that operation service handle the issue correctly. Only wrong
    usage is was on DistributedExecutorService.
    
Fixes https://github.com/hazelcast/hazelcast/issues/12956

