### PR TITLE
Added missing JavaDoc in core package

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -76,7 +76,6 @@
     <suppress checks="ClassDataAbstractionCoupling" files="com[\\/]hazelcast[\\/]cache[\\/]impl[\\/]DefaultOperationProvider"/>
 
     <!-- Core -->
-    <suppress checks="Javadoc(Method|Type|Variable)" files="com[\\/]hazelcast[\\/]core[\\/]"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]core[\\/]HazelcastInstance"/>
     <suppress checks="MethodCount|FileLength" files="com[\\/]hazelcast[\\/]core[\\/]IMap"/>
 

--- a/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicReference.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/AsyncAtomicReference.java
@@ -19,12 +19,15 @@ package com.hazelcast.core;
 import com.hazelcast.spi.annotation.Beta;
 
 /**
- * A {@link IAtomicReference} that exposes its operations using a {@link ICompletableFuture}
- * so it can be used in the reactive programming model approach.
+ * A {@link IAtomicReference} that exposes its operations using a
+ * {@link ICompletableFuture} so it can be used in the reactive programming
+ * model approach.
+ * <p>
+ * Instead of this interface, use the equivalent async methods in the public
+ * {@link IAtomicReference} interface. This interface has been deprecated
+ * and will be removed in a future version.
  *
- * Instead of this interface, use the equivalent async methods in the public {@link IAtomicReference} interface.
- * This interface has been deprecated and will be removed in a future version.
- *
+ * @param <E> the type of object referred to by this reference
  * @since 3.2
  */
 @Beta
@@ -38,7 +41,7 @@ public interface AsyncAtomicReference<E> extends IAtomicReference<E> {
      * @param expect the expected value
      * @param update the new value
      * @return true if successful; or false if the actual value
-     *         was not equal to the expected value.
+     * was not equal to the expected value.
      */
     ICompletableFuture<Boolean> asyncCompareAndSet(E expect, E update);
 
@@ -68,7 +71,7 @@ public interface AsyncAtomicReference<E> extends IAtomicReference<E> {
      * Sets and gets the value.
      *
      * @param update the new value
-     * @return  the new value
+     * @return the new value
      * @deprecated will be removed from Hazelcast 3.4 since it doesn't really serve a purpose.
      */
     ICompletableFuture<E> asyncSetAndGet(E update);
@@ -114,7 +117,7 @@ public interface AsyncAtomicReference<E> extends IAtomicReference<E> {
      * Alters the currently stored reference by applying a function on it on and gets the old value.
      *
      * @param function the function
-     * @return  the old value
+     * @return the old value
      * @throws IllegalArgumentException if function is null.
      */
     ICompletableFuture<E> asyncGetAndAlter(IFunction<E, E> function);
@@ -123,7 +126,7 @@ public interface AsyncAtomicReference<E> extends IAtomicReference<E> {
      * Applies a function on the value, the actual stored value will not change.
      *
      * @param function the function
-     * @return  the result of the function application
+     * @return the result of the function application
      * @throws IllegalArgumentException if function is null.
      */
     <R> ICompletableFuture<R> asyncApply(IFunction<E, R> function);

--- a/hazelcast/src/main/java/com/hazelcast/core/ClientType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ClientType.java
@@ -17,15 +17,46 @@
 package com.hazelcast.core;
 
 /**
- * Type of a client.
+ * Type of a Hazelcast client.
  */
 public enum ClientType {
+    /**
+     * Hazelcast Java client.
+     */
     JAVA,
+
+    /**
+     * Hazelcast .NET client.
+     */
     CSHARP,
+
+    /**
+     * Hazelcast C++ client.
+     */
     CPP,
+
+    /**
+     * Hazelcast Python client.
+     */
     PYTHON,
+
+    /**
+     * Hazelcast Ruby client.
+     */
     RUBY,
+
+    /**
+     * Hazelcast NodeJS client.
+     */
     NODEJS,
+
+    /**
+     * Hazelcast Go client.
+     */
     GO,
+
+    /**
+     * Other Hazelcast client.
+     */
     OTHER
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/DistributedObjectEvent.java
@@ -30,9 +30,7 @@ public class DistributedObjectEvent {
     protected DistributedObject distributedObject;
 
     private EventType eventType;
-
     private String serviceName;
-
     private String objectName;
 
     /**
@@ -103,10 +101,17 @@ public class DistributedObjectEvent {
     }
 
     /**
-     * Type of event.
+     * Type of the DistributedObjectEvent.
      */
     public enum EventType {
-        CREATED, DESTROYED
+        /**
+         * Event if a DistributedObjectEvent is created.
+         */
+        CREATED,
+        /**
+         * Event if a DistributedObjectEvent is destroyed.
+         */
+        DESTROYED
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEvent.java
@@ -33,38 +33,34 @@ public class EntryEvent<K, V> extends AbstractIMapEvent {
     private static final long serialVersionUID = -2296203982913729851L;
 
     protected K key;
-
     protected V oldValue;
-
     protected V value;
-
     protected V mergingValue;
 
     /**
      * Constructs an entry event.
      *
-     * @param source    The object on which the event initially occurred.
-     * @param member    The interface to the cluster member (node).
-     * @param eventType The event type as an enum {@link EntryEventType} integer.
-     * @param key       The key for this entry event.
-     * @param value     The value of the entry event.
-     * @throws IllegalArgumentException if source is null.
+     * @param source    The object on which the event initially occurred
+     * @param member    The interface to the cluster member (node)
+     * @param eventType The event type as an enum {@link EntryEventType} integer
+     * @param key       The key for this entry event
+     * @param value     The value of the entry event
+     * @throws IllegalArgumentException if source is {@code null}
      */
     public EntryEvent(Object source, Member member, int eventType, K key, V value) {
         this(source, member, eventType, key, null, value);
     }
 
-
     /**
      * Constructs an entry event.
      *
-     * @param source    The object on which the Event initially occurred.
-     * @param member    The interface to the cluster member (node).
-     * @param eventType The event type as an enum {@link EntryEventType} integer.
-     * @param key       The key of this entry event.
-     * @param oldValue  The old value of the entry event.
-     * @param value     The value of the entry event.
-     * @throws IllegalArgumentException if source is null.
+     * @param source    The object on which the Event initially occurred
+     * @param member    The interface to the cluster member (node)
+     * @param eventType The event type as an enum {@link EntryEventType} integer
+     * @param key       The key of this entry event
+     * @param oldValue  The old value of the entry event
+     * @param value     The value of the entry event
+     * @throws IllegalArgumentException if source is {@code null}
      */
     public EntryEvent(Object source, Member member, int eventType, K key, V oldValue, V value) {
         super(source, member, eventType);
@@ -76,14 +72,14 @@ public class EntryEvent<K, V> extends AbstractIMapEvent {
     /**
      * Constructs an entry event.
      *
-     * @param source       The object on which the Event initially occurred.
-     * @param member       The interface to the cluster member (node).
-     * @param eventType    The event type as an enum {@link EntryEventType} integer.
-     * @param key          The key of this entry event.
-     * @param oldValue     The old value of the entry event.
-     * @param value        The value of the entry event.
-     * @param mergingValue The incoming merging value of the entry event.
-     * @throws IllegalArgumentException if source is null.
+     * @param source       The object on which the Event initially occurred
+     * @param member       The interface to the cluster member (node)
+     * @param eventType    The event type as an enum {@link EntryEventType} integer
+     * @param key          The key of this entry event
+     * @param oldValue     The old value of the entry event
+     * @param value        The value of the entry event
+     * @param mergingValue The incoming merging value of the entry event
+     * @throws IllegalArgumentException if source is {@code null}
      */
     public EntryEvent(Object source, Member member, int eventType, K key, V oldValue, V value, V mergingValue) {
         super(source, member, eventType);
@@ -105,7 +101,7 @@ public class EntryEvent<K, V> extends AbstractIMapEvent {
     /**
      * Returns the old value of the entry event.
      *
-     * @return the old value of the entry event.
+     * @return the old value of the entry event
      */
     public V getOldValue() {
         return this.oldValue;
@@ -123,7 +119,7 @@ public class EntryEvent<K, V> extends AbstractIMapEvent {
     /**
      * Returns the incoming merging value of the entry event.
      *
-     * @return merge value
+     * @return the merging value
      */
     public V getMergingValue() {
         return mergingValue;

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryEventType.java
@@ -21,15 +21,54 @@ package com.hazelcast.core;
  */
 public enum EntryEventType {
 
+    /**
+     * Fired if an entry is added.
+     */
     ADDED(TypeId.ADDED),
+
+    /**
+     * Fired if an entry is removed.
+     */
     REMOVED(TypeId.REMOVED),
+
+    /**
+     * Fired if an entry is updated.
+     */
     UPDATED(TypeId.UPDATED),
+
+    /**
+     * Fired if an entry is evicted.
+     */
     EVICTED(TypeId.EVICTED),
+
+    /**
+     * Fired if all entries are evicted.
+     */
     EVICT_ALL(TypeId.EVICT_ALL),
+
+    /**
+     * Fired if all entries are cleared.
+     */
     CLEAR_ALL(TypeId.CLEAR_ALL),
+
+    /**
+     * Fired if an entry is merged after a network partition.
+     */
     MERGED(TypeId.MERGED),
+
+    /**
+     * Fired if an entry is expired.
+     */
     EXPIRED(TypeId.EXPIRED),
+
+    /**
+     * Fired if an entry is invalidated.
+     */
     INVALIDATION(TypeId.INVALIDATION),
+
+    /**
+     * Fired if an entry is loaded.
+     */
     LOADED(TypeId.LOADED);
 
     private int typeId;
@@ -39,14 +78,15 @@ public enum EntryEventType {
     }
 
     /**
-     * @return the event type ID.
+     * @return the event type ID
      */
     public int getType() {
         return typeId;
     }
 
     /**
-     * @return the matching EntryEventType for the supplied {@code typeId} or null if there is no match.
+     * @return the matching EntryEventType for the supplied {@code typeId}
+     * or {@code null} if there is no match
      */
     @SuppressWarnings("checkstyle:returncount")
     public static EntryEventType getByType(final int typeId) {
@@ -81,7 +121,7 @@ public enum EntryEventType {
      *
      * @see com.hazelcast.map.impl.MapListenerFlagOperator
      */
-    //CHECKSTYLE:OFF
+    @SuppressWarnings("checkstyle:magicnumber")
     private static class TypeId {
         private static final int ADDED = 1;
         private static final int REMOVED = 1 << 1;
@@ -94,5 +134,4 @@ public enum EntryEventType {
         private static final int INVALIDATION = 1 << 8;
         private static final int LOADED = 1 << 9;
     }
-    //CHECKSTYLE:ON
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicLong.java
@@ -17,36 +17,33 @@
 package com.hazelcast.core;
 
 /**
- * IAtomicLong is a redundant and highly available distributed alternative to the
- * {@link java.util.concurrent.atomic.AtomicLong java.util.concurrent.atomic.AtomicLong}.
- *
- * Asynchronous variants of all methods have been introduced in version 3.7.
- * Async methods return immediately an {@link ICompletableFuture} from which the operation's result
- * can be obtained either in a blocking manner or by registering a callback to be executed
- * upon completion. For example:
- *
+ * IAtomicLong is a redundant and highly available distributed alternative to
+ * the {@link java.util.concurrent.atomic.AtomicLong}.
  * <p>
- * <pre>
- *     ICompletableFuture&lt;Long&gt; future = atomicLong.addAndGetAsync(13);
- *     future.andThen(new ExecutionCallback&lt;Long&gt;() {
- *          void onResponse(Long response) {
- *              // do something with the result
- *          }
+ * Asynchronous variants of all methods have been introduced in version 3.7.
+ * Async methods return immediately an {@link ICompletableFuture} from which
+ * the operation's result can be obtained either in a blocking manner or by
+ * registering a callback to be executed upon completion. For example:
+ * <pre><code>
+ * ICompletableFuture<Long> future = atomicLong.addAndGetAsync(13);
+ * future.andThen(new ExecutionCallback&lt;Long&gt;() {
+ *     void onResponse(Long response) {
+ *         // do something with the result
+ *     }
  *
- *          void onFailure(Throwable t) {
- *              // handle failure
- *          }
- *     });
- * </pre>
- * </p>
- *
- * During a network partition event it is possible for the {@link IAtomicLong} to exist in each of the partitioned
- * clusters or to not exist at all. Under these circumstances the values held in the {@link IAtomicLong} may diverge.
- * Once the network partition heals, Hazelcast will use the value held in the largest cluster, in this case updates
- * made to the {@link IAtomicLong} in the smaller clusters will be lost.  Where the merging clusters are the same sizes
- * a winner of the merge will be randomly chosen.
- *
- * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster versions 3.10 and higher.
+ *     void onFailure(Throwable t) {
+ *         // handle failure
+ *     }
+ * });
+ * </code></pre>
+ * During a network partition event it is possible for the {@link IAtomicLong}
+ * to exist in each of the partitioned clusters or to not exist at all. Under
+ * these circumstances the values held in the {@link IAtomicLong} may diverge.
+ * Once the network partition heals, Hazelcast will use the configured
+ * split-brain merge policy to resolve conflicting values.
+ * <p>
+ * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in
+ * cluster versions 3.10 and higher.
  *
  * @see IAtomicReference
  */
@@ -73,8 +70,8 @@ public interface IAtomicLong extends DistributedObject {
      *
      * @param expect the expected value
      * @param update the new value
-     * @return true if successful; or false if the actual value
-     *         was not equal to the expected value.
+     * @return {@code true} if successful; or {@code false} if the actual value
+     * was not equal to the expected value.
      */
     boolean compareAndSet(long expect, long update);
 
@@ -133,27 +130,29 @@ public interface IAtomicLong extends DistributedObject {
      * Alters the currently stored value by applying a function on it.
      *
      * @param function the function applied to the currently stored value
-     * @throws IllegalArgumentException if function is null.
+     * @throws IllegalArgumentException if function is {@code null}
      * @since 3.2
      */
     void alter(IFunction<Long, Long> function);
 
     /**
-     * Alters the currently stored value by applying a function on it and gets the result.
+     * Alters the currently stored value by applying a function on it and
+     * gets the result.
      *
      * @param function the function applied to the currently stored value
-     * @return the new value.
-     * @throws IllegalArgumentException if function is null.
+     * @return the new value
+     * @throws IllegalArgumentException if function is {@code null}
      * @since 3.2
      */
     long alterAndGet(IFunction<Long, Long> function);
 
     /**
-     * Alters the currently stored value by applying a function on it on and gets the old value.
+     * Alters the currently stored value by applying a function on it on and
+     * gets the old value.
      *
      * @param function the function applied to the currently stored value
-     * @return  the old value
-     * @throws IllegalArgumentException if function is null.
+     * @return the old value
+     * @throws IllegalArgumentException if function is {@code null}
      * @since 3.2
      */
     long getAndAlter(IFunction<Long, Long> function);
@@ -162,38 +161,40 @@ public interface IAtomicLong extends DistributedObject {
      * Applies a function on the value, the actual stored value will not change.
      *
      * @param function the function applied to the value, the value is not changed
-     * @return  the result of the function application
-     * @throws IllegalArgumentException if function is null.
+     * @return the result of the function application
+     * @throws IllegalArgumentException if function is {@code null}
      * @since 3.2
      */
     <R> R apply(IFunction<Long, R> function);
 
     /**
      * Atomically adds the given value to the current value.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
-     * The operations result can be obtained in a blocking way, or a
-     * callback can be provided for execution upon completion, as demonstrated in the following examples:
      * <p>
-     * <pre>
-     *     ICompletableFuture&lt;Long&gt; future = atomicLong.addAndGetAsync(13);
-     *     // do something else, then read the result
-     *     Long result = future.get(); // this method will block until the result is available
-     * </pre>
-     * </p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      * <p>
-     * <pre>
-     *     ICompletableFuture&lt;Long&gt; future = atomicLong.addAndGetAsync(13);
-     *     future.andThen(new ExecutionCallback&lt;Long&gt;() {
-     *          void onResponse(Long response) {
-     *              // do something with the result
-     *          }
+     * The operations result can be obtained in a blocking way, or a callback
+     * can be provided for execution upon completion, as demonstrated in the
+     * following examples:
+     * <pre><code>
+     * ICompletableFuture<Long> future = atomicLong.addAndGetAsync(13);
+     * // do something else, then read the result
      *
-     *          void onFailure(Throwable t) {
-     *              // handle failure
-     *          }
-     *     });
-     * </pre>
-     * </p>
+     * // this method will block until the result is available
+     * Long result = future.get();
+     * </code></pre>
+     * <pre><code>
+     * ICompletableFuture<Long> future = atomicLong.addAndGetAsync(13);
+     * future.andThen(new ExecutionCallback&lt;Long&gt;() {
+     *     void onResponse(Long response) {
+     *         // do something with the result
+     *     }
+     *
+     *     void onFailure(Throwable t) {
+     *         // handle failure
+     *     }
+     * });
+     * </code></pre>
      *
      * @param delta the value to add
      * @return an {@link ICompletableFuture} bearing the response
@@ -204,27 +205,32 @@ public interface IAtomicLong extends DistributedObject {
     /**
      * Atomically sets the value to the given updated value
      * only if the current value {@code ==} the expected value.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * <p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      *
      * @param expect the expected value
      * @param update the new value
-     * @return an {@link ICompletableFuture} with value true if successful; or false if the actual value
-     *         was not equal to the expected value.
+     * @return an {@link ICompletableFuture} with value {@code true} if successful;
+     * or {@code false} if the actual value was not equal to the expected value
      * @since 3.7
      */
     ICompletableFuture<Boolean> compareAndSetAsync(long expect, long update);
 
     /**
      * Atomically decrements the current value by one.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * <p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      *
-     * @return an {@link ICompletableFuture} with the updated value.
+     * @return an {@link ICompletableFuture} with the updated value
      * @since 3.7
      */
     ICompletableFuture<Long> decrementAndGetAsync();
 
     /**
-     * Gets the current value. This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * Gets the current value. This method will dispatch a request and return
+     * immediately an {@link ICompletableFuture}.
      *
      * @return an {@link ICompletableFuture} with the current value
      * @since 3.7
@@ -233,7 +239,9 @@ public interface IAtomicLong extends DistributedObject {
 
     /**
      * Atomically adds the given value to the current value.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * <p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      *
      * @param delta the value to add
      * @return an {@link ICompletableFuture} with the old value before the addition
@@ -243,7 +251,9 @@ public interface IAtomicLong extends DistributedObject {
 
     /**
      * Atomically sets the given value and returns the old value.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * <p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      *
      * @param newValue the new value
      * @return an {@link ICompletableFuture} with the old value
@@ -253,7 +263,9 @@ public interface IAtomicLong extends DistributedObject {
 
     /**
      * Atomically increments the current value by one.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * <p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      *
      * @return an {@link ICompletableFuture} with the updated value
      * @since 3.7
@@ -262,7 +274,9 @@ public interface IAtomicLong extends DistributedObject {
 
     /**
      * Atomically increments the current value by one.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * <p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      *
      * @return an {@link ICompletableFuture} with the old value
      * @since 3.7
@@ -271,76 +285,86 @@ public interface IAtomicLong extends DistributedObject {
 
     /**
      * Atomically sets the given value.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * <p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      *
      * @param newValue the new value
-     * @return an {@link ICompletableFuture} API consumers can use to track execution of this request
+     * @return an {@link ICompletableFuture}
      * @since 3.7
      */
     ICompletableFuture<Void> setAsync(long newValue);
 
     /**
      * Alters the currently stored value by applying a function on it.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * <p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      *
      * @param function the function
-     * @throws IllegalArgumentException if function is null.
-     * @return an {@link ICompletableFuture} API consumers can use to track execution of this request
+     * @return an {@link ICompletableFuture} with the new value
+     * @throws IllegalArgumentException if function is {@code null}
      * @since 3.7
      */
     ICompletableFuture<Void> alterAsync(IFunction<Long, Long> function);
 
     /**
-     * Alters the currently stored value by applying a function on it and gets the result.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * Alters the currently stored value by applying a function on it and gets
+     * the result.
+     * <p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      *
      * @param function the function
-     * @return an {@link ICompletableFuture} with the new value.
-     * @throws IllegalArgumentException if function is null.
+     * @return an {@link ICompletableFuture} with the new value
+     * @throws IllegalArgumentException if function is {@code null}
      * @since 3.7
      */
     ICompletableFuture<Long> alterAndGetAsync(IFunction<Long, Long> function);
 
     /**
-     * Alters the currently stored value by applying a function on it on and gets the old value.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
+     * Alters the currently stored value by applying a function on it on and
+     * gets the old value.
+     * <p>
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}.
      *
      * @param function the function
      * @return an {@link ICompletableFuture} with the old value
-     * @throws IllegalArgumentException if function is null.
+     * @throws IllegalArgumentException if function is {@code null}
      * @since 3.7
      */
     ICompletableFuture<Long> getAndAlterAsync(IFunction<Long, Long> function);
 
     /**
-     * Applies a function on the value, the actual stored value will not change.
-     * This method will dispatch a request and return immediately an {@link ICompletableFuture}.
-     * Example:
+     * Applies a function on the value, the actual stored value will not
+     * change.
      * <p>
-     * <pre>
-     *     class IsOneFunction implements IFunction&lt;Long, Boolean&gt; {
-     *       &#64;Override
-     *       public Boolean apply(Long input) {
+     * This method will dispatch a request and return immediately an
+     * {@link ICompletableFuture}. For example:
+     * <pre><code>
+     * class IsOneFunction implements IFunction<Long, Boolean> {
+     *     &#64;Override
+     *     public Boolean apply(Long input) {
      *         return input.equals(1L);
-     *       }
      *     }
+     * }
      *
-     *     ICompletableFuture<Boolean> future = atomicLong.applyAsync(new IsOneFunction());
-     *     future.andThen(new ExecutionCallback&lt;Boolean&gt;() {
-     *        void onResponse(Boolean response) {
-     *            // do something with the response
-     *        }
+     * ICompletableFuture<Boolean> future = atomicLong.applyAsync(new IsOneFunction());
+     * future.andThen(new ExecutionCallback<;Boolean>() {
+     *    void onResponse(Boolean response) {
+     *        // do something with the response
+     *    }
      *
-     *        void onFailure(Throwable t) {
-     *            // handle failure
-     *        }
-     *     });
-     * </pre>
-     * </p>
+     *    void onFailure(Throwable t) {
+     *       // handle failure
+     *    }
+     * });
+     * </code></pre>
      *
      * @param function the function
      * @return an {@link ICompletableFuture} with the result of the function application
-     * @throws IllegalArgumentException if function is null.
+     * @throws IllegalArgumentException if function is {@code null}
      * @since 3.7
      */
     <R> ICompletableFuture<R> applyAsync(IFunction<Long, R> function);

--- a/hazelcast/src/main/java/com/hazelcast/core/IAtomicReference.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IAtomicReference.java
@@ -18,36 +18,36 @@ package com.hazelcast.core;
 
 
 /**
- * IAtomicReference is a redundant and highly available distributed alternative to the
- * {@link java.util.concurrent.atomic.AtomicReference java.util.concurrent.atomic.AtomicReference}.
- *
- * Asynchronous variants have been introduced in version 3.7.
- * Async methods return immediately an {@link ICompletableFuture} from which the operation's result
- * can be obtained either in a blocking manner or by registering a callback to be executed
- * upon completion. For example:
- *
+ * IAtomicReference is a redundant and highly available distributed alternative
+ * to the {@link java.util.concurrent.atomic.AtomicReference}.
  * <p>
- * <pre>
- *     ICompletableFuture&lt;E&gt; future = atomicRef.getAsync();
- *     future.andThen(new ExecutionCallback&lt;E&gt;() {
- *          void onResponse(Long response) {
- *              // do something with the result
- *          }
+ * Asynchronous variants have been introduced in version 3.7.
+ * Async methods return immediately an {@link ICompletableFuture} from which
+ * the operation's result can be obtained either in a blocking manner or by
+ * registering a callback to be executed upon completion. For example:
+ * <pre><code>
+ * ICompletableFuture<E> future = atomicRef.getAsync();
+ * future.andThen(new ExecutionCallback<E>() {
+ *     void onResponse(Long response) {
+ *         // do something with the result
+ *     }
  *
- *          void onFailure(Throwable t) {
- *              // handle failure
- *          }
- *     });
- * </pre>
- * </p>
+ *     void onFailure(Throwable t) {
+ *         // handle failure
+ *     }
+ * });
+ * </code></pre>
+ * During a network partition event it is possible for the
+ * {@link IAtomicReference} to exist in each of the partitioned clusters or to
+ * not exist at all. Under these circumstances the values held in the
+ * {@link IAtomicReference} may diverge. Once the network partition heals,
+ * Hazelcast will use the configured split-brain merge policy to resolve
+ * conflicting values.
+ * <p>
+ * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in
+ * cluster versions 3.10 and higher.
  *
- * <p>In split-brain scenarios, the atomicity of the reference is lost.  It is possible for different references to
- * exist in different cluster partitions. When the split-brain heals, Hazelcast employs a largest cluster wins
- * policy to decide which of the {@link IAtomicReference} to use.  When the cluster size are equal, a random winner
- * is chosen.
- *
- * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster versions 3.10 and higher.
- *
+ * @param <E> the type of object referred to by this reference
  * @see IAtomicLong
  * @since 3.2
  */
@@ -59,8 +59,8 @@ public interface IAtomicReference<E> extends DistributedObject {
      *
      * @param expect the expected value
      * @param update the new value
-     * @return true if successful; or false if the actual value
-     *         was not equal to the expected value.
+     * @return {@code true} if successful; or {@code false} if the actual value
+     * was not equal to the expected value
      */
     boolean compareAndSet(E expect, E update);
 
@@ -81,8 +81,8 @@ public interface IAtomicReference<E> extends DistributedObject {
     /**
      * Gets the old value and sets the new value.
      *
-     * @param newValue the new value.
-     * @return the old value.
+     * @param newValue the new value
+     * @return the old value
      */
     E getAndSet(E newValue);
 
@@ -90,15 +90,15 @@ public interface IAtomicReference<E> extends DistributedObject {
      * Sets and gets the value.
      *
      * @param update the new value
-     * @return  the new value
-     * @deprecated will be removed from Hazelcast 3.4 since it doesn't really serve a purpose.
+     * @return the new value
+     * @deprecated will be removed from Hazelcast 3.4 since it doesn't really serve a purpose
      */
     E setAndGet(E update);
 
     /**
-     * Checks if the stored reference is null.
+     * Checks if the stored reference is {@code null}.
      *
-     * @return true if null, false otherwise.
+     * @return {@code true} if {@code null}, {@code false} otherwise
      */
     boolean isNull();
 
@@ -110,8 +110,8 @@ public interface IAtomicReference<E> extends DistributedObject {
     /**
      * Checks if the reference contains the value.
      *
-     * @param value the value to check (is allowed to be null).
-     * @return true if the value is found, false otherwise.
+     * @param value the value to check (is allowed to be {@code null})
+     * @return {@code true} if the value is found, {@code false} otherwise
      */
     boolean contains(E value);
 
@@ -119,45 +119,48 @@ public interface IAtomicReference<E> extends DistributedObject {
      * Alters the currently stored reference by applying a function on it.
      *
      * @param function the function that alters the currently stored reference
-     * @throws IllegalArgumentException if function is null.
+     * @throws IllegalArgumentException if function is {@code null}
      */
     void alter(IFunction<E, E> function);
 
     /**
-     * Alters the currently stored reference by applying a function on it and gets the result.
+     * Alters the currently stored reference by applying a function on it and
+     * gets the result.
      *
      * @param function the function that alters the currently stored reference
-     * @return the new value, the result of the applied function.
-     * @throws IllegalArgumentException if function is null.
+     * @return the new value, the result of the applied function
+     * @throws IllegalArgumentException if function is {@code null}
      */
     E alterAndGet(IFunction<E, E> function);
 
     /**
-     * Alters the currently stored reference by applying a function on it on and gets the old value.
+     * Alters the currently stored reference by applying a function on it on
+     * and gets the old value.
      *
      * @param function the function that alters the currently stored reference
-     * @return  the old value, the value before the function is applied
-     * @throws IllegalArgumentException if function is null.
+     * @return the old value, the value before the function is applied
+     * @throws IllegalArgumentException if function is {@code null}
      */
     E getAndAlter(IFunction<E, E> function);
 
     /**
-     * Applies a function on the value, the actual stored value will not change.
+     * Applies a function on the value, the actual stored value will not
+     * change.
      *
      * @param function the function applied on the value, the stored value does not change
-     * @return  the result of the function application
-     * @throws IllegalArgumentException if function is null.
+     * @return the result of the function application
+     * @throws IllegalArgumentException if function is {@code null}
      */
     <R> R apply(IFunction<E, R> function);
 
     /**
-     * Atomically sets the value to the given updated value
-     * only if the current value {@code ==} the expected value.
+     * Atomically sets the value to the given updated value only if the
+     * current value {@code ==} the expected value.
      *
      * @param expect the expected value
      * @param update the new value
-     * @return true if successful; or false if the actual value
-     *         was not equal to the expected value.
+     * @return {@code true} if successful; or {@code false} if the actual value
+     * was not equal to the expected value
      */
     ICompletableFuture<Boolean> compareAndSetAsync(E expect, E update);
 
@@ -178,15 +181,15 @@ public interface IAtomicReference<E> extends DistributedObject {
     /**
      * Gets the value and sets the new value.
      *
-     * @param newValue the new value.
-     * @return the old value.
+     * @param newValue the new value
+     * @return the old value
      */
     ICompletableFuture<E> getAndSetAsync(E newValue);
 
     /**
-     * Checks if the stored reference is null.
+     * Checks if the stored reference is {@code null}.
      *
-     * @return true if null, false otherwise.
+     * @return {@code true} if {@code null}, {@code false} otherwise
      */
     ICompletableFuture<Boolean> isNullAsync();
 
@@ -198,8 +201,8 @@ public interface IAtomicReference<E> extends DistributedObject {
     /**
      * Checks if the reference contains the value.
      *
-     * @param expected the value to check (is allowed to be null).
-     * @return true if the value is found, false otherwise.
+     * @param expected the value to check (is allowed to be null)
+     * @return {@code true} if the value is found, {@code false} otherwise
      */
     ICompletableFuture<Boolean> containsAsync(E expected);
 
@@ -207,34 +210,37 @@ public interface IAtomicReference<E> extends DistributedObject {
      * Alters the currently stored reference by applying a function on it.
      *
      * @param function the function
-     * @throws IllegalArgumentException if function is null.
+     * @throws IllegalArgumentException if function is {@code null}
      */
     ICompletableFuture<Void> alterAsync(IFunction<E, E> function);
 
     /**
-     * Alters the currently stored reference by applying a function on it and gets the result.
+     * Alters the currently stored reference by applying a function on it and
+     * gets the result.
      *
      * @param function the function
-     * @return the new value.
-     * @throws IllegalArgumentException if function is null.
+     * @return the new value
+     * @throws IllegalArgumentException if function is {@code null}
      */
     ICompletableFuture<E> alterAndGetAsync(IFunction<E, E> function);
 
     /**
-     * Alters the currently stored reference by applying a function on it on and gets the old value.
+     * Alters the currently stored reference by applying a function on it on
+     * and gets the old value.
      *
      * @param function the function
-     * @return  the old value
-     * @throws IllegalArgumentException if function is null.
+     * @return the old value
+     * @throws IllegalArgumentException if function is {@code null}
      */
     ICompletableFuture<E> getAndAlterAsync(IFunction<E, E> function);
 
     /**
-     * Applies a function on the value, the actual stored value will not change.
+     * Applies a function on the value, the actual stored value will not
+     * change.
      *
      * @param function the function
-     * @return  the result of the function application
-     * @throws IllegalArgumentException if function is null.
+     * @return the result of the function application
+     * @throws IllegalArgumentException if function is {@code null}
      */
     <R> ICompletableFuture<R> applyAsync(IFunction<E, R> function);
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/IBiFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IBiFunction.java
@@ -16,6 +16,15 @@
 
 package com.hazelcast.core;
 
+/**
+ * Represents a function that accepts two arguments and produces a result.
+ * <p>
+ * This class is called IBiFunction instead of BiFunction to prevent clashes with the one in Java 8.
+ *
+ * @param <T> an argument
+ * @param <U> another argument
+ * @param <R> a result
+ */
 public interface IBiFunction<T, U, R> {
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IFunction.java
@@ -22,9 +22,9 @@ import java.io.Serializable;
 
 /**
  * Represents a function that accepts one argument and produces a result.
- *
+ * <p>
  * This class is called IFunction instead of Function to prevent clashes with the one in Java 8.
- *
+ * <p>
  * Serialized instances of this interface are used in client-member communication, so changing an implementation's binary format
  * will render it incompatible with its previous versions.
  *
@@ -32,7 +32,6 @@ import java.io.Serializable;
  * @param <R> a result
  * @since 3.2
  */
-
 @BinaryInterface
 public interface IFunction<T, R> extends Serializable {
 

--- a/hazelcast/src/main/java/com/hazelcast/core/ISet.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ISet.java
@@ -20,15 +20,18 @@ import java.util.Set;
 
 /**
  * Concurrent, distributed implementation of {@link Set}
- * <p/>
- * <b>This class is <i>not</i> a general-purpose <tt>Set</tt> implementation! While this class implements
- * the <tt>Set</tt> interface, it intentionally violates <tt>Set's</tt> general contract, which mandates the
- * use of the <tt>equals</tt> method when comparing objects. Instead of the equals method this implementation
- * compares the serialized byte version of the objects.</b>
+ * <p>
+ * <b>Note:</b> This class is <i>not</i> a general-purpose {@link Set}
+ * implementation! While this class implements the {@link Set} interface,
+ * it intentionally violates {@link Set}'s general contract, which mandates the
+ * use of the {@code equals() method when comparing objects. Instead of the
+ * equals method this implementation compares the serialized byte version
+ * of the objects.
+ * <p>
+ * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster
+ * versions 3.10 and higher.
  *
- * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster versions 3.10 and higher.
- *
- * @param <E>
+ * @param <E> the type of elements maintained by this set
  * @see Set
  */
 public interface ISet<E> extends Set<E>, ICollection<E> {

--- a/hazelcast/src/main/java/com/hazelcast/core/ITopic.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ITopic.java
@@ -20,20 +20,28 @@ import com.hazelcast.monitor.LocalTopicStats;
 import com.hazelcast.topic.TopicOverloadException;
 
 /**
- * Hazelcast provides distribution mechanism for publishing messages that are delivered to multiple subscribers,
- * which is also known as a publish/subscribe (pub/sub) messaging model. Publish and subscriptions are cluster-wide.
- * When a member subscribes for a topic, it is actually registering for messages published by any member in the cluster,
- * including the new members joined after you added the listener.
+ * Hazelcast provides distribution mechanism for publishing messages that are
+ * delivered to multiple subscribers, which is also known as a publish/subscribe
+ * (pub/sub) messaging model. Publish and subscriptions are cluster-wide.
  * <p>
- * Messages are ordered, meaning that listeners(subscribers)
- * will process the messages in the order they are actually published. If cluster member M publishes messages
- * m1, m2, m3...mn to a topic T, then Hazelcast makes sure that all of the subscribers of topic T will receive
- * and process m1, m2, m3...mn in order.
+ * When a member subscribes for a topic, it is actually registering for messages
+ * published by any member in the cluster, including the new members joined after
+ * you added the listener.
  * <p>
- * Since Hazelcast 3.5 it is possible to have reliable topics. Normally all topics rely on the shared eventing system and
- * shared threads. With Hazelcast 3.5 it is possible to configure a topic to be reliable and to get its own
- * {@link com.hazelcast.ringbuffer.Ringbuffer} to store events and to get its own executor to process events. The events
- * in the ringbuffer are replicated, so they won't get lost when a node goes down.
+ * Messages are ordered, meaning that listeners(subscribers) will process the
+ * messages in the order they are actually published. If cluster member M
+ * publishes messages m1, m2, m3...mn to a topic T, then Hazelcast makes sure
+ * that all of the subscribers of topic T will receive and process m1, m2,
+ * m3...mn in order.
+ * <p>
+ * Since Hazelcast 3.5 it is possible to have reliable topics. Normally all
+ * topics rely on the shared eventing system and shared threads. With Hazelcast
+ * 3.5 it is possible to configure a topic to be reliable and to get its own
+ * {@link com.hazelcast.ringbuffer.Ringbuffer} to store events and to get its
+ * own executor to process events. The events in the ringbuffer are replicated,
+ * so they won't get lost when a node goes down.
+ *
+ * @param <E> the type of the message
  */
 public interface ITopic<E> extends DistributedObject {
 
@@ -48,14 +56,16 @@ public interface ITopic<E> extends DistributedObject {
      * Publishes the message to all subscribers of this topic.
      *
      * @param message the message to publish to all subscribers of this topic
-     * @throws TopicOverloadException if the consumer is too slow (only works in combination with reliable topic)
+     * @throws TopicOverloadException if the consumer is too slow
+     *                                (only works in combination with reliable topic)
      */
     void publish(E message);
 
     /**
      * Subscribes to this topic. When someone publishes a message on this topic.
-     * onMessage() function of the given MessageListener is called. More than one message listener can be
-     * added on one instance.
+     * <p>
+     * onMessage() function of the given MessageListener is called. More than
+     * one message listener can be added on one instance.
      *
      * @param listener the MessageListener to add
      * @return returns the registration ID
@@ -65,6 +75,7 @@ public interface ITopic<E> extends DistributedObject {
 
     /**
      * Stops receiving messages for the given message listener.
+     * <p>
      * If the given listener already removed, this method does nothing.
      *
      * @param registrationId ID of listener registration

--- a/hazelcast/src/main/java/com/hazelcast/core/ItemEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ItemEvent.java
@@ -19,8 +19,9 @@ package com.hazelcast.core;
 import java.util.EventObject;
 
 /**
- * Map Item event.
+ * Event for a collection item.
  *
+ * @param <E> type of the item
  * @see com.hazelcast.core.EntryEvent
  * @see com.hazelcast.core.ICollection#addItemListener(ItemListener, boolean)
  */
@@ -28,6 +29,7 @@ import java.util.EventObject;
 public class ItemEvent<E> extends EventObject {
 
     protected E item;
+
     private final ItemEventType eventType;
     private final Member member;
 
@@ -41,7 +43,7 @@ public class ItemEvent<E> extends EventObject {
     /**
      * Returns the event type.
      *
-     * @return the event type.
+     * @return the event type
      */
     public ItemEventType getEventType() {
         return eventType;
@@ -50,7 +52,7 @@ public class ItemEvent<E> extends EventObject {
     /**
      * Returns the item related to the event.
      *
-     * @return the item related to the event.
+     * @return the item related to the event
      */
     public E getItem() {
         return item;
@@ -59,7 +61,7 @@ public class ItemEvent<E> extends EventObject {
     /**
      * Returns the member that fired this event.
      *
-     * @return the member that fired this event.
+     * @return the member that fired this event
      */
     public Member getMember() {
         return member;

--- a/hazelcast/src/main/java/com/hazelcast/core/ItemEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ItemEventType.java
@@ -17,10 +17,17 @@
 package com.hazelcast.core;
 
 /**
- * Type of item event.
+ * Type of item events.
  */
 public enum ItemEventType {
+    /**
+     * Fired when an item is added.
+     */
     ADDED(1),
+
+    /**
+     * Fired when an item is removed.
+     */
     REMOVED(2);
 
     private int type;

--- a/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
@@ -17,8 +17,9 @@
 package com.hazelcast.core;
 
 /**
- * Lifecycle event fired when HazelcastInstance's state changes.
- * Events are fired when instance:
+ * Lifecycle events are fired when the HazelcastInstance state changes.
+ * <p>
+ * Events are fired when the instance is:
  * <ul>
  * <li>Starting</li>
  * <li>Started</li>
@@ -32,33 +33,57 @@ package com.hazelcast.core;
  * @see HazelcastInstance#getLifecycleService()
  */
 public final class LifecycleEvent {
+
     /**
-     * lifecycle states
+     * Lifecycle states
      */
     public enum LifecycleState {
-        STARTING,
-        STARTED,
-        SHUTTING_DOWN,
-        SHUTDOWN,
         /**
-         * Fired on each cluster member just before start of a merge process into another cluster.
-         * This is typically used when a split-brain situation is healed.
-         *
+         * Fired when the member is starting.
+         */
+        STARTING,
+
+        /**
+         * Fired when the member start is completed.
+         */
+        STARTED,
+
+        /**
+         * Fired when the member is shutting down.
+         */
+        SHUTTING_DOWN,
+
+        /**
+         * Fired when the member shut down is completed.
+         */
+        SHUTDOWN,
+
+        /**
+         * Fired on each cluster member just before the start of a merge
+         * process into another cluster. This is typically used when a
+         * split-brain situation is healed.
          */
         MERGING,
 
         /**
-         * Indicates merge process was successful and data have been merged.
-         *
+         * Fired when the merge process was successful and all data has been
+         * merged.
          */
         MERGED,
 
         /**
-         * Indicates merge process failed for some reason.
-         *
+         * Fired when the merge process failed for some reason.
          */
         MERGE_FAILED,
+
+        /**
+         * Fired when a client is connected to the member.
+         */
         CLIENT_CONNECTED,
+
+        /**
+         * Fired when a client is disconnected to the member.
+         */
         CLIENT_DISCONNECTED
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapLoader.java
@@ -25,33 +25,47 @@ import java.util.Map;
  * Hazelcast distributed map implementation is an in-memory data store but
  * it can be backed by any type of data store such as RDBMS, OODBMS, or simply
  * a file based data store.
- * <p/>
- * {@link com.hazelcast.core.IMap#get(Object)} normally returns the value that is available in-memory. If the entry
- * doesn't exist in-memory, Hazelcast returns null. If a Loader implementation is provided then, instead of returning
- * null, Hazelcast will attempt to load the unknown entry by calling the implementation's {@link #load(Object)} or
- * {@link #loadAll(Collection)}  methods. Loaded entries will be placed into the distributed map and they will stay
- * in-memory until they are explicitly removed or implicitly evicted (if eviction is configured).
- * <p/>
- * MapLoader implementations are executed by a partition thread, therefore care should
- * be taken not to block the thread with an expensive operation or an operation that may potentially
- * never return, the partition thread does not time out the operation.  Whilst the partition thread is
- * executing the MapLoader it is unable to respond to requests for data on any other structure that
- * may reside in the same partition, or to respond to other partitions mapped to the same partition thread. For example
- * a very slow MapLoader for one map could block a request for data on another map, or even a queue. It is
- * therefore strongly recommended not to use MapLoader to call across a WAN or to a system which will take
- * on average longer than a few milliseconds to respond.
- * <p/>
- * MapLoaders should not be used to perform cascading operations on other data structures via a
- * {@link HazelcastInstance}, the MapLoader should only concern itself with the operation on the assigned map.
- * If the MapLoader attempts to access another data structure on a different partition to the key used in the MapLoader,
- * a {@link java.lang.IllegalThreadStateException} is thrown.  A MapLoader can only interact with other data structures
- * that reside on the same partition.
- * <p/>
- * If a blocked partition thread is called from a Hazelcast Client the caller will also block indefinitely, for example
- * {@link com.hazelcast.core.IMap#get(Object)}. If the same call is made from another cluster member the operation will
- * eventually timeout with a {@link OperationTimeoutException}.
+ * <p>
+ * {@link com.hazelcast.core.IMap#get(Object)} normally returns the value that
+ * is available in-memory. If the entry doesn't exist in-memory, Hazelcast
+ * returns {@code null}. If a Loader implementation is provided then, instead
+ * of returning {@code null}, Hazelcast will attempt to load the unknown entry
+ * by calling the implementation's {@link #load(Object)} or
+ * {@link #loadAll(Collection)}  methods. Loaded entries will be placed into
+ * the distributed map and they will stay in-memory until they are explicitly
+ * removed or implicitly evicted (if eviction is configured).
+ * <p>
+ * MapLoader implementations are executed by a partition thread, therefore care
+ * should be taken not to block the thread with an expensive operation or an
+ * operation that may potentially never return, the partition thread does not
+ * time out the operation. Whilst the partition thread is executing the
+ * MapLoader it is unable to respond to requests for data on any other
+ * structure that may reside in the same partition, or to respond to other
+ * partitions mapped to the same partition thread. For example a very slow
+ * MapLoader for one map could block a request for data on another map, or even
+ * a queue. It is therefore strongly recommended not to use MapLoader to call
+ * across a WAN or to a system which will take on average longer than a few
+ * milliseconds to respond.
+ * <p>
+ * MapLoaders should not be used to perform cascading operations on other data
+ * structures via a {@link HazelcastInstance}, the MapLoader should only
+ * concern itself with the operation on the assigned map. If the MapLoader
+ * attempts to access another data structure on a different partition to the
+ * key used in the MapLoader, a {@link java.lang.IllegalThreadStateException}
+ * is thrown. A MapLoader can only interact with other data structures that
+ * reside on the same partition.
+ * <p>
+ * If a blocked partition thread is called from a Hazelcast Client the caller
+ * will also block indefinitely, for example
+ * {@link com.hazelcast.core.IMap#get(Object)}. If the same call is made from
+ * another cluster member the operation will eventually timeout with a
+ * {@link OperationTimeoutException}.
+ *
+ * @param <K> type of the MapLoader key
+ * @param <V> type of the MapLoader value
  */
 public interface MapLoader<K, V> {
+
     /**
      * Loads the value of a given key. If distributed map doesn't contain the value
      * for the given key then Hazelcast will call implementation's load (key) method
@@ -66,10 +80,10 @@ public interface MapLoader<K, V> {
     /**
      * Loads given keys. This is batch load operation so that implementation can
      * optimize the multiple loads.
-     *
+     * <p>
      * For any key in the input keys, there should be a single mapping in the resulting map. Also the resulting
      * map should not have any keys that are not part of the input keys.
-     *
+     * <p>
      * The given collection should not contain any <code>null</code> keys.
      * The returned Map should not contain any <code>null</code> keys or values.
      * <p>
@@ -86,7 +100,7 @@ public interface MapLoader<K, V> {
      * by loading them in batches. The {@link Iterator} of this {@link Iterable} may implement the
      * {@link Closeable} interface in which case it will be closed once iteration is over.
      * This is intended for releasing resources such as closing a JDBC result set.
-     *
+     * <p>
      * The returned Iterable should not contain any <code>null</code> keys.
      *
      * @return all the keys. Keys inside the Iterable cannot be null.

--- a/hazelcast/src/main/java/com/hazelcast/core/MapStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapStore.java
@@ -21,23 +21,28 @@ import java.util.Map;
 
 /**
  * Hazelcast distributed map implementation is an in-memory data store, but
- * it can be backed by any type of data store such as RDBMS, OODBMS, NOSQL, or simply
- * a file-based data store.
- * <p/>
- * IMap.put(key, value) normally stores the entry into JVM's memory. If MapStore
- * implementation is provided then Hazelcast will also call the MapStore
- * implementation to store the entry into a user-defined storage, such as
- * RDBMS or some other external storage system. It is completely up to the user
- * how the key-value will be stored or deleted.
- * <p/>
+ * it can be backed by any type of data store such as RDBMS, OODBMS, NOSQL,
+ * or simply a file-based data store.
+ * <p>
+ * IMap.put(key, value) normally stores the entry into JVM's memory. If the
+ * MapStore implementation is provided then Hazelcast will also call the
+ * MapStore implementation to store the entry into a user-defined storage, such
+ * as RDBMS or some other external storage system. It is completely up to the
+ * user how the key-value will be stored or deleted.
+ * <p>
  * Same goes for IMap.remove(key).
- * <p/>
- * Store implementation can be called synchronously (write-through)
- * or asynchronously (write-behind) depending on the configuration.
+ * <p>
+ * Store implementation can be called synchronously (write-through) or
+ * asynchronously (write-behind) depending on the configuration.
+ *
+ * @param <K> type of the MapStore key
+ * @param <V> type of the MapStore value
  */
 public interface MapStore<K, V> extends MapLoader<K, V> {
+
     /**
      * Stores the key-value pair.
+     * <p>
      * If an exception is thrown then the put operation will fail.
      *
      * @param key   key of the entry to store
@@ -46,15 +51,18 @@ public interface MapStore<K, V> extends MapLoader<K, V> {
     void store(K key, V value);
 
     /**
-     * Stores multiple entries. Implementation of this method can optimize the
-     * store operation by storing all entries in one database connection.
-     * storeAll is used when writeDelaySeconds is positive (write-behind).
-     * If an exception is thrown, the entries will try to be stored one by one using the store() method.
-     *
-     * Note: on the retry phase only entries left in the map will be stored one-by-one. In this way a
-     * MapStore implementation can handle partial storeAll cases when some entries were stored successfully
-     * before failure happens. Entries removed from the map will be not passed to subsequent call to
-     * store() method any more.
+     * Stores multiple entries.
+     * <p>
+     * Implementation of this method can optimize the store operation by
+     * storing all entries in one database connection. storeAll() is used when
+     * writeDelaySeconds is positive (write-behind).If an exception is thrown,
+     * the entries will try to be stored one by one using the store() method.
+     * <p>
+     * Note: on the retry phase only entries left in the map will be stored
+     * one-by-one. In this way a MapStore implementation can handle partial
+     * storeAll() cases when some entries were stored successfully before a
+     * failure happens. Entries removed from the map will be not passed to
+     * subsequent call to store() method any more.
      *
      * @param map map of entries to store
      */
@@ -62,21 +70,25 @@ public interface MapStore<K, V> extends MapLoader<K, V> {
 
     /**
      * Deletes the entry with a given key from the store.
+     * <p>
      * If an exception is thrown the remove operation will fail.
      *
-     * @param key the key to delete from the store.
+     * @param key the key to delete from the store
      */
     void delete(K key);
 
     /**
      * Deletes multiple entries from the store.
-     * If an exception is thrown the entries will try to be deleted one by one using the delete() method.
+     * <p>
+     * If an exception is thrown the entries will try to be deleted one by one
+     * using the delete() method.
+     * <p>
+     * Note: on the retry phase only entries left in the keys will be deleted
+     * one-by-one. In this way a MapStore implementation can handle partial
+     * deleteAll() cases when some entries were deleted successfully before a
+     * failure happens. Entries removed from the keys will be not passed to
+     * subsequent call to delete() method any more.
      *
-     * Note: on the retry phase only entries left in the keys will be deleted one-by-one. In this way a
-     * MapStore implementation can handle partial deleteAll cases when some entries were deleted successfully
-     * before failure happens. Entries removed from the keys will be not passed to subsequent call to
-     * delete() method any more.
-
      * @param keys the keys of the entries to delete.
      */
     void deleteAll(Collection<K> keys);

--- a/hazelcast/src/main/java/com/hazelcast/core/MapStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MapStoreFactory.java
@@ -20,6 +20,9 @@ import java.util.Properties;
 
 /**
  * Factory for MapLoader or MapStore instances, specifiable in MapStoreConfig.
+ *
+ * @param <K> type of the MapStore key
+ * @param <V> type of the MapStore value
  */
 public interface MapStoreFactory<K, V> {
 

--- a/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MemberAttributeEvent.java
@@ -31,6 +31,9 @@ import static com.hazelcast.cluster.MemberAttributeOperationType.PUT;
 import static com.hazelcast.nio.serialization.SerializableByConvention.Reason.PUBLIC_API;
 import static java.util.Collections.EMPTY_SET;
 
+/**
+ * Event for member attribute changes.
+ */
 @SuppressFBWarnings("SE_BAD_FIELD")
 @SerializableByConvention(PUBLIC_API)
 public class MemberAttributeEvent extends MembershipEvent implements DataSerializable {
@@ -105,5 +108,4 @@ public class MemberAttributeEvent extends MembershipEvent implements DataSeriali
         }
         this.source = member;
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/MultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/MultiMap.java
@@ -28,34 +28,32 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * A specialized map whose keys can be associated with multiple values.
- * <p/>
  * <p>
  * <b>Gotchas:</b>
  * <ul>
  * <li>
- * Methods -- including but not limited to <tt>get</tt>, <tt>containsKey</tt>,
- * <tt>containsValue</tt>, <tt>remove</tt>, <tt>put</tt>,
- * <tt>lock</tt>, and <tt>unlock</tt>  -- do not use <tt>hashCode</tt> and <tt>equals</tt>
+ * Methods -- including but not limited to {@code get}, {@code containsKey},
+ * {@code containsValue}, {@code remove}, {@code put},
+ * {@code lock}, and {@code unlock}  -- do not use {@code hashCode} and {@code equals}
  * implementations of the keys.
- * Instead, they use <tt>hashCode</tt> and <tt>equals</tt> of the binary (serialized) forms of the objects.
+ * Instead, they use {@code hashCode} and {@code equals} of the binary (serialized) forms of the objects.
  * </li>
  * <li>
- * Methods -- including but not limited to <tt>get</tt>, <tt>remove</tt>,
- * <tt>keySet</tt>, <tt>values</tt>, <tt>entrySet</tt> --
+ * Methods -- including but not limited to {@code get}, {@code remove},
+ * {@code keySet}, {@code values}, {@code entrySet} --
  * return a collection clone of the values. The collection is <b>NOT</b> backed by the map,
  * so changes to the map are <b>NOT</b> reflected in the collection, and vice-versa.
  * </li>
  * </ul>
- * </p>
- *
+ * <p>
  * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster versions 3.10 and higher.
  *
- * @author oztalip
+ * @param <K> type of the multimap key
+ * @param <V> type of the multimap value
  * @see IMap
  */
 @SuppressWarnings("checkstyle:methodcount")
-public interface MultiMap<K, V>
-        extends BaseMultiMap<K, V>, DistributedObject {
+public interface MultiMap<K, V> extends BaseMultiMap<K, V>, DistributedObject {
 
     /**
      * Returns the name of this multimap.
@@ -66,99 +64,89 @@ public interface MultiMap<K, V>
 
     /**
      * Stores a key-value pair in the multimap.
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
-     * </p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
      * @param key   the key to be stored
      * @param value the value to be stored
-     * @return true if size of the multimap is increased, false if the multimap
-     * already contains the key-value pair.
+     * @return {@code true} if size of the multimap is increased,
+     * {@code false} if the multimap already contains the key-value pair
      */
     boolean put(K key, V value);
 
     /**
      * Returns the collection of values associated with the key.
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
-     * </p>
-     * <p/>
-     * <p><b>Warning-2:</b></p>
-     * The collection is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the collection, and vice-versa.
+     * <b>Warning 1:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
+     * <p>
+     * <b>Warning 2:</b> The collection is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the collection,
+     * and vice-versa.
      *
      * @param key the key whose associated values are to be returned
-     * @return the collection of the values associated with the key.
+     * @return the collection of the values associated with the key
      */
     Collection<V> get(K key);
 
     /**
      * Removes the given key value pair from the multimap.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
+     * <p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
      * @param key   the key of the entry to remove
      * @param value the value of the entry to remove
-     * @return true if the size of the multimap changed after the remove operation, false otherwise.
+     * @return {@code true} if the size of the multimap changed after the remove operation,
+     * {@code false} otherwise
      */
     boolean remove(Object key, Object value);
 
     /**
      * Removes all the entries with the given key.
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
-     * </p>
-     * <p/>
-     * <p><b>Warning-2:</b></p>
-     * The collection is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the collection, and vice-versa.
+     * <b>Warning 1:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
+     * <p>
+     * <b>Warning 2:</b> The collection is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the collection,
+     * and vice-versa.
      *
      * @param key the key of the entries to remove
-     * @return the collection of removed values associated with the given key. The returned collection
-     * might be modifiable but it has no effect on the multimap.
+     * @return the collection of removed values associated with the given key.
+     * The returned collection might be modifiable but it has no effect on the multimap.
      */
     Collection<V> remove(Object key);
 
     /**
-     *  Deletes all the entries with the given key.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
+     * Deletes all the entries with the given key.
+     * <p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
      * @param key the key of the entry to remove
      */
 
     void delete(Object key);
+
     /**
      * Returns the locally owned set of keys.
-     * <p/>
-     * Each key in this map is owned and managed by a specific
-     * member in the cluster.
-     * <p/>
-     * Note that ownership of these keys might change over time
-     * so that key ownerships can be almost evenly distributed
-     * in the cluster.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * The set is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * <p>
+     * Each key in this map is owned and managed by a specific member in the
+     * cluster.
+     * <p>
+     * Note that ownership of these keys might change over time so that key
+     * ownerships can be almost evenly distributed in the cluster.
+     * <p>
+     * <b>Warning:</b> The collection is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the collection,
+     * and vice-versa.
      *
      * @return the locally owned keys
      */
@@ -166,81 +154,80 @@ public interface MultiMap<K, V>
 
     /**
      * Returns the set of keys in the multimap.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * The set is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * <p>
+     * <b>Warning:</b> The collection is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the collection,
+     * and vice-versa.
      *
-     * @return the set of keys in the multimap. The returned set might be modifiable
-     * but it has no effect on the multimap.
+     * @return the set of keys in the multimap (the returned set might be
+     * modifiable but it has no effect on the multimap)
      */
     Set<K> keySet();
 
     /**
      * Returns the collection of values in the multimap.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * The collection is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the collection, and vice-versa.
+     * <p>
+     * <b>Warning:</b> The collection is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the collection,
+     * and vice-versa.
      *
-     * @return the collection of values in the multimap. the returned collection might be modifiable
-     * but it has no effect on the multimap.
+     * @return the collection of values in the multimap (the returned
+     * collection might be modifiable but it has no effect on the multimap)
      */
     Collection<V> values();
 
     /**
      * Returns the set of key-value pairs in the multimap.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * The set is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * <p>
+     * <b>Warning:</b> The collection is <b>NOT</b> backed by the map,
+     * so changes to the map are <b>NOT</b> reflected in the collection,
+     * and vice-versa.
      *
-     * @return the set of key-value pairs in the multimap. The returned set might be modifiable
-     * but it has no effect on the multimap.
+     * @return the set of key-value pairs in the multimap (the returned
+     * set might be modifiable but it has no effect on the multimap)
      */
     Set<Map.Entry<K, V>> entrySet();
 
     /**
      * Returns whether the multimap contains an entry with the key.
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
-     * </p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
-     * @param key the key whose existence is checked.
-     * @return true if the multimap contains an entry with the key, false otherwise.
+     * @param key the key whose existence is checked
+     * @return {@code true} if the multimap contains an entry with the key,
+     * {@code false} otherwise
      */
     boolean containsKey(K key);
 
     /**
      * Returns whether the multimap contains an entry with the value.
-     * <p/>
      *
-     * @param value the value whose existence is checked.
-     * @return true if the multimap contains an entry with the value, false otherwise.
+     * @param value the value whose existence is checked
+     * @return {@code true} if the multimap contains an entry with the value,
+     * {@code false} otherwise.
      */
     boolean containsValue(Object value);
 
     /**
      * Returns whether the multimap contains the given key-value pair.
-     * <p/>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in <tt>key</tt>'s class.
+     * <p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
-     * @param key   the key whose existence is checked.
-     * @param value the value whose existence is checked.
-     * @return true if the multimap contains the key-value pair, false otherwise.
+     * @param key   the key whose existence is checked
+     * @param value the value whose existence is checked
+     * @return {@code true} if the multimap contains the key-value pair,
+     * {@code false} otherwise
      */
     boolean containsEntry(K key, V value);
 
     /**
      * Returns the number of key-value pairs in the multimap.
      *
-     * @return the number of key-value pairs in the multimap.
+     * @return the number of key-value pairs in the multimap
      */
     int size();
 
@@ -251,13 +238,10 @@ public interface MultiMap<K, V>
 
     /**
      * Returns the number of values that match the given key in the multimap.
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
-     * </p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
      * @param key the key whose values count is to be returned
      * @return the number of values that match the given key in the multimap
@@ -265,18 +249,21 @@ public interface MultiMap<K, V>
     int valueCount(K key);
 
     /**
-     * Adds a local entry listener for this multimap. The added listener will be only
-     * listening for the events (add/remove/update) of the locally owned entries.
-     * <p/>
-     * Note that entries in distributed multimap are partitioned across
-     * the cluster members; each member owns and manages some portion of the
-     * entries. Owned entries are called local entries. This
-     * listener will be listening for the events of local entries. Let's say
-     * your cluster has member1 and member2. On member2 you added a local listener, and from
-     * member1, you call <code>multimap.put(key2, value2)</code>.
-     * If the key2 is owned by member2, then the local listener will be
-     * notified for the add/update event. Also note that entries can migrate to
-     * other nodes for load balancing and/or membership change.
+     * Adds a local entry listener for this multimap.
+     * <p>
+     * The added listener will be only listening for the events
+     * (add/remove/update) of the locally owned entries.
+     * <p>
+     * Note that entries in distributed multimap are partitioned across the
+     * cluster members; each member owns and manages some portion of the
+     * entries. Owned entries are called local entries. This listener will be
+     * listening for the events of local entries.
+     * <p>
+     * For example your cluster has member1 and member2. On member2 you added a
+     * local listener, and from member1, you call {@code multimap.put(key2, value2)}.
+     * If the key2 is owned by member2, then the local listener will be notified
+     * for the add/update event. Also note that entries can migrate to other
+     * nodes for load balancing and/or membership change.
      *
      * @param listener entry listener for this multimap
      * @return returns registration ID for the entry listener
@@ -285,18 +272,21 @@ public interface MultiMap<K, V>
     String addLocalEntryListener(EntryListener<K, V> listener);
 
     /**
-     * Adds an entry listener for this multimap. The listener will be notified
-     * for all multimap add/remove/update/evict events.
+     * Adds an entry listener for this multimap.
+     * <p>
+     * The listener will be notified for all multimap
+     * add/remove/update/evict events.
      *
      * @param listener     entry listener for this multimap
-     * @param includeValue true if <tt>EntryEvent</tt> should
-     *                     contain the value, false otherwise
+     * @param includeValue {@code true} if {@code EntryEvent} should contain the value,
+     *                     {@code false} otherwise
      * @return returns registration ID for the entry listener
      */
     String addEntryListener(EntryListener<K, V> listener, boolean includeValue);
 
     /**
      * Removes the specified entry listener.
+     * <p>
      * Returns silently if no such listener was added before.
      *
      * @param registrationId registration ID of listener
@@ -306,189 +296,178 @@ public interface MultiMap<K, V>
 
     /**
      * Adds the specified entry listener for the specified key.
-     * The listener will be notified for all
-     * add/remove/update/evict events for the specified key only.
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
-     * </p>
+     * The listener will be notified for all add/remove/update/evict events for
+     * the specified key only.
+     * <p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
      * @param listener     the entry listener
      * @param key          the key to listen to
-     * @param includeValue true if <tt>EntryEvent</tt> should
-     *                     contain the value, false otherwise
+     * @param includeValue {@code true} if {@code EntryEvent} should contain the value,
+     *                     {@code false} otherwise
      * @return returns registration ID
      */
     String addEntryListener(EntryListener<K, V> listener, K key, boolean includeValue);
 
     /**
      * Acquires a lock for the specified key.
-     * <p>If the lock is not available, then
-     * the current thread becomes disabled for thread scheduling
-     * purposes and lies dormant until the lock has been acquired.
-     * <p/>
-     * The scope of the lock is for this multimap only.
-     * The acquired lock is only for the key in this multimap.
-     * <p/>
-     * Locks are re-entrant, so if the key is locked N times, then
-     * it should be unlocked N times before another thread can acquire it.
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
-     * </p>
+     * If the lock is not available, then the current thread becomes disabled
+     * for thread scheduling purposes and lies dormant until the lock has
+     * been acquired.
+     * <p>
+     * The scope of the lock is for this multimap only. The acquired lock is
+     * only for the key in this multimap.
+     * <p>
+     * Locks are re-entrant, so if the key is locked N times, then it should
+     * be unlocked N times before another thread can acquire it.
+     * <p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
-     * @param key the key to lock.
+     * @param key the key to lock
      */
     void lock(K key);
 
     /**
      * Acquires the lock for the specified key for the specified lease time.
-     * <p>After the lease time, the lock will be released.
-     * <p/>
-     * <p>If the lock is not available, then
-     * the current thread becomes disabled for thread scheduling
-     * purposes and lies dormant until the lock has been acquired.
-     * <p/>
-     * Scope of the lock is for this map only.
-     * The acquired lock is only for the key in this map.
-     * <p/>
-     * Locks are re-entrant, so if the key is locked N times, then
-     * it should be unlocked N times before another thread can acquire it.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
+     * <p>
+     * After the lease time, the lock will be released.
+     * <p>
+     * If the lock is not available, then the current thread becomes disabled
+     * for thread scheduling purposes and lies dormant until the lock has been
+     * acquired.
+     * <p>
+     * Scope of the lock is for this map only.The acquired lock is only for
+     * the key in this map.
+     * <p>
+     * Locks are re-entrant, so if the key is locked N times, then it should
+     * be unlocked N times before another thread can acquire it.
+     * <p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
-     * @param key       the key to lock.
-     * @param leaseTime time to wait before releasing the lock.
-     * @param timeUnit  unit of time for the lease time.
+     * @param key       the key to lock
+     * @param leaseTime time to wait before releasing the lock
+     * @param timeUnit  unit of time for the lease time
      */
     void lock(K key, long leaseTime, TimeUnit timeUnit);
 
     /**
      * Checks the lock for the specified key.
-     * <p>If the lock is acquired, this method returns true, else it returns false.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
+     * <p>
+     * If the lock is acquired, this method returns {@code true}, else it
+     * returns {@code false}.
+     * <p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
      * @param key key to lock to be checked.
-     * @return true if the lock is acquired, false otherwise.
+     * @return {@code true} if the lock is acquired, {@code false} otherwise.
      */
     boolean isLocked(K key);
 
     /**
      * Tries to acquire the lock for the specified key.
-     * <p>If the lock is not available, then the current thread
-     * does not wait and the method returns false immediately.
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
-     * </p>
+     * If the lock is not available, then the current thread does not wait and
+     * the method returns false immediately.
+     * <p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
      * @param key the key to lock.
-     * @return true if lock is acquired, false otherwise.
+     * @return {@code true} if lock is acquired, {@code false} otherwise
      */
     boolean tryLock(K key);
 
     /**
      * Tries to acquire the lock for the specified key.
-     * <p>If the lock is not available, then
-     * the current thread becomes disabled for thread scheduling
-     * purposes and lies dormant until one of two things happens:
+     * <p>
+     * If the lock is not available, then the current thread becomes disabled
+     * for thread scheduling purposes and lies dormant until one of two things
+     * happens:
      * <ul>
      * <li>the lock is acquired by the current thread, or
      * <li>the specified waiting time elapses.
      * </ul>
-     * <p/>
-     * <p><b>Warning:</b></p>
      * <p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
-     * </p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
      * @param time     the maximum time to wait for the lock
-     * @param timeunit the time unit of the <tt>time</tt> argument
-     * @return true if the lock was acquired, false
-     * if the waiting time elapsed before the lock was acquired.
+     * @param timeunit the time unit of the {@code time} argument
+     * @return {@code true} if the lock was acquired, {@code false} if the
+     * waiting time elapsed before the lock was acquired
      */
-    boolean tryLock(K key, long time, TimeUnit timeunit)
-            throws InterruptedException;
+    boolean tryLock(K key, long time, TimeUnit timeunit) throws InterruptedException;
 
     /**
-     * Tries to acquire the lock for the specified key for the specified lease time.
-     * <p>After lease time, the lock will be released.
-     * <p/>
-     * <p>If the lock is not available, then
-     * the current thread becomes disabled for thread scheduling
-     * purposes and lies dormant until one of two things happens:
+     * Tries to acquire the lock for the specified key for the specified
+     * lease time.
+     * <p>
+     * After lease time, the lock will be released.
+     * <p>
+     * If the lock is not available, then the current thread becomes disabled
+     * for thread scheduling purposes and lies dormant until one of two things
+     * happens:
      * <ul>
      * <li>the lock is acquired by the current thread, or
      * <li>the specified waiting time elapses.
      * </ul>
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
-     * @param key           key to lock in this map.
-     * @param time          maximum time to wait for the lock.
-     * @param timeunit      time unit of the <tt>time</tt> argument.
-     * @param leaseTime     time to wait before releasing the lock.
-     * @param leaseTimeunit unit of time to specify lease time.
-     * @return <tt>true</tt> if the lock was acquired and <tt>false</tt>
-     * if the waiting time elapsed before the lock was acquired.
-     * @throws NullPointerException if the specified key is null.
+     * @param key           key to lock in this map
+     * @param time          maximum time to wait for the lock
+     * @param timeunit      time unit of the {@code time} argument
+     * @param leaseTime     time to wait before releasing the lock
+     * @param leaseTimeunit unit of time to specify lease time
+     * @return {@code true} if the lock was acquired and {@code false} if the
+     * waiting time elapsed before the lock was acquired
+     * @throws NullPointerException if the specified key is {@code null}
      */
-    boolean tryLock(K key, long time, TimeUnit timeunit, long leaseTime, TimeUnit leaseTimeunit)
-            throws InterruptedException;
+    boolean tryLock(K key, long time, TimeUnit timeunit, long leaseTime, TimeUnit leaseTimeunit) throws InterruptedException;
 
     /**
-     * Releases the lock for the specified key. It never blocks and
-     * returns immediately.
-     * <p/>
-     * <p><b>Warning:</b></p>
+     * Releases the lock for the specified key.
      * <p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of the binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in the <tt>key</tt>'s class.
-     * </p>
+     * It never blocks and returns immediately.
+     * <p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
-     * @param key the key to lock.
+     * @param key the key to lock
      */
     void unlock(K key);
 
     /**
      * Releases the lock for the specified key regardless of the lock owner.
-     * It always successfully unlocks the key, never blocks
-     * and returns immediately.
-     * <p/>
-     * <p><b>Warning:</b></p>
-     * This method uses <tt>hashCode</tt> and <tt>equals</tt> of binary form of
-     * the <tt>key</tt>, not the actual implementations of <tt>hashCode</tt> and <tt>equals</tt>
-     * defined in <tt>key</tt>'s class.
+     * <p>
+     * It always successfully unlocks the key, never blocks and returns immediately.
+     * <p>
+     * <b>Warning:</b> This method uses {@code hashCode} and {@code equals} of
+     * the binary form of the {@code key}, not the actual implementations of
+     * {@code hashCode} and {@code equals} defined in the {@code key}'s class.
      *
-     * @param key key to lock.
+     * @param key key to lock
      */
     void forceUnlock(K key);
 
     /**
-     * Returns <tt>LocalMultiMapStats</tt> for this map.
-     * <tt>LocalMultiMapStats</tt> is the statistics for the local portion of this
+     * Returns {@code LocalMultiMapStats} for this map.
+     * <p>
+     * {@code LocalMultiMapStats} is the statistics for the local portion of this
      * distributed multi map and contains information such as ownedEntryCount
      * backupEntryCount, lastUpdateTime, and lockedEntryCount.
      * <p/>
@@ -501,11 +480,14 @@ public interface MultiMap<K, V>
     LocalMultiMapStats getLocalMultiMapStats();
 
     /**
-     * Executes a predefined aggregation on the multimaps data set. The {@link com.hazelcast.mapreduce.aggregation.Supplier}
-     * is used to either select or to select and extract a (sub-)value. A predefined set of aggregations can be found in
+     * Executes a predefined aggregation on the multimaps data set.
+     * <p>
+     * The {@link com.hazelcast.mapreduce.aggregation.Supplier} is used to
+     * either select or to select and extract a (sub-)value.
+     * A predefined set of aggregations can be found in
      * {@link com.hazelcast.mapreduce.aggregation.Aggregations}.
-     *
-     * Method does not honour Quorum
+     * <p>
+     * Method does not honor Quorum.
      *
      * @param supplier        the supplier to select and / or extract a (sub-)value from the multimap
      * @param aggregation     the aggregation that is being executed against the multimap
@@ -520,11 +502,14 @@ public interface MultiMap<K, V>
                                              Aggregation<K, SuppliedValue, Result> aggregation);
 
     /**
-     * Executes a predefined aggregation on the multimaps data set. The {@link com.hazelcast.mapreduce.aggregation.Supplier}
-     * is used to either select, or to select and extract, a (sub-)value. A predefined set of aggregations can be found in
+     * Executes a predefined aggregation on the multimaps data set.
+     * <p>
+     * The {@link com.hazelcast.mapreduce.aggregation.Supplier} is used to
+     * either select, or to select and extract, a (sub-)value.
+     * A predefined set of aggregations can be found in
      * {@link com.hazelcast.mapreduce.aggregation.Aggregations}.
-     *
-     * Method does not honour Quorum
+     * <p>
+     * Method does not honor Quorum.
      *
      * @param supplier        the supplier to select and / or extract a (sub-)value from the multimap
      * @param aggregation     the aggregation that is being executed against the multimap

--- a/hazelcast/src/main/java/com/hazelcast/core/QueueStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/QueueStoreFactory.java
@@ -18,6 +18,11 @@ package com.hazelcast.core;
 
 import java.util.Properties;
 
+/**
+ * Creates a new {@link QueueStore}.
+ *
+ * @param <T> type of the queue items
+ */
 public interface QueueStoreFactory<T> {
 
     QueueStore<T> newQueueStore(String name, Properties properties);

--- a/hazelcast/src/main/java/com/hazelcast/core/RingbufferStoreFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/RingbufferStoreFactory.java
@@ -18,6 +18,11 @@ package com.hazelcast.core;
 
 import java.util.Properties;
 
+/**
+ * Creates a new {@link RingbufferStore}.
+ *
+ * @param <T> type of the ringbuffer items
+ */
 public interface RingbufferStoreFactory<T> {
 
     RingbufferStore<T> newRingbufferStore(String name, Properties properties);

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalList.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalList.java
@@ -20,27 +20,33 @@ import com.hazelcast.transaction.TransactionalObject;
 
 /**
  * Transactional implementation of {@link IList}.
+ * <p>
+ * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in
+ * cluster versions 3.10 and higher.
  *
- * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster versions 3.10 and higher.
+ * @param <E> the type of elements maintained by this list
  */
 public interface TransactionalList<E> extends TransactionalObject {
 
     /**
      * Adds a new item to the transactional list.
+     *
      * @param e the new item added to the transactional list
-     * @return true if the item is added successfully, false otherwise
+     * @return {@code true} if the item is added successfully
      */
     boolean add(E e);
 
     /**
-     * Remove item from the transactional list
+     * Removes an item from the transactional list.
+     *
      * @param e item to remove the transactional list
-     * @return true if the item is removed successfully, false otherwise
+     * @return {@code true} if the item is removed successfully
      */
     boolean remove(E e);
 
     /**
-     * Returns the size of the list
+     * Returns the size of the list.
+     *
      * @return the size of the list
      */
     int size();

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
@@ -26,15 +26,13 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Transactional implementation of {@link BaseMap}.
- * <p/>
  * <h2>MapStore Interaction</h2>
- * When using MapStore, the call to any MapStore method is outside the transactional boundary.
- * If you need to have an XATransaction spanning Hazelcast operations and one more other XAResources
- * (such as a database), you should not use MapStore. Instead, enlist both resources in a transaction as shown below:
- * <p/>
- * <pre>
- * <code>
- *
+ * When using MapStore, the call to any MapStore method is outside the
+ * transactional boundary. If you need to have an XATransaction spanning
+ * Hazelcast operations and one more other XAResources (such as a database),
+ * you should not use MapStore. Instead, enlist both resources in a transaction
+ * as shown below:
+ * <pre><code>
  * HazelcastInstance client = HazelcastClient.newHazelcastClient();
  *
  * UserTransactionManager tm = new UserTransactionManager();
@@ -62,11 +60,10 @@ import java.util.concurrent.TimeUnit;
  *      transaction.delistResource(xaResource, XAResource.TMFAIL);
  *      tm.rollback();
  * }
- * </code>
- * </pre>
+ * </code></pre>
  *
- * @param <K> key
- * @param <V> value
+ * @param <K> type of the map key
+ * @param <V> type of the map value
  * @see BaseMap
  * @see IMap
  */
@@ -75,8 +72,8 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
     /**
      * Transactional implementation of {@link IMap#containsKey(Object)}.
      *
+     * @throws NullPointerException if the specified key is {@code null}
      * @see IMap#containsKey(Object)
-     * @throws NullPointerException if the specified key is null.
      */
     @Override
     boolean containsKey(Object key);
@@ -84,17 +81,18 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
     /**
      * Transactional implementation of {@link IMap#get(Object)}.
      *
+     * @throws NullPointerException if the specified key is {@code null}
      * @see IMap#get(Object)
-     * @throws NullPointerException if the specified key is null.
      */
     @Override
     V get(Object key);
 
     /**
-     * Locks the key and then gets and returns the value to which the specified key is mapped.
-     * Lock will be released at the end of the transaction (either commit or rollback).
+     * Locks the key and then gets and returns the value to which the specified
+     * key is mapped. The lock will be released at the end of the transaction
+     * (either commit or rollback).
      *
-     * @throws NullPointerException         if the specified key is null.
+     * @throws NullPointerException         if the specified key is {@code null}
      * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#get(Object)
      */
@@ -118,10 +116,11 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
 
     /**
      * Transactional implementation of {@link IMap#put(Object, Object)}.
-     * <p/>
-     * The object to be put will be accessible only in the current transaction context till transaction is committed.
+     * <p>
+     * The object to be put will be accessible only in the current transaction
+     * context till transaction is committed.
      *
-     * @throws NullPointerException         if the specified key or value is null.
+     * @throws NullPointerException         if the specified key or value is {@code null}
      * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#put(Object, Object)
      */
@@ -129,23 +128,25 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
     V put(K key, V value);
 
     /**
-     * Transactional implementation of {@link IMap#put(Object, Object, long, java.util.concurrent.TimeUnit)}.
-     * <p/>
-     * The object to be put will be accessible only in the current transaction context till transaction is committed.
+     * Transactional implementation of {@link IMap#put(Object, Object, long, TimeUnit)}.
+     * <p>
+     * The object to be put will be accessible only in the current transaction
+     * context till transaction is committed.
      *
-     * @throws NullPointerException         if the specified key, value or timeunit is null.
+     * @throws NullPointerException         if the specified key, value or timeunit is {@code null}
      * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
-     * @see IMap#put(Object, Object, long, java.util.concurrent.TimeUnit)
+     * @see IMap#put(Object, Object, long, TimeUnit)
      */
     @Override
     V put(K key, V value, long ttl, TimeUnit timeunit);
 
     /**
      * Transactional implementation of {@link IMap#set(Object, Object)}.
-     * <p/>
-     * The object to be set will be accessible only in the current transaction context till transaction is committed.
+     * <p>
+     * The object to be set will be accessible only in the current transaction
+     * context till transaction is committed.
      *
-     * @throws NullPointerException         if the specified key or value is null.
+     * @throws NullPointerException         if the specified key or value is {@code null}
      * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#set(Object, Object)
      */
@@ -154,10 +155,11 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
 
     /**
      * Transactional implementation of {@link IMap#putIfAbsent(Object, Object)}.
-     * <p/>
-     * The object to be put will be accessible only in the current transaction context until the transaction is committed.
+     * <p>
+     * The object to be put will be accessible only in the current transaction
+     * context until the transaction is committed.
      *
-     * @throws NullPointerException         if the specified key or value is null.
+     * @throws NullPointerException         if the specified key or value is {@code null}
      * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#putIfAbsent(Object, Object)
      */
@@ -166,10 +168,11 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
 
     /**
      * Transactional implementation of {@link IMap#replace(Object, Object)}.
-     * <p/>
-     * The object to be replaced will be accessible only in the current transaction context until the transaction is committed.
+     * <p>
+     * The object to be replaced will be accessible only in the current transaction
+     * context until the transaction is committed.
      *
-     * @throws NullPointerException         if the specified key or null.
+     * @throws NullPointerException         if the specified key or {@code null}
      * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#replace(Object, Object)
      */
@@ -178,10 +181,11 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
 
     /**
      * Transactional implementation of {@link IMap#replace(Object, Object, Object)}.
-     * <p/>
-     * The object to be replaced will be accessible only in the current transaction context until the transaction is committed.
+     * <p>
+     * The object to be replaced will be accessible only in the current transaction
+     * context until the transaction is committed.
      *
-     * @throws NullPointerException         if the specified key, oldValue or newValue is null.
+     * @throws NullPointerException         if the specified key, oldValue or newValue is {@code null}
      * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#replace(Object, Object, Object)
      */
@@ -190,10 +194,11 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
 
     /**
      * Transactional implementation of {@link IMap#remove(Object)}.
-     * <p/>
-     * The object to be removed will be removed from only the current transaction context until the transaction is committed.
+     * <p>
+     * The object to be removed will be removed from only the current transaction
+     * context until the transaction is committed.
      *
-     * @throws NullPointerException         if the specified key is null.
+     * @throws NullPointerException         if the specified key is {@code null}
      * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#remove(Object)
      */
@@ -202,10 +207,11 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
 
     /**
      * Transactional implementation of {@link IMap#delete(Object)}.
-     * <p/>
-     * The object to be deleted will be removed from only the current transaction context until the transaction is committed.
+     * <p>
+     * The object to be deleted will be removed from only the current transaction
+     * context until the transaction is committed.
      *
-     * @throws NullPointerException         if the specified key is null.
+     * @throws NullPointerException         if the specified key is {@code null}
      * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#delete(Object)
      */
@@ -214,10 +220,11 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
 
     /**
      * Transactional implementation of {@link IMap#remove(Object, Object)}.
-     * <p/>
-     * The object to be removed will be removed from only the current transaction context until the transaction is committed.
+     * <p>
+     * The object to be removed will be removed from only the current transaction
+     * context until the transaction is committed.
      *
-     * @throws NullPointerException         if the specified key or value null.
+     * @throws NullPointerException         if the specified key or value {@code null}
      * @throws TransactionTimedOutException if the key could not be locked for update in the transaction timeout
      * @see IMap#remove(Object, Object)
      */
@@ -235,8 +242,8 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
     /**
      * Transactional implementation of {@link IMap#keySet(com.hazelcast.query.Predicate)}.
      *
+     * @throws NullPointerException if the specified predicate is {@code null}
      * @see IMap#keySet(com.hazelcast.query.Predicate)
-     * @throws NullPointerException if the specified predicate is null.
      */
     @Override
     Set<K> keySet(Predicate predicate);
@@ -252,8 +259,8 @@ public interface TransactionalMap<K, V> extends TransactionalObject, BaseMap<K, 
     /**
      * Transactional implementation of {@link IMap#values(com.hazelcast.query.Predicate)}.
      *
+     * @throws NullPointerException if the specified predicate is {@code null}
      * @see IMap#values(com.hazelcast.query.Predicate)
-     * @throws NullPointerException if the specified predicate is null.
      */
     @Override
     Collection<V> values(Predicate predicate);

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalMultiMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalMultiMap.java
@@ -22,11 +22,12 @@ import java.util.Collection;
 
 /**
  * Transactional implementation of {@link BaseMultiMap}.
+ * <p>
+ * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in
+ * cluster versions 3.10 and higher.
  *
- * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster versions 3.10 and higher.
- *
- * @param <K> key
- * @param <V> value
+ * @param <K> type of the multimap key
+ * @param <V> type of the multimap value
  * @see BaseMultiMap
  * @see MultiMap
  */

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalQueue.java
@@ -23,9 +23,9 @@ import java.util.concurrent.TimeUnit;
 /**
  * Transactional implementation of {@link BaseQueue}.
  *
+ * @param <E> the type of elements held in this collection
  * @see BaseQueue
  * @see IQueue
- * @param <E>
  */
 public interface TransactionalQueue<E> extends TransactionalObject, BaseQueue<E> {
 

--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalSet.java
@@ -20,27 +20,33 @@ import com.hazelcast.transaction.TransactionalObject;
 
 /**
  * Transactional implementation of {@link ISet}.
+ * <p>
+ * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in
+ * cluster versions 3.10 and higher.
  *
- * Supports Quorum {@link com.hazelcast.config.QuorumConfig} since 3.10 in cluster versions 3.10 and higher.
+ * @param <E> the type of elements maintained by this set
  */
 public interface TransactionalSet<E> extends TransactionalObject {
 
     /**
      * Add new item to transactional set.
+     *
      * @param e item added to transactional set
-     * @return true if item is added successfully
+     * @return {@code true} if item is added successfully
      */
     boolean add(E e);
 
     /**
      * Remove item from transactional set.
+     *
      * @param e item removed from transactional set
-     * @return true if item is remove successfully
+     * @return {@code true} if item is remove successfully
      */
     boolean remove(E e);
 
     /**
      * Returns the size of the set.
+     *
      * @return the size of the set
      */
     int size();


### PR DESCRIPTION
Also fixed the JavaDoc for `IAtomicLong` and `IAtomicReference` which support split-brain merge policies now.