### PR TITLE
Race on client message buffer on retries

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/BufferBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/util/BufferBuilder.java
@@ -101,6 +101,20 @@ public class BufferBuilder {
         return this;
     }
 
+    /**
+     * Creates ClientProtocolBuffer safe/unsafe according to property with existing byteArray
+     *
+     * @param byteArray existing byteArray
+     * @return ClientProtocolBuffer
+     */
+    public static ClientProtocolBuffer createBuffer(byte[] byteArray) {
+        if (USE_UNSAFE) {
+            return new UnsafeBuffer(byteArray);
+        } else {
+            return new SafeBuffer(byteArray);
+        }
+    }
+
     private void ensureCapacity(int additionalCapacity) {
         int requiredCapacity = position + additionalCapacity;
 


### PR DESCRIPTION
Investigation on following leads to a race on client message.
https://github.com/hazelcast/hazelcast/issues/8254
https://github.com/hazelcast/hazelcast/issues/12954

These failures have similar logs as following:
```
10:57:11,295  WARN |testListenersNonSmartRoutingTerminateRandomNode| - [ClientInvocationService] hz.client_3.responsethread-1- - hz.client_3 [dev] [3.10-SNAPSHOT]
Future.complete(Object) on completed future.
		Request: ClientMessage{length=64, correlationId=27, operation=MultiMap.addEntryListener, messageType=20e, partitionId=-1, isComplete=true, isRetryable=false, isEvent=false, writeOffset=0}
, current value: ClientMessage{length=62, correlationId=7, operation=null, messageType=68, partitionId=-1, isComplete=true, isRetryable=false, isEvent=false, writeOffset=0}
, offered value: ClientMessage{length=22, correlationId=27, operation=null, messageType=68, partitionId=-1, isComplete=false, isRetryable=false, isEvent=false, writeOffset=0}
```

Only point that could lead to this that I found is fixed here. Fail is very rare and
I could not manage to write a test that will fail constantly.

Fail scenerio is as follows:
A client message is trying to be send and it is on output queue of a client connection.
For some reason, invocation needs to be retried. Retry modifies the correlation id of client message.
This leads to a shared buffer between two threads written without proper guards.

fixes https://github.com/hazelcast/hazelcast/issues/8254
fixes https://github.com/hazelcast/hazelcast/issues/12954

(cherry picked from commit e2ec6e2e1db17ae1c8aa4a71a38d2a118d9cc016)