### PR TITLE
[BACKPORT] Add QueueUtil utility class

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/QueueUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/QueueUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import java.util.Queue;
+
+/**
+ * Utility class for Queues
+ */
+public final class QueueUtil {
+
+    private QueueUtil() {
+    }
+
+    /**
+     * Drains the provided queue by the size of the queue as it is known
+     * upfront draining.
+     * <p>
+     * The rational for using this method is the same as for using
+     * {@link Queue#clear()}: to remove all the elements from the queue.
+     * There are two major differences to highlight:
+     * <ol>
+     * <li>This method doesn't guarantee that the queue is empty on
+     * return if it is written concurrently.</li>
+     * <li>This method returns the number of drained elements, while
+     * {@link Queue#clear()} doesn't.</li>
+     * </ol>
+     *
+     * These points makes this method more applicable than
+     * {@link Queue#clear()} is in conditions where the queue is written
+     * concurrently without blocking the writer threads for the time of
+     * draining the queue and the caller needs to know the number of
+     * elements removed from the queue.
+     *
+     * @param queue The queue to be drained
+     * @return The number of elements drained from the queue
+     */
+    public static int drainQueue(Queue<?> queue) {
+        return drainQueue(queue, queue.size());
+    }
+
+    /**
+     * Drains the provided queue by the count provided in {@code elementsToDrain}.
+     *
+     * @param queue           The queue to be drained
+     * @param elementsToDrain The number of elements to be drained from
+     *                        the queue
+     * @return The number of elements drained from the queue
+     */
+    public static int drainQueue(Queue<?> queue, int elementsToDrain) {
+        int drained = 0;
+        boolean drainMore = true;
+        for (int i = 0; i < elementsToDrain && drainMore; i++) {
+            Object polled = queue.poll();
+            if (polled != null) {
+                drained++;
+            } else {
+                drainMore = false;
+            }
+        }
+
+        return drained;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/util/QueueUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/QueueUtilTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertUtilityConstructor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class QueueUtilTest {
+
+    @Test
+    public void testConstructor() {
+        assertUtilityConstructor(QueueUtil.class);
+    }
+
+    @Test
+    public void drainQueueToZero() {
+        Queue<Integer> queue = new LinkedList<Integer>();
+        for (int i = 0; i < 100; i++) {
+            queue.offer(i);
+        }
+
+        int drained = QueueUtil.drainQueue(queue);
+        assertEquals(100, drained);
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    public void drainQueueToNonZero() {
+        Queue<Integer> queue = new LinkedList<Integer>();
+        for (int i = 0; i < 100; i++) {
+            queue.offer(i);
+        }
+
+        int drained = QueueUtil.drainQueue(queue, 50);
+        assertEquals(50, drained);
+        assertEquals(50, queue.size());
+    }
+}


### PR DESCRIPTION
Utility methods for draining a queue. See the javadoc for more justification.

Backport of #12981

(cherry picked from commit 255d5a6ba9095603ff97891a0039975020e8e61f)