### PR TITLE
Added pre-commit script to check for tests with missing annotations

### DIFF
--- a/src/git-hooks/pre-commit
+++ b/src/git-hooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+exec 1>&2
+
+# check tests for missing @Run or @RunWith annotation
+RUN=$(find . -name "*Test.java" -exec grep -L "@Run" {} \; | grep -vi abstract | egrep -v "/(annotation|standalone|generated-test-sources)/")
+if [ -n "$RUN" ]; then
+  echo "Missing @Run or @RunWith annotation: $RUN"
+  exit 1
+fi
+
+# check tests for missing @Category annotation
+CATEGORY=$(find . -name "*Test.java" -exec grep -L "@Category" {} \; | grep -vi abstract | egrep -v "/(annotation|standalone|generated-test-sources)/")
+if [ -n "$CATEGORY" ]; then
+  echo "Missing @Category annotation: $CATEGORY"
+  exit 1
+fi


### PR DESCRIPTION
Note: Git hooks are always local, they are not managed via the VCS. So you have to copy this script manually to your `./git/hooks` folder. The script has to be executable (e.g. `chmod +x`).

This PR doesn't add a check automatically, it just provides the script for developers. This seems to be the best practice for Git hooks. This will also solve any possible errors with Windows or other systems.

I've chosen `src/git-hooks` as folder, so we don't have another folder on the top level, which will distract us.

If you try to commit a test with missing annotations, you will get an error on the command line:
```bash
donnerbart@workstation:~/IdeaProjects/hazelcast$ git commit -m "foo"
Missing @Run or @RunWith annotation: ./hazelcast/src/test/java/com/hazelcast/map/MissingAnnotationsTest.java
donnerbart@workstation:~/IdeaProjects/hazelcast$ git commit -m "foo"
Missing @Category annotation: ./hazelcast/src/test/java/com/hazelcast/map/MissingAnnotationsTest.java
```
It also works in IDEA:
![screenshot from 2018-05-02 16-28-13](https://user-images.githubusercontent.com/4196298/39530251-dd07bae6-4e28-11e8-857e-88786f2460c5.png)

The script takes ~3 seconds on my machine. I'm open to suggestions for improving the performance :)