### PR TITLE
[BACKPORT]Cache configs on smaller brain and re-store missing ones after join

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractMergeRunnable.java
@@ -111,12 +111,17 @@ public abstract class AbstractMergeRunnable<K, V, Store, MergingItem extends Mer
 
     @Override
     public final void run() {
+        onRunStart();
         int mergedCount = 0;
 
         mergedCount += mergeWithSplitBrainMergePolicy();
         mergedCount += mergeWithLegacyMergePolicy();
 
         waitMergeEnd(mergedCount);
+    }
+
+    protected void onRunStart() {
+        // Implementers can override this method.
     }
 
     private int mergeWithSplitBrainMergePolicy() {


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/13028

cherry-picked from https://github.com/hazelcast/hazelcast/pull/13094