### PR TITLE
Fix for MapStableReadStressTest.testChangingCluster

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/stress/MapStableReadStressTest.java
@@ -72,7 +72,7 @@ public class MapStableReadStressTest extends StressTestSupport {
         }
     }
 
-    @Test
+    @Test(timeout = 600000)
     public void testChangingCluster() {
         test(true);
     }
@@ -92,6 +92,7 @@ public class MapStableReadStressTest extends StressTestSupport {
     }
 
     private void fillMap() {
+        long timeMillis = System.currentTimeMillis();
         System.out.println("==================================================================");
         System.out.println("Inserting data in map");
         System.out.println("==================================================================");
@@ -102,9 +103,10 @@ public class MapStableReadStressTest extends StressTestSupport {
                 System.out.println("Inserted data: " + k);
             }
         }
+        long timeTookToInsertData = System.currentTimeMillis() - timeMillis;
 
         System.out.println("==================================================================");
-        System.out.println("Completed with inserting data in map");
+        System.out.println("Completed with inserting data in map in " + timeTookToInsertData + " millis ");
         System.out.println("==================================================================");
     }
 


### PR DESCRIPTION
The test tooks around 4 minutes normally. The default timeout is 5 minutes.
This could easily lead to false alarms.
In this pr, we increase the default timeout to avoid these failures.

fixes https://github.com/hazelcast/hazelcast/issues/13085

(cherry picked from commit f770a5adda9cc13f0a7b56f5c36ff0e3317e3770)