### PR TITLE
Fix compile error in TestUtil with JDK 6

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
@@ -30,8 +30,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
+import static com.hazelcast.util.EmptyStatement.ignore;
 
 @SuppressWarnings("WeakerAccess")
 public final class TestUtil {
@@ -184,8 +184,17 @@ public final class TestUtil {
         } catch (IOException e) {
             return false;
         } finally {
-            closeResource(ds);
-            closeResource(ss);
+            // ServerSocket is not Closeable in Java 6, so we cannot use IOUtil.closeResource() yet
+            if (ds != null) {
+                ds.close();
+            }
+            try {
+                if (ss != null) {
+                    ss.close();
+                }
+            } catch (IOException e) {
+                ignore(e);
+            }
         }
     }
 


### PR DESCRIPTION
Latest change in `TestUtil` breaks JDK 6, since `ServerSocket` is not `Closeable` yet. Bummer!

I've added a comment, so nobody tries to fix this again (which is most probably future-me) :smiley_cat: 