### PR TITLE
Cleanup of TestUtil

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ConnectedClientOperationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ConnectedClientOperationTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.ClientType;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -61,7 +60,7 @@ public class ConnectedClientOperationTest extends HazelcastTestSupport {
             factory.newHazelcastClient();
         }
 
-        Node node = TestUtil.getNode(h1);
+        Node node = getNode(h1);
         Map<ClientType, Integer> clientStats = node.clientEngine.getConnectedClientStats();
 
         assertEquals(numberOfClients, clientStats.get(ClientType.JAVA).intValue());
@@ -76,7 +75,7 @@ public class ConnectedClientOperationTest extends HazelcastTestSupport {
     @Test
     public void testGetConnectedClientsOperation_WhenZeroClientConnects() throws Exception {
         HazelcastInstance instance = factory.newHazelcastInstance();
-        Node node = TestUtil.getNode(instance);
+        Node node = getNode(instance);
 
         Operation operation = new GetConnectedClientsOperation();
         OperationService operationService = node.nodeEngine.getOperationService();
@@ -93,7 +92,7 @@ public class ConnectedClientOperationTest extends HazelcastTestSupport {
         factory.newHazelcastClient();
         factory.newHazelcastClient();
 
-        Node node = TestUtil.getNode(instance);
+        Node node = getNode(instance);
         Operation operation = new GetConnectedClientsOperation();
         OperationService operationService = node.nodeEngine.getOperationService();
         Future<Map<String, ClientType>> future =

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapIssueTest.java
@@ -25,7 +25,6 @@ import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapService;
@@ -81,8 +80,8 @@ public class ClientMapIssueTest extends HazelcastTestSupport {
         instance1.getLifecycleService().terminate();
         instance1 = hazelcastFactory.newHazelcastInstance(config);
 
-        final EventService eventService1 = TestUtil.getNode(instance1).nodeEngine.getEventService();
-        final EventService eventService2 = TestUtil.getNode(instance2).nodeEngine.getEventService();
+        final EventService eventService1 = getNodeEngineImpl(instance1).getEventService();
+        final EventService eventService2 = getNodeEngineImpl(instance2).getEventService();
 
         assertTrueEventually(new AssertTask() {
             @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationTest.java
@@ -27,7 +27,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.nio.Address;
@@ -92,7 +91,7 @@ public class ClientInvocationTest extends ClientTestSupport {
         }
 
         // crash the server
-        TestUtil.getNode(server).getConnectionManager().shutdown();
+        getNode(server).getConnectionManager().shutdown();
         server.getLifecycleService().terminate();
 
         int callBackCount = 0;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -36,7 +36,6 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.internal.networking.OutboundFrame;
 import com.hazelcast.internal.networking.nio.NioEventLoopGroup;
 import com.hazelcast.logging.ILogger;
@@ -61,6 +60,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
 
 class TestClientRegistry {
 
@@ -146,12 +147,11 @@ class TestClientRegistry {
                 if (instance == null) {
                     throw new IOException("Can not connected to " + address + ": instance does not exist");
                 }
-                Node node = TestUtil.getNode(instance);
                 Address localAddress = new Address(host, ports.incrementAndGet());
                 LockPair lockPair = getLockPair(address);
 
-                MockedClientConnection connection = new MockedClientConnection(client,
-                        connectionIdGen.incrementAndGet(), node.nodeEngine, address, localAddress, lockPair);
+                MockedClientConnection connection = new MockedClientConnection(client, connectionIdGen.incrementAndGet(),
+                        getNodeEngineImpl(instance), address, localAddress, lockPair);
                 LOGGER.info("Created connection to endpoint: " + address + ", connection: " + connection);
                 return connection;
             } catch (Exception e) {

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
@@ -130,11 +130,12 @@ public abstract class CacheTestSupport extends HazelcastTestSupport {
     }
 
     private int getPartitionCount() {
-        Node node = getNode(getHazelcastInstance());
-        if (node != null) {
+        try {
+            Node node = getNode(getHazelcastInstance());
             return node.getProperties().getInteger(GroupProperty.PARTITION_COUNT);
+        } catch (IllegalArgumentException e) {
+            return parseInt(GroupProperty.PARTITION_COUNT.getDefaultValue());
         }
-        return parseInt(GroupProperty.PARTITION_COUNT.getDefaultValue());
     }
 
     protected void assertThatNoCacheEvictionHappened(ICache cache) {

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/InternalCacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/InternalCacheRecordStoreTest.java
@@ -23,7 +23,6 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -119,7 +118,7 @@ public class InternalCacheRecordStoreTest extends CacheTestSupport {
         HazelcastCacheManager hzCacheManager = (HazelcastCacheManager) cacheManager;
 
         HazelcastInstance instance1 = hzCacheManager.getHazelcastInstance();
-        Node node1 = TestUtil.getNode(instance1);
+        Node node1 = getNode(instance1);
         NodeEngineImpl nodeEngine1 = node1.getNodeEngine();
         InternalPartitionService partitionService1 = nodeEngine1.getPartitionService();
         int partitionCount = partitionService1.getPartitionCount();
@@ -139,7 +138,7 @@ public class InternalCacheRecordStoreTest extends CacheTestSupport {
         }
 
         HazelcastInstance instance2 = getHazelcastInstance();
-        Node node2 = TestUtil.getNode(instance2);
+        Node node2 = getNode(instance2);
 
         warmUpPartitions(instance1, instance2);
         waitAllForSafeState(instance1, instance2);

--- a/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
@@ -24,8 +24,6 @@ import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
@@ -71,18 +69,12 @@ public abstract class CacheRecordStoreTestSupport
     }
 
     protected ICacheService getCacheService(HazelcastInstance instance) {
-        Node node = TestUtil.getNode(instance);
-        return node.getNodeEngine().getService(ICacheService.SERVICE_NAME);
-    }
-
-    protected NodeEngine getNodeEngine(HazelcastInstance instance) {
-        Node node = TestUtil.getNode(instance);
-        return node.getNodeEngine();
+        return getNodeEngineImpl(instance).getService(ICacheService.SERVICE_NAME);
     }
 
     protected ICacheRecordStore createCacheRecordStore(HazelcastInstance instance, String cacheName,
                                                        int partitionId, InMemoryFormat inMemoryFormat) {
-        NodeEngine nodeEngine = getNodeEngine(instance);
+        NodeEngine nodeEngine = getNodeEngineImpl(instance);
         ICacheService cacheService = getCacheService(instance);
         CacheConfig cacheConfig = createCacheConfig(cacheName, inMemoryFormat);
         cacheService.putCacheConfigIfAbsent(cacheConfig);

--- a/hazelcast/src/test/java/com/hazelcast/client/test/DistortInvalidationMetadataEntryProcessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/DistortInvalidationMetadataEntryProcessor.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.Offloadable;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.internal.nearcache.impl.invalidation.Invalidator;
 import com.hazelcast.internal.nearcache.impl.invalidation.MetaDataGenerator;
 import com.hazelcast.internal.partition.InternalPartitionService;
@@ -40,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
+import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
 import static com.hazelcast.util.RandomPicker.getInt;
 import static java.lang.Integer.MAX_VALUE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -121,7 +121,7 @@ public class DistortInvalidationMetadataEntryProcessor extends AbstractEntryProc
     }
 
     private void distortRandomPartitionSequence(String mapName, HazelcastInstance member) {
-        NodeEngineImpl nodeEngineImpl = TestUtil.getNode(member).nodeEngine;
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(member);
         MapService mapService = nodeEngineImpl.getService(SERVICE_NAME);
         MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         MapNearCacheManager mapNearCacheManager = mapServiceContext.getMapNearCacheManager();
@@ -133,7 +133,7 @@ public class DistortInvalidationMetadataEntryProcessor extends AbstractEntryProc
     }
 
     private void distortRandomPartitionUuid(HazelcastInstance member) {
-        NodeEngineImpl nodeEngineImpl = TestUtil.getNode(member).nodeEngine;
+        NodeEngineImpl nodeEngineImpl = getNodeEngineImpl(member);
         int partitionCount = nodeEngineImpl.getPartitionService().getPartitionCount();
         int partitionId = getInt(partitionCount);
         MapService mapService = nodeEngineImpl.getService(SERVICE_NAME);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterInfoTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterInfoTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.cluster;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -55,14 +54,14 @@ public class ClusterInfoTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_start_time_single_node_cluster() throws Exception {
+    public void test_start_time_single_node_cluster() {
         HazelcastInstance h1 = factory.newHazelcastInstance();
-        Node node1 = TestUtil.getNode(h1);
+        Node node1 = getNode(h1);
         assertNotEquals(Long.MIN_VALUE, node1.getClusterService().getClusterClock().getClusterStartTime());
     }
 
     @Test
-    public void all_nodes_should_have_the_same_cluster_start_time_and_cluster_id() throws Exception {
+    public void all_nodes_should_have_the_same_cluster_start_time_and_cluster_id() {
         HazelcastInstance h1 = factory.newHazelcastInstance();
         HazelcastInstance h2 = factory.newHazelcastInstance();
         HazelcastInstance h3 = factory.newHazelcastInstance();
@@ -70,9 +69,9 @@ public class ClusterInfoTest extends HazelcastTestSupport {
         assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
 
-        Node node1 = TestUtil.getNode(h1);
-        Node node2 = TestUtil.getNode(h2);
-        Node node3 = TestUtil.getNode(h3);
+        Node node1 = getNode(h1);
+        Node node2 = getNode(h2);
+        Node node3 = getNode(h3);
 
         //All nodes should have same startTime
         final ClusterServiceImpl clusterService = node1.getClusterService();
@@ -100,7 +99,7 @@ public class ClusterInfoTest extends HazelcastTestSupport {
         assertClusterSize(3, h1, h3);
         assertClusterSizeEventually(3, h2);
 
-        Node node1 = TestUtil.getNode(h1);
+        Node node1 = getNode(h1);
         final ClusterServiceImpl clusterService = node1.getClusterService();
         long node1ClusterStartTime = clusterService.getClusterClock().getClusterStartTime();
         long clusterUpTime = clusterService.getClusterClock().getClusterUpTime();
@@ -113,9 +112,9 @@ public class ClusterInfoTest extends HazelcastTestSupport {
 
         HazelcastInstance h4 = factory.newHazelcastInstance();
 
-        Node node2 = TestUtil.getNode(h2);
-        Node node3 = TestUtil.getNode(h3);
-        Node node4 = TestUtil.getNode(h4);
+        Node node2 = getNode(h2);
+        Node node3 = getNode(h3);
+        Node node4 = getNode(h4);
 
         //All nodes should have the same cluster start time
         assertNotEquals(node1ClusterStartTime, Long.MIN_VALUE);

--- a/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/CacheConfigTest.java
@@ -28,9 +28,6 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExp
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceFactory;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
-import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -551,13 +548,7 @@ public class CacheConfigTest extends HazelcastTestSupport {
     }
 
     private ICacheService getCacheService(HazelcastInstance instance) {
-        Node node = TestUtil.getNode(instance);
-        return node.getNodeEngine().getService(ICacheService.SERVICE_NAME);
-    }
-
-    private NodeEngine getNodeEngine(HazelcastInstance instance) {
-        Node node = TestUtil.getNode(instance);
-        return node.getNodeEngine();
+        return getNodeEngineImpl(instance).getService(ICacheService.SERVICE_NAME);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/DistributedObjectTest.java
@@ -19,9 +19,10 @@ package com.hazelcast.core;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ServiceConfig;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.spi.InitializingObject;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.RemoteService;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -193,17 +194,17 @@ public class DistributedObjectTest extends HazelcastTestSupport {
         }
 
         for (int i = 0; i < nodeCount; i++) {
-            Node node = TestUtil.getNode(instances[i]);
-            ProxyServiceImpl proxyService = (ProxyServiceImpl) node.nodeEngine.getProxyService();
+            NodeEngine nodeEngine = getNodeEngineImpl(instances[i]);
+            OperationService operationService = nodeEngine.getOperationService();
+            ProxyServiceImpl proxyService = (ProxyServiceImpl) nodeEngine.getProxyService();
             Operation postJoinOperation = proxyService.getPostJoinOperation();
 
             for (int j = 0; j < nodeCount; j++) {
                 if (i == j) {
                     continue;
                 }
-
-                Node node2 = TestUtil.getNode(instances[j]);
-                node.nodeEngine.getOperationService().send(postJoinOperation, node2.address);
+                Node node2 = getNode(instances[j]);
+                operationService.send(postJoinOperation, node2.address);
             }
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
@@ -30,74 +30,130 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
 
+@SuppressWarnings("WeakerAccess")
 public final class TestUtil {
 
-    static final private SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+    private static final SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
 
     private TestUtil() {
     }
 
+    /**
+     * Serializes the given object with a default {@link SerializationService}.
+     *
+     * @param obj the object to serialize
+     * @return the serialized {@link Data} instance
+     */
     public static Data toData(Object obj) {
         return serializationService.toData(obj);
     }
 
+    /**
+     * Deserializes the given {@link Data} instance with a default {@link SerializationService}.
+     *
+     * @param data the {@link Data} instance to deserialize
+     * @return the deserialized object
+     */
     public static Object toObject(Data data) {
         return serializationService.toObject(data);
     }
 
+    /**
+     * Retrieves the {@link Node} from a given Hazelcast instance.
+     *
+     * @param hz the Hazelcast instance to retrieve the Node from
+     * @return the {@link Node} from the given Hazelcast instance
+     */
     public static Node getNode(HazelcastInstance hz) {
-        HazelcastInstanceImpl impl = getHazelcastInstanceImpl(hz);
-        return impl != null ? impl.node : null;
+        HazelcastInstanceImpl hazelcastInstanceImpl = getHazelcastInstanceImpl(hz);
+        return hazelcastInstanceImpl.node;
     }
 
+    /**
+     * Retrieves the {@link HazelcastInstanceImpl} from a given Hazelcast instance.
+     *
+     * @param hz the Hazelcast instance to retrieve the implementation from
+     * @return the {@link HazelcastInstanceImpl} of the given Hazelcast instance
+     * @throws IllegalArgumentException if the {@link HazelcastInstanceImpl} could not be retrieved,
+     *                                  e.g. when called with a Hazelcast client instance
+     */
     public static HazelcastInstanceImpl getHazelcastInstanceImpl(HazelcastInstance hz) {
-        HazelcastInstanceImpl impl = null;
         if (hz instanceof HazelcastInstanceProxy) {
-            impl = ((HazelcastInstanceProxy) hz).original;
+            HazelcastInstanceProxy proxy = (HazelcastInstanceProxy) hz;
+            if (proxy.original != null) {
+                return proxy.original;
+            }
         } else if (hz instanceof HazelcastInstanceImpl) {
-            impl = (HazelcastInstanceImpl) hz;
+            return (HazelcastInstanceImpl) hz;
         }
-        return impl;
+        throw new IllegalArgumentException("Cannot retrieve HazelcastInstanceImpl from " + hz.getClass().getSimpleName());
     }
 
+    /**
+     * Terminates the given Hazelcast instance.
+     *
+     * @param hz the instance to terminate
+     */
     public static void terminateInstance(HazelcastInstance hz) {
         hz.getLifecycleService().terminate();
     }
 
+    /**
+     * Assigns the partition owners of the given Hazelcast instances.
+     *
+     * @param instances the given Hazelcast instances
+     */
     public static void warmUpPartitions(HazelcastInstance... instances) {
         for (HazelcastInstance instance : instances) {
-            if (instance == null) {
-                continue;
-            }
-            final PartitionService ps = instance.getPartitionService();
-            for (Partition partition : ps.getPartitions()) {
-                while (partition.getOwner() == null) {
-                    sleepMillis(10);
-                }
-            }
+            warmupPartitions(instance);
         }
     }
 
+    /**
+     * Assigns the partition owners of the given Hazelcast instances.
+     *
+     * @param instances the given Hazelcast instances
+     */
     public static void warmUpPartitions(Collection<HazelcastInstance> instances) {
         for (HazelcastInstance instance : instances) {
-            if (instance == null) {
-                continue;
-            }
-            final PartitionService ps = instance.getPartitionService();
-            for (Partition partition : ps.getPartitions()) {
-                while (partition.getOwner() == null) {
-                    sleepMillis(10);
-                }
+            warmupPartitions(instance);
+        }
+    }
+
+    private static void warmupPartitions(HazelcastInstance instance) {
+        if (instance == null) {
+            return;
+        }
+        PartitionService ps = instance.getPartitionService();
+        for (Partition partition : ps.getPartitions()) {
+            while (partition.getOwner() == null) {
+                sleepMillis(10);
             }
         }
     }
 
-    public static Integer getAvailablePort(int basePort) {
+    /**
+     * Returns the next available port (starting from a base port).
+     *
+     * @param basePort the starting port
+     * @return the next available port
+     * @see #isPortAvailable(int)
+     */
+    public static int getAvailablePort(int basePort) {
         return getAvailablePorts(basePort, 1).get(0);
     }
 
+    /**
+     * Returns a list of available ports (starting from a base port).
+     *
+     * @param basePort  the starting port
+     * @param portCount the number of ports to search
+     * @return a list of available ports
+     * @see #isPortAvailable(int)
+     */
     public static List<Integer> getAvailablePorts(int basePort, int portCount) {
         List<Integer> availablePorts = new ArrayList<Integer>();
         int port = basePort;
@@ -110,7 +166,12 @@ public final class TestUtil {
         return availablePorts;
     }
 
-    // Checks the DatagramSocket as well to check if the port is available in UDP and TCP.
+    /**
+     * Checks the DatagramSocket as well if the port is available in UDP and TCP.
+     *
+     * @param port the port to check
+     * @return {@code true} if the port is available in UDP and TCP, {@code false} otherwise
+     */
     public static boolean isPortAvailable(int port) {
         ServerSocket ss = null;
         DatagramSocket ds = null;
@@ -121,33 +182,25 @@ public final class TestUtil {
             ds.setReuseAddress(true);
             return true;
         } catch (IOException e) {
-
+            return false;
         } finally {
-            if (ds != null) {
-                ds.close();
-            }
-            if (ss != null) {
-                try {
-                    ss.close();
-                } catch (IOException e) {
-
-                }
-            }
+            closeResource(ds);
+            closeResource(ss);
         }
-
-        return false;
     }
 
     /**
-     * Sets or removes (in case value==null) a system property. It's only a helper method, which avoids
-     * {@link NullPointerException} thrown from {@link System#setProperty(String, String)} method, when the value is
-     * <code>null</code>.
+     * Sets or removes a system property.
+     * <p>
+     * When the value is {@code null}, the system property will be removed.
+     * <p>
+     * Avoids a {@link NullPointerException} when calling {@link System#setProperty(String, String)} with a {@code null} value.
      *
      * @param key   property name
      * @param value property value
-     * @return the previous string value of the system property
+     * @return the previous string value of the system property, or {@code null} if it did not have one
      */
-    public static String setSystemProperty(final String key, final String value) {
+    public static String setSystemProperty(String key, String value) {
         return value == null ? System.clearProperty(key) : System.setProperty(key, value);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/DiscoveryJoinerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/DiscoveryJoinerTest.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
@@ -36,6 +35,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static com.hazelcast.instance.TestUtil.getNode;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -47,7 +47,7 @@ public class DiscoveryJoinerTest {
     @Mock
     private DiscoveryService service = mock(DiscoveryService.class);
 
-    List<DiscoveryNode> discoveryNodes;
+    private List<DiscoveryNode> discoveryNodes;
     private TestHazelcastInstanceFactory factory;
     private HazelcastInstance hz;
 
@@ -70,16 +70,16 @@ public class DiscoveryJoinerTest {
     }
 
     @Test
-    public void test_DiscoveryJoiner_returns_public_address() throws Exception {
-        DiscoveryJoiner joiner = new DiscoveryJoiner(TestUtil.getNode(hz), service, true);
+    public void test_DiscoveryJoiner_returns_public_address() {
+        DiscoveryJoiner joiner = new DiscoveryJoiner(getNode(hz), service, true);
         doReturn(discoveryNodes).when(service).discoverNodes();
         Collection<Address> addresses = joiner.getPossibleAddresses();
         assertEquals("[[127.0.0.1]:50001, [127.0.0.1]:50002]", addresses.toString());
     }
 
     @Test
-    public void test_DiscoveryJoiner_returns_private_address() throws Exception {
-        DiscoveryJoiner joiner = new DiscoveryJoiner(TestUtil.getNode(hz), service, false);
+    public void test_DiscoveryJoiner_returns_private_address() {
+        DiscoveryJoiner joiner = new DiscoveryJoiner(getNode(hz), service, false);
         doReturn(discoveryNodes).when(service).discoverNodes();
         Collection<Address> addresses = joiner.getPossibleAddresses();
         assertEquals("[[127.0.0.2]:50001, [127.0.0.2]:50002]", addresses.toString());

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionStrategyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/EvictionStrategyTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.cache.impl.record.CacheObjectRecord;
 import com.hazelcast.cache.impl.record.CacheRecordHashMap;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.internal.eviction.impl.evaluator.EvictionPolicyEvaluator;
 import com.hazelcast.internal.eviction.impl.strategy.sampling.SampleableEvictableStore;
 import com.hazelcast.internal.eviction.impl.strategy.sampling.SamplingEvictionStrategy;
@@ -108,7 +107,7 @@ public class EvictionStrategyTest<K, V extends Evictable, S extends SampleableEv
         final int RECORD_COUNT = 100;
         final int EXPECTED_EVICTED_RECORD_VALUE = RECORD_COUNT / 2;
 
-        Node node = TestUtil.getNode(instance);
+        Node node = getNode(instance);
 
         SerializationService serializationService = node.getSerializationService();
         ICacheService cacheService = node.getNodeEngine().getService(ICacheService.SERVICE_NAME);

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/TestPartitionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/TestPartitionUtils.java
@@ -44,21 +44,20 @@ import static com.hazelcast.instance.TestUtil.getNode;
 import static com.hazelcast.internal.partition.InternalPartition.MAX_REPLICA_COUNT;
 import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
 
+@SuppressWarnings("WeakerAccess")
 public final class TestPartitionUtils {
 
     private TestPartitionUtils() {
     }
 
     public static PartitionServiceState getPartitionServiceState(HazelcastInstance instance) {
-        return getPartitionServiceState(getNode(instance));
-    }
-
-    public static PartitionServiceState getPartitionServiceState(Node node) {
-        if (node == null) {
+        try {
+            Node node = getNode(instance);
+            InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) node.getPartitionService();
+            return partitionService.getPartitionReplicaStateChecker().getPartitionServiceState();
+        } catch (IllegalArgumentException e) {
             return PartitionServiceState.SAFE;
         }
-        InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) node.getPartitionService();
-        return partitionService.getPartitionReplicaStateChecker().getPartitionServiceState();
     }
 
     public static Map<Integer, PartitionReplicaVersionsView> getAllReplicaVersions(List<HazelcastInstance> instances) {
@@ -70,8 +69,7 @@ public final class TestPartitionUtils {
     }
 
     public static Map<Integer, PartitionReplicaVersionsView> getOwnedReplicaVersions(Node node) {
-        Map<Integer, PartitionReplicaVersionsView> ownedReplicaVersions =
-                new HashMap<Integer, PartitionReplicaVersionsView>();
+        Map<Integer, PartitionReplicaVersionsView> ownedReplicaVersions = new HashMap<Integer, PartitionReplicaVersionsView>();
         collectOwnedReplicaVersions(node, ownedReplicaVersions);
         return ownedReplicaVersions;
     }
@@ -122,7 +120,7 @@ public final class TestPartitionUtils {
 
         for (HazelcastInstance instance : instances) {
             Node node = getNode(instance);
-            if (node != null && node.isMaster()) {
+            if (node.isMaster()) {
                 return getAllReplicaAddresses(node);
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
@@ -19,8 +19,6 @@ package com.hazelcast.map;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.HazelcastInstanceImpl;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.impl.operation.BaseRemoveOperation;
 import com.hazelcast.map.impl.operation.KeyBasedMapOperation;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
@@ -28,9 +26,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -67,14 +65,13 @@ public class MapRemoveFailingBackupTest extends HazelcastTestSupport {
         config.getMapConfig(mapName).setReadBackupData(true);
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);
         HazelcastInstance hz2 = factory.newHazelcastInstance(config);
-        final HazelcastInstanceImpl hz1Impl = TestUtil.getHazelcastInstanceImpl(hz1);
+        final NodeEngine nodeEngine = getNodeEngineImpl(hz1);
         final IMap<Object, Object> map1 = hz1.getMap(mapName);
         final IMap<Object, Object> map2 = hz2.getMap(mapName);
         MapProxyImpl<Object, Object> mock1 = (MapProxyImpl<Object, Object>) spy(map1);
         when(mock1.remove(anyString())).then(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
-                NodeEngineImpl nodeEngine = hz1Impl.node.nodeEngine;
                 Object object = invocation.getArguments()[0];
                 final Data key = nodeEngine.toData(object);
                 RemoveOperation operation = new RemoveOperation(mapName, key);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteThroughTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreWriteThroughTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.core.EntryAdapter;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.impl.mapstore.MapStoreTest.TestMapStore;
 import com.hazelcast.map.impl.mapstore.MapStoreWriteBehindTest.FailAwareMapStore;
 import com.hazelcast.query.SampleTestObjects.Employee;
@@ -78,7 +77,7 @@ public class MapStoreWriteThroughTest extends AbstractMapStoreTest {
         testMapStore.assertAwait(1);
         assertEquals(1, testMapStore.getInitCount());
         assertEquals("default", testMapStore.getMapName());
-        assertEquals(TestUtil.getNode(instance), TestUtil.getNode(testMapStore.getHazelcastInstance()));
+        assertEquals(getNode(instance), getNode(testMapStore.getHazelcastInstance()));
     }
 
     @Test(timeout = 120000)

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionTest.java
@@ -29,8 +29,6 @@ import com.hazelcast.core.IQueue;
 import com.hazelcast.core.MapStoreAdapter;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.core.TransactionalQueue;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.map.impl.operation.DefaultMapOperationProvider;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
@@ -41,6 +39,7 @@ import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.SampleTestObjects;
 import com.hazelcast.query.SampleTestObjects.Employee;
 import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.ExpectedRuntimeException;
@@ -161,9 +160,9 @@ public class MapTransactionTest extends HazelcastTestSupport {
         });
 
 
-        Node node = TestUtil.getNode(instance1);
-        Data keyData = node.nodeEngine.toData(keyOwnedByInstance2);
-        LockService lockService = node.nodeEngine.getService(LockService.SERVICE_NAME);
+        NodeEngine nodeEngine = getNodeEngineImpl(instance1);
+        Data keyData = nodeEngine.toData(keyOwnedByInstance2);
+        LockService lockService = nodeEngine.getService(LockService.SERVICE_NAME);
         for (LockResource lockResource : lockService.getAllLocks()) {
             if (keyData.equals(lockResource.getKey())) {
                 assertEquals(0, lockResource.getLockCount());

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -35,7 +35,6 @@ import com.hazelcast.core.Member;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.nio.Address;
@@ -351,8 +350,7 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
     public void testSPIAwareMemberGroupFactoryInvalidConfig() throws Exception {
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
         try {
-            MemberGroupFactory groupFactory
-                    = new SPIAwareMemberGroupFactory(TestUtil.getNode(hazelcastInstance).getDiscoveryService());
+            MemberGroupFactory groupFactory = new SPIAwareMemberGroupFactory(getNode(hazelcastInstance).getDiscoveryService());
             Collection<Member> members = createMembers();
             groupFactory.createMemberGroups(members);
         } finally {
@@ -366,7 +364,7 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
         Config config = getDiscoverySPIConfig(xmlFileName);
         // we create this instance in order to fully create Node
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
-        Node node = TestUtil.getNode(hazelcastInstance);
+        Node node = getNode(hazelcastInstance);
         assertNotNull(node);
 
         MemberGroupFactory groupFactory = new SPIAwareMemberGroupFactory(node.getDiscoveryService());

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
@@ -22,8 +22,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.core.OperationTimeoutException;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -116,10 +114,9 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
         warmUpPartitions(instances);
 
         final HazelcastInstance hz = instances[memberCount - 1];
-        Node node = TestUtil.getNode(hz);
-        NodeEngine nodeEngine = node.nodeEngine;
+        NodeEngine nodeEngine = getNodeEngineImpl(hz);
         OperationService operationService = nodeEngine.getOperationService();
-        int partitionId = (int) (Math.random() * node.getPartitionService().getPartitionCount());
+        int partitionId = (int) (Math.random() * nodeEngine.getPartitionService().getPartitionCount());
 
         InternalCompletableFuture<Object> future = operationService
                 .invokeOnPartition(null, new TimedOutBackupAwareOperation(), partitionId);

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -630,8 +630,8 @@ public abstract class HazelcastTestSupport {
         if (h1 == null || h2 == null) {
             return;
         }
-        Node n1 = TestUtil.getNode(h1);
-        Node n2 = TestUtil.getNode(h2);
+        Node n1 = getNode(h1);
+        Node n2 = getNode(h2);
         suspectMember(n1, n2);
         suspectMember(n2, n1);
     }
@@ -672,7 +672,7 @@ public abstract class HazelcastTestSupport {
     }
 
     public static boolean isInstanceInSafeState(HazelcastInstance instance) {
-        Node node = TestUtil.getNode(instance);
+        Node node = getNode(instance);
         if (node == null) {
             return true;
         }


### PR DESCRIPTION
* added Javadoc to `TestUtil`
* changed methods `getHazelcastInstanceImpl()` and `getNode()` in `TestUtil` to throw an exception instead of returning `null`, when no internals could be retrieved (this prevents a NPE warning in IDEA, which makes no sense since no test will work if `null` would be returned)
* replaced usage of `TestUtil.getNode()` when `HazelcastTestSupport` was already extended or `getNodeEngineImpl()` was a better fit

We have a lot of tests which use `TestUtil.getNode().getPartitionService()` or similar. This leads to a "dereferencing possible null pointer" warning, since the method can return `null`. This can be avoided by throwing an exception instead of `null`, which will make the usage easier (since no warnings). This should not change the behavior, since all tests I saw will just crash with a NPE if we cannot retrieve the `HazelcastInstanceImpl` or `Node`.

I just had to fix `CacheTestSupport` and `TestPartitionUtils` so far, to deal with `IllegalArgumentException` instead of `null`, which are both used from clients and members.