### PR TITLE
[WIP] Add stop state to WAN publisher

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
@@ -53,11 +53,22 @@ public interface LocalWanPublisherStats extends JsonSerializable {
     int getOutboundQueueSize();
 
     /**
-     * Returns if the wan replication on this member is paused
+     * Returns {@code true} if the WAN replication on this hazelcast instance
+     * is paused.
      *
-     * @return true the wan replication on this member is paused
+     * @return {@code true} if the WAN replication on this member is paused
+     * @see com.hazelcast.wan.WanReplicationService#pause(String, String)
      */
     boolean isPaused();
+
+    /**
+     * Returns {@code true} if the WAN replication on this hazelcast instance
+     * is stopped.
+     *
+     * @return {@code true} if the WAN replication on this member is stopped
+     * @see com.hazelcast.wan.WanReplicationService#stop(String, String)
+     */
+    boolean isStopped();
 
     /**
      * Returns the counter for the successfully transfered map WAN events.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
@@ -38,6 +38,7 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
 
     private volatile boolean connected;
     private volatile boolean paused;
+    private volatile boolean stopped;
     private volatile int outboundQueueSize;
     private volatile long totalPublishLatency;
     private volatile long totalPublishedEventCount;
@@ -69,6 +70,15 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
 
     public void setPaused(boolean paused) {
         this.paused = paused;
+    }
+
+    @Override
+    public boolean isStopped() {
+        return stopped;
+    }
+
+    public void setStopped(boolean stopped) {
+        this.stopped = stopped;
     }
 
     @Override
@@ -112,6 +122,7 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
         root.add("totalPublishedEventCount", totalPublishedEventCount);
         root.add("outboundQueueSize", outboundQueueSize);
         root.add("paused", paused);
+        root.add("stopped", stopped);
         return root;
     }
 
@@ -122,6 +133,7 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
         totalPublishedEventCount = getLong(json, "totalPublishedEventCount", -1);
         outboundQueueSize = getInt(json, "outboundQueueSize", -1);
         paused = getBoolean(json, "paused");
+        stopped = getBoolean(json, "stopped");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -52,20 +52,34 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
     void shutdown();
 
     /**
-     * Pauses wan replication to target group for the called node
+     * Pauses WAN replication for the given {@code wanReplicationName} and
+     * {@code targetGroupName} on this hazelcast instance.
      *
-     * @param name name of WAN replication configuration
-     * @param targetGroupName name of wan target cluster config
+     * @param wanReplicationName name of WAN replication configuration
+     * @param targetGroupName    WAN target cluster group name
+     * @throws UnsupportedOperationException if called on an OS instance
      */
-    void pause(String name, String targetGroupName);
+    void pause(String wanReplicationName, String targetGroupName);
 
     /**
-     * Resumes wan replication to target group for the called node.
+     * Stops WAN replication for the given {@code wanReplicationName} and
+     * {@code targetGroupName} on this hazelcast instance.
      *
-     * @param name name of WAN replication configuration
-     * @param targetGroupName name of wan target cluster config
+     * @param wanReplicationName name of WAN replication configuration
+     * @param targetGroupName    WAN target cluster group name
+     * @throws UnsupportedOperationException if called on an OS instance
      */
-    void resume(String name, String targetGroupName);
+    void stop(String wanReplicationName, String targetGroupName);
+
+    /**
+     * Resumes WAN replication for the given {@code wanReplicationName} and
+     * {@code targetGroupName} on this hazelcast instance.
+     *
+     * @param wanReplicationName name of WAN replication configuration
+     * @param targetGroupName    WAN target cluster group name
+     * @throws UnsupportedOperationException if called on an OS instance
+     */
+    void resume(String wanReplicationName, String targetGroupName);
 
     void checkWanReplicationQueues(String name);
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -107,13 +107,18 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
-    public void pause(String name, String targetGroupName) {
-        throw new UnsupportedOperationException("Pausing wan replication is not supported.");
+    public void pause(String wanReplicationName, String targetGroupName) {
+        throw new UnsupportedOperationException("Pausing WAN replication is not supported.");
     }
 
     @Override
-    public void resume(String name, String targetGroupName) {
-        throw new UnsupportedOperationException("Resuming wan replication is not supported");
+    public void stop(String wanReplicationName, String targetGroupName) {
+        throw new UnsupportedOperationException("Stopping WAN replication is not supported");
+    }
+
+    @Override
+    public void resume(String wanReplicationName, String targetGroupName) {
+        throw new UnsupportedOperationException("Resuming WAN replication is not supported");
     }
 
     @Override


### PR DESCRIPTION
The stop state allows the user to stop adding events to the WAN queues
in addition to the paused state where events are added but not polled.
The publisher may now also be started in STOPPED or PAUSED state.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2145