### PR TITLE
Changes LOAD_TYPE parameter in NioPipeline to non-static

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
@@ -71,7 +71,7 @@ public final class NioInboundPipeline extends NioPipeline {
 
     @Override
     public long load() {
-        switch (LOAD_TYPE) {
+        switch (loadType) {
             case LOAD_BALANCING_HANDLE:
                 return processCount.get();
             case LOAD_BALANCING_BYTE:

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -86,7 +86,7 @@ public final class NioOutboundPipeline extends NioPipeline {
 
     @Override
     public long load() {
-        switch (LOAD_TYPE) {
+        switch (loadType) {
             case LOAD_BALANCING_HANDLE:
                 return processCount.get();
             case LOAD_BALANCING_BYTE:

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
@@ -41,7 +41,7 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable, Runn
     protected static final int LOAD_BALANCING_FRAME = 2;
 
     // for the time being we configure using a int until we have decided which load strategy to use.
-    protected static final int LOAD_TYPE = Integer.getInteger("hazelcast.io.load", LOAD_BALANCING_BYTE);
+    protected final int loadType = Integer.getInteger("hazelcast.io.load", LOAD_BALANCING_BYTE);
 
     @Probe
     final SwCounter processCount = newSwCounter();


### PR DESCRIPTION
Since this value is a static final, its value is loaded when the classloader loads the class. So we cannot change its value during the test. The test runs in nightly configuration and constantly fails. If https://hazelcast-l337.ci.cloudbees.com/view/Official%20Builds/job/jiri-nightly/ passes, then this PR solves the problem.

Credits to @Holmistr for spotting the problem.
Fixes #7662