### PR TITLE
Fix client cacheManager.getCache(null) behaviour

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/HazelcastClientCacheManager.java
@@ -120,6 +120,9 @@ public final class HazelcastClientCacheManager extends AbstractHazelcastCacheMan
 
     @Override
     protected <K, V> CacheConfig<K, V> findCacheConfig(String cacheName, String simpleCacheName) {
+        if (simpleCacheName == null) {
+            return null;
+        }
         CacheConfig<K, V> config = clientCacheProxyFactory.getCacheConfig(cacheName);
         if (config == null) {
             // if cache config not found, try to find it from partition

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -529,6 +529,11 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
     }
 
     @Test
+    public void testGetCacheWithNullName() {
+        assertNull(cacheManager.getCache(null));
+    }
+
+    @Test
     public void testRemovingSameEntryTwiceShouldTriggerEntryListenerOnlyOnce() {
         String cacheName = randomString();
 


### PR DESCRIPTION
member side cacheManager.getCache(null) returns null.

Reference implementation returns null.
https://github.com/jsr107/RI/blob/master/cache-ri-impl/src/main/java/org/jsr107/ri/RICacheManager.java#L239

Client was throwing NullPointerException. It is changed to return
null with this pr.

fixes https://github.com/hazelcast/hazelcast/issues/13243

(cherry picked from commit 3026d0430c2c003621e2d7778c4394bb654b7f4b)