### PR TITLE
Introduce a test rule that can change logging configuration only for …

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/logging/Log4j2Factory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/Log4j2Factory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.logging;
 
+import com.hazelcast.spi.annotation.PrivateApi;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 
@@ -33,11 +34,12 @@ public class Log4j2Factory extends LoggerFactorySupport {
         return new Log4j2Logger(LogManager.getContext().getLogger(name));
     }
 
-    static class Log4j2Logger extends AbstractLogger {
+    @PrivateApi
+    public static class Log4j2Logger extends AbstractLogger {
 
         private final ExtendedLogger logger;
 
-        Log4j2Logger(ExtendedLogger logger) {
+        public Log4j2Logger(ExtendedLogger logger) {
             this.logger = logger;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/logging/LoggerFactorySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/LoggerFactorySupport.java
@@ -39,4 +39,8 @@ public abstract class LoggerFactorySupport implements LoggerFactory {
     }
 
     protected abstract ILogger createLogger(String name);
+
+    public void clearLoadedLoggers() {
+        mapLoggers.clear();
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.core.MapEvent;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -37,6 +38,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.Preconditions;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -70,6 +72,12 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class BasicMapTest extends HazelcastTestSupport {
+
+    /**
+     * This rule is here artificially just to test that ChangeLoggingRule is working (meaning not broken).
+     */
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2.xml");
 
     static final int INSTANCE_COUNT = 3;
     static final Random RANDOM = new Random();

--- a/hazelcast/src/test/java/com/hazelcast/test/ChangeLoggingRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ChangeLoggingRule.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import com.hazelcast.logging.Logger;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Test rule that allows to change logging setting on-the-fly for a single test.
+ * Example of usage, add this to your test class:
+ *
+ * <pre>
+ * @ClassRule
+ * public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-info.xml");
+ * </pre>
+ *
+ */
+public class ChangeLoggingRule implements TestRule {
+
+    private final String configFile;
+
+    public ChangeLoggingRule(String configFile) {
+        this.configFile = configFile;
+    }
+
+    @Override
+    public Statement apply(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                TestLoggerFactory testLoggerFactory = (TestLoggerFactory) Logger.newLoggerFactory(null);
+                testLoggerFactory.changeConfigFile(configFile); //setting the desired configuration
+                try {
+                    base.evaluate();
+                } finally {
+                    testLoggerFactory.changeConfigFile(null); //resetting to default behavior
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
…specified test

This would be extremely helpful tool for tackling down test failures. Typically you don't want to setup debug/trace logging for whole testsuite, it would be huge + adding extensive logging commonly causes delays and the rarely occurring issues no longer occur. 

This PR adds ability by simply adding:
```
@ClassRule
public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule(<your config>);
```
to the test to configure the logging at your taste only for this test.

I'm not extremely knowledgeable of the HZ internals, hence please review carefully if it's the correct way of achieving it.
