### PR TITLE
Shutdown client instances properly in cache tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheClearTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CacheClearTest;
 import com.hazelcast.cache.ICache;
+import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
@@ -210,6 +211,7 @@ public class ClientCacheClearTest extends CacheClearTest {
         // Client factory is already shutdown at this test's super class (`CachePutAllTest`)
         // because it is returned instance factory from overridden `getInstanceFactory` method.
         client = null;
+        HazelcastClientManager.shutdownAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CacheContextTest;
+import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -48,6 +49,7 @@ public class ClientCacheContextTest extends CacheContextTest {
         driverInstance.shutdown();
         hazelcastInstance1.shutdown();
         hazelcastInstance2.shutdown();
+        HazelcastClientManager.shutdownAll();
     }
 
     @Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheCreationTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CacheCreationTest;
 import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.spi.properties.ClientProperty;
@@ -104,5 +105,11 @@ public class ClientCacheCreationTest extends CacheCreationTest {
     @Ignore("Only applicable for member-side HazelcastInstance")
     @Override
     public void createInvalidCache_fromDeclarativeConfig_throwsException_fromHazelcastInstanceCreation() {
+    }
+
+    @Override
+    public void teardown() {
+        super.teardown();
+        HazelcastClientManager.shutdownAll();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheEventJournalBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheEventJournalBasicTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.impl.journal.CacheEventJournalBasicTest;
+import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
@@ -58,5 +59,6 @@ public class ClientCacheEventJournalBasicTest extends CacheEventJournalBasicTest
     @After
     public final void terminate() {
         factory.terminateAll();
+        HazelcastClientManager.shutdownAll();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheIteratorTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CacheIteratorAbstractTest;
+import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
@@ -47,6 +48,7 @@ public class ClientCacheIteratorTest extends CacheIteratorAbstractTest {
     @After
     public void tear() {
         factory.shutdownAll();
+        HazelcastClientManager.shutdownAll();
     }
 
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionIteratorTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionIteratorTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.cache;
 
+import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
@@ -39,5 +40,11 @@ public class ClientCachePartitionIteratorTest extends AbstractClientCachePartiti
 
         HazelcastInstance client = factory.newHazelcastClient();
         cachingProvider = HazelcastClientCachingProvider.createCachingProvider(client);
+    }
+
+    @Override
+    public void teardown() {
+        super.teardown();
+        HazelcastClientManager.shutdownAll();
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionLostListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionLostListenerTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.cache.impl.event.CachePartitionLostEvent;
 import com.hazelcast.cache.impl.event.CachePartitionLostListener;
+import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
@@ -63,6 +64,7 @@ public class ClientCachePartitionLostListenerTest extends HazelcastTestSupport {
     @After
     public void tearDown() {
         hazelcastFactory.terminateAll();
+        HazelcastClientManager.shutdownAll();
     }
 
     @Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePutAllTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePutAllTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CachePutAllTest;
+import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
@@ -60,6 +61,7 @@ public class ClientCachePutAllTest extends CachePutAllTest {
         // Client factory is already shutdown at this test's super class (`CachePutAllTest`)
         // because it is returned instance factory from overridden `getInstanceFactory` method.
         client = null;
+        HazelcastClientManager.shutdownAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheReadWriteThroughTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheReadWriteThroughTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CacheReadWriteThroughTest;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
@@ -85,6 +86,7 @@ public class ClientCacheReadWriteThroughTest extends CacheReadWriteThroughTest {
     @Override
     protected void onTearDown() {
         serverCachingProvider.close();
+        HazelcastClientManager.shutdownAll();
     }
 
     // https://github.com/hazelcast/hazelcast/issues/6676

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachingProviderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachingProviderTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.cache;
 
 import com.hazelcast.cache.CachingProviderTest;
 import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.cache.impl.HazelcastClientCachingProvider;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
@@ -116,6 +117,7 @@ public class ClientCachingProviderTest extends CachingProviderTest {
                 iter.remove();
             }
         }
+        HazelcastClientManager.shutdownAll();
     }
 
 }


### PR DESCRIPTION
The root cause of https://github.com/hazelcast/hazelcast/issues/12938 is that some instances end up hanging there. As it turns out, quite a few tests have this problems, this PR closes the client instances properly.

Please review carefully, I'm not that familiar with this part of the testsuite, maybe I missed something or maybe there's a better place to put the clear.

fixes https://github.com/hazelcast/hazelcast/issues/12938