### PR TITLE
Propagate RejectedExecutionException from Connection Manager when not in the shutdown procedure

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionManager.java
@@ -616,6 +616,9 @@ public class TcpIpConnectionManager implements ConnectionManager, Consumer<Packe
                 scheduler.schedule(sendTask, (retries + 1) * DELAY_FACTOR, TimeUnit.MILLISECONDS);
                 return true;
             } catch (RejectedExecutionException e) {
+                if (live) {
+                    throw e;
+                }
                 if (logger.isFinestEnabled()) {
                     logger.finest("Packet send task is rejected. Packet cannot be sent to " + target);
                 }


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast/pull/10666 introduced logging,
because the exception is expected during shutdown. However we should
not swallow the exception when we are NOT in the shutdown.

Also align the mock connection manager to behave as the real manager.