### PR TITLE
Code cleanup in HttpHeadCommand class

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommand.java
@@ -18,28 +18,9 @@ package com.hazelcast.internal.ascii.rest;
 
 import com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType;
 
-import java.nio.ByteBuffer;
-
 public class HttpHeadCommand extends HttpCommand {
-    private boolean nextLine;
 
     public HttpHeadCommand(String uri) {
         super(TextCommandType.HTTP_HEAD, uri);
-    }
-
-    @Override
-    public boolean readFrom(ByteBuffer src) {
-        while (src.hasRemaining()) {
-            char c = (char) src.get();
-            if (c == '\n') {
-                if (nextLine) {
-                    return true;
-                }
-                nextLine = true;
-            } else if (c != '\r') {
-                nextLine = false;
-            }
-        }
-        return false;
     }
 }


### PR DESCRIPTION
Removed duplicate `readFrom` method and `nextLine` variable, which is already implemented in `HttpCommand` class. (sonar cleanup)