### PR TITLE
Race on client message buffer on retries

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.util.BufferBuilder;
 import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.client.spi.EventHandler;
@@ -36,6 +37,7 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.sequence.CallIdSequence;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -64,7 +66,7 @@ public class ClientInvocation implements Runnable {
     private final ClientClusterService clientClusterService;
     private final AbstractClientInvocationService invocationService;
     private final ClientExecutionService executionService;
-    private final ClientMessage clientMessage;
+    private volatile ClientMessage clientMessage;
     private final CallIdSequence callIdSequence;
     private final Address address;
     private final int partitionId;
@@ -178,6 +180,9 @@ public class ClientInvocation implements Runnable {
     }
 
     private void retry() {
+        // retry modifies the client message and should not reuse the client message.
+        // It could be the case that it is in write queue of the connection.
+        clientMessage = copyMessage();
         // first we force a new invocation slot because we are going to return our old invocation slot immediately after
         // It is important that we first 'force' taking a new slot; otherwise it could be that a sneaky invocation gets
         // through that takes our slot!
@@ -190,6 +195,12 @@ public class ClientInvocation implements Runnable {
         } catch (Throwable e) {
             clientInvocationFuture.complete(e);
         }
+    }
+
+    private ClientMessage copyMessage() {
+        byte[] oldBinary = clientMessage.buffer().byteArray();
+        byte[] bytes = Arrays.copyOf(oldBinary, oldBinary.length);
+        return ClientMessage.createForDecode(BufferBuilder.createBuffer(bytes), 0);
     }
 
     public void notify(ClientMessage clientMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/BufferBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/BufferBuilder.java
@@ -101,6 +101,20 @@ public class BufferBuilder {
         return this;
     }
 
+    /**
+     * Creates ClientProtocolBuffer safe/unsafe according to property with existing byteArray
+     *
+     * @param byteArray existing byteArray
+     * @return ClientProtocolBuffer
+     */
+    public static ClientProtocolBuffer createBuffer(byte[] byteArray) {
+        if (USE_UNSAFE) {
+            return new UnsafeBuffer(byteArray);
+        } else {
+            return new SafeBuffer(byteArray);
+        }
+    }
+
     private void ensureCapacity(int additionalCapacity) {
         int requiredCapacity = position + additionalCapacity;
 


### PR DESCRIPTION
Investigation on following leads to a race on client message.
https://github.com/hazelcast/hazelcast/issues/8254
https://github.com/hazelcast/hazelcast/issues/12954

These failures have similar logs as following:
```
10:57:11,295  WARN |testListenersNonSmartRoutingTerminateRandomNode| - [ClientInvocationService] hz.client_3.responsethread-1- - hz.client_3 [dev] [3.10-SNAPSHOT]
Future.complete(Object) on completed future.
		Request: ClientMessage{length=64, correlationId=27, operation=MultiMap.addEntryListener, messageType=20e, partitionId=-1, isComplete=true, isRetryable=false, isEvent=false, writeOffset=0}
, current value: ClientMessage{length=62, correlationId=7, operation=null, messageType=68, partitionId=-1, isComplete=true, isRetryable=false, isEvent=false, writeOffset=0}
, offered value: ClientMessage{length=22, correlationId=27, operation=null, messageType=68, partitionId=-1, isComplete=false, isRetryable=false, isEvent=false, writeOffset=0}
```

Only point that could lead to this that I found is fixed here. Fail is very rare and
I could not manage to write a test that will fail constantly.

Fail scenerio is as follows:
A client message is trying to be send and it is on output queue of a client connection.
For some reason, invocation needs to be retried. Retry modifies the correlation id of client message.
This leads to a shared buffer between two threads written without proper guards.

fixes https://github.com/hazelcast/hazelcast/issues/8254
fixes https://github.com/hazelcast/hazelcast/issues/12954