### PR TITLE
[BACKPORT] Fix partition table lazy init bug

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -81,17 +81,20 @@ public interface InternalPartitionService extends IPartitionService {
     /**
      * Causes the partition table to be arranged and published to members if :
      * <ul>
-     * <li>the instance has started</li>
+     * <li>this instance has started</li>
+     * <li>this instance is the master</li>
      * <li>the cluster is {@link ClusterState#ACTIVE}</li>
-     * <li>if it has not already been arranged</li>
+     * <li>if the partition table has not already been arranged</li>
      * <li>if there is no cluster membership change</li>
      * </ul>
-     * If this node is not the master, it will trigger the master to assign the partitions.
+     * If this instance is not the master, it will trigger the master to assign the partitions.
      *
      * @throws HazelcastException if the partition state generator failed to arrange the partitions
+     * @return {@link PartitionRuntimeState} if this node is the master and the partition table is initialized
+     *
      * @see PartitionStateManager#initializePartitionAssignments(java.util.Set)
      */
-    void firstArrangement();
+    PartitionRuntimeState firstArrangement();
 
     /**
      * Creates the current partition runtime state. May return {@code null} if the node should fetch the most recent partition

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AssignPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AssignPartitions.java
@@ -16,21 +16,25 @@
 
 package com.hazelcast.internal.partition.operation;
 
+import com.hazelcast.internal.partition.MigrationCycleOperation;
+import com.hazelcast.internal.partition.PartitionRuntimeState;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 
 /** Sent from non-master nodes to the master to initialize the partition assignment. */
-public class AssignPartitions extends AbstractPartitionOperation {
+public class AssignPartitions extends AbstractPartitionOperation implements MigrationCycleOperation {
+
+    private PartitionRuntimeState partitionState;
 
     @Override
     public void run() {
         InternalPartitionServiceImpl service = getService();
-        service.firstArrangement();
+        partitionState = service.firstArrangement();
     }
 
     @Override
     public Object getResponse() {
-        return Boolean.TRUE;
+        return partitionState;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_InitInvocationTargetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_InitInvocationTargetTest.java
@@ -16,21 +16,46 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_TABLE_SEND_INTERVAL;
+import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
+import static com.hazelcast.test.PacketFiltersUtil.resetPacketFiltersFrom;
+import static java.util.Collections.singletonList;
+
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class Invocation_InitInvocationTargetTest {
+public class Invocation_InitInvocationTargetTest extends HazelcastTestSupport {
 
     @Test
-    @Ignore
-    public void test() {
-        // TODO: needs to be implemented
+    public void testPartitionTableIsFetchedLazilyOnPartitionInvocation() throws ExecutionException, InterruptedException {
+        Config config = new Config();
+        config.setProperty(PARTITION_TABLE_SEND_INTERVAL.getName(), String.valueOf(Integer.MAX_VALUE));
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = factory.newInstances(config);
+
+        dropOperationsBetween(instances[0], instances[1], PartitionDataSerializerHook.F_ID,
+                singletonList(PartitionDataSerializerHook.PARTITION_STATE_OP));
+
+        InternalOperationService operationService = getNodeEngineImpl(instances[1]).getOperationService();
+        Future<Object> future = operationService.invokeOnPartition(null, new DummyOperation(), 0);
+
+        resetPacketFiltersFrom(instances[0]);
+
+        future.get();
     }
 }


### PR DESCRIPTION
When a partition invocation retries because the partition table is not known in a non-master member, the retry occurs on the invocation monitor thread. If the partition table is still not known, PartitionInvocation tries to fetch it from the master by invoking AssignPartitions while initializing the invocation target. However, the internal AssignPartitions invocation fails because the invocation occurs on a OperationHostileThread.

This fix marks AssignPartitions operation as MigrationCycleOperation because it is a cheap one and we don't block the invocation monitor thread for its invocation.

Backport of #12992 