### PR TITLE
Separate WAN event diagnostics per publisher

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
@@ -33,14 +33,28 @@ public final class MapUtil {
      * to minimize rehash operations
      */
     public static <K, V> Map<K, V> createHashMap(int expectedMapSize) {
-        int initialCapacity = (int) (expectedMapSize / HASHMAP_DEFAULT_LOAD_FACTOR) + 1;
+        int initialCapacity = calculateInitialCapacity(expectedMapSize);
         return new HashMap<K, V>(initialCapacity);
     }
 
     /**
+     * Returns the initial hash map capacity needed for the expected map size.
+     * To avoid resizing the map, the initial capacity should be different than
+     * the expected size, depending on the load factor.
+     *
+     * @param expectedMapSize the expected map size
+     * @return the necessary initial capacity
+     * @see HashMap
+     */
+    public static int calculateInitialCapacity(int expectedMapSize) {
+        return (int) (expectedMapSize / HASHMAP_DEFAULT_LOAD_FACTOR) + 1;
+    }
+
+    /**
      * Test the given map and return {@code true} if the map is null or empty.
+     *
      * @param map the map to test
-     * @return    {@code true} if {@code map} is null or empty, otherwise {@code false}.
+     * @return {@code true} if {@code map} is null or empty, otherwise {@code false}.
      */
     public static boolean isNullOrEmpty(Map map) {
         return map == null || map.isEmpty();

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -54,7 +54,7 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
     /**
      * Pauses wan replication to target group for the called node
      *
-     * @param name name of WAN replication configuration
+     * @param name            name of WAN replication configuration
      * @param targetGroupName name of wan target cluster config
      */
     void pause(String name, String targetGroupName);
@@ -62,7 +62,7 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
     /**
      * Resumes wan replication to target group for the called node.
      *
-     * @param name name of WAN replication configuration
+     * @param name            name of WAN replication configuration
      * @param targetGroupName name of wan target cluster config
      */
     void resume(String name, String targetGroupName);
@@ -115,16 +115,30 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
 
     /**
      * Returns a counter of received and processed WAN replication events.
+     *
+     * @param serviceName the name of the service for the WAN events
+     * @return the WAN event counter
      */
     WanEventCounter getReceivedEventCounter(String serviceName);
 
     /**
      * Returns a counter of sent and processed WAN replication events.
+     *
+     * @param wanReplicationName the name of the wan replication config
+     * @param targetGroupName    the target cluster group name
+     * @param serviceName        the name of the service for the WAN events
+     * @return the WAN event counter
      */
-    WanEventCounter getSentEventCounter(String serviceName);
+    WanEventCounter getSentEventCounter(String wanReplicationName,
+                                        String targetGroupName,
+                                        String serviceName);
 
     /**
-     * Removes the WAN event counters for the given {@code dataStructureName}.
+     * Removes all WAN event counters for the given {@code serviceName} and
+     * {@code dataStructureName}.
+     *
+     * @param serviceName       the name of the service for the WAN events
+     * @param dataStructureName the distributed object name
      */
     void removeWanEventCounters(String serviceName, String dataStructureName);
 }

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanEventCounterPublisherContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanEventCounterPublisherContainer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wan.impl;
+
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.map.impl.MapService;
+
+/**
+ * Thread safe container for {@link WanEventCounterContainer}s grouped by
+ * WAN replication name and target group name.
+ */
+class WanEventCounterPublisherContainer {
+    private final WanEventCounter mapEventCounters = new WanEventCounter();
+    private final WanEventCounter cacheEventCounters = new WanEventCounter();
+
+    /**
+     * Removes the counter for the given {@code serviceName} and {@code dataStructureName}.
+     */
+    void removeCounter(String serviceName, String dataStructureName) {
+        getWanEventCounter(serviceName).removeCounter(dataStructureName);
+    }
+
+    /**
+     * Returns the {@link WanEventCounter} for the given {@code serviceName}
+     */
+    WanEventCounter getWanEventCounter(String serviceName) {
+        if (MapService.SERVICE_NAME.equals(serviceName)) {
+            return mapEventCounters;
+        } else if (CacheService.SERVICE_NAME.equals(serviceName)) {
+            return cacheEventCounters;
+        } else {
+            throw new IllegalArgumentException("Unsupported service for counting WAN events " + serviceName);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -157,17 +157,19 @@ public class WanReplicationServiceImpl implements WanReplicationService {
 
     @Override
     public WanEventCounter getReceivedEventCounter(String serviceName) {
-        return receivedWanEventCounters.getWanEventCounter(serviceName);
+        return receivedWanEventCounters.getWanEventCounter("", "", serviceName);
     }
 
     @Override
-    public WanEventCounter getSentEventCounter(String serviceName) {
-        return sentWanEventCounters.getWanEventCounter(serviceName);
+    public WanEventCounter getSentEventCounter(String wanReplicationName,
+                                               String targetGroupName,
+                                               String serviceName) {
+        return sentWanEventCounters.getWanEventCounter(wanReplicationName, targetGroupName, serviceName);
     }
 
     @Override
-    public void removeWanEventCounters(String serviceName, String dataStructureName) {
-        receivedWanEventCounters.removeCounter(serviceName, dataStructureName);
-        sentWanEventCounters.removeCounter(serviceName, dataStructureName);
+    public void removeWanEventCounters(String serviceName, String objectName) {
+        receivedWanEventCounters.removeCounter(serviceName, objectName);
+        sentWanEventCounters.removeCounter(serviceName, objectName);
     }
 }


### PR DESCRIPTION
Until now, WAN events were shown for all publishers in total, per map
and cache. This is not sufficient for detecting issues when replicating
to multiple clusters (multiple publishers) and some of those publishers
might be having issues while others do not.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2143