### PR TITLE
Minor nio error handling rename cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelErrorHandler.java
@@ -26,7 +26,7 @@ package com.hazelcast.internal.networking;
 public interface ChannelErrorHandler {
 
     /**
-     * Called when an error happened.
+     * Called when an error was detected.
      *
      * @param channel the Channel that ran into an error. It could be that
      *                the Channel is null if error

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
@@ -107,7 +107,7 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable, Runn
                 try {
                     getSelectionKey();
                 } catch (Throwable t) {
-                    onFailure(t);
+                    onError(t);
                 }
             }
         });
@@ -230,7 +230,7 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable, Runn
             try {
                 process();
             } catch (Throwable t) {
-                onFailure(t);
+                onError(t);
             }
         } else {
             // the pipeline is executed on the wrong IOThread, so send the
@@ -247,16 +247,16 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable, Runn
      * The idiom to use a handler is:
      * <code>
      * try{
-     * handler.handle();
+     *     handler.handle();
      * } catch(Throwable t) {
-     * handler.onFailure(t);
+     *    handler.onError(t);
      * }
      * </code>
      *
-     * @param e
+     * @param cause
      */
-    public void onFailure(Throwable e) {
-        if (e instanceof InterruptedException) {
+    public void onError(Throwable cause) {
+        if (cause instanceof InterruptedException) {
             currentThread().interrupt();
         }
 
@@ -264,7 +264,7 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable, Runn
             selectionKey.cancel();
         }
 
-        errorHandler.onError(channel, e);
+        errorHandler.onError(channel, cause);
     }
 
     /**
@@ -302,7 +302,7 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable, Runn
             try {
                 startMigration(newOwner);
             } catch (Throwable t) {
-                onFailure(t);
+                onError(t);
             }
         }
 
@@ -355,7 +355,7 @@ public abstract class NioPipeline implements MigratablePipeline, Closeable, Runn
                 selectionKey = getSelectionKey();
                 registerOp(initialOps);
             } catch (Throwable t) {
-                onFailure(t);
+                onError(t);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -363,7 +363,7 @@ public class NioThread extends Thread implements OperationHostileThread {
             eventCount.inc();
             pipeline.process();
         } catch (Throwable t) {
-            pipeline.onFailure(t);
+            pipeline.onError(t);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioThreadAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioThreadAbstractTest.java
@@ -121,7 +121,7 @@ public abstract class NioThreadAbstractTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                verify(handler).onFailure(isA(CancelledKeyException.class));
+                verify(handler).onError(isA(CancelledKeyException.class));
             }
         });
         assertStillRunning();
@@ -141,7 +141,7 @@ public abstract class NioThreadAbstractTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                verify(handler).onFailure(isA(ExpectedRuntimeException.class));
+                verify(handler).onError(isA(ExpectedRuntimeException.class));
             }
         });
         assertStillRunning();


### PR DESCRIPTION
NioPipeline.onFailure is renamed to onError to allign
it with ChannelErrorHandler.onError.