### PR TITLE
Fix max count check against capacity in rb.readManyAsync

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientRingbufferProxy.java
@@ -220,7 +220,7 @@ public class ClientRingbufferProxy<E> extends ClientProxy implements Ringbuffer<
             return new CompletedFuture<ReadResultSet<E>>(getSerializationService(), e, userExecutor);
         }
 
-        checkTrue(minCount <= capacity, "the minCount should be smaller than or equal to the capacity");
+        checkTrue(maxCount <= capacity, "the maxCount should be smaller than or equal to the capacity");
         checkTrue(maxCount <= MAX_BATCH_SIZE, "maxCount can't be larger than " + MAX_BATCH_SIZE);
 
         ClientMessage request = RingbufferReadManyCodec.encodeRequest(

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/Issue7317Test.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/Issue7317Test.java
@@ -15,6 +15,7 @@
  */
 package com.hazelcast.client.topic;
 
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
@@ -22,6 +23,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ITopic;
 import com.hazelcast.core.Message;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.ReliableMessageListener;
@@ -34,10 +36,8 @@ import org.junit.runner.RunWith;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Test for #7317 (https://github.com/hazelcast/hazelcast/issues/7317), contributed
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class Issue7317Test {
+public class Issue7317Test extends HazelcastTestSupport {
 
     static final String smallRB = "foo";
     static final int smallRBCapacity = 3;
@@ -63,7 +63,9 @@ public class Issue7317Test {
         rbConf.setCapacity(smallRBCapacity);
         serverConfig.addRingBufferConfig(rbConf);
         hazelcastFactory.newHazelcastInstance(serverConfig);
-        client = hazelcastFactory.newHazelcastClient();
+        ClientConfig config = new ClientConfig();
+        config.getReliableTopicConfig(smallRB).setReadBatchSize(smallRBCapacity);
+        client = hazelcastFactory.newHazelcastClient(config);
     }
 
     @After
@@ -118,7 +120,7 @@ public class Issue7317Test {
         }
         ReliableMessageListener<String> listener = new Issue7317MessageListener(messages, cdl);
         String reg = rTopic.addMessageListener(listener);
-        assertTrue(cdl.await(5, TimeUnit.SECONDS));
+        assertOpenEventually(cdl);
         rTopic.removeMessageListener(reg);
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferProxy.java
@@ -199,7 +199,7 @@ public class RingbufferProxy<E> extends AbstractDistributedObject<RingbufferServ
         checkSequence(startSequence);
         checkNotNegative(minCount, "minCount can't be smaller than 0");
         checkTrue(maxCount >= minCount, "maxCount should be equal or larger than minCount");
-        checkTrue(minCount <= config.getCapacity(), "the minCount should be smaller than or equal to the capacity");
+        checkTrue(maxCount <= config.getCapacity(), "the maxCount should be smaller than or equal to the capacity");
         checkTrue(maxCount <= MAX_BATCH_SIZE, "maxCount can't be larger than " + MAX_BATCH_SIZE);
 
         Operation op = new ReadManyOperation<E>(name, startSequence, minCount, maxCount, filter)

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
@@ -752,8 +752,8 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void readManyAsync_whenMinCountLargerThanCapacity() {
-        ringbuffer.readManyAsync(0, RingbufferConfig.DEFAULT_CAPACITY + 1, RingbufferConfig.DEFAULT_CAPACITY + 1, null);
+    public void readManyAsync_whenMaxCountLargerThanCapacity() {
+        ringbuffer.readManyAsync(0, 1, RingbufferConfig.DEFAULT_CAPACITY + 1, null);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Documentation states that readManyAsync throws IllegalArgumentException
if maxCount larger than the capacity of the ringbuffer.

Check is made against mincount by mistake. Corrected with maxcount.