### PR TITLE
Add stop state to WAN publisher

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.spring;
 
-import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.CachePartitionLostListenerConfig;
 import com.hazelcast.config.CacheSimpleConfig;
@@ -53,6 +52,7 @@ import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.MapPartitionLostListenerConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.config.MultiMapConfig;
@@ -1018,9 +1018,9 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         final String nodeName = cleanNodeName(child);
                         if ("properties".equals(nodeName)) {
                             handleProperties(child, publisherBuilder);
-                        } else if ("queue-full-behavior".equals(nodeName)) {
-                            publisherBuilder.addPropertyValue(xmlToJavaName(nodeName), getTextContent(child));
-                        } else if ("queue-capacity".equals(nodeName)) {
+                        } else if ("queue-full-behavior".equals(nodeName)
+                                || "initial-publisher-state".equals(nodeName)
+                                || "queue-capacity".equals(nodeName)) {
                             publisherBuilder.addPropertyValue(xmlToJavaName(nodeName), getTextContent(child));
                         } else if ("aws".equals(nodeName)) {
                             handleAws(child, publisherBuilder);

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.9.xsd
@@ -2199,6 +2199,24 @@
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element name="queue-full-behavior" type="wan-queue-full-behavior" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="initial-publisher-state" type="initial-publisher-state" minOccurs="0" maxOccurs="1"
+                                    default="REPLICATING">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Defines the initial state in which a WAN publisher is started.
+                                    - REPLICATING (default):
+                                    State where both enqueuing new events is allowed, enqueued events are replicated to the target cluster
+                                    and WAN sync is enabled.
+                                    - PAUSED:
+                                    State where new events are enqueued but they are dequeued. Some events which have been dequeued before
+                                    the state was switched may still be replicated to the target cluster but further events will not be
+                                    replicated. WAN sync is enabled.
+                                    - STOPPED:
+                                    State where neither new events are enqueued nor dequeued. As with the PAUSED state, some events might
+                                    still be replicated after the publisher has switched to this state. WAN sync is enabled.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
                         <xs:element name="queue-capacity" type="parameterized-positive-integer" default="10000" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="aws" type="aws" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
@@ -3051,12 +3069,24 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="initial-publisher-state-format-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="REPLICATING"/>
+            <xs:enumeration value="PAUSED"/>
+            <xs:enumeration value="STOPPED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="wan-ack-type">
         <xs:union memberTypes="wan-ack-type-format-enum non-space-string"/>
     </xs:simpleType>
 
     <xs:simpleType name="wan-queue-full-behavior">
         <xs:union memberTypes="wan-queue-full-behavior-format-enum non-space-string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="initial-publisher-state">
+        <xs:union memberTypes="initial-publisher-state-format-enum non-space-string"/>
     </xs:simpleType>
 
     <xs:complexType name="hot-restart-persistence">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -73,6 +73,7 @@ import com.hazelcast.config.WANQueueFullBehavior;
 import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.config.WanConsumerConfig;
 import com.hazelcast.config.WanPublisherConfig;
+import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.EntryListener;
@@ -771,6 +772,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("tokyo", publisherConfig.getGroupName());
         assertEquals("com.hazelcast.enterprise.wan.replication.WanBatchReplication", publisherConfig.getClassName());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, publisherConfig.getQueueFullBehavior());
+        assertEquals(WanPublisherState.STOPPED, publisherConfig.getInitialPublisherState());
         assertEquals(1000, publisherConfig.getQueueCapacity());
         Map<String, Comparable> publisherProps = publisherConfig.getProperties();
         assertEquals("50", publisherProps.get("batch.size"));

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -61,6 +61,7 @@
             <hz:wan-replication name="testWan">
                 <hz:wan-publisher group-name="tokyo" class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">
                     <hz:queue-full-behavior>THROW_EXCEPTION</hz:queue-full-behavior>
+                    <hz:initial-publisher-state>STOPPED</hz:initial-publisher-state>
                     <hz:queue-capacity>1000</hz:queue-capacity>
                     <hz:properties>
                         <hz:property name="batch.size">50</hz:property>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -482,6 +482,7 @@ public class ConfigXmlGenerator {
                 gen.open("wan-publisher", "group-name", p.getGroupName())
                    .node("class-name", p.getClassName())
                    .node("queue-full-behavior", p.getQueueFullBehavior())
+                   .node("initial-publisher-state", p.getInitialPublisherState())
                    .node("queue-capacity", p.getQueueCapacity())
                    .appendProperties(p.getProperties());
                 awsConfigXmlGenerator(gen, p.getAwsConfig());

--- a/hazelcast/src/main/java/com/hazelcast/config/WANQueueFullBehavior.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WANQueueFullBehavior.java
@@ -56,9 +56,9 @@ public enum WANQueueFullBehavior {
     }
 
     /**
-     * Returns the EntryEventType as an enum.
+     * Returns the WANQueueFullBehavior as an enum.
      *
-     * @return the EntryEventType as an enum
+     * @return the WANQueueFullBehavior as an enum
      */
     public static WANQueueFullBehavior getByType(final int id) {
         for (WANQueueFullBehavior behavior : values()) {

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherState.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherState.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Defines the state in which a WAN publisher can be in if it is not shutting
+ * down.
+ */
+public enum WanPublisherState {
+    /**
+     * State where both enqueuing new events is allowed, enqueued events are
+     * replicated to the target cluster and WAN sync is enabled.
+     * The publisher is most often in REPLICATING state when the target cluster
+     * is operational.
+     */
+    REPLICATING((byte) 0, true, true),
+    /**
+     * State where new events are enqueued but they are dequeued. Some events
+     * which have been dequeued before the state was switched may still be
+     * replicated to the target cluster but further events will not be
+     * replicated. WAN sync is enabled.
+     * For instance, this state may be useful if you know that the target cluster
+     * is temporarily unavailable (is under maintenance) and that the WAN queues
+     * can hold as many events as is necessary to reconcile the state between
+     * two clusters once the target cluster becomes available.
+     */
+    PAUSED((byte) 1, true, false),
+    /**
+     * State where neither new events are enqueued nor dequeued. As with the
+     * {@link #PAUSED} state, some events might still be replicated after the
+     * publisher has switched to this state. WAN sync is enabled.
+     * For instance, this state may be useful if you know that the target cluster
+     * is being shut down, decomissioned and being put out of use and that it
+     * will never come back. In such cases, you may additionally clear the WAN
+     * queues to release the consumed heap after the publisher has been switched
+     * into this state.
+     * An another example would be starting a publisher in STOPPED state. This
+     * may be the case where you know that the target cluster is not initially
+     * available and will be unavailable for a definite period but at some point
+     * it will become available. Once it becomes available, you can then switch
+     * the publisher state to REPLICATING to begin replicating to that cluster.
+     *
+     * @see com.hazelcast.wan.WanReplicationService#clearQueues(String, String)
+     */
+    STOPPED((byte) 2, false, false);
+
+    private static final WanPublisherState[] STATE_VALUES = values();
+    private final boolean enqueueNewEvents;
+    private final boolean replicateEnqueuedEvents;
+    private final byte id;
+
+    WanPublisherState(byte id,
+                      boolean enqueueNewEvents,
+                      boolean replicateEnqueuedEvents) {
+        this.id = id;
+        this.enqueueNewEvents = enqueueNewEvents;
+        this.replicateEnqueuedEvents = replicateEnqueuedEvents;
+    }
+
+    /**
+     * Returns the WanPublisherState as an enum.
+     */
+    public static WanPublisherState getByType(final byte id) {
+        for (WanPublisherState state : STATE_VALUES) {
+            if (state.id == id) {
+                return state;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if this state allows enqueueing new events,
+     * {@code false} otherwise.
+     */
+    public boolean isEnqueueNewEvents() {
+        return enqueueNewEvents;
+    }
+
+    /**
+     * Returns {@code true} if this state allows dequeueing and replicating
+     * events, {@code false} otherwise.
+     */
+    public boolean isReplicateEnqueuedEvents() {
+        return replicateEnqueuedEvents;
+    }
+
+    /**
+     * Returns the ID of the WAN publisher state.
+     */
+    public byte getId() {
+        return id;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -569,6 +569,10 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         } else if ("queue-full-behavior".equals(targetChildName)) {
             String queueFullBehavior = getTextContent(targetChild);
             publisherConfig.setQueueFullBehavior(WANQueueFullBehavior.valueOf(upperCaseInternal(queueFullBehavior)));
+        } else if ("initial-publisher-state".equals(targetChildName)) {
+            String initialPublisherState = getTextContent(targetChild);
+            publisherConfig.setInitialPublisherState(
+                    WanPublisherState.valueOf(upperCaseInternal(initialPublisherState)));
         } else if ("queue-capacity".equals(targetChildName)) {
             int queueCapacity = getIntegerValue("queue-capacity", getTextContent(targetChild));
             publisherConfig.setQueueCapacity(queueCapacity);

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
@@ -17,6 +17,7 @@
 
 package com.hazelcast.monitor;
 
+import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.internal.management.JsonSerializable;
 import com.hazelcast.wan.impl.WanEventCounter.EventCounter;
 
@@ -53,11 +54,12 @@ public interface LocalWanPublisherStats extends JsonSerializable {
     int getOutboundQueueSize();
 
     /**
-     * Returns if the wan replication on this member is paused
+     * Returns the current {@link WanPublisherState} of this publisher.
      *
-     * @return true the wan replication on this member is paused
+     * @see com.hazelcast.wan.WanReplicationService#pause(String, String)
+     * @see com.hazelcast.wan.WanReplicationService#stop(String, String)
      */
-    boolean isPaused();
+    WanPublisherState getPublisherState();
 
     /**
      * Returns the counter for the successfully transfered map WAN events.

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -52,20 +52,34 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
     void shutdown();
 
     /**
-     * Pauses wan replication to target group for the called node
+     * Pauses WAN replication for the given {@code wanReplicationName} and
+     * {@code targetGroupName} on this hazelcast instance.
      *
-     * @param name name of WAN replication configuration
-     * @param targetGroupName name of wan target cluster config
+     * @param wanReplicationName name of WAN replication configuration
+     * @param targetGroupName    WAN target cluster group name
+     * @throws UnsupportedOperationException if called on an OS instance
      */
-    void pause(String name, String targetGroupName);
+    void pause(String wanReplicationName, String targetGroupName);
 
     /**
-     * Resumes wan replication to target group for the called node.
+     * Stops WAN replication for the given {@code wanReplicationName} and
+     * {@code targetGroupName} on this hazelcast instance.
      *
-     * @param name name of WAN replication configuration
-     * @param targetGroupName name of wan target cluster config
+     * @param wanReplicationName name of WAN replication configuration
+     * @param targetGroupName    WAN target cluster group name
+     * @throws UnsupportedOperationException if called on an OS instance
      */
-    void resume(String name, String targetGroupName);
+    void stop(String wanReplicationName, String targetGroupName);
+
+    /**
+     * Resumes WAN replication for the given {@code wanReplicationName} and
+     * {@code targetGroupName} on this hazelcast instance.
+     *
+     * @param wanReplicationName name of WAN replication configuration
+     * @param targetGroupName    WAN target cluster group name
+     * @throws UnsupportedOperationException if called on an OS instance
+     */
+    void resume(String wanReplicationName, String targetGroupName);
 
     void checkWanReplicationQueues(String name);
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -107,13 +107,18 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
-    public void pause(String name, String targetGroupName) {
-        throw new UnsupportedOperationException("Pausing wan replication is not supported.");
+    public void pause(String wanReplicationName, String targetGroupName) {
+        throw new UnsupportedOperationException("Pausing WAN replication is not supported.");
     }
 
     @Override
-    public void resume(String name, String targetGroupName) {
-        throw new UnsupportedOperationException("Resuming wan replication is not supported");
+    public void stop(String wanReplicationName, String targetGroupName) {
+        throw new UnsupportedOperationException("Stopping WAN replication is not supported");
+    }
+
+    @Override
+    public void resume(String wanReplicationName, String targetGroupName) {
+        throw new UnsupportedOperationException("Resuming WAN replication is not supported");
     }
 
     @Override

--- a/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.9.xsd
@@ -2072,6 +2072,24 @@
             </xs:element>
             <xs:element name="queue-capacity" type="xs:integer" default="10000" minOccurs="0" maxOccurs="1"/>
             <xs:element name="queue-full-behavior" type="wan-queue-full-behavior" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="initial-publisher-state" type="initial-publisher-state" minOccurs="0" maxOccurs="1"
+                        default="REPLICATING">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines the initial state in which a WAN publisher is started.
+                        - REPLICATING (default):
+                        State where both enqueuing new events is allowed, enqueued events are replicated to the target cluster
+                        and WAN sync is enabled.
+                        - PAUSED:
+                        State where new events are enqueued but they are dequeued. Some events which have been dequeued before
+                        the state was switched may still be replicated to the target cluster but further events will not be
+                        replicated. WAN sync is enabled.
+                        - STOPPED:
+                        State where neither new events are enqueued nor dequeued. As with the PAUSED state, some events might
+                        still be replicated after the publisher has switched to this state. WAN sync is enabled.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="aws" type="aws" minOccurs="0" maxOccurs="1"/>
             <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
             <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
@@ -3274,6 +3292,14 @@
             <xs:enumeration value="DISCARD_AFTER_MUTATION"/>
             <xs:enumeration value="THROW_EXCEPTION"/>
             <xs:enumeration value="THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="initial-publisher-state">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="REPLICATING"/>
+            <xs:enumeration value="PAUSED"/>
+            <xs:enumeration value="STOPPED"/>
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -152,6 +152,18 @@ https://hazelcast.org/documentation/.
         - THROW_EXCEPTION:
             The WAN queue size is checked before each supported mutating operation. If one of the queues of the target
             cluster is full, WANReplicationQueueFullException is thrown and the operation is not allowed.
+        * <initial-publisher-state>:
+        Defines the initial state in which a WAN publisher is started.
+        - REPLICATING (default):
+            State where both enqueuing new events is allowed, enqueued events are replicated to the target cluster
+            and WAN sync is enabled.
+        - PAUSED:
+            State where new events are enqueued but they are dequeued. Some events which have been dequeued before
+            the state was switched may still be replicated to the target cluster but further events will not be
+            replicated. WAN sync is enabled.
+        - STOPPED:
+            State where neither new events are enqueued nor dequeued. As with the PAUSED state, some events might
+            still be replicated after the publisher has switched to this state. WAN sync is enabled.
         * <aws>:
             Set its "enabled" attribute to true for discovery within Amazon EC2. It has the following sub-elements:
             - <access-key>:
@@ -203,6 +215,7 @@ https://hazelcast.org/documentation/.
             <class-name>com.hazelcast.enterprise.wan.replication.WanBatchReplication</class-name>
             <queue-capacity>15000</queue-capacity>
             <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>
+            <initial-publisher-state>REPLICATING</initial-publisher-state>
             <properties>
                 <property name="endpoints">10.3.5.1:5701,10.3.5.2:5701</property>
                 <property name="batch.size">1000</property>

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -837,6 +837,7 @@ class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.getGroupName(), c2.getGroupName())
                     && nullSafeEqual(c1.getQueueCapacity(), c2.getQueueCapacity())
                     && nullSafeEqual(c1.getQueueFullBehavior(), c2.getQueueFullBehavior())
+                    && nullSafeEqual(c1.getInitialPublisherState(), c2.getInitialPublisherState())
                     && new AwsConfigChecker().check(c1.getAwsConfig(), c2.getAwsConfig())
                     && new DiscoveryConfigChecker().check(c1.getDiscoveryConfig(), c2.getDiscoveryConfig())
                     && nullSafeEqual(c1.getClassName(), c2.getClassName())

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -275,6 +275,7 @@ public class ConfigXmlGeneratorTest {
                 .setGroupName("dummyGroup")
                 .setClassName("dummyClass")
                 .setAwsConfig(getDummyAwsConfig())
+                .setInitialPublisherState(WanPublisherState.STOPPED)
                 .setDiscoveryConfig(getDummyDiscoveryConfig());
         wanConfig.setWanPublisherConfigs(Collections.singletonList(publisherConfig));
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1199,6 +1199,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 "      <wan-publisher group-name=\"ankara\">\n" +
                 "         <class-name>com.hazelcast.wan.custom.WanPublisher</class-name>\n" +
                 "         <queue-full-behavior>THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE</queue-full-behavior>\n" +
+                "         <initial-publisher-state>STOPPED</initial-publisher-state>\n" +
                 "      </wan-publisher>\n" +
                 "      <wan-consumer>\n" +
                 "         <class-name>com.hazelcast.wan.custom.WanConsumer</class-name>\n" +
@@ -1219,6 +1220,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("istanbul", publisherConfig1.getGroupName());
         assertEquals("com.hazelcast.wan.custom.WanPublisher", publisherConfig1.getClassName());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, publisherConfig1.getQueueFullBehavior());
+        assertEquals(WanPublisherState.REPLICATING, publisherConfig1.getInitialPublisherState());
         assertEquals(21, publisherConfig1.getQueueCapacity());
         Map<String, Comparable> pubProperties = publisherConfig1.getProperties();
         assertEquals("prop.publisher", pubProperties.get("custom.prop.publisher"));
@@ -1231,6 +1233,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         WanPublisherConfig publisherConfig2 = publisherConfigs.get(1);
         assertEquals("ankara", publisherConfig2.getGroupName());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, publisherConfig2.getQueueFullBehavior());
+        assertEquals(WanPublisherState.STOPPED, publisherConfig2.getInitialPublisherState());
 
         WanConsumerConfig consumerConfig = wanConfig.getWanConsumerConfig();
         assertEquals("com.hazelcast.wan.custom.WanConsumer", consumerConfig.getClassName());

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -60,6 +60,7 @@
             <class-name>com.hazelcast.enterprise.wan.replication.WanBatchReplication</class-name>
             <queue-capacity>1000</queue-capacity>
             <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>
+            <initial-publisher-state>REPLICATING</initial-publisher-state>
             <properties>
                 <property name="batch.size">50</property>
                 <property name="batch.max.delay.millis">3000</property>
@@ -74,6 +75,7 @@
         <wan-publisher group-name="istanbul">
             <class-name>com.hazelcast.wan.custom.WanPublisher</class-name>
             <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>
+            <initial-publisher-state>STOPPED</initial-publisher-state>
             <queue-capacity>10000</queue-capacity>
             <aws enabled="false" connection-timeout-seconds="10">
                 <access-key>sample-access-key</access-key>


### PR DESCRIPTION
The stop state allows the user to stop adding events to the WAN queues
in addition to the paused state where events are added but not polled.
The publisher may now also be started in STOPPED or PAUSED state.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2152