### PR TITLE
Wait for Map loader changes propagation after calling loadAll

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapDataStructureAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/adapter/IMapDataStructureAdapterTest.java
@@ -377,6 +377,7 @@ public class IMapDataStructureAdapterTest extends HazelcastTestSupport {
         mapStore.setKeys(singleton(23));
 
         adapterWithLoader.loadAll(true);
+        adapterWithLoader.waitUntilLoaded();
 
         assertEquals("newValue-23", mapWithLoader.get(23));
     }


### PR DESCRIPTION
Fixes #13234.
The PR adds `IMapDataStructureAdapter.waitUntilLoaded()` call after the `loadAll`. It ensures the load operation finishes on all partitions before checking value in the test Map.