### PR TITLE
[BACKPORT] Avoid full scans induced by paging predicate

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/PagingPredicate.java
@@ -182,7 +182,7 @@ public class PagingPredicate<K, V> implements IndexAwarePredicate<K, V>, Identif
 
         Set<QueryableEntry<K, V>> set = ((IndexAwarePredicate<K, V>) predicate).filter(queryContext);
         if (set == null || set.isEmpty()) {
-            return null;
+            return set;
         }
         List<QueryableEntry<K, V>> resultList = new ArrayList<QueryableEntry<K, V>>();
         Map.Entry<Integer, Map.Entry> nearestAnchorEntry = getNearestAnchorEntry();

--- a/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/PagingPredicateTest.java
@@ -42,6 +42,7 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -281,6 +282,23 @@ public class PagingPredicateTest extends HazelcastTestSupport {
                 assertEquals(0, map.keySet(predicate).size());
             }
         }
+    }
+
+    @Test
+    public void testEmptyIndexResultIsNotCausingFullScan() {
+        map.addIndex("this", false);
+        for (int i = 0; i < size; ++i) {
+            map.set(i, i);
+        }
+
+        int resultSize = map.entrySet(new PagingPredicate(Predicates.equal("this", size), pageSize) {
+            @Override
+            public boolean apply(Map.Entry mapEntry) {
+                fail("full scan is not expected");
+                return false;
+            }
+        }).size();
+        assertEquals(0, resultSize);
     }
 
     static class TestComparator implements Comparator<Map.Entry<Integer, Integer>>, Serializable {


### PR DESCRIPTION
If the inner predicate of the paging predicate returns an empty result
set, the paging predicate returns null as the indexed query result, this
interpreted as an absence of the indexed result by the query engine and
the execution falls back to the full scan. This change fixes this
misbehavior.

(cherry-picked from b24588a1b32e6ce449629eb7b337b9af36be85d6)

Fixes: https://github.com/hazelcast/hazelcast/issues/13159