### PR TITLE
Cleanup of CacheContextTest

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheContextTest.java
@@ -24,32 +24,33 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import javax.cache.spi.CachingProvider;
-
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientCacheContextTest extends CacheContextTest {
+
     private TestHazelcastFactory factory = new TestHazelcastFactory();
 
+    @Before
     @Override
-    protected CachingProvider initAndGetCachingProvider() {
+    public void setup() {
         hazelcastInstance1 = factory.newHazelcastInstance();
         hazelcastInstance2 = factory.newHazelcastInstance();
 
         driverInstance = factory.newHazelcastClient();
-        return HazelcastClientCachingProvider.createCachingProvider(driverInstance);
+        provider = HazelcastClientCachingProvider.createCachingProvider(driverInstance);
     }
 
     @After
     public void tearDown() {
+        HazelcastClientManager.shutdownAll();
         driverInstance.shutdown();
         hazelcastInstance1.shutdown();
         hazelcastInstance2.shutdown();
-        HazelcastClientManager.shutdownAll();
     }
 
     @Test
@@ -66,5 +67,4 @@ public class ClientCacheContextTest extends CacheContextTest {
     public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterTerminate() {
         cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.TERMINATE);
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheContextTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheContextTest.java
@@ -20,13 +20,13 @@ import com.hazelcast.cache.impl.CacheContext;
 import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -51,49 +51,44 @@ import static org.junit.Assert.assertNotNull;
 @Category({QuickTest.class, ParallelTest.class})
 public class CacheContextTest extends HazelcastTestSupport {
 
+    private static final String CACHE_NAME = "MyCache";
+    private static final String CACHE_NAME_WITH_PREFIX = "/hz/" + CACHE_NAME;
+
     protected HazelcastInstance driverInstance;
     protected HazelcastInstance hazelcastInstance1;
     protected HazelcastInstance hazelcastInstance2;
+    protected CachingProvider provider;
 
-    protected CachingProvider initAndGetCachingProvider() {
+    @Before
+    public void setup() {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
         hazelcastInstance1 = factory.newHazelcastInstance();
         hazelcastInstance2 = factory.newHazelcastInstance();
+
         driverInstance = hazelcastInstance1;
-        return HazelcastServerCachingProvider.createCachingProvider(driverInstance);
+        provider = HazelcastServerCachingProvider.createCachingProvider(driverInstance);
     }
 
-    public static class TestListener
-            implements CacheEntryCreatedListener<String, String>, Serializable {
-
-        @Override
-        public void onCreated(Iterable<CacheEntryEvent<? extends String, ? extends String>> cacheEntryEvents)
-                throws CacheEntryListenerException {
-        }
-
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterDeregister() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.DEREGISTER);
     }
 
-    protected CacheService getCacheService(HazelcastInstance instance) {
-        return TestUtil.getNode(instance).getNodeEngine().getService(CacheService.SERVICE_NAME);
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterShutdown() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.SHUTDOWN);
     }
 
-    protected enum DecreaseType {
-
-        DEREGISTER,
-        SHUTDOWN,
-        TERMINATE
-
+    @Test
+    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterTerminate() {
+        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.TERMINATE);
     }
 
     protected void cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType decreaseType) {
-        final String CACHE_NAME = "MyCache";
-        final String CACHE_NAME_WITH_PREFIX = "/hz/" + CACHE_NAME;
-
-        CachingProvider provider = initAndGetCachingProvider();
         CacheManager cacheManager = provider.getCacheManager();
-        CacheEntryListenerConfiguration<String, String> cacheEntryListenerConfig =
-                new MutableCacheEntryListenerConfiguration<String, String>(
-                        FactoryBuilder.factoryOf(new TestListener()), null, true, true);
+        CacheEntryListenerConfiguration<String, String> cacheEntryListenerConfig
+                = new MutableCacheEntryListenerConfiguration<String, String>(
+                FactoryBuilder.factoryOf(new TestListener()), null, true, true);
         CompleteConfiguration<String, String> cacheConfig = new MutableConfiguration<String, String>();
         Cache<String, String> cache = cacheManager.createCache(CACHE_NAME, cacheConfig);
 
@@ -104,14 +99,14 @@ public class CacheContextTest extends HazelcastTestSupport {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertNotNull(cacheService1.getCacheContext(CACHE_NAME_WITH_PREFIX));
             }
         });
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertNotNull(cacheService2.getCacheContext(CACHE_NAME_WITH_PREFIX));
             }
         });
@@ -121,13 +116,13 @@ public class CacheContextTest extends HazelcastTestSupport {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(1, cacheContext1.getCacheEntryListenerCount());
             }
         });
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(1, cacheContext2.getCacheEntryListenerCount());
             }
         });
@@ -148,31 +143,33 @@ public class CacheContextTest extends HazelcastTestSupport {
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(0, cacheContext1.getCacheEntryListenerCount());
             }
         });
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertEquals(0, cacheContext2.getCacheEntryListenerCount());
             }
         });
     }
 
-    @Test
-    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterDeregister() {
-        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.DEREGISTER);
+    private CacheService getCacheService(HazelcastInstance instance) {
+        return getNodeEngineImpl(instance).getService(CacheService.SERVICE_NAME);
     }
 
-    @Test
-    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterShutdown() {
-        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.SHUTDOWN);
+    protected enum DecreaseType {
+        DEREGISTER,
+        SHUTDOWN,
+        TERMINATE
     }
 
-    @Test
-    public void cacheEntryListenerCountIncreasedAfterRegisterAndDecreasedAfterTerminate() {
-        cacheEntryListenerCountIncreasedAndDecreasedCorrectly(DecreaseType.TERMINATE);
-    }
+    public static class TestListener implements CacheEntryCreatedListener<String, String>, Serializable {
 
+        @Override
+        public void onCreated(Iterable<CacheEntryEvent<? extends String, ? extends String>> cacheEntryEvents)
+                throws CacheEntryListenerException {
+        }
+    }
 }


### PR DESCRIPTION
Replaced custom method overwriting with a proper `@Before` method.

Should not change the logic of the tests.