### PR TITLE
Add ProbeBuilder to MetricsRegistry

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
@@ -44,8 +44,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * This class is the main entry point for collecting and sending the client
- * statistics to the cluster. If the client statistics feature is enabled
- * it will be scheduled for periodic statistics collection and send.
+ * statistics to the cluster. If the client statistics feature is enabled,
+ * it will be scheduled for periodic statistics collection and sent.
  */
 public class Statistics {
     /**
@@ -56,7 +56,7 @@ public class Statistics {
     public static final HazelcastProperty ENABLED = new HazelcastProperty("hazelcast.client.statistics.enabled", false);
 
     /**
-     * The period in seconds the statistics runs.
+     * The period in seconds the statistics run.
      */
     public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty("hazelcast.client.statistics.period.seconds", 3,
             SECONDS);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -31,10 +31,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 /**
- * Client Delegating Future is used to delegate ClientInvocationFuture to user to be used with
- * andThen or get. It converts ClientMessage coming from ClientInvocationFuture to user object
+ * The Client Delegating Future is used to delegate {@link
+ * ClientInvocationFuture} to a user type to be used with {@code andThen()} or
+ * {@code get()}. It converts {@link ClientMessage} coming from {@link
+ * ClientInvocationFuture} to a user object.
  *
- * @param <V> Value type that user expecting
+ * @param <V> Value type that the user expects
  */
 public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -75,8 +75,8 @@ public interface MetricsRegistry {
      * implementation, e.g. a new OperationService implementation, that doesn't
      * provide the operation.count probe.
      *
-     * Multiple calls with the same name, return different Gauge instances; so
-     * the Gauge instance is not cached. This is done to prevent memory leaks.
+     * Multiple calls with the same name return different Gauge instances; so the Gauge instance is not cached. This is
+     * done to prevent memory leaks.
      *
      * @param name the name of the metric.
      * @return the created LongGauge.
@@ -105,15 +105,14 @@ public interface MetricsRegistry {
     Set<String> getNames();
 
     /**
-     * Scans the source object for any fields/methods that have been annotated
-     * with {@link Probe} annotation, and registering these fields/methods as
-     * probes instances.
+     * Scans the source object for any fields/methods that have been annotated with {@link Probe} annotation, and
+     * registers these fields/methods as probes instances.
      * <p>
-     * If a probe is called 'queueSize' and the namePrefix is 'operations',
-     * then the name of the probe-instance is 'operations.queueSize'.
+     * If a probe is called 'queueSize' and the namePrefix is 'operations', then the name of the probe instance
+     * is 'operations.queueSize'.
      * <p>
-     * If probes with the same name already exist, then the probes are replaced.
-     * <p>
+     * If a probe with the same name already exists, then the probe is replaced.
+     *
      * If an object has no @Gauge annotations, the call is ignored.
      *
      * @param source     the object to scan.
@@ -123,6 +122,28 @@ public interface MetricsRegistry {
      * on a field/method of unsupported type.
      */
     <S> void scanAndRegister(S source, String namePrefix);
+
+    /**
+     * Scans the source object for any fields/methods that have been annotated
+     * with {@link Probe} annotation, and registers these fields/methods as
+     * probes instances.
+     * <p>
+     * If a probe is called 'queueSize' and the namePrefix is '[operations.'
+     * and nameSuffix is ']', then the name of the probe instance is
+     * '[operations.queueSize]'.
+     * <p>
+     * If a probe with the same name already exists, then the probe is replaced.
+     * <p>
+     * If an object has no @Gauge annotations, the call is ignored.
+     *
+     * @param source     the object to scan.
+     * @param namePrefix the name prefix.
+     * @param nameSuffix the name suffix.
+     * @throws NullPointerException     if namePrefix or source is null.
+     * @throws IllegalArgumentException if the source contains Gauge annotation
+     * on a field/method of unsupported type.
+     */
+    <S> void scanAndRegister(S source, String namePrefix, String nameSuffix);
 
     /**
      * Registers a probe.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsUtil.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+import javax.annotation.Nonnull;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A utility to escape and parse metric key in tagged format:<pre>
+ *     [tag1=value1,tag2=value2,...]
+ * </pre>
+ */
+public final class MetricsUtil {
+
+    private MetricsUtil() {
+    }
+
+    /**
+     * Escapes a user-supplied string value that is to be used as metrics key
+     * tag or value.
+     * <p>
+     * Prefixes comma ({@code ","}), equals sign ({@code "="}) and backslash
+     * ({@code "\"}) with another backslash.
+     */
+    @Nonnull
+    public static String escapeMetricKeyPart(@Nonnull String s) {
+        int i = 0;
+        int l = s.length();
+        while (i < l) {
+            char ch = s.charAt(i);
+            if (ch == ',' || ch == '=' || ch == '\\') {
+                break;
+            }
+            i++;
+        }
+        if (i == l) {
+            return s;
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 3);
+        sb.append(s, 0, i);
+        while (i < l) {
+            char ch = s.charAt(i++);
+            if (ch == ',' || ch == '=' || ch == '\\') {
+                sb.append('\\');
+            }
+            sb.append(ch);
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Parses metric key in tagged format into a list of tag-value tuples.
+     * Correctly handles the escaped values.
+     *
+     * @throws IllegalArgumentException if the metricKey format is invalid
+     * (invalid escape, missing square bracket, empty tag name...)
+     */
+    @Nonnull
+    public static List<Map.Entry<String, String>> parseMetricKey(@Nonnull String metricKey) {
+        assert metricKey.charAt(0) == '[' && metricKey.charAt(metricKey.length() - 1) == ']' :
+                "key not enclosed in []: " + metricKey;
+
+        StringBuilder sb = new StringBuilder();
+        List<Map.Entry<String, String>> result = new ArrayList<Map.Entry<String, String>>();
+        int l = metricKey.length() - 1;
+        String tag = null;
+        boolean inTag = true;
+        for (int i = 1; i < l; i++) {
+            char ch = metricKey.charAt(i);
+            switch (ch) {
+                case '=':
+                    if (!inTag) {
+                        throw new IllegalArgumentException("equals sign not after tag: " + metricKey);
+                    }
+                    tag = sb.toString();
+                    if (tag.length() == 0) {
+                        throw new IllegalArgumentException("empty tag name: " + metricKey);
+                    }
+                    sb.setLength(0);
+                    inTag = false;
+                    continue;
+
+                case ',':
+                    if (inTag) {
+                        throw new IllegalArgumentException("comma in tag: " + metricKey);
+                    }
+                    result.add(new SimpleImmutableEntry<String, String>(tag, sb.toString()));
+                    sb.setLength(0);
+                    inTag = true;
+                    tag = null;
+                    continue;
+
+                default:
+                    if (ch == '\\') {
+                        // the next character will be treated literally
+                        ch = metricKey.charAt(++i);
+                    }
+                    if (i == l) {
+                        throw new IllegalArgumentException("backslash at the end: " + metricKey);
+                    }
+                    sb.append(ch);
+            }
+        }
+        // final entry
+        if (tag != null) {
+            result.add(new SimpleImmutableEntry<String, String>(tag, sb.toString()));
+        } else if (sb.length() > 0) {
+            throw new IllegalArgumentException("unfinished tag at the end: " + metricKey);
+        }
+        return result;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsUtil.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.metrics;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.annotation.Nonnull;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
@@ -66,6 +68,7 @@ public final class MetricsUtil {
         return sb.toString();
     }
 
+    @SuppressFBWarnings(value = "ES_COMPARING_PARAMETER_STRING_WITH_EQ", justification = "it's intentional")
     public static boolean containsSpecialCharacters(String namePart) {
         // escapeMetricNamePart method returns input object of no escaping is needed,
         // we assume that.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
+import static com.hazelcast.internal.metrics.ProbeUnit.UNSPECIFIED;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -84,4 +85,9 @@ public @interface Probe {
      * @return the ProbeLevel.
      */
     ProbeLevel level() default INFO;
+
+    /**
+     * Measurement unit of a Probe. Not used on member, becomes a part of the key.
+     */
+    ProbeUnit unit() default UNSPECIFIED;
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
-import static com.hazelcast.internal.metrics.ProbeUnit.UNSPECIFIED;
+import static com.hazelcast.internal.metrics.ProbeUnit.COUNT;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -89,5 +89,5 @@ public @interface Probe {
     /**
      * Measurement unit of a Probe. Not used on member, becomes a part of the key.
      */
-    ProbeUnit unit() default UNSPECIFIED;
+    ProbeUnit unit() default COUNT;
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+/**
+ * Immutable builder object to register Probes.
+ */
+public interface ProbeBuilder {
+
+    /**
+     * Returns a new ProbeBuilder instance with the given tag added.
+     */
+    ProbeBuilder withTag(String tag, String value);
+
+    /**
+     * Builds the String name for manually registering probes.
+     */
+    String metricName();
+
+    /**
+     * Registers a single probe.
+     * <p>
+     * If a probe for the given name exists, it will be overwritten silently.
+     *
+     * @param source the object to pass to probeFn
+     * @param metricName the value of "metric" tag
+     * @param level the ProbeLevel
+     * @param probeFn the probe function
+     * @throws NullPointerException if any of the arguments is null
+     */
+    <S> void register(S source, String metricName, ProbeLevel level, DoubleProbeFunction<S> probeFn);
+
+    /**
+     * Registers a single probe.
+     * <p>
+     * If a probe for the given name exists, it will be overwritten silently.
+     *
+     * @param source the object to pass to probeFn
+     * @param metricName the value of "metric" tag
+     * @param level the ProbeLevel
+     * @param probeFn the probe function
+     * @throws NullPointerException if any of the arguments is null
+     */
+    <S> void register(S source, String metricName, ProbeLevel level, LongProbeFunction<S> probeFn);
+
+    /**
+     * Scans the source object for any fields/methods that have been annotated
+     * with {@link Probe} annotation, and registers these fields/methods as
+     * probe instances.
+     * <p>
+     * If a probe with the same name already exists, the probe is overwritten
+     * silently.
+     * <p>
+     * If an object has no @Probe annotations, the call is ignored.
+     *
+     * @param source     the object to scan
+     * @throws IllegalArgumentException if the source contains Probe annotation
+     * on a field/method of unsupported type.
+     */
+    <S> void scanAndRegister(S source);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeBuilder.java
@@ -27,11 +27,6 @@ public interface ProbeBuilder {
     ProbeBuilder withTag(String tag, String value);
 
     /**
-     * Builds the String name for manually registering probes.
-     */
-    String metricName();
-
-    /**
      * Registers a single probe.
      * <p>
      * If a probe for the given name exists, it will be overwritten silently.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeUnit.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeUnit.java
@@ -20,11 +20,16 @@ package com.hazelcast.internal.metrics;
  * Measurement unit of a Probe. Not used on member, becomes a part of the key.
  */
 public enum ProbeUnit {
-    UNSPECIFIED,
+    /** Size, counter, represented in bytes */
     BYTES,
+    /** Timestamp or duration represented in ms */
     MS,
+    /** An integer mostly in range 0..100 or a double mostly in range 0..1 */
     PERCENT,
+    /** Number of items: size, counter... */
     COUNT,
+    /** 0 or 1 */
     BOOLEAN,
+    /** 0..n, ordinal of an enum */
     ENUM,
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeUnit.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeUnit.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+/**
+ * Measurement unit of a Probe. Not used on member, becomes a part of the key.
+ */
+public enum ProbeUnit {
+    UNSPECIFIED,
+    BYTES,
+    MS,
+    PERCENT,
+    COUNT,
+    BOOLEAN,
+    ENUM,
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
@@ -55,7 +55,7 @@ class DoubleGaugeImpl extends AbstractGauge implements DoubleGauge {
                 return doubleFunction.get(source);
             }
         } catch (Exception e) {
-            metricsRegistry.logger.warning("Failed to access probe:" + name, e);
+            metricsRegistry.logger.warning("Failed to access the probe: " + name, e);
             return DEFAULT_VALUE;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -55,18 +55,18 @@ abstract class FieldProbe implements ProbeFunction {
         field.setAccessible(true);
     }
 
-    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
-        String name = getName(namePrefix);
+    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix, String nameSuffix) {
+        String name = getName(namePrefix, nameSuffix);
         metricsRegistry.registerInternal(source, name, probe.level(), this);
     }
 
-    private String getName(String namePrefix) {
+    private String getName(String namePrefix, String nameSuffix) {
         String name = field.getName();
         if (!probe.name().equals("")) {
             name = probe.name();
         }
 
-        return namePrefix + "." + name;
+        return namePrefix + name + nameSuffix;
     }
 
     static <S> FieldProbe createFieldProbe(Field field, Probe probe) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -61,8 +61,8 @@ abstract class FieldProbe implements ProbeFunction {
     }
 
     void register(ProbeBuilderImpl builder, Object source) {
-        ((ProbeBuilderImpl) builder
-                .withTag("unit", probe.unit().name().toLowerCase()))
+        builder
+                .withTag("unit", probe.unit().name().toLowerCase())
                 .register(source, getProbeOrFieldName(), probe.level(), this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -20,7 +20,6 @@ import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeFunction;
-import com.hazelcast.internal.metrics.ProbeUnit;
 import com.hazelcast.internal.util.counters.Counter;
 
 import java.lang.reflect.Field;
@@ -62,10 +61,9 @@ abstract class FieldProbe implements ProbeFunction {
     }
 
     void register(ProbeBuilderImpl builder, Object source) {
-        if (probe.unit() != ProbeUnit.UNSPECIFIED) {
-            builder = (ProbeBuilderImpl) builder.withTag("unit", probe.unit().name());
-        }
-        builder.register(source, getProbeOrFieldName(), probe.level(), this);
+        ((ProbeBuilderImpl) builder
+                .withTag("unit", probe.unit().name().toLowerCase()))
+                .register(source, getProbeOrFieldName(), probe.level(), this);
     }
 
     private String getProbeOrFieldName() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LockStripe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LockStripe.java
@@ -22,11 +22,11 @@ import static java.lang.System.identityHashCode;
 /**
  * A stripe of locks to synchronize on a source object.
  *
- * We don't want to lock an 'source' objects because we don't own them to prevent running into unnecessary lock contention
+ * We don't want to lock on 'source' objects because we don't own them, to prevent running into unnecessary lock contention
  * issues.
  *
  * We rely on the identity hashcode of the object and not on the {@link Object#hashCode()} method to prevent running into
- * faulty or thread unsafe implementations.
+ * faulty or thread-unsafe implementations.
  */
 class LockStripe {
 
@@ -42,6 +42,6 @@ class LockStripe {
 
     Object getLock(Object source) {
         int hash = identityHashCode(source);
-        return hashToIndex(hash, stripe.length);
+        return stripe[hashToIndex(hash, stripe.length)];
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
@@ -56,7 +56,7 @@ class LongGaugeImpl extends AbstractGauge implements LongGauge {
                 return Math.round(doubleResult);
             }
         } catch (Exception e) {
-            metricsRegistry.logger.warning("Failed to access probe:" + name, e);
+            metricsRegistry.logger.warning("Failed to access the probe: " + name, e);
             return DEFAULT_VALUE;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -20,7 +20,6 @@ import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.metrics.ProbeFunction;
-import com.hazelcast.internal.metrics.ProbeUnit;
 import com.hazelcast.internal.util.counters.Counter;
 
 import java.lang.reflect.Method;
@@ -65,10 +64,9 @@ abstract class MethodProbe implements ProbeFunction {
     }
 
     void register(ProbeBuilderImpl builder, Object source) {
-        if (probe.unit() != ProbeUnit.UNSPECIFIED) {
-            builder = (ProbeBuilderImpl) builder.withTag("unit", probe.unit().name());
-        }
-        builder.register(source, getProbeOrMethodName(), probe.level(), this);
+        ((ProbeBuilderImpl) builder
+                .withTag("unit", probe.unit().name().toLowerCase()))
+                .register(source, getProbeOrMethodName(), probe.level(), this);
     }
 
     private String getProbeOrMethodName() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -64,8 +64,8 @@ abstract class MethodProbe implements ProbeFunction {
     }
 
     void register(ProbeBuilderImpl builder, Object source) {
-        ((ProbeBuilderImpl) builder
-                .withTag("unit", probe.unit().name().toLowerCase()))
+        builder
+                .withTag("unit", probe.unit().name().toLowerCase())
                 .register(source, getProbeOrMethodName(), probe.level(), this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -58,12 +58,12 @@ abstract class MethodProbe implements ProbeFunction {
         method.setAccessible(true);
     }
 
-    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
-        String name = getName(namePrefix);
+    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix, String nameSuffix) {
+        String name = getName(namePrefix, nameSuffix);
         metricsRegistry.registerInternal(source, name, probe.level(), this);
     }
 
-    private String getName(String namePrefix) {
+    private String getName(String namePrefix, String nameSuffix) {
         String name;
         if (probe.name().equals("")) {
             name = getterIntoProperty(method.getName());
@@ -71,7 +71,7 @@ abstract class MethodProbe implements ProbeFunction {
             name = probe.name();
         }
 
-        return namePrefix + "." + name;
+        return namePrefix + name + nameSuffix;
     }
 
     static <S> MethodProbe createMethodProbe(Method method, Probe probe) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -141,6 +141,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
 
     @Override
     public <S> void scanAndRegister(S source, String namePrefix) {
+        checkNotNull(namePrefix, "namePrefix can't be null");
         scanAndRegister(source, namePrefix + '.', "");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -141,11 +141,17 @@ public class MetricsRegistryImpl implements MetricsRegistry {
 
     @Override
     public <S> void scanAndRegister(S source, String namePrefix) {
+        scanAndRegister(source, namePrefix + '.', "");
+    }
+
+    @Override
+    public <S> void scanAndRegister(S source, String namePrefix, String nameSuffix) {
         checkNotNull(source, "source can't be null");
         checkNotNull(namePrefix, "namePrefix can't be null");
+        checkNotNull(nameSuffix, "nameSuffix can't be null");
 
         SourceMetadata metadata = loadSourceMetadata(source.getClass());
-        metadata.register(this, source, namePrefix);
+        metadata.register(this, source, namePrefix, nameSuffix);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
@@ -41,7 +41,7 @@ public class ProbeBuilderImpl implements ProbeBuilder {
     }
 
     @Override
-    public ProbeBuilder withTag(String tag, String value) {
+    public ProbeBuilderImpl withTag(String tag, String value) {
         assert containsSpecialCharacters(tag) : "tag contains special characters";
         return new ProbeBuilderImpl(
                 metricsRegistry, keyPrefix
@@ -49,8 +49,7 @@ public class ProbeBuilderImpl implements ProbeBuilder {
                         + tag + '=' + escapeMetricNamePart(value));
     }
 
-    @Override
-    public String metricName() {
+    private String metricName() {
         return keyPrefix + ']';
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.DoubleProbeFunction;
+import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.ProbeBuilder;
+import com.hazelcast.internal.metrics.ProbeFunction;
+import com.hazelcast.internal.metrics.ProbeLevel;
+
+import static com.hazelcast.internal.metrics.MetricsUtil.containsSpecialCharacters;
+import static com.hazelcast.internal.metrics.MetricsUtil.escapeMetricNamePart;
+
+public class ProbeBuilderImpl implements ProbeBuilder {
+
+    private final MetricsRegistryImpl metricsRegistry;
+    private final String keyPrefix;
+
+    ProbeBuilderImpl(MetricsRegistryImpl metricsRegistry) {
+        this.metricsRegistry = metricsRegistry;
+        this.keyPrefix = "[";
+    }
+
+    private ProbeBuilderImpl(MetricsRegistryImpl metricsRegistry, String keyPrefix) {
+        this.metricsRegistry = metricsRegistry;
+        this.keyPrefix = keyPrefix;
+    }
+
+    @Override
+    public ProbeBuilder withTag(String tag, String value) {
+        assert containsSpecialCharacters(tag) : "tag contains special characters";
+        return new ProbeBuilderImpl(
+                metricsRegistry, keyPrefix
+                        + (keyPrefix.length() == 1 ? "" : ",")
+                        + tag + '=' + escapeMetricNamePart(value));
+    }
+
+    @Override
+    public String metricName() {
+        return keyPrefix + ']';
+    }
+
+    @Override
+    public <S> void register(S source, String metricName, ProbeLevel level, DoubleProbeFunction<S> probe) {
+        metricsRegistry.register(source, withTag("metric", metricName).metricName(), level, probe);
+    }
+
+    @Override
+    public <S> void register(S source, String metricName, ProbeLevel level, LongProbeFunction<S> probe) {
+        metricsRegistry.register(source, withTag("metric", metricName).metricName(), level, probe);
+    }
+
+    <S> void register(S source, String metricName, ProbeLevel level, ProbeFunction probe) {
+        metricsRegistry.registerInternal(source, withTag("metric", metricName).metricName(), level, probe);
+    }
+
+    @Override
+    public <S> void scanAndRegister(S source) {
+        SourceMetadata metadata = metricsRegistry.loadSourceMetadata(source.getClass());
+        for (FieldProbe field : metadata.fields()) {
+            field.register(this, source);
+        }
+
+        for (MethodProbe method : metadata.methods()) {
+            method.register(this, source);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
@@ -47,17 +47,17 @@ final class SourceMetadata {
         }
     }
 
-    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix, String nameSuffix) {
+    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
         for (FieldProbe field : fields) {
-            field.register(metricsRegistry, source, namePrefix, nameSuffix);
+            field.register(metricsRegistry, source, namePrefix);
         }
 
         for (MethodProbe method : methods) {
-            method.register(metricsRegistry, source, namePrefix, nameSuffix);
+            method.register(metricsRegistry, source, namePrefix);
         }
     }
 
-    void scanFields(Class<?> clazz) {
+    private void scanFields(Class<?> clazz) {
         for (Field field : clazz.getDeclaredFields()) {
             Probe probe = field.getAnnotation(Probe.class);
 
@@ -70,7 +70,7 @@ final class SourceMetadata {
         }
     }
 
-    void scanMethods(Class<?> clazz) {
+    private void scanMethods(Class<?> clazz) {
         for (Method method : clazz.getDeclaredMethods()) {
             Probe probe = method.getAnnotation(Probe.class);
 
@@ -81,5 +81,19 @@ final class SourceMetadata {
             MethodProbe methodProbe = createMethodProbe(method, probe);
             methods.add(methodProbe);
         }
+    }
+
+    /**
+     * Don't modify the returned list!
+     */
+    public List<FieldProbe> fields() {
+        return fields;
+    }
+
+    /**
+     * Don't modify the returned list!
+     */
+    public List<MethodProbe> methods() {
+        return methods;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
@@ -47,13 +47,13 @@ final class SourceMetadata {
         }
     }
 
-    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
+    void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix, String nameSuffix) {
         for (FieldProbe field : fields) {
-            field.register(metricsRegistry, source, namePrefix);
+            field.register(metricsRegistry, source, namePrefix, nameSuffix);
         }
 
         for (MethodProbe method : methods) {
-            method.register(metricsRegistry, source, namePrefix);
+            method.register(metricsRegistry, source, namePrefix, nameSuffix);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorOptimizer.java
@@ -35,7 +35,7 @@ import static java.lang.System.arraycopy;
  * The SelectorOptimizer optimizes the Selector so less litter is being created.
  * The Selector uses a HashSet, but this creates an object for every add of a
  * selection key. With this SelectorOptimizer a SelectionKeysSet, which contains
- * an  an array, is being used since every key is going to be inserted only once.
+ * an array, is being used since every key is going to be inserted only once.
  *
  * This trick comes from Netty.
  */

--- a/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
@@ -66,7 +66,7 @@ public final class Bits {
      */
     public static final int DOUBLE_SIZE_IN_BYTES = 8;
     /**
-     * for null arrays, this value writen to stream to represent null array size.
+     * for null arrays, this value is written to the stream to represent null array size.
      */
     public static final int NULL_ARRAY_LENGTH = -1;
     /**

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -23,12 +23,12 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 /**
- * The ArrayRingbuffer is responsible for storing the actual content of a
+ * The ArrayRingbuffer is responsible for storing the actual contents of a
  * ringbuffer.
  * <p>
  * Currently the Ringbuffer is not a partitioned data-structure. So all
  * data of a ringbuffer is stored in a single partition and replicated to
- * the replica's. No thread-safety is needed since a partition can only be
+ * the replicas. No thread safety is needed since a partition can only be
  * accessed by a single thread at any given moment.
  *
  * @param <E> the type of the data stored in the ringbuffer

--- a/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
@@ -263,10 +263,10 @@ public final class StringUtil {
      * Example: 'getFoo' is converted into 'foo'
      *
      * It's written defensively, when output is not a getter then it
-     * return the original name.
+     * returns the original name.
      *
-     * It converters name starting with the get- prefix only. When a getter
-     * starts with is- prefix (=boolean) then it does not convert it.
+     * It only converts names starting with a get- prefix. When a getter
+     * starts with an is- prefix (=boolean) then it does not convert it.
      *
      * @param getterName
      * @return property matching the given getter

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricsUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricsUtilTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map.Entry;
+
+import static com.hazelcast.internal.metrics.MetricsUtil.escapeMetricKeyPart;
+import static com.hazelcast.internal.metrics.MetricsUtil.parseMetricKey;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+public class MetricsUtilTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void test_escapeMetricKeyPart() {
+        assertSame("", escapeMetricKeyPart(""));
+        assertSame("aaa", escapeMetricKeyPart("aaa"));
+        assertEquals("\\=", escapeMetricKeyPart("="));
+        assertEquals("\\,", escapeMetricKeyPart(","));
+        assertEquals("\\\\", escapeMetricKeyPart("\\"));
+        assertEquals("a\\=b", escapeMetricKeyPart("a=b"));
+        assertEquals("\\=b", escapeMetricKeyPart("=b"));
+        assertEquals("a\\=", escapeMetricKeyPart("a="));
+    }
+
+    @Test
+    public void test_parseMetricKey() {
+        // empty list
+        assertEquals(emptyList(), parseMetricKey("[]"));
+        // normal single tag
+        assertEquals(singletonList(entry("tag", "value")), parseMetricKey("[tag=value]"));
+        // normal multiple tags
+        assertEquals(asList(entry("tag1", "value1"), entry("tag2", "value2")),
+                parseMetricKey("[tag1=value1,tag2=value2]"));
+        // empty value
+        assertEquals(singletonList(entry("tag=", "value,")), parseMetricKey("[tag\\==value\\,]"));
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_keyNotEnclosed() {
+        exception.expectMessage("key not enclosed in []");
+        parseMetricKey("tag=value");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_emptyTagName() {
+        exception.expectMessage("empty tag name");
+        parseMetricKey("[=value]");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_equalsSignAfterValue() {
+        exception.expectMessage("equals sign not after tag");
+        parseMetricKey("[tag=value=]");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_commaInTag1() {
+        exception.expectMessage("comma in tag");
+        parseMetricKey("[,]");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_backslashAtTheEnd1() {
+        exception.expectMessage("backslash at the end");
+        parseMetricKey("[\\]");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_backslashAtTheEnd2() {
+        exception.expectMessage("backslash at the end");
+        parseMetricKey("[tag=value\\]");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_unfinishedTagAtTheEnd() {
+        exception.expectMessage("unfinished tag at the end");
+        parseMetricKey("[tag=value,tag2]");
+    }
+
+    private Entry<String, String> entry(String key, String value) {
+        return new SimpleImmutableEntry<String, String>(key, value);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricsUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricsUtilTest.java
@@ -60,7 +60,7 @@ public class MetricsUtilTest {
         // normal multiple tags
         assertEquals(asList(entry("tag1", "value1"), entry("tag2", "value2")),
                 parseMetricName("[tag1=value1,tag2=value2]"));
-        // empty value
+        // tag with escaped characters
         assertEquals(singletonList(entry("tag=", "value,")), parseMetricName("[tag\\==value\\,]"));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricsUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricsUtilTest.java
@@ -25,8 +25,8 @@ import org.junit.runner.RunWith;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Map.Entry;
 
-import static com.hazelcast.internal.metrics.MetricsUtil.escapeMetricKeyPart;
-import static com.hazelcast.internal.metrics.MetricsUtil.parseMetricKey;
+import static com.hazelcast.internal.metrics.MetricsUtil.escapeMetricNamePart;
+import static com.hazelcast.internal.metrics.MetricsUtil.parseMetricName;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
@@ -41,69 +41,69 @@ public class MetricsUtilTest {
 
     @Test
     public void test_escapeMetricKeyPart() {
-        assertSame("", escapeMetricKeyPart(""));
-        assertSame("aaa", escapeMetricKeyPart("aaa"));
-        assertEquals("\\=", escapeMetricKeyPart("="));
-        assertEquals("\\,", escapeMetricKeyPart(","));
-        assertEquals("\\\\", escapeMetricKeyPart("\\"));
-        assertEquals("a\\=b", escapeMetricKeyPart("a=b"));
-        assertEquals("\\=b", escapeMetricKeyPart("=b"));
-        assertEquals("a\\=", escapeMetricKeyPart("a="));
+        assertSame("", escapeMetricNamePart(""));
+        assertSame("aaa", escapeMetricNamePart("aaa"));
+        assertEquals("\\=", escapeMetricNamePart("="));
+        assertEquals("\\,", escapeMetricNamePart(","));
+        assertEquals("\\\\", escapeMetricNamePart("\\"));
+        assertEquals("a\\=b", escapeMetricNamePart("a=b"));
+        assertEquals("\\=b", escapeMetricNamePart("=b"));
+        assertEquals("a\\=", escapeMetricNamePart("a="));
     }
 
     @Test
     public void test_parseMetricKey() {
         // empty list
-        assertEquals(emptyList(), parseMetricKey("[]"));
+        assertEquals(emptyList(), parseMetricName("[]"));
         // normal single tag
-        assertEquals(singletonList(entry("tag", "value")), parseMetricKey("[tag=value]"));
+        assertEquals(singletonList(entry("tag", "value")), parseMetricName("[tag=value]"));
         // normal multiple tags
         assertEquals(asList(entry("tag1", "value1"), entry("tag2", "value2")),
-                parseMetricKey("[tag1=value1,tag2=value2]"));
+                parseMetricName("[tag1=value1,tag2=value2]"));
         // empty value
-        assertEquals(singletonList(entry("tag=", "value,")), parseMetricKey("[tag\\==value\\,]"));
+        assertEquals(singletonList(entry("tag=", "value,")), parseMetricName("[tag\\==value\\,]"));
     }
 
     @Test
     public void test_parseMetricKey_fail_keyNotEnclosed() {
         exception.expectMessage("key not enclosed in []");
-        parseMetricKey("tag=value");
+        parseMetricName("tag=value");
     }
 
     @Test
     public void test_parseMetricKey_fail_emptyTagName() {
         exception.expectMessage("empty tag name");
-        parseMetricKey("[=value]");
+        parseMetricName("[=value]");
     }
 
     @Test
     public void test_parseMetricKey_fail_equalsSignAfterValue() {
         exception.expectMessage("equals sign not after tag");
-        parseMetricKey("[tag=value=]");
+        parseMetricName("[tag=value=]");
     }
 
     @Test
     public void test_parseMetricKey_fail_commaInTag1() {
         exception.expectMessage("comma in tag");
-        parseMetricKey("[,]");
+        parseMetricName("[,]");
     }
 
     @Test
     public void test_parseMetricKey_fail_backslashAtTheEnd1() {
         exception.expectMessage("backslash at the end");
-        parseMetricKey("[\\]");
+        parseMetricName("[\\]");
     }
 
     @Test
     public void test_parseMetricKey_fail_backslashAtTheEnd2() {
         exception.expectMessage("backslash at the end");
-        parseMetricKey("[tag=value\\]");
+        parseMetricName("[tag=value\\]");
     }
 
     @Test
     public void test_parseMetricKey_fail_unfinishedTagAtTheEnd() {
         exception.expectMessage("unfinished tag at the end");
-        parseMetricKey("[tag=value,tag2]");
+        parseMetricName("[tag=value,tag2]");
     }
 
     private Entry<String, String> entry(String key, String value) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
@@ -86,7 +86,7 @@ public class MethodProbeTest extends HazelcastTestSupport {
         MethodProbe methodProbe = createMethodProbe(method, probe);
 
         MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(mock(ILogger.class), ProbeLevel.DEBUG);
-        methodProbe.register(metricsRegistry, source, "prefix.", "");
+        methodProbe.register(metricsRegistry, source, "prefix");
 
         Set<String> names = metricsRegistry.getNames();
         assertEquals(1, names.size());

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/MethodProbeTest.java
@@ -86,7 +86,7 @@ public class MethodProbeTest extends HazelcastTestSupport {
         MethodProbe methodProbe = createMethodProbe(method, probe);
 
         MetricsRegistryImpl metricsRegistry = new MetricsRegistryImpl(mock(ILogger.class), ProbeLevel.DEBUG);
-        methodProbe.register(metricsRegistry, source, "prefix");
+        methodProbe.register(metricsRegistry, source, "prefix.", "");
 
         Set<String> names = metricsRegistry.getNames();
         assertEquals(1, names.size());


### PR DESCRIPTION
Add an option to add name suffix to Metrics Registry probes when doing `scanAndRegister`. This is needed for the new structure of metric names: they are enclosed in `[]` and have a `tag=value` structure.