### PR TITLE
[BACKPORT] Use default timeout for MapLoaderMultiNodeTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderMultiNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapLoaderMultiNodeTest.java
@@ -36,7 +36,6 @@ import org.junit.runner.RunWith;
 
 import static com.hazelcast.config.MapStoreConfig.InitialLoadMode.EAGER;
 import static com.hazelcast.config.MapStoreConfig.InitialLoadMode.LAZY;
-import static com.hazelcast.test.TimeConstants.MINUTE;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -53,13 +52,13 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
     private CountingMapLoader mapLoader;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         nodeFactory = createHazelcastInstanceFactory(NODE_COUNT + 2);
         mapLoader = new CountingMapLoader(MAP_STORE_ENTRY_COUNT);
     }
 
-    @Test(timeout = MINUTE)
-    public void testLoads_whenMapLazyAndCheckingSize() throws Exception {
+    @Test
+    public void testLoads_whenMapLazyAndCheckingSize() {
         Config cfg = newConfig(mapName, LAZY);
 
         IMap<Object, Object> map = getMap(mapName, cfg);
@@ -67,8 +66,8 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
         assertSizeAndLoadCount(map);
     }
 
-    @Test(timeout = MINUTE)
-    public void testLoadsAll_whenMapCreatedInEager() throws Exception {
+    @Test
+    public void testLoadsAll_whenMapCreatedInEager() {
         Config cfg = newConfig(mapName, EAGER);
 
         IMap<Object, Object> map = getMap(mapName, cfg);
@@ -76,8 +75,8 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
         assertSizeAndLoadCount(map);
     }
 
-    @Test(timeout = MINUTE)
-    public void testLoadsNothing_whenMapCreatedLazy() throws Exception {
+    @Test
+    public void testLoadsNothing_whenMapCreatedLazy() {
         Config cfg = newConfig(mapName, InitialLoadMode.LAZY);
 
         getMap(mapName, cfg);
@@ -85,8 +84,8 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
         assertEquals(0, mapLoader.getLoadedValueCount());
     }
 
-    @Test(timeout = MINUTE)
-    public void testLoadsMap_whenLazyAndValueRetrieved() throws Exception {
+    @Test
+    public void testLoadsMap_whenLazyAndValueRetrieved() {
         Config cfg = newConfig(mapName, InitialLoadMode.LAZY);
 
         IMap<Object, Object> map = getMap(mapName, cfg);
@@ -95,8 +94,8 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
         assertSizeAndLoadCount(map);
     }
 
-    @Test(timeout = MINUTE)
-    public void testLoadsAll_whenLazyModeAndLoadAll() throws Exception {
+    @Test
+    public void testLoadsAll_whenLazyModeAndLoadAll() {
         Config cfg = newConfig(mapName, LAZY);
 
         IMap<Object, Object> map = getMap(mapName, cfg);
@@ -106,8 +105,8 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
         assertSizeAndLoadCount(map);
     }
 
-    @Test(timeout = MINUTE)
-    public void testDoesNotLoadAgain_whenLoadedAndNodeAdded() throws Exception {
+    @Test
+    public void testDoesNotLoadAgain_whenLoadedAndNodeAdded() {
         Config cfg = newConfig(mapName, EAGER);
 
         IMap<Object, Object> map = getMap(mapName, cfg);
@@ -117,8 +116,8 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
         assertSizeAndLoadCount(map);
     }
 
-    @Test(timeout = MINUTE)
-    public void testDoesNotLoadAgain_whenLoadedLazyAndNodeAdded() throws Exception {
+    @Test
+    public void testDoesNotLoadAgain_whenLoadedLazyAndNodeAdded() {
         Config cfg = newConfig(mapName, LAZY);
 
         IMap<Object, Object> map = getMap(mapName, cfg);
@@ -129,8 +128,8 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
         assertSizeAndLoadCount(map);
     }
 
-    @Test(timeout = MINUTE)
-    public void testLoadAgain_whenLoadedAllCalledMultipleTimes() throws Exception {
+    @Test
+    public void testLoadAgain_whenLoadedAllCalledMultipleTimes() {
         Config cfg = newConfig(mapName, LAZY);
 
         IMap<Object, Object> map = getMap(mapName, cfg);
@@ -142,8 +141,8 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
         assertEquals(2 * MAP_STORE_ENTRY_COUNT, mapLoader.getLoadedValueCount());
     }
 
-    @Test(timeout = MINUTE)
-    public void testLoadsOnce_whenSizeCheckedTwice() throws Exception {
+    @Test
+    public void testLoadsOnce_whenSizeCheckedTwice() {
 
         mapLoader = new CountingMapLoader(MAP_STORE_ENTRY_COUNT, true);
         Config cfg = newConfig(mapName, LAZY);
@@ -179,8 +178,7 @@ public class MapLoaderMultiNodeTest extends HazelcastTestSupport {
         cfg.setProperty(GroupProperty.MAP_LOAD_CHUNK_SIZE.getName(), Integer.toString(BATCH_SIZE));
         cfg.setProperty(GroupProperty.PARTITION_COUNT.getName(), "31");
 
-        MapStoreConfig mapStoreConfig = new MapStoreConfig()
-                .setImplementation(loader).setInitialLoadMode(loadMode);
+        MapStoreConfig mapStoreConfig = new MapStoreConfig().setImplementation(loader).setInitialLoadMode(loadMode);
 
         cfg.getMapConfig(mapName).setMapStoreConfig(mapStoreConfig).setBackupCount(backups);
 


### PR DESCRIPTION
Resets MapLoaderMultiNodeTest timeouts to the default one, which should
be 300 seconds (5 minutes).

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/1889