### PR TITLE
Fixed NoClassDefFoundError in Windows test runs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@
                         -Dhazelcast.phone.home.enabled=false
                         -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.test.use.network=false
+                        -Dlog4j.skipJansi=true
                         ${extraVmArgs}
                     </argLine>
                     <includes>
@@ -290,6 +291,7 @@
                         -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.logging.type=none
                         -Dhazelcast.test.use.network=true
+                        -Dlog4j.skipJansi=true
                         ${extraVmArgs}
                     </argLine>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
@@ -369,6 +371,7 @@
                                         -Dhazelcast.test.use.network=false
                                         -Dhazelcast.test.multiple.jvm=true
                                         -Dlog4j.configurationFile=log4j2-info.xml
+                                        -Dlog4j.skipJansi=true
                                         ${extraVmArgs}
                                         ${jacocoArgLine}
                                     </argLine>
@@ -409,6 +412,7 @@
                                         -Dhazelcast.logging.type=none
                                         -Dhazelcast.test.use.network=false
                                         -Dlog4j.configurationFile=log4j2-info.xml
+                                        -Dlog4j.skipJansi=true
                                         ${extraVmArgs}
                                         ${jacocoArgLine}
                                     </argLine>
@@ -460,6 +464,7 @@
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <includes>
@@ -497,6 +502,7 @@
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <useManifestOnlyJar>false</useManifestOnlyJar>
@@ -598,9 +604,9 @@
                     -Dhazelcast.mancenter.enabled=false
                     -Dhazelcast.logging.type=none
                     -Dhazelcast.test.use.network=false
-                    -Dlog4j.skipJansi=true
                     -Dhazelcast.operation.call.timeout.millis=120000
                     -Dhazelcast.graceful.shutdown.max.wait=240
+                    -Dlog4j.skipJansi=true
                     ${extraVmArgs}
                 </argLine>
             </properties>
@@ -675,6 +681,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <groups>
@@ -946,6 +953,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <useManifestOnlyJar>false</useManifestOnlyJar>
@@ -1023,6 +1031,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <useManifestOnlyJar>false</useManifestOnlyJar>
@@ -1065,6 +1074,7 @@
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <includes>
@@ -1121,6 +1131,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
                                 -Dhazelcast.test.sample.serialized.objects=${target.dir}/serialized-objects-${project.version}-
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <includes>


### PR DESCRIPTION
Windows test runs fail with a
```
java.lang.NoClassDefFoundError:
Could not initialize class org.fusesource.jansi.WindowsAnsiOutputStream
```

This can be fixed by configuring log4j with `-Dlog4j.skipJansi`

We already did this in some test profiles, I've added this to all test profiles now.

Fixes https://github.com/hazelcast/hazelcast/issues/13184