### PR TITLE
[BACKPORT] Reset Cache.cacheManager to null when Cache is closed

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxyBase.java
@@ -130,12 +130,17 @@ abstract class AbstractClientCacheProxyBase<K, V> extends ClientProxy implements
         if (!isClosed.compareAndSet(false, true)) {
             return;
         }
-        closeInternal();
+        close0(false);
     }
 
-    protected void closeInternal() {
+    private void close0(boolean destroy) {
         waitOnGoingLoadAllCallsToFinish();
         closeListeners();
+        if (!destroy) {
+            // when cache is being destroyed, the CacheManager is still required for cleanup and reset in postDestroy
+            // when cache is being closed, the CacheManager is reset now
+            resetCacheManager();
+        }
     }
 
     private void waitOnGoingLoadAllCallsToFinish() {
@@ -159,7 +164,7 @@ abstract class AbstractClientCacheProxyBase<K, V> extends ClientProxy implements
         if (!isDestroyed.compareAndSet(false, true)) {
             return false;
         }
-        closeInternal();
+        close0(true);
         isClosed.set(true);
         return true;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -176,11 +176,17 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
     }
 
     @Override
+    public void resetCacheManager() {
+        cacheManagerRef.set(null);
+    }
+
+    @Override
     protected void postDestroy() {
         CacheManager cacheManager = cacheManagerRef.get();
         if (cacheManager != null) {
             cacheManager.destroyCache(getName());
         }
+        resetCacheManager();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractHazelcastCacheManager.java
@@ -250,6 +250,9 @@ public abstract class AbstractHazelcastCacheManager
                 cache = cacheProxy;
             }
         }
+        if (cache != null) {
+            cache.setCacheManager(this);
+        }
         return cache;
     }
 
@@ -328,7 +331,6 @@ public abstract class AbstractHazelcastCacheManager
             cache.close();
         }
         postClose();
-        // TODO: do we need to clear it as "caches.clear();"?
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractInternalCacheProxy.java
@@ -123,11 +123,17 @@ abstract class AbstractInternalCacheProxy<K, V>
     }
 
     @Override
+    public void resetCacheManager() {
+        cacheManagerRef.set(null);
+    }
+
+    @Override
     protected void postDestroy() {
         CacheManager cacheManager = cacheManagerRef.get();
         if (cacheManager != null) {
             cacheManager.destroyCache(getName());
         }
+        resetCacheManager();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheInternal.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheInternal.java
@@ -65,4 +65,10 @@ public interface ICacheInternal<K, V> extends ICache<K, V> {
      * @param cacheManager client or server {@link HazelcastCacheManager}
      */
     void setCacheManager(HazelcastCacheManager cacheManager);
+
+    /**
+     * Reset cache manager of this cache proxy to {@code null}. Whenever a Cache is not managed any more
+     * (for example after {@code Cache.close()} has been called), its {@code CacheManager} should be reset.
+     */
+    void resetCacheManager();
 }


### PR DESCRIPTION
When a Cache is closed, it is no longer managed by the CacheManager,
so its CacheManager should be reset to null and getCacheManager() should
return null as per spec. When reopened by the same CacheManager or
a new CacheManager for the same [URI, ClassLoader], it becomes managed
and its CacheManager is set again.

(cherry picked from commit f9135a9)

Backport of #13228 