### PR TITLE
Send end-of-sequence-event to query-cache if local promotion happened

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/EventLostEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/EventLostEvent.java
@@ -100,4 +100,13 @@ public class EventLostEvent implements IMapEvent {
 
         return 1 << ++eventFlagPosition;
     }
+
+    @Override
+    public String toString() {
+        return "EventLostEvent{"
+                + "partitionId=" + partitionId
+                + ", source='" + source + '\''
+                + ", member=" + member
+                + '}';
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfoSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfoSupplier.java
@@ -16,15 +16,18 @@
 
 package com.hazelcast.map.impl.querycache.accumulator;
 
+import java.util.concurrent.ConcurrentMap;
+
 /**
- * Supplies {@link AccumulatorInfo} according to name of {@code IMap} and name of {@code QueryCache}.
+ * Supplies {@link AccumulatorInfo} according to name of {@code IMap} and
+ * name of {@code QueryCache}.
  */
 public interface AccumulatorInfoSupplier {
 
     /**
      * Returns {@link AccumulatorInfo} for cache of ma{@code IMap}p.
      *
-     * @param mapName   map name.
+     * @param mapName map name.
      * @param cacheId cache name.
      * @return {@link AccumulatorInfo} for cache of map.
      */
@@ -33,7 +36,7 @@ public interface AccumulatorInfoSupplier {
     /**
      * Adds a new {@link AccumulatorInfo} for the query-cache of {@code IMap}.
      *
-     * @param mapName   map name.
+     * @param mapName map name.
      * @param cacheId cache name.
      */
     void putIfAbsent(String mapName, String cacheId, AccumulatorInfo info);
@@ -41,8 +44,13 @@ public interface AccumulatorInfoSupplier {
     /**
      * Removes {@link AccumulatorInfo} from this supplier.
      *
-     * @param mapName   map name.
+     * @param mapName map name.
      * @param cacheId cache name.
      */
     void remove(String mapName, String cacheId);
+
+    /**
+     * @return all {@link AccumulatorInfo} of all {@code QueryCache} by map name
+     */
+    ConcurrentMap<String, ConcurrentMap<String, AccumulatorInfo>> getAll();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/DefaultAccumulatorInfoSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/DefaultAccumulatorInfoSupplier.java
@@ -72,6 +72,11 @@ public class DefaultAccumulatorInfoSupplier implements AccumulatorInfoSupplier {
         cacheToInfoMap.remove(cacheId);
     }
 
+    @Override
+    public ConcurrentMap<String, ConcurrentMap<String, AccumulatorInfo>> getAll() {
+        return cacheInfoPerMap;
+    }
+
     // only for testing
     public int accumulatorInfoCountOfMap(String mapName) {
         ConcurrentMap<String, AccumulatorInfo> accumulatorInfo = cacheInfoPerMap.get(mapName);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -116,12 +116,12 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         SubscriberRegistry subscriberRegistry = mapSubscriberRegistry.getOrNull(mapName);
         if (subscriberRegistry == null) {
-            return true;
+            return false;
         }
 
         Accumulator accumulator = subscriberRegistry.getOrNull(cacheId);
         if (accumulator == null) {
-            return true;
+            return false;
         }
 
         SubscriberAccumulator subscriberAccumulator = (SubscriberAccumulator) accumulator;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
@@ -29,6 +29,7 @@ import com.hazelcast.map.impl.querycache.event.sequence.SubscriberSequencerProvi
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.map.impl.querycache.publisher.AccumulatorSweeper.END_SEQUENCE;
 import static com.hazelcast.map.impl.querycache.subscriber.EventPublisherHelper.publishEventLost;
 import static java.lang.String.format;
 
@@ -104,7 +105,7 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
         int partitionId = event.getPartitionId();
         long sequence = event.getSequence();
 
-        if (sequence == -1L) {
+        if (sequence == END_SEQUENCE) {
             brokenSequences.remove(partitionId);
         } else {
             Long expected = brokenSequences.get(partitionId);
@@ -180,6 +181,6 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
     }
 
     private boolean isEndEvent(QueryCacheEventData event) {
-        return event.getSequence() == -1L;
+        return event.getSequence() == END_SEQUENCE;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/listener/EventLostListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/listener/EventLostListener.java
@@ -21,6 +21,13 @@ import com.hazelcast.map.EventLostEvent;
 /**
  * Invoked upon lost of event or events.
  *
+ * That event lost can be both a real or a possible event lost situation.
+ * In real event lost situation we can be sure that a sequence of events
+ * are missing and a recovery can be tried but in possible event lost
+ * situation we cannot be sure whether or not there is an event lost, for
+ * example, after a node is killed suddenly, we cannot be sure that all
+ * events on the killed node are sent and received by query caches.
+ *
  * @since 3.5
  */
 public interface EventLostListener extends MapListener {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheCreateDestroyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheCreateDestroyTest.java
@@ -101,6 +101,23 @@ public class QueryCacheCreateDestroyTest extends HazelcastTestSupport {
         assertEquals(1000, queryCacheSize);
     }
 
+    @Test
+    public void tryRecover_fails_after_destroy() {
+        final String mapName = "someMap";
+        final String queryCacheName = "testCache";
+
+        HazelcastInstance server = factory.newHazelcastInstance(newConfigWithQueryCache(mapName, queryCacheName));
+        server.getMap(mapName);
+
+        IMap map = server.getMap(mapName);
+        QueryCache queryCache = map.getQueryCache(queryCacheName);
+
+        queryCache.destroy();
+
+        assertFalse(queryCache.tryRecover());
+    }
+
+
     private static Config newConfigWithQueryCache(String mapName, String queryCacheName) {
         QueryCacheConfig queryCacheConfig = new QueryCacheConfig(queryCacheName);
         queryCacheConfig.getPredicateConfig().setImplementation(new TruePredicate());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheDataSyncWithMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheDataSyncWithMapTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class QueryCacheWithMapWideEventsTest extends HazelcastTestSupport {
+public class QueryCacheDataSyncWithMapTest extends HazelcastTestSupport {
 
     protected String mapName = randomString();
     protected String cacheName = randomString();

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheNoEventLossTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheNoEventLossTest.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class QueryCacheMapWideEventsTest extends HazelcastTestSupport {
+public class QueryCacheNoEventLossTest extends HazelcastTestSupport {
 
     private static final String MAP_NAME = "mapName";
     private static final String QUERY_CACHE_NAME = "cacheName";


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/12928

Makes local promotions reset query-cache sequence numbers