### PR TITLE
InvocationFuture support for Exceptions as valid response values

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -726,7 +726,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             if (future.isDone()) {
                 return;
             }
-            future.complete(new TimeoutException("Authentication response did not come back in "
+            future.completeExceptionally(new TimeoutException("Authentication response did not come back in "
                     + authenticationTimeout + " millis"));
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/IExecutorDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/IExecutorDelegatingFuture.java
@@ -28,7 +28,6 @@ import com.hazelcast.client.util.ClientDelegatingFuture;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.nio.Address;
 
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
@@ -86,7 +85,7 @@ public final class IExecutorDelegatingFuture<V> extends ClientDelegatingFuture<V
             throw rethrow(e);
         }
 
-        complete(new CancellationException());
+        super.cancel(mayInterruptIfRunning);
         return cancelSuccessful;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -54,7 +54,7 @@ public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessa
 
     @Override
     protected void onInterruptDetected() {
-        complete(new InterruptedException());
+        completeExceptionally(new InterruptedException());
     }
 
     @Override
@@ -63,16 +63,8 @@ public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessa
     }
 
     @Override
-    protected Throwable unwrap(Throwable throwable) {
-        return throwable;
-    }
-
-    @Override
-    protected Object resolve(Object value) {
-        if (value instanceof Throwable) {
-            return new ExecutionException((Throwable) value);
-        }
-        return value;
+    protected Throwable unwrap(AltResult result) {
+        return result.getCause();
     }
 
     @Override
@@ -92,7 +84,9 @@ public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessa
 
     @Override
     public ClientMessage resolveAndThrowIfException(Object response) throws ExecutionException, InterruptedException {
-        if (response instanceof Throwable) {
+        if (response instanceof AltResult) {
+            response = ((AltResult) response).getCause();
+
             fixAsyncStackTrace((Throwable) response, Thread.currentThread().getStackTrace());
             if (response instanceof ExecutionException) {
                 throw (ExecutionException) response;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -110,6 +110,11 @@ public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
     }
 
     @Override
+    public boolean completeExceptionally(Throwable error) {
+        return future.completeExceptionally(error);
+    }
+
+    @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         return future.cancel(mayInterruptIfRunning);
     }

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/RetrieveAndDisposeResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/RetrieveAndDisposeResultOperation.java
@@ -24,6 +24,8 @@ import com.hazelcast.spi.BlockingOperation;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.impl.MutatingOperation;
 
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+
 public class RetrieveAndDisposeResultOperation extends DisposeResultOperation implements BlockingOperation,
         MutatingOperation {
 
@@ -44,6 +46,10 @@ public class RetrieveAndDisposeResultOperation extends DisposeResultOperation im
 
     @Override
     public Object getResponse() {
+        if (result instanceof Throwable) {
+            throw rethrow((Throwable) result);
+        }
+
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/RetrieveResultOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/operations/RetrieveResultOperation.java
@@ -28,6 +28,8 @@ import com.hazelcast.spi.WaitNotifyKey;
 
 import java.io.IOException;
 
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+
 /**
  * Used to retrieve the response of an execution with the given sequence
  */
@@ -53,6 +55,10 @@ public class RetrieveResultOperation extends AbstractDurableExecutorOperation im
 
     @Override
     public Object getResponse() {
+        if (result instanceof Throwable) {
+            throw rethrow((Throwable) result);
+        }
+
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/CancellableDelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/CancellableDelegatingFuture.java
@@ -24,7 +24,6 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.util.executor.DelegatingFuture;
 
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
@@ -80,7 +79,7 @@ final class CancellableDelegatingFuture<V> extends DelegatingFuture<V> {
             throw rethrow(e);
         }
 
-        complete(new CancellationException());
+        super.cancel(mayInterruptIfRunning);
         return cancelSuccessful;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/LocalRetryableExecution.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/LocalRetryableExecution.java
@@ -21,6 +21,7 @@ import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.properties.GroupProperty;
 
 import java.util.concurrent.CountDownLatch;
@@ -104,6 +105,10 @@ public class LocalRetryableExecution implements Runnable, OperationResponseHandl
     @Override
     public void sendResponse(Operation op, Object response) {
         tryCount++;
+        if (response instanceof ErrorResponse) {
+            response = ((ErrorResponse) response).getCause();
+        }
+
         if (response instanceof RetryableHazelcastException && tryCount < invocationMaxRetryCount) {
             Level level = tryCount > LOG_MAX_INVOCATION_COUNT ? WARNING : FINEST;
             if (logger.isLoggable(level)) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/InternalCompletableFuture.java
@@ -40,4 +40,12 @@ public interface InternalCompletableFuture<E> extends ICompletableFuture<E> {
      * @return {@code true} if this invocation caused this InternalCompletableFuture to complete, else {@code false}
      */
     boolean complete(Object value);
+
+    /**
+     * Completes this future with an exception.
+     *
+     * @param error the error (Exception) to complete this future with.
+     * @return {@code true} if this invocation caused this InternalCompletableFuture to complete, else {@code false}
+     */
+    boolean completeExceptionally(Throwable error);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -31,6 +31,7 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import java.util.concurrent.locks.LockSupport;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.isNotNull;
 import static java.util.concurrent.atomic.AtomicReferenceFieldUpdater.newUpdater;
 import static java.util.concurrent.locks.LockSupport.park;
@@ -129,12 +130,14 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        return complete(new CancellationException());
+        return completeExceptionally(new CancellationException());
     }
 
     @Override
     public boolean isCancelled() {
-        return state instanceof CancellationException;
+        Object state = resolve(this.state);
+        return state instanceof AltResult
+                && ((AltResult) state).cause instanceof CancellationException;
     }
 
     @Override
@@ -248,8 +251,8 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
                 public void run() {
                     try {
                         Object value = resolve(state);
-                        if (value instanceof Throwable) {
-                            Throwable error = unwrap((Throwable) value);
+                        if (value instanceof AltResult) {
+                            Throwable error = unwrap((AltResult) value);
                             callback.onFailure(error);
                         } else {
                             callback.onResponse((V) value);
@@ -259,7 +262,6 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
                                 + "for call " + invocationToString(), cause);
                     }
                 }
-
             });
         } catch (RejectedExecutionException e) {
             callback.onFailure(e);
@@ -267,7 +269,9 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
     }
 
     // this method should not be needed; but there is a difference between client and server how it handles async throwables
-    protected Throwable unwrap(Throwable throwable) {
+    protected Throwable unwrap(AltResult result) {
+        Throwable throwable = result.cause;
+
         if (throwable instanceof ExecutionException && throwable.getCause() != null) {
             return throwable.getCause();
         }
@@ -377,6 +381,12 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
         }
     }
 
+    @Override
+    public boolean completeExceptionally(Throwable error) {
+        checkNotNull(error);
+        return complete(new AltResult(error));
+    }
+
     protected void onComplete() {
 
     }
@@ -427,4 +437,23 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
             this.executor = executor;
         }
     }
+
+    @SuppressWarnings("checkstyle:visibilitymodifier")
+    protected static final class AltResult {
+        private final Throwable cause;
+
+        public AltResult(Throwable cause) {
+            this.cause = cause;
+        }
+
+        public Throwable getCause() {
+            return cause;
+        }
+
+        @Override
+        public String toString() {
+            return cause.toString();
+        }
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler.java
@@ -98,7 +98,7 @@ public final class InboundResponseHandler implements Consumer<Packet> {
                     break;
                 case ERROR_RESPONSE:
                     ErrorResponse errorResponse = serializationService.toObject(packet);
-                    notifyErrorResponse(callId, errorResponse.getCause(), sender);
+                    notifyErrorResponse(callId, errorResponse, sender);
                     break;
                 default:
                     logger.severe("Unrecognized type: " + typeId + " packet:" + packet);
@@ -130,7 +130,8 @@ public final class InboundResponseHandler implements Consumer<Packet> {
         }
     }
 
-    void notifyErrorResponse(long callId, Object cause, Address sender) {
+
+    void notifyErrorResponse(long callId, ErrorResponse response, Address sender) {
         responsesError.inc();
         Invocation invocation = invocationRegistry.get(callId);
 
@@ -142,7 +143,7 @@ public final class InboundResponseHandler implements Consumer<Packet> {
             return;
         }
 
-        invocation.notifyError(cause);
+        invocation.notifyError(response.getCause());
     }
 
     void notifyNormalResponse(long callId, Object value, int backupCount, Address sender) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation.PartitionResponse;
+import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -101,7 +102,7 @@ final class InvokeOnPartitions {
             try {
                 Future future = response.getValue();
                 PartitionResponse result = nodeEngine.toObject(future.get());
-                result.addResults(partitionResults);
+                result.drainTo(partitionResults);
             } catch (Throwable t) {
                 if (operationService.logger.isFinestEnabled()) {
                     operationService.logger.finest(t);
@@ -121,9 +122,19 @@ final class InvokeOnPartitions {
         for (Map.Entry<Integer, Object> partitionResult : partitionResults.entrySet()) {
             int partitionId = partitionResult.getKey();
             Object result = partitionResult.getValue();
-            if (result instanceof Throwable) {
+            // The concept is that we send an operation to each member of the cluster, which in turn, asks each partition
+            // for results, and returns an array with the responses.
+            // This can fail in two levels.
+            // a. The original operation (send to each member) could fail, in which case it will throw an Exception
+            // upon {@link Future.get} at {@link #awaitCompletion()}.
+            // b. The inner futures (the ones running per partition) could fail, in which case it will return any value
+            // (Object or Exception), types accepted by the caller API, or an Exception (due to some Error)
+            // wrapped in an ErrorResponse.
+            if (result instanceof ErrorResponse
+                    || result instanceof Throwable) {
                 failedPartitions.add(partitionId);
             }
+
         }
 
         for (Integer failedPartition : failedPartitions) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationRunnerImpl.java
@@ -367,9 +367,9 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
     private void sendResponseAfterOperationError(Operation operation, Throwable e) {
         try {
             if (node.getState() != NodeState.SHUT_DOWN) {
-                operation.sendResponse(e);
+                operation.sendResponse(errorResponse(operation, e));
             } else if (operation.executedLocally()) {
-                operation.sendResponse(new HazelcastInstanceNotActiveException());
+                operation.sendResponse(errorResponse(operation, new HazelcastInstanceNotActiveException()));
             }
         } catch (Throwable t) {
             logger.warning("While sending op error... op: " + operation + ", error: " + e, t);
@@ -423,6 +423,9 @@ class OperationRunnerImpl extends OperationRunner implements MetricsProvider {
         }
     }
 
+    private ErrorResponse errorResponse(Operation op, Throwable error) {
+        return new ErrorResponse(error, op.getCallId(), op.isUrgent());
+    }
     /**
      * This method has a direct dependency on how objects are serialized.
      * If the stream format is changed, this extraction method must be changed as well.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/PartitionIteratingOperation.java
@@ -292,7 +292,7 @@ public final class PartitionIteratingOperation extends Operation implements Iden
             this.results = results;
         }
 
-        public void addResults(Map<Integer, Object> partitionResults) {
+        public void drainTo(Map<Integer, Object> partitionResults) {
             if (results == null) {
                 return;
             }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/ErrorResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/responses/ErrorResponse.java
@@ -34,6 +34,10 @@ public class ErrorResponse extends Response {
         this.cause = cause;
     }
 
+    public void setCause(Throwable t) {
+        this.cause = t;
+    }
+
     public Throwable getCause() {
         return cause;
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/CompletedFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/CompletedFuture.java
@@ -80,6 +80,11 @@ public final class CompletedFuture<V> implements InternalCompletableFuture<V> {
     }
 
     @Override
+    public boolean completeExceptionally(Throwable error) {
+        return false;
+    }
+
+    @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
         return false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/DelegatingFuture.java
@@ -141,8 +141,9 @@ public class DelegatingFuture<V> implements InternalCompletableFuture<V> {
         return future.complete(value);
     }
 
-    protected void setError(Throwable error) {
-        future.complete(error);
+    @Override
+    public boolean completeExceptionally(Throwable error) {
+        return future.completeExceptionally(error);
     }
 
     protected ICompletableFuture getFuture() {

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceAbstractTest.java
@@ -83,6 +83,17 @@ public abstract class AtomicReferenceAbstractTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void setAndGet_exceptionValue() {
+        RuntimeException expected = new RuntimeException("my exception");
+        IAtomicReference<RuntimeException> ref = newInstance();
+
+        ref.set(expected);
+
+        RuntimeException actual = ref.get();
+        assertEquals("my exception", actual.getMessage());
+    }
+
+    @Test
     @SuppressWarnings("deprecation")
     public void setAndGet() {
         assertNull(ref.setAndGet(null));

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationAwareServiceEventTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationAwareServiceEventTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.spi.OperationResponseHandler;
 import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
+import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.spi.partition.MigrationEndpoint;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -125,7 +126,10 @@ public class MigrationAwareServiceEventTest extends HazelcastTestSupport {
         public void sendResponse(Operation operation, Object response) {
             assert operation instanceof DummyPartitionAwareOperation : "Invalid operation: " + operation;
             NodeEngine nodeEngine = operation.getNodeEngine();
-            if (!(response instanceof RetryableHazelcastException) && nodeEngine.isRunning()) {
+
+            if (!(response instanceof ErrorResponse
+                    && ((ErrorResponse) response).getCause() instanceof RetryableHazelcastException)
+                    && nodeEngine.isRunning()) {
                 DummyPartitionAwareOperation op = (DummyPartitionAwareOperation) operation;
                 failures.add("Unexpected response: " + response + ". Node: " + nodeEngine.getThisAddress()
                         + ", Event: " + op.event + ", Type: " + op.type);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractInvocationFuture_AbstractTest extends HazelcastTes
         @Override
         protected void onInterruptDetected() {
             interruptDetected = true;
-            complete(new InterruptedException());
+            completeExceptionally(new InterruptedException());
         }
 
         @Override
@@ -66,7 +66,9 @@ public abstract class AbstractInvocationFuture_AbstractTest extends HazelcastTes
 
         @Override
         protected Object resolveAndThrowIfException(Object state) throws ExecutionException, InterruptedException {
-            if (state instanceof Throwable) {
+            if (state instanceof AltResult) {
+                state = ((AltResult) state).getCause();
+
                 if (state instanceof Error) {
                     throw (Error) state;
                 } else if (state instanceof RuntimeException) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AndThenTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AndThenTest.java
@@ -125,7 +125,7 @@ public class AbstractInvocationFuture_AndThenTest extends AbstractInvocationFutu
         verifyZeroInteractions(callback);
 
         final ExpectedRuntimeException ex = new ExpectedRuntimeException();
-        future.complete(ex);
+        future.completeExceptionally(ex);
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -159,7 +159,7 @@ public class AbstractInvocationFuture_AndThenTest extends AbstractInvocationFutu
         future.andThen(callback);
 
         final MemberLeftException ex = new MemberLeftException();
-        future.complete(ex);
+        future.completeExceptionally(ex);
 
         assertTrueEventually(new AssertTask() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetSafely.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_GetSafely.java
@@ -54,7 +54,7 @@ public class AbstractInvocationFuture_GetSafely extends AbstractInvocationFuture
     @Test
     public void whenRuntimeException() throws Exception {
         ExpectedRuntimeException ex = new ExpectedRuntimeException();
-        future.complete(ex);
+        future.completeExceptionally(ex);
 
         Future joinFuture = spawn(new Callable<Object>() {
             @Override
@@ -75,7 +75,7 @@ public class AbstractInvocationFuture_GetSafely extends AbstractInvocationFuture
     @Test
     public void whenRegularException() throws Exception {
         Exception ex = new Exception();
-        future.complete(ex);
+        future.completeExceptionally(ex);
 
         Future joinFuture = spawn(new Callable<Object>() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_JoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_JoinTest.java
@@ -64,7 +64,7 @@ public class AbstractInvocationFuture_JoinTest extends AbstractInvocationFuture_
     @Test
     public void whenRuntimeException() throws Exception {
         ExpectedRuntimeException ex = new ExpectedRuntimeException();
-        future.complete(ex);
+        future.completeExceptionally(ex);
 
         Future joinFuture = spawn(new Callable<Object>() {
             @Override
@@ -85,7 +85,7 @@ public class AbstractInvocationFuture_JoinTest extends AbstractInvocationFuture_
     @Test
     public void whenRegularException() throws Exception {
         Exception ex = new Exception();
-        future.complete(ex);
+        future.completeExceptionally(ex);
 
         Future joinFuture = spawn(new Callable<Object>() {
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler_NotifyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InboundResponseHandler_NotifyTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.impl.responses.ErrorResponse;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.ExpectedRuntimeException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -176,7 +177,7 @@ public class InboundResponseHandler_NotifyTest extends HazelcastTestSupport {
         invocationRegistry.register(invocation);
 
         long callId = invocation.op.getCallId();
-        inboundResponseHandler.notifyErrorResponse(callId, new ExpectedRuntimeException(), null);
+        inboundResponseHandler.notifyErrorResponse(callId, new ErrorResponse(new ExpectedRuntimeException(), 0, false), null);
 
         try {
             invocation.future.join();
@@ -194,7 +195,7 @@ public class InboundResponseHandler_NotifyTest extends HazelcastTestSupport {
         long callId = invocation.op.getCallId();
         invocationRegistry.deregister(invocation);
 
-        inboundResponseHandler.notifyErrorResponse(callId, new ExpectedRuntimeException(), null);
+        inboundResponseHandler.notifyErrorResponse(callId, new ErrorResponse(new ExpectedRuntimeException(), 0, false), null);
 
         assertInvocationDeregisteredEventually(callId);
     }

--- a/hazelcast/src/test/java/com/hazelcast/util/executor/DelegatingFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/executor/DelegatingFutureTest.java
@@ -215,5 +215,10 @@ public class DelegatingFutureTest {
         public boolean complete(Object value) {
             return false;
         }
+
+        @Override
+        public boolean completeExceptionally(Throwable error) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Support for allowing Exceptions to be returned or be thrown. Similar to `j.u.c.CompletableFuture.completeExceptionally`, we can now store `Exception` response values, and the user can access them, as usual, with `Future.get()`

Changes shouldn't affect the fast path, and the additional litter caused, is only on erroneous responses.

- [x] Check whether this can be RU supported

Fixes #13138 