### PR TITLE
add messages to tests in testClientListenerDisconnected

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -296,7 +296,7 @@ public class ClientServiceTest extends ClientTestSupport {
         assertOpenEventually(clientListenerLatch);
     }
 
-    @Test(timeout = 120000)
+    @Test
     public void testClientListenerDisconnected() throws InterruptedException {
         Config config = new Config();
         config.setProperty(GroupProperty.IO_THREAD_COUNT.getName(), "1");
@@ -332,15 +332,15 @@ public class ClientServiceTest extends ClientTestSupport {
                 });
             }
 
-            assertOpenEventually(listenerLatch);
+            assertOpenEventually("Not all disconnected events arrived", listenerLatch);
 
-            assertTrueEventually(new AssertTask() {
+            assertTrueEventually("First server still have connected clients", new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     assertEquals(0, hz.getClientService().getConnectedClients().size());
                 }
             });
-            assertTrueEventually(new AssertTask() {
+            assertTrueEventually("Second server still have connected clients", new AssertTask() {
                 @Override
                 public void run() throws Exception {
                     assertEquals(0, hz2.getClientService().getConnectedClients().size());

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1235,7 +1235,7 @@ public abstract class HazelcastTestSupport {
         assertFalseEventually(task, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }
 
-    public static void assertTrueEventually(AssertTask task, long timeoutSeconds) {
+    public static void assertTrueEventually(String message, AssertTask task, long timeoutSeconds) {
         AssertionError error = null;
         // we are going to check five times a second
         int sleepMillis = 200;
@@ -1256,11 +1256,20 @@ public abstract class HazelcastTestSupport {
         if (error != null) {
             throw error;
         }
-        fail("assertTrueEventually() failed without AssertionError!");
+        fail("assertTrueEventually() failed without AssertionError! " + message);
+    }
+
+    public static void assertTrueEventually(AssertTask task, long timeoutSeconds) {
+        assertTrueEventually(null, task, timeoutSeconds);
+    }
+
+
+    public static void assertTrueEventually(String message, AssertTask task) {
+        assertTrueEventually(message, task, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }
 
     public static void assertTrueEventually(AssertTask task) {
-        assertTrueEventually(task, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
+        assertTrueEventually(null, task, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }
 
     public static void assertTrueDelayed5sec(AssertTask task) {
@@ -1433,6 +1442,7 @@ public abstract class HazelcastTestSupport {
     private interface Latch {
         boolean await(long timeout, TimeUnit unit)
                 throws InterruptedException;
+
         long getCount();
     }
 


### PR DESCRIPTION
Removed test timeout and added log messages to asserts to understand
where the test failed.

related to https://github.com/hazelcast/hazelcast/issues/12674