### PR TITLE
Fix client copy message logic

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -20,7 +20,6 @@ import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.impl.protocol.util.BufferBuilder;
 import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.client.spi.ClientExecutionService;
 import com.hazelcast.client.spi.EventHandler;
@@ -37,7 +36,6 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.sequence.CallIdSequence;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -183,7 +181,7 @@ public class ClientInvocation implements Runnable {
     private void retry() {
         // retry modifies the client message and should not reuse the client message.
         // It could be the case that it is in write queue of the connection.
-        clientMessage = copyMessage();
+        clientMessage = clientMessage.copy();
         // first we force a new invocation slot because we are going to return our old invocation slot immediately after
         // It is important that we first 'force' taking a new slot; otherwise it could be that a sneaky invocation gets
         // through that takes our slot!
@@ -196,12 +194,6 @@ public class ClientInvocation implements Runnable {
         } catch (Throwable e) {
             clientInvocationFuture.complete(e);
         }
-    }
-
-    private ClientMessage copyMessage() {
-        byte[] oldBinary = clientMessage.buffer().byteArray();
-        byte[] bytes = Arrays.copyOf(oldBinary, oldBinary.length);
-        return ClientMessage.createForDecode(BufferBuilder.createBuffer(bytes), 0);
     }
 
     public void notify(ClientMessage clientMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl.protocol;
 
 import com.hazelcast.client.impl.protocol.exception.MaxMessageSizeExceeded;
+import com.hazelcast.client.impl.protocol.util.BufferBuilder;
 import com.hazelcast.client.impl.protocol.util.ClientProtocolBuffer;
 import com.hazelcast.client.impl.protocol.util.MessageFlyweight;
 import com.hazelcast.client.impl.protocol.util.SafeBuffer;
@@ -25,6 +26,7 @@ import com.hazelcast.internal.networking.OutboundFrame;
 import com.hazelcast.nio.Bits;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 /**
  * <p>
@@ -388,6 +390,10 @@ public class ClientMessage
         this.operationName = operationName;
     }
 
+    public String getOperationName() {
+        return operationName;
+    }
+
     @Override
     public String toString() {
         int len = index();
@@ -437,6 +443,16 @@ public class ClientMessage
         ClientMessage clientMessage = new ClientMessage();
         clientMessage.wrapForDecode(buffer, offset);
         return clientMessage;
+    }
+
+    public ClientMessage copy() {
+        byte[] oldBinary = buffer().byteArray();
+        byte[] bytes = Arrays.copyOf(oldBinary, oldBinary.length);
+        ClientMessage newMessage = ClientMessage.createForDecode(BufferBuilder.createBuffer(bytes), 0);
+        newMessage.isRetryable = isRetryable;
+        newMessage.acquiresResource = acquiresResource;
+        newMessage.operationName = operationName;
+        return newMessage;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/ClientMessageTest.java
@@ -409,4 +409,32 @@ public class ClientMessageTest {
     public void testMessageSizeOverflow() {
         ClientMessage.findSuitableMessageSize(Integer.MAX_VALUE << 1);
     }
+
+    @Test
+    public void testCopyClientMessage() {
+        SafeBuffer byteBuffer = new SafeBuffer(new byte[1024]);
+
+        ClientMessage clientMessage = TestClientMessage.createForEncode(byteBuffer, 0);
+
+        clientMessage.setMessageType(7)
+                .setVersion((short) 3)
+                .addFlag(ClientMessage.BEGIN_AND_END_FLAGS)
+                .setCorrelationId(66).setPartitionId(77);
+
+        clientMessage.setRetryable(true);
+        clientMessage.setAcquiresResource(true);
+        clientMessage.setOperationName("operationName");
+
+
+        ClientMessage copyMessage = clientMessage.copy();
+        assertEquals(copyMessage, clientMessage);
+        assertEquals(copyMessage.getMessageType(), clientMessage.getMessageType());
+        assertEquals(copyMessage.getVersion(), clientMessage.getVersion());
+        assertEquals(copyMessage.getFlags(), clientMessage.getFlags());
+        assertEquals(copyMessage.getCorrelationId(), clientMessage.getCorrelationId());
+        assertEquals(copyMessage.getPartitionId(), clientMessage.getPartitionId());
+        assertEquals(copyMessage.isRetryable(), clientMessage.isComplete());
+        assertEquals(copyMessage.acquiresResource(), clientMessage.acquiresResource());
+        assertEquals(copyMessage.getOperationName(), clientMessage.getOperationName());
+    }
 }


### PR DESCRIPTION
When a message retried, the fields like acquiresResorce and
isRetryable are forgotten to be copied.
We make sure those fields are also carried to new client message
with this pr.

fixes https://github.com/hazelcast/hazelcast/issues/11487

(cherry picked from commit 5448dbf307c346f07a1420dd6adfb1ffee31670d)