### PR TITLE
Fixes tmp deadlock on NioOutboundPipeline.close

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -323,8 +323,13 @@ public final class NioOutboundPipeline extends NioPipeline {
         priorityWriteQueue.clear();
 
         CloseTask closeTask = new CloseTask();
-        addTaskAndWakeup(closeTask);
-        closeTask.awaitCompletion();
+        if (owner == NioThread.currentThread()) {
+            // needed to prevent running into a tmp self deadlock
+            closeTask.run();
+        } else {
+            addTaskAndWakeup(closeTask);
+            closeTask.awaitCompletion();
+        }
     }
 
     @Override


### PR DESCRIPTION
If the close method gets called from the NIO thread, e.g. when
a nio thread has encounterd an exception like EOFException, through
the ErrorHandler the NioOutboundPipeline.close() method is called
from the IO thread.

If we then schedule a closetask to be scheduled on the same NIO thread
there will be a tmp self deadlock because the only thread that can
execute this task, is blocked because it is waiting on the completion
of this task. So we get a 3s stall on the IO thread; which can have
massive performance implications!

So the fix is to add a check. If we are already on the NIO thread,
just run the task directly; don't offload it itself to prevent
ending up in a deadlock.