### PR TITLE
Optimized toArray(new Object[]) calls

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/AbstractLoadBalancer.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/AbstractLoadBalancer.java
@@ -33,7 +33,8 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public abstract class AbstractLoadBalancer implements LoadBalancer, InitialMembershipListener {
 
-    private final AtomicReference<Member[]> membersRef = new AtomicReference(new Member[]{});
+    private final AtomicReference<Member[]> membersRef = new AtomicReference<Member[]>(new Member[0]);
+
     private volatile Cluster clusterRef;
 
     @Override
@@ -44,7 +45,7 @@ public abstract class AbstractLoadBalancer implements LoadBalancer, InitialMembe
 
     private void setMembersRef() {
         Set<Member> memberSet = clusterRef.getMembers();
-        Member[] members = memberSet.toArray(new Member[memberSet.size()]);
+        Member[] members = memberSet.toArray(new Member[0]);
         membersRef.set(members);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientQueueTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientQueueTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -337,13 +338,12 @@ public class ClientQueueTest extends HazelcastTestSupport {
         }
 
         Object[] result = q.toArray();
-        assertEquals(offered, result);
+        assertArrayEquals(offered, result);
     }
 
     @Test
-    public void testToPartialArray() {
-        final int maxItems = 74;
-        final int arraySZ = maxItems / 2;
+    public void testToEmptyArray() {
+        final int maxItems = 23;
         IQueue<Integer> q = client.getQueue(randomString());
 
         Object[] offered = new Object[maxItems];
@@ -352,8 +352,23 @@ public class ClientQueueTest extends HazelcastTestSupport {
             offered[i] = i;
         }
 
-        Object[] result = q.toArray(new Object[arraySZ]);
-        assertEquals(offered, result);
+        Object[] result = q.toArray(new Object[0]);
+        assertArrayEquals(offered, result);
+    }
+
+    @Test
+    public void testToPreSizedArray() {
+        final int maxItems = 74;
+        IQueue<Integer> q = client.getQueue(randomString());
+
+        Object[] offered = new Object[maxItems];
+        for (int i = 0; i < maxItems; i++) {
+            q.offer(i);
+            offered[i] = i;
+        }
+
+        Object[] result = q.toArray(new Object[maxItems / 2]);
+        assertArrayEquals(offered, result);
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptionFactory.java
@@ -758,7 +758,7 @@ public class ClientExceptionFactory {
             causeClassName = null;
         }
 
-        StackTraceElement[] combinedStackTraceArray = combinedStackTrace.toArray(new StackTraceElement[combinedStackTrace.size()]);
+        StackTraceElement[] combinedStackTraceArray = combinedStackTrace.toArray(new StackTraceElement[0]);
         return ErrorCodec.encode(errorCode, throwable.getClass().getName(), message, combinedStackTraceArray,
                 causeErrorCode, causeClassName);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLoadGivenKeysMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapLoadGivenKeysMessageTask.java
@@ -40,7 +40,7 @@ public class MapLoadGivenKeysMessageTask
 
     @Override
     protected OperationFactory createOperationFactory() {
-        Data[] keys = parameters.keys.toArray(new Data[parameters.keys.size()]);
+        Data[] keys = parameters.keys.toArray(new Data[0]);
         MapOperationProvider operationProvider = getOperationProvider(parameters.name);
         return operationProvider.createLoadAllOperationFactory(parameters.name,
                 Arrays.asList(keys), parameters.replaceExistingValues);

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -180,7 +180,7 @@ public abstract class AbstractXmlConfigHelper {
 
         // schema validation
         SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        Schema schema = schemaFactory.newSchema(schemas.toArray(new Source[schemas.size()]));
+        Schema schema = schemaFactory.newSchema(schemas.toArray(new Source[0]));
         Validator validator = schema.newValidator();
         try {
             SAXSource source = new SAXSource(new InputSource(is));

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollection.java
@@ -35,7 +35,6 @@ import java.util.NoSuchElementException;
  */
 public final class MemberSelectingCollection<M extends Member> implements Collection<M> {
 
-
     private final Collection<M> members;
 
     private final MemberSelector selector;
@@ -86,8 +85,7 @@ public final class MemberSelectingCollection<M extends Member> implements Collec
                 result.add(member);
             }
         }
-
-        return result.toArray(new Object[result.size()]);
+        return result.toArray(new Object[0]);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorImpl.java
@@ -567,7 +567,7 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
             for (PartitionTable table : nodePartitionTables.values()) {
                 Set<Integer> partitions = table.getPartitions(index);
                 if (partitions.size() > avgCount) {
-                    Integer[] partitionArray = partitions.toArray(new Integer[partitions.size()]);
+                    Integer[] partitionArray = partitions.toArray(new Integer[0]);
                     while (partitions.size() > avgCount) {
                         int partitionId = partitionArray[partitions.size() - 1];
                         partitions.remove(partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassNameFilterParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/filter/ClassNameFilterParser.java
@@ -43,7 +43,7 @@ public final class ClassNameFilterParser {
         String whitelistedPrefixes = config.getWhitelistedPrefixes();
         Set<String> whitelistSet = parsePrefixes(whitelistedPrefixes);
         if (!whitelistSet.isEmpty()) {
-            ClassWhitelistFilter whitelistFilter = new ClassWhitelistFilter(whitelistSet.toArray(new String[]{}));
+            ClassWhitelistFilter whitelistFilter = new ClassWhitelistFilter(whitelistSet.toArray(new String[0]));
             classFilter = new AndFilter<String>(classFilter, whitelistFilter);
         }
         return classFilter;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/DefaultWriteBehindProcessor.java
@@ -53,7 +53,6 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
 
     private static final int RETRY_STORE_AFTER_WAIT_SECONDS = 1;
 
-
     private final List<StoreListener> storeListeners;
 
     DefaultWriteBehindProcessor(MapStoreContext mapStoreContext) {
@@ -142,7 +141,7 @@ class DefaultWriteBehindProcessor extends AbstractWriteBehindProcessor<DelayedEn
         if (size == 1 || !writeCoalescing) {
             return processEntriesOneByOne(delayedEntries, operationType);
         }
-        final DelayedEntry[] delayedEntriesArray = delayedEntries.toArray(new DelayedEntry[delayedEntries.size()]);
+        final DelayedEntry[] delayedEntriesArray = delayedEntries.toArray(new DelayedEntry[0]);
         final Map<Object, DelayedEntry> batchMap = prepareBatchMap(delayedEntriesArray);
 
         // if all batch is on same key, call single store.

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MappingPhase.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/MappingPhase.java
@@ -52,7 +52,7 @@ public abstract class MappingPhase<KeyIn, ValueIn, KeyOut, ValueOut> {
 
     public MappingPhase(Collection<? extends KeyIn> keys, KeyPredicate<? super KeyIn> predicate) {
         this.predicate = predicate;
-        this.keys = keys != null ? keys.toArray(new Object[keys.size()]) : null;
+        this.keys = keys != null ? keys.toArray(new Object[0]) : null;
     }
 
     public void cancel() {
@@ -112,7 +112,7 @@ public abstract class MappingPhase<KeyIn, ValueIn, KeyOut, ValueOut> {
         for (int i = 0; i < cache.length; i++) {
             List<Object> keys = mapping[i];
             if (keys != null) {
-                cache[i] = keys.toArray(new Object[keys.size()]);
+                cache[i] = keys.toArray(new Object[0]);
             }
         }
         return cache;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazyCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazyCollection.java
@@ -65,7 +65,7 @@ class LazyCollection<K, V> implements Collection<V> {
         while (iterator.hasNext()) {
             result.add(iterator.next());
         }
-        return result.toArray(new Object[result.size()]);
+        return result.toArray(new Object[0]);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazySet.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazySet.java
@@ -62,7 +62,7 @@ class LazySet<K, V, R> implements Set<R> {
         while (iterator.hasNext()) {
             result.add(iterator.next());
         }
-        return result.toArray(new Object[result.size()]);
+        return result.toArray(new Object[0]);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -441,7 +441,7 @@ public class NodeEngineImpl implements NodeEngine {
                 postJoinOps.add(postJoinOperation);
             }
         }
-        return postJoinOps.isEmpty() ? null : postJoinOps.toArray(new Operation[postJoinOps.size()]);
+        return postJoinOps.isEmpty() ? null : postJoinOps.toArray(new Operation[0]);
     }
 
     public Operation[] getPreJoinOperations() {
@@ -459,7 +459,7 @@ public class NodeEngineImpl implements NodeEngine {
                 preJoinOps.add(preJoinOperation);
             }
         }
-        return preJoinOps.isEmpty() ? null : preJoinOps.toArray(new Operation[preJoinOps.size()]);
+        return preJoinOps.isEmpty() ? null : preJoinOps.toArray(new Operation[0]);
     }
 
     public void reset() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -129,6 +129,7 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
      */
     private static final int MAX_RETRIES = 100;
 
+
     final ILogger logger;
     final NodeEngineImpl nodeEngine;
 
@@ -348,7 +349,7 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
         if (registrations == null || registrations.isEmpty()) {
             return EMPTY_REGISTRATIONS;
         } else {
-            return registrations.toArray(new Registration[registrations.size()]);
+            return registrations.toArray(new Registration[0]);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XAResourceImpl.java
@@ -66,7 +66,6 @@ public final class XAResourceImpl extends AbstractDistributedObject<XAService> i
 
     private static final int DEFAULT_TIMEOUT_SECONDS = (int) MILLISECONDS.toSeconds(TransactionOptions.DEFAULT_TIMEOUT_MILLIS);
 
-
     private final ConcurrentMap<Long, TransactionContext> threadContextMap = new ConcurrentHashMap<Long, TransactionContext>();
     private final ConcurrentMap<Xid, List<TransactionContext>> xidContextMap
             = new ConcurrentHashMap<Xid, List<TransactionContext>>();
@@ -274,7 +273,7 @@ public final class XAResourceImpl extends AbstractDistributedObject<XAService> i
                 }
             }
         }
-        return xids.toArray(new SerializableXID[xids.size()]);
+        return xids.toArray(new SerializableXID[0]);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
@@ -447,7 +447,7 @@ public final class AddressUtil {
         if (ipString.size() != IPV6_LENGTH) {
             throw new InvalidAddressException(address);
         }
-        final String[] addressParts = ipString.toArray(new String[ipString.size()]);
+        final String[] addressParts = ipString.toArray(new String[0]);
         checkIfAddressPartsAreValid(addressParts, address);
         matcher.setAddress(addressParts);
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
@@ -335,7 +335,7 @@ public final class StringUtil {
         }
         List<String> list = new ArrayList<String>(Arrays.asList(arr1));
         list.retainAll(Arrays.asList(arr2));
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
     }
 
     /**
@@ -351,7 +351,7 @@ public final class StringUtil {
         }
         List<String> list = new ArrayList<String>(Arrays.asList(arr1));
         list.removeAll(Arrays.asList(arr2));
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
@@ -447,7 +447,7 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
         ResponseCountingMultiExecutionCallback callback = new ResponseCountingMultiExecutionCallback(NODE_COUNT);
         int sum = 0;
         Set<Member> membersSet = instances[0].getCluster().getMembers();
-        Member[] members = membersSet.toArray(new Member[membersSet.size()]);
+        Member[] members = membersSet.toArray(new Member[0]);
         Random random = new Random();
         for (int i = 0; i < NODE_COUNT; i++) {
             IExecutorService service = instances[i].getExecutorService("testSubmitToMembersRunnable");
@@ -622,7 +622,7 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
         };
         int sum = 0;
         Set<Member> membersSet = instances[0].getCluster().getMembers();
-        Member[] members = membersSet.toArray(new Member[membersSet.size()]);
+        Member[] members = membersSet.toArray(new Member[0]);
         Random random = new Random();
         String name = "testSubmitToMembersCallable";
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/SmallClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/SmallClusterTest.java
@@ -129,7 +129,7 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
     public void submitToMembers_runnable() {
         int sum = 0;
         Set<Member> membersSet = instances[0].getCluster().getMembers();
-        Member[] members = membersSet.toArray(new Member[membersSet.size()]);
+        Member[] members = membersSet.toArray(new Member[0]);
         Random random = new Random();
 
         ResponseCountingMultiExecutionCallback callback = new ResponseCountingMultiExecutionCallback(instances.length);
@@ -242,7 +242,7 @@ public class SmallClusterTest extends ExecutorServiceTestSupport {
         ResponseCountingMultiExecutionCallback callback = new ResponseCountingMultiExecutionCallback(instances.length);
 
         Set<Member> membersSet = instances[0].getCluster().getMembers();
-        Member[] members = membersSet.toArray(new Member[membersSet.size()]);
+        Member[] members = membersSet.toArray(new Member[0]);
         Random random = new Random();
         String name = "testSubmitToMembersCallable";
         for (HazelcastInstance instance : instances) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/AbstractConcurrentArrayQueueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/concurrent/AbstractConcurrentArrayQueueTest.java
@@ -161,7 +161,7 @@ public abstract class AbstractConcurrentArrayQueueTest extends HazelcastTestSupp
 
     @Test(expected = UnsupportedOperationException.class)
     public void testToArray_withArray() {
-        queue.toArray(new Integer[1]);
+        queue.toArray(new Integer[0]);
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPredicateTest.java
@@ -29,13 +29,13 @@ import org.junit.runner.RunWith;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Arrays.sort;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -110,26 +110,26 @@ public class MapPredicateTest extends HazelcastTestSupport {
         map.put("b", "2");
         map.put("c", "3");
         assertEquals(3, map.size());
-        {
-            final Object[] values = map.values().toArray();
-            Arrays.sort(values);
-            assertArrayEquals(new Object[]{"1", "2", "3"}, values);
-        }
-        {
-            final String[] values = map.values().toArray(new String[3]);
-            Arrays.sort(values);
-            assertArrayEquals(new String[]{"1", "2", "3"}, values);
-        }
-        {
-            final String[] values = map.values().toArray(new String[2]);
-            Arrays.sort(values);
-            assertArrayEquals(new String[]{"1", "2", "3"}, values);
-        }
-        {
-            final String[] values = map.values().toArray(new String[5]);
-            Arrays.sort(values, 0, 3);
-            assertArrayEquals(new String[]{"1", "2", "3", null, null}, values);
-        }
+
+        // toArray() without array
+        Object[] values = map.values().toArray();
+        sort(values);
+        assertArrayEquals(new Object[]{"1", "2", "3"}, values);
+
+        // toArray() with empty array (too small)
+        values = map.values().toArray(new String[0]);
+        sort(values);
+        assertArrayEquals(new String[]{"1", "2", "3"}, values);
+
+        // toArray() with correctly sized array
+        values = map.values().toArray(new String[3]);
+        sort(values);
+        assertArrayEquals(new String[]{"1", "2", "3"}, values);
+
+        // toArray() with too large array
+        values = map.values().toArray(new String[5]);
+        sort(values, 0, 3);
+        assertArrayEquals(new String[]{"1", "2", "3", null, null}, values);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/ExpirationManagerStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/eviction/ExpirationManagerStressTest.java
@@ -100,7 +100,7 @@ public class ExpirationManagerStressTest extends HazelcastTestSupport {
         sleepSeconds(5);
         stop.set(true);
 
-        assertJoinable(threads.toArray(new Thread[threads.size()]));
+        assertJoinable(threads.toArray(new Thread[0]));
 
         assertTrue(expirationManager.isScheduled());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindWithEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindWithEntryProcessorTest.java
@@ -88,7 +88,7 @@ public class WriteBehindWithEntryProcessorTest extends HazelcastTestSupport {
             salaries.add(salary);
         }
 
-        return salaries.toArray(new Double[mapStore.queue.size()]);
+        return salaries.toArray(new Double[0]);
     }
 
     private void assertStoreOperationsCompleted(final int size, final JournalingMapStore mapStore) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryBasicTest.java
@@ -187,7 +187,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
         for (Value configObject : values) {
             names.add(configObject.getName());
         }
-        String[] array = names.toArray(new String[names.size()]);
+        String[] array = names.toArray(new String[0]);
         Arrays.sort(array);
         assertArrayEquals(names.toString(), expectedValues, array);
     }
@@ -209,7 +209,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
         for (Value configObject : values) {
             names.add(configObject.getName());
         }
-        String[] array = names.toArray(new String[names.size()]);
+        String[] array = names.toArray(new String[0]);
         Arrays.sort(array);
         assertArrayEquals(names.toString(), expectedValues, array);
     }
@@ -328,7 +328,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
         for (Value configObject : values) {
             names.add(configObject.getName());
         }
-        String[] array = names.toArray(new String[names.size()]);
+        String[] array = names.toArray(new String[0]);
         Arrays.sort(array);
         assertArrayEquals(names.toString(), expectedValues, array);
     }
@@ -350,7 +350,7 @@ public class QueryBasicTest extends HazelcastTestSupport {
         for (Value configObject : values) {
             names.add(configObject.getName());
         }
-        String[] array = names.toArray(new String[names.size()]);
+        String[] array = names.toArray(new String[0]);
         Arrays.sort(array);
         assertArrayEquals(names.toString(), expectedValues, array);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryIndexTest.java
@@ -119,7 +119,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
         for (Value configObject : values) {
             typeNames.add(configObject.getType().getTypeName());
         }
-        String[] array = typeNames.toArray(new String[typeNames.size()]);
+        String[] array = typeNames.toArray(new String[0]);
         Arrays.sort(array);
         assertArrayEquals(typeNames.toString(), new String[]{"type6", "type8"}, array);
     }
@@ -141,7 +141,7 @@ public class QueryIndexTest extends HazelcastTestSupport {
         for (Value configObject : values) {
             typeNames.add(configObject.getType().getTypeName());
         }
-        assertArrayEquals(typeNames.toString(), new String[]{"type1"}, typeNames.toArray(new String[typeNames.size()]));
+        assertArrayEquals(typeNames.toString(), new String[]{"type1"}, typeNames.toArray(new String[0]));
     }
 
     @Test(timeout = 1000 * 60)

--- a/hazelcast/src/test/java/com/hazelcast/osgi/TestBundleContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/TestBundleContext.java
@@ -112,7 +112,7 @@ class TestBundleContext implements BundleContext {
         synchronized (mutex) {
             List<ServiceReference> serviceReferences = serviceReferenceMap.get(clazz);
             if (serviceReferences != null && !serviceReferences.isEmpty()) {
-                return serviceReferences.toArray(new ServiceReference[serviceReferences.size()]);
+                return serviceReferences.toArray(new ServiceReference[0]);
             }
         }
         return null;
@@ -124,7 +124,7 @@ class TestBundleContext implements BundleContext {
         synchronized (mutex) {
             List<ServiceReference> serviceReferences = serviceReferenceMap.get(clazz);
             if (serviceReferences != null && !serviceReferences.isEmpty()) {
-                return serviceReferences.toArray(new ServiceReference[serviceReferences.size()]);
+                return serviceReferences.toArray(new ServiceReference[0]);
             }
         }
         return null;
@@ -139,7 +139,7 @@ class TestBundleContext implements BundleContext {
                 allServiceReferences.addAll(serviceReferences);
             }
         }
-        return allServiceReferences.toArray(new ServiceReference[allServiceReferences.size()]);
+        return allServiceReferences.toArray(new ServiceReference[0]);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -80,7 +80,7 @@ public class IndexesTest {
         }
         EntryObject entryObject = new PredicateBuilder().getEntryObject();
         PredicateBuilder predicate = entryObject.get("name").equal("0Name")
-                .and(entryObject.get("age").in(ages.toArray(new String[count])));
+                .and(entryObject.get("age").in(ages.toArray(new String[0])));
         Set<QueryableEntry> results = indexes.query(predicate);
         assertEquals(1, results.size());
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateTest.java
@@ -74,7 +74,7 @@ public class NestedPredicateTest extends HazelcastTestSupport {
 
         // THEN
         assertEquals(1, values.size());
-        assertEquals("body1", values.toArray(new Body[values.size()])[0].getName());
+        assertEquals("body1", values.toArray(new Body[0])[0].getName());
     }
 
     @Test
@@ -88,7 +88,7 @@ public class NestedPredicateTest extends HazelcastTestSupport {
 
         // THEN
         assertEquals(1, values.size());
-        assertEquals("body1", values.toArray(new Body[values.size()])[0].getName());
+        assertEquals("body1", values.toArray(new Body[0])[0].getName());
     }
 
     @Test
@@ -104,7 +104,7 @@ public class NestedPredicateTest extends HazelcastTestSupport {
 
         // THEN
         assertEquals(1, values.size());
-        assertEquals("body2", values.toArray(new Body[values.size()])[0].getName());
+        assertEquals("body2", values.toArray(new Body[0])[0].getName());
     }
 
     @Test
@@ -118,7 +118,7 @@ public class NestedPredicateTest extends HazelcastTestSupport {
 
         // THEN
         assertEquals(1, values.size());
-        assertEquals("body2", values.toArray(new Body[values.size()])[0].getName());
+        assertEquals("body2", values.toArray(new Body[0])[0].getName());
     }
 
     private static class Body implements Serializable {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateVersionedPortablesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateVersionedPortablesTest.java
@@ -97,7 +97,7 @@ public class NestedPredicateVersionedPortablesTest extends HazelcastTestSupport 
 
         // THEN
         assertEquals(1, values.size());
-        assertEquals("body1", values.toArray(new NestedPredicateVersionedPortablesTest.Body[values.size()])[0].getName());
+        assertEquals("body1", values.toArray(new Body[0])[0].getName());
 
     }
 
@@ -112,7 +112,7 @@ public class NestedPredicateVersionedPortablesTest extends HazelcastTestSupport 
 
         // THEN
         assertEquals(1, values.size());
-        assertEquals("body2", values.toArray(new NestedPredicateVersionedPortablesTest.Body[values.size()])[0].getName());
+        assertEquals("body2", values.toArray(new Body[0])[0].getName());
     }
 
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
@@ -95,7 +95,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
 
         // THEN
         assertEquals(1, values.size());
-        assertEquals("body1", values.toArray(new Body[values.size()])[0].getName());
+        assertEquals("body1", values.toArray(new Body[0])[0].getName());
         assertEquals(2 + 1, bodyExtractorExecutions);
         assertEquals(0, limbExtractorExecutions);
     }
@@ -111,7 +111,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
 
         // THEN
         assertEquals(1, values.size());
-        assertEquals("body1", values.toArray(new Body[values.size()])[0].getName());
+        assertEquals("body1", values.toArray(new Body[0])[0].getName());
         assertEquals(2 + 1, bodyExtractorExecutions);
         assertEquals(0, limbExtractorExecutions);
     }
@@ -129,7 +129,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
 
         // THEN
         assertEquals(1, values.size());
-        assertEquals("body2", values.toArray(new Body[values.size()])[0].getName());
+        assertEquals("body2", values.toArray(new Body[0])[0].getName());
         assertEquals(0, bodyExtractorExecutions);
         assertEquals(2 + 1, limbExtractorExecutions);
     }
@@ -191,7 +191,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
 
         // THEN
         assertEquals(1, values.size());
-        assertEquals("body2", values.toArray(new Body[values.size()])[0].getName());
+        assertEquals("body2", values.toArray(new Body[0])[0].getName());
         assertEquals(0, bodyExtractorExecutions);
         assertEquals(2 + 1, limbExtractorExecutions);
     }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/list/ListQuorumReadTest.java
@@ -112,12 +112,12 @@ public class ListQuorumReadTest extends AbstractQuorumTest {
 
     @Test
     public void getAllOperation_toArrayT_successful_whenQuorumSize_met() {
-        list(0).toArray(new Object[]{});
+        list(0).toArray(new Object[0]);
     }
 
     @Test(expected = QuorumException.class)
     public void getAllOperation_toArrayT_failing_whenQuorumSize_notMet() {
-        list(3).toArray(new Object[]{});
+        list(3).toArray(new Object[0]);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/set/SetQuorumReadTest.java
@@ -112,12 +112,12 @@ public class SetQuorumReadTest extends AbstractQuorumTest {
 
     @Test
     public void getAllOperation_toArrayT_successful_whenQuorumSize_met() {
-        set(0).toArray(new Object[]{});
+        set(0).toArray(new Object[0]);
     }
 
     @Test(expected = QuorumException.class)
     public void getAllOperation_toArrayT_successful_whenQuorumSize_notMet() {
-        set(3).toArray(new Object[]{});
+        set(3).toArray(new Object[0]);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -258,7 +258,7 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
         // indicate that we need to unblacklist addresses from the joiner when split-brain will be healed
         unblacklistHint = true;
         // create a new Hazelcast instance which has blocked addresses blacklisted in its joiner
-        return factory.newHazelcastInstance(config(), addressesToBlock.toArray(new Address[addressesToBlock.size()]));
+        return factory.newHazelcastInstance(config(), addressesToBlock.toArray(new Address[0]));
     }
 
     private void validateBrainsConfig(int[] clusterTopology) {

--- a/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
@@ -94,7 +94,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
         Collection<Integer> result = returnWithDeadline(futures, 10, TimeUnit.SECONDS, logAllExceptions(Level.WARNING));
         assertEquals(2, result.size());
 
-        Integer[] array = result.toArray(new Integer[result.size()]);
+        Integer[] array = result.toArray(new Integer[0]);
         assertEquals(1, (int) array[0]);
         assertEquals(2, (int) array[1]);
     }
@@ -112,7 +112,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
         Collection<Integer> result = returnWithDeadline(futures, 10, TimeUnit.SECONDS, logAllExceptions(Level.WARNING));
         assertEquals(2, result.size());
 
-        Integer[] array = result.toArray(new Integer[result.size()]);
+        Integer[] array = result.toArray(new Integer[0]);
         assertEquals(1, (int) array[0]);
         assertEquals(2, (int) array[1]);
     }

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/IntHashSetTest.java
@@ -296,7 +296,7 @@ public class IntHashSetTest extends HazelcastTestSupport {
         final IntHashSet initial = new IntHashSet(100, -1);
         initial.add(1);
         initial.add(13);
-        final Object[] ary = initial.toArray(new Integer[2]);
+        final Object[] ary = initial.toArray(new Integer[0]);
         final Set<Object> fromArray = new HashSet<Object>(Arrays.asList(ary));
         assertEquals(new HashSet<Object>(initial), fromArray);
     }

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/LongHashSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/LongHashSetTest.java
@@ -293,7 +293,7 @@ public class LongHashSetTest {
         final LongHashSet initial = new LongHashSet(100, -1);
         initial.add(1);
         initial.add(13);
-        final Object[] ary = initial.toArray(new Long[2]);
+        final Object[] ary = initial.toArray(new Long[0]);
         final Set<Object> fromArray = new HashSet<Object>(Arrays.asList(ary));
         assertEquals(new HashSet<Object>(initial), fromArray);
     }


### PR DESCRIPTION
Inspired by an IDEA warning and some good reads it seems safe to say, that calling `toArray(new T[0])` is faster than `toArray(new T[size])` since about 5 years.

Using array constants like Peter Lawrey suggests, doesn't seem to be justified and may have unwanted side effects (the constant array may be returned in some edge cases, so object identity issues can come up).

For further details I recommend the article from Aleksey Shipilёv.

![screenshot from 2018-05-11 15-22-54](https://user-images.githubusercontent.com/4196298/39926391-5c124574-552f-11e8-827f-5e6f363dfc35.png)
https://shipilev.net/blog/2016/arrays-wisdom-ancients/
https://vanillajava.blogspot.de/2011/06/performance-tip-avoid.html