### PR TITLE
Cache values() result for Type enum to prevent unneeded array creation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -333,12 +333,14 @@ public final class Packet extends HeapData implements OutboundFrame {
 
         final char headerEncoding;
 
+        private static final Type[] VALUES = values();
+
         Type() {
             headerEncoding = (char) encodeOrdinal();
         }
 
         public static Type fromFlags(int flags) {
-            return values()[headerDecode(flags)];
+            return VALUES[headerDecode(flags)];
         }
 
         public String describeFlags(char flags) {


### PR DESCRIPTION
This unneeded array creation is on hot path.