### PR TITLE
Updated map management

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheManager.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.nearcache;
 
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
+import com.hazelcast.util.function.Supplier;
 
 import java.util.Collection;
 
@@ -47,7 +48,7 @@ public interface NearCacheManager {
      * @param <V>             the value type of the {@link NearCache}
      * @return the created or existing {@link NearCache} instance associated with given {@code name}
      */
-    <K, V> NearCache<K, V> getOrCreateNearCache(String name, NearCacheConfig nearCacheConfig);
+    <K, V> NearCache<K, V> getOrCreateNearCache(String name, Supplier<NearCacheConfig> nearCacheConfig);
 
     /**
      * Creates a new {@link NearCache} with given configurations or returns existing one.
@@ -63,7 +64,7 @@ public interface NearCacheManager {
      * @return the created or existing {@link NearCache} instance associated with given {@code name}
      */
     <K, V> NearCache<K, V> getOrCreateNearCache(String name,
-                                                NearCacheConfig nearCacheConfig,
+                                                Supplier<NearCacheConfig> nearCacheConfig,
                                                 DataStructureAdapter dataStructureAdapter);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
@@ -24,6 +24,7 @@ import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.spi.TaskScheduler;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.function.Supplier;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -64,21 +65,21 @@ public class DefaultNearCacheManager implements NearCacheManager {
     }
 
     @Override
-    public <K, V> NearCache<K, V> getOrCreateNearCache(String name, NearCacheConfig nearCacheConfig) {
+    public <K, V> NearCache<K, V> getOrCreateNearCache(String name, Supplier<NearCacheConfig> nearCacheConfig) {
         return getOrCreateNearCache(name, nearCacheConfig, null);
     }
 
     @Override
     @SuppressWarnings("unchecked")
     public <K, V> NearCache<K, V> getOrCreateNearCache(String name,
-                                                       NearCacheConfig nearCacheConfig,
+                                                       Supplier<NearCacheConfig> nearCacheConfigSupplier,
                                                        DataStructureAdapter dataStructureAdapter) {
         NearCache<K, V> nearCache = nearCacheMap.get(name);
         if (nearCache == null) {
             synchronized (mutex) {
                 nearCache = nearCacheMap.get(name);
                 if (nearCache == null) {
-                    nearCache = createNearCache(name, nearCacheConfig);
+                    nearCache = createNearCache(name, nearCacheConfigSupplier);
                     nearCache.initialize();
 
                     nearCacheMap.put(name, nearCache);
@@ -93,8 +94,8 @@ public class DefaultNearCacheManager implements NearCacheManager {
         return nearCache;
     }
 
-    protected <K, V> NearCache<K, V> createNearCache(String name, NearCacheConfig nearCacheConfig) {
-        return new DefaultNearCache<K, V>(name, nearCacheConfig, serializationService, scheduler, classLoader);
+    protected <K, V> NearCache<K, V> createNearCache(String name, Supplier<NearCacheConfig> nearCacheConfigSupplier) {
+        return new DefaultNearCache<K, V>(name, nearCacheConfigSupplier, serializationService, scheduler, classLoader);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/maxsize/EntryCountNearCacheEvictionChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/maxsize/EntryCountNearCacheEvictionChecker.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.nearcache.impl.maxsize;
 
 import com.hazelcast.internal.eviction.EvictionChecker;
 import com.hazelcast.internal.nearcache.impl.SampleableNearCacheRecordMap;
+import com.hazelcast.util.function.Supplier;
 
 /**
  * Near Cache max-size policy implementation for {@link com.hazelcast.config.EvictionConfig.MaxSizePolicy#ENTRY_COUNT}.
@@ -30,16 +31,16 @@ public class EntryCountNearCacheEvictionChecker
         implements EvictionChecker {
 
     private final SampleableNearCacheRecordMap nearCacheRecordMap;
-    private final int maxSize;
+    private final Supplier<Integer> maxSizeSupplier;
 
-    public EntryCountNearCacheEvictionChecker(final int size,
+    public EntryCountNearCacheEvictionChecker(final Supplier<Integer> maxSizeSupplier,
                                               final SampleableNearCacheRecordMap nearCacheRecordMap) {
-        this.maxSize = size;
+        this.maxSizeSupplier = maxSizeSupplier;
         this.nearCacheRecordMap = nearCacheRecordMap;
     }
 
     @Override
     public boolean isEvictionRequired() {
-        return nearCacheRecordMap.size() >= maxSize;
+        return nearCacheRecordMap.size() >= maxSizeSupplier.get();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheDataRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheDataRecordStore.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.internal.nearcache.impl.record.NearCacheDataRecord;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.function.Supplier;
 
 import static com.hazelcast.internal.nearcache.NearCache.CACHED_AS_NULL;
 import static com.hazelcast.internal.nearcache.NearCacheRecord.TIME_NOT_SET;
@@ -37,10 +38,10 @@ import static com.hazelcast.util.Clock.currentTimeMillis;
 public class NearCacheDataRecordStore<K, V> extends BaseHeapNearCacheRecordStore<K, V, NearCacheDataRecord> {
 
     public NearCacheDataRecordStore(String name,
-                                    NearCacheConfig nearCacheConfig,
+                                    Supplier<NearCacheConfig> nearCacheConfigSupplier,
                                     SerializationService serializationService,
                                     ClassLoader classLoader) {
-        super(name, nearCacheConfig, serializationService, classLoader);
+        super(name, nearCacheConfigSupplier, serializationService, classLoader);
     }
 
     @Override
@@ -82,8 +83,8 @@ public class NearCacheDataRecordStore<K, V> extends BaseHeapNearCacheRecordStore
     protected NearCacheDataRecord valueToRecord(V value) {
         Data dataValue = toData(value);
         long creationTime = currentTimeMillis();
-        if (timeToLiveMillis > 0) {
-            return new NearCacheDataRecord(dataValue, creationTime, creationTime + timeToLiveMillis);
+        if (getTimeToLiveMillis() > 0) {
+            return new NearCacheDataRecord(dataValue, creationTime, creationTime + getTimeToLiveMillis());
         } else {
             return new NearCacheDataRecord(dataValue, creationTime, TIME_NOT_SET);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheObjectRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheObjectRecordStore.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.internal.nearcache.impl.record.NearCacheObjectRecord;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.function.Supplier;
 
 import static com.hazelcast.internal.nearcache.NearCache.CACHED_AS_NULL;
 import static com.hazelcast.internal.nearcache.NearCacheRecord.TIME_NOT_SET;
@@ -35,10 +36,10 @@ import static com.hazelcast.util.Clock.currentTimeMillis;
 public class NearCacheObjectRecordStore<K, V> extends BaseHeapNearCacheRecordStore<K, V, NearCacheObjectRecord<V>> {
 
     public NearCacheObjectRecordStore(String name,
-                                      NearCacheConfig nearCacheConfig,
+                                      Supplier<NearCacheConfig> nearCacheConfigSupplier,
                                       SerializationService serializationService,
                                       ClassLoader classLoader) {
-        super(name, nearCacheConfig, serializationService, classLoader);
+        super(name, nearCacheConfigSupplier, serializationService, classLoader);
     }
 
     @Override
@@ -57,8 +58,8 @@ public class NearCacheObjectRecordStore<K, V> extends BaseHeapNearCacheRecordSto
     protected NearCacheObjectRecord<V> valueToRecord(V value) {
         value = toValue(value);
         long creationTime = currentTimeMillis();
-        if (timeToLiveMillis > 0) {
-            return new NearCacheObjectRecord<V>(value, creationTime, creationTime + timeToLiveMillis);
+        if (getTimeToLiveMillis() > 0) {
+            return new NearCacheObjectRecord<V>(value, creationTime, creationTime + getTimeToLiveMillis());
         } else {
             return new NearCacheObjectRecord<V>(value, creationTime, TIME_NOT_SET);
         }

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/HazelcastConfigurator.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/HazelcastConfigurator.java
@@ -1,0 +1,41 @@
+package com.hazelcast.cache.eviction;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.management.operation.UpdateMapConfigOperation;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
+
+public class HazelcastConfigurator {
+    static MapConfig convertAndStoreMapConfig(String mapName, Config config, MyCustomSettings settings) {
+        System.out.println("convertAndStoreMapConfig for " + mapName);
+        MapConfig newMapConfig = new MapConfig(config.findMapConfig(mapName));
+        newMapConfig.getMaxSizeConfig().setSize(settings.getCapacity());
+        newMapConfig.setName(mapName);
+
+        NearCacheConfig nearCacheConfig = newMapConfig.getNearCacheConfig();
+        if (nearCacheConfig == null) {
+            nearCacheConfig = new NearCacheConfig();
+        }
+        nearCacheConfig.getEvictionConfig().setSize(settings.getCapacity());
+        newMapConfig.setNearCacheConfig(nearCacheConfig);
+        config.addMapConfig(newMapConfig);
+        return newMapConfig;
+    }
+
+    @SuppressWarnings("unchecked")
+    static void configureMap(HazelcastInstance hazelcast, String mapName, MyCustomSettings settings) {
+        MapConfig mapConfig = convertAndStoreMapConfig(mapName, hazelcast.getConfig(), settings);
+
+        UpdateMapConfigOperation operation = new UpdateMapConfigOperation(mapName, mapConfig);
+        MapProxyImpl proxy = hazelcast.getDistributedObject(MapService.SERVICE_NAME, mapName);
+        operation.setService(proxy.getService());
+        try {
+            operation.run();
+        } catch (Exception e) {
+            System.out.println("Error updating map settings!!!");
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/HazelcastConfigurator.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/HazelcastConfigurator.java
@@ -9,7 +9,7 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
 
 public class HazelcastConfigurator {
-    static MapConfig convertAndStoreMapConfig(String mapName, Config config, MyCustomSettings settings) {
+    static MapConfig updateMapConfig(String mapName, Config config, MyCustomSettings settings) {
         System.out.println("convertAndStoreMapConfig for " + mapName);
         MapConfig newMapConfig = new MapConfig(config.findMapConfig(mapName));
         newMapConfig.getMaxSizeConfig().setSize(settings.getCapacity());
@@ -21,13 +21,12 @@ public class HazelcastConfigurator {
         }
         nearCacheConfig.getEvictionConfig().setSize(settings.getCapacity());
         newMapConfig.setNearCacheConfig(nearCacheConfig);
-        config.addMapConfig(newMapConfig);
         return newMapConfig;
     }
 
     @SuppressWarnings("unchecked")
     static void configureMap(HazelcastInstance hazelcast, String mapName, MyCustomSettings settings) {
-        MapConfig mapConfig = convertAndStoreMapConfig(mapName, hazelcast.getConfig(), settings);
+        MapConfig mapConfig = updateMapConfig(mapName, hazelcast.getConfig(), settings);
 
         UpdateMapConfigOperation operation = new UpdateMapConfigOperation(mapName, mapConfig);
         MapProxyImpl proxy = hazelcast.getDistributedObject(MapService.SERVICE_NAME, mapName);

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/LeakingEvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/LeakingEvictionTest.java
@@ -1,0 +1,145 @@
+package com.hazelcast.cache.eviction;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.InterfacesConfig;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.cache.eviction.HazelcastConfigurator.configureMap;
+import static com.hazelcast.core.Hazelcast.newHazelcastInstance;
+import static java.util.UUID.randomUUID;
+
+@RunWith(JUnit4.class)
+public class LeakingEvictionTest {
+
+    protected static final String WILDCARD_NAME = "my.custom.map.*";
+    protected static final String MAP_NAME = "my.custom.map.test";
+
+    protected HazelcastInstance hazelcast1;
+    protected HazelcastInstance hazelcast2;
+    protected int size = 500;
+    protected int multiplier = 4;
+
+    @Before
+    public void setUp() {
+        Config hazelcastConfig = createHazelcastConfig();
+
+        System.out.print("Starting first node of the cluster... ");
+        hazelcast1 = newHazelcastInstance(hazelcastConfig);
+        System.out.println("[Done]");
+    }
+
+    @After
+    public void tearDown() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testCacheEviction() {
+        final List<String> keys = new ArrayList<String>();
+
+        // Configure new map
+        IMap map1 = hazelcast1.getMap(MAP_NAME);
+        System.out.print("Re-configuring map on node 1... ");
+        configureMap(hazelcast1, MAP_NAME, new MyCustomSettings(size));
+        System.out.println("[Done]");
+
+        System.out.print("Populating and checking map size from node 1: ");
+        for (int i = 0; i < size * multiplier; i++) {
+            String key = randomUUID().toString();
+            keys.add(key);
+            map1.put(key, randomUUID().toString());
+        }
+        System.out.println("Map size is " + map1.size());
+
+        System.out.print("Reading data from the map to populate near cache... ");
+        for (String key: keys) {
+            map1.get(key);
+        }
+        System.out.println("[Done]");
+        System.out.println("Map size is " + map1.size());
+
+        System.out.print("Starting second node of the cluster... ");
+        Config hazelcastConfig = createHazelcastConfig();
+        hazelcast2 = newHazelcastInstance(hazelcastConfig);
+        System.out.println("[Done]");
+        System.out.print("Re-configuring map on node 2... ");
+        IMap map2 = hazelcast2.getMap(MAP_NAME);
+        configureMap(hazelcast2, MAP_NAME, new MyCustomSettings(size));
+        System.out.println("[Done]");
+
+        System.out.print("Checking map size from node 2: ");
+        keys.clear();
+        for (int i = 0; i < size * multiplier; i++) {
+            String key = randomUUID().toString();
+            keys.add(key);
+            map2.put(key, randomUUID().toString());
+        }
+        System.out.println("Map size is " + map2.size());
+        for (String key: keys) {
+            map2.get(key);
+        }
+        System.out.println("[Done]");
+        System.out.println("Map size is " + map2.size());
+
+        /*System.out.print("Rerunning experiment for map from node 1... ");
+        for (int i = 0; i < size * multiplier; i++) {
+            String key = randomUUID().toString();
+            keys.add(key);
+            map1.put(key, randomUUID().toString());
+        }
+        System.out.println(map1.size());
+        System.out.print("Reading data to populate near cache... ");
+        for (String key: keys) {
+            map1.get(key);
+        }
+        System.out.println("[Done]");
+        System.out.println("Size: " + map1.size());*/
+    }
+
+    protected Config createHazelcastConfig() {
+        Config hazelcastConfig = new Config();
+        hazelcastConfig.addMapConfig(new MapConfig(hazelcastConfig.getMapConfig("default")));
+
+        hazelcastConfig.getNetworkConfig().setPortAutoIncrement(true);
+        hazelcastConfig.setProperty("hazelcast.map.invalidation.batch.enabled", "false");
+        hazelcastConfig.setProperty("hazelcast.map.invalidation.batch.size", "1");
+        NearCacheConfig nearCacheConfig = new NearCacheConfig()
+                .setInMemoryFormat(InMemoryFormat.OBJECT)
+                .setCacheLocalEntries(true);
+
+        hazelcastConfig.addMapConfig(new MapConfig(hazelcastConfig.getMapConfig("default"))
+                .setName(WILDCARD_NAME)
+                .setMaxSizeConfig(new MaxSizeConfig(50000, MaxSizeConfig.MaxSizePolicy.PER_NODE))
+                .setTimeToLiveSeconds(0)
+                .setBackupCount(0)
+                .setMaxIdleSeconds(0)
+                .setEvictionPolicy(EvictionPolicy.LRU)
+                .setAsyncBackupCount(0)
+                .setInMemoryFormat(InMemoryFormat.BINARY)
+                .setReadBackupData(false)
+                .setNearCacheConfig(nearCacheConfig)
+                .setMergePolicy("com.hazelcast.map.merge.PutIfAbsentMapMergePolicy"));
+
+        InterfacesConfig interfacesConfig = hazelcastConfig.getNetworkConfig().getInterfaces();
+        interfacesConfig.setEnabled(true);
+        interfacesConfig.addInterface("172.22.48.124"); // <- set correct value for your machine here
+        hazelcastConfig.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(true);
+
+        return hazelcastConfig;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/MyCustomSettings.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/MyCustomSettings.java
@@ -1,0 +1,22 @@
+package com.hazelcast.cache.eviction;
+
+import java.io.Serializable;
+
+class MyCustomSettings implements Serializable {
+    private int capacity;
+
+    public MyCustomSettings(int capacity) {
+        setCapacity(capacity);
+    }
+
+    public int getCapacity() {
+        return capacity;
+    }
+
+    public void setCapacity(int capacity) {
+        if (capacity < 0) {
+            throw new IllegalArgumentException("Capacity is less than 0!");
+        }
+        this.capacity = capacity;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/CommonNearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/CommonNearCacheTestSupport.java
@@ -61,10 +61,12 @@ public abstract class CommonNearCacheTestSupport extends HazelcastTestSupport {
         NearCacheRecordStore<K, V> recordStore = null;
         switch (inMemoryFormat) {
             case BINARY:
-                recordStore = new NearCacheDataRecordStore<K, V>(DEFAULT_NEAR_CACHE_NAME, nearCacheConfig, ss, null);
+                recordStore = new NearCacheDataRecordStore<K, V>(DEFAULT_NEAR_CACHE_NAME, supplierFor(nearCacheConfig),
+                        ss, null);
                 break;
             case OBJECT:
-                recordStore = new NearCacheObjectRecordStore<K, V>(DEFAULT_NEAR_CACHE_NAME, nearCacheConfig, ss, null);
+                recordStore = new NearCacheObjectRecordStore<K, V>(DEFAULT_NEAR_CACHE_NAME,
+                        supplierFor(nearCacheConfig), ss, null);
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported in-memory format: " + inMemoryFormat);

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheManagerTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheManagerTestSupport.java
@@ -51,7 +51,7 @@ public abstract class NearCacheManagerTestSupport extends CommonNearCacheTestSup
 
     protected NearCache createNearCache(NearCacheManager nearCacheManager, String name) {
         NearCacheConfig nearCacheConfig = createNearCacheConfig(DEFAULT_NEAR_CACHE_NAME, DEFAULT_MEMORY_FORMAT);
-        return nearCacheManager.getOrCreateNearCache(name, nearCacheConfig);
+        return nearCacheManager.getOrCreateNearCache(name, supplierFor(nearCacheConfig));
     }
 
     protected void doCreateAndGetNearCache() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTest.java
@@ -33,7 +33,7 @@ public class NearCacheTest extends NearCacheTestSupport {
     @Override
     protected NearCache<Integer, String> createNearCache(String name, NearCacheConfig nearCacheConfig,
                                                          ManagedNearCacheRecordStore nearCacheRecordStore) {
-        return new DefaultNearCache<Integer, String>(name, nearCacheConfig,
+        return new DefaultNearCache<Integer, String>(name, supplierFor(nearCacheConfig),
                 nearCacheRecordStore, ss, executionService.getGlobalTaskScheduler(), null);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/impl/store/AbstractNearCacheRecordStoreTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 
 import static com.hazelcast.internal.nearcache.NearCacheRecord.NOT_RESERVED;
 import static com.hazelcast.internal.nearcache.NearCacheRecord.READ_PERMITTED;
+import static com.hazelcast.test.HazelcastTestSupport.supplierFor;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
@@ -56,7 +57,8 @@ public class AbstractNearCacheRecordStoreTest {
 
         serializationService = new DefaultSerializationServiceBuilder().build();
 
-        store = new NearCacheObjectRecordStore("name", config, serializationService, getClass().getClassLoader());
+        store = new NearCacheObjectRecordStore("name", supplierFor(config), serializationService,
+                getClass().getClassLoader());
         store.initialize();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
@@ -286,7 +286,7 @@ public class NearCacheTestSupport extends HazelcastTestSupport {
         MapServiceContext mapServiceContext = service.getMapServiceContext();
         MapNearCacheManager mapNearCacheManager = mapServiceContext.getMapNearCacheManager();
         NearCacheConfig nearCacheConfig = nodeEngine.getConfig().getMapConfig(mapName).getNearCacheConfig();
-        return mapNearCacheManager.getOrCreateNearCache(mapName, nearCacheConfig);
+        return mapNearCacheManager.getOrCreateNearCache(mapName, supplierFor(nearCacheConfig));
     }
 
     protected int getNearCacheSize(IMap map) {

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -56,6 +56,7 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.jitter.JitterRule;
+import com.hazelcast.util.function.Supplier;
 import org.junit.After;
 import org.junit.ComparisonFailure;
 import org.junit.Rule;
@@ -1515,5 +1516,14 @@ public abstract class HazelcastTestSupport {
      */
     public static void assumeDifferentHashCodes() {
         assumeTrue("Hash codes are equal for different objects", EXPECT_DIFFERENT_HASHCODES);
+    }
+
+    public static <T> Supplier<T> supplierFor(final T value) {
+        return new Supplier<T>() {
+            @Override
+            public T get() {
+                return value;
+            }
+        };
     }
 }


### PR DESCRIPTION
Hazelcast Management Center allows to [re-configure maps at runtime](http://docs.hazelcast.org/docs/management-center/3.9-EA/manual/html/Managing_Maps.html). This is very useful feature, but it allows to tweak store configuration for distributed maps only, whereas near cache store config remains untouched. There are many business cases, when near cache for distributed maps needs to be updated as well, and as for now, there is no way to re-configure the near cache without cluster re-start.

This PR is draft implementation (proof of concept), which enables near cache configuration tweaks at runtime (similar to what is done for distributed maps).  Management Center needs to be updated separately.

What's done in scope of this PR:
1. Updated `UpdateMapConfigOperation` to apply near cache config changes
2. Updated near cache implementation to use config suppliers instead of final config objects, for "dynamic" updates of any config changes.