### PR TITLE
Fix MigrationInvocationsSafetyTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.instance.TestUtil.terminateInstance;
 import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
+import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.ASSIGN_PARTITIONS;
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.FETCH_PARTITION_STATE;
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.F_ID;
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.PARTITION_STATE_OP;
@@ -80,6 +81,8 @@ public class MigrationInvocationsSafetyTest extends PartitionCorrectnessTestSupp
 
         // nextMaster & slave1 won't receive partition table updates from initialMaster.
         dropOperationsBetween(initialMaster, asList(slave1, nextMaster), F_ID, singletonList(PARTITION_STATE_OP));
+        dropOperationsBetween(nextMaster, singletonList(initialMaster), F_ID, singletonList(ASSIGN_PARTITIONS));
+        dropOperationsBetween(slave1, singletonList(initialMaster), F_ID, singletonList(ASSIGN_PARTITIONS));
 
         warmUpPartitions(initialMaster, slave2, slave3);
 
@@ -128,6 +131,8 @@ public class MigrationInvocationsSafetyTest extends PartitionCorrectnessTestSupp
 
         // nextMaster & slave1 won't receive partition table updates from initialMaster.
         dropOperationsBetween(initialMaster, asList(slave1, nextMaster), F_ID, singletonList(PARTITION_STATE_OP));
+        dropOperationsBetween(nextMaster, singletonList(initialMaster), F_ID, singletonList(ASSIGN_PARTITIONS));
+        dropOperationsBetween(slave1, singletonList(initialMaster), F_ID, singletonList(ASSIGN_PARTITIONS));
 
         warmUpPartitions(initialMaster, slave2, slave3);
 


### PR DESCRIPTION
Test should drop assign-partitions requests from slaves to master,
in addition to periodic partition table updates from master,
to prevent slaves receiving partition table updates.

Fixes #13261

Backport of #13264