### PR TITLE
Split up MigrationPlanner::planMigrations to mitigate C2 compiler bug

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationPlanner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationPlanner.java
@@ -57,7 +57,7 @@ class MigrationPlanner {
         this.logger = logger;
     }
 
-    // checkstyle warnings are suppressed intentionally because the algorithm is followed easier within a single coherent method.
+    // the CheckStyle warnings are suppressed intentionally, because the algorithm is followed easier within fewer methods
     @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity", "checkstyle:methodlength"})
     void planMigrations(Address[] oldAddresses, Address[] newAddresses, MigrationDecisionCallback callback) {
         assert oldAddresses.length == newAddresses.length : "Replica addresses with different lengths! Old: "
@@ -69,7 +69,7 @@ class MigrationPlanner {
         initState(oldAddresses);
         assertNoDuplicate(oldAddresses, newAddresses);
 
-        // Fix cyclic partition replica movements.
+        // fix cyclic partition replica movements
         if (fixCycle(oldAddresses, newAddresses)) {
             log("Final state (after cycle fix): %s", Arrays.toString(newAddresses));
         }
@@ -81,7 +81,7 @@ class MigrationPlanner {
 
             if (newAddresses[currentIndex] == null) {
                 if (state[currentIndex] != null) {
-                    // Replica owner is removed and no one will own this replica.
+                    // replica owner is removed and no one will own this replica
                     log("New address is null at index: %d", currentIndex);
                     callback.migrate(state[currentIndex], currentIndex, -1, null, -1, -1);
                     state[currentIndex] = null;
@@ -93,7 +93,7 @@ class MigrationPlanner {
             if (state[currentIndex] == null) {
                 int i = getReplicaIndex(state, newAddresses[currentIndex]);
                 if (i == -1) {
-                    // Fresh replica copy is needed. COPY replica to newAddresses[currentIndex] from partition owner
+                    // fresh replica copy is needed, so COPY replica to newAddresses[currentIndex] from partition owner
                     log("COPY %s to index: %d", newAddresses[currentIndex], currentIndex);
                     callback.migrate(null, -1, -1, newAddresses[currentIndex], -1, currentIndex);
                     state[currentIndex] = newAddresses[currentIndex];
@@ -116,7 +116,7 @@ class MigrationPlanner {
             }
 
             if (newAddresses[currentIndex].equals(state[currentIndex])) {
-                // No change, no action needed.
+                // no change, no action needed
                 currentIndex++;
                 continue;
             }
@@ -133,13 +133,12 @@ class MigrationPlanner {
 
             if (getReplicaIndex(state, newAddresses[currentIndex]) == -1) {
                 int newIndex = getReplicaIndex(newAddresses, state[currentIndex]);
-
                 assert newIndex > currentIndex : "Migration decision algorithm failed during SHIFT DOWN! INITIAL: "
                         + Arrays.toString(oldAddresses) + ", CURRENT: " + Arrays.toString(state)
                         + ", FINAL: " + Arrays.toString(newAddresses);
 
                 if (state[newIndex] == null) {
-                    // IT IS A SHIFT DOWN
+                    // it is a SHIFT DOWN
                     log("SHIFT DOWN %s to index: %d, COPY %s to index: %d", state[currentIndex], newIndex,
                             newAddresses[currentIndex], currentIndex);
                     callback.migrate(state[currentIndex], currentIndex, newIndex, newAddresses[currentIndex], -1, currentIndex);
@@ -154,61 +153,64 @@ class MigrationPlanner {
                 continue;
             }
 
-            Address target = newAddresses[currentIndex];
-            int i = currentIndex;
-            while (true) {
-                int j = getReplicaIndex(state, target);
-
-                assert j != -1 : "Migration algorithm failed during SHIFT UP! " + target + " is not present in "
-                        + Arrays.toString(state) + ". INITIAL: " + Arrays.toString(oldAddresses)
-                        + ", FINAL: " + Arrays.toString(newAddresses);
-
-                if (newAddresses[j] == null) {
-                    if (state[i] == null) {
-                        log("SHIFT UP %s from old addresses index: %d to index: %d", state[j], j, i);
-                        callback.migrate(state[i], i, -1, state[j], j, i);
-                        state[i] = state[j];
-                    } else {
-                        int k = getReplicaIndex(newAddresses, state[i]);
-                        if (k == -1) {
-                            log("SHIFT UP %s from old addresses index: %d to index: %d with source: %s",
-                                    state[j], j, i, state[i]);
-                            callback.migrate(state[i], i, -1, state[j], j, i);
-                            state[i] = state[j];
-                        } else if (state[k] == null) {
-                            // shift up + shift down
-                            log("SHIFT UP %s from old addresses index: %d to index: %d AND SHIFT DOWN %s to index: %d",
-                                    state[j], j, i, state[i], k);
-                            callback.migrate(state[i], i, k, state[j], j, i);
-                            state[k] = state[i];
-                            state[i] = state[j];
-                        } else {
-                            // only shift up because source will come back with another move migration
-                            log("SHIFT UP %s from old addresses index: %d to index: %d with source: %s will get "
-                                    + "another MOVE migration to index: %d", state[j], j, i, state[i], k);
-                            callback.migrate(state[i], i, -1, state[j], j, i);
-                            state[i] = state[j];
-                        }
-                    }
-                    state[j] = null;
-                    break;
-                } else if (getReplicaIndex(state, newAddresses[j]) == -1) {
-                    // MOVE partition replica from its old owner to new owner
-                    log("MOVE-2 %s  to index: %d", newAddresses[j], j);
-                    callback.migrate(state[j], j, -1, newAddresses[j], -1, j);
-                    state[j] = newAddresses[j];
-                    break;
-                } else {
-                    // newAddresses[j] is also present in old partition replicas
-                    target = newAddresses[j];
-                    i = j;
-                }
-            }
+            planMigrations(oldAddresses, newAddresses, callback, currentIndex);
         }
 
         assert Arrays.equals(state, newAddresses)
                 : "Migration decisions failed! INITIAL: " + Arrays.toString(oldAddresses)
                 + " CURRENT: " + Arrays.toString(state) + ", FINAL: " + Arrays.toString(newAddresses);
+    }
+
+    private void planMigrations(Address[] oldAddresses, Address[] newAddresses, MigrationDecisionCallback callback,
+                                int currentIndex) {
+        while (true) {
+            int targetIndex = getReplicaIndex(state, newAddresses[currentIndex]);
+            assert targetIndex != -1 : "Migration algorithm failed during SHIFT UP! " + newAddresses[currentIndex]
+                    + " is not present in " + Arrays.toString(state) + ". INITIAL: " + Arrays.toString(oldAddresses)
+                    + ", FINAL: " + Arrays.toString(newAddresses);
+
+            if (newAddresses[targetIndex] == null) {
+                if (state[currentIndex] == null) {
+                    log("SHIFT UP %s from old addresses index: %d to index: %d", state[targetIndex], targetIndex, currentIndex);
+                    callback.migrate(state[currentIndex], currentIndex, -1, state[targetIndex], targetIndex, currentIndex);
+                    state[currentIndex] = state[targetIndex];
+                } else {
+                    int newIndex = getReplicaIndex(newAddresses, state[currentIndex]);
+                    if (newIndex == -1) {
+                        log("SHIFT UP %s from old addresses index: %d to index: %d with source: %s",
+                                state[targetIndex], targetIndex, currentIndex, state[currentIndex]);
+                        callback.migrate(state[currentIndex], currentIndex, -1, state[targetIndex], targetIndex, currentIndex);
+                        state[currentIndex] = state[targetIndex];
+                    } else if (state[newIndex] == null) {
+                        // SHIFT UP + SHIFT DOWN
+                        log("SHIFT UP %s from old addresses index: %d to index: %d AND SHIFT DOWN %s to index: %d",
+                                state[targetIndex], targetIndex, currentIndex, state[currentIndex], newIndex);
+                        callback.migrate(state[currentIndex], currentIndex, newIndex, state[targetIndex], targetIndex,
+                                currentIndex);
+                        state[newIndex] = state[currentIndex];
+                        state[currentIndex] = state[targetIndex];
+                    } else {
+                        // only SHIFT UP because source will come back with another move migration
+                        log("SHIFT UP %s from old addresses index: %d to index: %d with source: %s will get "
+                                        + "another MOVE migration to index: %d", state[targetIndex], targetIndex, currentIndex,
+                                state[currentIndex], newIndex);
+                        callback.migrate(state[currentIndex], currentIndex, -1, state[targetIndex], targetIndex, currentIndex);
+                        state[currentIndex] = state[targetIndex];
+                    }
+                }
+                state[targetIndex] = null;
+                break;
+            } else if (getReplicaIndex(state, newAddresses[targetIndex]) == -1) {
+                // MOVE partition replica from its old owner to new owner
+                log("MOVE-2 %s  to index: %d", newAddresses[targetIndex], targetIndex);
+                callback.migrate(state[targetIndex], targetIndex, -1, newAddresses[targetIndex], -1, targetIndex);
+                state[targetIndex] = newAddresses[targetIndex];
+                break;
+            } else {
+                // newAddresses[targetIndex] is also present in old partition replicas
+                currentIndex = targetIndex;
+            }
+        }
     }
 
     /**
@@ -291,8 +293,8 @@ class MigrationPlanner {
                 }
                 assert verificationSet.add(address)
                         : "Migration decision algorithm failed! DUPLICATE REPLICA ADDRESSES! INITIAL: " + Arrays
-                                .toString(oldAddresses) + ", CURRENT: " + Arrays.toString(state) + ", FINAL: " + Arrays
-                                .toString(newAddresses);
+                        .toString(oldAddresses) + ", CURRENT: " + Arrays.toString(state) + ", FINAL: " + Arrays
+                        .toString(newAddresses);
             }
         } finally {
             verificationSet.clear();
@@ -316,7 +318,6 @@ class MigrationPlanner {
                 return true;
             }
         }
-
         return false;
     }
 
@@ -340,7 +341,6 @@ class MigrationPlanner {
                 cyclic = true;
             }
         }
-
         return cyclic;
     }
 


### PR DESCRIPTION
We saw some recent C2 CompilerThread failures while optimizing this method. This change splits up the method, so it's easier to analyze by the JDK.

I think this is also better readable for human beings, since we don't have do deal with `i`, `j` and `k` in the pulled out method anymore.

See https://github.com/hazelcast/hazelcast/pull/13199#issuecomment-392704079