### PR TITLE
Added EntryLoadedListener

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEventType.java
@@ -29,7 +29,8 @@ public enum EntryEventType {
     CLEAR_ALL(TypeId.CLEAR_ALL),
     MERGED(TypeId.MERGED),
     EXPIRED(TypeId.EXPIRED),
-    INVALIDATION(TypeId.INVALIDATION);
+    INVALIDATION(TypeId.INVALIDATION),
+    LOADED(TypeId.LOADED);
 
     private int typeId;
 
@@ -68,6 +69,8 @@ public enum EntryEventType {
                 return EXPIRED;
             case TypeId.INVALIDATION:
                 return INVALIDATION;
+            case TypeId.LOADED:
+                return LOADED;
             default:
                 return null;
         }
@@ -89,6 +92,7 @@ public enum EntryEventType {
         private static final int MERGED = 1 << 6;
         private static final int EXPIRED = 1 << 7;
         private static final int INVALIDATION = 1 << 8;
+        private static final int LOADED = 1 << 9;
     }
     //CHECKSTYLE:ON
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdaptors.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdaptors.java
@@ -25,6 +25,7 @@ import com.hazelcast.map.impl.nearcache.invalidation.InvalidationListener;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryEvictedListener;
 import com.hazelcast.map.listener.EntryExpiredListener;
+import com.hazelcast.map.listener.EntryLoadedListener;
 import com.hazelcast.map.listener.EntryMergedListener;
 import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.map.listener.EntryUpdatedListener;
@@ -234,6 +235,26 @@ public final class MapListenerAdaptors {
                 }
             };
 
+    /**
+     * Converts an {@link EntryLoadedListener} to a {@link com.hazelcast.map.impl.ListenerAdapter}.
+     */
+    private static final ConstructorFunction<MapListener, ListenerAdapter> ENTRY_LOADED_LISTENER_ADAPTER_CONSTRUCTOR =
+            new ConstructorFunction<MapListener, ListenerAdapter>() {
+                @Override
+                public ListenerAdapter createNew(MapListener mapListener) {
+                    if (!(mapListener instanceof EntryLoadedListener)) {
+                        return null;
+                    }
+                    final EntryLoadedListener listener = (EntryLoadedListener) mapListener;
+                    return new ListenerAdapter<IMapEvent>() {
+                        @Override
+                        public void onEvent(IMapEvent event) {
+                            listener.entryLoaded((EntryEvent) event);
+                        }
+                    };
+                }
+            };
+
 
     /**
      * Register all {@link com.hazelcast.map.impl.ListenerAdapter} constructors
@@ -241,6 +262,7 @@ public final class MapListenerAdaptors {
      */
     static {
         CONSTRUCTORS.put(EntryEventType.ADDED, ENTRY_ADDED_LISTENER_ADAPTER_CONSTRUCTOR);
+        CONSTRUCTORS.put(EntryEventType.LOADED, ENTRY_LOADED_LISTENER_ADAPTER_CONSTRUCTOR);
         CONSTRUCTORS.put(EntryEventType.REMOVED, ENTRY_REMOVED_LISTENER_ADAPTER_CONSTRUCTOR);
         CONSTRUCTORS.put(EntryEventType.EVICTED, ENTRY_EVICTED_LISTENER_ADAPTER_CONSTRUCTOR);
         CONSTRUCTORS.put(EntryEventType.UPDATED, ENTRY_UPDATED_LISTENER_ADAPTER_CONSTRUCTOR);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -97,6 +97,27 @@ public interface MapEventPublisher {
     void publishEvent(Address caller, String mapName, EntryEventType eventType,
                       Data dataKey, Object dataOldValue, Object dataValue, Object dataMergingValue);
 
+    /**
+     * This method tries to publish events after a load happened in a backward
+     * compatible manner by choosing one of the two ways below:
+     *
+     * - As ADD events if listener implements only {@link
+     * com.hazelcast.map.listener.EntryAddedListener} but not {@link
+     * com.hazelcast.map.listener.EntryLoadedListener}, this is for the
+     * backward compatibility. Old listener implementation will continue
+     * to receive ADD events after loads happened.
+     *
+     * - As LOAD events if listener implements {@link
+     * com.hazelcast.map.listener.EntryLoadedListener}
+     *
+     * @param caller       the address of the caller that caused the event
+     * @param mapName      the map name
+     * @param dataKey      the key of the event map entry
+     * @param dataOldValue the old value of the map entry
+     * @param dataValue    the new value of the map entry
+     */
+    void publishLoadedOrAdded(Address caller, String mapName, Data dataKey, Object dataOldValue, Object dataValue);
+
     void publishMapPartitionLostEvent(Address caller, String mapName, int partitionId);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -43,6 +43,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 
+import static com.hazelcast.core.EntryEventType.ADDED;
+import static com.hazelcast.core.EntryEventType.LOADED;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.event.AbstractFilteringStrategy.FILTER_DOES_NOT_MATCH;
 import static com.hazelcast.util.CollectionUtil.isEmpty;
@@ -159,6 +161,21 @@ public class MapEventPublisherImpl implements MapEventPublisher {
         publishEvent(registrations, caller, mapName, eventType, dataKey, oldValue, value, mergingValue);
     }
 
+    @Override
+    public void publishLoadedOrAdded(Address caller, String mapName, Data dataKey, Object dataOldValue, Object dataValue) {
+        Collection<EventRegistration> registrations = getRegistrations(mapName);
+        for (EventRegistration registration : registrations) {
+            EventFilter filter = registration.getFilter();
+            if (filter instanceof EventListenerFilter) {
+                if (filter.eval(ADDED.getType()) && !filter.eval(LOADED.getType())) {
+                    publishEvent(caller, mapName, ADDED, dataKey, dataOldValue, dataValue);
+                } else {
+                    publishEvent(caller, mapName, LOADED, dataKey, dataOldValue, dataValue);
+                }
+            }
+        }
+    }
+
     /**
      * Publish the event to the specified listener {@code registrations} if the event passes the
      * filters specified by the {@link FilteringStrategy}.
@@ -179,7 +196,6 @@ public class MapEventPublisherImpl implements MapEventPublisher {
     private void publishEvent(Collection<EventRegistration> registrations, Address caller, String mapName,
                               EntryEventType eventType, Data dataKey, Object oldValue, Object newValue,
                               Object mergingValue) {
-
         EntryEventDataCache eventDataCache = filteringStrategy.getEntryEventDataCache();
 
         int orderKey = pickOrderKey(dataKey);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -37,7 +37,7 @@ public class ContainsKeyOperation extends ReadonlyKeyBasedMapOperation implement
 
     @Override
     public void run() {
-        containsKey = recordStore.containsKey(dataKey);
+        containsKey = recordStore.containsKey(dataKey, getCallerAddress());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -154,7 +154,7 @@ public final class EntryOperator {
             return this;
         }
 
-        oldValue = recordStore.get(dataKey, backup);
+        oldValue = recordStore.get(dataKey, backup, callerAddress);
         // predicated entry processors can only be applied to existing entries
         // so if we have a predicate and somehow(due to expiration or split-brain healing)
         // we found value null, we should skip that entry.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetAllOperation.java
@@ -62,7 +62,7 @@ public class GetAllOperation extends MapOperation implements ReadonlyOperation, 
                 partitionKeySet.add(key);
             }
         }
-        entries = recordStore.getAll(partitionKeySet);
+        entries = recordStore.getAll(partitionKeySet, getCallerAddress());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/GetOperation.java
@@ -38,7 +38,7 @@ public final class GetOperation extends ReadonlyKeyBasedMapOperation implements 
 
     @Override
     public void run() {
-        result = mapServiceContext.toData(recordStore.get(dataKey, false));
+        result = mapServiceContext.toData(recordStore.get(dataKey, false, getCallerAddress()));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.EntryViews;
 import com.hazelcast.map.impl.MapDataSerializerHook;
@@ -71,7 +70,8 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
 
             // here object conversion is for interceptors.
             Object value = hasInterceptor ? mapServiceContext.toObject(dataValue) : dataValue;
-            Object previousValue = recordStore.putFromLoad(key, value);
+
+            recordStore.putFromLoad(key, value, getCallerAddress());
             // the following check is for the case when the putFromLoad does not put the data due to various reasons
             // one of the reasons may be size eviction threshold has been reached
             if (value != null && !recordStore.existInMemory(key)) {
@@ -87,7 +87,6 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
                 checkNotNull(record, "Value loaded by a MapLoader cannot be null.");
                 value = record.getValue();
             }
-            publishEntryEvent(key, previousValue, value);
             publishWanReplicationEvent(key, value, record);
             addInvalidation(key);
         }
@@ -108,11 +107,6 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
 
     private void callAfterPutInterceptors(Object value) {
         mapService.getMapServiceContext().interceptAfterPut(name, value);
-    }
-
-    private void publishEntryEvent(Data key, Object previousValue, Object newValue) {
-        final EntryEventType eventType = previousValue == null ? EntryEventType.ADDED : EntryEventType.UPDATED;
-        mapEventPublisher.publishEvent(getCallerAddress(), name, eventType, key, previousValue, newValue);
     }
 
     private void publishWanReplicationEvent(Data key, Object value, Record record) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
@@ -33,7 +33,7 @@ public class PutIfAbsentOperation extends BasePutOperation implements MutatingOp
 
     @Override
     public void run() {
-        final Object oldValue = recordStore.putIfAbsent(dataKey, dataValue, ttl);
+        final Object oldValue = recordStore.putIfAbsent(dataKey, dataValue, ttl, getCallerAddress());
         dataOldValue = mapServiceContext.toData(oldValue);
         successful = dataOldValue == null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
@@ -85,6 +85,7 @@ class SubscriberAccumulatorHandler implements AccumulatorHandler<QueryCacheEvent
             case ADDED:
             case UPDATED:
             case MERGED:
+            case LOADED:
                 queryCache.setInternal(keyData, valueData, false, entryEventType);
                 break;
             case REMOVED:

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -19,7 +19,9 @@ package com.hazelcast.map.impl.recordstore;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.NativeMemoryConfig;
+import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.EntryViews;
 import com.hazelcast.map.impl.MapContainer;
@@ -41,6 +43,7 @@ import com.hazelcast.map.impl.querycache.publisher.PublisherRegistry;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.merge.MapMergePolicy;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.spi.NodeEngine;
@@ -66,6 +69,7 @@ import java.util.concurrent.Future;
 
 import static com.hazelcast.config.NativeMemoryConfig.MemoryAllocatorType.POOLED;
 import static com.hazelcast.core.EntryEventType.ADDED;
+import static com.hazelcast.core.EntryEventType.UPDATED;
 import static com.hazelcast.map.impl.ExpirationTimeSetter.setTTLAndUpdateExpiryTime;
 import static com.hazelcast.map.impl.mapstore.MapDataStores.EMPTY_MAP_DATA_STORE;
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
@@ -376,16 +380,18 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public Record loadRecordOrNull(Data key, boolean backup) {
+    public Record loadRecordOrNull(Data key, boolean backup, Address callerAddress) {
         Record record = null;
         Object value = mapDataStore.load(key);
         if (value != null) {
             record = createRecord(value, DEFAULT_TTL, getNow());
             storage.put(key, record);
-            eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
-                    key, record.getValue());
+            eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(),
+                    mapContainer.getObjectNamespace(), partitionId, key, record.getValue());
             if (!backup) {
                 saveIndex(record, null);
+                mapEventPublisher.publishEvent(callerAddress, name, EntryEventType.LOADED,
+                        key, null, value, null);
             }
             evictEntries(key);
         }
@@ -570,13 +576,13 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public Object get(Data key, boolean backup) {
+    public Object get(Data key, boolean backup, Address callerAddress) {
         checkIfLoaded();
         long now = getNow();
 
         Record record = getRecordOrNull(key, now, backup);
         if (record == null) {
-            record = loadRecordOrNull(key, backup);
+            record = loadRecordOrNull(key, backup, callerAddress);
         } else {
             accessRecord(record, now);
         }
@@ -601,7 +607,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public MapEntries getAll(Set<Data> keys) {
+    public MapEntries getAll(Set<Data> keys, Address callerAddress) {
         checkIfLoaded();
         long now = getNow();
 
@@ -618,13 +624,13 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             }
         }
 
-        Map loadedEntries = loadEntries(keys);
+        Map loadedEntries = loadEntries(keys, callerAddress);
         addMapEntrySet(loadedEntries, mapEntries);
 
         return mapEntries;
     }
 
-    protected Map<Data, Object> loadEntries(Set<Data> keys) {
+    protected Map<Data, Object> loadEntries(Set<Data> keys, Address callerAddress) {
         Map loadedEntries = mapDataStore.loadAll(keys);
         if (loadedEntries == null || loadedEntries.isEmpty()) {
             return Collections.emptyMap();
@@ -643,7 +649,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
             resultMap.put(key, value);
 
-            putFromLoad(key, value);
+            putFromLoad(key, value, callerAddress);
 
         }
 
@@ -680,13 +686,13 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public boolean containsKey(Data key) {
+    public boolean containsKey(Data key, Address callerAddress) {
         checkIfLoaded();
         long now = getNow();
 
         Record record = getRecordOrNull(key, now, false);
         if (record == null) {
-            record = loadRecordOrNull(key, false);
+            record = loadRecordOrNull(key, false, callerAddress);
         }
         boolean contains = record != null;
         if (contains) {
@@ -927,16 +933,16 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public Object putFromLoad(Data key, Object value) {
-        return putFromLoadInternal(key, value, DEFAULT_TTL, false);
+    public Object putFromLoad(Data key, Object value, Address callerAddress) {
+        return putFromLoadInternal(key, value, DEFAULT_TTL, false, callerAddress);
     }
 
     @Override
     public Object putFromLoadBackup(Data key, Object value) {
-        return putFromLoadInternal(key, value, DEFAULT_TTL, true);
+        return putFromLoadInternal(key, value, DEFAULT_TTL, true, null);
     }
 
-    private Object putFromLoadInternal(Data key, Object value, long ttl, boolean backup) {
+    private Object putFromLoadInternal(Data key, Object value, long ttl, boolean backup, Address callerAddress) {
         if (!isKeyAndValueLoadable(key, value)) {
             return null;
         }
@@ -951,22 +957,41 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
         Record record = getRecordOrNull(key, now, false);
         Object oldValue = null;
+        EntryEventType entryEventType = null;
         if (record == null) {
             value = mapServiceContext.interceptPut(name, null, value);
             record = createRecord(value, ttl, now);
             storage.put(key, record);
-            eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
-                    record.getKey(), record.getValue());
+            eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(),
+                    mapContainer.getObjectNamespace(), partitionId, record.getKey(), record.getValue());
         } else {
             oldValue = record.getValue();
             value = mapServiceContext.interceptPut(name, oldValue, value);
             updateRecord(key, record, value, now, true);
             setTTLAndUpdateExpiryTime(ttl, record, mapContainer.getMapConfig(), false);
+
+            entryEventType = UPDATED;
+
         }
         if (!backup) {
             saveIndex(record, oldValue);
+
+            if (entryEventType == UPDATED) {
+                mapEventPublisher.publishEvent(callerAddress, name, EntryEventType.UPDATED, key, oldValue, value);
+            } else {
+                if (is311OrLater()) {
+                    mapEventPublisher.publishLoadedOrAdded(callerAddress, name, key, null, value);
+                } else {
+                    mapEventPublisher.publishEvent(callerAddress, name, EntryEventType.ADDED, key, null, value);
+                }
+            }
         }
         return oldValue;
+    }
+
+    private boolean is311OrLater() {
+        return mapServiceContext.getNodeEngine().getClusterService()
+                .getClusterVersion().isGreaterOrEqual(Versions.V3_11);
     }
 
     protected boolean isKeyAndValueLoadable(Data key, Object value) {
@@ -994,7 +1019,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     @Override
-    public Object putIfAbsent(Data key, Object value, long ttl) {
+    public Object putIfAbsent(Data key, Object value, long ttl, Address callerAddress) {
         checkIfLoaded();
         long now = getNow();
         markRecordStoreExpirable(ttl);
@@ -1006,8 +1031,10 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             if (oldValue != null) {
                 record = createRecord(oldValue, DEFAULT_TTL, now);
                 storage.put(key, record);
+
                 eventJournal.writeAddEvent(mapContainer.getEventJournalConfig(), mapContainer.getObjectNamespace(), partitionId,
                         record.getKey(), record.getValue());
+                mapEventPublisher.publishEvent(callerAddress, name, EntryEventType.LOADED, key, null, oldValue);
             }
         } else {
             accessRecord(record, now);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -28,6 +28,7 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.monitor.LocalRecordStoreStats;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
@@ -63,7 +64,7 @@ public interface RecordStore<R extends Record> {
      */
     Object put(Data dataKey, Object dataValue, long ttl);
 
-    Object putIfAbsent(Data dataKey, Object value, long ttl);
+    Object putIfAbsent(Data dataKey, Object value, long ttl, Address callerAddress);
 
     R putBackup(Data key, Object value);
 
@@ -102,7 +103,7 @@ public interface RecordStore<R extends Record> {
      * @param backup  <code>true</code> if a backup partition, otherwise <code>false</code>.
      * @return value of an entry in {@link RecordStore}
      */
-    Object get(Data dataKey, boolean backup);
+    Object get(Data dataKey, boolean backup, Address callerAddress);
 
     /**
      * Called when {@link com.hazelcast.config.MapConfig#isReadBackupData} is <code>true</code> from
@@ -117,14 +118,14 @@ public interface RecordStore<R extends Record> {
      */
     Data readBackupData(Data key);
 
-    MapEntries getAll(Set<Data> keySet);
+    MapEntries getAll(Set<Data> keySet, Address callerAddress);
 
     /**
      * Checks if the key exist in memory without trying to load data from map-loader
      */
     boolean existInMemory(Data key);
 
-    boolean containsKey(Data dataKey);
+    boolean containsKey(Data dataKey, Address callerAddress);
 
     int getLockedEntryCount();
 
@@ -154,7 +155,7 @@ public interface RecordStore<R extends Record> {
      * <tt>null</tt> if there was no mapping for <tt>key</tt>.
      * @see com.hazelcast.map.impl.operation.PutFromLoadAllOperation
      */
-    Object putFromLoad(Data key, Object value);
+    Object putFromLoad(Data key, Object value, Address callerAddress);
 
     /**
      * Puts key-value pair to map which is the result of a load from map store operation on backup.
@@ -372,7 +373,7 @@ public interface RecordStore<R extends Record> {
 
     Record createRecord(Object value, long ttlMillis, long now);
 
-    Record loadRecordOrNull(Data key, boolean backup);
+    Record loadRecordOrNull(Data key, boolean backup, Address callerAddress);
 
     /**
      * This can be used to release unused resources.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -56,7 +56,7 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
         }
         Record record = recordStore.getRecordOrNull(dataKey);
         if (record == null && shouldLoad) {
-            record = recordStore.loadRecordOrNull(dataKey, false);
+            record = recordStore.loadRecordOrNull(dataKey, false, getCallerAddress());
         }
         Data value = record == null ? null : mapServiceContext.toData(record.getValue());
         response = new VersionedValue(value, record == null ? 0 : record.getVersion());

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EntryLoadedListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EntryLoadedListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.listener;
+
+import com.hazelcast.core.EntryEvent;
+
+/**
+ * Invoked upon load of an entry.
+ *
+ * EntryLoadedListener is notified upon load of an entry by a {@link
+ * com.hazelcast.core.MapLoader}. By using this listener and
+ * {@link EntryAddedListener}, one can distinguish an application put from
+ * map-loader load.
+ *
+ * @param <K> the type of key.
+ * @param <V> the type of value.
+ * @since 3.11
+ */
+public interface EntryLoadedListener<K, V> extends MapListener {
+
+    /**
+     * Invoked upon load of an entry.
+     *
+     * @param event the event invoked when an entry is loaded
+     */
+    void entryLoaded(EntryEvent<K, V> event);
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/MapListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/MapListener.java
@@ -43,7 +43,7 @@ import java.util.EventListener;
  * @see EntryRemovedListener
  * @see EntryMergedListener
  * @see EntryUpdatedListener
- *
+ * @see EntryLoadedListener
  * @since 3.5
  */
 public interface MapListener extends EventListener {

--- a/hazelcast/src/test/java/com/hazelcast/map/BackupExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BackupExpirationTest.java
@@ -165,7 +165,7 @@ public class BackupExpirationTest extends HazelcastTestSupport {
             Data dataKey = ss.toData(1);
             recordStore.put(dataKey, "value", 100);
             sleepSeconds(1);
-            recordStore.get(dataKey, false);
+            recordStore.get(dataKey, false, null);
 
             InvalidationQueue expiredKeys = recordStore.getExpiredKeys();
             return expiredKeys.size();

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerTest.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapLoader;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.EntryLoadedListener;
+import com.hazelcast.map.listener.EntryUpdatedListener;
+import com.hazelcast.map.listener.MapListener;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.core.EntryEventType.LOADED;
+import static org.junit.Assert.assertEquals;
+
+@SuppressWarnings("deprecation")
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class EntryLoadedListenerTest extends HazelcastTestSupport {
+
+    private static final TestHazelcastInstanceFactory FACTORY = new TestHazelcastInstanceFactory();
+
+    private static HazelcastInstance node;
+
+    @BeforeClass
+    public static void setUp() {
+        Config config = new Config();
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setEnabled(true);
+        mapStoreConfig.setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER);
+        mapStoreConfig.setClassName(TestMapLoader.class.getName());
+        config.getMapConfig("default").setMapStoreConfig(mapStoreConfig);
+
+        MapStoreConfig noInitialLoading = new MapStoreConfig();
+        noInitialLoading.setEnabled(true);
+        noInitialLoading.setClassName(TestMapLoaderWithoutInitialLoad.class.getName());
+        config.getMapConfig("noInitialLoading*").setMapStoreConfig(noInitialLoading);
+
+        FACTORY.newHazelcastInstance(config);
+        FACTORY.newHazelcastInstance(config);
+        node = FACTORY.newHazelcastInstance(config);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        FACTORY.shutdownAll();
+    }
+
+    @Test
+    public void load_listener_notified_when_containsKey_loads_from_map_loader() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = node.getMap("noInitialLoading_test_containsKey");
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                loadEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.containsKey(1);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(1, loadEventCount.get());
+            }
+        });
+    }
+
+    @Test
+    public void load_listener_notified_when_putIfAbsent_loads_from_map_loader() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = node.getMap("noInitialLoading_test_putIfAbsent");
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                loadEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.putIfAbsent(1, 100);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(1, loadEventCount.get());
+            }
+        });
+    }
+
+    @Test
+    public void load_listener_notified_when_get_loads_from_map_loader() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = node.getMap("noInitialLoading_test_get");
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                loadEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.get(1);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(1, loadEventCount.get());
+            }
+        });
+    }
+
+    @Test
+    public void load_listener_notified_when_get_after_evict() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = node.getMap("noInitialLoading_load_listener_notified_when_get_after_evict");
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                loadEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.put(1, 1);
+        map.evict(1);
+        map.get(1);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(1, loadEventCount.get());
+            }
+        }, 5);
+    }
+
+    @Test
+    public void load_listener_notified_when_getAll_loads_from_map_loader() {
+        final Queue<EntryEvent> entryEvents = new ConcurrentLinkedQueue<EntryEvent>();
+
+        IMap<Integer, Integer> map = node.getMap("noInitialLoading_test_getAll");
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                entryEvents.add(event);
+            }
+        }, true);
+
+
+        final List<Integer> keyList = Arrays.asList(1, 2, 3, 4, 5);
+        map.getAll(new HashSet<Integer>(keyList));
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(keyList.size(), entryEvents.size());
+                for (EntryEvent entryEvent : entryEvents) {
+                    assertEquals(LOADED, entryEvent.getEventType());
+                }
+            }
+        });
+    }
+
+    @Test
+    public void load_listener_notified_when_read_only_entry_processor_loads_from_map_loader() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = node.getMap("noInitialLoading_test_read_only_ep");
+
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                loadEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.executeOnKey(1, new Reader());
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(1, loadEventCount.get());
+            }
+        });
+    }
+
+    @Test
+    public void add_listener_not_notified_when_read_only_entry_processor_loads_from_map_loader() {
+        final AtomicInteger addEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = node.getMap("noInitialLoading_test_read_only_ep_not_notified");
+        map.addEntryListener(new EntryAddedListener<Integer, Integer>() {
+            @Override
+            public void entryAdded(EntryEvent<Integer, Integer> event) {
+                addEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.executeOnKey(1, new Reader());
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(0, addEventCount.get());
+            }
+        }, 3);
+    }
+
+    @Test
+    public void load_and_update_listener_notified_when_updater_entry_processor_loads_from_map_loader() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        final AtomicInteger updateEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = node.getMap("noInitialLoading_test_updater_ep");
+        map.addEntryListener(new LoadAndUpdateListener(loadEventCount, updateEventCount), true);
+
+        for (int i = 0; i < 10; i++) {
+            map.executeOnKey(i, new Updater());
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(10, loadEventCount.get());
+                assertEquals(10, updateEventCount.get());
+            }
+        });
+    }
+
+    @Test
+    public void load_listener_notified_but_add_listener_not_notified_after_loadAll() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        final AtomicInteger addEventCount = new AtomicInteger();
+
+        IMap<Integer, Integer> map = node.getMap("load_listener_notified_but_add_listener_not_notified_after_loadAll");
+        map.clear();
+
+        MapListener listener = new LoadAndAddListener(loadEventCount, addEventCount);
+        map.addEntryListener(listener, true);
+
+        map.loadAll(true);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(5, loadEventCount.get());
+            }
+        });
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(0, addEventCount.get());
+            }
+        }, 3);
+    }
+
+    @Test
+    public void add_listener_notified_after_loadAll() {
+        final AtomicInteger addEventCount = new AtomicInteger();
+
+        IMap<Integer, Integer> map = node.getMap("add_listener_notified_after_loadAll");
+        map.clear();
+
+        MapListener listener = new AddListener(addEventCount);
+        map.addEntryListener(listener, true);
+
+        map.loadAll(true);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(5, addEventCount.get());
+            }
+        });
+    }
+
+    static class LoadAndAddListener implements EntryLoadedListener<Integer, Integer>,
+            EntryAddedListener<Integer, Integer> {
+
+        private final AtomicInteger loadEventCount;
+        private final AtomicInteger addEventCount;
+
+        public LoadAndAddListener(AtomicInteger loadEventCount, AtomicInteger addEventCount) {
+            this.loadEventCount = loadEventCount;
+            this.addEventCount = addEventCount;
+        }
+
+        @Override
+        public void entryLoaded(EntryEvent<Integer, Integer> event) {
+            loadEventCount.incrementAndGet();
+        }
+
+        @Override
+        public void entryAdded(EntryEvent<Integer, Integer> event) {
+            addEventCount.incrementAndGet();
+        }
+    }
+
+    static class LoadAndUpdateListener implements EntryLoadedListener<Integer, Integer>,
+            EntryUpdatedListener<Integer, Integer> {
+
+        private final AtomicInteger loadEventCount;
+        private final AtomicInteger updateEventCount;
+
+        public LoadAndUpdateListener(AtomicInteger loadEventCount, AtomicInteger updateEventCount) {
+            this.loadEventCount = loadEventCount;
+            this.updateEventCount = updateEventCount;
+        }
+
+        @Override
+        public void entryLoaded(EntryEvent<Integer, Integer> event) {
+            loadEventCount.incrementAndGet();
+        }
+
+        @Override
+        public void entryUpdated(EntryEvent<Integer, Integer> event) {
+            updateEventCount.incrementAndGet();
+        }
+    }
+
+    static class AddListener implements EntryAddedListener<Integer, Integer> {
+
+        private final AtomicInteger addEventCount;
+
+        public AddListener(AtomicInteger addEventCount) {
+            this.addEventCount = addEventCount;
+        }
+
+        @Override
+        public void entryAdded(EntryEvent<Integer, Integer> event) {
+            addEventCount.incrementAndGet();
+        }
+    }
+
+    public static class TestMapLoader implements MapLoader<Integer, Integer> {
+
+        AtomicInteger sequence = new AtomicInteger();
+
+        public TestMapLoader() {
+        }
+
+        @Override
+        public Integer load(Integer key) {
+            return sequence.incrementAndGet();
+        }
+
+        @Override
+        public Map<Integer, Integer> loadAll(Collection<Integer> keys) {
+            HashMap<Integer, Integer> map = new HashMap<Integer, Integer>();
+            for (Integer key : keys) {
+                map.put(key, sequence.incrementAndGet());
+            }
+            return map;
+        }
+
+        @Override
+        public Iterable<Integer> loadAllKeys() {
+            return Arrays.asList(1, 2, 3, 4, 5);
+        }
+    }
+
+    public static class TestMapLoaderWithoutInitialLoad extends TestMapLoader {
+
+        public TestMapLoaderWithoutInitialLoad() {
+        }
+
+        @Override
+        public Iterable<Integer> loadAllKeys() {
+            return Collections.emptyList();
+        }
+    }
+
+    public static class Updater extends AbstractEntryProcessor<Integer, Integer> {
+        @Override
+        public Object process(Map.Entry<Integer, Integer> entry) {
+            entry.setValue(entry.getValue() + 1);
+            return entry.getValue();
+        }
+    }
+
+    public static class Reader extends AbstractEntryProcessor<Integer, Integer> {
+        @Override
+        public Object process(Map.Entry<Integer, Integer> entry) {
+            return entry.getValue();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/backup/TestBackupUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/backup/TestBackupUtils.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertNull;
 
 /**
  * Convenience for accessing and asserting backup records.
- *
  */
 public final class TestBackupUtils {
     private static final int DEFAULT_REPLICA_INDEX = 1;
@@ -49,8 +48,8 @@ public final class TestBackupUtils {
      *
      * @param cluster all instances in the cluster
      * @param mapName map to access
-     * @param <K> type of keys
-     * @param <V> type of values
+     * @param <K>     type of keys
+     * @param <V>     type of values
      * @return accessor for a given map and first backup replica
      */
     public static <K, V> BackupAccessor<K, V> newMapAccessor(HazelcastInstance[] cluster, String mapName) {
@@ -61,11 +60,11 @@ public final class TestBackupUtils {
      * Create a new instance of {@link BackupAccessor} for a given map.
      * It allows to access an arbitrary replica index as long as it's greater or equals 1
      *
-     * @param cluster all instances in the cluster
-     * @param mapName map to access
+     * @param cluster      all instances in the cluster
+     * @param mapName      map to access
      * @param replicaIndex replica index to access
-     * @param <K> type of keys
-     * @param <V> type of values
+     * @param <K>          type of keys
+     * @param <V>          type of values
      * @return accessor for a given map and replica index
      */
     public static <K, V> BackupAccessor<K, V> newMapAccessor(HazelcastInstance[] cluster, String mapName, int replicaIndex) {
@@ -76,10 +75,10 @@ public final class TestBackupUtils {
      * Create a new instance of {@link BackupAccessor} for a given cache.
      * It access a first backup replica.
      *
-     * @param cluster all instances in the cluster
+     * @param cluster   all instances in the cluster
      * @param cacheName cache to access
-     * @param <K> type of keys
-     * @param <V> type of values
+     * @param <K>       type of keys
+     * @param <V>       type of values
      * @return accessor for a given cache and first backup replica
      */
     public static <K, V> BackupAccessor<K, V> newCacheAccessor(HazelcastInstance[] cluster, String cacheName) {
@@ -90,11 +89,11 @@ public final class TestBackupUtils {
      * Create a new instance of {@link BackupAccessor} for a given cache.
      * It allows to access an arbitrary replica index as long as it's greater or equals 1
      *
-     * @param cluster all instances in the cluster
-     * @param cacheName cache to access
+     * @param cluster      all instances in the cluster
+     * @param cacheName    cache to access
      * @param replicaIndex replica index to access
-     * @param <K> type of keys
-     * @param <V> type of values
+     * @param <K>          type of keys
+     * @param <V>          type of values
      * @return accessor for a given cache and replica index
      */
     public static <K, V> BackupAccessor<K, V> newCacheAccessor(HazelcastInstance[] cluster, String cacheName, int replicaIndex) {
@@ -137,7 +136,7 @@ public final class TestBackupUtils {
     // ##### PRIVATE STUFF BELLOW, NO NEED TO TOUCH IT IN REGULAR TESTS #####
     // ######################################################################
 
-    private static class CacheBackupAccessor<K, V> extends BackupAccessorSupport<K, V> implements BackupAccessor<K ,V> {
+    private static class CacheBackupAccessor<K, V> extends BackupAccessorSupport<K, V> implements BackupAccessor<K, V> {
         private final String cacheName;
         private final int replicaIndex;
 
@@ -305,7 +304,7 @@ public final class TestBackupUtils {
                         return null;
                     }
                     Data keyData = serializationService.toData(key);
-                    Object o = recordStore.get(keyData, true);
+                    Object o = recordStore.get(keyData, true, null);
                     if (o == null) {
                         return null;
                     }


### PR DESCRIPTION
EntryLoadedListener is notified upon load of an entry by a map loader.
By using this listener and EntryAddedListener, one can distinguish an
application put from map-loader load.

One important change to preserve behavior as backward compatible, put-from-load-all-operation was previously firing ADD event, with this PR it will fire LOAD event if there is an EntryLoadedListener implemented, otherwise it will continue to fire ADD event. 

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/2141

closes https://github.com/hazelcast/hazelcast/issues/1542

