### PR TITLE
[BACKPORT] Fixed possible NPE in client quorum tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientCacheQuorumReadTest extends CacheQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cache/ClientCacheQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientCacheQuorumWriteTest extends CacheQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cardinality/ClientCardinalityEstimatorQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cardinality/ClientCardinalityEstimatorQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientCardinalityEstimatorQuorumReadTest extends CardinalityEstimat
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cardinality/ClientCardinalityEstimatorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/cardinality/ClientCardinalityEstimatorQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientCardinalityEstimatorQuorumWriteTest extends CardinalityEstima
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/countdownlatch/ClientCountDownLatchQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/countdownlatch/ClientCountDownLatchQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientCountDownLatchQuorumReadTest extends CountDownLatchQuorumRead
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/countdownlatch/ClientCountDownLatchQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/countdownlatch/ClientCountDownLatchQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientCountDownLatchQuorumWriteTest extends CountDownLatchQuorumWri
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/durableexecutor/ClientDurableExecutorQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/durableexecutor/ClientDurableExecutorQuorumReadTest.java
@@ -48,8 +48,10 @@ public class ClientDurableExecutorQuorumReadTest extends DurableExecutorQuorumRe
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/durableexecutor/ClientDurableExecutorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/durableexecutor/ClientDurableExecutorQuorumWriteTest.java
@@ -48,8 +48,10 @@ public class ClientDurableExecutorQuorumWriteTest extends DurableExecutorQuorumW
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumReadTest.java
@@ -48,8 +48,10 @@ public class ClientExecutorQuorumReadTest extends ExecutorQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/executor/ClientExecutorQuorumWriteTest.java
@@ -49,8 +49,10 @@ public class ClientExecutorQuorumWriteTest extends ExecutorQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientListQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientListQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientListQuorumReadTest extends ListQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientListQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientListQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientListQuorumWriteTest extends ListQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientTransactionalListQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientTransactionalListQuorumReadTest.java
@@ -48,8 +48,10 @@ public class ClientTransactionalListQuorumReadTest extends TransactionalListQuor
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientTransactionalListQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/list/ClientTransactionalListQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientTransactionalListQuorumWriteTest extends TransactionalListQuo
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/lock/ClientLockQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/lock/ClientLockQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientLockQuorumReadTest extends LockQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/lock/ClientLockQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/lock/ClientLockQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientLockQuorumWriteTest extends LockQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientMapQuorumReadTest extends MapQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientMapQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientMapQuorumWriteTest extends MapQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientTransactionalMapQuorumReadTest extends TransactionalMapQuorum
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/map/ClientTransactionalMapQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientTransactionalMapQuorumWriteTest extends TransactionalMapQuoru
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientMultiMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientMultiMapQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientMultiMapQuorumReadTest extends MultiMapQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientMultiMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientMultiMapQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientMultiMapQuorumWriteTest extends MultiMapQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientTransactionalMultiMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientTransactionalMultiMapQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientTransactionalMultiMapQuorumReadTest extends TransactionalMult
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientTransactionalMultiMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/multimap/ClientTransactionalMultiMapQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientTransactionalMultiMapQuorumWriteTest extends TransactionalMul
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/pncounter/ClientPNCounterQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/pncounter/ClientPNCounterQuorumReadTest.java
@@ -31,8 +31,10 @@ public class ClientPNCounterQuorumReadTest extends PNCounterQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/pncounter/ClientPNCounterQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/pncounter/ClientPNCounterQuorumWriteTest.java
@@ -31,8 +31,10 @@ public class ClientPNCounterQuorumWriteTest extends PNCounterQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientQueueQuorumReadTest extends QueueQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientQueueQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientQueueQuorumWriteTest extends QueueQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientTransactionalQueueQuorumReadTest extends TransactionalQueueQu
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/queue/ClientTransactionalQueueQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientTransactionalQueueQuorumWriteTest extends TransactionalQueueQ
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/replicatedmap/ClientReplicatedMapQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/replicatedmap/ClientReplicatedMapQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientReplicatedMapQuorumReadTest extends ReplicatedMapQuorumReadTe
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/replicatedmap/ClientReplicatedMapQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/replicatedmap/ClientReplicatedMapQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientReplicatedMapQuorumWriteTest extends ReplicatedMapQuorumWrite
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ringbuffer/ClientRingbufferQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ringbuffer/ClientRingbufferQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientRingbufferQuorumReadTest extends RingbufferQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ringbuffer/ClientRingbufferQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/ringbuffer/ClientRingbufferQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientRingbufferQuorumWriteTest extends RingbufferQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientScheduledExecutorQuorumReadTest extends ScheduledExecutorQuor
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientScheduledExecutorQuorumWriteTest extends ScheduledExecutorQuo
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/semaphore/ClientSemaphoreQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/semaphore/ClientSemaphoreQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientSemaphoreQuorumReadTest extends SemaphoreQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/semaphore/ClientSemaphoreQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/semaphore/ClientSemaphoreQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientSemaphoreQuorumWriteTest extends SemaphoreQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientSetQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientSetQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientSetQuorumReadTest extends SetQuorumReadTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientSetQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientSetQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientSetQuorumWriteTest extends SetQuorumWriteTest {
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientTransactionalSetQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientTransactionalSetQuorumReadTest.java
@@ -47,8 +47,10 @@ public class ClientTransactionalSetQuorumReadTest extends TransactionalSetQuorum
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientTransactionalSetQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/set/ClientTransactionalSetQuorumWriteTest.java
@@ -47,8 +47,10 @@ public class ClientTransactionalSetQuorumWriteTest extends TransactionalSetQuoru
 
     @AfterClass
     public static void tearDown() {
+        if (clients != null) {
+            clients.terminateAll();
+        }
         shutdownTestEnvironment();
-        clients.terminateAll();
     }
 
     @Override


### PR DESCRIPTION
* if there is a startup error, test will fail with a NPE during teardown
* clients should also be shutdown before the cluster, to prevent
  reconnection attempts to a shutdown cluster

(cherry picked from commit fa281ad)

Backport of https://github.com/hazelcast/hazelcast/pull/13099