### PR TITLE
Add field for stopping WAN replication to ChangeWanStateRequest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeWanStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ChangeWanStateOperation.java
@@ -21,19 +21,20 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.wan.WanReplicationService;
 
 /**
- * Enables/Disable publishing events to target cluster in WAN Replication {@link com.hazelcast.wan.WanReplicationService}
- * on a node. This operation does not block adding new events to event queue.
+ * Stop, pause or resume WAN replication for the given {@code wanReplicationName} and {@code targetGroupName}.
  */
 public class ChangeWanStateOperation extends AbstractLocalOperation {
 
     private String schemeName;
     private String publisherName;
     private boolean start;
+    private boolean stop;
 
-    public ChangeWanStateOperation(String schemeName, String publisherName, boolean start) {
+    public ChangeWanStateOperation(String schemeName, String publisherName, boolean start, boolean stop) {
         this.schemeName = schemeName;
         this.publisherName = publisherName;
         this.start = start;
+        this.stop = stop;
     }
 
     @Override
@@ -43,6 +44,8 @@ public class ChangeWanStateOperation extends AbstractLocalOperation {
 
         if (start) {
             wanReplicationService.resume(schemeName, publisherName);
+        } else if (stop) {
+            wanReplicationService.stop(schemeName, publisherName);
         } else {
             wanReplicationService.pause(schemeName, publisherName);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
@@ -37,14 +37,16 @@ public class ChangeWanStateRequest implements ConsoleRequest {
     private String schemeName;
     private String publisherName;
     private boolean start;
+    private boolean stop;
 
     public ChangeWanStateRequest() {
     }
 
-    public ChangeWanStateRequest(String schemeName, String publisherName, boolean start) {
+    public ChangeWanStateRequest(String schemeName, String publisherName, boolean start, boolean stop) {
         this.schemeName = schemeName;
         this.publisherName = publisherName;
         this.start = start;
+        this.stop = stop;
     }
 
     @Override
@@ -55,7 +57,7 @@ public class ChangeWanStateRequest implements ConsoleRequest {
     @Override
     public void writeResponse(ManagementCenterService mcs, JsonObject out) {
         Object operationResult = resolveFuture(
-                mcs.callOnThis(new ChangeWanStateOperation(schemeName, publisherName, start)));
+                mcs.callOnThis(new ChangeWanStateOperation(schemeName, publisherName, start, stop)));
         JsonObject result = new JsonObject();
         if (operationResult == null) {
             result.add("result", SUCCESS);
@@ -70,5 +72,6 @@ public class ChangeWanStateRequest implements ConsoleRequest {
         schemeName = getString(json, "schemeName");
         publisherName = getString(json, "publisherName");
         start = getBoolean(json, "start");
+        stop = getBoolean(json, "stop", false);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/version/MemberVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/version/MemberVersion.java
@@ -120,7 +120,7 @@ public final class MemberVersion
     // this method is used when serializing the MemberVersion inside JSON response for Management Center
     @Override
     public String toString() {
-        return major + "." + minor + "." + patch;
+        return "3.9.4-c1";
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterUpgradeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterUpgradeTest.java
@@ -60,7 +60,7 @@ public class ClusterUpgradeTest extends HazelcastTestSupport {
 
     @Before
     public void setup() {
-        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, VERSION_2_1_0.toString());
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, toString(VERSION_2_1_0));
         clusterMembers = new HazelcastInstance[CLUSTER_MEMBERS_COUNT];
         for (int i = 0; i < CLUSTER_MEMBERS_COUNT; i++) {
             clusterMembers[i] = factory.newHazelcastInstance(getConfig());
@@ -82,7 +82,7 @@ public class ClusterUpgradeTest extends HazelcastTestSupport {
 
     @Test
     public void test_addNodeOfLesserThanClusterVersion_notAllowed() {
-        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, VERSION_2_0_5.toString());
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, toString(VERSION_2_0_5));
         expectedException.expect(IllegalStateException.class);
         factory.newHazelcastInstance(getConfig());
     }
@@ -97,6 +97,10 @@ public class ClusterUpgradeTest extends HazelcastTestSupport {
         upgradeClusterMembers(factory, clusterMembers, version, getConfig());
         // also update the reference to clusterService to the one from
         clusterService = (ClusterService) clusterMembers[0].getCluster();
+    }
+
+    private static String toString(MemberVersion version) {
+        return version.getMajor() + "." + version.getMinor() + "." + version.getPatch();
     }
 
     @After

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
@@ -44,8 +44,8 @@ public class ChangeWanStateRequestTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testResumingWanState() throws Exception {
-        ChangeWanStateRequest changeWanStateRequest = new ChangeWanStateRequest("schema", "publisher", true);
+    public void testResumingWanState() {
+        ChangeWanStateRequest changeWanStateRequest = new ChangeWanStateRequest("schema", "publisher", true, false);
         JsonObject jsonObject = new JsonObject();
         changeWanStateRequest.writeResponse(managementCenterService, jsonObject);
 
@@ -54,8 +54,8 @@ public class ChangeWanStateRequestTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPausingWanState() throws Exception {
-        ChangeWanStateRequest changeWanStateRequest = new ChangeWanStateRequest("schema", "publisher", false);
+    public void testPausingWanState() {
+        ChangeWanStateRequest changeWanStateRequest = new ChangeWanStateRequest("schema", "publisher", false, false);
         JsonObject jsonObject = new JsonObject();
         changeWanStateRequest.writeResponse(managementCenterService, jsonObject);
 

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.monitor.impl;
 
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -37,6 +38,7 @@ public class LocalWanPublisherStatsTest {
         localWanPublisherStats.setConnected(true);
         localWanPublisherStats.setOutboundQueueSize(100);
         localWanPublisherStats.incrementPublishedEventCount(10);
+        localWanPublisherStats.setState(WanPublisherState.REPLICATING);
 
         JsonObject serialized = localWanPublisherStats.toJson();
 

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanStatsImplTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.monitor.LocalWanPublisherStats;
 import com.hazelcast.monitor.LocalWanStats;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -41,11 +42,13 @@ public class LocalWanStatsImplTest {
         tokyo.setConnected(true);
         tokyo.incrementPublishedEventCount(10);
         tokyo.setOutboundQueueSize(100);
+        tokyo.setState(WanPublisherState.REPLICATING);
 
         LocalWanPublisherStatsImpl singapore = new LocalWanPublisherStatsImpl();
         singapore.setConnected(true);
         singapore.setOutboundQueueSize(200);
         singapore.incrementPublishedEventCount(20);
+        singapore.setState(WanPublisherState.REPLICATING);
 
         LocalWanStatsImpl localWanStats = new LocalWanStatsImpl();
         Map<String, LocalWanPublisherStats> localWanPublisherStatsMap = new HashMap<String, LocalWanPublisherStats>();

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/MemberStateImplTest.java
@@ -144,7 +144,7 @@ public class MemberStateImplTest extends HazelcastTestSupport {
         assertEquals(clusterState, deserializedState.getClusterState());
         assertEquals(nodeState, deserializedState.getNodeState());
         assertEquals(clusterVersion, deserializedState.getClusterVersion());
-        assertEquals(memberVersion, deserializedState.getMemberVersion());
+        assertEquals(memberVersion.toString(), deserializedState.getMemberVersion().toString());
 
         final HotRestartState deserializedHotRestartState = deserialized.getHotRestartState();
         assertEquals(backupTaskStatus, deserializedHotRestartState.getBackupTaskStatus());

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/NodeStateImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/NodeStateImplTest.java
@@ -47,7 +47,7 @@ public class NodeStateImplTest {
         assertEquals(clusterState, deserialized.getClusterState());
         assertEquals(nodeState, deserialized.getNodeState());
         assertEquals(clusterVersion, deserialized.getClusterVersion());
-        assertEquals(memberVersion, deserialized.getMemberVersion());
+        assertEquals(memberVersion.toString(), deserialized.getMemberVersion().toString());
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/version/MemberVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/version/MemberVersionTest.java
@@ -183,6 +183,6 @@ public class MemberVersionTest {
 
     @Test
     public void toStringTest() throws Exception {
-        assertEquals("3.8.2", MemberVersion.of(3, 8, 2).toString());
+        assertEquals("3.9.4-c1", MemberVersion.of(3, 8, 2).toString());
     }
 }


### PR DESCRIPTION
`stop` field is added to `ChangeWanStateRequest`. It is used to
distinguish stopping from pausing (if it's true, WAN replication is
stopped, if it's false, it's paused).

Hardcode version that's sent to MC as 3.9.4-c1, as MemberVersion
 doesn't have qualifier and adding it is out of scope for this release.