### PR TITLE
Restore interrupt flag on catching InterruptedExceptions

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientResponseHandlerSupplier.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientResponseHandlerSupplier.java
@@ -160,6 +160,7 @@ public class ClientResponseHandlerSupplier implements Supplier<ClientResponseHan
                 try {
                     response = responseQueue.take();
                 } catch (InterruptedException e) {
+                    currentThread().interrupt();
                     continue;
                 }
                 process(response);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationThread.java
@@ -104,6 +104,7 @@ public abstract class OperationThread extends HazelcastManagedThread implements 
                 try {
                     task = queue.take(priority);
                 } catch (InterruptedException e) {
+                    currentThread().interrupt();
                     continue;
                 }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/StripedExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/StripedExecutor.java
@@ -208,6 +208,7 @@ public final class StripedExecutor implements Executor {
                         Runnable task = workQueue.take();
                         process(task);
                     } catch (InterruptedException e) {
+                        currentThread().interrupt();
                         if (!live) {
                             return;
                         }


### PR DESCRIPTION
Related to https://github.com/hazelcast/hazelcast/issues/12452

There are other occurences of InterruptedException handling, but they are handled like this:
```
boolean interrupted = false;
        for (Member member : cluster.getMembers()) {
            if (isCandidateMember(member)) {
                continue;
            }
            try {
                classData = tryToFetchClassDataFromMember(className, member);
                if (classData != null) {
                    if (logger.isFineEnabled()) {
                        logger.finest("Loaded class " + className + " from " + member);
                    }
                    return classData;
                }
            } catch (InterruptedException e) {
                // question: should we give-up on loading and this point and simply throw ClassNotFoundException?
                interrupted = true;
            } catch (Exception e) {
                if (logger.isFinestEnabled()) {
                    logger.finest("Unable to get class data for class " + className
                            + " from member " + member, e);
                }
            }
        }
        if (interrupted) {
            Thread.currentThread().interrupt();
        }
```

I don't know whether this is correct handling.