### PR TITLE
Add operation flushing support for use in test

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/OperationExecutor.java
@@ -204,4 +204,18 @@ public interface OperationExecutor extends Consumer<Packet>, LiveOperationsTrack
      * Shuts down this OperationExecutor. Any pending tasks are discarded.
      */
     void shutdown();
+
+    /**
+     * Flushes the operations scheduled on this operation executor.
+     * <p>
+     * The calling thread is blocked until all the operations submitted to this
+     * operation executor are completed.
+     * <p>
+     * WARNING: This method has a high impact on the performance because it
+     * produces major stalls in the underlying thread pools. Use it for testing
+     * and debugging purposes only.
+     *
+     * @throws InterruptedException if the flush was interrupted.
+     */
+    void flush() throws InterruptedException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -145,4 +145,18 @@ public interface InternalOperationService extends OperationService {
     List<SlowOperationDTO> getSlowOperationDTOs();
 
     <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback);
+
+    /**
+     * Flushes the operations scheduled on this operation service.
+     * <p>
+     * The calling thread is blocked until all the operations submitted to this
+     * operation service are completed.
+     * <p>
+     * WARNING: This method has a high impact on the performance because it
+     * produces major stalls in the underlying thread pool. Use it for testing
+     * and debugging purposes only.
+     *
+     * @throws InterruptedException if the flush was interrupted.
+     */
+    void flush() throws InterruptedException;
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -342,6 +342,11 @@ public final class OperationServiceImpl implements InternalOperationService, Met
     }
 
     @Override
+    public void flush() throws InterruptedException {
+        operationExecutor.flush();
+    }
+
+    @Override
     public void onStartAsyncOperation(Operation op) {
         asyncOperations.add(op);
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -634,6 +634,18 @@ public abstract class HazelcastTestSupport {
         }
         Node n1 = getNode(h1);
         Node n2 = getNode(h2);
+
+        try {
+            // We have to flush the operations here because only after the
+            // flushing we may be sure that there are no heartbeats left in the
+            // queues which may invalidate the suspicions.
+
+            n1.getNodeEngine().getOperationService().flush();
+            n2.getNodeEngine().getOperationService().flush();
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Flush was interrupted", e);
+        }
+
         suspectMember(n1, n2);
         suspectMember(n2, n1);
     }


### PR DESCRIPTION
While testing/debugging, sometimes there is a need to make sure that
certain operations are finished before starting another batch of
operations. This change brings such support.

Fixes: https://github.com/hazelcast/hazelcast/issues/13097