### PR TITLE
Handle rejectedExecutionExc on deregisterListener method

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListenerTests.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/listeners/ListenerTests.java
@@ -115,4 +115,13 @@ public class ListenerTests extends ClientTestSupport {
         executorService.shutdown();
 
     }
+
+    @Test
+    public void testRemoveListenerOnClosedClient() {
+        factory.newHazelcastInstance();
+        HazelcastInstance client = factory.newHazelcastClient();
+        IMap<Object, Object> map = client.getMap("test");
+        client.shutdown();
+        assertTrue(map.removeEntryListener("test"));
+    }
 }


### PR DESCRIPTION
Related to test failure here
https://github.com/hazelcast/hazelcast/issues/13098

Tests passes succesfully but teardown throws `RejectedExecutionException`

Here is the scenerio:

1. Server shuts down
2. Client disconnected from cluster.
3. Client exhausts all retries and shuts itself down.
4. `AbstractHazelcastCachingProvider.close` called on client by user(from test in this case).
5. This needs to clean up listeners.
6. Since client is shutdown(executors are closed), it gets RejectedExecutionException.

As a fix we catch RejectedExecutionException and ignore it.
Since listeners are cleaned up by the server side, we can ignore
the exception and return true safely on deregisterListener.

fixes https://github.com/hazelcast/hazelcast/issues/13098