### PR TITLE
[BACKPORT] Increase timeouts for Sonar builds (OS)

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -318,7 +318,8 @@ public class TestHazelcastInstanceFactory {
             config = new XmlConfigBuilder().build();
         }
         config.setProperty(GroupProperty.WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
-        config.setProperty(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT.getName(), "120");
+        String gracefulShutdownMaxWaitValue = System.getProperty(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT.getName(), "120");
+        config.setProperty(GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT.getName(), gracefulShutdownMaxWaitValue);
         config.setProperty(GroupProperty.PARTITION_BACKUP_SYNC_INTERVAL.getName(), "1");
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         return config;

--- a/pom.xml
+++ b/pom.xml
@@ -565,6 +565,8 @@
                     -Dhazelcast.logging.type=none
                     -Dhazelcast.test.use.network=false
                     -Dlog4j.skipJansi=true
+                    -Dhazelcast.operation.call.timeout.millis=120000
+                    -Dhazelcast.graceful.shutdown.max.wait=240
                     ${extraVmArgs}
                 </argLine>
             </properties>


### PR DESCRIPTION
Compensates for the increased execution time caused by the bytecode
instrumentation done by Sonar.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/1427

(cherry picked from 32d1504ed44fb81259d1138c2fc6d4a666f0b71e)