### PR TITLE
Disable caching of HazelcastAPIDelegatingClassLoaders with custom parent

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.nio.IOUtil.toByteArray;
 import static com.hazelcast.test.compatibility.SamplingSerializationService.isTestClass;
+import static java.util.Collections.enumeration;
 
 /**
  * Classloader which delegates to its parent except when the fully qualified name of the class starts with
@@ -66,7 +67,9 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
     @Override
     public Enumeration<URL> getResources(String name) throws IOException {
         Utils.debug("Calling getResource with " + name);
-        checkResourceExcluded(name);
+        if (checkResourceExcluded(name)) {
+            return enumeration(Collections.<URL>emptyList());
+        }
         if (name.contains("hazelcast")) {
             return findResources(name);
         }
@@ -76,7 +79,9 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
     @Override
     public URL getResource(String name) {
         Utils.debug("Getting resource " + name);
-        checkResourceExcluded(name);
+        if (checkResourceExcluded(name)) {
+            return null;
+        }
         if (name.contains("hazelcast")) {
             return findResource(name);
         }
@@ -85,7 +90,9 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
 
     @Override
     public InputStream getResourceAsStream(String name) {
-        checkResourceExcluded(name);
+        if (checkResourceExcluded(name)) {
+            return null;
+        }
         return super.getResourceAsStream(name);
     }
 
@@ -184,9 +191,8 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
         }
     }
 
-    private void checkResourceExcluded(String resourceName) {
-        if (parent instanceof FilteringClassLoader) {
-            ((FilteringClassLoader) parent).checkResourceExcluded(resourceName);
-        }
+    private boolean checkResourceExcluded(String resourceName) {
+        return (parent instanceof FilteringClassLoader)
+                && ((FilteringClassLoader) parent).checkResourceExcluded(resourceName);
     }
 }


### PR DESCRIPTION
When a compatibility test requests a `ClassLoader` for a given
target Hazelcast version, a custom parent `ClassLoader` may be used (eg
in `UserCodeDeployment` tests that configure a `FilteringClassLoader`).
Caching this `HazelcastAPIDelegatingClassloader` will apply the `FilteringClassLoader` in other
unrelated tests and cause inadvertent failures.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2052