### PR TITLE
Only increment cache eviction stats on primary record store

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/stats/ClientCacheStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/stats/ClientCacheStatsTest.java
@@ -129,8 +129,11 @@ public class ClientCacheStatsTest extends CacheStatsTest {
     @Override
     @Test
     public void testEvictions() {
+        ICache<Integer, String> cache = createCache();
+        CacheStatistics stats = cache.getLocalCacheStatistics();
+
         expectedException.expect(UnsupportedOperationException.class);
-        super.testEvictions();
+        stats.getCacheEvictions();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -292,7 +292,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         }
 
         boolean evicted = evictionStrategy.evict(records, evictionPolicyEvaluator, evictionChecker, this);
-        if (isStatisticsEnabled() && evicted) {
+        if (isStatisticsEnabled() && evicted && primary) {
             statistics.increaseCacheEvictions(1);
         }
         return evicted;

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
@@ -53,7 +53,7 @@ public abstract class CacheTestSupport extends HazelcastTestSupport {
 
     @After
     public final void tearDown() {
-        if (cacheManager != null) {
+        if (cacheManager != null && !cacheManager.isClosed()) {
             Iterable<String> cacheNames = cacheManager.getCacheNames();
             for (String name : cacheNames) {
                 cacheManager.destroyCache(name);


### PR DESCRIPTION
When a `Cache` operation results in eviction being triggered, evictions on its backups should not increment local cache statistics.

Fixes #12931 