### PR TITLE
Fix clientDisconnected event miss

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -18,11 +18,15 @@ package com.hazelcast.client.impl;
 
 import com.hazelcast.client.ClientEndpoint;
 import com.hazelcast.client.ClientEndpointManager;
+import com.hazelcast.client.ClientEvent;
+import com.hazelcast.client.ClientEventType;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
 import com.hazelcast.internal.util.counters.MwCounter;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
+import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
@@ -32,6 +36,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.client.impl.ClientEngineImpl.SERVICE_NAME;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.internal.util.counters.MwCounter.newMwCounter;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -43,6 +48,7 @@ import static com.hazelcast.util.SetUtil.createHashSet;
 public class ClientEndpointManagerImpl implements ClientEndpointManager {
 
     private final ILogger logger;
+    private final EventService eventService;
 
     @Probe(name = "count", level = MANDATORY)
     private final ConcurrentMap<Connection, ClientEndpoint> endpoints =
@@ -53,7 +59,7 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
 
     public ClientEndpointManagerImpl(NodeEngine nodeEngine) {
         this.logger = nodeEngine.getLogger(ClientEndpointManager.class);
-
+        this.eventService = nodeEngine.getEventService();
         MetricsRegistry metricsRegistry = ((NodeEngineImpl) nodeEngine).getMetricsRegistry();
         metricsRegistry.scanAndRegister(this, "client.endpoint");
     }
@@ -87,6 +93,11 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
             return false;
         } else {
             totalRegistrations.inc();
+            ClientEvent event = new ClientEvent(endpoint.getUuid(),
+                    ClientEventType.CONNECTED,
+                    endpoint.getSocketAddress(),
+                    endpoint.getClientType());
+            sendClientEvent(event);
             return true;
         }
     }
@@ -102,6 +113,12 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
             return;
         }
 
+        ClientEvent event = new ClientEvent(endpoint.getUuid(),
+                ClientEventType.DISCONNECTED,
+                endpoint.getSocketAddress(),
+                endpoint.getClientType());
+        sendClientEvent(event);
+
         logger.info("Destroying " + endpoint);
         try {
             endpoint.destroy();
@@ -109,6 +126,12 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
             logger.warning(e);
         }
 
+    }
+
+    private void sendClientEvent(ClientEvent event) {
+        final Collection<EventRegistration> regs = eventService.getRegistrations(SERVICE_NAME, SERVICE_NAME);
+        String uuid = event.getUuid();
+        eventService.publishEvent(SERVICE_NAME, regs, event, uuid.hashCode());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -51,7 +51,6 @@ import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.CoreService;
 import com.hazelcast.spi.EventPublishingService;
-import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.ManagedService;
@@ -321,18 +320,6 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
                 ((TcpIpConnection) conn).setEndPoint(address);
             }
         }
-        ClientEvent event = new ClientEvent(endpoint.getUuid(),
-                ClientEventType.CONNECTED,
-                endpoint.getSocketAddress(),
-                endpoint.getClientType());
-        sendClientEvent(event);
-    }
-
-    private void sendClientEvent(ClientEvent event) {
-        final EventService eventService = nodeEngine.getEventService();
-        final Collection<EventRegistration> regs = eventService.getRegistrations(SERVICE_NAME, SERVICE_NAME);
-        String uuid = event.getUuid();
-        eventService.publishEvent(SERVICE_NAME, regs, event, uuid.hashCode());
     }
 
     @Override
@@ -467,11 +454,6 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
             }
 
             endpointManager.removeEndpoint(endpoint);
-            ClientEvent event = new ClientEvent(endpoint.getUuid(),
-                    ClientEventType.DISCONNECTED,
-                    endpoint.getSocketAddress(),
-                    endpoint.getClientType());
-            sendClientEvent(event);
 
             if (!endpoint.isOwnerConnection()) {
                 logger.finest("connectionRemoved: Not the owner conn:" + connection + " for endpoint " + endpoint);


### PR DESCRIPTION
Event firing is missed in case of a race between
ClientEngineImpl.connectionRemoved and
ClientHeartbeatMonitor.cleanupEndpointsWithDeadConnections.

Both trying to remove an endpoint(`removeEndpoint`).
If cleanupEndpointsWithDeadConnections happens to remove first,
then event is not fired.

As a fix, I moved to event firing to more centralized place so
that first call to `removeEndpoint` will fire the disconnected
event.

fixes https://github.com/hazelcast/hazelcast/issues/12674