### PR TITLE
Remove EvictionTest.testTTL_prolongationAfterNonTTLUpdate_Quick

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -112,26 +112,8 @@ public class EvictionTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testTTL_prolongationAfterNonTTLUpdate_Quick() {
-        final IMap<Integer, String> map = createSimpleMap();
-
-        long sleepRef = System.currentTimeMillis();
-        map.put(1, "value0", 3, TimeUnit.SECONDS);
-        // 1 second safety margin before eviction
-        sleepAtMostSeconds(sleepRef, 2);
-        assertTrue(map.containsKey(1));
-
-        sleepRef = System.currentTimeMillis();
-        // this should prolong the life of the entry for another 3 seconds
-        map.put(1, "value1");
-        // 4 seconds of wait time in total, 1 second safety margin after a potential eviction
-        sleepAtMostSeconds(sleepRef, 2);
-        assertTrue(map.containsKey(1));
-    }
-
-    @Test
     @Category(SlowTest.class)
-    public void testTTL_prolongationAfterNonTTLUpdate_Slow() throws ExecutionException, InterruptedException {
+    public void testTTL_prolongationAfterNonTTLUpdate() throws ExecutionException, InterruptedException {
         final IMap<Integer, String> map = createSimpleMap();
 
         long sleepRef = System.currentTimeMillis();


### PR DESCRIPTION
Let me justify the reasons behind removing:

* the test is extremely fragile (as also @mmedenjak says in here https://github.com/hazelcast/hazelcast/pull/12730) - even with @blazember 's hiccup protection, the hiccup can be that long that it will still remove the entry when the test resumes
* the reason for high hiccups is the fact that it's running in the PR builder, where there is a parallelism involved. The _Slow version of this test is actually verifying the same functionality, but it not part of the PR builder, it's part of nightly build.
* based on the previous point, the only risk of removing this quick test is that we won't find possible bug in PR builder, but we will definitely find it during nightly build, so max. 24 hours later. Given the high fragility of the Quick version in PR builder, it's definitely worth to just remove it in exchange for more stable PR builder and 24 hours delayed detection.

Fixes: https://github.com/hazelcast/hazelcast/issues/12376