### PR TITLE
Send disconnected event after destroy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEndpointManagerImpl.java
@@ -113,12 +113,6 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
             return;
         }
 
-        ClientEvent event = new ClientEvent(endpoint.getUuid(),
-                ClientEventType.DISCONNECTED,
-                endpoint.getSocketAddress(),
-                endpoint.getClientType());
-        sendClientEvent(event);
-
         logger.info("Destroying " + endpoint);
         try {
             endpoint.destroy();
@@ -126,6 +120,11 @@ public class ClientEndpointManagerImpl implements ClientEndpointManager {
             logger.warning(e);
         }
 
+        ClientEvent event = new ClientEvent(endpoint.getUuid(),
+                ClientEventType.DISCONNECTED,
+                endpoint.getSocketAddress(),
+                endpoint.getClientType());
+        sendClientEvent(event);
     }
 
     private void sendClientEvent(ClientEvent event) {


### PR DESCRIPTION
This bug introduced recently when trying to fix
disconnected event miss. This is a follow-up fix to
following prs:

maint  https://github.com/hazelcast/hazelcast/pull/13230
master https://github.com/hazelcast/hazelcast/pull/13229

fixes https://github.com/hazelcast/hazelcast/issues/13270

(cherry picked from commit 8a35f4af634f09310524a0741a2ac78d993b1df1)