### PR TITLE
Avoid npe exception on ClientEngineImpl bind

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -77,6 +77,7 @@ import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.executor.ExecutorType;
 
 import javax.security.auth.login.LoginException;
+import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -312,8 +313,12 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
     public void bind(final ClientEndpoint endpoint) {
         final Connection conn = endpoint.getConnection();
         if (conn instanceof TcpIpConnection) {
-            Address address = new Address(conn.getRemoteSocketAddress());
-            ((TcpIpConnection) conn).setEndPoint(address);
+            InetSocketAddress socketAddress = conn.getRemoteSocketAddress();
+            //socket address can be null if connection closed before bind
+            if (socketAddress != null) {
+                Address address = new Address(socketAddress);
+                ((TcpIpConnection) conn).setEndPoint(address);
+            }
         }
         ClientEvent event = new ClientEvent(endpoint.getUuid(),
                 ClientEventType.CONNECTED,


### PR DESCRIPTION
If connection closed before `bind`, we can get NPE.
This pr avoid npe. I skipped any logging since we will have
connection closed logs and also
"Connection is closed, won't write packet" .. with related message
printed. These are more than enouhg to understand the case.

fixes https://github.com/hazelcast/hazelcast/issues/13118

(cherry picked from commit b2a50d62c26ac0008960d600dab710aed56d3c34)