### PR TITLE
make client RingBuffer.readManyAsync consistent with members

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
@@ -41,9 +41,11 @@ import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.StaleSequenceException;
 import com.hazelcast.ringbuffer.impl.client.PortableReadResultSet;
+import com.hazelcast.util.executor.CompletedFuture;
 
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.ringbuffer.impl.RingbufferProxy.MAX_BATCH_SIZE;
@@ -208,7 +210,17 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
         checkSequence(startSequence);
         checkNotNegative(minCount, "minCount can't be smaller than 0");
         checkTrue(maxCount >= minCount, "maxCount should be equal or larger than minCount");
-        checkTrue(minCount <= capacity(), "the minCount should be smaller than or equal to the capacity");
+
+        try {
+            capacity();
+        } catch (Throwable e) {
+            //in case of exception return the exception via future to behave consistently to member
+            e = new ExecutionException(e);
+            ExecutorService userExecutor = getContext().getExecutionService().getUserExecutor();
+            return new CompletedFuture<ReadResultSet<E>>(getSerializationService(), e, userExecutor);
+        }
+
+        checkTrue(minCount <= capacity, "the minCount should be smaller than or equal to the capacity");
         checkTrue(maxCount <= MAX_BATCH_SIZE, "maxCount can't be larger than " + MAX_BATCH_SIZE);
 
         ClientMessage request = RingbufferReadManyCodec.encodeRequest(

--- a/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/ringbuffer/RingbufferQuorumReadTest.java
@@ -39,7 +39,6 @@ import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.fail;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
@@ -132,16 +131,13 @@ public class RingbufferQuorumReadTest extends AbstractQuorumTest {
         ring(0).readManyAsync(1L, 1, 1, new Filter()).get();
     }
 
-    @Test
-    public void readManyAsync_noQuorum() {
+    @Test(expected = QuorumException.class)
+    public void readManyAsync_noQuorum() throws Throwable {
         try {
             ring(3).readManyAsync(1L, 1, 1, new Filter()).get();
         } catch (Exception ex) {
-            if (ex instanceof QuorumException || ex.getCause() instanceof QuorumException) {
-                return;
-            }
+            throw ex.getCause();
         }
-        fail("Expected QuorumException top-level or as cause");
     }
 
     private static class Filter implements IFunction {


### PR DESCRIPTION
readManyAsync throws different exception when there is no quorum.

Client fails with QuorumException.
Member fails with ExecutionException(cause QuorumException).

This pr makes client behave similarly to member.

fixes https://github.com/hazelcast/hazelcast/issues/12108

(cherry picked from commit 3f5c81f74df8dc8aae3daa0fc8f47189621540dd)