### PR TITLE
Use MetricsRegistry argument

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImpl.java
@@ -76,7 +76,7 @@ public class OperationParkerImpl implements OperationParker, LiveOperationsTrack
 
     @Override
     public void provideMetrics(MetricsRegistry registry) {
-        nodeEngine.getMetricsRegistry().scanAndRegister(this, "operation-parker");
+        registry.scanAndRegister(this, "operation-parker");
     }
 
     @Override


### PR DESCRIPTION
One of the `MetricProvider`s would do `nodeEngine.getMetricsRegistry()` instead of using the `registry` provided by the method parameter. I checked other implementations but none had a similar case so this most likely was accidentally left over from a previous change or something.