### PR TITLE
Filter out load events for WAN

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -87,9 +87,9 @@ public final class EntryViews {
                 .setLastStoredTime(record.getLastStoredTime());
     }
 
-    public static <K, V> EntryView<K, V> convertToLazyEntryView(EntryView<K, V> entryView,
-                                                                SerializationService serializationService,
-                                                                MapMergePolicy mergePolicy) {
+    public static <K, V> EntryView<K, V> toLazyEntryView(EntryView<K, V> entryView,
+                                                         SerializationService serializationService,
+                                                         MapMergePolicy mergePolicy) {
         return new LazyEntryView<K, V>(entryView.getKey(), entryView.getValue(), serializationService, mergePolicy)
                 .setCost(entryView.getCost())
                 .setVersion(entryView.getVersion())

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisher.java
@@ -32,10 +32,13 @@ public interface MapEventPublisher {
     /**
      * Notifies the WAN subsystem of a map update on a replica owner.
      *
-     * @param mapName   the map name
-     * @param entryView the updated entry
+     * @param mapName           the map name
+     * @param entryView         the updated entry
+     * @param hasLoadProvenance {@code true} to indicate the provenance of
+     *                          update is a load from map-loader, otherwise
+     *                          set {@code false}
      */
-    void publishWanUpdate(String mapName, EntryView<Data, Data> entryView);
+    void publishWanUpdate(String mapName, EntryView<Data, Data> entryView, boolean hasLoadProvenance);
 
     /**
      * Notifies the WAN subsystem of a map entry removal on a replica owner.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperation.java
@@ -192,6 +192,10 @@ public abstract class MapOperation extends AbstractNamedOperation implements Ide
     }
 
     protected final void publishWanUpdate(Data dataKey, Object value) {
+        publishWanUpdateInternal(dataKey, value, false);
+    }
+
+    private void publishWanUpdateInternal(Data dataKey, Object value, boolean hasLoadProvenance) {
         if (!canPublishWANEvent()) {
             return;
         }
@@ -204,7 +208,11 @@ public abstract class MapOperation extends AbstractNamedOperation implements Ide
         Data dataValue = toHeapData(mapServiceContext.toData(value));
         EntryView entryView = createSimpleEntryView(toHeapData(dataKey), dataValue, record);
 
-        mapEventPublisher.publishWanUpdate(name, entryView);
+        mapEventPublisher.publishWanUpdate(name, entryView, hasLoadProvenance);
+    }
+
+    protected final void publishLoadAsWanUpdate(Data dataKey, Object value) {
+        publishWanUpdateInternal(dataKey, value, true);
     }
 
     protected final void publishWanRemove(Data dataKey) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllBackupOperation.java
@@ -62,7 +62,7 @@ public class PutFromLoadAllBackupOperation extends MapOperation implements Backu
                 continue;
             }
 
-            publishWanUpdate(key, value);
+            publishLoadAsWanUpdate(key, value);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutFromLoadAllOperation.java
@@ -69,8 +69,9 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
             Object value = hasInterceptor ? mapServiceContext.toObject(dataValue) : dataValue;
 
             recordStore.putFromLoad(key, value, getCallerAddress());
-            // the following check is for the case when the putFromLoad does not put the data due to various reasons
-            // one of the reasons may be size eviction threshold has been reached
+            // the following check is for the case when the putFromLoad does not put
+            // the data due to various reasons one of the reasons may be size
+            // eviction threshold has been reached
             if (value != null && !recordStore.existInMemory(key)) {
                 continue;
             }
@@ -84,7 +85,7 @@ public class PutFromLoadAllOperation extends MapOperation implements PartitionAw
                 checkNotNull(record, "Value loaded by a MapLoader cannot be null.");
                 value = record.getValue();
             }
-            publishWanUpdate(key, value);
+            publishLoadAsWanUpdate(key, value);
             addInvalidation(key);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTTLBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTTLBackupOperation.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.core.EntryView;
-import com.hazelcast.map.impl.EntryViews;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
@@ -46,12 +44,8 @@ public class SetTTLBackupOperation extends KeyBasedMapOperation implements Backu
     @Override
     public void afterRun() throws Exception {
         Record record = recordStore.getRecord(dataKey);
-        if (record == null) {
-            return;
-        }
-        if (mapContainer.isWanReplicationEnabled()) {
-            EntryView entryView = EntryViews.toSimpleEntryView(record);
-            mapEventPublisher.publishWanUpdate(name, entryView);
+        if (record != null) {
+            publishWanUpdate(dataKey, record.getValue());
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTTLOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTTLOperation.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.core.EntryView;
-import com.hazelcast.map.impl.EntryViews;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
@@ -48,14 +46,10 @@ public class SetTTLOperation extends LockAwareOperation implements BackupAwareOp
     @Override
     public void afterRun() throws Exception {
         Record record = recordStore.getRecord(dataKey);
-        if (record == null) {
-            return;
+        if (record != null) {
+            publishWanUpdate(dataKey, record.getValue());
+            invalidateNearCache(dataKey);
         }
-        if (mapContainer.isWanReplicationEnabled()) {
-            EntryView entryView = EntryViews.toSimpleEntryView(record);
-            mapEventPublisher.publishWanUpdate(name, entryView);
-        }
-        invalidateNearCache(dataKey);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -70,6 +70,7 @@ import java.util.concurrent.Future;
 import static com.hazelcast.config.NativeMemoryConfig.MemoryAllocatorType.POOLED;
 import static com.hazelcast.core.EntryEventType.ADDED;
 import static com.hazelcast.core.EntryEventType.UPDATED;
+import static com.hazelcast.map.impl.EntryViews.toLazyEntryView;
 import static com.hazelcast.map.impl.ExpirationTimeSetter.setTTLAndUpdateExpiryTime;
 import static com.hazelcast.map.impl.mapstore.MapDataStores.EMPTY_MAP_DATA_STORE;
 import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
@@ -829,7 +830,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         long now = getNow();
 
         Record record = getRecordOrNull(key, now, false);
-        mergingEntry = EntryViews.convertToLazyEntryView(mergingEntry, serializationService, mergePolicy);
+        mergingEntry = toLazyEntryView(mergingEntry, serializationService, mergePolicy);
         Object newValue;
         Object oldValue = null;
         if (record == null) {
@@ -1137,7 +1138,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
                 FutureUtil.checkAllDone(doneFutures);
             } catch (Exception e) {
                 logger.severe("Exception while loading map " + name, e);
-                ExceptionUtil.rethrow(e);
+                throw ExceptionUtil.rethrow(e);
             } finally {
                 loadingFutures.removeAll(doneFutures);
             }


### PR DESCRIPTION
ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/2185

- Main fix: Added `publishLoadAsWanUpdate` method and it is used in `PutFromLoadAllOperation`