### PR TITLE
[BACKPORT] Add ProbeBuilder to MetricsRegistry (#13153)

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
@@ -44,8 +44,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * This class is the main entry point for collecting and sending the client
- * statistics to the cluster. If the client statistics feature is enabled
- * it will be scheduled for periodic statistics collection and send.
+ * statistics to the cluster. If the client statistics feature is enabled,
+ * it will be scheduled for periodic statistics collection and sent.
  */
 public class Statistics {
     /**
@@ -56,7 +56,7 @@ public class Statistics {
     public static final HazelcastProperty ENABLED = new HazelcastProperty("hazelcast.client.statistics.enabled", false);
 
     /**
-     * The period in seconds the statistics runs.
+     * The period in seconds the statistics run.
      */
     public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty("hazelcast.client.statistics.period.seconds", 3,
             SECONDS);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -31,10 +31,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 
 /**
- * Client Delegating Future is used to delegate ClientInvocationFuture to user to be used with
- * andThen or get. It converts ClientMessage coming from ClientInvocationFuture to user object
+ * The Client Delegating Future is used to delegate {@link
+ * ClientInvocationFuture} to a user type to be used with {@code andThen()} or
+ * {@code get()}. It converts {@link ClientMessage} coming from {@link
+ * ClientInvocationFuture} to a user object.
  *
- * @param <V> Value type that user expecting
+ * @param <V> Value type that the user expects
  */
 public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -22,33 +22,39 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
- * The MetricsRegistry is responsible for recording all kinds of Hazelcast/JVM specific information to
- * help out with issues like performance or stability problems.
+ * The MetricsRegistry is a registry of various Hazelcast/JVM internal
+ * information to help out with debugging, performance or stability issues.
+ * Each HazelcastInstance has one local MetricsRegistry instance.
+ * <p>
+ * A MetricsRegistry can contain many {@link Probe} instances. A probe is
+ * registered under a name, and can be read by creating a {@link Gauge}, see
+ * {@link #newLongGauge(String)}.
+ * <p>
+ * The name has this form:<pre>
+ *     [tag1=foo,tag2=bar,...]
+ * </pre>
+ * Special characters in values must be escaped, use {@link ProbeBuilder} to
+ * register metrics with properly escaped values.
+ * <p>
+ * The metrics registry doesn't interpret the name in any way, it is treated as
+ * is. For example, {@code [tag1=foo,tag2=bar]} and {@code [tag2=bar,tag1=foo]}
+ * will be treated as two different metrics even though they have same tags and
+ * values. Clients making use of the metrics can use the tags. For backwards
+ * compatibility, the name does not have to be enclosed in {@code []}.
  *
- * Each HazelcastInstance has its own MetricsRegistry instance.
+ * <h3>Duplicate Registrations</h3> The MetricsRegistry is lenient regarding
+ * duplicate registrations of probes. So if there is an existing probe for a
+ * given name and a new probe with the same name is registered, the old probe
+ * is overwritten. The reason to be lenient is that the MetricRegistry should
+ * not throw exception. Of course, there will be a log warning.
  *
- * A MetricsRegistry can contain many {@link Probe} instances. A probe is registered under a certain name,
- * and can be read by creating a Gauge, see {@link #newLongGauge(String)}.
- *
- * This name can be any string, e.g.:
- * <ol>
- * <li>proxy.count</li>
- * <li>operation.completed.count</li>
- * <li>operation.partition[14].count</li>
- * </ol>
- * For the time being there the MetricsRegistry doesn't require any syntax for the name content; so any String is fine.
- *
- * <h1>Duplicate Registrations</h1>
- * The MetricsRegistry is lenient regarding duplicate registrations of probes. So if there is an existing probe for a
- * given name and a new probe with the same name is registered, the old probe is overwritten. The reason to be lenient
- * is that the MetricRegistry should not throw exception. Of course there will be a log warning.
- *
- * <h1>Performance</h1>
- * The MetricRegistry is designed for low overhead probes. So once a probe is registered, there is no overhead
- * for the provider of the probe data. The provider could have for example a volatile long field and increment
- * this using a lazy-set. As long as the MetricRegistry can frequently read out this field, the MetricRegistry
- * is perfectly happy with such low overhead probes. So it is up to the provider of the probe
- * how much overhead is required.
+ * <h3>Performance</h3> The MetricRegistry is designed for low overhead probes.
+ * So once a probe is registered, there is no overhead for the provider of the
+ * probe data. The provider could have for example a volatile long field and
+ * increment this using a lazy-set. As long as the MetricRegistry can
+ * frequently read out this field, the MetricRegistry is perfectly happy with
+ * such low overhead probes. So it is up to the provider of the probe how much
+ * overhead is required.
  */
 public interface MetricsRegistry {
 
@@ -60,14 +66,17 @@ public interface MetricsRegistry {
     /**
      * Creates a {@link LongGauge} for a given metric name.
      *
-     * If no gauge exists for the name, it will be created but no probe is set. The reason to do so is that you don't want to
-     * depend on the order of registration. Perhaps you want to read out e.g. operations.count gauge, but the OperationService
-     * has not started yet and the metric is not yet available. Another cause is that perhaps a probe is not registered, but
-     * the metric is created. For example when experimenting with a new implementation, e.g. a new OperationService
-     * implementation, that doesn't provide the operation.count probe.
+     * If no gauge exists for the name, it will be created but no probe is set.
+     * The reason to do so is that you don't want to depend on the order of
+     * registration. Perhaps you want to read out e.g. operations.count gauge,
+     * but the OperationService has not started yet and the metric is not yet
+     * available. Another cause is that perhaps a probe is not registered, but
+     * the metric is created. For example when experimenting with a new
+     * implementation, e.g. a new OperationService implementation, that doesn't
+     * provide the operation.count probe.
      *
-     * Multiple calls with the same name, return different Gauge instances; so the Gauge instance is not cached. This is
-     * done to prevent memory leaks.
+     * Multiple calls with the same name return different Gauge instances; so
+     * the Gauge instance is not cached. This is done to prevent memory leaks.
      *
      * @param name the name of the metric.
      * @return the created LongGauge.
@@ -95,20 +104,22 @@ public interface MetricsRegistry {
     Set<String> getNames();
 
     /**
-     * Scans the source object for any fields/methods that have been annotated with {@link Probe} annotation, and
-     * registering these fields/methods as probes instances.
-     *
-     * If a probe is called, 'queueSize' and the namePrefix is 'operations, then the name of the probe-instance
-     * is 'operations.queueSize'.
-     *
-     * If probes with the same name already exist, then the probes are replaced.
-     *
-     * If an object has no @Gauge annotations, the call is ignored.
+     * Scans the source object for any fields/methods that have been annotated
+     * with {@link Probe} annotation, and registers these fields/methods as
+     * probe instances.
+     * <p>
+     * If a probe is called 'queueSize' and the namePrefix is 'operations',
+     * then the name of the probe instance is 'operations.queueSize'.
+     * <p>
+     * If a probe with the same name already exists, then the probe is replaced.
+     * <p>
+     * If an object has no @Probe annotations, the call is ignored.
      *
      * @param source     the object to scan.
      * @param namePrefix the name prefix.
      * @throws NullPointerException     if namePrefix or source is null.
-     * @throws IllegalArgumentException if the source contains Gauge annotation on a field/method of unsupported type.
+     * @throws IllegalArgumentException if the source contains a Probe
+     *      annotation on a field/method of unsupported type.
      */
     <S> void scanAndRegister(S source, String namePrefix);
 
@@ -183,4 +194,9 @@ public interface MetricsRegistry {
      * @param objects the array of objects to check.
      */
     void discardMetrics(Object... objects);
+
+    /**
+     * Creates a new {@link ProbeBuilder}.
+     */
+    ProbeBuilder newProbeBuilder();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsUtil.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import javax.annotation.Nonnull;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * A utility to escape and parse metric key in tagged format:<pre>
+ *     [tag1=value1,tag2=value2,...]
+ * </pre>
+ */
+public final class MetricsUtil {
+
+    private MetricsUtil() {
+    }
+
+    /**
+     * Escapes a user-supplied string value that is to be used as metrics key
+     * tag or value.
+     * <p>
+     * Prefixes comma ({@code ","}), equals sign ({@code "="}) and backslash
+     * ({@code "\"}) with another backslash.
+     */
+    @Nonnull
+    public static String escapeMetricNamePart(@Nonnull String namePart) {
+        int i = 0;
+        int l = namePart.length();
+        while (i < l) {
+            char ch = namePart.charAt(i);
+            if (ch == ',' || ch == '=' || ch == '\\') {
+                break;
+            }
+            i++;
+        }
+        if (i == l) {
+            return namePart;
+        }
+        StringBuilder sb = new StringBuilder(namePart.length() + 3);
+        sb.append(namePart, 0, i);
+        while (i < l) {
+            char ch = namePart.charAt(i++);
+            if (ch == ',' || ch == '=' || ch == '\\') {
+                sb.append('\\');
+            }
+            sb.append(ch);
+        }
+        return sb.toString();
+    }
+
+    @SuppressFBWarnings(value = "ES_COMPARING_PARAMETER_STRING_WITH_EQ", justification = "it's intentional")
+    public static boolean containsSpecialCharacters(String namePart) {
+        // escapeMetricNamePart method returns input object of no escaping is needed,
+        // we assume that.
+        //noinspection StringEquality
+        return escapeMetricNamePart(namePart) == namePart;
+    }
+
+    /**
+     * Parses metric name in tagged format into a list of tag-value tuples.
+     * Correctly handles the escaped values.
+     *
+     * @throws IllegalArgumentException if the metricName format is invalid
+     * (missing square bracket, invalid escape, empty tag name...)
+     */
+    @Nonnull
+    public static List<Map.Entry<String, String>> parseMetricName(@Nonnull String metricName) {
+        if (metricName.charAt(0) != '[' || metricName.charAt(metricName.length() - 1) != ']') {
+            throw new IllegalArgumentException("key not enclosed in []: " + metricName);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        List<Map.Entry<String, String>> result = new ArrayList<Map.Entry<String, String>>();
+        int l = metricName.length() - 1;
+        String tag = null;
+        boolean inTag = true;
+        for (int i = 1; i < l; i++) {
+            char ch = metricName.charAt(i);
+            switch (ch) {
+                case '=':
+                    tag = handleEqualsSign(metricName, sb, inTag);
+                    inTag = false;
+                    continue;
+
+                case ',':
+                    handleComma(metricName, sb, result, tag, inTag);
+                    inTag = true;
+                    tag = null;
+                    continue;
+
+                default:
+                    if (ch == '\\') {
+                        // the next character will be treated literally
+                        ch = metricName.charAt(++i);
+                    }
+                    if (i == l) {
+                        throw new IllegalArgumentException("backslash at the end: " + metricName);
+                    }
+                    sb.append(ch);
+            }
+        }
+        // final entry
+        if (tag != null) {
+            result.add(new SimpleImmutableEntry<String, String>(tag, sb.toString()));
+        } else if (sb.length() > 0) {
+            throw new IllegalArgumentException("unfinished tag at the end: " + metricName);
+        }
+        return result;
+    }
+
+    private static void handleComma(@Nonnull String metricKey, StringBuilder sb, List<Entry<String, String>> result,
+                                    String tag, boolean inTag) {
+        if (inTag) {
+            throw new IllegalArgumentException("comma in tag: " + metricKey);
+        }
+        result.add(new SimpleImmutableEntry<String, String>(tag, sb.toString()));
+        sb.setLength(0);
+    }
+
+    private static String handleEqualsSign(@Nonnull String metricKey, StringBuilder sb, boolean inTag) {
+        String tag;
+        if (!inTag) {
+            throw new IllegalArgumentException("equals sign not after tag: " + metricKey);
+        }
+        tag = sb.toString();
+        if (tag.length() == 0) {
+            throw new IllegalArgumentException("empty tag name: " + metricKey);
+        }
+        sb.setLength(0);
+        return tag;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/Probe.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
+import static com.hazelcast.internal.metrics.ProbeUnit.COUNT;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -79,4 +80,9 @@ public @interface Probe {
      * @return the ProbeLevel.
      */
     ProbeLevel level() default INFO;
+
+    /**
+     * Measurement unit of a Probe. Not used on member, becomes a part of the key.
+     */
+    ProbeUnit unit() default COUNT;
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+/**
+ * Immutable builder object to register Probes.
+ */
+public interface ProbeBuilder {
+
+    /**
+     * Returns a new ProbeBuilder instance with the given tag added.
+     */
+    ProbeBuilder withTag(String tag, String value);
+
+    /**
+     * Registers a single probe.
+     * <p>
+     * If a probe for the given name exists, it will be overwritten silently.
+     *
+     * @param source the object to pass to probeFn
+     * @param metricName the value of "metric" tag
+     * @param level the ProbeLevel
+     * @param probeFn the probe function
+     * @throws NullPointerException if any of the arguments is null
+     */
+    <S> void register(S source, String metricName, ProbeLevel level, DoubleProbeFunction<S> probeFn);
+
+    /**
+     * Registers a single probe.
+     * <p>
+     * If a probe for the given name exists, it will be overwritten silently.
+     *
+     * @param source the object to pass to probeFn
+     * @param metricName the value of "metric" tag
+     * @param level the ProbeLevel
+     * @param probeFn the probe function
+     * @throws NullPointerException if any of the arguments is null
+     */
+    <S> void register(S source, String metricName, ProbeLevel level, LongProbeFunction<S> probeFn);
+
+    /**
+     * Scans the source object for any fields/methods that have been annotated
+     * with {@link Probe} annotation, and registers these fields/methods as
+     * probe instances.
+     * <p>
+     * If a probe with the same name already exists, the probe is overwritten
+     * silently.
+     * <p>
+     * If an object has no @Probe annotations, the call is ignored.
+     *
+     * @param source     the object to scan
+     * @throws IllegalArgumentException if the source contains Probe annotation
+     * on a field/method of unsupported type.
+     */
+    <S> void scanAndRegister(S source);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeUnit.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeUnit.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+/**
+ * Measurement unit of a Probe. Not used on member, becomes a part of the key.
+ */
+public enum ProbeUnit {
+    /** Size, counter, represented in bytes */
+    BYTES,
+    /** Timestamp or duration represented in ms */
+    MS,
+    /** An integer mostly in range 0..100 or a double mostly in range 0..1 */
+    PERCENT,
+    /** Number of items: size, counter... */
+    COUNT,
+    /** 0 or 1 */
+    BOOLEAN,
+    /** 0..n, ordinal of an enum */
+    ENUM,
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/DoubleGaugeImpl.java
@@ -55,7 +55,7 @@ class DoubleGaugeImpl extends AbstractGauge implements DoubleGauge {
                 return doubleFunction.get(source);
             }
         } catch (Exception e) {
-            metricsRegistry.logger.warning("Failed to access probe:" + name, e);
+            metricsRegistry.logger.warning("Failed to access the probe: " + name, e);
             return DEFAULT_VALUE;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -56,17 +56,18 @@ abstract class FieldProbe implements ProbeFunction {
     }
 
     void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
-        String name = getName(namePrefix);
+        String name = namePrefix + '.' + getProbeOrFieldName();
         metricsRegistry.registerInternal(source, name, probe.level(), this);
     }
 
-    private String getName(String namePrefix) {
-        String name = field.getName();
-        if (!probe.name().equals("")) {
-            name = probe.name();
-        }
+    void register(ProbeBuilderImpl builder, Object source) {
+        builder
+                .withTag("unit", probe.unit().name().toLowerCase())
+                .register(source, getProbeOrFieldName(), probe.level(), this);
+    }
 
-        return namePrefix + "." + name;
+    private String getProbeOrFieldName() {
+        return probe.name().length() != 0 ? probe.name() : field.getName();
     }
 
     static <S> FieldProbe createFieldProbe(Field field, Probe probe) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LockStripe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LockStripe.java
@@ -22,11 +22,11 @@ import static java.lang.System.identityHashCode;
 /**
  * A stripe of locks to synchronize on a source object.
  *
- * We don't want to lock an 'source' objects because we don't own them to prevent running into unnecessary lock contention
+ * We don't want to lock on 'source' objects because we don't own them, to prevent running into unnecessary lock contention
  * issues.
  *
  * We rely on the identity hashcode of the object and not on the {@link Object#hashCode()} method to prevent running into
- * faulty or thread unsafe implementations.
+ * faulty or thread-unsafe implementations.
  */
 class LockStripe {
 
@@ -42,6 +42,6 @@ class LockStripe {
 
     Object getLock(Object source) {
         int hash = identityHashCode(source);
-        return hashToIndex(hash, stripe.length);
+        return stripe[hashToIndex(hash, stripe.length)];
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/LongGaugeImpl.java
@@ -56,7 +56,7 @@ class LongGaugeImpl extends AbstractGauge implements LongGauge {
                 return Math.round(doubleResult);
             }
         } catch (Exception e) {
-            metricsRegistry.logger.warning("Failed to access probe:" + name, e);
+            metricsRegistry.logger.warning("Failed to access the probe: " + name, e);
             return DEFAULT_VALUE;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -59,19 +59,20 @@ abstract class MethodProbe implements ProbeFunction {
     }
 
     void register(MetricsRegistryImpl metricsRegistry, Object source, String namePrefix) {
-        String name = getName(namePrefix);
+        String name = namePrefix + '.' + getProbeOrMethodName();
         metricsRegistry.registerInternal(source, name, probe.level(), this);
     }
 
-    private String getName(String namePrefix) {
-        String name;
-        if (probe.name().equals("")) {
-            name = getterIntoProperty(method.getName());
-        } else {
-            name = probe.name();
-        }
+    void register(ProbeBuilderImpl builder, Object source) {
+        builder
+                .withTag("unit", probe.unit().name().toLowerCase())
+                .register(source, getProbeOrMethodName(), probe.level(), this);
+    }
 
-        return namePrefix + "." + name;
+    private String getProbeOrMethodName() {
+        return probe.name().length() != 0
+                ? probe.name()
+                : getterIntoProperty(method.getName());
     }
 
     static <S> MethodProbe createMethodProbe(Method method, Probe probe) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -22,6 +22,7 @@ import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricsProvider;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.ProbeBuilder;
 import com.hazelcast.internal.metrics.ProbeFunction;
 import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
@@ -60,7 +61,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     };
 
     final ILogger logger;
-    final ProbeLevel minimumLevel;
+    private final ProbeLevel minimumLevel;
 
     private final ScheduledExecutorService scheduledExecutorService;
     private final ConcurrentMap<String, ProbeInstance> probeInstances = new ConcurrentHashMap<String, ProbeInstance>();
@@ -128,7 +129,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
      * @param clazz the Class to be analyzed.
      * @return the loaded SourceMetadata.
      */
-    private SourceMetadata loadSourceMetadata(Class<?> clazz) {
+    SourceMetadata loadSourceMetadata(Class<?> clazz) {
         SourceMetadata metadata = metadataMap.get(clazz);
         if (metadata == null) {
             metadata = new SourceMetadata(clazz);
@@ -351,9 +352,14 @@ public class MetricsRegistryImpl implements MetricsRegistry {
             this.probeInstances = null;
         }
 
-        public SortedProbeInstances(long mod, List<ProbeInstance> probeInstances) {
+        SortedProbeInstances(long mod, List<ProbeInstance> probeInstances) {
             this.mod = mod;
             this.probeInstances = probeInstances;
         }
+    }
+
+    @Override
+    public ProbeBuilder newProbeBuilder() {
+        return new ProbeBuilderImpl(this);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.DoubleProbeFunction;
+import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.ProbeBuilder;
+import com.hazelcast.internal.metrics.ProbeFunction;
+import com.hazelcast.internal.metrics.ProbeLevel;
+
+import static com.hazelcast.internal.metrics.MetricsUtil.containsSpecialCharacters;
+import static com.hazelcast.internal.metrics.MetricsUtil.escapeMetricNamePart;
+
+public class ProbeBuilderImpl implements ProbeBuilder {
+
+    private final MetricsRegistryImpl metricsRegistry;
+    private final String keyPrefix;
+
+    ProbeBuilderImpl(MetricsRegistryImpl metricsRegistry) {
+        this.metricsRegistry = metricsRegistry;
+        this.keyPrefix = "[";
+    }
+
+    private ProbeBuilderImpl(MetricsRegistryImpl metricsRegistry, String keyPrefix) {
+        this.metricsRegistry = metricsRegistry;
+        this.keyPrefix = keyPrefix;
+    }
+
+    @Override
+    public ProbeBuilderImpl withTag(String tag, String value) {
+        assert containsSpecialCharacters(tag) : "tag contains special characters";
+        return new ProbeBuilderImpl(
+                metricsRegistry, keyPrefix
+                        + (keyPrefix.length() == 1 ? "" : ",")
+                        + tag + '=' + escapeMetricNamePart(value));
+    }
+
+    private String metricName() {
+        return keyPrefix + ']';
+    }
+
+    @Override
+    public <S> void register(S source, String metricName, ProbeLevel level, DoubleProbeFunction<S> probe) {
+        metricsRegistry.register(source, withTag("metric", metricName).metricName(), level, probe);
+    }
+
+    @Override
+    public <S> void register(S source, String metricName, ProbeLevel level, LongProbeFunction<S> probe) {
+        metricsRegistry.register(source, withTag("metric", metricName).metricName(), level, probe);
+    }
+
+    <S> void register(S source, String metricName, ProbeLevel level, ProbeFunction probe) {
+        metricsRegistry.registerInternal(source, withTag("metric", metricName).metricName(), level, probe);
+    }
+
+    @Override
+    public <S> void scanAndRegister(S source) {
+        SourceMetadata metadata = metricsRegistry.loadSourceMetadata(source.getClass());
+        for (FieldProbe field : metadata.fields()) {
+            field.register(this, source);
+        }
+
+        for (MethodProbe method : metadata.methods()) {
+            method.register(this, source);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/SourceMetadata.java
@@ -57,7 +57,7 @@ final class SourceMetadata {
         }
     }
 
-    void scanFields(Class<?> clazz) {
+    private void scanFields(Class<?> clazz) {
         for (Field field : clazz.getDeclaredFields()) {
             Probe probe = field.getAnnotation(Probe.class);
 
@@ -70,7 +70,7 @@ final class SourceMetadata {
         }
     }
 
-    void scanMethods(Class<?> clazz) {
+    private void scanMethods(Class<?> clazz) {
         for (Method method : clazz.getDeclaredMethods()) {
             Probe probe = method.getAnnotation(Probe.class);
 
@@ -81,5 +81,19 @@ final class SourceMetadata {
             MethodProbe methodProbe = createMethodProbe(method, probe);
             methods.add(methodProbe);
         }
+    }
+
+    /**
+     * Don't modify the returned list!
+     */
+    public List<FieldProbe> fields() {
+        return fields;
+    }
+
+    /**
+     * Don't modify the returned list!
+     */
+    public List<MethodProbe> methods() {
+        return methods;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorOptimizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/SelectorOptimizer.java
@@ -35,7 +35,7 @@ import static java.lang.System.arraycopy;
  * The SelectorOptimizer optimizes the Selector so less litter is being created.
  * The Selector uses a HashSet, but this creates an object for every add of a
  * selection key. With this SelectorOptimizer a SelectionKeysSet, which contains
- * an  an array, is being used since every key is going to be inserted only once.
+ * an array, is being used since every key is going to be inserted only once.
  *
  * This trick comes from Netty.
  */

--- a/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
@@ -66,7 +66,7 @@ public final class Bits {
      */
     public static final int DOUBLE_SIZE_IN_BYTES = 8;
     /**
-     * for null arrays, this value writen to stream to represent null array size.
+     * for null arrays, this value is written to the stream to represent null array size.
      */
     public static final int NULL_ARRAY_LENGTH = -1;
     /**

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/ArrayRingbuffer.java
@@ -23,12 +23,12 @@ import java.util.Arrays;
 import java.util.Iterator;
 
 /**
- * The ArrayRingbuffer is responsible for storing the actual content of a
+ * The ArrayRingbuffer is responsible for storing the actual contents of a
  * ringbuffer.
  * <p>
  * Currently the Ringbuffer is not a partitioned data-structure. So all
  * data of a ringbuffer is stored in a single partition and replicated to
- * the replica's. No thread-safety is needed since a partition can only be
+ * the replicas. No thread safety is needed since a partition can only be
  * accessed by a single thread at any given moment.
  *
  * @param <E> the type of the data stored in the ringbuffer

--- a/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
@@ -263,10 +263,10 @@ public final class StringUtil {
      * Example: 'getFoo' is converted into 'foo'
      *
      * It's written defensively, when output is not a getter then it
-     * return the original name.
+     * returns the original name.
      *
-     * It converters name starting with the get- prefix only. When a getter
-     * starts with is- prefix (=boolean) then it does not convert it.
+     * It only converts names starting with a get- prefix. When a getter
+     * starts with an is- prefix (=boolean) then it does not convert it.
      *
      * @param getterName
      * @return property matching the given getter

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricsUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricsUtilTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map.Entry;
+
+import static com.hazelcast.internal.metrics.MetricsUtil.escapeMetricNamePart;
+import static com.hazelcast.internal.metrics.MetricsUtil.parseMetricName;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+@RunWith(HazelcastParallelClassRunner.class)
+public class MetricsUtilTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void test_escapeMetricKeyPart() {
+        assertSame("", escapeMetricNamePart(""));
+        assertSame("aaa", escapeMetricNamePart("aaa"));
+        assertEquals("\\=", escapeMetricNamePart("="));
+        assertEquals("\\,", escapeMetricNamePart(","));
+        assertEquals("\\\\", escapeMetricNamePart("\\"));
+        assertEquals("a\\=b", escapeMetricNamePart("a=b"));
+        assertEquals("\\=b", escapeMetricNamePart("=b"));
+        assertEquals("a\\=", escapeMetricNamePart("a="));
+    }
+
+    @Test
+    public void test_parseMetricKey() {
+        // empty list
+        assertEquals(emptyList(), parseMetricName("[]"));
+        // normal single tag
+        assertEquals(singletonList(entry("tag", "value")), parseMetricName("[tag=value]"));
+        // normal multiple tags
+        assertEquals(asList(entry("tag1", "value1"), entry("tag2", "value2")),
+                parseMetricName("[tag1=value1,tag2=value2]"));
+        // tag with escaped characters
+        assertEquals(singletonList(entry("tag=", "value,")), parseMetricName("[tag\\==value\\,]"));
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_keyNotEnclosed() {
+        exception.expectMessage("key not enclosed in []");
+        parseMetricName("tag=value");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_emptyTagName() {
+        exception.expectMessage("empty tag name");
+        parseMetricName("[=value]");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_equalsSignAfterValue() {
+        exception.expectMessage("equals sign not after tag");
+        parseMetricName("[tag=value=]");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_commaInTag1() {
+        exception.expectMessage("comma in tag");
+        parseMetricName("[,]");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_backslashAtTheEnd1() {
+        exception.expectMessage("backslash at the end");
+        parseMetricName("[\\]");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_backslashAtTheEnd2() {
+        exception.expectMessage("backslash at the end");
+        parseMetricName("[tag=value\\]");
+    }
+
+    @Test
+    public void test_parseMetricKey_fail_unfinishedTagAtTheEnd() {
+        exception.expectMessage("unfinished tag at the end");
+        parseMetricName("[tag=value,tag2]");
+    }
+
+    private Entry<String, String> entry(String key, String value) {
+        return new SimpleImmutableEntry<String, String>(key, value);
+    }
+}


### PR DESCRIPTION
This commit adds a structure to metric name. The ProbeBuilder is used to
register metrics with such structured name. It is backwards compatible:
new format is enclosed in `[]`. However, the Metrics registry never
parses the metric names, it handles them literally. The structure will
be used by the new Jet ManCenter, and in the future by IMDG ManCenter.