### PR TITLE
Adds prefix support to java-serialization-filter lists

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.11.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.11.xsd
@@ -578,6 +578,16 @@
                 </xs:annotation>
             </xs:element>
         </xs:all>
+        <xs:attribute name="defaults-disabled" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Disables including default list entries (hardcoded in Hazelcast source code).
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:boolean"/>
+            </xs:simpleType>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="filter-list">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
@@ -592,6 +602,13 @@
                 <xs:annotation>
                     <xs:documentation>
                         Name of a package to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="prefix" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Class name prefix to be included in the list.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/serialization/ClientDeserializationProtectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/serialization/ClientDeserializationProtectionTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.serialization;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.ClassFilter;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JavaSerializationFilterConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+
+import example.serialization.TestDeserialized;
+
+/**
+ * Tests untrusted deserialization protection.
+ * 
+ * <pre>
+ * Given: Hazelcast member and clients are started.
+ * </pre>
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientDeserializationProtectionTest extends HazelcastTestSupport {
+
+    protected static TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @AfterClass
+    public static final void stopHazelcastInstances() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Before
+    public void killAllHazelcastInstances() throws IOException {
+        hazelcastFactory.terminateAll();
+        TestDeserialized.IS_DESERIALIZED = false;
+    }
+
+    /**
+     * <pre>
+     * When: An untrusted serialized object is stored from client and read from member, the default Whitelist is used.
+     * Then: Deserialization fails.
+     * </pre>
+     */
+    @Test
+    public void testDefaultDeserializationFilter_readOnMember() {
+        JavaSerializationFilterConfig filterConfig = new JavaSerializationFilterConfig();
+        Config config = new Config();
+        config.getSerializationConfig().setJavaSerializationFilterConfig(filterConfig);
+        HazelcastInstance member = hazelcastFactory.newInstances(config, 1)[0];
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getSerializationConfig().setJavaSerializationFilterConfig(filterConfig);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        client.getMap("test").put("key", new TestDeserialized());
+        try {
+            member.getMap("test").get("key");
+            fail("Deserialization should have failed");
+        } catch (HazelcastSerializationException e) {
+            assertFalse(TestDeserialized.IS_DESERIALIZED);
+        }
+    }
+
+    /**
+     * <pre>
+     * When: An untrusted serialized object is stored by member and read from client, the default Whitelist is used.
+     * Then: Deserialization fails.
+     * </pre>
+     */
+    @Test
+    public void testDefaultDeserializationFilter_readOnClient() {
+        JavaSerializationFilterConfig filterConfig = new JavaSerializationFilterConfig();
+        Config config = new Config();
+        config.getSerializationConfig().setJavaSerializationFilterConfig(filterConfig);
+        HazelcastInstance member = hazelcastFactory.newInstances(config, 1)[0];
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getSerializationConfig().setJavaSerializationFilterConfig(filterConfig);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        member.getMap("test").put("key", new TestDeserialized());
+        try {
+            client.getMap("test").get("key");
+            fail("Deserialization should have failed");
+        } catch (HazelcastSerializationException e) {
+            assertFalse(TestDeserialized.IS_DESERIALIZED);
+        }
+    }
+
+    /**
+     * <pre>
+     * When: Default Whitelist is disabled and classname of the test serialized object is blacklisted. The object is read from client.
+     * Then: Deserialization fails.
+     * </pre>
+     */
+    @Test
+    public void testClassBlacklisted() {
+        ClassFilter blacklist = new ClassFilter().addClasses(TestDeserialized.class.getName());
+        JavaSerializationFilterConfig filterConfig = new JavaSerializationFilterConfig().setDefaultsDisabled(true)
+                .setBlacklist(blacklist);
+
+        Config config = new Config();
+        config.getSerializationConfig().setJavaSerializationFilterConfig(filterConfig);
+        HazelcastInstance member = hazelcastFactory.newInstances(config, 1)[0];
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getSerializationConfig().setJavaSerializationFilterConfig(filterConfig);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        member.getMap("test").put("key", new TestDeserialized());
+        try {
+            client.getMap("test").get("key");
+            fail("Deserialization should have failed");
+        } catch (HazelcastSerializationException e) {
+            assertFalse(TestDeserialized.IS_DESERIALIZED);
+        }
+    }
+
+    /**
+     * <pre>
+     * When: Deserialization filtering is not explicitly enabled and object is read from client.
+     * Then: Untrusted deserialization is possible.
+     * </pre>
+     */
+    @Test
+    public void testNoDeserializationFilter() {
+        Config config = new Config();
+        HazelcastInstance member = hazelcastFactory.newInstances(config, 1)[0];
+        ClientConfig clientConfig = new ClientConfig();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        member.getMap("test").put("key", new TestDeserialized());
+        assertNotNull(client.getMap("test").get("key"));
+        assertTrue(TestDeserialized.IS_DESERIALIZED);
+    }
+
+    /**
+     * <pre>
+     * When: Deserialization filtering is enabled and classname of test object is whitelisted.
+     * Then: The deserialization is possible.
+     * </pre>
+     */
+    @Test
+    public void testClassWhitelisted() {
+        JavaSerializationFilterConfig filterConfig = new JavaSerializationFilterConfig();
+        filterConfig.getWhitelist().addClasses(TestDeserialized.class.getName());
+        Config config = new Config();
+        config.getSerializationConfig().setJavaSerializationFilterConfig(filterConfig);
+        HazelcastInstance member = hazelcastFactory.newInstances(config, 1)[0];
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getSerializationConfig().setJavaSerializationFilterConfig(filterConfig);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        member.getMap("test").put("key", new TestDeserialized());
+        assertNotNull(client.getMap("test").get("key"));
+        assertTrue(TestDeserialized.IS_DESERIALIZED);
+    }
+}

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
@@ -527,6 +527,9 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
                     filterConfigBuilder.addPropertyValue("whitelist", createFilterListBean(child));
                 }
             }
+            Node defaultsDisabledAttr = node.getAttributes().getNamedItem("defaults-disabled");
+            boolean defaultsDisabled = getBooleanValue(getTextContent(defaultsDisabledAttr));
+            filterConfigBuilder.addPropertyValue("defaultsDisabled", defaultsDisabled);
             serializationConfigBuilder.addPropertyValue("javaSerializationFilterConfig",
                     filterConfigBuilder.getBeanDefinition());
         }
@@ -535,16 +538,20 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
             BeanDefinitionBuilder filterListBuilder = createBeanBuilder(ClassFilter.class);
             ManagedSet<String> classes = new ManagedSet<String>();
             ManagedSet<String> packages = new ManagedSet<String>();
+            ManagedSet<String> prefixes = new ManagedSet<String>();
             for (Node child : childElements(node)) {
                 String name = cleanNodeName(child);
                 if ("class".equals(name)) {
                     classes.add(getTextContent(child));
                 } else if ("package".equals(name)) {
                     packages.add(getTextContent(child));
+                } else if ("prefix".equals(name)) {
+                    prefixes.add(getTextContent(child));
                 }
             }
             filterListBuilder.addPropertyValue("classes", classes);
             filterListBuilder.addPropertyValue("packages", packages);
+            filterListBuilder.addPropertyValue("prefixes", prefixes);
             return filterListBuilder.getBeanDefinition();
         }
     }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
@@ -1771,6 +1771,16 @@
                     </xs:annotation>
                 </xs:element>
             </xs:sequence>
+            <xs:attribute name="defaults-disabled" use="optional" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        Disables including default list entries (hardcoded in Hazelcast source code).
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:boolean"/>
+                </xs:simpleType>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 
@@ -1787,6 +1797,13 @@
                 <xs:annotation>
                     <xs:documentation>
                         Name of a package to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="prefix" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Class name prefix to be included in the list.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1288,13 +1288,18 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     public void testJavaSerializationFilterConfig() {
         JavaSerializationFilterConfig filterConfig = config.getSerializationConfig().getJavaSerializationFilterConfig();
         assertNotNull(filterConfig);
-        
+        assertTrue(filterConfig.isDefaultsDisabled());
+
         ClassFilter blacklist = filterConfig.getBlacklist();
         assertNotNull(blacklist);
         assertEquals(1, blacklist.getClasses().size());
         assertTrue(blacklist.getClasses().contains("com.acme.app.BeanComparator"));
         assertEquals(0, blacklist.getPackages().size());
-        
+        Set<String> prefixes = blacklist.getPrefixes();
+        assertTrue(prefixes.contains("a.dangerous.package."));
+        assertTrue(prefixes.contains("justaprefix"));
+        assertEquals(2, prefixes.size());
+
         ClassFilter whitelist = filterConfig.getWhitelist();
         assertNotNull(whitelist);
         assertEquals(2, whitelist.getClasses().size());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -551,9 +551,11 @@
                     <hz:serializer type-class="com.hazelcast.spring.serialization.DummySerializableObject2"
                                    implementation="dummySerializer"/>
                 </hz:serializers>
-                <hz:java-serialization-filter>
+                <hz:java-serialization-filter defaults-disabled="true">
                     <hz:blacklist>
                         <hz:class>com.acme.app.BeanComparator</hz:class>
+                        <hz:prefix>a.dangerous.package.</hz:prefix>
+                        <hz:prefix>justaprefix</hz:prefix>
                     </hz:blacklist>
                     <hz:whitelist>
                         <hz:class>java.lang.String</hz:class>

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -512,6 +512,9 @@ public abstract class AbstractXmlConfigHelper {
     protected void fillJavaSerializationFilter(final Node node, SerializationConfig serializationConfig) {
         JavaSerializationFilterConfig filterConfig = new JavaSerializationFilterConfig();
         serializationConfig.setJavaSerializationFilterConfig(filterConfig);
+        Node defaultsDisabledNode = node.getAttributes().getNamedItem("defaults-disabled");
+        boolean defaultsDisabled = defaultsDisabledNode != null && getBooleanValue(getTextContent(defaultsDisabledNode));
+        filterConfig.setDefaultsDisabled(defaultsDisabled);
         for (Node child : childElements(node)) {
             final String name = cleanNodeName(child);
             if ("blacklist".equals(name)) {
@@ -532,6 +535,8 @@ public abstract class AbstractXmlConfigHelper {
                 list.addClasses(getTextContent(child));
             } else if ("package".equals(name)) {
                 list.addPackages(getTextContent(child));
+            } else if ("prefix".equals(name)) {
+                list.addPrefixes(getTextContent(child));
             }
         }
         return list;

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -403,7 +403,7 @@ public class ConfigXmlGenerator {
         gen.node("check-class-def-errors", c.isCheckClassDefErrors());
         JavaSerializationFilterConfig javaSerializationFilterConfig = c.getJavaSerializationFilterConfig();
         if (javaSerializationFilterConfig != null) {
-            gen.open("java-serialization-filter");
+            gen.open("java-serialization-filter", "defaults-disabled", javaSerializationFilterConfig.isDefaultsDisabled());
             appendFilterList(gen, "blacklist", javaSerializationFilterConfig.getBlacklist());
             appendFilterList(gen, "whitelist", javaSerializationFilterConfig.getWhitelist());
             gen.close();
@@ -1415,6 +1415,9 @@ public class ConfigXmlGenerator {
         }
         for (String packageName : classFilterList.getPackages()) {
             gen.node("package", packageName);
+        }
+        for (String prefix : classFilterList.getPrefixes()) {
+            gen.node("prefix", prefix);
         }
         gen.close();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/JavaSerializationFilterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JavaSerializationFilterConfig.java
@@ -23,22 +23,11 @@ public class JavaSerializationFilterConfig {
 
     private volatile ClassFilter blacklist;
     private volatile ClassFilter whitelist;
+    private volatile boolean defaultsDisabled;
 
     public ClassFilter getBlacklist() {
         if (blacklist == null) {
             blacklist = new ClassFilter();
-            // default blacklist - some well-known vulnerable classes/packages
-            blacklist.addClasses(
-                    "com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl",
-                    "bsh.XThis",
-                    "org.apache.commons.beanutils.BeanComparator",
-                    "org.codehaus.groovy.runtime.ConvertedClosure",
-                    "org.codehaus.groovy.runtime.MethodClosure",
-                    "org.springframework.beans.factory.ObjectFactory",
-                    "com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl")
-            .addPackages(
-                    "org.apache.commons.collections.functors",
-                    "org.apache.commons.collections4.functors");
         }
         return blacklist;
     }
@@ -60,12 +49,22 @@ public class JavaSerializationFilterConfig {
         return this;
     }
 
+    public boolean isDefaultsDisabled() {
+        return defaultsDisabled;
+    }
+
+    public JavaSerializationFilterConfig setDefaultsDisabled(boolean defaultsDisabled) {
+        this.defaultsDisabled = defaultsDisabled;
+        return this;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((blacklist == null) ? 0 : blacklist.hashCode());
         result = prime * result + ((whitelist == null) ? 0 : whitelist.hashCode());
+        result = prime * result + (defaultsDisabled ? 0 : 1);
         return result;
     }
 
@@ -79,12 +78,14 @@ public class JavaSerializationFilterConfig {
         }
         JavaSerializationFilterConfig other = (JavaSerializationFilterConfig) obj;
         return ((blacklist == null && other.blacklist == null) || (blacklist != null && blacklist.equals(other.blacklist)))
-                && ((whitelist == null && other.whitelist == null) || (whitelist != null && whitelist.equals(other.whitelist)));
+                && ((whitelist == null && other.whitelist == null) || (whitelist != null && whitelist.equals(other.whitelist)))
+                && defaultsDisabled == other.defaultsDisabled;
     }
 
     @Override
     public String toString() {
-        return "JavaSerializationFilterConfig{ blacklist=" + blacklist + ", whitelist=" + whitelist + "}";
+        return "JavaSerializationFilterConfig{defaultsDisabled=" + defaultsDisabled + ", blacklist=" + blacklist
+                + ", whitelist=" + whitelist + "}";
     }
 
 }

--- a/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
@@ -3164,6 +3164,16 @@
                 </xs:annotation>
             </xs:element>
         </xs:all>
+        <xs:attribute name="defaults-disabled" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Disables including default list entries (hardcoded in Hazelcast source code).
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:boolean"/>
+            </xs:simpleType>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="filter-list">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
@@ -3178,6 +3188,13 @@
                 <xs:annotation>
                     <xs:documentation>
                         Name of a package to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="prefix" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Class name prefix to be included in the list.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1809,7 +1809,7 @@
                         class-name="com.hazelcast.examples.SerializerFactory"/>
         </serializers>
         <check-class-def-errors>true</check-class-def-errors>
-        <java-serialization-filter>
+        <java-serialization-filter defaults-disabled="true">
             <blacklist>
                 <class>com.acme.app.BeanComparator</class>
             </blacklist>
@@ -1818,6 +1818,8 @@
                 <class>example.Foo</class>
                 <package>com.acme.app</package>
                 <package>com.acme.app.subpkg</package>
+                <prefix>com.hazelcast.</prefix>
+                <prefix>java</prefix>
             </whitelist>
         </java-serialization-filter>
     </serialization>

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -44,6 +44,8 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.test.annotation.QuickTest;
 
+import example.serialization.TestDeserialized;
+
 /**
  * Tests if deserialization blacklisting works for MutlicastService.
  */
@@ -58,6 +60,7 @@ public class MulticastDeserializationTest {
     @Before
     @After
     public void killAllHazelcastInstances() throws IOException {
+        TestDeserialized.IS_DESERIALIZED = false;
         HazelcastInstanceFactory.terminateAll();
     }
 
@@ -72,6 +75,7 @@ public class MulticastDeserializationTest {
     public void test() throws Exception {
         Config config = new Config();
         JavaSerializationFilterConfig javaSerializationFilterConfig = new JavaSerializationFilterConfig();
+        javaSerializationFilterConfig.setDefaultsDisabled(true);
         javaSerializationFilterConfig.getBlacklist().addClasses(TestDeserialized.class.getName());
         config.getSerializationConfig().setJavaSerializationFilterConfig(javaSerializationFilterConfig);
         NetworkConfig networkConfig = config.getNetworkConfig();
@@ -118,18 +122,6 @@ public class MulticastDeserializationTest {
             if (multicastSocket != null) {
                 multicastSocket.close();
             }
-        }
-    }
-
-    public static class TestDeserialized implements Serializable {
-        private static final long serialVersionUID = 1L;
-        public static volatile boolean IS_DESERIALIZED = false;
-
-        private void writeObject(java.io.ObjectOutputStream out) throws IOException {
-        }
-
-        private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
-            IS_DESERIALIZED = true;
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -361,9 +361,10 @@ public class ConfigXmlGeneratorTest {
                 .setTypeClassName("TypeClass");
 
         JavaSerializationFilterConfig filterConfig = new JavaSerializationFilterConfig();
-        filterConfig.getBlacklist().addClasses("example.Class1", "acme.Test").addPackages("org.infinitban");
-        filterConfig.getWhitelist().addClasses("WhiteOne", "WhiteTwo").addPackages("com.hazelcast", "test.package");
-                
+        filterConfig.getBlacklist().addClasses("example.Class1", "acme.Test").addPackages("org.infinitban")
+            .addPrefixes("dangerous.", "bang");
+        filterConfig.getWhitelist().addClasses("WhiteOne", "WhiteTwo").addPackages("com.hazelcast", "test.package")
+            .addPrefixes("java");
 
         SerializationConfig expectedConfig = new SerializationConfig()
                 .setAllowUnsafe(true)

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -2389,12 +2389,15 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     public void testJavaSerializationFilter() {
         String xml = HAZELCAST_START_TAG
                 + "  <serialization>\n"
-                + "      <java-serialization-filter>\n"
+                + "      <java-serialization-filter defaults-disabled='true'>\n"
                 + "          <whitelist>\n"
                 + "              <class>java.lang.String</class>\n"
                 + "              <class>example.Foo</class>\n"
                 + "              <package>com.acme.app</package>\n"
                 + "              <package>com.acme.app.subpkg</package>\n"
+                + "              <prefix>java</prefix>\n"
+                + "              <prefix>com.hazelcast.</prefix>\n"
+                + "              <prefix>[</prefix>\n"
                 + "          </whitelist>\n"
                 + "          <blacklist>\n"
                 + "              <class>com.acme.app.BeanComparator</class>\n"
@@ -2414,6 +2417,8 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(whiteList.getClasses().contains("example.Foo"));
         assertTrue(whiteList.getPackages().contains("com.acme.app"));
         assertTrue(whiteList.getPackages().contains("com.acme.app.subpkg"));
+        assertTrue(whiteList.getPrefixes().contains("java"));
+        assertTrue(whiteList.getPrefixes().contains("["));
         assertTrue(blackList.getClasses().contains("com.acme.app.BeanComparator"));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/DeserializationProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/DeserializationProtectionTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.serialization;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.ClassFilter;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JavaSerializationFilterConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+
+import example.serialization.TestDeserialized;
+
+/**
+ * Tests untrusted deserialization protection.
+ *
+ * <pre>
+ * Given: 2 node cluster is started.
+ * </pre>
+ */
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class DeserializationProtectionTest extends HazelcastTestSupport {
+
+    @Before
+    @After
+    public void killAllHazelcastInstances() throws IOException {
+        TestDeserialized.IS_DESERIALIZED = false;
+    }
+
+    /**
+     * Test default filter configuration.
+     *
+     * <pre>
+     * When: An untrusted serialized object is stored on target Hazelcast instance and default Whitelist is used.
+     * Then: Deserialization fails.
+     * </pre>
+     */
+    @Test
+    public void testDefaultDeserializationFilter_keyNotOwnedByTarget() {
+        assertDeserializationFails(new JavaSerializationFilterConfig(), true);
+    }
+
+    /**
+     * <pre>
+     * When: An untrusted serialized object is stored on source Hazelcast instance and default Whitelist is used.
+     * Then: Deserialization fails.
+     * </pre>
+     */
+    @Test
+    public void testDefaultDeserializationFilter_keyOwnedBySource() {
+        assertDeserializationFails(new JavaSerializationFilterConfig(), false);
+    }
+
+    /**
+     * <pre>
+     * When: Default Whitelist is disabled and classname of the test serialized object is blacklisted.
+     * Then: Deserialization fails.
+     * </pre>
+     */
+    @Test
+    public void testClassBlacklisted() {
+        ClassFilter blacklist = new ClassFilter().addClasses(TestDeserialized.class.getName());
+        JavaSerializationFilterConfig filterConfig = new JavaSerializationFilterConfig().setDefaultsDisabled(true)
+                .setBlacklist(blacklist);
+        assertDeserializationFails(filterConfig, false);
+    }
+
+    /**
+     * <pre>
+     * When: Deserialization filtering is not explicitly enabled.
+     * Then: Untrusted deserialization is possible.
+     * </pre>
+     */
+    @Test
+    public void testNoDeserializationFilter() {
+        assertDeserializationPass(null);
+    }
+
+    /**
+     * <pre>
+     * When: Deserialization filtering is enabled and classname of test object is whitelisted.
+     * Then: The deserialization is possible.
+     * </pre>
+     */
+    @Test
+    public void testClassWhitelisted() {
+        JavaSerializationFilterConfig filterConfig = new JavaSerializationFilterConfig();
+        filterConfig.getWhitelist().addClasses(TestDeserialized.class.getName());
+        assertDeserializationPass(filterConfig);
+    }
+
+    private void assertDeserializationFails(JavaSerializationFilterConfig javaSerializationFilterConfig,
+            boolean keyOwnedByTarget) {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        Config config = new Config();
+        config.getSerializationConfig().setJavaSerializationFilterConfig(javaSerializationFilterConfig);
+        HazelcastInstance[] instances = factory.newInstances(config);
+        String key = generateKeyOwnedBy(instances[keyOwnedByTarget ? 1 : 0]);
+        instances[0].getMap("test").put(key, new TestDeserialized());
+        try {
+            instances[1].getMap("test").get(key);
+            fail("Deserialization should have failed");
+        } catch (HazelcastSerializationException e) {
+            assertFalse(TestDeserialized.IS_DESERIALIZED);
+        }
+    }
+
+    private void assertDeserializationPass(JavaSerializationFilterConfig filterConfig) {
+        Config config = new Config();
+        config.getSerializationConfig().setJavaSerializationFilterConfig(filterConfig);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = factory.newInstances(config);
+        instances[0].getMap("test").put("a", new TestDeserialized());
+        assertNotNull(instances[1].getMap("test").get("a"));
+        assertTrue(TestDeserialized.IS_DESERIALIZED);
+    }
+
+}

--- a/hazelcast/src/test/java/example/serialization/TestDeserialized.java
+++ b/hazelcast/src/test/java/example/serialization/TestDeserialized.java
@@ -1,0 +1,16 @@
+package example.serialization;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class TestDeserialized implements Serializable {
+    private static final long serialVersionUID = 1L;
+    public static volatile boolean IS_DESERIALIZED = false;
+
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        IS_DESERIALIZED = true;
+    }
+}

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -639,7 +639,7 @@
                         class-name="com.hazelcast.examples.SerializerFactory"/>
         </serializers>
         <check-class-def-errors>false</check-class-def-errors>
-        <java-serialization-filter>
+        <java-serialization-filter defaults-disabled="true">
             <blacklist>
                 <class>com.acme.app.BeanComparator</class>
             </blacklist>
@@ -648,6 +648,9 @@
                 <class>example.Foo</class>
                 <package>com.acme.app</package>
                 <package>com.acme.app.subpkg</package>
+                <prefix>java</prefix>
+                <prefix>com.</prefix>
+                <prefix>[</prefix>
             </whitelist>
         </java-serialization-filter>
     </serialization>


### PR DESCRIPTION
This PR simplifies the usage of `<java-serialization-filter>` feature (introduced in hazelcast/hazelcast#12230) by adding prefix based listing.
The commit also changes default behavior of the feature (once enabled). It newly uses a whitelist instead of a blacklist as a default configuration.
The default whitelist contains following prefixes:
* `"java"`
* `"com.hazelcast."`
* `"["` (primitives & arrays)

The usage of default whitelist can be suppressed by setting `defaults-disabled` attribute to `true`.

**Example**
```xml
<serialization>
	<java-serialization-filter defaults-disabled="true">
		<whitelist>
			<class>example.Foo</class>
			<package>com.acme.app</package>
			<prefix>com.hazelcast.</package>
			<prefix>java.</package>
			<prefix>javax.</package>
			<prefix>[</package>
		</whitelist>
		<blacklist>
			<class>com.acme.app.BeanComparator</class>
		</blacklist>
	</java-serialization-filter>
</serialization>
```