### PR TITLE
Shutdown previous members before retry in QueryCacheMapWideEventsTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMapWideEventsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMapWideEventsTest.java
@@ -56,9 +56,7 @@ public class QueryCacheMapWideEventsTest extends HazelcastTestSupport {
     private static final String QUERY_CACHE_NAME = "cacheName";
     private static final String PARTITION_COUNT = "1999";
     private static final int TEST_DURATION_SECONDS = 3;
-    private static final int TEN_MINUTES_TIMEOUT = 60000 * 10;
 
-    private AtomicInteger eventLostCounter = new AtomicInteger();
     private TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
 
     @Test
@@ -66,19 +64,24 @@ public class QueryCacheMapWideEventsTest extends HazelcastTestSupport {
         no_event_lost_during_migrations(1, 0);
     }
 
-    @Test(timeout = TEN_MINUTES_TIMEOUT)
+    @Test
     @Category(SlowTest.class)
     public void no_event_lost_during_migrations__with_many_parallel_nodes() {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                no_event_lost_during_migrations(3, 5);
+                try {
+                    no_event_lost_during_migrations(3, 5);
+                } finally {
+                    factory.shutdownAll();
+                }
             }
         });
     }
 
     private void no_event_lost_during_migrations(int parallelNodeCount, int startNewNodeAfterSeconds) {
-        newQueryCacheOnNewNode();
+        final AtomicInteger eventLostCounter = new AtomicInteger();
+        newQueryCacheOnNewNode(eventLostCounter);
 
         List<Thread> threads = new ArrayList<Thread>();
         for (int i = 0; i < parallelNodeCount; i++) {
@@ -86,7 +89,7 @@ public class QueryCacheMapWideEventsTest extends HazelcastTestSupport {
             Thread doMapClear = new Thread() {
                 @Override
                 public void run() {
-                    IMap map = newQueryCacheOnNewNode();
+                    IMap map = newQueryCacheOnNewNode(eventLostCounter);
 
                     long endMillis = System.currentTimeMillis() + SECONDS.toMillis(TEST_DURATION_SECONDS);
                     while (System.currentTimeMillis() < endMillis) {
@@ -143,17 +146,16 @@ public class QueryCacheMapWideEventsTest extends HazelcastTestSupport {
         }
     }
 
-    private IMap newQueryCacheOnNewNode() {
+    private IMap newQueryCacheOnNewNode(final AtomicInteger eventLostCounter) {
         HazelcastInstance node = factory.newHazelcastInstance(newConfig());
         waitClusterForSafeState(node);
         IMap map = node.getMap(MAP_NAME);
-        QueryCache queryCache = map.getQueryCache(QUERY_CACHE_NAME);
-        addEventLostListenerToQueryCache(queryCache);
+        addEventLostListenerToQueryCache(map, eventLostCounter);
         return map;
     }
 
-    private void addEventLostListenerToQueryCache(QueryCache queryCache) {
-        queryCache.addEntryListener(new EventLostListener() {
+    private void addEventLostListenerToQueryCache(IMap map, final AtomicInteger eventLostCounter) {
+        map.getQueryCache(QUERY_CACHE_NAME).addEntryListener(new EventLostListener() {
             @Override
             public void eventLost(EventLostEvent event) {
                 eventLostCounter.incrementAndGet();


### PR DESCRIPTION
Logs from http://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-3.x-nightly/81/testReport/junit/com.hazelcast.map.impl.querycache/QueryCacheMapWideEventsTest/no_event_lost_during_migrations__with_many_parallel_nodes
```
Members {size:43, ver:43} [
	Member [127.0.0.1]:5608 - c79cba1f-c48d-41ea-9f48-cb8ab6271979
	Member [127.0.0.1]:5609 - ac531e1c-df13-402d-86a5-17e73826c1a8
	Member [127.0.0.1]:5610 - 80fa261f-0c11-41c2-be27-3e1624e48f71
	Member [127.0.0.1]:5611 - a85ae984-5539-49ea-952b-12b917b573f5 this
	Member [127.0.0.1]:5612 - 6883053d-6c76-423f-bb31-880245fcd207
	Member [127.0.0.1]:5613 - 31cf6795-ce3c-4944-a00f-d435d4b80ac0
	Member [127.0.0.1]:5614 - ac0b9cd3-892d-44a9-ac4a-2361ce7c5d27
	Member [127.0.0.1]:5615 - 8af1939b-2555-4de0-84b0-1f399aae8124
	Member [127.0.0.1]:5616 - fcc69642-cbb0-4509-b96c-149c3ae592db
	Member [127.0.0.1]:5617 - 3c172ba6-85f6-48a0-aa46-080323a552f2
	Member [127.0.0.1]:5618 - a51fcfa6-2d80-4d69-94e9-b63361d89df6
	Member [127.0.0.1]:5619 - fc2302a6-9f98-4db0-80c9-d05a9a9faad0
	Member [127.0.0.1]:5620 - 6c18539e-89bd-455e-a8dd-ece0da6a9e79
	Member [127.0.0.1]:5621 - e439008e-bfdf-4922-9dc6-dedb2dc1691c
	Member [127.0.0.1]:5622 - 139e0592-6440-4184-8294-ba336f9f7bb1
	Member [127.0.0.1]:5623 - fd6db703-f5c6-44da-8461-63cccad07d17
	Member [127.0.0.1]:5624 - 1deaafb4-e41c-467b-bbf1-f616b1140b5c
	Member [127.0.0.1]:5625 - 80dfef9a-23c1-491b-98a8-4b26b4d0b26d
	Member [127.0.0.1]:5626 - 64932844-924d-48b7-b4a3-5b2df76a33db
	Member [127.0.0.1]:5627 - feccf423-5301-4717-9822-700af71150b7
	Member [127.0.0.1]:5628 - 46a9b01c-da4c-43e1-a70c-d892d1ebaf3d
	Member [127.0.0.1]:5629 - 7f7d1b2b-20d6-470c-a56c-8dea2cfd514a
	Member [127.0.0.1]:5630 - 254a6d03-e6c3-47e9-8ecb-ebd357988715
	Member [127.0.0.1]:5631 - ba23e9f2-a405-406f-a4d9-903c78f870ee
	Member [127.0.0.1]:5632 - 8f2501f6-f941-4e7e-a875-563ecc519252
	Member [127.0.0.1]:5633 - 6a5ee222-c588-4f69-a962-325ad3523094
	Member [127.0.0.1]:5634 - e9d7d1ce-882a-4e44-8512-e6f29cc74dce
	Member [127.0.0.1]:5635 - d73cff4c-41b4-4b42-80d7-024e8bc112a7
	Member [127.0.0.1]:5636 - f8d1d4e5-76e0-4776-81da-f3ade07155dc
	Member [127.0.0.1]:5637 - 96e647f7-b6b4-40a1-96bb-2c84fb55454f
	Member [127.0.0.1]:5638 - 315ae97e-7e41-4995-a747-9a0617a8971a
	Member [127.0.0.1]:5639 - 62d9d651-3ae5-41d2-b1f2-d5e5a6fd5dc8
	Member [127.0.0.1]:5640 - fea2a4c5-80e9-4c1f-84d5-fad472e0f355
	Member [127.0.0.1]:5641 - 0616cecd-9828-45c7-94f6-29240826e476
	Member [127.0.0.1]:5642 - 6e8fee82-0607-4345-b1ec-860197e664bc
	Member [127.0.0.1]:5643 - d97e591a-0eba-44df-a251-dd56eff44b1e
	Member [127.0.0.1]:5644 - fb8d989e-d410-4500-9313-3e58bf3cc7c8
	Member [127.0.0.1]:5645 - 1fd32861-f11f-4a81-a6d2-be173fc8f437
	Member [127.0.0.1]:5646 - a54652a4-0e42-4817-b6f6-19e27454b4fe
	Member [127.0.0.1]:5647 - 8d727df9-8945-44c0-bf3b-a5fca5ec18c8
	Member [127.0.0.1]:5648 - cded0061-932e-4efb-a506-519ad0e8d178
	Member [127.0.0.1]:5649 - 38b3e962-4051-4658-8eee-4655d99872ad
	Member [127.0.0.1]:5650 - ecadf06f-dcef-4ed0-aa83-2fa77b7a7221
]
```

Failure logs show about 50 nodes active just before this test fails. The test is supposed to use only 4 nodes. However it started members inside an `assertTrueEventually` block. Therefore, the test recreated new members each time it fails.

The test also used instance variable `eventLostCount` for counting lost events. This variable is shared between the two tests in this class. Also each retry re-used this variable so it is never reset between retries.

Hopefully fixes #12740