### PR TITLE
[BACKPORT] Collection of test fixes for Windows

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/HotRestartPersistenceConfig.java
@@ -203,17 +203,16 @@ public class HotRestartPersistenceConfig {
     }
 
     @Override
-    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public final boolean equals(Object o) {
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof HotRestartPersistenceConfig)) {
+        if (!(o instanceof HotRestartPersistenceConfig)) {
             return false;
         }
 
         HotRestartPersistenceConfig that = (HotRestartPersistenceConfig) o;
-
         if (enabled != that.enabled) {
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
@@ -69,14 +69,12 @@ public final class OperatingSystemMetricSet {
         );
     }
 
-    // This method doesn't depend on the OperatingSystemMXBean so it can be tested. Due to not knowing
-    // the exact OperatingSystemMXBean class it is very difficult to get this class tested.
     static void registerMethod(MetricsRegistry metricsRegistry, Object osBean, String methodName, String name) {
         registerMethod(metricsRegistry, osBean, methodName, name, 1);
     }
 
-    private static void registerMethod(MetricsRegistry metricsRegistry, Object osBean, String methodName,
-            String name, final long multiplier) {
+    private static void registerMethod(MetricsRegistry metricsRegistry, Object osBean, String methodName, String name,
+                                       final long multiplier) {
         final Method method = getMethod(osBean, methodName);
 
         if (method == null) {
@@ -84,21 +82,19 @@ public final class OperatingSystemMetricSet {
         }
 
         if (long.class.equals(method.getReturnType())) {
-            metricsRegistry.register(osBean, name, MANDATORY,
-                    new LongProbeFunction() {
-                        @Override
-                        public long get(Object bean) throws Exception {
-                            return (Long) method.invoke(bean, EMPTY_ARGS) * multiplier;
-                        }
-                    });
+            metricsRegistry.register(osBean, name, MANDATORY, new LongProbeFunction() {
+                @Override
+                public long get(Object bean) throws Exception {
+                    return (Long) method.invoke(bean, EMPTY_ARGS) * multiplier;
+                }
+            });
         } else {
-            metricsRegistry.register(osBean, name, MANDATORY,
-                    new DoubleProbeFunction() {
-                        @Override
-                        public double get(Object bean) throws Exception {
-                            return (Double) method.invoke(bean, EMPTY_ARGS) * multiplier;
-                        }
-                    });
+            metricsRegistry.register(osBean, name, MANDATORY, new DoubleProbeFunction() {
+                @Override
+                public double get(Object bean) throws Exception {
+                    return (Double) method.invoke(bean, EMPTY_ARGS) * multiplier;
+                }
+            });
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -273,8 +273,8 @@ public class ConfigXmlGeneratorTest {
                 .setClusterDataRecoveryPolicy(HotRestartClusterDataRecoveryPolicy.FULL_RECOVERY_ONLY)
                 .setValidationTimeoutSeconds(100)
                 .setDataLoadTimeoutSeconds(130)
-                .setBaseDir(new File("/nonexisting-base"))
-                .setBackupDir(new File("/nonexisting-backup"))
+                .setBaseDir(new File("nonExisting-base").getAbsoluteFile())
+                .setBackupDir(new File("nonExisting-backup").getAbsoluteFile())
                 .setParallelism(5);
 
         HotRestartPersistenceConfig actualConfig = getNewConfigViaXMLGenerator(cfg).getHotRestartPersistenceConfig();

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1524,6 +1524,10 @@ public abstract class HazelcastTestSupport {
         assumeFalse("Zing JDK6 used", JAVA_VERSION.startsWith("1.6.") && JVM_NAME.startsWith("Zing"));
     }
 
+    public static void assumeThatNoWindowsOS() {
+        assumeFalse(System.getProperty("os.name").toLowerCase().contains("windows"));
+    }
+
     /**
      * Throws {@link org.junit.AssumptionViolatedException} if two new Objects have the same hashCode (e.g. when running tests
      * with static hashCode ({@code -XX:hashCode=2}).

--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@
                         -Dhazelcast.phone.home.enabled=false
                         -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.test.use.network=false
+                        -Dlog4j.skipJansi=true
                         ${extraVmArgs}
                     </argLine>
                     <includes>
@@ -290,6 +291,7 @@
                         -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.logging.type=none
                         -Dhazelcast.test.use.network=true
+                        -Dlog4j.skipJansi=true
                         ${extraVmArgs}
                     </argLine>
                     <useManifestOnlyJar>false</useManifestOnlyJar>
@@ -344,6 +346,7 @@
                                         -Dhazelcast.test.use.network=false
                                         -Dhazelcast.test.multiple.jvm=true
                                         -Dlog4j.configurationFile=log4j2-info.xml
+                                        -Dlog4j.skipJansi=true
                                         ${extraVmArgs}
                                     </argLine>
                                     <includes>
@@ -383,6 +386,7 @@
                                         -Dhazelcast.logging.type=none
                                         -Dhazelcast.test.use.network=false
                                         -Dlog4j.configurationFile=log4j2-info.xml
+                                        -Dlog4j.skipJansi=true
                                         ${extraVmArgs}
                                     </argLine>
                                     <includes>
@@ -433,6 +437,7 @@
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <includes>
@@ -470,6 +475,7 @@
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <useManifestOnlyJar>false</useManifestOnlyJar>
@@ -571,9 +577,9 @@
                     -Dhazelcast.mancenter.enabled=false
                     -Dhazelcast.logging.type=none
                     -Dhazelcast.test.use.network=false
-                    -Dlog4j.skipJansi=true
                     -Dhazelcast.operation.call.timeout.millis=120000
                     -Dhazelcast.graceful.shutdown.max.wait=240
+                    -Dlog4j.skipJansi=true
                     ${extraVmArgs}
                 </argLine>
             </properties>
@@ -648,6 +654,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <groups>
@@ -919,6 +926,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <useManifestOnlyJar>false</useManifestOnlyJar>
@@ -996,6 +1004,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
                                 -Dhazelcast.test.use.network=true
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <useManifestOnlyJar>false</useManifestOnlyJar>
@@ -1038,6 +1047,7 @@
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <includes>
@@ -1094,6 +1104,7 @@
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
                                 -Dhazelcast.test.sample.serialized.objects=${target.dir}/serialized-objects-${project.version}-
+                                -Dlog4j.skipJansi=true
                                 ${extraVmArgs}
                             </argLine>
                             <includes>


### PR DESCRIPTION
I could cherry-pick all PRs from master without merge conflicts, beside the `IOUtilsTest`. I had to remove the `touch()` tests there (since that method is in `master` only) and re-add some `throws Exceptions` for the `compress()` and `decompress()` methods. Beside that the test is the same like in master though.

This should fix all known Windows test failures in the maintenance branch.