### PR TITLE
Native address null check should be done using `address != 0`

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArrayBase.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArrayBase.java
@@ -75,7 +75,7 @@ public abstract class HashSlotArrayBase implements HashSlotArray {
      * Base address of the memory region containing the hash slots. Preceded by a header that stores metadata
      * ({@code capacity}, {@code size}, and {@code expandAt}).
      */
-    private long baseAddress;
+    private long baseAddress = HEADER_SIZE;
 
     /**
      * The initial capacity of a newly created array.
@@ -325,8 +325,8 @@ public abstract class HashSlotArrayBase implements HashSlotArray {
     }
 
     protected final void assertValid() {
-        assert baseAddress >= HEADER_SIZE : "This instance doesn't point to a valid hashtable. Base address = "
-                + baseAddress;
+        assert baseAddress - HEADER_SIZE != NULL_ADDRESS
+                : "This instance doesn't point to a valid hashtable. Base address = " + baseAddress;
     }
 
     protected final MemoryAllocator malloc() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray12byteKeyImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray12byteKeyImplTest.java
@@ -369,7 +369,7 @@ public class HashSlotArray12byteKeyImplTest {
 
     private long insert(long key1, int key2) {
         final long valueAddress = hsa.ensure(key1, key2);
-        assertTrue(valueAddress > 0);
+        assertNotEquals(NULL_ADDRESS, valueAddress);
         // Value length must be at least 16 bytes
         mem.putLong(valueAddress, key1);
         mem.putInt(valueAddress + 8L, key2);

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray16byteKeyImplTest.java
@@ -400,7 +400,7 @@ public class HashSlotArray16byteKeyImplTest {
 
     private long insert(long key1, long key2) {
         final long valueAddress = hsa.ensure(key1, key2);
-        assertTrue(valueAddress > 0);
+        assertNotEquals(NULL_ADDRESS, valueAddress);
         // Value length must be at least 16 bytes
         mem.putLong(valueAddress, key1);
         mem.putLong(valueAddress + 8L, key2);

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/hashslot/impl/HashSlotArray8byteKeyImplTest.java
@@ -305,7 +305,7 @@ public class HashSlotArray8byteKeyImplTest {
 
     private long insert(long key) {
         final long valueAddress = hsa.ensure(key);
-        assertTrue(valueAddress > 0);
+        assertNotEquals(NULL_ADDRESS, valueAddress);
         mem.putLong(valueAddress, key);
         return valueAddress;
     }


### PR DESCRIPTION
Native address is an unsigned number. Address should be considered
`NULL` only when `address == 0`.

Fixes hazelcast/hazelcast-enterprise#2150

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2155