### PR TITLE
Fixes cache config propagation on a mixed 3.9 - 3.10 cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -793,7 +793,10 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
         } else {
             // RU_COMPAT_3_9
             OperationService operationService = nodeEngine.getOperationService();
-            CacheCreateConfigOperation op = new CacheCreateConfigOperation(cacheConfig, true, false);
+            // 3.9 members must receive a CacheConfig object instead of a PreJoinCacheConfig
+            // to ensure the PreJoinCacheConfig object is not leaked to AbstractCacheService#configs
+            // otherwise it may be returned to clients causing compatibility issues
+            CacheCreateConfigOperation op = new CacheCreateConfigOperation(cacheConfig.asCacheConfig(), true, false);
             return operationService.invokeOnTarget(CacheService.SERVICE_NAME, op, nodeEngine.getThisAddress());
         }
     }


### PR DESCRIPTION
While doing a rolling upgrade with a mixed 3.9 - 3.10 cluster running
on 3.9 cluster version, cache configs must be converted to `CacheConfig`
before dispatched to 3.9 members. Otherwise, a `PreJoinCacheConfig` could
be stored on a 3.9 member's cache configs registry
(`AbstractCacheService#configs`) and from there it may leak to a
client getting the cache config causing deserialization errors on the
client side. Compatibility test is added in enterprise-side PR.

Kudos @mmedenjak for locating the issue and fix.