### PR TITLE
Add ability to WAN sync only entries updated in a certain time frame

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -137,6 +137,16 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
+    public void syncMap(String wanReplicationName, String targetGroupName, String mapName, long fromTimestamp, long toTimestamp) {
+        throw new UnsupportedOperationException("WAN sync for map is not supported.");
+    }
+
+    @Override
+    public void syncAllMaps(String wanReplicationName, String targetGroupName, long fromTimestamp, long toTimestamp) {
+        throw new UnsupportedOperationException("WAN sync is not supported.");
+    }
+
+    @Override
     public void clearQueues(String wanReplicationName, String targetGroupName) {
         throw new UnsupportedOperationException("Clearing WAN replication queues is not supported.");
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -224,6 +224,25 @@ public class HTTPCommunicator {
         return doPost(url, wanRepName, targetGroupName).response;
     }
 
+    public String syncMapOverWAN(String wanRepName,
+                                 String targetGroupName,
+                                 String mapName,
+                                 long fromTimestamp,
+                                 long toTimestamp) throws IOException {
+        String url = address + "mancenter/wan/sync/map";
+        return doPost(url, wanRepName, targetGroupName, mapName, String.valueOf(fromTimestamp), String.valueOf(toTimestamp))
+                .response;
+    }
+
+    public String syncMapsOverWAN(String wanRepName,
+                                  String targetGroupName,
+                                  long fromTimestamp,
+                                  long toTimestamp) throws IOException {
+        String url = address + "mancenter/wan/sync/allmaps";
+        return doPost(url, wanRepName, targetGroupName, String.valueOf(fromTimestamp), String.valueOf(toTimestamp))
+                .response;
+    }
+
     public String wanClearQueues(String wanRepName, String targetGroupName) throws IOException {
         String url = address + "mancenter/wan/clearWanQueues";
         return doPost(url, wanRepName, targetGroupName).response;


### PR DESCRIPTION
WAN sync always transferred all entries for all partitions. Sometimes
this is too much data and the user might roughly know the time frame for
which he wants to sync entries. For instance, this may be the case when
there was an outage and the user needs to sync only entries changes
during that outage.
We now add the ability to define the from and to timestamp when syncing
entries. The existing WAN sync (without timestamps) will continue to
work in mixed version clusters but trying to sync entries in a certain
time frame will pass the initial check and fail later. In a cluster
where all members support the timestamped WAN sync feature, there should
not be any failures.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2154