### PR TITLE
WAN persist option

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -443,11 +443,11 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     getAttribute(node, "heartbeat-interval-millis"),
                     ProbabilisticQuorumConfigBuilder.DEFAULT_HEARTBEAT_INTERVAL_MILLIS);
             quorumConfigBuilder = QuorumConfig.newProbabilisticQuorumConfigBuilder(name, quorumSize)
-                                              .withAcceptableHeartbeatPauseMillis(acceptableHeartPause)
-                                              .withSuspicionThreshold(threshold)
-                                              .withHeartbeatIntervalMillis(heartbeatIntervalMillis)
-                                              .withMinStdDeviationMillis(minStdDeviation)
-                                              .withMaxSampleSize(maxSampleSize);
+                    .withAcceptableHeartbeatPauseMillis(acceptableHeartPause)
+                    .withSuspicionThreshold(threshold)
+                    .withHeartbeatIntervalMillis(heartbeatIntervalMillis)
+                    .withMinStdDeviationMillis(minStdDeviation)
+                    .withMaxSampleSize(maxSampleSize);
             return quorumConfigBuilder;
         }
 
@@ -1279,12 +1279,17 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     wanPublishers.add(childBeanDefinition);
                 } else if ("wan-consumer".equals(nName)) {
                     BeanDefinitionBuilder consumerConfigBuilder = createBeanBuilder(WanConsumerConfig.class);
+
                     String className = getAttribute(n, "class-name");
                     String implementation = getAttribute(n, "implementation");
+                    boolean persistWanReplicatedData = getBooleanValue(getAttribute(n, "persist-wan-replicated-data"));
+
                     consumerConfigBuilder.addPropertyValue("className", className);
                     if (implementation != null) {
                         consumerConfigBuilder.addPropertyReference("implementation", implementation);
                     }
+                    consumerConfigBuilder.addPropertyValue("persistWanReplicatedData", persistWanReplicatedData);
+
                     isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation'"
                             + " attributes is required to create WanConsumerConfig!");
                     for (Node child : childElements(n)) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
@@ -2738,6 +2738,15 @@
                         <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
                     </xs:sequence>
                     <xs:attributeGroup ref="class-or-bean-name"/>
+                    <xs:attribute name="persist-wan-replicated-data" use="optional" type="parameterized-boolean" default="true">
+                        <xs:annotation>
+                            <xs:documentation>
+                                When true, an incoming event over WAN replication can be persisted to a
+                                database for example, otherwise it will not be persisted. Default value
+                                is true.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
                 </xs:complexType>
             </xs:element>
         </xs:sequence>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -287,7 +287,6 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("PUT_IF_ABSENT", wanRef.getMergePolicy());
         assertEquals(1, wanRef.getFilters().size());
         assertEquals("com.example.SampleFilter", wanRef.getFilters().get(0));
-        assertFalse(wanRef.isRepublishingEnabled());
     }
 
     @Test
@@ -943,12 +942,14 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("com.hazelcast.wan.custom.WanConsumer", consumerConfig.getClassName());
         Map<String, Comparable> consumerProps = consumerConfig.getProperties();
         assertEquals("prop.consumer", consumerProps.get("custom.prop.consumer"));
+        assertTrue(consumerConfig.isPersistWanReplicatedData());
 
         WanReplicationConfig config2 = config.getWanReplicationConfig("testWan2");
         WanConsumerConfig consumerConfig2 = config2.getWanConsumerConfig();
         consumerConfig2.setProperties(consumerProps);
         assertInstanceOf(DummyWanConsumer.class, consumerConfig2.getImplementation());
         assertEquals("prop.consumer", consumerConfig2.getProperties().get("custom.prop.consumer"));
+        assertFalse(consumerConfig2.isPersistWanReplicatedData());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -109,14 +109,15 @@
                 <hz:wan-publisher group-name="ankara" class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">
                     <hz:queue-capacity>${wan.queue.capacity}</hz:queue-capacity>
                 </hz:wan-publisher>
-                <hz:wan-consumer class-name="com.hazelcast.wan.custom.WanConsumer">
+                <hz:wan-consumer class-name="com.hazelcast.wan.custom.WanConsumer"
+                                 persist-wan-replicated-data="true">
                     <hz:properties>
                         <hz:property name="custom.prop.consumer">prop.consumer</hz:property>
                     </hz:properties>
                 </hz:wan-consumer>
             </hz:wan-replication>
             <hz:wan-replication name="testWan2">
-                <hz:wan-consumer implementation="wanConsumer"/>
+                <hz:wan-consumer implementation="wanConsumer" persist-wan-replicated-data="false"/>
             </hz:wan-replication>
             <hz:network port="${cluster.port}" port-auto-increment="false" port-count="42">
                 <hz:outbound-ports>
@@ -463,7 +464,8 @@
             </hz:map>
 
             <hz:cache name="testCache" disable-per-entry-invalidation-events="true">
-                <hz:wan-replication-ref name="testWan" merge-policy="PUT_IF_ABSENT" republishing-enabled="false">
+                <hz:wan-replication-ref name="testWan" merge-policy="PUT_IF_ABSENT"
+                                        republishing-enabled="false">
                     <hz:filters>
                         <hz:filter-impl>com.example.SampleFilter</hz:filter-impl>
                     </hz:filters>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -109,6 +109,7 @@ public class AddMapConfigMessageTask
             }
             config.setQueryCacheConfigs(queryCacheConfigs);
         }
+        config.setWanReplicationRef(parameters.wanReplicationRef);
         return config;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -87,9 +87,9 @@ public class ConfigXmlGenerator {
     /**
      * Creates a ConfigXmlGenerator.
      *
-     * @param formatted {@code true} if the XML should be formatted, {@code false} otherwise
+     * @param formatted           {@code true} if the XML should be formatted, {@code false} otherwise
      * @param maskSensitiveFields {@code true} if the sensitive fields (like passwords) should be masked in the
-     *                                        output XML, {@code false} otherwise
+     *                            output XML, {@code false} otherwise
      */
     public ConfigXmlGenerator(boolean formatted, boolean maskSensitiveFields) {
         this.formatted = formatted;
@@ -261,13 +261,13 @@ public class ConfigXmlGenerator {
         }
 
         gen.open("security", "enabled", c.isEnabled())
-           .node("client-block-unmapped-actions", c.getClientBlockUnmappedActions());
+                .node("client-block-unmapped-actions", c.getClientBlockUnmappedActions());
 
         PermissionPolicyConfig ppc = c.getClientPolicyConfig();
         if (ppc.getClassName() != null) {
             gen.open("client-permission-policy", "class-name", ppc.getClassName())
-               .appendProperties(ppc.getProperties())
-               .close();
+                    .appendProperties(ppc.getProperties())
+                    .close();
         }
 
         appendLoginModules(gen, "client-login-modules", c.getClientLoginModuleConfigs());
@@ -276,8 +276,8 @@ public class ConfigXmlGenerator {
         CredentialsFactoryConfig cfc = c.getMemberCredentialsConfig();
         if (cfc.getClassName() != null) {
             gen.open("member-credentials-factory", "class-name", cfc.getClassName())
-               .appendProperties(cfc.getProperties())
-               .close();
+                    .appendProperties(cfc.getProperties())
+                    .close();
         }
 
         List<SecurityInterceptorConfig> sic = c.getSecurityInterceptorConfigs();
@@ -285,7 +285,7 @@ public class ConfigXmlGenerator {
             gen.open("security-interceptors");
             for (SecurityInterceptorConfig s : sic) {
                 gen.open("interceptor", "class-name", s.getClassName())
-                   .close();
+                        .close();
             }
             gen.close();
         }
@@ -340,8 +340,8 @@ public class ConfigXmlGenerator {
                     attrs.add(lm.getUsage().name());
                 }
                 gen.open("login-module", attrs.toArray())
-                   .appendProperties(lm.getProperties())
-                   .close();
+                        .appendProperties(lm.getProperties())
+                        .close();
             }
             gen.close();
         }
@@ -495,10 +495,10 @@ public class ConfigXmlGenerator {
     private static void pnCounterXmlGenerator(XmlGenerator gen, Config config) {
         for (PNCounterConfig counterConfig : config.getPNCounterConfigs().values()) {
             gen.open("pn-counter", "name", counterConfig.getName())
-               .node("replica-count", counterConfig.getReplicaCount())
-               .node("quorum-ref", counterConfig.getQuorumName())
-               .node("statistics-enabled", counterConfig.isStatisticsEnabled())
-               .close();
+                    .node("replica-count", counterConfig.getReplicaCount())
+                    .node("quorum-ref", counterConfig.getQuorumName())
+                    .node("statistics-enabled", counterConfig.isStatisticsEnabled())
+                    .close();
         }
     }
 
@@ -659,11 +659,11 @@ public class ConfigXmlGenerator {
             gen.open("wan-replication", "name", wan.getName());
             for (WanPublisherConfig p : wan.getWanPublisherConfigs()) {
                 gen.open("wan-publisher", "group-name", p.getGroupName())
-                   .node("class-name", p.getClassName())
-                   .node("queue-full-behavior", p.getQueueFullBehavior())
-                   .node("initial-publisher-state", p.getInitialPublisherState())
-                   .node("queue-capacity", p.getQueueCapacity())
-                   .appendProperties(p.getProperties());
+                        .node("class-name", p.getClassName())
+                        .node("queue-full-behavior", p.getQueueFullBehavior())
+                        .node("initial-publisher-state", p.getInitialPublisherState())
+                        .node("queue-capacity", p.getQueueCapacity())
+                        .appendProperties(p.getProperties());
                 awsConfigXmlGenerator(gen, p.getAwsConfig());
                 discoveryStrategyConfigXmlGenerator(gen, p.getDiscoveryConfig());
                 gen.close();
@@ -672,10 +672,11 @@ public class ConfigXmlGenerator {
             WanConsumerConfig consumerConfig = wan.getWanConsumerConfig();
             if (consumerConfig != null) {
                 gen.open("wan-consumer")
-                   .node("class-name", classNameOrImplClass(consumerConfig.getClassName(),
-                           consumerConfig.getImplementation()))
-                   .appendProperties(consumerConfig.getProperties())
-                   .close();
+                        .node("class-name", classNameOrImplClass(consumerConfig.getClassName(),
+                                consumerConfig.getImplementation()))
+                        .node("persist-wan-replicated-data", consumerConfig.isPersistWanReplicatedData())
+                        .appendProperties(consumerConfig.getProperties())
+                        .close();
             }
             gen.close();
         }
@@ -992,12 +993,12 @@ public class ConfigXmlGenerator {
             MapStoreConfig.InitialLoadMode initialMode = s.getInitialLoadMode();
 
             gen.open("map-store", "enabled", s.isEnabled(), "initial-mode", initialMode.toString())
-               .node("class-name", clazz)
-               .node("factory-class-name", factoryClass)
-               .node("write-delay-seconds", s.getWriteDelaySeconds())
-               .node("write-batch-size", s.getWriteBatchSize())
-               .appendProperties(s.getProperties())
-               .close();
+                    .node("class-name", clazz)
+                    .node("factory-class-name", factoryClass)
+                    .node("write-delay-seconds", s.getWriteDelaySeconds())
+                    .node("write-batch-size", s.getWriteBatchSize())
+                    .appendProperties(s.getProperties())
+                    .close();
         }
     }
 
@@ -1011,13 +1012,13 @@ public class ConfigXmlGenerator {
             }
 
             gen.node("in-memory-format", n.getInMemoryFormat())
-               .node("invalidate-on-change", n.isInvalidateOnChange())
-               .node("time-to-live-seconds", n.getTimeToLiveSeconds())
-               .node("max-idle-seconds", n.getMaxIdleSeconds())
-               .node("serialize-keys", n.isSerializeKeys())
-               .node("cache-local-entries", n.isCacheLocalEntries())
-               .node("max-size", n.getMaxSize())
-               .node("eviction-policy", n.getEvictionPolicy());
+                    .node("invalidate-on-change", n.isInvalidateOnChange())
+                    .node("time-to-live-seconds", n.getTimeToLiveSeconds())
+                    .node("max-idle-seconds", n.getMaxIdleSeconds())
+                    .node("serialize-keys", n.isSerializeKeys())
+                    .node("cache-local-entries", n.isCacheLocalEntries())
+                    .node("max-size", n.getMaxSize())
+                    .node("eviction-policy", n.getEvictionPolicy());
 
             evictionConfigXmlGenerator(gen, n.getEvictionConfig());
             gen.close();
@@ -1205,13 +1206,13 @@ public class ConfigXmlGenerator {
 
         gen.open("failure-detector");
         gen.open("icmp", "enabled", icmpFailureDetectorConfig.isEnabled())
-           .node("ttl", icmpFailureDetectorConfig.getTtl())
-           .node("interval-milliseconds", icmpFailureDetectorConfig.getIntervalMilliseconds())
-           .node("max-attempts", icmpFailureDetectorConfig.getMaxAttempts())
-           .node("timeout-milliseconds", icmpFailureDetectorConfig.getTimeoutMilliseconds())
-           .node("fail-fast-on-startup", icmpFailureDetectorConfig.isFailFastOnStartup())
-           .node("parallel-mode", icmpFailureDetectorConfig.isParallelMode())
-           .close();
+                .node("ttl", icmpFailureDetectorConfig.getTtl())
+                .node("interval-milliseconds", icmpFailureDetectorConfig.getIntervalMilliseconds())
+                .node("max-attempts", icmpFailureDetectorConfig.getMaxAttempts())
+                .node("timeout-milliseconds", icmpFailureDetectorConfig.getTimeoutMilliseconds())
+                .node("fail-fast-on-startup", icmpFailureDetectorConfig.isFailFastOnStartup())
+                .node("parallel-mode", icmpFailureDetectorConfig.isParallelMode())
+                .close();
         gen.close();
     }
 
@@ -1250,7 +1251,7 @@ public class ConfigXmlGenerator {
         gen.open("crdt-replication");
         if (replicationConfig != null) {
             gen.node("replication-period-millis", replicationConfig.getReplicationPeriodMillis())
-               .node("max-concurrent-replication-targets", replicationConfig.getMaxConcurrentReplicationTargets());
+                    .node("max-concurrent-replication-targets", replicationConfig.getMaxConcurrentReplicationTargets());
         }
         gen.close();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -168,12 +168,11 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
     private transient boolean optimizeQueryExplicitlyInvoked;
     private transient boolean setCacheDeserializedValuesExplicitlyInvoked;
 
+    public MapConfig() {
+    }
 
     public MapConfig(String name) {
         this.name = name;
-    }
-
-    public MapConfig() {
     }
 
     public MapConfig(MapConfig config) {

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationRef.java
@@ -37,29 +37,28 @@ import java.util.List;
 @BinaryInterface
 public class WanReplicationRef implements DataSerializable, Serializable {
 
+    private boolean republishingEnabled = true;
     private String name;
     private String mergePolicy;
     private List<String> filters = new LinkedList<String>();
-    private boolean republishingEnabled = true;
 
     private WanReplicationRefReadOnly readOnly;
 
     public WanReplicationRef() {
     }
 
-    public WanReplicationRef(String name, String mergePolicy, List<String> filters, boolean republishingEnabled) {
+    public WanReplicationRef(WanReplicationRef ref) {
+        this(ref.name, ref.mergePolicy, ref.filters, ref.republishingEnabled);
+        this.readOnly = ref.readOnly;
+    }
+
+    public WanReplicationRef(String name, String mergePolicy, List<String> filters,
+                             boolean republishingEnabled) {
         this.name = name;
         this.mergePolicy = mergePolicy;
         this.filters = filters;
         this.republishingEnabled = republishingEnabled;
-    }
-
-    public WanReplicationRef(WanReplicationRef ref) {
-        this.name = ref.name;
-        this.mergePolicy = ref.mergePolicy;
-        this.filters = ref.filters;
-        this.republishingEnabled = ref.republishingEnabled;
-        this.readOnly = ref.readOnly;
+        this.readOnly = null;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -391,7 +391,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             handleCardinalityEstimator(node);
         } else if (FLAKE_ID_GENERATOR.isEqual(nodeName)) {
             handleFlakeIdGenerator(node);
-        }  else if (CRDT_REPLICATION.isEqual(nodeName)) {
+        } else if (CRDT_REPLICATION.isEqual(nodeName)) {
             handleCRDTReplication(node);
         } else if (PN_COUNTER.isEqual(nodeName)) {
             handlePNCounter(node);
@@ -683,6 +683,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             consumerConfig.setClassName(getTextContent(targetChild));
         } else if ("properties".equals(targetChildName)) {
             fillProperties(targetChild, consumerConfig.getProperties());
+        } else if ("persist-wan-replicated-data".equals(targetChildName)) {
+            consumerConfig.setPersistWanReplicatedData(getBooleanValue(getTextContent(targetChild)));
         }
     }
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
@@ -2481,6 +2481,15 @@
                 </xs:annotation>
             </xs:element>
             <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="persist-wan-replicated-data" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        When true, an incoming event over WAN replication can be persisted to a
+                        database for example, otherwise it will not be persisted. Default value
+                        is true.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:all>
     </xs:complexType>
     <xs:complexType name="ssl">

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.quorum.impl.ProbabilisticQuorumFunction;
 import com.hazelcast.quorum.impl.RecentlyActiveQuorumFunction;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
 import org.junit.Test;
@@ -64,7 +65,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category(QuickTest.class)
+@Category({QuickTest.class, ParallelTest.class})
 @SuppressWarnings({"WeakerAccess", "deprecation"})
 public class XMLConfigBuilderTest extends HazelcastTestSupport {
 
@@ -1114,7 +1115,8 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
-        WanReplicationRef wanRef = config.getMapConfig(mapName).getWanReplicationRef();
+        MapConfig mapConfig = config.getMapConfig(mapName);
+        WanReplicationRef wanRef = mapConfig.getWanReplicationRef();
 
         assertEquals(refName, wanRef.getName());
         assertEquals(mergePolicy, wanRef.getMergePolicy());
@@ -1395,6 +1397,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "         <properties>\n"
                 + "            <property name=\"custom.prop.consumer\">prop.consumer</property>\n"
                 + "         </properties>\n"
+                + "      <persist-wan-replicated-data>false</persist-wan-replicated-data>\n"
                 + "      </wan-consumer>\n"
                 + "   </wan-replication>"
                 + HAZELCAST_END_TAG;
@@ -1428,6 +1431,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("com.hazelcast.wan.custom.WanConsumer", consumerConfig.getClassName());
         Map<String, Comparable> consProperties = consumerConfig.getProperties();
         assertEquals("prop.consumer", consProperties.get("custom.prop.consumer"));
+        assertFalse(consumerConfig.isPersistWanReplicatedData());
     }
 
     private void assertDiscoveryConfig(DiscoveryConfig c) {

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/CacheConfigHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/CacheConfigHelper.java
@@ -55,8 +55,8 @@ public abstract class CacheConfigHelper {
         cacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
         cacheConfig.setBackupCount(3);
         cacheConfig.setAsyncBackupCount(2);
-        cacheConfig.setWanReplicationRef(new WanReplicationRef(randomName(), "com.hazelcast.MergePolicy",
-                Collections.singletonList("filter"), true));
+        cacheConfig.setWanReplicationRef(new WanReplicationRef(randomName(),
+                "com.hazelcast.MergePolicy", Collections.singletonList("filter"), true));
         cacheConfig.addCacheEntryListenerConfiguration(new MutableCacheEntryListenerConfiguration(
                 new CacheConfigTest.EntryListenerFactory(), null, false, true));
         cacheConfig.setMergePolicy("mergePolicy");

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -110,6 +110,7 @@
             <properties>
                 <property name="custom.prop.consumer">prop.consumer</property>
             </properties>
+            <persist-wan-replicated-data>true</persist-wan-replicated-data>
         </wan-consumer>
     </wan-replication>
     <network>


### PR DESCRIPTION
__Reasoning:__
Right now when an ADD event comes into a target cluster we fire the MapStore, so a entry is put into a Cluster A and it goes into Cluster B and also into the Backing Store of Cluster B. The User may wish to disable this behavior by using this new `persist-wan-replicated-data` option.

__Example Configuration:__
Added `persist-wan-replicated-data` option as in the example below: 
```
  <wan-replication name="my-wan-cluster">
        <wan-consumer>
            <class-name>com.hazelcast.wan.custom.WanConsumer</class-name>
            <properties>
                <property name="custom.prop.consumer">prop.consumer</property>
            </properties>
            <persist-wan-replicated-data>true</persist-wan-replicated-data>
        </wan-consumer>
    </wan-replication>
```
__Note:__ This PR only adds configuration part. Part to block store when `persist-wan-replicated-data` is off will be introduced upon merge of this PR.
