### PR TITLE
Remove maxJoinTimeMillis from logs when node is shutting down

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -99,7 +99,6 @@ import static com.hazelcast.spi.properties.GroupProperty.DISCOVERY_SPI_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT;
 import static com.hazelcast.spi.properties.GroupProperty.LOGGING_TYPE;
-import static com.hazelcast.spi.properties.GroupProperty.MAX_JOIN_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_POLICY;
 import static com.hazelcast.util.EmptyStatement.ignore;
@@ -730,8 +729,7 @@ public class Node {
         }
 
         if (!clusterService.isJoined()) {
-            long maxJoinTimeMillis = properties.getMillis(MAX_JOIN_SECONDS);
-            logger.severe("Could not join cluster in " + maxJoinTimeMillis + " ms. Shutting down now!");
+            logger.severe("Could not join cluster. Shutting down now!");
             shutdownNodeByFiringEvents(Node.this, true);
         }
     }


### PR DESCRIPTION
The information is misleading, since it's not always true. For example, if there is any exception while joining the cluster, then the log is printed all of the sudden, not after `maxJoinTimeMillis`. This time is nowhere checked, so shouldn't be logged IMO.

See: hazelcast/hazelcast-aws#64