### PR TITLE
Fixed ConfigXmlGeneratorTest for Windows

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
@@ -203,17 +203,16 @@ public class HotRestartPersistenceConfig {
     }
 
     @Override
-    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof HotRestartPersistenceConfig)) {
+        if (!(o instanceof HotRestartPersistenceConfig)) {
             return false;
         }
 
         HotRestartPersistenceConfig that = (HotRestartPersistenceConfig) o;
-
         if (enabled != that.enabled) {
             return false;
         }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -273,8 +273,8 @@ public class ConfigXmlGeneratorTest {
                 .setClusterDataRecoveryPolicy(HotRestartClusterDataRecoveryPolicy.FULL_RECOVERY_ONLY)
                 .setValidationTimeoutSeconds(100)
                 .setDataLoadTimeoutSeconds(130)
-                .setBaseDir(new File("/nonexisting-base"))
-                .setBackupDir(new File("/nonexisting-backup"))
+                .setBaseDir(new File("nonExisting-base").getAbsoluteFile())
+                .setBackupDir(new File("nonExisting-backup").getAbsoluteFile())
                 .setParallelism(5);
 
         HotRestartPersistenceConfig actualConfig = getNewConfigViaXMLGenerator(cfg).getHotRestartPersistenceConfig();


### PR DESCRIPTION
The `ConfigXmlGenerator` writes the absolute path in the XML output. The given n`ew File("/nonexisting-xxx")` is an absolute path in Linux, but on Windows this is changed to `"C:\nonexisting-xxx"`, which doesn't match the given input.

A solution for both operating systems is to create a file with a relative path and give the absolute file from that as test input.

I've verified locally, that the test now works under Windows.

Fixes https://github.com/hazelcast/hazelcast/issues/13194