### PR TITLE
Fixed OperatingSystemMetricSetTest for Windows

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
@@ -69,14 +69,12 @@ public final class OperatingSystemMetricSet {
         );
     }
 
-    // This method doesn't depend on the OperatingSystemMXBean so it can be tested. Due to not knowing
-    // the exact OperatingSystemMXBean class it is very difficult to get this class tested.
     static void registerMethod(MetricsRegistry metricsRegistry, Object osBean, String methodName, String name) {
         registerMethod(metricsRegistry, osBean, methodName, name, 1);
     }
 
-    private static void registerMethod(MetricsRegistry metricsRegistry, Object osBean, String methodName,
-            String name, final long multiplier) {
+    private static void registerMethod(MetricsRegistry metricsRegistry, Object osBean, String methodName, String name,
+                                       final long multiplier) {
         final Method method = getMethod(osBean, methodName);
 
         if (method == null) {
@@ -84,21 +82,19 @@ public final class OperatingSystemMetricSet {
         }
 
         if (long.class.equals(method.getReturnType())) {
-            metricsRegistry.register(osBean, name, MANDATORY,
-                    new LongProbeFunction() {
-                        @Override
-                        public long get(Object bean) throws Exception {
-                            return (Long) method.invoke(bean, EMPTY_ARGS) * multiplier;
-                        }
-                    });
+            metricsRegistry.register(osBean, name, MANDATORY, new LongProbeFunction() {
+                @Override
+                public long get(Object bean) throws Exception {
+                    return (Long) method.invoke(bean, EMPTY_ARGS) * multiplier;
+                }
+            });
         } else {
-            metricsRegistry.register(osBean, name, MANDATORY,
-                    new DoubleProbeFunction() {
-                        @Override
-                        public double get(Object bean) throws Exception {
-                            return (Double) method.invoke(bean, EMPTY_ARGS) * multiplier;
-                        }
-                    });
+            metricsRegistry.register(osBean, name, MANDATORY, new DoubleProbeFunction() {
+                @Override
+                public double get(Object bean) throws Exception {
+                    return (Double) method.invoke(bean, EMPTY_ARGS) * multiplier;
+                }
+            });
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1534,6 +1534,10 @@ public abstract class HazelcastTestSupport {
         assumeFalse("Zing JDK6 used", JAVA_VERSION.startsWith("1.6.") && JVM_NAME.startsWith("Zing"));
     }
 
+    public static void assumeThatNoWindowsOS() {
+        assumeFalse(System.getProperty("os.name").toLowerCase().contains("windows"));
+    }
+
     /**
      * Throws {@link AssumptionViolatedException} if two new Objects have the same hashCode (e.g. when running tests
      * with static hashCode ({@code -XX:hashCode=2}).


### PR DESCRIPTION
The file descriptor sensors are not implemented on Windows.

The according checks for those sensors can be guarded with a test assumption, just like the `processCpuLoad` and `systemCpuLoad` for the `UnixOperatingSystem` implementation test.

I've also removed the comments that the `OperatingSystemMetricSet` is hard to test. The code coverage is at 95% and it's easy to add a test assumption whenever we see a test failing in a new test environment.

I've verified locally, that the test now works under Windows.

Fixes https://github.com/hazelcast/hazelcast/issues/13196