### PR TITLE
Preparation for 3.10 -> 3.11 compatibility tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastAPIDelegatingClassloader.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.nio.IOUtil.toByteArray;
 import static com.hazelcast.test.compatibility.SamplingSerializationService.isTestClass;
+import static java.util.Collections.enumeration;
 
 /**
  * Classloader which delegates to its parent except when the fully qualified name of the class starts with
@@ -66,7 +67,9 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
     @Override
     public Enumeration<URL> getResources(String name) throws IOException {
         Utils.debug("Calling getResource with " + name);
-        checkResourceExcluded(name);
+        if (checkResourceExcluded(name)) {
+            return enumeration(Collections.<URL>emptyList());
+        }
         if (name.contains("hazelcast")) {
             return findResources(name);
         }
@@ -76,7 +79,9 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
     @Override
     public URL getResource(String name) {
         Utils.debug("Getting resource " + name);
-        checkResourceExcluded(name);
+        if (checkResourceExcluded(name)) {
+            return null;
+        }
         if (name.contains("hazelcast")) {
             return findResource(name);
         }
@@ -85,7 +90,9 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
 
     @Override
     public InputStream getResourceAsStream(String name) {
-        checkResourceExcluded(name);
+        if (checkResourceExcluded(name)) {
+            return null;
+        }
         return super.getResourceAsStream(name);
     }
 
@@ -184,9 +191,8 @@ public class HazelcastAPIDelegatingClassloader extends URLClassLoader {
         }
     }
 
-    private void checkResourceExcluded(String resourceName) {
-        if (parent instanceof FilteringClassLoader) {
-            ((FilteringClassLoader) parent).checkResourceExcluded(resourceName);
-        }
+    private boolean checkResourceExcluded(String resourceName) {
+        return (parent instanceof FilteringClassLoader)
+                && ((FilteringClassLoader) parent).checkResourceExcluded(resourceName);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
@@ -103,10 +103,7 @@ public class HazelcastProxyFactory {
         subclassProxiedClasses.add(CLASS_NAME_LIFECYCLE_EVENT);
         SUBCLASS_PROXYING_WHITELIST = subclassProxiedClasses;
 
-        // RU_COMPAT_3_9 revise refactored interfaces mapping in 3.11 development cycle
         Map<String, String> refactoredInterfaces = new HashMap<String, String>();
-        refactoredInterfaces.put(CLASS_NAME_EVENT_JOURNAL_READER, CLASS_NAME_EVENT_JOURNAL_READER_39);
-        refactoredInterfaces.put(CLASS_NAME_EVENT_JOURNAL_READER_39, CLASS_NAME_EVENT_JOURNAL_READER);
         REFACTORED_INTERFACES = refactoredInterfaces;
     }
 


### PR DESCRIPTION
Includes forward port of #13036 

Also, removes 3.9-specific content from refactored interfaces map as it is causing failures while testing 3.10 -> 3.11 compatibility.