### PR TITLE
[DO NO MERGE] Dump class histogram on test failure

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -55,6 +55,7 @@ import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.classhistogram.ClassHistogramRule;
 import com.hazelcast.test.jitter.JitterRule;
 import org.junit.After;
 import org.junit.AssumptionViolatedException;
@@ -126,6 +127,9 @@ public abstract class HazelcastTestSupport {
 
     @Rule
     public DumpBuildInfoOnFailureRule dumpInfoRule = new DumpBuildInfoOnFailureRule();
+
+    @Rule
+    public ClassHistogramRule classHistogramRule = new ClassHistogramRule();
 
     static {
         ASSERT_TRUE_EVENTUALLY_TIMEOUT = getInteger("hazelcast.assertTrueEventually.timeout", 120);

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -57,6 +57,7 @@ import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.classhistogram.ClassHistogramRule;
 import com.hazelcast.test.jitter.JitterRule;
+import com.hazelcast.test.perfcounter.PerfCounterRule;
 import org.junit.After;
 import org.junit.AssumptionViolatedException;
 import org.junit.ComparisonFailure;
@@ -130,6 +131,9 @@ public abstract class HazelcastTestSupport {
 
     @Rule
     public ClassHistogramRule classHistogramRule = new ClassHistogramRule();
+
+    @Rule
+    public PerfCounterRule perfCounterRule = new PerfCounterRule();
 
     static {
         ASSERT_TRUE_EVENTUALLY_TIMEOUT = getInteger("hazelcast.assertTrueEventually.timeout", 120);

--- a/hazelcast/src/test/java/com/hazelcast/test/classhistogram/ClassHistogram.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/classhistogram/ClassHistogram.java
@@ -5,41 +5,35 @@ import com.hazelcast.test.process.ExecutionResult;
 
 import java.io.IOException;
 
-import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
-
-public class ClassHistogram {
+final class ClassHistogram {
     private static final boolean DEBUG = Boolean.getBoolean("hazelcast.test.debug.class.histogram");
+
+    private ClassHistogram() {
+
+    }
 
     /**
      * Dump class histogram to standard output
      *
      * @param maxLines maximum number of lines to be written. If histogram has more lines then it'll be truncated
      */
-    public static void dump(int maxLines) {
+    static void dump(int maxLines) {
         Long processIdOrNull = ProcessUtils.getOwnPidOrNull();
         if (processIdOrNull == null) {
             System.out.println("Cannot find own process id.");
             return;
         }
 
-        ExecutionResult result;
         try {
-            result = executeHistogramTool(maxLines, processIdOrNull);
+            ExecutionResult result = executeHistogramTool(maxLines, processIdOrNull);
+            ProcessUtils.printResult("Class Histogram", result);
         } catch (IOException e) {
             System.out.println("Cannot find histogram generator.");
             if (DEBUG) {
                 e.printStackTrace();
             }
-            return;
         }
 
-        if (result.getExitCode() == 0) {
-            System.out.println("Class Histogram: " + LINE_SEPARATOR + result.getSysout());
-        } else {
-            System.out.println("Error while generating class histogram. Exit code: " + result.getExitCode()
-                    + " Standard output: " + LINE_SEPARATOR + result.getSysout()
-                    + " Error output " + LINE_SEPARATOR + result.getErrout());
-        }
     }
 
     private static ExecutionResult executeHistogramTool(int maxLines, long processId) throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/test/classhistogram/ClassHistogram.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/classhistogram/ClassHistogram.java
@@ -1,0 +1,56 @@
+package com.hazelcast.test.classhistogram;
+
+import com.hazelcast.test.process.ProcessUtils;
+import com.hazelcast.test.process.ExecutionResult;
+
+import java.io.IOException;
+
+import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
+
+public class ClassHistogram {
+    private static final boolean DEBUG = Boolean.getBoolean("hazelcast.test.debug.class.histogram");
+
+    /**
+     * Dump class histogram to standard output
+     *
+     * @param maxLines maximum number of lines to be written. If histogram has more lines then it'll be truncated
+     */
+    public static void dump(int maxLines) {
+        Long processIdOrNull = ProcessUtils.getOwnPidOrNull();
+        if (processIdOrNull == null) {
+            System.out.println("Cannot find own process id.");
+            return;
+        }
+
+        ExecutionResult result;
+        try {
+            result = executeHistogramTool(maxLines, processIdOrNull);
+        } catch (IOException e) {
+            System.out.println("Cannot find histogram generator.");
+            if (DEBUG) {
+                e.printStackTrace();
+            }
+            return;
+        }
+
+        if (result.getExitCode() == 0) {
+            System.out.println("Class Histogram: " + LINE_SEPARATOR + result.getSysout());
+        } else {
+            System.out.println("Error while generating class histogram. Exit code: " + result.getExitCode()
+                    + " Standard output: " + LINE_SEPARATOR + result.getSysout()
+                    + " Error output " + LINE_SEPARATOR + result.getErrout());
+        }
+    }
+
+    private static ExecutionResult executeHistogramTool(int maxLines, long processId) throws IOException {
+        try {
+            return ProcessUtils.executeBlocking(maxLines, "jcmd", Long.toString(processId), "GC.class_histogram");
+        } catch (IOException e) {
+            if (DEBUG) {
+                e.printStackTrace();
+            }
+            //fallback to jmap. this is an older tool, jcmd is prefered nowdays
+            return ProcessUtils.executeBlocking(maxLines, "jmap", "-histo:live", Long.toString(processId));
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/classhistogram/ClassHistogramRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/classhistogram/ClassHistogramRule.java
@@ -1,0 +1,36 @@
+package com.hazelcast.test.classhistogram;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * JUnit rule to dump class histogram on a test failure.
+ *
+ * It gives you an insight into a heap state. This can help
+ * with reasoning about a test failure when you suspect the failure is related to
+ * memory utilization.
+ *
+ * This is a best effort rule as it depends on number of JVM-specific tools/APIs.
+ *
+ * @see com.hazelcast.test.jitter.JitterRule
+ *
+ */
+public class ClassHistogramRule implements TestRule {
+    private static final int MAX_LINES_TO_DUMP = 100;
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                } catch (Throwable t) {
+                    ClassHistogram.dump(MAX_LINES_TO_DUMP);
+                    throw t;
+                }
+            }
+        };
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/classhistogram/RemoveMeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/classhistogram/RemoveMeTest.java
@@ -1,0 +1,21 @@
+package com.hazelcast.test.classhistogram;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class RemoveMeTest extends HazelcastTestSupport {
+
+    @Test
+    public void foo() {
+        fail("remove this test before merging. this is just to try the class histogram rule");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/perfcounter/PerfCounter.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/perfcounter/PerfCounter.java
@@ -1,0 +1,24 @@
+package com.hazelcast.test.perfcounter;
+
+import com.hazelcast.test.process.ExecutionResult;
+import com.hazelcast.test.process.ProcessUtils;
+
+import java.io.IOException;
+
+class PerfCounter {
+
+    static void dump(int maxLines) {
+        Long processIdOrNull = ProcessUtils.getOwnPidOrNull();
+        if (processIdOrNull == null) {
+            System.out.println("Cannot find own process id.");
+            return;
+        }
+
+        try {
+            ExecutionResult executionResult = ProcessUtils.executeBlocking(maxLines, "jcmd", Long.toString(processIdOrNull), "PerfCounter.print");
+            ProcessUtils.printResult("Perf Counter", executionResult);
+        } catch (IOException e) {
+            System.out.println("Cannot find jcmd");
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/perfcounter/PerfCounterRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/perfcounter/PerfCounterRule.java
@@ -1,0 +1,30 @@
+package com.hazelcast.test.perfcounter;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * JUnit rule to dump JVM perf counter on a test failure.
+ *
+ * This is a best effort rule as it depends on number of JVM-specific tools/APIs.
+ *
+ */
+public class PerfCounterRule implements TestRule {
+    private static final int MAX_LINES_TO_DUMP = 1000;
+
+    @Override
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    base.evaluate();
+                } catch (Throwable t) {
+                    PerfCounter.dump(MAX_LINES_TO_DUMP);
+                    throw t;
+                }
+            }
+        };
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/process/ExecutionResult.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/process/ExecutionResult.java
@@ -1,0 +1,25 @@
+package com.hazelcast.test.process;
+
+public final class ExecutionResult {
+    private final int exitCode;
+    private final String sysout;
+    private final String errout;
+
+    ExecutionResult(int exitCode, String sysout, String errout) {
+        this.exitCode = exitCode;
+        this.sysout = sysout;
+        this.errout = errout;
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    public String getSysout() {
+        return sysout;
+    }
+
+    public String getErrout() {
+        return errout;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/process/ProcessUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/process/ProcessUtils.java
@@ -9,6 +9,7 @@ import java.io.InputStreamReader;
 import java.lang.management.ManagementFactory;
 
 import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
+import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 
 /**
  * Utility to deal with processes.
@@ -16,7 +17,6 @@ import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
  *
  */
 public final class ProcessUtils {
-
     private ProcessUtils() {
 
     }
@@ -72,6 +72,18 @@ public final class ProcessUtils {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Interrupted while waiting for external process", e);
         }
+    }
+
+    public static void printResult(String name, ExecutionResult result) {
+        StringBuilder sb = new StringBuilder();
+        if (result.getExitCode() == 0) {
+            sb.append(name).append(LINE_SEPARATOR).append(result.getSysout());
+        } else {
+            sb.append("Error while generating ").append(name).append("Exit code").append(result.getExitCode())
+                    .append("Standard output: ").append(LINE_SEPARATOR).append(result.getSysout())
+                    .append("Error output: ").append(LINE_SEPARATOR).append(result.getExitCode());
+        }
+        System.out.println(sb);
     }
 
     private static class StreamPump extends Thread {

--- a/hazelcast/src/test/java/com/hazelcast/test/process/ProcessUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/process/ProcessUtils.java
@@ -1,0 +1,118 @@
+package com.hazelcast.test.process;
+
+import com.hazelcast.util.StringUtil;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.management.ManagementFactory;
+
+import static com.hazelcast.util.ExceptionUtil.sneakyThrow;
+
+/**
+ * Utility to deal with processes.
+ * This is intended to be used in tests only.
+ *
+ */
+public final class ProcessUtils {
+
+    private ProcessUtils() {
+
+    }
+
+    /**
+     * Best effort utility to get PID of own JVM
+     *
+     * @return own process ID or null
+     */
+    public static Long getOwnPidOrNull() {
+        // there is no public API to get own PID in pre-JDK9
+        // this is a hack which may or may not work depending on JDK impl
+        final String jvmName = ManagementFactory.getRuntimeMXBean().getName();
+        final int index = jvmName.indexOf('@');
+        if (index < 1) {
+            return null;
+        }
+        try {
+            return Long.parseLong(jvmName.substring(0, index));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Executor external process
+     *
+     * @param maxOutputLines Maximum number of lines to capture
+     * @param command A string array containing the program and its arguments
+     * @return Execution Result
+     * @throws IOException when command cannot be executed
+     */
+    public static ExecutionResult executeBlocking(int maxOutputLines, String...command) throws IOException {
+        ProcessBuilder processBuilder = new ProcessBuilder(command);
+        try {
+            Process process = processBuilder.start();
+            StringBuilder sysout = new StringBuilder();
+            StringBuilder errout = new StringBuilder();
+
+            StreamPump sysoutThread = new StreamPump(process.getInputStream(), sysout, maxOutputLines);
+            sysoutThread.start();
+            StreamPump erroutThread = new StreamPump(process.getErrorStream(), errout, maxOutputLines);
+            erroutThread.start();
+
+            int exitCode = process.waitFor();
+            sysoutThread.requestStop();
+            erroutThread.requestStop();
+            sysoutThread.join();
+            erroutThread.join();
+
+            return new ExecutionResult(exitCode, sysout.toString(), errout.toString());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for external process", e);
+        }
+    }
+
+    private static class StreamPump extends Thread {
+        private final InputStream from;
+        private final StringBuilder sb;
+        private final int maxLine;
+
+        private volatile boolean stopRequested;
+
+        private StreamPump(InputStream from, StringBuilder sb, int maxLines) {
+            this.from = from;
+            this.sb = sb;
+            this.maxLine = maxLines;
+        }
+
+        @Override
+        public void run() {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(from));
+            int truncatedLines = 0;
+            for (int i = 0; !stopRequested; i++) {
+                try {
+                    String line = reader.readLine();
+                    if (i < maxLine) {
+                        if (line != null) {
+                            sb.append(line).append(StringUtil.LINE_SEPARATOR);
+                        }
+                    } else {
+                        truncatedLines++;
+                    }
+                } catch (IOException e) {
+                    sneakyThrow(e);
+                }
+            }
+            if (truncatedLines != 0) {
+                sb.append("[... truncated ").append(truncatedLines).append(" lines ...]");
+            }
+        }
+
+        private void requestStop() {
+            stopRequested = true;
+            this.interrupt();
+        }
+    }
+}


### PR DESCRIPTION
Introducing a JUnit rule which dumps a class histogram on test failure.
It's best-effort only as there is no public Java api to do this.

The idea is this could help to better understand test failure related
to memory utilization / GC pressure.

In theory in could be hooked into the JitterRule and dump the histogram
only when significant jitter was recorded. I decided to keep it simple
for now.

Example output:
```
Class Histogram: 
16158:

 num     #instances         #bytes  class name
----------------------------------------------
   1:         12369        1688872  <methodKlass>
   2:         12369        1582904  <constMethodKlass>
   3:          1095        1107944  <constantPoolKlass>
   4:          1095         765872  <instanceKlassKlass>
   5:           916         636096  <constantPoolCacheKlass>
   6:          2142         409936  [B
   7:          2990         344520  [C
   8:          1200         105208  java.lang.Class
   9:          3154         100928  java.lang.String
  10:          1701          97136  [S
  11:          1660          91416  [[I
  12:            88          49984  <objArrayKlassKlass>
  13:           440          38720  java.lang.reflect.Method
  14:            76          35904  <methodDataKlass>
  15:           448          24848  [Ljava.lang.Object;
  16:           690          22080  java.util.HashMap$Entry
  17:           184          17568  [Ljava.util.HashMap$Entry;
  18:           229          14656  java.net.URL
  19:           343          13720  java.util.LinkedHashMap$Entry
  20:           190          13680  java.lang.reflect.Field
  21:           334          13360  java.lang.ref.Finalizer
  22:           406          12992  java.util.Hashtable$Entry
  23:           420           9616  [Ljava.lang.Class;
  24:            86           6880  java.util.jar.JarFile$JarFileEntry
  25:           257           6168  java.lang.Long
  26:           121           5808  java.util.HashMap
  27:            95           5320  java.util.jar.JarFile
  28:           108           5184  sun.misc.URLClassPath$JarLoader
  29:             8           4544  <typeArrayKlassKlass>
  30:           142           4544  java.io.FileInputStream
  31:           260           4160  java.lang.Integer
  32:            71           3976  java.lang.Package
  33:            54           3888  java.lang.reflect.Constructor
  34:           146           3504  java.io.FileDescriptor
  35:           145           3480  java.util.LinkedList$Entry
  36:            61           3416  java.util.LinkedHashMap
  37:           106           3392  java.util.Vector
  38:            19           3360  [Ljava.util.Hashtable$Entry;
  39:            89           3128  [Ljava.lang.String;
  40:            78           3120  java.lang.ref.SoftReference
  41:            63           3024  java.lang.Class$ReflectionData
  42:           181           2896  java.lang.Object
  43:           119           2856  java.util.jar.Attributes$Name
  44:           116           2784  java.io.ExpiringCache$Entry
  45:            87           2784  java.util.zip.Inflater
  46:            18           2760  [I
  47:            50           2560  [Ljava.lang.reflect.Method;
  48:           154           2464  java.util.concurrent.atomic.AtomicInteger
  49:             8           2176  [Z
  50:            11           2112  <klassKlass>
  51:            87           2088  java.util.zip.ZStreamRef
  52:            48           1920  java.util.concurrent.ConcurrentHashMap$Segment
  53:            77           1848  java.lang.ProcessEnvironment$Variable
  54:            77           1848  java.lang.ProcessEnvironment$Value
  55:            54           1728  java.util.concurrent.locks.ReentrantLock$NonfairSync
  56:            41           1640  java.io.ObjectStreamField
  57:            47           1504  java.util.concurrent.ConcurrentHashMap$HashEntry
  58:            48           1216  [Ljava.util.concurrent.ConcurrentHashMap$HashEntry;
  59:            50           1200  java.util.LinkedList
  60:            22           1120  [Ljava.lang.reflect.Field;
  61:             1           1040  [Ljava.lang.Integer;
  62:             1           1040  [Ljava.lang.Long;
  63:            30            960  java.security.Provider$EngineDescription
  64:            12            960  [Ljava.util.concurrent.ConcurrentHashMap$Segment;
  65:             8            896  java.lang.Thread
  66:            34            816  java.util.ArrayList
  67:            33            792  sun.reflect.annotation.AnnotationInvocationHandler
  68:             9            720  [Ljava.lang.ThreadLocal$ThreadLocalMap$Entry;
  69:            20            640  java.lang.ThreadLocal$ThreadLocalMap$Entry
  70:            26            624  java.util.regex.Pattern$GroupTail
  71:            39            624  java.util.regex.Pattern$CharPropertyNames$1
  72:            19            608  java.util.Locale
  73:            25            608  [Ljava.lang.reflect.Constructor;
  74:            24            576  java.util.regex.Pattern$GroupHead
  75:            12            576  java.util.concurrent.ConcurrentHashMap
  76:            14            560  java.security.AccessControlContext
  77:            23            552  sun.reflect.NativeConstructorAccessorImpl
  78:            13            520  java.util.WeakHashMap$Entry
  79:            16            488  [Ljava.io.ObjectStreamField;
  80:            15            480  java.util.regex.Pattern$Curly
  81:             7            448  java.util.regex.Pattern
  82:            14            448  java.util.regex.Pattern$Branch
  83:             9            432  java.util.Properties
  84:             4            392  [J
  85:            12            384  java.lang.ref.WeakReference
  86:            12            384  org.junit.runner.Description
  87:            16            384  java.util.Arrays$ArrayList
  88:            23            368  sun.reflect.DelegatingConstructorAccessorImpl
  89:             9            360  java.security.ProtectionDomain
  90:            11            352  sun.reflect.annotation.AnnotationType
  91:            14            344  [Ljava.util.regex.Pattern$Node;
  92:            17            336  [Ljava.lang.annotation.Annotation;
  93:             7            336  java.util.Hashtable
  94:            14            336  java.util.regex.Pattern$Single
  95:            14            336  java.util.concurrent.ConcurrentLinkedQueue$Node
  96:            10            320  java.security.Permissions
[... truncated 781 lines ...]
```