### PR TITLE
Fixes NIO close deadlock

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -49,6 +49,7 @@ import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.internal.networking.ChannelFactory;
 import com.hazelcast.internal.networking.nio.NioEventLoopGroup;
 import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.util.concurrent.ThreadFactoryImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
@@ -98,6 +99,7 @@ import static com.hazelcast.client.spi.properties.ClientProperty.IO_OUTPUT_THREA
 import static com.hazelcast.client.spi.properties.ClientProperty.SHUFFLE_MEMBER_LIST;
 import static com.hazelcast.spi.properties.GroupProperty.SOCKET_CLIENT_BUFFER_DIRECT;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
@@ -256,6 +258,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             outputThreads = configuredOutputThreads;
         }
 
+        ExecutorService executor = newFixedThreadPool(1, new ThreadFactoryImpl("ChannelClose.thread-", true));
         return new NioEventLoopGroup(
                 new NioEventLoopGroup.Context()
                         .loggingService(client.getLoggingService())
@@ -265,6 +268,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                         .inputThreadCount(inputThreads)
                         .outputThreadCount(outputThreads)
                         .balancerIntervalSeconds(properties.getInteger(IO_BALANCER_INTERVAL_SECONDS))
+                        .executor(executor)
                         .channelInitializer(new ClientChannelInitializer(getBufferSize(), directBuffer)));
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
@@ -174,11 +174,14 @@ public interface Channel extends Closeable {
     /**
      * Closes the Channel.
      *
+     * Closing is done asynchronously so that the calling thread (which
+     * could be an IO thread for example) isn't blocked.
+     *
      * This method is thread-safe.
      *
      * When the channel already is closed, the call is ignored.
      */
-    void close() throws IOException;
+    void close();
 
     /**
      * Checks if this Channel is closed. This method is very cheap to make.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.networking.AbstractChannel;
 import com.hazelcast.internal.networking.OutboundFrame;
 
 import java.nio.channels.SocketChannel;
+import java.util.concurrent.Executor;
 
 import static com.hazelcast.nio.IOUtil.closeResource;
 
@@ -37,9 +38,10 @@ public class NioChannel extends AbstractChannel {
         super(socketChannel, clientMode);
     }
 
-    public void init(NioInboundPipeline inboundPipeline, NioOutboundPipeline outboundPipeline) {
+    public void init(NioInboundPipeline inboundPipeline, NioOutboundPipeline outboundPipeline, Executor executor) {
         this.inboundPipeline = inboundPipeline;
         this.outboundPipeline = outboundPipeline;
+        this.executor = executor;
     }
 
     public NioOutboundPipeline outboundPipeline() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -319,6 +319,8 @@ public final class NioOutboundPipeline extends NioPipeline {
 
     @Override
     public void close() {
+        assert !(Thread.currentThread() instanceof NioThread);
+
         writeQueue.clear();
         priorityWriteQueue.clear();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ThreadFactoryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/concurrent/ThreadFactoryImpl.java
@@ -22,13 +22,21 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ThreadFactoryImpl implements ThreadFactory {
     private final String basename;
     private final AtomicInteger id = new AtomicInteger();
+    private final boolean daemon;
 
     public ThreadFactoryImpl(String basename) {
+        this(basename, false);
+    }
+
+    public ThreadFactoryImpl(String basename, boolean daemon) {
         this.basename = basename;
+        this.daemon = daemon;
     }
 
     @Override
     public Thread newThread(Runnable r) {
-        return new Thread(r, basename + id.incrementAndGet());
+        Thread thread = new Thread(r, basename + id.incrementAndGet());
+        thread.setDaemon(daemon);
+        return thread;
     }
 }


### PR DESCRIPTION
Fixes tmp deadlock on NioOutboundPipeline.close
    
If the close method gets called from the NIO thread, e.g. when
a nio thread has encounterd an exception like EOFException, through
the ErrorHandler the NioOutboundPipeline.close() method is called
from the IO thread.
    
If we then schedule a closetask to be scheduled on the same NIO thread
there will be a tmp self deadlock because the only thread that can
execute this task, is blocked because it is waiting on the completion
of this task. So we get a 3s stall on the IO thread; which can have
massive performance implications!
    
So the fix is to always offload closing to a channel to an
executor so the NIO thread will never get blocked.
