### PR TITLE
Hazelcast XML fixes

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-default.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-default.xml
@@ -15,8 +15,20 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.11.xsd"
-           xmlns="http://www.hazelcast.com/schema/client-config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!--
+  The default Hazelcast client configuration.
+
+  This XML file is used when no hazelcast-client.xml is present.
+
+  To learn how to configure Hazelcast, please see the schema at
+  https://hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd
+  or the Reference Manual at https://hazelcast.org/documentation/
+-->
+
+<!--suppress XmlDefaultAttributeValue -->
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.11.xsd">
 
 </hazelcast-client>

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -15,9 +15,23 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xsi:schemaLocation="http://www.hazelcast.com/schema/client-config hazelcast-client-config-3.11.xsd"
-                  xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<!--
+  This is a full example hazelcast-client.xml that includes all the
+  configuration elements and attributes of a Hazelcast client.
+
+  To use this, rename it to hazelcast-client.xml and place it in
+  the directory where you start your Hazelcast client.
+
+  To learn how to configure Hazelcast, please see the schema at
+  https://hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd
+  or the Reference Manual at https://hazelcast.org/documentation/
+-->
+
+<!--suppress XmlDefaultAttributeValue -->
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/config/hazelcast-client-config-3.11.xsd">
 
     <config-replacers fail-if-value-missing="false">
         <replacer class-name="com.hazelcast.config.replacer.EncryptionReplacer">

--- a/hazelcast-client/src/test/resources/hazelcast-cache-entrylistener-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-cache-entrylistener-test.xml
@@ -15,11 +15,6 @@
   ~ limitations under the License.
   -->
 
-<!--
-    The default Hazelcast configuration. This is used when no hazelcast.xml is present.
-    Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.11.xsd
-    or the documentation at https://hazelcast.org/documentation/
--->
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config

--- a/hazelcast-client/src/test/resources/hazelcast-client-querycache-xml-config-wildcard-test.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-querycache-xml-config-wildcard-test.xml
@@ -15,11 +15,6 @@
   ~ limitations under the License.
   -->
 
-<!--
-    The default Hazelcast configuration. This is used when no hazelcast.xml is present.
-    Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.11.xsd
-    or the documentation at https://hazelcast.org/documentation/
--->
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config

--- a/hazelcast-client/src/test/resources/test-hazelcast-jcache.xml
+++ b/hazelcast-client/src/test/resources/test-hazelcast-jcache.xml
@@ -1,22 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2008, Hazelcast, Inc. All Rights Reserved.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
-<!--
-  ~ Copyright (c) 2008, Hazelcast, Inc. All Rights Reserved.
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -16,10 +16,15 @@
   -->
 
 <!--
-    The default Hazelcast configuration. This is used when no hazelcast.xml is present.
-    Please see the schema for how to configure Hazelcast at https://hazelcast.com/schema/config/hazelcast-config-3.11.xsd
-    or the documentation at https://hazelcast.org/documentation/
+  The default Hazelcast configuration.
+
+  This XML file is used when no hazelcast.xml is present.
+
+  To learn how to configure Hazelcast, please see the schema at
+  https://hazelcast.com/schema/config/hazelcast-config-3.11.xsd
+  or the Reference Manual at https://hazelcast.org/documentation/
 -->
+
 <!--suppress XmlDefaultAttributeValue -->
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -89,7 +94,7 @@
             <iteration-count>19</iteration-count>
         </symmetric-encryption>
         <failure-detector>
-            <icmp enabled="false"></icmp>
+            <icmp enabled="false"/>
         </failure-detector>
     </network>
     <partition-group enabled="false"/>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -16,12 +16,17 @@
   -->
 
 <!--
-This is a full example hazelcast.xml that includes all the configuration elements and attributes of Hazelcast.
-To use this, rename it to hazelcast.xml and place it in the directory where you start Hazelcast.
-Please see the schema to learn how to configure Hazelcast at 
-https://hazelcast.com/schema/config/hazelcast-config-3.11.xsd or the Reference Manual at
-https://hazelcast.org/documentation/.
+  This is a full example hazelcast.xml that includes all the
+  configuration elements and attributes of a Hazelcast member.
+
+  To use this, rename it to hazelcast.xml and place it in
+  the directory where you start your Hazelcast member.
+
+  To learn how to configure Hazelcast, please see the schema at
+  https://hazelcast.com/schema/config/hazelcast-config-3.11.xsd
+  or the Reference Manual at https://hazelcast.org/documentation/
 -->
+
 <!--suppress XmlDefaultAttributeValue -->
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -2013,13 +2018,9 @@ https://hazelcast.org/documentation/.
     <quorum name="quorumRuleWithThreeMembers" enabled="true">
         <quorum-size>3</quorum-size>
         <quorum-type>READ_WRITE</quorum-type>
-        <quorum-function-class-name>
-            com.your-package.AbsPresMyQuorum
-        </quorum-function-class-name>
+        <quorum-function-class-name>com.your-package.AbsPresMyQuorum</quorum-function-class-name>
         <quorum-listeners>
-            <quorum-listener>
-                com.your-package.ThreeMemberQuorumListener
-            </quorum-listener>
+            <quorum-listener>com.your-package.ThreeMemberQuorumListener</quorum-listener>
         </quorum-listeners>
     </quorum>
     <!--

--- a/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-mapstore-config.xml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-mapstore-config.xml
@@ -17,8 +17,7 @@
 
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="
-           http://www.hazelcast.com/schema/config
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
            http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
 
     <group>

--- a/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
+++ b/src/test/resources/test-hazelcast-discovery-spi-metadata.xml
@@ -15,9 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.11.xsd"
-           xmlns="http://www.hazelcast.com/schema/config"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
 
     <properties>
         <property name="hazelcast.discovery.enabled">true</property>


### PR DESCRIPTION
* fixed a duplicated copyright header
* fixed a copyright header with the wrong date
* fixed the description for member/client default and full-example files
* removed the copied default XML description from non-default XML files
* unified the schema location format of all XML files