### PR TITLE
[FORWARDPORT] Clarify inner classes behavior for DataSerializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataSerializable.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/DataSerializable.java
@@ -22,9 +22,15 @@ import com.hazelcast.nio.ObjectDataOutput;
 import java.io.IOException;
 
 /**
- * DataSerializable is a serialization method as an alternative to standard Java serialization.
- * DataSerializable is very similar to {@link java.io.Externalizable} and relies on reflection to create
- * instances using classnames.
+ * DataSerializable is a serialization method alternative to standard Java
+ * serialization. DataSerializable is very similar to {@link java.io.Externalizable}
+ * and relies on reflection to create instances using class names.
+ * <p>
+ * Conforming classes must provide a no-arguments constructor to facilitate the
+ * creation of their instances during the deserialization. Anonymous, local and
+ * non-static member classes can't satisfy this requirement since their
+ * constructors are always accepting an instance of the enclosing class as an
+ * implicit argument, therefore they must be avoided.
  *
  * @see com.hazelcast.nio.serialization.IdentifiedDataSerializable
  * @see com.hazelcast.nio.serialization.Portable

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
@@ -21,10 +21,12 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.impl.VersionedDataSerializableFactory;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.version.Version;
@@ -35,15 +37,15 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 
-public class DataSerializableSerializationTest {
+public class DataSerializableSerializationTest extends HazelcastTestSupport {
 
-    private SerializationService ss = new DefaultSerializationServiceBuilder()
-            .setVersion(InternalSerializationService.VERSION_1)
-            .build();
+    private SerializationService ss = new DefaultSerializationServiceBuilder().setVersion(InternalSerializationService.VERSION_1)
+                                                                              .build();
 
     @Test
     public void serializeAndDeserialize_DataSerializable() {
@@ -58,11 +60,9 @@ public class DataSerializableSerializationTest {
     @Test
     public void serializeAndDeserialize_IdentifiedDataSerializable() {
         IDSPerson person = new IDSPerson("James Bond");
-        SerializationService ss = new DefaultSerializationServiceBuilder()
-                .addDataSerializableFactory(1, new IDSPersonFactory())
-                .setVersion(InternalSerializationService.VERSION_1)
-                .build();
-
+        SerializationService ss = new DefaultSerializationServiceBuilder().addDataSerializableFactory(1, new IDSPersonFactory())
+                                                                          .setVersion(InternalSerializationService.VERSION_1)
+                                                                          .build();
 
         IDSPerson deserialized = ss.toObject(ss.toData(person));
 
@@ -74,8 +74,7 @@ public class DataSerializableSerializationTest {
     public void serializeAndDeserialize_IdentifiedDataSerializable_versionedFactory() {
         IDSPerson person = new IDSPerson("James Bond");
         SerializationService ss = new DefaultSerializationServiceBuilder()
-                .addDataSerializableFactory(1, new IDSPersonFactoryVersioned())
-                .setVersion(InternalSerializationService.VERSION_1)
+                .addDataSerializableFactory(1, new IDSPersonFactoryVersioned()).setVersion(InternalSerializationService.VERSION_1)
                 .build();
 
         IDSPerson deserialized = ss.toObject(ss.toData(person));
@@ -84,6 +83,64 @@ public class DataSerializableSerializationTest {
         assertEquals(person.name, deserialized.name);
     }
 
+    @Test
+    public void testClarifiedExceptionsForUnsupportedClassTypes() {
+        class LocalClass implements DataSerializable {
+            @Override
+            public void writeData(ObjectDataOutput out) {
+            }
+
+            @Override
+            public void readData(ObjectDataInput in) {
+            }
+        }
+
+        DataSerializable anonymousInstance = new DataSerializable() {
+            @Override
+            public void writeData(ObjectDataOutput out) {
+            }
+
+            @Override
+            public void readData(ObjectDataInput in) {
+            }
+        };
+
+        DataSerializable[] throwingInstances = {new LocalClass(), anonymousInstance, new NonStaticMemberClass()};
+
+        for (DataSerializable throwingInstance : throwingInstances) {
+            try {
+                ss.toObject(ss.toData(throwingInstance));
+            } catch (HazelcastSerializationException e) {
+                assertInstanceOf(NoSuchMethodException.class, e.getCause());
+                assertContains(e.getCause().getMessage(), "can't conform to DataSerializable");
+                assertInstanceOf(NoSuchMethodException.class, e.getCause().getCause());
+                continue;
+            }
+            fail("deserialization of '" + throwingInstance.getClass() + "' is expected to fail");
+        }
+
+        for (DataSerializable throwingInstance : throwingInstances) {
+            try {
+                ss.toObject(ss.toData(throwingInstance), throwingInstance.getClass());
+            } catch (HazelcastSerializationException e) {
+                assertInstanceOf(InstantiationException.class, e.getCause());
+                assertContains(e.getCause().getMessage(), "can't conform to DataSerializable");
+                assertInstanceOf(InstantiationException.class, e.getCause().getCause());
+                continue;
+            }
+            fail("deserialization of '" + throwingInstance.getClass() + "' is expected to fail");
+        }
+    }
+
+    public class NonStaticMemberClass implements DataSerializable {
+        @Override
+        public void writeData(ObjectDataOutput out) {
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) {
+        }
+    }
 
     private static class DSPerson implements DataSerializable {
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionsTest.java
@@ -85,20 +85,7 @@ public class OperationServiceImpl_invokeOnPartitionsTest extends HazelcastTestSu
     private static class OperationFactoryImpl extends AbstractOperationFactor {
         @Override
         public Operation createOperation() {
-            return new Operation() {
-
-                private int response;
-
-                @Override
-                public void run() throws Exception {
-                    response = getPartitionId() * 2;
-                }
-
-                @Override
-                public Object getResponse() {
-                    return response;
-                }
-            };
+            return new OperationImpl();
         }
 
         @Override
@@ -115,21 +102,7 @@ public class OperationServiceImpl_invokeOnPartitionsTest extends HazelcastTestSu
     private static class SlowOperationFactoryImpl extends AbstractOperationFactor {
         @Override
         public Operation createOperation() {
-            return new Operation() {
-
-                private int response;
-
-                @Override
-                public void run() throws Exception {
-                    sleepSeconds(5);
-                    response = getPartitionId() * 2;
-                }
-
-                @Override
-                public Object getResponse() {
-                    return response;
-                }
-            };
+            return new SlowOperation();
         }
 
         @Override
@@ -159,4 +132,34 @@ public class OperationServiceImpl_invokeOnPartitionsTest extends HazelcastTestSu
         public void readData(ObjectDataInput in) throws IOException {
         }
     }
+
+    private static class OperationImpl extends Operation {
+        private int response;
+
+        @Override
+        public void run() {
+            response = getPartitionId() * 2;
+        }
+
+        @Override
+        public Object getResponse() {
+            return response;
+        }
+    }
+
+    private static class SlowOperation extends Operation {
+        private int response;
+
+        @Override
+        public void run() {
+            sleepSeconds(5);
+            response = getPartitionId() * 2;
+        }
+
+        @Override
+        public Object getResponse() {
+            return response;
+        }
+    }
+
 }


### PR DESCRIPTION
Anonymous, local and non-static member classes can't be instantiated by
DataSerializable deserializer since they can't provide a no-arguments
constructor as it implicitly required by the DataSerializable contract.
This change clarifies this requirement.

(cherry-picked from 39f38da9e98a33abf8357b31c18e608346497933)

Fixes: https://github.com/hazelcast/hazelcast/issues/12138