### PR TITLE
Cleanup Near Cache tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheBasicSlowTest.java
@@ -17,13 +17,17 @@
 package com.hazelcast.client.cache.nearcache;
 
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.NearCacheConfig;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
@@ -31,37 +35,36 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCach
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category(SlowTest.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({SlowTest.class, ParallelTest.class})
 public class ClientCacheNearCacheBasicSlowTest extends ClientCacheNearCacheBasicTest {
 
-    @Parameterized.Parameter
-    public InMemoryFormat inMemoryFormat;
-
-    @Parameterized.Parameter(value = 1)
-    public boolean serializeKeys;
-
-    @Parameterized.Parameter(value = 2)
-    public NearCacheConfig.LocalUpdatePolicy localUpdatePolicy;
-
-    @Parameterized.Parameters(name = "format:{0} serializeKeys:{1} localUpdatePolicy:{2}")
+    @Parameters(name = "format:{0} serializeKeys:{1} localUpdatePolicy:{2}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
-                {InMemoryFormat.BINARY, true, NearCacheConfig.LocalUpdatePolicy.INVALIDATE},
-                {InMemoryFormat.BINARY, true, NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE},
-                {InMemoryFormat.BINARY, false, NearCacheConfig.LocalUpdatePolicy.INVALIDATE},
-                {InMemoryFormat.BINARY, false, NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE},
-                {InMemoryFormat.OBJECT, true, NearCacheConfig.LocalUpdatePolicy.INVALIDATE},
-                {InMemoryFormat.OBJECT, true, NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE},
-                {InMemoryFormat.OBJECT, false, NearCacheConfig.LocalUpdatePolicy.INVALIDATE},
-                {InMemoryFormat.OBJECT, false, NearCacheConfig.LocalUpdatePolicy.CACHE_ON_UPDATE},
+                {InMemoryFormat.BINARY, true, LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.BINARY, true, LocalUpdatePolicy.CACHE_ON_UPDATE},
+                {InMemoryFormat.BINARY, false, LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.BINARY, false, LocalUpdatePolicy.CACHE_ON_UPDATE},
+                {InMemoryFormat.OBJECT, true, LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.OBJECT, true, LocalUpdatePolicy.CACHE_ON_UPDATE},
+                {InMemoryFormat.OBJECT, false, LocalUpdatePolicy.INVALIDATE},
+                {InMemoryFormat.OBJECT, false, LocalUpdatePolicy.CACHE_ON_UPDATE},
         });
     }
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public boolean serializeKeys;
+
+    @Parameter(value = 2)
+    public LocalUpdatePolicy localUpdatePolicy;
 
     @Before
     public void setUp() {
         nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys)
                 .setLocalUpdatePolicy(localUpdatePolicy);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCachePreloaderSlowTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client.cache.nearcache;
 
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
@@ -33,7 +33,7 @@ import java.util.Collection;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({SlowTest.class, ParallelTest.class})
 public class ClientCacheNearCachePreloaderSlowTest extends ClientCacheNearCachePreloaderTest {
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/nearcache/ClientCacheNearCacheSerializationCountTest.java
@@ -40,7 +40,6 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -66,6 +65,10 @@ import static com.hazelcast.config.NearCacheConfig.LocalUpdatePolicy.INVALIDATE;
 import static com.hazelcast.internal.adapter.DataStructureAdapter.DataStructureMethods.GET;
 import static com.hazelcast.internal.adapter.DataStructureAdapter.DataStructureMethods.GET_ALL;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static com.hazelcast.spi.properties.GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_SIZE;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
 import static java.util.Arrays.asList;
 
 /**
@@ -197,9 +200,12 @@ public class ClientCacheNearCacheSerializationCountTest extends AbstractNearCach
 
     @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
-        Config config = getConfig()
-                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "1")
-                .setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
+        Config config = smallInstanceConfig()
+                // we don't want to have the invalidations from the initial population being sent during this test
+                .setProperty(CACHE_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), String.valueOf(Integer.MAX_VALUE))
+                .setProperty(CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE))
+                .setProperty(PARTITION_COUNT.getName(), "1")
+                .setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
         prepareSerializationConfig(config.getSerializationConfig());
 
         HazelcastInstance member = hazelcastFactory.newHazelcastInstance(config);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheBasicSlowTest.java
@@ -17,12 +17,16 @@
 package com.hazelcast.client.map.impl.nearcache;
 
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
@@ -30,17 +34,11 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCach
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category(SlowTest.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({SlowTest.class, ParallelTest.class})
 public class ClientMapNearCacheBasicSlowTest extends ClientMapNearCacheBasicTest {
 
-    @Parameterized.Parameter
-    public InMemoryFormat inMemoryFormat;
-
-    @Parameterized.Parameter(value = 1)
-    public boolean serializeKeys;
-
-    @Parameterized.Parameters(name = "format:{0} serializeKeys:{1}")
+    @Parameters(name = "format:{0} serializeKeys:{1}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
                 {InMemoryFormat.BINARY, true},
@@ -50,10 +48,14 @@ public class ClientMapNearCacheBasicSlowTest extends ClientMapNearCacheBasicTest
         });
     }
 
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public boolean serializeKeys;
+
     @Before
     public void setUp() {
         nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys);
     }
-
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCachePreloaderSlowTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.client.map.impl.nearcache;
 
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
@@ -33,7 +33,7 @@ import java.util.Collection;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category({SlowTest.class, ParallelTest.class})
 public class ClientMapNearCachePreloaderSlowTest extends ClientMapNearCachePreloaderTest {
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSerializationCountTest.java
@@ -34,7 +34,6 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -54,6 +53,10 @@ import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.internal.adapter.DataStructureAdapter.DataStructureMethods.GET;
 import static com.hazelcast.internal.adapter.DataStructureAdapter.DataStructureMethods.GET_ALL;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
 import static java.util.Arrays.asList;
 
 /**
@@ -160,9 +163,12 @@ public class ClientMapNearCacheSerializationCountTest extends AbstractNearCacheS
 
     @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
-        Config config = getConfig()
-                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "1")
-                .setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
+        Config config = smallInstanceConfig()
+                // we don't want to have the invalidations from the initial population being sent during this test
+                .setProperty(MAP_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), String.valueOf(Integer.MAX_VALUE))
+                .setProperty(MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE))
+                .setProperty(PARTITION_COUNT.getName(), "1")
+                .setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
         config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
                 .setInMemoryFormat(mapInMemoryFormat)
                 .setBackupCount(0)

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/ClientMapNearCacheSlowTest.java
@@ -17,11 +17,14 @@
 package com.hazelcast.client.map.impl.nearcache;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_ENABLED;
 import static java.lang.Boolean.FALSE;
@@ -29,18 +32,17 @@ import static java.lang.Boolean.TRUE;
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
 @Category(SlowTest.class)
-@SuppressWarnings("WeakerAccess")
 public class ClientMapNearCacheSlowTest extends ClientMapNearCacheTest {
 
-    @Parameterized.Parameter
-    public boolean batchInvalidationEnabled;
-
-    @Parameterized.Parameters(name = "batchInvalidationEnabled:{0}")
+    @Parameters(name = "batchInvalidationEnabled:{0}")
     public static Iterable<Object[]> parameters() {
         return asList(new Object[]{TRUE}, new Object[]{FALSE});
     }
+
+    @Parameter
+    public boolean batchInvalidationEnabled;
 
     @Override
     protected Config newConfig() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/LiteMemberClientMapNearCacheBasicSlowTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/LiteMemberClientMapNearCacheBasicSlowTest.java
@@ -17,12 +17,16 @@
 package com.hazelcast.client.map.impl.nearcache;
 
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.util.Collection;
 
@@ -30,17 +34,11 @@ import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCach
 import static java.util.Arrays.asList;
 
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
-@Category(SlowTest.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({SlowTest.class, ParallelTest.class})
 public class LiteMemberClientMapNearCacheBasicSlowTest extends LiteMemberClientMapNearCacheBasicTest {
 
-    @Parameterized.Parameter
-    public InMemoryFormat inMemoryFormat;
-
-    @Parameterized.Parameter(value = 1)
-    public boolean serializeKeys;
-
-    @Parameterized.Parameters(name = "format:{0} serializeKeys:{1}")
+    @Parameters(name = "format:{0} serializeKeys:{1}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][]{
                 {InMemoryFormat.BINARY, true},
@@ -50,9 +48,14 @@ public class LiteMemberClientMapNearCacheBasicSlowTest extends LiteMemberClientM
         });
     }
 
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameter(value = 1)
+    public boolean serializeKeys;
+
     @Before
     public void setUp() {
         nearCacheConfig = createNearCacheConfig(inMemoryFormat, serializeKeys);
     }
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/nearcache/ClientReplicatedMapNearCacheSerializationCountTest.java
@@ -34,7 +34,6 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -52,6 +51,8 @@ import static com.hazelcast.config.InMemoryFormat.BINARY;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.internal.adapter.DataStructureAdapter.DataStructureMethods.GET;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
 import static java.util.Arrays.asList;
 
 /**
@@ -141,8 +142,8 @@ public class ClientReplicatedMapNearCacheSerializationCountTest extends Abstract
     @Override
     protected <K, V> NearCacheTestContext<K, V, Data, String> createContext() {
         Config config = getConfig()
-                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "1")
-                .setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
+                .setProperty(PARTITION_COUNT.getName(), "1")
+                .setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
         config.getReplicatedMapConfig(DEFAULT_NEAR_CACHE_NAME)
                 .setInMemoryFormat(replicatedMapInMemoryFormat);
         prepareSerializationConfig(config.getSerializationConfig());

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/CommonNearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/CommonNearCacheTestSupport.java
@@ -35,11 +35,11 @@ import java.util.concurrent.ScheduledExecutorService;
 
 public abstract class CommonNearCacheTestSupport extends HazelcastTestSupport {
 
-    protected static final int DEFAULT_RECORD_COUNT = 100;
-    protected static final String DEFAULT_NEAR_CACHE_NAME = "TestNearCache";
+    static final int DEFAULT_RECORD_COUNT = 100;
+    static final String DEFAULT_NEAR_CACHE_NAME = "TestNearCache";
 
-    protected List<ScheduledExecutorService> scheduledExecutorServices = new ArrayList<ScheduledExecutorService>();
-    protected SerializationService ss = new DefaultSerializationServiceBuilder()
+    private List<ScheduledExecutorService> scheduledExecutorServices = new ArrayList<ScheduledExecutorService>();
+    private SerializationService ss = new DefaultSerializationServiceBuilder()
             .setVersion(InternalSerializationService.VERSION_1).build();
 
     @After
@@ -50,15 +50,14 @@ public abstract class CommonNearCacheTestSupport extends HazelcastTestSupport {
         scheduledExecutorServices.clear();
     }
 
-    protected NearCacheConfig createNearCacheConfig(String name, InMemoryFormat inMemoryFormat) {
+    NearCacheConfig createNearCacheConfig(String name, InMemoryFormat inMemoryFormat) {
         return new NearCacheConfig()
                 .setName(name)
                 .setInMemoryFormat(inMemoryFormat);
     }
 
-    protected <K, V> NearCacheRecordStore<K, V> createNearCacheRecordStore(NearCacheConfig nearCacheConfig,
-                                                                           InMemoryFormat inMemoryFormat) {
-        NearCacheRecordStore<K, V> recordStore = null;
+    <K, V> NearCacheRecordStore<K, V> createNearCacheRecordStore(NearCacheConfig nearCacheConfig, InMemoryFormat inMemoryFormat) {
+        NearCacheRecordStore<K, V> recordStore;
         switch (inMemoryFormat) {
             case BINARY:
                 recordStore = new NearCacheDataRecordStore<K, V>(DEFAULT_NEAR_CACHE_NAME, nearCacheConfig, ss, null);
@@ -70,11 +69,11 @@ public abstract class CommonNearCacheTestSupport extends HazelcastTestSupport {
                 throw new IllegalArgumentException("Unsupported in-memory format: " + inMemoryFormat);
         }
         recordStore.initialize();
-
         return recordStore;
     }
 
-    protected TaskScheduler createTaskScheduler() {
+    @SuppressWarnings("unused")
+    TaskScheduler createTaskScheduler() {
         ScheduledExecutorService scheduledExecutorService = Executors.newScheduledThreadPool(1);
         scheduledExecutorServices.add(scheduledExecutorService);
         return new DelegatingTaskScheduler(scheduledExecutorService, scheduledExecutorService);

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheManagerTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheManagerTestSupport.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class NearCacheManagerTestSupport extends CommonNearCacheTestSupport {
 
-    protected static final int DEFAULT_NEAR_CACHE_COUNT = 5;
+    private static final int DEFAULT_NEAR_CACHE_COUNT = 5;
 
     protected abstract NearCacheManager createNearCacheManager();
 
@@ -43,18 +43,13 @@ public abstract class NearCacheManagerTestSupport extends CommonNearCacheTestSup
     protected ExecutionService executionService;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         HazelcastInstance instance = createHazelcastInstance();
         ss = getSerializationService(instance);
         executionService = getNodeEngineImpl(instance).getExecutionService();
     }
 
-    protected NearCache createNearCache(NearCacheManager nearCacheManager, String name) {
-        NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, DEFAULT_MEMORY_FORMAT);
-        return nearCacheManager.getOrCreateNearCache(name, nearCacheConfig);
-    }
-
-    protected void doCreateAndGetNearCache() {
+    void doCreateAndGetNearCache() {
         NearCacheManager nearCacheManager = createNearCacheManager();
 
         assertNull(nearCacheManager.getNearCache(DEFAULT_NEAR_CACHE_NAME));
@@ -71,7 +66,7 @@ public abstract class NearCacheManagerTestSupport extends CommonNearCacheTestSup
         assertEquals(createdNearCache1, nearCaches.iterator().next());
     }
 
-    protected void doListNearCaches() {
+    void doListNearCaches() {
         NearCacheManager nearCacheManager = createNearCacheManager();
 
         Set<String> nearCacheNames = new HashSet<String>();
@@ -93,7 +88,7 @@ public abstract class NearCacheManagerTestSupport extends CommonNearCacheTestSup
         }
     }
 
-    protected void doClearNearCacheAndClearAllNearCaches() {
+    void doClearNearCacheAndClearAllNearCaches() {
         NearCacheManager nearCacheManager = createNearCacheManager();
         for (int i = 0; i < DEFAULT_NEAR_CACHE_COUNT; i++) {
             createNearCache(nearCacheManager, DEFAULT_NEAR_CACHE_NAME + "-" + i);
@@ -118,7 +113,7 @@ public abstract class NearCacheManagerTestSupport extends CommonNearCacheTestSup
         assertFalse(nearCacheManager.clearNearCache(DEFAULT_NEAR_CACHE_NAME + "-" + DEFAULT_NEAR_CACHE_COUNT));
     }
 
-    protected void doDestroyNearCacheAndDestroyAllNearCaches() {
+    void doDestroyNearCacheAndDestroyAllNearCaches() {
         NearCacheManager nearCacheManager = createNearCacheManager();
 
         for (int i = 0; i < DEFAULT_NEAR_CACHE_COUNT; i++) {
@@ -149,5 +144,10 @@ public abstract class NearCacheManagerTestSupport extends CommonNearCacheTestSup
         Collection<NearCache> nearCaches4 = nearCacheManager.listAllNearCaches();
         // destroy all also removes Near Caches
         assertEquals(0, nearCaches4.size());
+    }
+
+    private NearCache createNearCache(NearCacheManager nearCacheManager, String name) {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, DEFAULT_MEMORY_FORMAT);
+        return nearCacheManager.getOrCreateNearCache(name, nearCacheConfig);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTestSupport.java
@@ -26,11 +26,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTestSupport {
+abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTestSupport {
 
-    protected void putAndGetRecord(InMemoryFormat inMemoryFormat) {
-        NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(
-                createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat), inMemoryFormat);
+    void putAndGetRecord(InMemoryFormat inMemoryFormat) {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat);
+        NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(nearCacheConfig, inMemoryFormat);
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             nearCacheRecordStore.put(i, null, "Record-" + i);
@@ -43,7 +43,7 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
         }
     }
 
-    protected void putAndRemoveRecord(InMemoryFormat inMemoryFormat) {
+    void putAndRemoveRecord(InMemoryFormat inMemoryFormat) {
         NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat);
         NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(nearCacheConfig, inMemoryFormat);
 
@@ -63,7 +63,7 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
         assertEquals(0, nearCacheRecordStore.size());
     }
 
-    protected void clearRecordsOrDestroyStore(InMemoryFormat inMemoryFormat, boolean destroy) {
+    void clearRecordsOrDestroyStore(InMemoryFormat inMemoryFormat, boolean destroy) {
         NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat);
         NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(nearCacheConfig, inMemoryFormat);
 
@@ -82,7 +82,7 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
         assertEquals(0, nearCacheRecordStore.size());
     }
 
-    protected void statsCalculated(InMemoryFormat inMemoryFormat) {
+    void statsCalculated(InMemoryFormat inMemoryFormat) {
         long creationStartTime = System.currentTimeMillis();
         NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat);
         NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(nearCacheConfig, inMemoryFormat);
@@ -111,19 +111,21 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
         // Note that System.currentTimeMillis() is not monotonically increasing.
         // Below assertions can fail anytime but for testing purposes we can use `assertTrueEventually`.
         long nearCacheStatsCreationTime = nearCacheStats.getCreationTime();
-        assertTrue("nearCacheStatsCreationTime=" + nearCacheStatsCreationTime
-                + ", and creationStartTime=" + creationStartTime, nearCacheStatsCreationTime >= creationStartTime);
-        assertTrue("nearCacheStatsCreationTime=" + nearCacheStatsCreationTime
-                + ", and creationEndTime=" + creationEndTime, nearCacheStatsCreationTime <= creationEndTime);
+        assertTrue("nearCacheStatsCreationTime=" + nearCacheStatsCreationTime + ", and creationStartTime=" + creationStartTime,
+                nearCacheStatsCreationTime >= creationStartTime);
+        assertTrue("nearCacheStatsCreationTime=" + nearCacheStatsCreationTime + ", and creationEndTime=" + creationEndTime,
+                nearCacheStatsCreationTime <= creationEndTime);
         assertEquals(expectedHits, nearCacheStats.getHits());
         assertEquals(expectedMisses, nearCacheStats.getMisses());
         assertEquals(expectedEntryCount, nearCacheStats.getOwnedEntryCount());
         switch (inMemoryFormat) {
+            case NATIVE:
             case BINARY:
                 assertTrue(memoryCostWhenFull > 0);
                 break;
             case OBJECT:
                 assertEquals(0, memoryCostWhenFull);
+                break;
         }
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
@@ -134,6 +136,7 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
 
         assertEquals(expectedEntryCount, nearCacheStats.getOwnedEntryCount());
         switch (inMemoryFormat) {
+            case NATIVE:
             case BINARY:
                 assertTrue(nearCacheStats.getOwnedEntryMemoryCost() > 0);
                 assertTrue(nearCacheStats.getOwnedEntryMemoryCost() < memoryCostWhenFull);
@@ -144,23 +147,16 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
         }
 
         nearCacheRecordStore.clear();
-
-        switch (inMemoryFormat) {
-            case BINARY:
-            case OBJECT:
-                assertEquals(0, nearCacheStats.getOwnedEntryMemoryCost());
-                break;
-        }
+        assertEquals(0, nearCacheStats.getOwnedEntryMemoryCost());
     }
 
-    protected void ttlEvaluated(InMemoryFormat inMemoryFormat) {
+    void ttlEvaluated(InMemoryFormat inMemoryFormat) {
         int ttlSeconds = 3;
 
-        NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat);
-        nearCacheConfig.setTimeToLiveSeconds(ttlSeconds);
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat)
+                .setTimeToLiveSeconds(ttlSeconds);
 
-        NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(
-                nearCacheConfig, inMemoryFormat);
+        NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(nearCacheConfig, inMemoryFormat);
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             nearCacheRecordStore.put(i, null, "Record-" + i);
@@ -177,14 +173,13 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
         }
     }
 
-    protected void maxIdleTimeEvaluatedSuccessfully(InMemoryFormat inMemoryFormat) {
+    void maxIdleTimeEvaluatedSuccessfully(InMemoryFormat inMemoryFormat) {
         int maxIdleSeconds = 3;
 
-        NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat);
-        nearCacheConfig.setMaxIdleSeconds(maxIdleSeconds);
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat)
+                .setMaxIdleSeconds(maxIdleSeconds);
 
-        NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(
-                nearCacheConfig, inMemoryFormat);
+        NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(nearCacheConfig, inMemoryFormat);
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             nearCacheRecordStore.put(i, null, "Record-" + i);
@@ -201,7 +196,7 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
         }
     }
 
-    protected void expiredRecordsCleanedUpSuccessfully(InMemoryFormat inMemoryFormat, boolean useIdleTime) {
+    void expiredRecordsCleanedUpSuccessfully(InMemoryFormat inMemoryFormat, boolean useIdleTime) {
         int cleanUpThresholdSeconds = 3;
 
         NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat);
@@ -211,8 +206,7 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
             nearCacheConfig.setTimeToLiveSeconds(cleanUpThresholdSeconds);
         }
 
-        NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(
-                nearCacheConfig, inMemoryFormat);
+        NearCacheRecordStore<Integer, String> nearCacheRecordStore = createNearCacheRecordStore(nearCacheConfig, inMemoryFormat);
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
             nearCacheRecordStore.put(i, null, "Record-" + i);
@@ -229,14 +223,13 @@ public abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTes
         assertEquals(0, nearCacheStats.getOwnedEntryMemoryCost());
     }
 
-    protected void createNearCacheWithMaxSizePolicy(InMemoryFormat inMemoryFormat, EvictionConfig.MaxSizePolicy maxSizePolicy,
-                                                    int size) {
-        NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat);
+    void createNearCacheWithMaxSizePolicy(InMemoryFormat inMemoryFormat, EvictionConfig.MaxSizePolicy maxSizePolicy, int size) {
+        EvictionConfig evictionConfig = new EvictionConfig()
+                .setMaximumSizePolicy(maxSizePolicy)
+                .setSize(size);
 
-        EvictionConfig evictionConfig = new EvictionConfig();
-        evictionConfig.setMaximumSizePolicy(maxSizePolicy);
-        evictionConfig.setSize(size);
-        nearCacheConfig.setEvictionConfig(evictionConfig);
+        NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, inMemoryFormat)
+                .setEvictionConfig(evictionConfig);
 
         createNearCacheRecordStore(nearCacheConfig, inMemoryFormat);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTest.java
@@ -33,8 +33,8 @@ public class NearCacheTest extends NearCacheTestSupport {
     @Override
     protected NearCache<Integer, String> createNearCache(String name, NearCacheConfig nearCacheConfig,
                                                          ManagedNearCacheRecordStore nearCacheRecordStore) {
-        return new DefaultNearCache<Integer, String>(name, nearCacheConfig,
-                nearCacheRecordStore, ss, executionService.getGlobalTaskScheduler(), null);
+        return new DefaultNearCache<Integer, String>(name, nearCacheConfig, nearCacheRecordStore, ss,
+                executionService.getGlobalTaskScheduler(), null);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("WeakerAccess")
 public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
 
     protected SerializationService ss;
@@ -51,8 +52,7 @@ public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
         executionService = getNodeEngineImpl(instance).getExecutionService();
     }
 
-    protected abstract NearCache<Integer, String> createNearCache(String name,
-                                                                  NearCacheConfig nearCacheConfig,
+    protected abstract NearCache<Integer, String> createNearCache(String name, NearCacheConfig nearCacheConfig,
                                                                   ManagedNearCacheRecordStore nearCacheRecordStore);
 
     protected NearCache<Integer, String> createNearCache(String name, ManagedNearCacheRecordStore nearCacheRecordStore) {
@@ -224,7 +224,7 @@ public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
         // expiration will be called eventually
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertTrue(managedNearCacheRecordStore.doExpirationCalled);
             }
         });

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/LiteMemberMapNearCacheSerializationCountTest.java
@@ -33,7 +33,6 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -54,6 +53,10 @@ import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.internal.adapter.DataStructureAdapter.DataStructureMethods.GET;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
 import static java.util.Arrays.asList;
 
 /**
@@ -169,9 +172,12 @@ public class LiteMemberMapNearCacheSerializationCountTest extends AbstractNearCa
     }
 
     protected Config createConfig(NearCacheConfig nearCacheConfig, boolean liteMember) {
-        Config config = getConfig()
-                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "1")
-                .setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "1")
+        Config config = smallInstanceConfig()
+                // we don't want to have the invalidations from the initial population being sent during this test
+                .setProperty(MAP_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), String.valueOf(Integer.MAX_VALUE))
+                .setProperty(MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE))
+                .setProperty(PARTITION_COUNT.getName(), "1")
+                .setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "1")
                 .setLiteMember(liteMember);
         MapConfig mapConfig = config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
                 .setInMemoryFormat(mapInMemoryFormat)

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/MapNearCacheSerializationCountTest.java
@@ -32,7 +32,6 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -54,6 +53,10 @@ import static com.hazelcast.internal.adapter.DataStructureAdapter.DataStructureM
 import static com.hazelcast.internal.adapter.DataStructureAdapter.DataStructureMethods.GET_ALL;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
 import static java.util.Arrays.asList;
 
 /**
@@ -179,9 +182,12 @@ public class MapNearCacheSerializationCountTest extends AbstractNearCacheSeriali
     }
 
     private Config getConfig(boolean withNearCache) {
-        Config config = getConfig()
-                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "1")
-                .setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
+        Config config = smallInstanceConfig()
+                // we don't want to have the invalidations from the initial population being sent during this test
+                .setProperty(MAP_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), String.valueOf(Integer.MAX_VALUE))
+                .setProperty(MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE))
+                .setProperty(PARTITION_COUNT.getName(), "1")
+                .setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
         MapConfig mapConfig = config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
                 .setInMemoryFormat(mapInMemoryFormat)
                 .setBackupCount(0)

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/TxnMapNearCacheSerializationCountTest.java
@@ -31,7 +31,6 @@ import com.hazelcast.internal.nearcache.NearCacheTestContext;
 import com.hazelcast.internal.nearcache.NearCacheTestContextBuilder;
 import com.hazelcast.internal.nearcache.NearCacheTestUtils;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -52,6 +51,10 @@ import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.internal.adapter.DataStructureAdapter.DataStructureMethods.GET;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.createNearCacheConfig;
 import static com.hazelcast.internal.nearcache.NearCacheTestUtils.getMapNearCacheManager;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_INVALIDATION_MESSAGE_BATCH_SIZE;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_OPERATION_THREAD_COUNT;
 import static java.util.Arrays.asList;
 
 /**
@@ -156,9 +159,12 @@ public class TxnMapNearCacheSerializationCountTest extends AbstractNearCacheSeri
     }
 
     private Config getConfig(boolean withNearCache) {
-        Config config = getConfig()
-                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "1")
-                .setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
+        Config config = smallInstanceConfig()
+                // we don't want to have the invalidations from the initial population being sent during this test
+                .setProperty(MAP_INVALIDATION_MESSAGE_BATCH_SIZE.getName(), String.valueOf(Integer.MAX_VALUE))
+                .setProperty(MAP_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE))
+                .setProperty(PARTITION_COUNT.getName(), "1")
+                .setProperty(PARTITION_OPERATION_THREAD_COUNT.getName(), "1");
         MapConfig mapConfig = config.getMapConfig(DEFAULT_NEAR_CACHE_NAME)
                 .setInMemoryFormat(mapInMemoryFormat)
                 .setBackupCount(0)


### PR DESCRIPTION
*  Cleanup Near Cache tests based on `CommonNearCacheTestSupport`

* Improved Near Cache SlowTests 
  * added missing `ParallelTest` annotations to tests (only non-preloader tests, which cannot run in parallel)
  * changed tests to `HazelcastParallelParametersRunnerFactory` to speed up non-`ParallelTest` executions
  * cleanup of tests

* Fixed possible race condition in Near Cache serialization count tests 

  The Near Cache serialization count tests fail, when the invalidations from the initial population are sent and executed (because we'll have to re-populate the Near Cache in that case, which causes additional
(de)serializations).

  We can fix this by increasing the batch size and frequency seconds to very large values, so no invalidations are executed during the test.

  In addition we can use the `smallInstanceConfig()` to reduce the resource usage of the tests.