### PR TITLE
Converted operationBatch from int[] to BitSet

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -41,7 +41,7 @@ import com.hazelcast.util.scheduler.ScheduledEntry;
 import com.hazelcast.util.scheduler.ScheduledEntryProcessor;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -436,20 +436,18 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
                     || !partitionService.isMigrationAllowed()) {
                 return;
             }
-            nodeEngine.getOperationService().execute(new PartitionAntiEntropyTaskFactory(), getLocalPartitions());
+            nodeEngine.getOperationService().executeOnPartitions(new PartitionAntiEntropyTaskFactory(), getLocalPartitions());
         }
 
-        private int[] getLocalPartitions() {
-            InternalPartition[] partitions = partitionStateManager.getPartitions();
-            int[] partitionIDs = new int[partitions.length];
-            int ix = 0;
+        private BitSet getLocalPartitions() {
+            BitSet localPartitions = new BitSet(partitionService.getPartitionCount());
 
-            for (InternalPartition partition : partitions) {
+            for (InternalPartition partition : partitionService.getInternalPartitions()) {
                 if (partition.isLocal()) {
-                    partitionIDs[ix++] = partition.getPartitionId();
+                    localPartitions.set(partition.getPartitionId());
                 }
             }
-            return Arrays.copyOfRange(partitionIDs, 0, ix);
+            return localPartitions;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -23,6 +23,8 @@ import com.hazelcast.spi.impl.PartitionSpecificRunnable;
 import com.hazelcast.spi.impl.operationexecutor.impl.OperationExecutorImpl;
 import com.hazelcast.spi.impl.operationservice.PartitionTaskFactory;
 
+import java.util.BitSet;
+
 /**
  * The OperationExecutor is responsible for scheduling work (packets/operations)
  * to be executed. It can be compared to a {@link java.util.concurrent.Executor}
@@ -101,14 +103,26 @@ public interface OperationExecutor extends PacketHandler, LiveOperationsTracker 
     /**
      * Executes a task from the taskFactory for each of the given partitions.
      *
-     * For more detail see
-     * {@link com.hazelcast.spi.impl.operationservice.InternalOperationService#execute(PartitionTaskFactory, int[])}
+     * The reason this method exists is to prevent a bubble of operations/tasks
+     * to be created on the work-queue if the regular {@link #execute(Operation)}
+     * would be called in a loop.
+     *
+     * The consequence of this bubble is that no other operations can interleave
+     * and this can lead to very bad latency for the other operations.
+     *
+     * This method can be used to create Operations and Runnable's to be executed
+     * on a partition thread.
+     *
+     * No check is done if the partition is actually local or not!
      *
      * @param taskFactory the {@link PartitionTaskFactory} responsible for creating
      *                    tasks.
-     * @param partitions the partitions to execute tasks on.
+     * @param partitions  the partitions to execute tasks on. This BitSet should not
+     *                    modified after this method is called. For each of the
+     *                    partitions there is a bit indicating if a task should be
+     *                    executed on the partition.
      */
-    void execute(PartitionTaskFactory taskFactory, int[] partitions);
+    void executeOnPartitions(PartitionTaskFactory taskFactory, BitSet partitions);
 
     /**
      * Executes the given {@link PartitionSpecificRunnable} at some point in the
@@ -133,7 +147,7 @@ public interface OperationExecutor extends PacketHandler, LiveOperationsTracker 
      * @param op the {@link Operation} to run.
      * @throws java.lang.NullPointerException if op is null.
      * @throws IllegalThreadStateException    if the operation is not allowed
-     * to be run on the calling thread.
+     *                                        to be run on the calling thread.
      */
     void run(Operation op);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl.java
@@ -41,6 +41,7 @@ import com.hazelcast.spi.properties.HazelcastProperty;
 import com.hazelcast.util.concurrent.IdleStrategy;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.util.BitSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -354,7 +355,7 @@ public final class OperationExecutorImpl implements OperationExecutor, MetricsPr
     }
 
     @Override
-    public void execute(PartitionTaskFactory taskFactory, int[] partitions) {
+    public void executeOnPartitions(PartitionTaskFactory taskFactory, BitSet partitions) {
         checkNotNull(taskFactory, "taskFactory can't be null");
         checkNotNull(partitions, "partitions can't be null");
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -21,7 +21,9 @@ import com.hazelcast.internal.management.dto.SlowOperationDTO;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
 
+import java.util.BitSet;
 import java.util.List;
 
 /**
@@ -85,9 +87,8 @@ public interface InternalOperationService extends OperationService {
     /**
      * Should be called when the asynchronous operation has completed.
      *
-     * @see #onStartAsyncOperation(Operation)
-     *
      * @param op
+     * @see #onStartAsyncOperation(Operation)
      */
     void onCompletionAsyncOperation(Operation op);
 
@@ -126,22 +127,15 @@ public interface InternalOperationService extends OperationService {
      * Executes for each of the partitions, a task created by the
      * taskFactory.
      *
-     * The reason this method exists is to prevent a bubble of operations/tasks
-     * to be created on the work-queue if the regular {@link #execute(Operation)}
-     * would be called in a loop.
-     *
-     * The consequence of this bubble is that no other operations can interleave
-     * and this can lead to very bad latency for the other operations.
-     *
-     * This method can be used to create Operations and Runnable's to be executed
-     * on a partition thread.
+     * For more info see the
+     * {@link OperationExecutor#executeOnPartitions(PartitionTaskFactory, BitSet)}
      *
      * @param taskFactory the PartitionTaskFactory used to create
-     *                         operations.
-     * @param partitions the partitions to execute an operation on.
+     *                    operations.
+     * @param partitions  the partitions to execute an operation on.
      * @throws NullPointerException if taskFactory or partitions is null.
      */
-    void execute(PartitionTaskFactory taskFactory, int[] partitions);
+    void executeOnPartitions(PartitionTaskFactory taskFactory, BitSet partitions);
 
     /**
      * Returns information about long running operations.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -53,6 +53,7 @@ import com.hazelcast.util.executor.ExecutorType;
 import com.hazelcast.util.executor.ManagedExecutorService;
 
 import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -262,8 +263,8 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     }
 
     @Override
-    public void execute(PartitionTaskFactory taskFactory, int[] partitions) {
-        operationExecutor.execute(taskFactory, partitions);
+    public void executeOnPartitions(PartitionTaskFactory taskFactory, BitSet partitions) {
+        operationExecutor.executeOnPartitions(taskFactory, partitions);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -33,6 +33,7 @@ import com.hazelcast.spi.impl.operationservice.impl.responses.NormalResponse;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
+import java.util.BitSet;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
@@ -136,7 +137,15 @@ public final class PartitionIteratingOperation extends Operation implements Iden
             }
         };
 
-        getOperationService().execute(f, partitions);
+        getOperationService().executeOnPartitions(f, toPartitionBitSet());
+    }
+
+    private BitSet toPartitionBitSet() {
+        BitSet bitSet = new BitSet(getNodeEngine().getPartitionService().getPartitionCount());
+        for (int partition : partitions) {
+            bitSet.set(partition);
+        }
+        return bitSet;
     }
 
     private void executePartitionAwareOperations(PartitionAwareOperationFactory givenFactory) {
@@ -167,7 +176,7 @@ public final class PartitionIteratingOperation extends Operation implements Iden
             }
         };
 
-        getOperationService().execute(f, partitions);
+        getOperationService().executeOnPartitions(f, toPartitionBitSet());
     }
 
     private InternalOperationService getOperationService() {


### PR DESCRIPTION
makes it less of a PITA to use.

Also renamed execute method to executeOnPartitions

And some minor javadoc improvements.

For enterprise version

https://github.com/hazelcast/hazelcast-enterprise/pull/2092