### PR TITLE
Add ability to WAN sync only entries updated in a certain time frame

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -370,6 +370,26 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
     }
 
     /**
+     * Decodes HTTP post params contained in {@link HttpPostCommand#getData()}. The data
+     * should be encoded in UTF-8 and joined together with an ampersand (&).
+     *
+     * @param command    the HTTP post command
+     * @param paramCount the number of parameters expected in the command
+     * @return the decoded params
+     * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
+     *                                      named character encoding is not supported
+     */
+    private static String[] decodeParams(HttpPostCommand command, int paramCount) throws UnsupportedEncodingException {
+        final byte[] data = command.getData();
+        final String[] encoded = bytesToString(data).split("&");
+        final String[] decoded = new String[encoded.length];
+        for (int i = 0; i < encoded.length && i < paramCount; i++) {
+            decoded[i] = URLDecoder.decode(encoded[i], "UTF-8");
+        }
+        return decoded;
+    }
+
+    /**
      * Initiates a WAN sync for a single map and the wan replication name and target group defined
      * by the command parameters.
      *
@@ -379,38 +399,28 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
      */
     private void handleWanSyncMap(HttpPostCommand command) throws UnsupportedEncodingException {
         String res;
-        final String[] params = decodeParams(command, 3);
+        final String[] params = decodeParams(command, 5);
         final String wanRepName = params[0];
         final String targetGroup = params[1];
         final String mapName = params[2];
+        final long fromTimestamp =
+                params.length > 3 && params[3] != null
+                        ? Long.valueOf(params[3])
+                        : Long.MIN_VALUE;
+        final long toTimestamp =
+                params.length > 4 && params[4] != null
+                        ? Long.valueOf(params[4])
+                        : Long.MAX_VALUE;
+        final WanReplicationService service = textCommandService.getNode().getNodeEngine().getWanReplicationService();
         try {
-            textCommandService.getNode().getNodeEngine().getWanReplicationService().syncMap(wanRepName, targetGroup, mapName);
+            if (fromTimestamp == Long.MIN_VALUE && toTimestamp == Long.MAX_VALUE) {
+                service.syncMap(wanRepName, targetGroup, mapName);
+            } else {
+                service.syncMap(wanRepName, targetGroup, mapName, fromTimestamp, toTimestamp);
+            }
             res = response(ResponseType.SUCCESS, "message", "Sync initiated");
         } catch (Exception ex) {
             logger.warning("Error occurred while syncing map", ex);
-            res = exceptionResponse(ex);
-        }
-        sendResponse(command, res);
-    }
-
-    /**
-     * Initiates WAN sync for all maps and the wan replication name and target group defined
-     * by the command parameters.
-     *
-     * @param command the HTTP command
-     * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
-     *                                      named character encoding is not supported
-     */
-    private void handleWanSyncAllMaps(HttpPostCommand command) throws UnsupportedEncodingException {
-        String res;
-        final String[] params = decodeParams(command, 2);
-        final String wanRepName = params[0];
-        final String targetGroup = params[1];
-        try {
-            textCommandService.getNode().getNodeEngine().getWanReplicationService().syncAllMaps(wanRepName, targetGroup);
-            res = response(ResponseType.SUCCESS, "message", "Sync initiated");
-        } catch (Exception ex) {
-            logger.warning("Error occurred while syncing maps", ex);
             res = exceptionResponse(ex);
         }
         sendResponse(command, res);
@@ -544,23 +554,39 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
     }
 
     /**
-     * Decodes HTTP post params contained in {@link HttpPostCommand#getData()}. The data
-     * should be encoded in UTF-8 and joined together with an ampersand (&).
+     * Initiates WAN sync for all maps and the wan replication name and target group defined
+     * by the command parameters.
      *
-     * @param command    the HTTP post command
-     * @param paramCount the number of parameters expected in the command
-     * @return the decoded params
+     * @param command the HTTP command
      * @throws UnsupportedEncodingException If character encoding needs to be consulted, but
      *                                      named character encoding is not supported
      */
-    private static String[] decodeParams(HttpPostCommand command, int paramCount) throws UnsupportedEncodingException {
-        final byte[] data = command.getData();
-        final String[] encoded = bytesToString(data).split("&");
-        final String[] decoded = new String[encoded.length];
-        for (int i = 0; i < paramCount; i++) {
-            decoded[i] = URLDecoder.decode(encoded[i], "UTF-8");
+    private void handleWanSyncAllMaps(HttpPostCommand command) throws UnsupportedEncodingException {
+        String res;
+        final String[] params = decodeParams(command, 4);
+        final String wanRepName = params[0];
+        final String targetGroup = params[1];
+        final long fromTimestamp =
+                params.length > 2 && params[2] != null
+                        ? Long.valueOf(params[2])
+                        : Long.MIN_VALUE;
+        final long toTimestamp =
+                params.length > 3 && params[3] != null
+                        ? Long.valueOf(params[3])
+                        : Long.MAX_VALUE;
+        final WanReplicationService service = textCommandService.getNode().getNodeEngine().getWanReplicationService();
+        try {
+            if (fromTimestamp == Long.MIN_VALUE && toTimestamp == Long.MAX_VALUE) {
+                service.syncAllMaps(wanRepName, targetGroup);
+            } else {
+                service.syncAllMaps(wanRepName, targetGroup, fromTimestamp, toTimestamp);
+            }
+            res = response(ResponseType.SUCCESS, "message", "Sync initiated");
+        } catch (Exception ex) {
+            logger.warning("Error occurred while syncing maps", ex);
+            res = exceptionResponse(ex);
         }
-        return decoded;
+        sendResponse(command, res);
     }
 
     private boolean checkCredentials(HttpPostCommand command) throws UnsupportedEncodingException {

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -18,10 +18,12 @@ package com.hazelcast.wan;
 
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.internal.cluster.ClusterService;
 import com.hazelcast.monitor.LocalWanStats;
 import com.hazelcast.monitor.WanSyncState;
 import com.hazelcast.spi.CoreService;
 import com.hazelcast.spi.StatisticsAwareService;
+import com.hazelcast.util.Clock;
 import com.hazelcast.wan.impl.WanEventCounter;
 
 /**
@@ -54,7 +56,7 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
     /**
      * Pauses wan replication to target group for the called node
      *
-     * @param name name of WAN replication configuration
+     * @param name            name of WAN replication configuration
      * @param targetGroupName name of wan target cluster config
      */
     void pause(String name, String targetGroupName);
@@ -62,7 +64,7 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
     /**
      * Resumes wan replication to target group for the called node.
      *
-     * @param name name of WAN replication configuration
+     * @param name            name of WAN replication configuration
      * @param targetGroupName name of wan target cluster config
      */
     void resume(String name, String targetGroupName);
@@ -70,8 +72,10 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
     void checkWanReplicationQueues(String name);
 
     /**
-     * Initiate wan sync for a specific map.
-     * NOTE: not supported on OS, only on EE
+     * Initiate WAN sync for a specific map.
+     * <p>
+     * NOTE: This method will throw a {@link UnsupportedOperationException} if
+     * invoked on OS.
      *
      * @param wanReplicationName the name of the wan replication config
      * @param targetGroupName    the group name on the target cluster
@@ -83,16 +87,83 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
     void syncMap(String wanReplicationName, String targetGroupName, String mapName);
 
     /**
-     * Initiate wan sync for all maps.
-     * NOTE: not supported on OS, only on EE
+     * Initiate WAN sync for all maps.
+     * <p>
+     * NOTE: This method will throw a {@link UnsupportedOperationException} if
+     * invoked on OS.
      *
      * @param wanReplicationName the name of the wan replication config
      * @param targetGroupName    the group name on the target cluster
      * @throws UnsupportedOperationException if the operation is not supported (not EE)
-     * @throws InvalidConfigurationException if there is no WAN replication config for {@code wanReplicationName}
+     * @throws InvalidConfigurationException if there is no WAN replication
+     *                                       config for {@code wanReplicationName}
      * @throws SyncFailedException           if there is a sync request in progress
      */
     void syncAllMaps(String wanReplicationName, String targetGroupName);
+
+    /**
+     * Initiate WAN sync for a specific map.
+     * This method may sync only some entries which have been updated in a
+     * certain time interval. The interval is defined by the {@code fromTimestamp}
+     * and {@code toTimestamp} parameters. These parameters represent the
+     * timestamp as defined by the {@link Clock#currentTimeMillis()} method.
+     * <p>
+     * NOTE: This method will throw a {@link UnsupportedOperationException} if
+     * invoked on OS or if the cluster version is less than 3.9.
+     * <p>
+     * If the cluster contains members with versions less than 3.9.5, this
+     * invocation will pass but the WAN sync will fail.
+     *
+     * @param wanReplicationName the name of the wan replication config
+     * @param targetGroupName    the group name on the target cluster
+     * @param mapName            the map name
+     * @param fromTimestamp      the earliest time since when the entry must have been changed
+     * @param toTimestamp        the latest time until when the entry must have been changed
+     * @throws UnsupportedOperationException if the operation is not supported
+     *                                       (not EE) or when the cluster version is less than
+     *                                       {@link com.hazelcast.internal.cluster.Versions#CURRENT_CLUSTER_VERSION}
+     * @throws InvalidConfigurationException if there is no WAN replication
+     *                                       config for {@code wanReplicationName}
+     * @throws SyncFailedException           if there is a sync request in progress
+     * @see Clock#currentTimeMillis()
+     * @see ClusterService#getClusterVersion()
+     */
+    void syncMap(String wanReplicationName,
+                 String targetGroupName,
+                 String mapName,
+                 long fromTimestamp,
+                 long toTimestamp);
+
+    /**
+     * Initiate WAN sync for all maps.
+     * This method may sync only some entries which have been updated in a
+     * certain time interval. The interval is defined by the {@code fromTimestamp}
+     * and {@code toTimestamp} parameters. These parameters represent the
+     * timestamp as defined by the {@link Clock#currentTimeMillis()} method.
+     * <p>
+     * NOTE: This method will throw a {@link UnsupportedOperationException} if
+     * invoked on OS or if the cluster version is less than 3.9.
+     * <p>
+     * If the cluster contains members with versions less than 3.9.5, this
+     * invocation will pass but the WAN sync will fail.
+     *
+     * @param wanReplicationName the name of the wan replication config
+     * @param targetGroupName    the group name on the target cluster
+     * @param fromTimestamp      the earliest time since when the entry must
+     *                           have been changed
+     * @param toTimestamp        the latest time until when the entry must have
+     *                           been changed
+     * @throws UnsupportedOperationException if the operation is not supported (not EE)
+     * @throws InvalidConfigurationException if there is no WAN replication
+     *                                       config for {@code wanReplicationName}
+     * @throws SyncFailedException           if there is a sync request in progress
+     * @see Clock#currentTimeMillis()
+     * @see ClusterService#getClusterVersion()
+     */
+    void syncAllMaps(String wanReplicationName,
+                     String targetGroupName,
+                     long fromTimestamp,
+                     long toTimestamp);
 
     /**
      * Clears WAN replication queues of the given wanReplicationName for the given target.

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -132,6 +132,16 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
+    public void syncMap(String wanReplicationName, String targetGroupName, String mapName, long fromTimestamp, long toTimestamp) {
+        throw new UnsupportedOperationException("WAN sync for map is not supported.");
+    }
+
+    @Override
+    public void syncAllMaps(String wanReplicationName, String targetGroupName, long fromTimestamp, long toTimestamp) {
+        throw new UnsupportedOperationException("WAN sync is not supported.");
+    }
+
+    @Override
     public void clearQueues(String wanReplicationName, String targetGroupName) {
         throw new UnsupportedOperationException("Clearing WAN replication queues is not supported.");
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -224,6 +224,25 @@ public class HTTPCommunicator {
         return doPost(url, wanRepName, targetGroupName).response;
     }
 
+    public String syncMapOverWAN(String wanRepName,
+                                 String targetGroupName,
+                                 String mapName,
+                                 long fromTimestamp,
+                                 long toTimestamp) throws IOException {
+        String url = address + "mancenter/wan/sync/map";
+        return doPost(url, wanRepName, targetGroupName, mapName, String.valueOf(fromTimestamp), String.valueOf(toTimestamp))
+                .response;
+    }
+
+    public String syncMapsOverWAN(String wanRepName,
+                                  String targetGroupName,
+                                  long fromTimestamp,
+                                  long toTimestamp) throws IOException {
+        String url = address + "mancenter/wan/sync/allmaps";
+        return doPost(url, wanRepName, targetGroupName, String.valueOf(fromTimestamp), String.valueOf(toTimestamp))
+                .response;
+    }
+
     public String wanClearQueues(String wanRepName, String targetGroupName) throws IOException {
         String url = address + "mancenter/wan/clearWanQueues";
         return doPost(url, wanRepName, targetGroupName).response;


### PR DESCRIPTION
WAN sync always transferred all entries for all partitions. Sometimes
this is too much data and the user might roughly know the time frame for
which he wants to sync entries. For instance, this may be the case when
there was an outage and the user needs to sync only entries changes
during that outage.
We now add the ability to define the from and to timestamp when syncing
entries. The existing WAN sync (without timestamps) will continue to
work in mixed version clusters but trying to sync entries in a certain
time frame will pass the initial check and fail later. In a cluster
where all members support the timestamped WAN sync feature, there should
not be any failures.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2144