### PR TITLE
Reset local metadata of partition upon run of clear-all operation.

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapInvalidationMemberAddRemoveTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapInvalidationMemberAddRemoveTest.java
@@ -50,10 +50,10 @@ import static org.junit.Assert.assertEquals;
 public class ClientMapInvalidationMemberAddRemoveTest extends NearCacheTestSupport {
 
     private static final int TEST_RUN_SECONDS = 30;
-    private static final int KEY_COUNT = 100000;
-    private static final int INVALIDATION_BATCH_SIZE = 10000;
+    private static final int KEY_COUNT = 1000;
+    private static final int INVALIDATION_BATCH_SIZE = 100;
     private static final int RECONCILIATION_INTERVAL_SECS = 30;
-    private static final int NEAR_CACHE_POPULATE_THREAD_COUNT = 3;
+    private static final int NEAR_CACHE_POPULATE_THREAD_COUNT = 5;
 
     private final TestHazelcastFactory factory = new TestHazelcastFactory();
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -427,14 +427,6 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         invalidateEntry(key, SOURCE_NOT_AVAILABLE);
     }
 
-    protected void invalidateAllEntries() {
-        invalidateAllEntries(SOURCE_NOT_AVAILABLE);
-    }
-
-    protected void invalidateAllEntries(String source) {
-        invalidateEntry(null, source);
-    }
-
     protected void updateGetAndPutStat(boolean isPutSucceed, boolean getValue, boolean oldValueNull, long start) {
         if (isStatisticsEnabled()) {
             if (isPutSucceed) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventHandler.java
@@ -128,6 +128,10 @@ public class CacheEventHandler {
         }
     }
 
+    public void resetPartitionMetaData(String name, int partitionId) {
+        invalidator.resetPartitionMetaData(name, partitionId);
+    }
+
     public void destroy(String name, String sourceUuid) {
         invalidator.destroy(name, sourceUuid);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearOperation.java
@@ -71,12 +71,15 @@ public class CacheClearOperation
     public void afterRun() throws Exception {
         super.afterRun();
 
+        CacheService cacheService = getService();
+        int partitionId = getPartitionId();
+
         IPartitionService partitionService = getNodeEngine().getPartitionService();
-        if (partitionService.getPartitionId(name) == getPartitionId()) {
-            CacheService cacheService = getService();
+        if (partitionService.getPartitionId(name) == partitionId) {
             cacheService.sendInvalidationEvent(name, null, SOURCE_NOT_AVAILABLE);
         }
 
+        cacheService.getCacheEventHandler().resetPartitionMetaData(name, partitionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/Invalidator.java
@@ -89,6 +89,12 @@ public abstract class Invalidator {
         return metaDataGenerator;
     }
 
+    public final void resetPartitionMetaData(String dataStructureName, int partitionId) {
+        MetaDataGenerator metaDataGenerator = getMetaDataGenerator();
+        metaDataGenerator.regenerateUuid(partitionId);
+        metaDataGenerator.resetSequence(dataStructureName, partitionId);
+    }
+
     private Invalidation newKeyInvalidation(Data key, String dataStructureName, String sourceUuid) {
         int partitionId = getPartitionId(key);
         return newInvalidation(key, dataStructureName, sourceUuid, partitionId);

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/invalidation/MetaDataGenerator.java
@@ -37,7 +37,6 @@ import static com.hazelcast.util.UuidUtil.newUnsecureUUID;
  */
 public class MetaDataGenerator {
 
-
     private final int partitionCount;
     private final ConstructorFunction<String, AtomicLongArray> sequenceGeneratorConstructor
             = new ConstructorFunction<String, AtomicLongArray>() {
@@ -110,6 +109,10 @@ public class MetaDataGenerator {
 
     public void regenerateUuid(int partitionId) {
         uuids.put(partitionId, uuidConstructor.createNew(partitionId));
+    }
+
+    public void resetSequence(String name, int partitionId) {
+        sequenceGenerator(name).set(partitionId, 0);
     }
 
     // used for testing

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -127,13 +127,17 @@ public abstract class MapOperation extends AbstractNamedOperation implements Ide
      * This method helps to add clearing Near Cache event only from one-partition which matches partitionId of the map name.
      */
     protected final void invalidateAllKeysInNearCaches() {
-        if (!mapContainer.hasInvalidationListener()
-                || getPartitionId() != getNodeEngine().getPartitionService().getPartitionId(name)) {
-            return;
-        }
+        if (mapContainer.hasInvalidationListener()) {
 
-        Invalidator invalidator = getNearCacheInvalidator();
-        invalidator.invalidateAllKeys(name, getCallerUuid());
+            int partitionId = getPartitionId();
+            Invalidator invalidator = getNearCacheInvalidator();
+
+            if (partitionId == getNodeEngine().getPartitionService().getPartitionId(name)) {
+                invalidator.invalidateAllKeys(name, getCallerUuid());
+            }
+
+            invalidator.resetPartitionMetaData(name, getPartitionId());
+        }
     }
 
     private Invalidator getNearCacheInvalidator() {


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/13210

__ABOUT FIX:__
Clear operation runs on every partition but only creates invalidation
on the owner partition of data-structures name. If this owner is on a
suddenly killed node and if there is a running clear operation on the
cluster at the same time, we can be in a situation that no invalidation is
generated because the owner partition of data-structures name was on
the killed node and other nodes not yet aware of the new owner for that
partition. This may cause indefinitely seen stale values on near
cache side.

With this PR, we are resetting local metadata of all partitions upon
run of clear operation so reconciliation task will manage to remove
stales.

__PR:__
- Added `resetPartitionMetaData` 		
- Map and Cache tests synced.

backport:https://github.com/hazelcast/hazelcast/pull/13241
