### PR TITLE
ClientMessage has connection field just like Packet

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientChannelInitializer.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientChannelInitializer.java
@@ -25,7 +25,6 @@ import com.hazelcast.internal.networking.ChannelInboundHandler;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.networking.ChannelOutboundHandler;
 import com.hazelcast.internal.networking.InitResult;
-import com.hazelcast.nio.Connection;
 
 import java.nio.ByteBuffer;
 
@@ -56,7 +55,7 @@ class ClientChannelInitializer implements ChannelInitializer {
         ChannelInboundHandler inboundHandler = new ClientMessageDecoder(clientConnection,
                 new ClientMessageHandler() {
                     @Override
-                    public void handle(ClientMessage message, Connection connection) {
+                    public void handle(ClientMessage message) {
                         clientConnection.handleClientMessage(message);
                     }
                 });

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnection.java
@@ -254,7 +254,7 @@ public class ClientConnection implements Connection {
             AbstractClientListenerService listenerService = (AbstractClientListenerService) client.getListenerService();
             listenerService.handleClientMessage(message, this);
         } else {
-            responseHandler.handle(message, this);
+            responseHandler.handle(message);
         }
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientResponseHandler.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientResponseHandler.java
@@ -16,12 +16,11 @@
 
 package com.hazelcast.client.spi.impl;
 
-import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 
 /**
  * Responsible for handling responses to invocations.
  */
 public interface ClientResponseHandler {
-    void handle(ClientMessage message, ClientConnection connection);
+    void handle(ClientMessage message);
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientResponseHandlerSupplier.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientResponseHandlerSupplier.java
@@ -110,18 +110,19 @@ public class ClientResponseHandlerSupplier implements Supplier<ClientResponseHan
         return responseHandler;
     }
 
-    private void process(ClientConnection connection, ClientMessage message) {
+    private void process(ClientMessage response) {
         try {
-            handleClientMessage(message);
+            handleResponse(response);
         } catch (Exception e) {
-            logger.severe("Failed to process task: " + new ClientPacket(connection, message)
+            logger.severe("Failed to process response: " + response
                     + " on responseThread: " + Thread.currentThread().getName(), e);
         } finally {
+            ClientConnection connection = (ClientConnection) response.getConnection();
             connection.decrementPendingPacketCount();
         }
     }
 
-    private void handleClientMessage(ClientMessage clientMessage) {
+    private void handleResponse(ClientMessage clientMessage) {
         long correlationId = clientMessage.getCorrelationId();
 
         ClientInvocation future = invocationService.deRegisterCallId(correlationId);
@@ -138,12 +139,12 @@ public class ClientResponseHandlerSupplier implements Supplier<ClientResponseHan
     }
 
     private class ResponseThread extends Thread {
-        private final BlockingQueue<ClientPacket> responseQueue;
+        private final BlockingQueue<ClientMessage> responseQueue;
 
         ResponseThread(String name) {
             super(name);
             setContextClassLoader(client.getClientConfig().getClassLoader());
-            this.responseQueue = new MPSCQueue<ClientPacket>(this, getIdleStrategy(client.getProperties(), IDLE_STRATEGY));
+            this.responseQueue = new MPSCQueue<ClientMessage>(this, getIdleStrategy(client.getProperties(), IDLE_STRATEGY));
         }
 
         @Override
@@ -159,48 +160,36 @@ public class ClientResponseHandlerSupplier implements Supplier<ClientResponseHan
 
         private void doRun() {
             while (!invocationService.isShutdown()) {
-                ClientPacket task;
+                ClientMessage response;
                 try {
-                    task = responseQueue.take();
+                    response = responseQueue.take();
                 } catch (InterruptedException e) {
                     continue;
                 }
-                process(task.connection, task.message);
+                process(response);
             }
         }
     }
 
     class SyncResponseHandler implements ClientResponseHandler {
         @Override
-        public void handle(ClientMessage message, ClientConnection connection) {
-            process(connection, message);
+        public void handle(ClientMessage message) {
+            process(message);
         }
     }
 
     class AsyncSingleThreadedResponseHandler implements ClientResponseHandler {
         @Override
-        public void handle(ClientMessage message, ClientConnection connection) {
-            responseThreads[0].responseQueue.add(new ClientPacket(connection, message));
+        public void handle(ClientMessage message) {
+            responseThreads[0].responseQueue.add(message);
         }
     }
 
     class AsyncMultiThreadedResponseHandler implements ClientResponseHandler {
         @Override
-        public void handle(ClientMessage message, ClientConnection connection) {
+        public void handle(ClientMessage message) {
             int threadIndex = hashToIndex(INT_HOLDER.get().getAndInc(), responseThreads.length);
-            responseThreads[threadIndex].responseQueue.add(new ClientPacket(connection, message));
-        }
-    }
-
-    // https://github.com/hazelcast/hazelcast/issues/12632
-    private static class ClientPacket {
-
-        private final ClientConnection connection;
-        private final ClientMessage message;
-
-        ClientPacket(ClientConnection connection, ClientMessage message) {
-            this.connection = connection;
-            this.message = message;
+            responseThreads[threadIndex].responseQueue.add(message);
         }
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -259,9 +259,10 @@ class TestClientRegistry {
 
                 @Override
                 public void run() {
-                    ClientMessage newPacket = readFromPacket((ClientMessage) frame);
+                    ClientMessage clientMessage = readFromPacket((ClientMessage) frame);
                     lastWriteTime = System.currentTimeMillis();
-                    serverSideConnection.handleClientMessage(newPacket);
+                    clientMessage.setConnection(serverSideConnection);
+                    serverSideConnection.handleClientMessage(clientMessage);
                 }
             });
             return true;
@@ -387,6 +388,7 @@ class TestClientRegistry {
             if (isAlive()) {
                 lastWriteTimeMillis = System.currentTimeMillis();
                 ClientMessage newPacket = readFromPacket(packet);
+                newPacket.setConnection(responseConnection);
                 responseConnection.handleClientMessage(newPacket);
                 return true;
             }
@@ -395,7 +397,7 @@ class TestClientRegistry {
 
         void handleClientMessage(ClientMessage newPacket) {
             lastReadTimeMillis = System.currentTimeMillis();
-            remoteNodeEngine.getNode().clientEngine.handle(newPacket, this);
+            remoteNodeEngine.getNode().clientEngine.handle(newPacket);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -216,8 +216,9 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
     }
 
     @Override
-    public void handle(ClientMessage clientMessage, Connection connection) {
+    public void handle(ClientMessage clientMessage) {
         int partitionId = clientMessage.getPartitionId();
+        Connection connection = clientMessage.getConnection();
         MessageTask messageTask = messageTaskFactory.create(clientMessage, connection);
         InternalOperationService operationService = nodeEngine.getOperationService();
         if (partitionId < 0) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.impl.protocol.util.SafeBuffer;
 import com.hazelcast.client.impl.protocol.util.UnsafeBuffer;
 import com.hazelcast.internal.networking.OutboundFrame;
 import com.hazelcast.nio.Bits;
+import com.hazelcast.nio.Connection;
 
 import java.nio.ByteBuffer;
 
@@ -109,8 +110,17 @@ public class ClientMessage
     private transient boolean isRetryable;
     private transient boolean acquiresResource;
     private transient String operationName;
+    private Connection connection;
 
     protected ClientMessage() {
+    }
+
+    public Connection getConnection() {
+        return connection;
+    }
+
+    public void setConnection(Connection connection) {
+        this.connection = connection;
     }
 
     protected void wrapForEncode(ClientProtocolBuffer buffer, int offset) {
@@ -392,7 +402,8 @@ public class ClientMessage
     public String toString() {
         int len = index();
         final StringBuilder sb = new StringBuilder("ClientMessage{");
-        sb.append("length=").append(len);
+        sb.append("connection=").append(connection);
+        sb.append(", length=").append(len);
         if (len >= HEADER_SIZE) {
             sb.append(", correlationId=").append(getCorrelationId());
             sb.append(", operation=").append(operationName);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoder.java
@@ -93,7 +93,7 @@ public class ClientMessageDecoder extends ChannelInboundHandlerWithCounters {
 
     private void handleMessage(ClientMessage message) {
         message.index(message.getDataOffset());
-        messageHandler.handle(message, connection);
+        message.setConnection(connection);
+        messageHandler.handle(message);
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/ClientMessageHandler.java
@@ -17,10 +17,9 @@
 package com.hazelcast.client.impl.protocol.util;
 
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.nio.Connection;
 
 /**
- * Implementers will be responsible to messageHandler the constructed message
+ * Implementers will be responsible to handle the constructed message
  */
 public interface ClientMessageHandler {
 
@@ -28,7 +27,6 @@ public interface ClientMessageHandler {
      * Received message to be processed
      *
      * @param message the ClientMessage the process
-     * @param connection the connection responsible for creating the message
      */
-    void handle(ClientMessage message, Connection connection);
+    void handle(ClientMessage message);
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/util/ClientMessageDecoderTest.java
@@ -67,6 +67,6 @@ public class ClientMessageDecoderTest {
 
         decoder.onRead(bb);
 
-        verify(messageHandler).handle(any(ClientMessage.class), eq(connection));
+        verify(messageHandler).handle(any(ClientMessage.class));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageSplitAndBuildTest.java
@@ -58,7 +58,7 @@ public class ClientMessageSplitAndBuildTest {
                 mock(Connection.class),
                 new ClientMessageHandler() {
                     @Override
-                    public void handle(ClientMessage message, Connection connection) {
+                    public void handle(ClientMessage message) {
                         message.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
                         assertEquals(expectedClientMessage, message);
                     }
@@ -107,7 +107,7 @@ public class ClientMessageSplitAndBuildTest {
                 mock(Connection.class),
                 new ClientMessageHandler() {
                     @Override
-                    public void handle(ClientMessage message, Connection connection) {
+                    public void handle(ClientMessage message) {
                         int correlationId = (int) message.getCorrelationId();
                         message.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
                         assertEquals(expectedClientMessages.get(correlationId), message);
@@ -142,7 +142,7 @@ public class ClientMessageSplitAndBuildTest {
                 mock(Connection.class),
                 new ClientMessageHandler() {
                     @Override
-                    public void handle(ClientMessage message, Connection connection) {
+                    public void handle(ClientMessage message) {
                         message.addFlag(ClientMessage.BEGIN_AND_END_FLAGS);
                         assertEquals(expectedClientMessage, message);
                     }


### PR DESCRIPTION
This makes ClientMessages easier to process. The ClientMessageHandler
and PacketHandler can both be replaced by a Consumer. Which would not
be possible if a connection parameter needs to be passed.

The consumer based approach is needed for the NIO pipeline.

fixes https://github.com/hazelcast/hazelcast/issues/12632