### PR TITLE
[BACKPORT 3.10.x] Added category SerializationSamplesExcluded

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterUpgradeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterUpgradeTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SerializationSamplesExcluded;
 import com.hazelcast.version.MemberVersion;
 import org.junit.After;
 import org.junit.Before;
@@ -40,7 +41,7 @@ import static com.hazelcast.test.TestClusterUpgradeUtils.upgradeClusterMembers;
  * Create a cluster, then change cluster version. This test uses artificial version numbers, to avoid relying on current version.
  */
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelTest.class, SerializationSamplesExcluded.class})
 public class ClusterUpgradeTest extends HazelcastTestSupport {
 
     static final MemberVersion VERSION_2_0_5 = MemberVersion.of(2, 0, 5);

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_MemberIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_MemberIntegrationTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SerializationSamplesExcluded;
 import com.hazelcast.util.function.Supplier;
 import org.junit.After;
 import org.junit.Before;
@@ -41,7 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelTest.class, SerializationSamplesExcluded.class})
 public class FlakeIdGenerator_MemberIntegrationTest extends HazelcastTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberListJoinVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MemberListJoinVersionTest.java
@@ -27,6 +27,8 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SerializationSamplesExcluded;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -57,7 +59,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelTest.class, SerializationSamplesExcluded.class})
 public class MemberListJoinVersionTest extends HazelcastTestSupport {
 
     private TestHazelcastInstanceFactory factory;

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -35,6 +35,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SerializationSamplesExcluded;
 import com.hazelcast.util.UuidUtil;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,7 +67,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelTest.class, SerializationSamplesExcluded.class})
 public class PromoteLiteMemberTest extends HazelcastTestSupport {
 
     @Rule

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigRollingUpgradeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigRollingUpgradeTest.java
@@ -27,6 +27,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SerializationSamplesExcluded;
 import com.hazelcast.version.Version;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,7 +38,7 @@ import static com.hazelcast.internal.cluster.Versions.V3_8;
 import static com.hazelcast.internal.cluster.Versions.V3_9;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class, ParallelTest.class, SerializationSamplesExcluded.class})
 public class DynamicConfigRollingUpgradeTest extends HazelcastTestSupport {
 
     @Test(expected = UnsupportedOperationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/quorum/QuorumRollingUpgradeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/QuorumRollingUpgradeTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.TransactionalSet;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SerializationSamplesExcluded;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionOptions;
 import org.junit.AfterClass;
@@ -41,7 +42,7 @@ import static com.hazelcast.transaction.TransactionOptions.TransactionType.ONE_P
  * Quorum test proving that newly supported quorum-aware structures do not respect quorum below version 3.10.
  */
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class})
+@Category({QuickTest.class, SerializationSamplesExcluded.class})
 public class QuorumRollingUpgradeTest extends AbstractQuorumTest {
 
     private static final int NO_QUORUM_CLUSTER = 3;

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/SerializationSamplesExcluded.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/SerializationSamplesExcluded.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.annotation;
+
+/**
+ * Annotates tests which should not be used for generating serialization samples used in compatibility checks.
+ * <p/>
+ * See {@code generate-compatibility-samples} Maven profile in root {@code pom.xml}.
+ */
+public final class SerializationSamplesExcluded {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1238,7 +1238,8 @@
                             <groups>com.hazelcast.test.annotation.QuickTest</groups>
                             <excludedGroups>
                                 com.hazelcast.test.annotation.SlowTest,
-                                com.hazelcast.test.annotation.NightlyTest
+                                com.hazelcast.test.annotation.NightlyTest,
+                                com.hazelcast.test.annotation.SerializationSamplesExcluded
                             </excludedGroups>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
Backport of #12987
Adds a new test category class which flags to-be-excluded tests from generating deserialization samples.
This decreases count of false negatives in `SerializedObjectsCompatibilityTest`.