### PR TITLE
moved parameter creation part into another method at PhoneHome - related to OEM changes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -111,7 +111,7 @@ public class DefaultNodeExtension implements NodeExtension {
     protected final ILogger logger;
     protected final ILogger systemLogger;
     protected final List<ClusterVersionListener> clusterVersionListeners = new CopyOnWriteArrayList<ClusterVersionListener>();
-    private final PhoneHome phoneHome;
+    protected PhoneHome phoneHome;
 
     private final MemoryStats memoryStats = new DefaultMemoryStats();
 
@@ -120,7 +120,7 @@ public class DefaultNodeExtension implements NodeExtension {
         this.logger = node.getLogger(NodeExtension.class);
         this.systemLogger = node.getLogger("com.hazelcast.system");
         checkSecurityAllowed();
-        this.phoneHome = new PhoneHome(node);
+        createAndSetPhoneHome();
     }
 
     private void checkSecurityAllowed() {
@@ -459,5 +459,9 @@ public class DefaultNodeExtension implements NodeExtension {
     @Override
     public void sendPhoneHome() {
         phoneHome.check(node);
+    }
+
+    public void createAndSetPhoneHome() {
+        this.phoneHome = new PhoneHome(node);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -461,7 +461,7 @@ public class DefaultNodeExtension implements NodeExtension {
         phoneHome.check(node);
     }
 
-    public void createAndSetPhoneHome() {
+    protected void createAndSetPhoneHome() {
         this.phoneHome = new PhoneHome(node);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -87,6 +87,7 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.ByteArrayProcessor;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.ExceptionUtil;
+import com.hazelcast.util.PhoneHome;
 import com.hazelcast.util.Preconditions;
 import com.hazelcast.util.UuidUtil;
 import com.hazelcast.util.function.Supplier;
@@ -110,6 +111,7 @@ public class DefaultNodeExtension implements NodeExtension {
     protected final ILogger logger;
     protected final ILogger systemLogger;
     protected final List<ClusterVersionListener> clusterVersionListeners = new CopyOnWriteArrayList<ClusterVersionListener>();
+    private final PhoneHome phoneHome;
 
     private final MemoryStats memoryStats = new DefaultMemoryStats();
 
@@ -118,6 +120,7 @@ public class DefaultNodeExtension implements NodeExtension {
         this.logger = node.getLogger(NodeExtension.class);
         this.systemLogger = node.getLogger("com.hazelcast.system");
         checkSecurityAllowed();
+        this.phoneHome = new PhoneHome(node);
     }
 
     private void checkSecurityAllowed() {
@@ -287,6 +290,9 @@ public class DefaultNodeExtension implements NodeExtension {
     @Override
     public void shutdown() {
         logger.info("Destroying node NodeExtension.");
+        if (phoneHome != null) {
+            phoneHome.shutdown();
+        }
     }
 
     @Override
@@ -448,5 +454,10 @@ public class DefaultNodeExtension implements NodeExtension {
     @Override
     public TextCommandService createTextCommandService() {
         return new TextCommandServiceImpl(node);
+    }
+
+    @Override
+    public void sendPhoneHome() {
+        phoneHome.check(node);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -78,7 +78,6 @@ import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.FutureUtil;
-import com.hazelcast.util.PhoneHome;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -147,8 +147,6 @@ public class Node {
 
     private final NodeShutdownHookThread shutdownHookThread;
 
-    private final PhoneHome phoneHome = new PhoneHome();
-
     private final InternalSerializationService serializationService;
 
     private final ClassLoader configClassLoader;
@@ -411,7 +409,7 @@ public class Node {
             logger.warning("ManagementCenterService could not be constructed!", e);
         }
         nodeExtension.afterStart();
-        phoneHome.check(this, getBuildInfo().getVersion(), buildInfo.isEnterprise());
+        nodeExtension.sendPhoneHome();
         healthMonitor.start();
     }
 
@@ -497,7 +495,7 @@ public class Node {
         if (nodeExtension != null) {
             nodeExtension.beforeShutdown();
         }
-        phoneHome.shutdown();
+
         if (managementCenterService != null) {
             managementCenterService.shutdown();
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -273,4 +273,9 @@ public interface NodeExtension {
      * @param diagnostics the diagnostics on which plugins should be registered
      */
     void registerPlugins(Diagnostics diagnostics);
+
+    /**
+     * Send PhoneHome ping from OS or EE instance to PhoneHome application
+     */
+    void sendPhoneHome();
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -76,11 +76,8 @@ public class PhoneHome {
     private static final String FALSE = "false";
 
     volatile ScheduledFuture<?> phoneHomeFuture;
-    ILogger logger;
+    private ILogger logger;
     private final BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
-
-    public PhoneHome() {
-    }
 
     public PhoneHome(Node hazelcastNode) {
         logger = hazelcastNode.getLogger(PhoneHome.class);
@@ -88,7 +85,6 @@ public class PhoneHome {
 
     @SuppressWarnings("deprecation")
     public void check(final Node hazelcastNode) {
-        ILogger logger = hazelcastNode.getLogger(PhoneHome.class);
         if (!hazelcastNode.getProperties().getBoolean(GroupProperty.VERSION_CHECK_ENABLED)) {
             logger.warning(GroupProperty.VERSION_CHECK_ENABLED.getName() + " property is deprecated. Please use "
                     + GroupProperty.PHONE_HOME_ENABLED.getName() + " instead to disable phone home.");
@@ -185,7 +181,7 @@ public class PhoneHome {
         return parameterCreator;
     }
 
-    public String getDownloadId() {
+    private String getDownloadId() {
         String downloadId = "source";
         InputStream is = null;
         try {

--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -76,7 +76,7 @@ public class PhoneHome {
     private static final String FALSE = "false";
 
     volatile ScheduledFuture<?> phoneHomeFuture;
-    private ILogger logger;
+    private final ILogger logger;
     private final BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
 
     public PhoneHome(Node hazelcastNode) {

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -240,4 +240,8 @@ public class SamplingNodeExtension implements NodeExtension {
     public TextCommandService createTextCommandService() {
         return nodeExtension.createTextCommandService();
     }
+
+    @Override
+    public void sendPhoneHome() {
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.util;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.Node;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -51,20 +52,21 @@ public class PhoneHomeTest extends HazelcastTestSupport {
     public void testPhoneHomeParameters() {
         HazelcastInstance hz = createHazelcastInstance();
         Node node = getNode(hz);
-        PhoneHome phoneHome = new PhoneHome();
+        PhoneHome phoneHome = new PhoneHome(node);
 
         sleepAtLeastMillis(1);
-        Map<String, String> parameters = phoneHome.phoneHome(node, "test_version", false);
+        Map<String, String> parameters = phoneHome.phoneHome(node);
         RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
         OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
-        assertEquals(parameters.get("version"), "test_version");
+        assertEquals(parameters.get("version"), BuildInfoProvider.getBuildInfo().getVersion());
         assertEquals(parameters.get("m"), node.getLocalMember().getUuid());
-        assertEquals(parameters.get("e"), "false");
-        assertEquals(parameters.get("l"), "");
+        assertEquals(parameters.get("e"), null);
+        assertEquals(parameters.get("oem"), null);
+        assertEquals(parameters.get("l"), null);
+        assertEquals(parameters.get("hdgb"), null);
         assertEquals(parameters.get("p"), "source");
         assertEquals(parameters.get("crsz"), "A");
         assertEquals(parameters.get("cssz"), "A");
-        assertEquals(parameters.get("hdgb"), "0");
         assertEquals(parameters.get("ccpp"), "0");
         assertEquals(parameters.get("cdn"), "0");
         assertEquals(parameters.get("cjv"), "0");
@@ -94,10 +96,10 @@ public class PhoneHomeTest extends HazelcastTestSupport {
 
         HazelcastInstance hz = createHazelcastInstance(config);
         Node node = getNode(hz);
-        PhoneHome phoneHome = new PhoneHome();
+        PhoneHome phoneHome = new PhoneHome(node);
 
         sleepAtLeastMillis(1);
-        Map<String, String> parameters = phoneHome.phoneHome(node, "test_version", false);
+        Map<String, String> parameters = phoneHome.phoneHome(node);
         assertEquals(parameters.get("mcver"), "MC_NOT_AVAILABLE");
         assertEquals(parameters.get("mclicense"), "MC_NOT_AVAILABLE");
     }
@@ -111,8 +113,8 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         HazelcastInstance hz = createHazelcastInstance(config);
         Node node = getNode(hz);
 
-        PhoneHome phoneHome = new PhoneHome();
-        phoneHome.check(node, "test_version", false);
+        PhoneHome phoneHome = new PhoneHome(node);
+        phoneHome.check(node);
         assertNull(phoneHome.phoneHomeFuture);
     }
 
@@ -124,8 +126,8 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         HazelcastInstance hz = createHazelcastInstance(config);
         Node node = getNode(hz);
 
-        PhoneHome phoneHome = new PhoneHome();
-        phoneHome.check(node, "test_version", false);
+        PhoneHome phoneHome = new PhoneHome(node);
+        phoneHome.check(node);
         assertNull(phoneHome.phoneHomeFuture);
     }
 
@@ -139,8 +141,8 @@ public class PhoneHomeTest extends HazelcastTestSupport {
         HazelcastInstance hz = createHazelcastInstance(config);
         Node node = getNode(hz);
 
-        PhoneHome phoneHome = new PhoneHome();
-        phoneHome.check(node, "test_version", false);
+        PhoneHome phoneHome = new PhoneHome(node);
+        phoneHome.check(node);
         assertNotNull(phoneHome.phoneHomeFuture);
         assertFalse(phoneHome.phoneHomeFuture.isDone());
         assertFalse(phoneHome.phoneHomeFuture.isCancelled());

--- a/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
@@ -153,7 +153,9 @@ public class PhoneHomeTest extends HazelcastTestSupport {
 
     @Test
     public void testConvertToLetter() {
-        PhoneHome phoneHome = new PhoneHome();
+        HazelcastInstance hz = createHazelcastInstance();
+        Node node = getNode(hz);
+        PhoneHome phoneHome = new PhoneHome(node);
         assertEquals("A", phoneHome.convertToLetter(4));
         assertEquals("B", phoneHome.convertToLetter(9));
         assertEquals("C", phoneHome.convertToLetter(19));


### PR DESCRIPTION
To override createParameters() at EE side easily and avoid two ping mechanism(both os and ee sides), I have created sendPhoneHome() at NodeExtension class.

call-home counterpart --> https://github.com/hazelcast/callhome/pull/10
ee counterpart --> https://github.com/hazelcast/hazelcast-enterprise/pull/2157