### PR TITLE
Enhance exception handling in compatibility tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ProxyInvocationHandler.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ProxyInvocationHandler.java
@@ -118,7 +118,7 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
         } catch (IllegalAccessException e) {
             throw Utils.rethrow(e);
         } catch (InvocationTargetException e) {
-            throw e.getTargetException();
+            throw Utils.transferThrowable(e.getTargetException());
         }
         return delegateResult;
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/Utils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/Utils.java
@@ -61,7 +61,7 @@ public class Utils {
 
             return transferredThrowable;
         } catch (Exception e) {
-            throw new GuardianException("Throwable transfer failed for: " + throwable.getMessage(), e);
+            throw new GuardianException("Throwable transfer failed for: " + throwable, e);
         }
     }
 


### PR DESCRIPTION
Before this change custom Hazelcast exceptions thrown by older versions
were not catchable by regular catch statements in the tests because
their classes were loaded by class loaders different from the class
loader hosting the tests.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/1589