### PR TITLE
Lower heartbeat interval/timeout for quorum tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/PartitionedCluster.java
@@ -54,6 +54,8 @@ public class PartitionedCluster {
     public static Config createClusterConfig(Config config) {
         config.setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "9999");
         config.setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "9999");
+        config.setProperty(GroupProperty.MAX_NO_HEARTBEAT_SECONDS.getName(), "10");
+        config.setProperty(GroupProperty.HEARTBEAT_INTERVAL_SECONDS.getName(), "1");
         config.getGroupConfig().setName(generateRandomString(10));
         config.addQuorumConfig(createSuccessfulSplitTestQuorum());
         return config;
@@ -92,7 +94,7 @@ public class PartitionedCluster {
 
         splitCluster();
 
-        assertOpenEventually(splitLatch, 30);
+        assertOpenEventually(splitLatch, 60);
         assertClusterSizeEventually(3, instance[0], instance[1], instance[2]);
         assertClusterSizeEventually(2, instance[3], instance[4]);
 


### PR DESCRIPTION
During cluster split done in quorum tests we may encounter the
following situation:

1. Communication between split sub-clusters is blocked by blacklisting
the sub-cluster members and closing the active connections between them.

2. To force the formation of the sub-clusters, all the members of one
sub-cluster are marked as suspicious in another one and wise versa.

3. But there might be "phantom" heartbeat operations queued for the
execution, but not yet executed on the members, such heartbeats can
remove the suspicion from the member. This delays the sub-cluster
formation until a heartbeat timeout will be triggered. Which is 60
seconds by default, but the tests expect the sub-cluster formation to be
finished under 30 seconds.

This change lowers heartbeat interval/timeout and increases the
expected cluster formation time to avoid sub-cluster formation timeouts.

Fixes: https://github.com/hazelcast/hazelcast/issues/13097