### PR TITLE
Improved HazelcastStarter for SplitBrainTestSupport and Node access

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicServerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicServerTest.java
@@ -41,6 +41,7 @@ public class CacheBasicServerTest extends CacheBasicAbstractTest {
 
     @Override
     protected HazelcastInstance getHazelcastInstance() {
-        return factory.newHazelcastInstance(createConfig());
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfig());
+        return getHazelcastInstanceImpl(instance);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheTestSupport.java
@@ -22,7 +22,9 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.instance.TestUtil;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.After;
@@ -115,7 +117,8 @@ public abstract class CacheTestSupport extends HazelcastTestSupport {
     }
 
     protected CachingProvider getCachingProvider(HazelcastInstance instance) {
-        return HazelcastServerCachingProvider.createCachingProvider(instance);
+        HazelcastInstanceImpl hazelcastInstanceImpl = TestUtil.getHazelcastInstanceImpl(instance);
+        return HazelcastServerCachingProvider.createCachingProvider(hazelcastInstanceImpl);
     }
 
     protected int getMaxCacheSizeWithoutEviction(CacheConfig cacheConfig) {

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/LegacyCacheSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/LegacyCacheSplitBrainTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.SplitBrainTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -213,8 +214,9 @@ public class LegacyCacheSplitBrainTest extends SplitBrainTestSupport {
         assertEquals(1, cache2.get("key"));
     }
 
-    private static Cache createCache(HazelcastInstance hazelcastInstance, CacheConfig cacheConfig) {
-        CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(hazelcastInstance);
+    private static Cache createCache(HazelcastInstance hz, CacheConfig cacheConfig) {
+        HazelcastInstanceImpl hazelcastInstanceImpl = getHazelcastInstanceImpl(hz);
+        CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(hazelcastInstanceImpl);
         CacheManager cacheManager = cachingProvider.getCacheManager();
         return cacheManager.createCache(cacheConfig.getName(), cacheConfig);
     }

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestUtil.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.PartitionService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.starter.HazelcastStarter;
 
 import java.io.IOException;
 import java.net.DatagramSocket;
@@ -32,6 +33,7 @@ import java.util.List;
 
 import static com.hazelcast.test.HazelcastTestSupport.sleepMillis;
 import static com.hazelcast.util.EmptyStatement.ignore;
+import static java.lang.reflect.Proxy.isProxyClass;
 
 @SuppressWarnings("WeakerAccess")
 public final class TestUtil {
@@ -68,8 +70,12 @@ public final class TestUtil {
      * @return the {@link Node} from the given Hazelcast instance
      */
     public static Node getNode(HazelcastInstance hz) {
-        HazelcastInstanceImpl hazelcastInstanceImpl = getHazelcastInstanceImpl(hz);
-        return hazelcastInstanceImpl.node;
+        if (isProxyClass(hz.getClass())) {
+            return HazelcastStarter.getNode(hz);
+        } else {
+            HazelcastInstanceImpl hazelcastInstanceImpl = getHazelcastInstanceImpl(hz);
+            return hazelcastInstanceImpl.node;
+        }
     }
 
     /**
@@ -81,15 +87,19 @@ public final class TestUtil {
      *                                  e.g. when called with a Hazelcast client instance
      */
     public static HazelcastInstanceImpl getHazelcastInstanceImpl(HazelcastInstance hz) {
-        if (hz instanceof HazelcastInstanceProxy) {
+        if (hz instanceof HazelcastInstanceImpl) {
+            return (HazelcastInstanceImpl) hz;
+        } else if (hz instanceof HazelcastInstanceProxy) {
             HazelcastInstanceProxy proxy = (HazelcastInstanceProxy) hz;
             if (proxy.original != null) {
                 return proxy.original;
             }
-        } else if (hz instanceof HazelcastInstanceImpl) {
-            return (HazelcastInstanceImpl) hz;
         }
-        throw new IllegalArgumentException("Cannot retrieve HazelcastInstanceImpl from " + hz.getClass().getSimpleName());
+        Class<? extends HazelcastInstance> clazz = hz.getClass();
+        if (isProxyClass(clazz)) {
+            return HazelcastStarter.getHazelcastInstanceImpl(hz);
+        }
+        throw new IllegalArgumentException("The given HazelcastInstance is not an active HazelcastInstanceImpl: " + clazz);
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -28,10 +28,12 @@ import com.hazelcast.core.Partition;
 import com.hazelcast.core.PartitionService;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
@@ -241,6 +243,10 @@ public abstract class HazelcastTestSupport {
 
     public static Node getNode(HazelcastInstance hz) {
         return TestUtil.getNode(hz);
+    }
+
+    public static HazelcastInstanceImpl getHazelcastInstanceImpl(HazelcastInstance hz) {
+        return TestUtil.getHazelcastInstanceImpl(hz);
     }
 
     public static NodeEngineImpl getNodeEngineImpl(HazelcastInstance hz) {
@@ -671,9 +677,10 @@ public abstract class HazelcastTestSupport {
 
     public static void suspectMember(Node suspectingNode, Node suspectedNode, String reason) {
         if (suspectingNode != null && suspectedNode != null) {
-            Member suspectedMember = suspectingNode.getClusterService().getMember(suspectedNode.getLocalMember().getAddress());
+            ClusterServiceImpl clusterService = suspectingNode.getClusterService();
+            Member suspectedMember = clusterService.getMember(suspectedNode.getLocalMember().getAddress());
             if (suspectedMember != null) {
-                suspectingNode.clusterService.suspectMember(suspectedMember, reason, true);
+                clusterService.suspectMember(suspectedMember, reason, true);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/SplitBrainTestSupport.java
@@ -18,7 +18,6 @@ package com.hazelcast.test;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.instance.HazelcastInstanceImpl;
@@ -44,6 +43,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+import static com.hazelcast.test.starter.ReflectionUtils.isInstanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -329,7 +330,8 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
     }
 
     private static FirewallingConnectionManager getFireWalledConnectionManager(HazelcastInstance hz) {
-        return (FirewallingConnectionManager) getNode(hz).getConnectionManager();
+        Node node = getNode(hz);
+        return (FirewallingConnectionManager) node.getConnectionManager();
     }
 
     protected Brains getBrains() {
@@ -366,18 +368,16 @@ public abstract class SplitBrainTestSupport extends HazelcastTestSupport {
     }
 
     private static boolean isInstanceActive(HazelcastInstance instance) {
-        if (instance instanceof HazelcastInstanceProxy) {
+        if (isInstanceOf(instance, HazelcastInstanceProxy.class)) {
             try {
-                ((HazelcastInstanceProxy) instance).getOriginal();
-                return true;
-            } catch (HazelcastInstanceNotActiveException exception) {
-                return false;
+                return getFieldValueReflectively(instance, "original") != null;
+            } catch (IllegalAccessException e) {
+                throw new AssertionError("Could not get original field from HazelcastInstanceProxy: " + e.getMessage());
             }
-        } else if (instance instanceof HazelcastInstanceImpl) {
+        } else if (isInstanceOf(instance, HazelcastInstanceImpl.class)) {
             return getNode(instance).getState() == NodeState.ACTIVE;
-        } else {
-            throw new AssertionError("Unsupported HazelcastInstance type");
         }
+        throw new AssertionError("Unsupported HazelcastInstance type: " + instance.getClass().getName());
     }
 
     public static void blockCommunicationBetween(HazelcastInstance h1, HazelcastInstance h2) {

--- a/hazelcast/src/test/java/com/hazelcast/test/backup/CacheBackupAccessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/backup/CacheBackupAccessor.java
@@ -24,6 +24,7 @@ import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.cache.impl.ICacheRecordStore;
 import com.hazelcast.cache.impl.record.CacheRecord;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
@@ -37,6 +38,7 @@ import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.spi.CachingProvider;
 import java.util.Map;
 
+import static com.hazelcast.test.HazelcastTestSupport.getHazelcastInstanceImpl;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
 import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
 import static com.hazelcast.test.TestTaskExecutorUtil.runOnPartitionThread;
@@ -68,7 +70,8 @@ class CacheBackupAccessor<K, V> extends AbstractBackupAccessor<K, V> implements 
             }
 
             HazelcastInstance hz = getInstanceWithAddress(replicaAddress);
-            CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(hz);
+            HazelcastInstanceImpl hazelcastInstanceImpl = getHazelcastInstanceImpl(hz);
+            CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(hazelcastInstanceImpl);
             HazelcastCacheManager cacheManager = (HazelcastServerCacheManager) provider.getCacheManager();
 
             NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
@@ -111,7 +114,8 @@ class CacheBackupAccessor<K, V> extends AbstractBackupAccessor<K, V> implements 
     }
 
     private static String getCacheNameWithPrefix(HazelcastInstance hz, String cacheName) {
-        CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(hz);
+        HazelcastInstanceImpl hazelcastInstanceImpl = getHazelcastInstanceImpl(hz);
+        CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(hazelcastInstanceImpl);
         HazelcastCacheManager cacheManager = (HazelcastServerCacheManager) provider.getCacheManager();
         return cacheManager.getCacheNameWithPrefix(cacheName);
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
@@ -34,6 +34,7 @@ import net.bytebuddy.matcher.ElementMatchers;
 import net.bytebuddy.matcher.LatentMatcher;
 import org.reflections.Reflections;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
@@ -45,6 +46,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.hazelcast.nio.ClassLoaderUtil.getAllInterfaces;
 import static com.hazelcast.test.starter.HazelcastAPIDelegatingClassloader.DELEGATION_WHITE_LIST;
@@ -54,6 +56,7 @@ import static com.hazelcast.test.starter.HazelcastStarterUtils.newCollectionFor;
 import static com.hazelcast.test.starter.ReflectionUtils.getConstructor;
 import static com.hazelcast.test.starter.ReflectionUtils.getReflectionsForTestPackage;
 import static com.hazelcast.util.ConcurrentReferenceHashMap.ReferenceType.STRONG;
+import static java.lang.System.arraycopy;
 import static java.util.Arrays.asList;
 import static net.bytebuddy.jar.asm.Opcodes.ACC_PUBLIC;
 import static net.bytebuddy.matcher.ElementMatchers.is;
@@ -126,10 +129,9 @@ public class HazelcastProxyFactory {
      * @param ifaces        interfaces implemented by delegateClass
      */
     public static ProxyPolicy shouldProxy(Class<?> delegateClass, Class<?>[] ifaces) {
-        if (delegateClass.isPrimitive() || isJDKClass(delegateClass)) {
+        if (delegateClass.isPrimitive() || isJDKClass(delegateClass) || isHazelcastAPIDelegatingClassloader(delegateClass)) {
             return ProxyPolicy.RETURN_SAME;
         }
-
         String className = delegateClass.getName();
         if (DELEGATION_WHITE_LIST.contains(className)) {
             return RETURN_SAME;
@@ -151,14 +153,28 @@ public class HazelcastProxyFactory {
      * which is valid in the current Hazelcast version.
      */
     public static Object proxyObjectForStarter(ClassLoader targetClassLoader, Object arg) throws ClassNotFoundException {
+        if (arg == null) {
+            return null;
+        }
+
         // handle JDK collections (e.g. ArrayList)
         if (isJDKClass(arg.getClass()) && Collection.class.isAssignableFrom(arg.getClass())) {
             Collection<Object> targetCollection = newCollectionFor(arg.getClass());
-            Collection collectionArg = (Collection) arg;
-            for (Object o : collectionArg) {
-                targetCollection.add(proxyObjectForStarter(targetClassLoader, o));
+            for (Object item : (Collection) arg) {
+                targetCollection.add(proxyObjectForStarter(targetClassLoader, item));
             }
             return targetCollection;
+        } else if (isJDKClass(arg.getClass()) && Map.class.isAssignableFrom(arg.getClass())) {
+            Map<Object, Object> targetMap = new ConcurrentHashMap<Object, Object>();
+            Map mapArg = (Map) arg;
+            for (Object entry : mapArg.entrySet()) {
+                Object key = proxyObjectForStarter(targetClassLoader, ((Map.Entry) entry).getKey());
+                Object value = proxyObjectForStarter(targetClassLoader, ((Map.Entry) entry).getValue());
+                targetMap.put(key, value);
+            }
+            return targetMap;
+        } else if (arg.getClass().isArray()) {
+            return toArray(targetClassLoader, arg);
         }
 
         if (arg.getClass().getClassLoader() == targetClassLoader) {
@@ -215,14 +231,18 @@ public class HazelcastProxyFactory {
      * Generates a JDK dynamic proxy implementing the expected interfaces.
      */
     @SuppressWarnings("unchecked")
-    private static <T> T generateProxyForInterface(Object delegate, ClassLoader proxyTargetClassloader,
-                                                   Class<?>... expectedInterfaces) {
+    public static <T> T generateProxyForInterface(Object delegate, ClassLoader proxyTargetClassloader,
+                                                  Class<?>... expectedInterfaces) {
         InvocationHandler myInvocationHandler = new ProxyInvocationHandler(delegate);
         return (T) Proxy.newProxyInstance(proxyTargetClassloader, expectedInterfaces, myInvocationHandler);
     }
 
     private static boolean isJDKClass(Class clazz) {
         return clazz.getClassLoader() == String.class.getClassLoader();
+    }
+
+    private static boolean isHazelcastAPIDelegatingClassloader(Class clazz) {
+        return HazelcastAPIDelegatingClassloader.class.equals(clazz);
     }
 
     private static Object constructWithJdkProxy(ClassLoader targetClassLoader, Object arg, Class<?>[] ifaces,
@@ -296,6 +316,32 @@ public class HazelcastProxyFactory {
         return constructorFunction.createNew(delegate);
     }
 
+    private static Object toArray(ClassLoader targetClassLoader, Object arg) throws ClassNotFoundException {
+        if (arg instanceof byte[]) {
+            byte[] srcArray = ((byte[]) arg);
+            byte[] targetArray = new byte[srcArray.length];
+            arraycopy(srcArray, 0, targetArray, 0, srcArray.length);
+            return targetArray;
+        } else if (arg instanceof int[]) {
+            int[] srcArray = ((int[]) arg);
+            int[] targetArray = new int[srcArray.length];
+            arraycopy(srcArray, 0, targetArray, 0, srcArray.length);
+            return targetArray;
+        } else if (arg instanceof long[]) {
+            long[] srcArray = ((long[]) arg);
+            long[] targetArray = new long[srcArray.length];
+            arraycopy(srcArray, 0, targetArray, 0, srcArray.length);
+            return targetArray;
+        }
+        Object[] srcArray = ((Object[]) arg);
+        Class<?> targetClass = targetClassLoader.loadClass(srcArray.getClass().getComponentType().getName());
+        Object[] targetArray = (Object[]) Array.newInstance(targetClass, srcArray.length);
+        for (int i = 0; i < srcArray.length; i++) {
+            targetArray[i] = proxyObjectForStarter(targetClassLoader, srcArray[i]);
+        }
+        return targetArray;
+    }
+
     /**
      * Returns all interfaces implemented by {@code type}, along with
      * {@code type} itself if it's an interface.
@@ -310,8 +356,8 @@ public class HazelcastProxyFactory {
         return interfaces.toArray(new Class<?>[0]);
     }
 
-    private static boolean isParameterizedType(Class<?> klass) {
-        return klass.getTypeParameters().length > 0;
+    private static boolean isParameterizedType(Class<?> clazz) {
+        return clazz.getTypeParameters().length > 0;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/AbstractAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/AbstractAnswer.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.test.starter.HazelcastAPIDelegatingClassloader;
+import com.hazelcast.test.starter.ReflectionUtils;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyObjectForStarter;
+import static com.hazelcast.test.starter.ReflectionUtils.getMethod;
+import static com.hazelcast.util.Preconditions.checkInstanceOf;
+import static com.hazelcast.util.Preconditions.checkNotInstanceOf;
+import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.RootCauseMatcher.getRootCause;
+import static java.lang.reflect.Modifier.isFinal;
+import static java.lang.reflect.Modifier.isPrivate;
+import static java.lang.reflect.Modifier.isProtected;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Abstract superclass for {@link org.mockito.stubbing.Answer} to create a mock
+ * with a default answer of a proxied class for the target classloader.
+ * <p>
+ * The goal of the mocking approach is to create proxy instances for the target
+ * classloader as lazy as possible. This makes the access to internals much
+ * easier, since we don't need to be able to construct all internal states as
+ * soon as e.g. {@link java.util.LinkedList.Node} is retrieved. We can just
+ * follow the usage and create mocks until we really need to access some data.
+ */
+abstract class AbstractAnswer implements Answer {
+
+    static final ClassLoader targetClassloader = AbstractAnswer.class.getClassLoader();
+
+    final Object delegate;
+    final Class<?> delegateClass;
+    final ClassLoader delegateClassloader;
+
+    AbstractAnswer(Object delegate) {
+        this(delegate, delegate.getClass().getClassLoader());
+    }
+
+    AbstractAnswer(Object delegate, ClassLoader delegateClassloader) {
+        this.delegate = checkNotNull(delegate, "delegate object cannot be null");
+        this.delegateClass = delegate.getClass();
+        this.delegateClassloader = delegateClassloader;
+
+        // these constraints are necessary to prevent very hard to debug classloading issues
+        checkNotInstanceOf(HazelcastAPIDelegatingClassloader.class, Thread.currentThread().getContextClassLoader(),
+                "The TCCL cannot be an instance of HazelcastAPIDelegatingClassloader."
+                        + " If you are executing a task from the test classloader on a proxied Hazelcast instance,"
+                        + " you have to set the TCCL to the test classloader, to prevent classloading issues,"
+                        + " see AbstractClassLoaderAwareCallable");
+        checkInstanceOf(HazelcastAPIDelegatingClassloader.class, delegateClassloader,
+                "The delegateClassloader should be an instance of HazelcastAPIDelegatingClassloader"
+                        + " (delegateClassloader: " + delegateClassloader + ") (delegateClass: " + delegateClass + ")");
+        if (delegateClassloader.equals(targetClassloader)) {
+            throw new IllegalArgumentException("The delegateClassloader cannot be the same as the targetClassloader"
+                    + " (delegateClassloader: " + delegateClassloader + ") (targetClassloader: " + targetClassloader + ")");
+        }
+
+        // disable asserts in the proxied classloader, which might fail due to instanceOf checks
+        delegateClassloader.setDefaultAssertionStatus(false);
+    }
+
+    @Override
+    public Object answer(InvocationOnMock invocation) throws Throwable {
+        String methodName = invocation.getMethod().getName();
+        Object[] arguments = invocation.getArguments();
+        if (arguments.length > 0) {
+            arguments = proxyArgumentsIfNeeded(arguments, delegateClassloader);
+        }
+        return answer(invocation, methodName, arguments);
+    }
+
+    /**
+     * Answers the given {@link InvocationOnMock}.
+     * <p>
+     * The given method name is extracted from the invoked method.
+     * The given arguments are already proxied if needed.
+     *
+     * @param invocation the {@link InvocationOnMock} to invoke
+     * @param methodName the name of the invoked method
+     * @param arguments  the (proxied) arguments to use for the invocation
+     * @return the (proxied) result of the invocation
+     * @throws Exception if the invocation fails
+     */
+    abstract Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception;
+
+    /**
+     * Calls the getLogger(String) method of the delegate instance, regardless
+     * if the argument was of type String or Class.
+     *
+     * @param arguments the arguments to use for the invocation
+     * @return the (proxied) Logger instance from the invocation
+     * @throws Exception if the invocation fails
+     */
+    Object getLogger(Object... arguments) throws Exception {
+        // we always call the getLogger(String) method, to avoid the lookup of the correct target class
+        Method delegateMethod = getDelegateMethod("getLogger", String.class);
+        String className = (arguments[0] instanceof String) ? (String) arguments[0] : ((Class) arguments[0]).getName();
+        return invoke(delegateMethod, className);
+    }
+
+    /**
+     * Returns the delegate {@link Method} of the delegate class, which
+     * matches the given method name and parameter types.
+     *
+     * @param methodName     the method name to lookup
+     * @param parameterTypes the parameter types to lookup
+     * @return the found {@link Method} on the delegate class
+     * @throws NoSuchMethodException when no method could be found
+     */
+    Method getDelegateMethod(String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+        return getMethod(delegateClass, methodName, parameterTypes);
+    }
+
+    /**
+     * Invokes the given {@link InvocationOnMock} and returns a non-proxied
+     * result.
+     * <p>
+     * This method is used to retrieve the result to create another mock.
+     *
+     * @param invocation the {@link InvocationOnMock} to invoke
+     * @param arguments  the arguments to use for the invocation
+     * @return the plain result from the invocation
+     * @throws Exception if the invocation fails
+     */
+    Object invokeForMock(InvocationOnMock invocation, Object... arguments) throws Exception {
+        return invoke(false, invocation, arguments);
+    }
+
+    /**
+     * Invokes the given {@link InvocationOnMock} and returns a proxied result,
+     * if needed.
+     * <p>
+     * This method is used for most invocations and tries to resolve the
+     * delegate method to call on its own.
+     *
+     * @param invocation the {@link InvocationOnMock} to invoke
+     * @param arguments  the arguments to use for the invocation
+     * @return the (proxied) result from the invocation
+     * @throws Exception if the invocation fails
+     */
+    Object invoke(InvocationOnMock invocation, Object... arguments) throws Exception {
+        return invoke(true, invocation, arguments);
+    }
+
+    /**
+     * Invokes the given {@link Method} and returns a proxied result, if
+     * needed.
+     * <p>
+     * This method is used for invocations which need their own method lookup.
+     *
+     * @param delegateMethod the {@link Method} to invoke
+     * @param arguments      the arguments to use for the invocation
+     * @return the (proxied) result from the invocation
+     * @throws Exception if the invocation fails
+     */
+    Object invoke(Method delegateMethod, Object... arguments) throws Exception {
+        return invoke(true, delegateMethod, arguments);
+    }
+
+    /**
+     * Invokes the given {@link InvocationOnMock} and returns a proxied or
+     * non-proxied result as requested.
+     *
+     * @param proxyResult {@code true} if the result should be proxied,
+     *                    {@code false} otherwise
+     * @param invocation  the {@link InvocationOnMock} to invoke
+     * @param arguments   the arguments to use for the invocation
+     * @return the (proxied) result from the invocation
+     * @throws Exception if the invocation fails
+     */
+    private Object invoke(boolean proxyResult, InvocationOnMock invocation, Object... arguments) throws Exception {
+        Method originalMethod = invocation.getMethod();
+        Object[] originalArguments = invocation.getArguments();
+        // if an argument was proxied, we need to replace the parameterType for a correct method lookup
+        Class<?>[] parameterTypes = originalMethod.getParameterTypes();
+        for (int i = 0; i < originalArguments.length; i++) {
+            if (arguments[i] == null) {
+                continue;
+            }
+            Class<?> argumentClass = arguments[i].getClass();
+            if (parameterTypes[i].isPrimitive()
+                    || Object.class.equals(parameterTypes[i])
+                    || Collection.class.isAssignableFrom(parameterTypes[i])
+                    || Map.class.isAssignableFrom(parameterTypes[i])
+                    || argumentClass.getClassLoader() == null
+                    || argumentClass.getClassLoader().equals(originalArguments[i].getClass().getClassLoader())
+                    || !argumentClass.getName().startsWith("com.hazelcast")) {
+                continue;
+            }
+            parameterTypes[i] = argumentClass;
+        }
+        Method delegateMethod = getDelegateMethod(originalMethod.getName(), parameterTypes);
+        return invoke(proxyResult, delegateMethod, arguments);
+    }
+
+    /**
+     * Invokes the given {@link Method} and returns a proxied or non-proxied
+     * result as requested.
+     *
+     * @param proxyResult    {@code true} if the result should be proxied,
+     *                       {@code false} otherwise
+     * @param delegateMethod the {@link Method} to invoke
+     * @param arguments      the arguments to use for the invocation
+     * @return the (proxied) result from the invocation
+     * @throws Exception if the invocation fails
+     */
+    private Object invoke(boolean proxyResult, Method delegateMethod, Object... arguments) throws Exception {
+        Object result = invokeDelegateMethod(delegateMethod, arguments);
+        if (result == null) {
+            return null;
+        }
+
+        // collection and map like return types need to return a specialized mock,
+        // to resolve their items and entries as late as possible, and to apply
+        // updates on the original data structure to the mocked structure as well
+        Class<?> resultClass = ReflectionUtils.getClass(result);
+        Class<?> delegateReturnType = delegateMethod.getReturnType();
+        if (Map.Entry.class.isAssignableFrom(delegateReturnType)) {
+            return mock(Map.Entry.class, new MapEntryAnswer(result, delegateClassloader));
+        } else if (Map.class.isAssignableFrom(delegateReturnType)) {
+            return createMapMock(resultClass, result);
+        } else if (Collection.class.isAssignableFrom(delegateReturnType)) {
+            return createCollectionMock(resultClass, result);
+        } else if (Iterator.class.isAssignableFrom(delegateReturnType)) {
+            return createIteratorMock(resultClass, result);
+        }
+        // some Hazelcast return types need to return a specialized mock
+        if (!resultClass.isArray() && resultClass.getPackage().getName().contains("com.hazelcast")) {
+            String resultClassName = resultClass.getName();
+            if (resultClassName.contains("Container") || resultClassName.contains("MultiMapValue")) {
+                return createMockForTargetClass(result, new DataStructureContainerAnswer(result));
+            } else if ((resultClassName.contains("Item") || resultClassName.contains("Record"))
+                    && !resultClassName.contains("HiDensity")) {
+                return createMockForTargetClass(result, new DataStructureElementAnswer(result));
+            }
+        }
+        return proxyResult ? proxyObjectForStarter(targetClassloader, result) : result;
+    }
+
+    /**
+     * Invokes the given {@link Method} and returns the result.
+     * <p>
+     * Handles some exceptions for debugging or root cause extraction.
+     *
+     * @param delegateMethod the {@link Method} to invoke
+     * @param arguments      the arguments to use for the invocation
+     * @return the proxied result from the invocation
+     * @throws Exception if the invocation fails
+     */
+    private Object invokeDelegateMethod(Method delegateMethod, Object... arguments) throws Exception {
+        try {
+            return delegateMethod.invoke(delegate, arguments);
+        } catch (IllegalArgumentException e) {
+            // this is a poor man's debugging for argument type mismatch errors
+            if ("argument type mismatch".equals(e.getMessage())) {
+                StringBuilder sb = new StringBuilder("argument type mismatch when calling ")
+                        .append(delegateMethod.getName()).append("()\n");
+                Class<?>[] parameterTypes = delegateMethod.getParameterTypes();
+                for (int i = 0; i < parameterTypes.length; i++) {
+                    sb.append("parameterType: ").append(parameterTypes[i])
+                            .append(" with argument ").append(arguments[i] == null ? "null" : arguments[i].getClass())
+                            .append("\n");
+                }
+                System.err.println(sb.toString());
+            }
+            throw e;
+        } catch (InvocationTargetException e) {
+            // some methods throw an IllegalStateException, which is asserted in tests
+            // we could maybe use ExceptionUtil.peel() to improve this
+            Throwable cause = getRootCause(e);
+            if (cause instanceof IllegalStateException) {
+                throw (IllegalStateException) cause;
+            }
+            throw e;
+        }
+    }
+
+    private Object createMapMock(Class<?> targetClass, Object map) {
+        if (isNotMockable(targetClass)) {
+            targetClass = ConcurrentHashMap.class;
+        }
+        return mock(targetClass, new MapAnswer(map, delegateClassloader));
+    }
+
+    private Object createCollectionMock(Class<?> targetClass, Object collection) {
+        if (isNotMockable(targetClass)) {
+            if (Set.class.isAssignableFrom(targetClass)) {
+                targetClass = HashSet.class;
+            } else {
+                targetClass = LinkedList.class;
+            }
+        }
+        return mock(targetClass, new CollectionAnswer(collection, delegateClassloader));
+    }
+
+    private Object createIteratorMock(Class<?> targetClass, Object iterator) {
+        if (isNotMockable(targetClass)) {
+            targetClass = Iterator.class;
+        }
+        return mock(targetClass, new IteratorAnswer(iterator, delegateClassloader));
+    }
+
+    /**
+     * Creates a mock with the given default {@link Answer} and the class of
+     * the given delegate instance in the target classloader.
+     * <p>
+     * Can be used if the target class is not constant, but depends on the
+     * given delegate instance (e.g. to create the correct mock for
+     * {@link com.hazelcast.spi.NodeEngine#getService(String)}).
+     *
+     * @param delegate the delegate to retrieve the class from
+     * @param answer   the default {@link Answer} to create the mock with
+     * @return the created mock for the target class
+     * @throws Exception if the mocking fails
+     */
+    static Object createMockForTargetClass(Object delegate, AbstractAnswer answer) throws Exception {
+        Class<?> delegateClass = ReflectionUtils.getClass(delegate);
+        Class<?> targetClass = targetClassloader.loadClass(delegateClass.getName());
+        return mock(targetClass, answer);
+    }
+
+    /**
+     * Checks if the given class is mockable or not.
+     *
+     * @param targetClass the class to check
+     * @return {@code true} if the class is mockable, {@code false} otherwise
+     */
+    private static boolean isNotMockable(Class<?> targetClass) {
+        int modifiers = targetClass.getModifiers();
+        return isFinal(modifiers) || isPrivate(modifiers) || isProtected(modifiers);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/CacheManagerAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/CacheManagerAnswer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.cache.impl.CacheProxy;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.instance.Node;
+import com.hazelcast.spi.NodeEngine;
+import org.mockito.invocation.InvocationOnMock;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link javax.cache.CacheManager}.
+ */
+class CacheManagerAnswer extends AbstractAnswer {
+
+    CacheManagerAnswer(Object delegate) {
+        super(delegate);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 1 && methodName.equals("getCacheByFullName")) {
+            String cacheName = (String) arguments[0];
+            Object original = getFieldValueReflectively(delegate, "original");
+            Object delegateNode = getFieldValueReflectively(original, "node");
+            Node node = mock(Node.class, new NodeAnswer(delegateNode));
+            NodeEngine nodeEngine = node.getNodeEngine();
+            CacheConfig cacheConfig = new CacheConfig(node.getConfig().getCacheConfig(cacheName));
+            CacheService cacheService = nodeEngine.getService(CacheService.SERVICE_NAME);
+
+            // we have to create the mock with useConstructor(), otherwise the
+            // calls to the AbstractDistributedObject (its base class) won't
+            // work properly, since the NodeEngine field is not set (final
+            // method calls are not mocked in the used Mockito version)
+            Object cacheProxy = invokeForMock(invocation, arguments);
+            return mock(CacheProxy.class, withSettings()
+                    .useConstructor(cacheConfig, nodeEngine, cacheService)
+                    .defaultAnswer(new CacheProxyAnswer(cacheProxy)));
+        } else if (arguments.length == 0) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in CacheManagerAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/CacheProxyAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/CacheProxyAnswer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.cache.HazelcastCacheManager;
+import com.hazelcast.config.CacheConfig;
+import org.mockito.invocation.InvocationOnMock;
+
+import java.lang.reflect.Method;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link com.hazelcast.cache.impl.CacheProxy}.
+ */
+class CacheProxyAnswer extends AbstractAnswer {
+
+    private final Class<?> delegateHazelcastCacheManagerClass;
+    private final Class<?> delegateCacheConfigClass;
+
+    CacheProxyAnswer(Object delegate) throws Exception {
+        super(delegate);
+        delegateHazelcastCacheManagerClass = delegateClassloader.loadClass(HazelcastCacheManager.class.getName());
+        delegateCacheConfigClass = delegateClassloader.loadClass(CacheConfig.class.getName());
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (methodName.equals("invoke") || methodName.equals("invokeAll")) {
+            // TODO: we have to deal with the Object... argument variations manually for now
+            if (arguments.length < 3) {
+                arguments = new Object[]{arguments[0], arguments[1], new Object[]{}};
+            } else if (arguments.length == 3) {
+                arguments = new Object[]{arguments[0], arguments[1], new Object[]{arguments[2]}};
+            }
+        } else if (arguments.length == 1 && methodName.equals("setCacheManager")) {
+            Object cacheManager = getDelegateMethod("getCacheManager").invoke(delegate);
+            Method delegateMethod = getDelegateMethod(methodName, delegateHazelcastCacheManagerClass);
+            return delegateMethod.invoke(delegate, cacheManager);
+        } else if (arguments.length == 1 && methodName.equals("getConfiguration")) {
+            return invoke(invocation, delegateCacheConfigClass);
+        }
+        return invoke(invocation, arguments);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/ClusterServiceAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/ClusterServiceAnswer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.core.Member;
+import org.mockito.invocation.InvocationOnMock;
+
+import java.lang.reflect.Method;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link com.hazelcast.internal.cluster.ClusterService}.
+ */
+class ClusterServiceAnswer extends AbstractAnswer {
+
+    private final Class delegateMemberClass;
+
+    ClusterServiceAnswer(Object delegate) throws Exception {
+        super(delegate);
+        delegateMemberClass = delegateClassloader.loadClass(Member.class.getName());
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 3 && methodName.equals("suspectMember")) {
+            return suspectMember(methodName, arguments);
+        } else if (arguments.length == 1 && methodName.equals("getMember")) {
+            return invoke(invocation, arguments);
+        } else if (arguments.length == 0 && methodName.startsWith("get")) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in ClusterServiceAnswer: " + methodName);
+    }
+
+    private Object suspectMember(String methodName, Object[] arguments) throws Exception {
+        Method delegateMethod = getDelegateMethod(methodName, delegateMemberClass, String.class, Boolean.TYPE);
+        return invoke(delegateMethod, arguments);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/CollectionAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/CollectionAnswer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import org.mockito.invocation.InvocationOnMock;
+
+import java.lang.reflect.Method;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link java.util.Collection}.
+ */
+class CollectionAnswer extends AbstractAnswer {
+
+    CollectionAnswer(Object delegate, ClassLoader delegateClassloader) {
+        super(delegate, delegateClassloader);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 1 && methodName.equals("get")) {
+            Method delegateMethod = getDelegateMethod(methodName, Object.class);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 0) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in CollectionAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/DataStructureContainerAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/DataStructureContainerAnswer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import org.mockito.invocation.InvocationOnMock;
+
+import java.lang.reflect.Method;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * container of a Hazelcast data structure, e.g.
+ * {@link com.hazelcast.multimap.impl.MultiMapValue} or
+ * {@link com.hazelcast.collection.impl.queue.QueueContainer}.
+ */
+class DataStructureContainerAnswer extends AbstractAnswer {
+
+    DataStructureContainerAnswer(Object delegate) {
+        super(delegate);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 1 && methodName.equals("readAsData")) {
+            // RingbufferContainer
+            Method delegateMethod = getDelegateMethod(methodName, Long.TYPE);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 1 && methodName.equals("getCollection")) {
+            // MultiMapValue
+            Method delegateMethod = getDelegateMethod(methodName, Boolean.TYPE);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 0) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in DataStructureContainerAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/DataStructureElementAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/DataStructureElementAnswer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * entry or item of a Hazelcast data structure, e.g.
+ * {@link com.hazelcast.collection.impl.queue.QueueItem}.
+ */
+class DataStructureElementAnswer extends AbstractAnswer {
+
+    DataStructureElementAnswer(Object delegate) {
+        super(delegate);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 0) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in DataStructureElementAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/FirewallingConnectionManagerAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/FirewallingConnectionManagerAnswer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link com.hazelcast.nio.tcp.FirewallingConnectionManager}.
+ */
+class FirewallingConnectionManagerAnswer extends AbstractAnswer {
+
+    FirewallingConnectionManagerAnswer(Object delegate) {
+        super(delegate);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (methodName.equals("blockNewConnection")
+                || methodName.equals("closeActiveConnection")
+                || methodName.equals("unblock")) {
+            return invoke(invocation, arguments);
+        } else if (arguments.length == 0 && methodName.equals("toString")) {
+            return delegate.toString();
+        }
+        throw new UnsupportedOperationException("Method is not implemented FirewallingConnectionManagerAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/HazelcastInstanceImplAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/HazelcastInstanceImplAnswer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.instance.HazelcastInstanceCacheManager;
+import com.hazelcast.instance.LifecycleServiceImpl;
+import org.mockito.invocation.InvocationOnMock;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link com.hazelcast.instance.HazelcastInstanceImpl}.
+ * <p>
+ * Usage:
+ * <pre><code>
+ *   Object delegate = HazelcastStarter.getHazelcastInstanceImpl(hz, classloader);
+ *   mock(HazelcastInstanceImpl.class, new HazelcastInstanceImplAnswer(delegate);
+ * </code></pre>
+ */
+public class HazelcastInstanceImplAnswer extends AbstractAnswer {
+
+    public HazelcastInstanceImplAnswer(Object delegate) {
+        super(delegate);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 0 && methodName.equals("getCacheManager")) {
+            Object cacheManager = invokeForMock(invocation);
+            return mock(HazelcastInstanceCacheManager.class, new CacheManagerAnswer(cacheManager));
+        } else if (arguments.length == 0 && methodName.equals("getLifecycleService")) {
+            Object lifecycleService = invokeForMock(invocation);
+            return mock(LifecycleServiceImpl.class, new ServiceAnswer(lifecycleService));
+        }
+        return invoke(invocation, arguments);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/IteratorAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/IteratorAnswer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link java.util.Iterator}.
+ */
+class IteratorAnswer extends AbstractAnswer {
+
+    IteratorAnswer(Object delegate, ClassLoader delegateClassloader) {
+        super(delegate, delegateClassloader);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 0) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in IteratorAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/MapAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/MapAnswer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import org.mockito.invocation.InvocationOnMock;
+
+import java.lang.reflect.Method;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link java.util.Map}.
+ */
+class MapAnswer extends AbstractAnswer {
+
+    MapAnswer(Object delegate, ClassLoader delegateClassloader) {
+        super(delegate, delegateClassloader);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 1 && methodName.equals("get")) {
+            Method delegateMethod = getDelegateMethod(methodName, Object.class);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 0) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in MapAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/MapEntryAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/MapEntryAnswer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import org.mockito.invocation.InvocationOnMock;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link java.util.Map.Entry}.
+ */
+class MapEntryAnswer extends AbstractAnswer {
+
+    MapEntryAnswer(Object delegate, ClassLoader delegateClassloader) {
+        super(delegate, delegateClassloader);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 0) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in MapEntryAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/MapServiceContextAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/MapServiceContextAnswer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.PartitionContainer;
+import org.mockito.invocation.InvocationOnMock;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link MapServiceContext}.
+ */
+class MapServiceContextAnswer extends AbstractAnswer {
+
+    MapServiceContextAnswer(Object delegate) {
+        super(delegate);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 1 && methodName.equals("getPartitionContainer")) {
+            return getPartitionContainer(methodName, arguments);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in MapServiceContextAnswer: " + methodName);
+    }
+
+    private Object getPartitionContainer(String methodName, Object[] arguments) throws Exception {
+        Method delegateMethod = getDelegateMethod(methodName, Integer.TYPE);
+        Object container = delegateMethod.invoke(delegate, arguments);
+        if (container == null) {
+            return null;
+        }
+        return mock(PartitionContainer.class, new PartitionContainerAnswer(container));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/NodeAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/NodeAnswer.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import org.mockito.invocation.InvocationOnMock;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link com.hazelcast.instance.Node}.
+ * <p>
+ * Usage:
+ * <pre><code>
+ *   Object delegate = HazelcastStarter.getNode(hz, classloader);
+ *   mock(Node.class, new NodeAnswer(delegate);
+ * </code></pre>
+ */
+public class NodeAnswer extends AbstractAnswer {
+
+    public NodeAnswer(Object delegate) {
+        super(delegate);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 1 && methodName.equals("getLogger")) {
+            return getLogger(arguments);
+        } else if (arguments.length == 0 && methodName.equals("getClusterService")) {
+            Object clusterService = invokeForMock(invocation);
+            return mock(ClusterServiceImpl.class, new ClusterServiceAnswer(clusterService));
+        } else if (arguments.length == 0 && methodName.equals("getPartitionService")) {
+            Object partitionService = invokeForMock(invocation);
+            return mock(InternalPartitionService.class, new PartitionServiceAnswer(partitionService));
+        } else if (arguments.length == 0 && methodName.equals("getNodeEngine")) {
+            Object nodeEngine = invokeForMock(invocation);
+            return mock(NodeEngineImpl.class, new NodeEngineAnswer(nodeEngine));
+        } else if (arguments.length == 0 && methodName.equals("getConnectionManager")) {
+            Object connectionManager = invokeForMock(invocation);
+            return createMockForTargetClass(connectionManager, new FirewallingConnectionManagerAnswer(connectionManager));
+        } else if (arguments.length == 0 && (methodName.startsWith("get") || methodName.startsWith("is"))) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in NodeAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/NodeEngineAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/NodeEngineAnswer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import org.mockito.invocation.InvocationOnMock;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link com.hazelcast.spi.NodeEngine}.
+ */
+public class NodeEngineAnswer extends AbstractAnswer {
+
+    public NodeEngineAnswer(Object delegate) {
+        super(delegate);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 1 && methodName.equals("getLogger")) {
+            return getLogger(arguments);
+        } else if (arguments.length == 1 && methodName.equals("getService")) {
+            Object service = invokeForMock(invocation, arguments);
+            return createMockForTargetClass(service, new ServiceAnswer(service));
+        } else if (arguments.length == 0 && methodName.equals("getOperationService")) {
+            Object operationService = invokeForMock(invocation);
+            return mock(InternalOperationService.class, new OperationServiceAnswer(operationService));
+        } else if (arguments.length == 0 && methodName.equals("getConfigClassLoader")) {
+            return targetClassloader;
+        } else if (arguments.length == 0 && (methodName.startsWith("get") || methodName.startsWith("is"))) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in NodeEngineAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/OperationServiceAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/OperationServiceAnswer.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.PartitionSpecificRunnable;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.TestTaskExecutorUtil.PartitionSpecificRunnableWithResultQueue;
+import org.mockito.invocation.InvocationOnMock;
+
+import java.lang.reflect.Method;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyObjectForStarter;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link com.hazelcast.spi.OperationService}.
+ * <p>
+ * This class uses (de)serialization to transfer Hazelcast operations from the
+ * test classloader to the delegate classloader.
+ */
+class OperationServiceAnswer extends AbstractAnswer {
+
+    private final SerializationService serializationService;
+    private final Object delegateSerializationService;
+    private final Method delegateToObjectMethod;
+    private final Class<?> delegateOperationClass;
+    private final Class<?> delegatePartitionSpecificRunnableClass;
+
+    OperationServiceAnswer(Object delegate) throws Exception {
+        super(delegate);
+        serializationService = new DefaultSerializationServiceBuilder().build();
+        delegateSerializationService = getFieldValueReflectively(delegate, "serializationService");
+        delegateToObjectMethod = delegateSerializationService.getClass().getMethod("toObject", Object.class);
+        delegateOperationClass = delegateClassloader.loadClass(Operation.class.getName());
+        delegatePartitionSpecificRunnableClass = delegateClassloader.loadClass(PartitionSpecificRunnable.class.getName());
+    }
+
+    @Override
+    public Object answer(InvocationOnMock invocation) throws Throwable {
+        String methodName = invocation.getMethod().getName();
+        Object[] arguments = invocation.getArguments();
+        Class[] argumentClasses = new Class[arguments.length];
+        for (int i = 0; i < arguments.length; i++) {
+            if (arguments[i] instanceof Operation) {
+                // transfer the operation to the delegateClassloader via (de)serialization
+                Object dataOperation = serializationService.toData(arguments[i]);
+                Object delegateDataOperation = proxyObjectForStarter(delegateClassloader, dataOperation);
+                Object delegateOperation = delegateToObjectMethod.invoke(delegateSerializationService, delegateDataOperation);
+                arguments[i] = delegateOperationClass.cast(delegateOperation);
+                argumentClasses[i] = delegateOperationClass;
+            } else if (arguments[i] instanceof Integer) {
+                argumentClasses[i] = Integer.TYPE;
+            } else if (arguments[i] instanceof PartitionSpecificRunnableWithResultQueue) {
+                argumentClasses[i] = delegatePartitionSpecificRunnableClass;
+            } else {
+                argumentClasses[i] = arguments[i].getClass();
+            }
+        }
+        Method delegateMethod = getDelegateMethod(methodName, argumentClasses);
+        Object[] proxiedArguments = proxyArgumentsIfNeeded(arguments, delegateClassloader);
+        return invoke(delegateMethod, proxiedArguments);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/PartitionContainerAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/PartitionContainerAnswer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.map.impl.recordstore.RecordStore;
+import org.mockito.invocation.InvocationOnMock;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link com.hazelcast.map.impl.PartitionContainer}
+ * or {@link com.hazelcast.multimap.impl.MultiMapPartitionContainer}.
+ */
+class PartitionContainerAnswer extends AbstractAnswer {
+
+    PartitionContainerAnswer(Object delegate) {
+        super(delegate);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 1 && methodName.equals("getExistingRecordStore")) {
+            // PartitionContainer
+            return getRecordStore(methodName, arguments);
+        } else if (arguments.length == 1 && methodName.equals("getMultiMapContainer")) {
+            // MultiMapPartitionContainer
+            return invoke(invocation, arguments);
+        } else if (arguments.length == 0) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in PartitionContainerAnswer: " + methodName);
+    }
+
+    private Object getRecordStore(String methodName, Object[] arguments) throws Exception {
+        Method delegateMethod = getDelegateMethod(methodName, String.class);
+        Object recordStore = delegateMethod.invoke(delegate, arguments);
+        if (recordStore == null) {
+            return null;
+        }
+        return mock(RecordStore.class, new RecordStoreAnswer(recordStore));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/PartitionServiceAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/PartitionServiceAnswer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import org.mockito.invocation.InvocationOnMock;
+
+import java.lang.reflect.Method;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link com.hazelcast.internal.partition.InternalPartitionService}.
+ */
+class PartitionServiceAnswer extends AbstractAnswer {
+
+    PartitionServiceAnswer(Object delegate) {
+        super(delegate);
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 1 && methodName.equals("getPartitionId")) {
+            Method delegateMethod = getDelegateMethod(methodName, Object.class);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 1 && methodName.equals("getPartition")) {
+            return invoke(invocation, arguments);
+        } else if (arguments.length == 0 && methodName.startsWith("get")) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in PartitionServiceAnswer: " + methodName);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/RecordStoreAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/RecordStoreAnswer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.Data;
+import org.mockito.invocation.InvocationOnMock;
+
+import javax.cache.expiry.ExpiryPolicy;
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+import static java.util.Arrays.copyOf;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * {@link com.hazelcast.map.impl.recordstore.RecordStore} or
+ * {@link com.hazelcast.cache.impl.ICacheRecordStore}.
+ */
+class RecordStoreAnswer extends AbstractAnswer {
+
+    private final Class<?> delegateDataClass;
+    private final Class<?> delegateAddressClass;
+    private final Class<?> delegateExpiryPolicyClass;
+
+    RecordStoreAnswer(Object delegate) throws Exception {
+        super(delegate);
+        delegateDataClass = delegateClassloader.loadClass(Data.class.getName());
+        delegateAddressClass = delegateClassloader.loadClass(Address.class.getName());
+        delegateExpiryPolicyClass = delegateClassloader.loadClass(ExpiryPolicy.class.getName());
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 3 && methodName.equals("get")) {
+            // RecordStore
+            return getMapValue(methodName, arguments);
+        } else if (arguments.length == 3 && methodName.equals("setExpiryPolicy")) {
+            // ICacheRecordStore
+            return setExpiryPolicy(invocation, methodName, arguments);
+        } else if (arguments.length == 2 && methodName.equals("get")) {
+            // ICacheRecordStore
+            return getCacheValue(methodName, arguments);
+        } else if (arguments.length == 0 && methodName.equals("getReadOnlyRecords")) {
+            // ICacheRecordStore
+            return invoke(invocation);
+        } else if (arguments.length == 0 && methodName.equals("size")) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in RecordStoreAnswer: " + methodName);
+    }
+
+    private Object getMapValue(String methodName, Object[] arguments) throws Exception {
+        // the RecordStore.get() method changed its signature between 3.10 and 3.11
+        try {
+            Method delegateMethod = getDelegateMethod(methodName, delegateDataClass, Boolean.TYPE, delegateAddressClass);
+            return invoke(delegateMethod, arguments);
+        } catch (NoSuchMethodException e) {
+            Method delegateMethod = getDelegateMethod(methodName, delegateDataClass, Boolean.TYPE);
+            return invoke(delegateMethod, arguments[0], arguments[1]);
+        }
+    }
+
+    private Object getCacheValue(String methodName, Object[] arguments) throws Exception {
+        Method delegateMethod = getDelegateMethod(methodName, delegateDataClass, delegateExpiryPolicyClass);
+        return invoke(delegateMethod, arguments);
+    }
+
+    private Object setExpiryPolicy(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        // the ICacheRecordStore.setExpiryPolicy() method changed its signature between 3.10 and 3.11
+        try {
+            return invoke(invocation, arguments);
+        } catch (NoSuchMethodException e) {
+            Method delegateMethod = getDelegateMethod(methodName, Collection.class, Object.class, String.class, Integer.TYPE);
+            Object[] legacyArguments = copyOf(arguments, 4);
+            legacyArguments[3] = 0;
+            return invoke(delegateMethod, legacyArguments);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/ServiceAnswer.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/ServiceAnswer.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer;
+
+import com.hazelcast.cache.impl.ICacheRecordStore;
+import com.hazelcast.cache.impl.PreJoinCacheConfig;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.multimap.impl.MultiMapPartitionContainer;
+import com.hazelcast.spi.ObjectNamespace;
+import org.mockito.invocation.InvocationOnMock;
+
+import java.lang.reflect.Method;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Default {@link org.mockito.stubbing.Answer} to create a mock for a proxied
+ * Hazelcast {@code Service}.
+ */
+class ServiceAnswer extends AbstractAnswer {
+
+    private final Class<?> objectNamespaceClass;
+    private final Class<?> preJoinCacheConfigClass;
+    private final Class<?> cacheConfigClass;
+    private final Class<?> inMemoryFormatClass;
+
+    ServiceAnswer(Object delegate) throws Exception {
+        super(delegate);
+        objectNamespaceClass = delegateClassloader.loadClass(ObjectNamespace.class.getName());
+        preJoinCacheConfigClass = delegateClassloader.loadClass(PreJoinCacheConfig.class.getName());
+        cacheConfigClass = delegateClassloader.loadClass(CacheConfig.class.getName());
+        inMemoryFormatClass = delegateClassloader.loadClass(InMemoryFormat.class.getName());
+    }
+
+    @Override
+    Object answer(InvocationOnMock invocation, String methodName, Object[] arguments) throws Exception {
+        if (arguments.length == 2 && methodName.equals("getContainerOrNull")) {
+            // RingbufferService
+            Method delegateMethod = getDelegateMethod(methodName, Integer.TYPE, objectNamespaceClass);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 2 && methodName.equals("getOrCreateContainer")) {
+            // QueueService
+            Method delegateMethod = getDelegateMethod(methodName, String.class, Boolean.TYPE);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 1 && (methodName.equals("getLongContainer")
+                || methodName.equals("getReferenceContainer")
+                || methodName.equals("getCardinalityEstimatorContainer"))) {
+            // AtomicLongService, AtomicReferenceService, CardinalityEstimatorService
+            Method delegateMethod = getDelegateMethod(methodName, String.class);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 1 && methodName.equals("getPartitionContainer")) {
+            // MultiMapService
+            Method delegateMethod = getDelegateMethod(methodName, Integer.TYPE);
+            return getMultiMapPartitionContainer(delegateMethod, arguments);
+        } else if (arguments.length == 2 && methodName.equals("getCacheOperationProvider")) {
+            // CacheService
+            Method delegateMethod = delegateClass.getMethod(methodName, String.class, inMemoryFormatClass);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 2 && methodName.equals("getRecordStore")) {
+            // CacheService
+            Method delegateMethod = delegateClass.getMethod(methodName, String.class, Integer.TYPE);
+            return getICacheRecordStore(delegateMethod, arguments);
+        } else if (arguments.length == 1 && (methodName.equals("getCacheConfig")
+                || methodName.equals("findCacheConfig"))) {
+            // CacheService
+            return invoke(invocation, arguments);
+        } else if (arguments.length == 1 && methodName.equals("createCacheConfigOnAllMembers")) {
+            // CacheService
+            Method delegateMethod = delegateClass.getMethod(methodName, preJoinCacheConfigClass);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 1 && methodName.equals("putCacheConfigIfAbsent")) {
+            // CacheService
+            Method delegateMethod = delegateClass.getMethod(methodName, cacheConfigClass);
+            return invoke(delegateMethod, arguments);
+        } else if (arguments.length == 1 && methodName.equals("deleteCacheConfig")) {
+            // CacheService
+            return invoke(invocation, arguments);
+        } else if (arguments.length == 1 && (methodName.equals("addLifecycleListener"))) {
+            // LifecycleService
+            // FIXME
+            return null;
+        } else if (arguments.length == 1 && (methodName.equals("removeLifecycleListener"))) {
+            // LifecycleService
+            // FIXME
+            return null;
+        } else if (arguments.length == 0 && methodName.equals("getMapServiceContext")) {
+            // MapService
+            Object mapServiceContext = invokeForMock(invocation);
+            return mock(MapServiceContext.class, new MapServiceContextAnswer(mapServiceContext));
+        } else if (arguments.length == 0 && methodName.startsWith("isRunning")) {
+            // LifecycleService
+            return invoke(invocation);
+        } else if (arguments.length == 0 && methodName.startsWith("get")) {
+            return invoke(invocation);
+        }
+        throw new UnsupportedOperationException("Method is not implemented in ServiceAnswer: " + methodName);
+    }
+
+    private Object getMultiMapPartitionContainer(Method delegateMethod, Object[] arguments) throws Exception {
+        Object container = delegateMethod.invoke(delegate, arguments);
+        if (container == null) {
+            return null;
+        }
+        return mock(MultiMapPartitionContainer.class, new PartitionContainerAnswer(container));
+    }
+
+    private Object getICacheRecordStore(Method delegateMethod, Object[] arguments) throws Exception {
+        Object recordStore = delegateMethod.invoke(delegate, arguments);
+        if (recordStore == null) {
+            return null;
+        }
+        return mock(ICacheRecordStore.class, new RecordStoreAnswer(recordStore));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/test/AnswerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/test/AnswerTest.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.answer.test;
+
+import com.hazelcast.cache.HazelcastCacheManager;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.HazelcastServerCacheManager;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.cache.impl.ICacheRecordStore;
+import com.hazelcast.collection.impl.collection.CollectionContainer;
+import com.hazelcast.collection.impl.collection.CollectionItem;
+import com.hazelcast.collection.impl.collection.CollectionService;
+import com.hazelcast.collection.impl.list.ListService;
+import com.hazelcast.collection.impl.queue.QueueContainer;
+import com.hazelcast.collection.impl.queue.QueueItem;
+import com.hazelcast.collection.impl.queue.QueueService;
+import com.hazelcast.collection.impl.set.SetService;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.IQueue;
+import com.hazelcast.core.ISet;
+import com.hazelcast.core.LifecycleService;
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.internal.partition.InternalPartition;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.partition.impl.PartitionServiceState;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.PartitionContainer;
+import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.multimap.impl.MultiMapContainer;
+import com.hazelcast.multimap.impl.MultiMapPartitionContainer;
+import com.hazelcast.multimap.impl.MultiMapRecord;
+import com.hazelcast.multimap.impl.MultiMapService;
+import com.hazelcast.multimap.impl.MultiMapValue;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.starter.HazelcastStarter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.Cache;
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import javax.cache.processor.EntryProcessorResult;
+import javax.cache.processor.MutableEntry;
+import javax.cache.spi.CachingProvider;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.internal.cluster.Versions.PREVIOUS_CLUSTER_VERSION;
+import static com.hazelcast.internal.partition.TestPartitionUtils.getPartitionServiceState;
+import static java.lang.reflect.Proxy.isProxyClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class AnswerTest extends HazelcastTestSupport {
+
+    private HazelcastInstance hz;
+
+    @Before
+    public void setUp() {
+        Config config = smallInstanceConfig()
+                .setInstanceName("test-name");
+
+        // we always want to ensure, that the access to internals work with a previous minor version
+        hz = HazelcastStarter.newHazelcastInstance(PREVIOUS_CLUSTER_VERSION.toString(), config, false);
+    }
+
+    @After
+    public void tearDown() {
+        if (hz != null) {
+            hz.shutdown();
+        }
+    }
+
+    @Test
+    public void testHazelcastInstanceImpl() {
+        HazelcastInstanceImpl hazelcastInstance = HazelcastStarter.getHazelcastInstanceImpl(hz);
+
+        LifecycleService lifecycleService = hazelcastInstance.getLifecycleService();
+        assertNotNull("LifecycleService should not be null ", lifecycleService);
+        assertTrue("Expected LifecycleService.isRunning() to be true", lifecycleService.isRunning());
+    }
+
+    @Test
+    public void testNode() {
+        Node node = HazelcastStarter.getNode(hz);
+        assertNotNull("Node should not be null", node);
+        assertNotNull("NodeEngine should not be null", node.getNodeEngine());
+        assertNotNull("ClusterService should not be null", node.getClusterService());
+        assertEquals("Expected NodeState to be ACTIVE", NodeState.ACTIVE, node.getState());
+        assertTrue("Expected isRunning() to be true", node.isRunning());
+        assertTrue("Expected isMaster() to be true", node.isMaster());
+        Address localAddress = hz.getCluster().getLocalMember().getAddress();
+        assertEquals("Expected the same address from HazelcastInstance and Node", localAddress, node.getThisAddress());
+    }
+
+    @Test
+    public void testNodeEngine() {
+        Node node = HazelcastStarter.getNode(hz);
+
+        NodeEngineImpl nodeEngine = node.getNodeEngine();
+        assertNotNull("NodeEngine should not be null", nodeEngine);
+
+        HazelcastInstance hazelcastInstance = nodeEngine.getHazelcastInstance();
+        assertNotNull("HazelcastInstance should not be null", hazelcastInstance);
+
+        SerializationService serializationService = nodeEngine.getSerializationService();
+        assertNotNull("SerializationService should not be null", serializationService);
+
+        InternalOperationService operationService = nodeEngine.getOperationService();
+        assertNotNull("InternalOperationService should not be null", operationService);
+
+        CollectionService collectionService = nodeEngine.getService(SetService.SERVICE_NAME);
+        assertNotNull("CollectionService from ISet should not be null", collectionService);
+
+        collectionService = nodeEngine.getService(ListService.SERVICE_NAME);
+        assertNotNull("CollectionService from IList should not be null", collectionService);
+
+        MultiMapService multiMapService = nodeEngine.getService(MultiMapService.SERVICE_NAME);
+        assertNotNull("MultiMapService should not be null", multiMapService);
+    }
+
+    @Test
+    public void testClusterService() {
+        Node node = HazelcastStarter.getNode(hz);
+        ClusterServiceImpl clusterService = node.getClusterService();
+
+        MemberImpl localMember = clusterService.getLocalMember();
+        assertNotNull("localMember should not be null", localMember);
+        assertTrue("Member should be the local member", localMember.localMember());
+        assertFalse("Member should be no lite member", localMember.isLiteMember());
+        assertEquals("Expected the same address from Node and local member", node.getThisAddress(), localMember.getAddress());
+
+        MemberImpl member = clusterService.getMember(node.getThisAddress());
+        assertEquals("Expected the same member via getMember(thisAddress) as the local member", localMember, member);
+    }
+
+    @Test
+    public void testPartitionService() {
+        Node node = HazelcastStarter.getNode(hz);
+        InternalPartitionService partitionService = node.getPartitionService();
+        int expectedPartitionCount = Integer.parseInt(hz.getConfig().getProperty(GroupProperty.PARTITION_COUNT.getName()));
+
+        IPartition[] partitions = partitionService.getPartitions();
+        assertNotNull("partitions should not be null", partitions);
+        assertEqualsStringFormat("Expected %s partitions, but found %s", expectedPartitionCount, partitions.length);
+
+        int partitionCount = partitionService.getPartitionCount();
+        assertEqualsStringFormat("Expected partitionCount of %s, but was %s", expectedPartitionCount, partitionCount);
+
+        InternalPartition partition = partitionService.getPartition(expectedPartitionCount / 2);
+        assertNotNull("partition should not be null", partition);
+        assertTrue("partition should be local", partition.isLocal());
+        assertEquals("partition should be owned by this node", node.getThisAddress(), partition.getOwnerOrNull());
+
+        PartitionServiceState partitionServiceState = getPartitionServiceState(hz);
+        assertEquals("Expected SAFE PartitionServiceState (before shutdown)", PartitionServiceState.SAFE, partitionServiceState);
+
+        hz.shutdown();
+
+        partitionServiceState = getPartitionServiceState(hz);
+        assertEquals("Expected SAFE PartitionServiceState (after shutdown)", PartitionServiceState.SAFE, partitionServiceState);
+    }
+
+    @Test
+    public void testSerializationService() {
+        Node node = HazelcastStarter.getNode(hz);
+        NodeEngineImpl nodeEngine = node.getNodeEngine();
+        SerializationService serializationService = nodeEngine.getSerializationService();
+
+        int original = 42;
+        Data data = serializationService.toData(original);
+        assertNotNull("data should not be null", data);
+        assertFalse("data should be no proxy class", isProxyClass(data.getClass()));
+        assertEquals("toObject() should return original value", original, serializationService.toObject(data));
+
+        SerializationService localSerializationService = new DefaultSerializationServiceBuilder().build();
+        Data localData = localSerializationService.toData(original);
+        assertEquals("data should be the same as from local SerializationService", localData, data);
+    }
+
+    @Test
+    public void testSetService() {
+        Node node = HazelcastStarter.getNode(hz);
+        NodeEngineImpl nodeEngine = node.getNodeEngine();
+        SerializationService serializationService = nodeEngine.getSerializationService();
+        SetService setService = nodeEngine.getService(SetService.SERVICE_NAME);
+
+        assertEquals(SetService.SERVICE_NAME, setService.getServiceName());
+        ConcurrentMap<String, ? extends CollectionContainer> containerMap = setService.getContainerMap();
+        assertTrue("containerMap should be empty", containerMap.isEmpty());
+
+        ISet<Object> set = hz.getSet("mySet");
+        set.add(42);
+
+        assertFalse("containerMap should be empty", containerMap.isEmpty());
+        CollectionContainer container = containerMap.get("mySet");
+        assertEquals("Expected one item in the collection container", 1, container.size());
+
+        Collection<CollectionItem> collection = container.getCollection();
+        assertEquals("Expected one primary item in the container", 1, collection.size());
+        Map<Long, CollectionItem> backupMap = container.getMap();
+        assertEquals("Expected one backup item in the container", 1, backupMap.size());
+
+        Collection<CollectionItem> values = backupMap.values();
+        Iterator<CollectionItem> iterator = values.iterator();
+        assertNotNull("containerMap iterator should not be null", iterator);
+        assertTrue("containerMap iterator should have a next item", iterator.hasNext());
+        CollectionItem collectionItem = iterator.next();
+        assertNotNull("collectionItem should not be null", collectionItem);
+        Data dataValue = collectionItem.getValue();
+        assertNotNull("collectionItem should have a value", dataValue);
+        Object value = serializationService.toObject(dataValue);
+        assertEquals("Expected collectionItem value to be 42", 42, value);
+
+        assertTrue("set should contain 42", set.contains(42));
+        set.clear();
+        assertFalse("set should not contain 42", set.contains(42));
+
+        set.destroy();
+    }
+
+    @Test
+    public void testQueueService() {
+        Node node = HazelcastStarter.getNode(hz);
+        NodeEngineImpl nodeEngine = node.getNodeEngine();
+        SerializationService serializationService = nodeEngine.getSerializationService();
+        QueueService queueService = nodeEngine.getService(QueueService.SERVICE_NAME);
+
+        IQueue<Object> queue = hz.getQueue("myQueue");
+        queue.add(42);
+
+        QueueContainer container = queueService.getOrCreateContainer("myQueue", false);
+        assertNotNull("container should not be null", container);
+        assertEquals("Expected one item in the queue container", 1, container.size());
+
+        Collection<QueueItem> collection = container.getItemQueue();
+        assertEquals("Expected one primary item in the container", 1, collection.size());
+        Map<Long, QueueItem> backupMap = container.getBackupMap();
+        assertEquals("Expected one backup item in the container", 1, backupMap.size());
+
+        Collection<QueueItem> values = backupMap.values();
+        Iterator<QueueItem> iterator = values.iterator();
+        assertNotNull("backupMap iterator should not be null", iterator);
+        assertTrue("backupMap iterator should have a next item", iterator.hasNext());
+        QueueItem queueItem = iterator.next();
+        assertNotNull("queueItem should not be null", queueItem);
+        Data dataValue = queueItem.getData();
+        assertNotNull("queueItem should have a value", dataValue);
+        Object value = serializationService.toObject(dataValue);
+        assertEquals("Expected collectionItem value to be 42", 42, value);
+
+        assertTrue("queue should contain 42", queue.contains(42));
+        queue.clear();
+        assertFalse("queue should not contain 42", queue.contains(42));
+
+        queue.destroy();
+    }
+
+    @Test
+    public void testCacheService() {
+        Node node = HazelcastStarter.getNode(hz);
+        NodeEngineImpl nodeEngine = node.getNodeEngine();
+        HazelcastInstanceImpl hazelcastInstance = HazelcastStarter.getHazelcastInstanceImpl(hz);
+
+        SerializationService serializationService = nodeEngine.getSerializationService();
+        String key = randomString();
+        Data keyData = serializationService.toData(key);
+        int partitionId = hz.getPartitionService().getPartition(key).getPartitionId();
+
+        CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(hazelcastInstance);
+        HazelcastCacheManager cacheManager = (HazelcastServerCacheManager) provider.getCacheManager();
+
+        Cache<String, Integer> cache = cacheManager.getCache("myCache");
+        assertNull("cache should be null", cache);
+
+        CacheConfig<String, Integer> cacheConfig = new CacheConfig<String, Integer>("myCache");
+        cache = cacheManager.createCache("myCache", cacheConfig);
+        assertNotNull("cache should not be null", cache);
+
+        cacheManager.getCache("myCache");
+        assertNotNull("cache should not be null", cache);
+        cache.put(key, 23);
+
+        // ICacheRecordStore access
+        CacheService cacheService = nodeEngine.getService(CacheService.SERVICE_NAME);
+        String cacheNameWithPrefix = cacheManager.getCacheNameWithPrefix("myCache");
+        ICacheRecordStore recordStore = cacheService.getRecordStore(cacheNameWithPrefix, partitionId);
+        assertNotNull("recordStore should not be null", recordStore);
+        assertEquals("Expected one item in the recordStore", 1, recordStore.size());
+
+        Object dataValue = recordStore.get(keyData, null);
+        assertNotNull("dataValue should not be null", dataValue);
+        int value = serializationService.toObject(dataValue);
+        assertEquals("Expected the value to be 23", 23, value);
+
+        // EntryProcessor invocation
+        Map<String, EntryProcessorResult<Integer>> resultMap;
+        int result;
+
+        result = cache.invoke(key, new IntegerValueEntryProcessor());
+        assertEquals("Expected the result to be -23 (after invoke())", -23, result);
+
+        result = cache.invoke(key, new IntegerValueEntryProcessor(), 42);
+        assertEquals("Expected the value to be 42 (after invoke())", 42, result);
+
+        resultMap = cache.invokeAll(Collections.singleton(key), new IntegerValueEntryProcessor());
+        result = resultMap.get(key).get();
+        assertEquals("Expected the value to be -23 (after invokeAll())", -23, result);
+
+        resultMap = cache.invokeAll(Collections.singleton(key), new IntegerValueEntryProcessor(), 42);
+        result = resultMap.get(key).get();
+        assertEquals("Expected the value to be 42 (after invokeAll())", 42, result);
+
+        // clear and destroy
+        assertTrue("cache should contain key", cache.containsKey(key));
+        cache.clear();
+        assertFalse("cache should not contain key", cache.containsKey(key));
+
+        cacheManager.destroyCache("myCache");
+    }
+
+    @Test
+    public void testMapService() {
+        Node node = HazelcastStarter.getNode(hz);
+        NodeEngineImpl nodeEngine = node.getNodeEngine();
+
+        SerializationService serializationService = nodeEngine.getSerializationService();
+        String key = randomString();
+        Data keyData = serializationService.toData(key);
+        int partitionId = hz.getPartitionService().getPartition(key).getPartitionId();
+
+        MapService mapService = nodeEngine.getService(MapService.SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        assertNotNull("mapServiceContext should not be null", mapServiceContext);
+
+        PartitionContainer partitionContainer = mapServiceContext.getPartitionContainer(partitionId);
+        assertNotNull("partitionContainer should not be null", partitionContainer);
+
+        RecordStore recordStore = partitionContainer.getExistingRecordStore("myMap");
+        assertNull("recordStore should be null", recordStore);
+
+        IMap<Object, Object> map = hz.getMap("myMap");
+        map.put(key, 23);
+
+        recordStore = partitionContainer.getExistingRecordStore("myMap");
+        assertNotNull("recordStore should not be null", recordStore);
+        assertEquals("Expected one item in the recordStore", 1, recordStore.size());
+
+        Object dataValue = recordStore.get(keyData, true, null);
+        assertNotNull("dataValue should not be null", dataValue);
+        int value = serializationService.toObject(dataValue);
+        assertEquals("Expected value to be 23", 23, value);
+
+        assertTrue("map should contain key", map.containsKey(key));
+        map.clear();
+        assertFalse("map should not contain key", map.containsKey(key));
+
+        map.destroy();
+    }
+
+    @Test
+    public void testMultiMapService() {
+        Node node = HazelcastStarter.getNode(hz);
+        NodeEngineImpl nodeEngine = node.getNodeEngine();
+        MultiMapService multiMapService = nodeEngine.getService(MultiMapService.SERVICE_NAME);
+
+        SerializationService serializationService = nodeEngine.getSerializationService();
+        String key = randomString();
+        Data keyData = serializationService.toData(key);
+        int partitionId = hz.getPartitionService().getPartition(key).getPartitionId();
+
+        MultiMap<String, String> multiMap = hz.getMultiMap("myMultiMap");
+        multiMap.put(key, "value1");
+        multiMap.put(key, "value2");
+
+        MultiMapPartitionContainer partitionContainer = multiMapService.getPartitionContainer(partitionId);
+        MultiMapContainer multiMapContainer = partitionContainer.getMultiMapContainer("myMultiMap");
+
+        ConcurrentMap<Data, MultiMapValue> multiMapValues = multiMapContainer.getMultiMapValues();
+        for (Map.Entry<Data, MultiMapValue> entry : multiMapValues.entrySet()) {
+            Data actualKeyData = entry.getKey();
+            MultiMapValue multiMapValue = entry.getValue();
+
+            String actualKey = serializationService.toObject(actualKeyData);
+            assertEquals(keyData, actualKeyData);
+            assertEquals(key, actualKey);
+
+            Collection<MultiMapRecord> collection = multiMapValue.getCollection(false);
+            Collection<String> actualValues = new ArrayList<String>(collection.size());
+            for (MultiMapRecord record : collection) {
+                String value = serializationService.toObject(record.getObject());
+                actualValues.add(value);
+            }
+            assertEquals("MultiMapValue should contain 2 MultiMapRecords", 2, actualValues.size());
+            assertTrue("MultiMapValue should contain value1", actualValues.contains("value1"));
+            assertTrue("MultiMapValue should contain value2", actualValues.contains("value2"));
+        }
+
+        assertTrue("multiMap should contain key", multiMap.containsKey(key));
+        multiMap.clear();
+        assertFalse("multiMap should not contain key", multiMap.containsKey(key));
+
+        multiMap.destroy();
+    }
+
+    private static class IntegerValueEntryProcessor implements EntryProcessor<String, Integer, Integer>, Serializable {
+
+        @Override
+        public Integer process(MutableEntry<String, Integer> entry, Object... arguments) throws EntryProcessorException {
+            if (arguments.length > 0) {
+                return (Integer) arguments[0];
+            }
+            return -entry.getValue();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/CacheConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/CacheConfigConstructor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import static com.hazelcast.test.starter.ReflectionUtils.setFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.config.CacheConfig", "com.hazelcast.cache.impl.PreJoinCacheConfig"})
+public class CacheConfigConstructor extends AbstractConfigConstructor {
+
+    public CacheConfigConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        ClassLoader classloader = targetClass.getClassLoader();
+        Object otherConfig = cloneConfig(delegate, classloader);
+        setFieldValueReflectively(otherConfig, "classLoader", classloader);
+        return otherConfig;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/DistributedObjectNamespaceConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/DistributedObjectNamespaceConstructor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.spi.DistributedObjectNamespace"})
+public class DistributedObjectNamespaceConstructor extends AbstractStarterObjectConstructor {
+
+    public DistributedObjectNamespaceConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        // obtain reference to constructor DistributedObjectNamespace(String serviceName, String objectName)
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(String.class, String.class);
+
+        Object service = getFieldValueReflectively(delegate, "service");
+        Object objectName = getFieldValueReflectively(delegate, "objectName");
+        Object[] args = new Object[]{service, objectName};
+
+        return constructor.newInstance(args);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/DynamicConfigurationAwareConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/DynamicConfigurationAwareConfigConstructor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig"})
+public class DynamicConfigurationAwareConfigConstructor extends AbstractConfigConstructor {
+
+    public DynamicConfigurationAwareConfigConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        ClassLoader classloader = targetClass.getClassLoader();
+        Class<?> configClass = classloader.loadClass("com.hazelcast.config.Config");
+        Class<?> propertiesClass = classloader.loadClass("com.hazelcast.spi.properties.HazelcastProperties");
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(configClass, propertiesClass);
+
+        Object config = getFieldValueReflectively(delegate, "staticConfig");
+        Object clonedConfig = cloneConfig(config, classloader);
+
+        Constructor<?> propertiesConstructor = propertiesClass.getDeclaredConstructor(configClass);
+        Object clonedHazelcastProperties = propertiesConstructor.newInstance(clonedConfig);
+
+        Method setClassLoaderMethod = configClass.getMethod("setClassLoader", ClassLoader.class);
+        setClassLoaderMethod.invoke(clonedConfig, classloader);
+
+        Object[] args = new Object[]{clonedConfig, clonedHazelcastProperties};
+        return constructor.newInstance(args);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/FirewallingConnectionManagerConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/FirewallingConnectionManagerConstructor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import java.lang.reflect.Constructor;
+import java.util.Set;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.nio.tcp.FirewallingConnectionManager"})
+public class FirewallingConnectionManagerConstructor extends AbstractStarterObjectConstructor {
+
+    public FirewallingConnectionManagerConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        // obtain reference to constructor FirewallingConnectionManager(ConnectionManager, Set<Address>)
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(ConnectionManager.class, Set.class);
+
+        Object connectionManager = getFieldValueReflectively(delegate, "delegate");
+        Set blockedAddresses = (Set) getFieldValueReflectively(delegate, "blockedAddresses");
+        Object[] args = new Object[]{connectionManager, blockedAddresses};
+
+        Object[] proxiedArgs = proxyArgumentsIfNeeded(args, targetClass.getClassLoader());
+        return constructor.newInstance(proxiedArgs);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/FirewallingNodeContextConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/FirewallingNodeContextConstructor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.instance.FirewallingNodeContext"})
+public class FirewallingNodeContextConstructor extends AbstractStarterObjectConstructor {
+
+    public FirewallingNodeContextConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        return targetClass.newInstance();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/HazelcastPropertiesConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/HazelcastPropertiesConstructor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import java.lang.reflect.Constructor;
+import java.util.Properties;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.spi.properties.HazelcastProperties"})
+public class HazelcastPropertiesConstructor extends AbstractStarterObjectConstructor {
+
+    public HazelcastPropertiesConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        // obtain reference to constructor HazelcastProperties(Properties nullableProperties)
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(Properties.class);
+
+        Properties properties = (Properties) getFieldValueReflectively(delegate, "properties");
+        Object[] args = new Object[]{properties};
+
+        return constructor.newInstance(args);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/HeapDataConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/HeapDataConstructor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.internal.serialization.impl.HeapData"})
+public class HeapDataConstructor extends AbstractStarterObjectConstructor {
+
+    public HeapDataConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        // obtain reference to constructor HeapData(byte[] payload)
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(byte[].class);
+
+        byte[] payload = (byte[]) getFieldValueReflectively(delegate, "payload");
+        Object[] args = new Object[]{payload};
+
+        return constructor.newInstance(args);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/InternalPartitionImplConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/InternalPartitionImplConstructor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.internal.partition.impl.InternalPartitionImpl"})
+public class InternalPartitionImplConstructor extends AbstractStarterObjectConstructor {
+
+    public InternalPartitionImplConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        ClassLoader classloader = targetClass.getClassLoader();
+        Class<?> partitionListenerClass = classloader.loadClass("com.hazelcast.internal.partition.PartitionListener");
+        Class<?> addressClass = classloader.loadClass("com.hazelcast.nio.Address");
+        Class<?> addressArrayClass = Array.newInstance(addressClass, 0).getClass();
+        // obtain reference to constructor InternalPartitionImpl(int partitionId, PartitionListener listener,
+        //                                                       Address thisAddress, Address[] addresses)
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(Integer.TYPE, partitionListenerClass, addressClass,
+                addressArrayClass);
+
+        Integer partitionId = (Integer) getFieldValueReflectively(delegate, "partitionId");
+        Object partitionListener = getFieldValueReflectively(delegate, "partitionListener");
+        Object thisAddress = getFieldValueReflectively(delegate, "thisAddress");
+        Object addresses = getFieldValueReflectively(delegate, "addresses");
+        Object[] args = new Object[]{partitionId, partitionListener, thisAddress, addresses};
+
+        Object[] proxiedArgs = proxyArgumentsIfNeeded(args, classloader);
+        return constructor.newInstance(proxiedArgs);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/MemberImplConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/MemberImplConstructor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+import com.hazelcast.version.MemberVersion;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.instance.MemberImpl"})
+public class MemberImplConstructor extends AbstractStarterObjectConstructor {
+
+    public MemberImplConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        Object address = getFieldValueReflectively(delegate, "address");
+        Object memberVersion = getMemberVersion(delegate);
+        Boolean localMember = (Boolean) getFieldValueReflectively(delegate, "localMember");
+        String uuid = (String) getFieldValueReflectively(delegate, "uuid");
+        Object attributes = getFieldValueReflectively(delegate, "attributes");
+        Boolean liteMember = (Boolean) getFieldValueReflectively(delegate, "liteMember");
+
+        ClassLoader targetClassloader = targetClass.getClassLoader();
+        Class<?> addressClass = targetClassloader.loadClass("com.hazelcast.nio.Address");
+        Class<?> memberVersionClass = targetClassloader.loadClass("com.hazelcast.version.MemberVersion");
+
+        // obtain reference to constructor MemberImpl(Address address, MemberVersion version, boolean localMember,
+        //                                            String uuid, Map<String, Object> attributes, boolean liteMember)
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(addressClass, memberVersionClass, Boolean.TYPE,
+                String.class, Map.class, Boolean.TYPE);
+        Object[] args = new Object[]{
+                address,
+                memberVersion,
+                localMember,
+                uuid,
+                attributes,
+                liteMember,
+        };
+
+        Object[] proxiedArgs = proxyArgumentsIfNeeded(args, targetClassloader);
+        return constructor.newInstance(proxiedArgs);
+    }
+
+    private static Object getMemberVersion(Object delegate) throws Exception {
+        // older Hazelcast versions don't have the version field
+        try {
+            return getFieldValueReflectively(delegate, "version");
+        } catch (NoSuchFieldError e) {
+            return MemberVersion.UNKNOWN;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/MemberVersionConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/MemberVersionConstructor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.version.MemberVersion"})
+public class MemberVersionConstructor extends AbstractStarterObjectConstructor {
+
+    public MemberVersionConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        // obtain reference to constructor MemberVersion(int major, int minor, int patch)
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(Integer.TYPE, Integer.TYPE, Integer.TYPE);
+
+        Byte major = (Byte) getFieldValueReflectively(delegate, "major");
+        Byte minor = (Byte) getFieldValueReflectively(delegate, "minor");
+        Byte patch = (Byte) getFieldValueReflectively(delegate, "patch");
+        Object[] args = new Object[]{major, minor, patch};
+
+        return constructor.newInstance(args);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/MergePolicyProviderConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/MergePolicyProviderConstructor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+import com.hazelcast.test.starter.answer.NodeEngineAnswer;
+
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+import static org.mockito.Mockito.mock;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.spi.merge.SplitBrainMergePolicyProvider",
+        "com.hazelcast.cache.impl.merge.policy.CacheMergePolicyProvider"})
+public class MergePolicyProviderConstructor extends AbstractStarterObjectConstructor {
+
+    public MergePolicyProviderConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        ClassLoader classloader = targetClass.getClassLoader();
+        Class<?> nodeEngineClass = classloader.loadClass("com.hazelcast.spi.NodeEngine");
+        // obtain reference to constructor ...MergePolicyProvider(NodeEngine nodeEngine)
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(nodeEngineClass);
+
+        Object nodeEngine = getFieldValueReflectively(delegate, "nodeEngine");
+        Object[] args = new Object[]{mock(nodeEngineClass, new NodeEngineAnswer(nodeEngine))};
+
+        return constructor.newInstance(args);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/MultiMapRecordConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/MultiMapRecordConstructor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.multimap.impl.MultiMapRecord"})
+public class MultiMapRecordConstructor extends AbstractStarterObjectConstructor {
+
+    public MultiMapRecordConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        // obtain reference to constructor MultiMapRecord(long recordId, Object object)
+        Constructor<?> constructor = targetClass.getDeclaredConstructor(Long.TYPE, Object.class);
+
+        Long recordId = (Long) getFieldValueReflectively(delegate, "recordId");
+        Object object = getFieldValueReflectively(delegate, "object");
+        Object[] args = new Object[]{recordId, object};
+
+        return constructor.newInstance(args);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/ScheduledTaskHandlerImplConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/ScheduledTaskHandlerImplConstructor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import java.lang.reflect.Constructor;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.scheduledexecutor.impl.ScheduledTaskHandlerImpl"})
+public class ScheduledTaskHandlerImplConstructor extends AbstractStarterObjectConstructor {
+
+    public ScheduledTaskHandlerImplConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @Override
+    Object createNew0(Object delegate) throws Exception {
+        Object address = getFieldValueReflectively(delegate, "address");
+        Integer partitionId = (Integer) getFieldValueReflectively(delegate, "partitionId");
+        String schedulerName = (String) getFieldValueReflectively(delegate, "schedulerName");
+        String taskName = (String) getFieldValueReflectively(delegate, "taskName");
+
+        if (address != null) {
+            ClassLoader targetClassloader = targetClass.getClassLoader();
+            Class<?> addressClass = targetClassloader.loadClass("com.hazelcast.nio.Address");
+
+            // obtain reference to constructor ScheduledTaskHandlerImpl(Address address, String schedulerName, String taskName)
+            Constructor<?> constructor = targetClass.getDeclaredConstructor(addressClass, String.class, String.class);
+            constructor.setAccessible(true);
+
+            Object[] args = new Object[]{address, schedulerName, taskName};
+            Object[] proxiedArgs = proxyArgumentsIfNeeded(args, targetClassloader);
+            return constructor.newInstance(proxiedArgs);
+        } else {
+            // obtain reference to constructor ScheduledTaskHandlerImpl(int partitionId, String schedulerName, String taskName)
+            Constructor<?> constructor = targetClass.getDeclaredConstructor(Integer.TYPE, String.class, String.class);
+            constructor.setAccessible(true);
+
+            Object[] args = new Object[]{partitionId, schedulerName, taskName};
+            return constructor.newInstance(args);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/CacheConfigConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/CacheConfigConstructorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.CacheConfigConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CacheConfigConstructorTest {
+
+    @Test
+    public void testConstructor() {
+        CacheConfig cacheConfig = new CacheConfig();
+        cacheConfig.setName("myCache");
+        cacheConfig.setInMemoryFormat(InMemoryFormat.NATIVE);
+        cacheConfig.setBackupCount(1);
+        cacheConfig.setAsyncBackupCount(2);
+
+        CacheConfigConstructor constructor = new CacheConfigConstructor(CacheConfig.class);
+        CacheConfig clonedCacheConfig = (CacheConfig) constructor.createNew(cacheConfig);
+
+        assertEquals(cacheConfig.getName(), clonedCacheConfig.getName());
+        assertEquals(cacheConfig.getNameWithPrefix(), clonedCacheConfig.getNameWithPrefix());
+        assertEquals(cacheConfig.getInMemoryFormat(), clonedCacheConfig.getInMemoryFormat());
+        assertEquals(cacheConfig.getBackupCount(), clonedCacheConfig.getBackupCount());
+        assertEquals(cacheConfig.getAsyncBackupCount(), clonedCacheConfig.getAsyncBackupCount());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/DistributedObjectNamespaceConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/DistributedObjectNamespaceConstructorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.DistributedObjectNamespaceConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.ringbuffer.impl.RingbufferService.getRingbufferNamespace;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DistributedObjectNamespaceConstructorTest {
+
+    @Test
+    public void testConstructor() {
+        ObjectNamespace objectNamespace = getRingbufferNamespace("myRingbuffer");
+
+        DistributedObjectNamespaceConstructor constructor
+                = new DistributedObjectNamespaceConstructor(DistributedObjectNamespace.class);
+        ObjectNamespace clonedObjectNamespace = (ObjectNamespace) constructor.createNew(objectNamespace);
+
+        assertEquals(objectNamespace.getServiceName(), clonedObjectNamespace.getServiceName());
+        assertEquals(objectNamespace.getObjectName(), clonedObjectNamespace.getObjectName());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/DynamicConfigurationAwareConfigConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/DynamicConfigurationAwareConfigConstructorTest.java
@@ -20,22 +20,23 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.internal.dynamicconfig.DynamicConfigurationAwareConfig;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.test.starter.constructor.ConfigConstructor;
+import com.hazelcast.test.starter.constructor.DynamicConfigurationAwareConfigConstructor;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Properties;
-
 import static com.hazelcast.test.HazelcastTestSupport.assertPropertiesEquals;
+import static com.hazelcast.test.starter.constructor.test.ConfigConstructorTest.buildPropertiesWithDefaults;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ConfigConstructorTest {
+public class DynamicConfigurationAwareConfigConstructorTest {
 
     @Test
     public void testConstructor() {
@@ -46,23 +47,19 @@ public class ConfigConstructorTest {
                 .addListenerConfig(new ListenerConfig("com.hazelcast.test.MyListenerConfig"))
                 .setProperties(buildPropertiesWithDefaults());
 
-        ConfigConstructor constructor = new ConfigConstructor(Config.class);
-        Config clonedConfig = (Config) constructor.createNew(config);
+        HazelcastProperties properties = new HazelcastProperties(config);
 
-        assertEquals(config.getInstanceName(), clonedConfig.getInstanceName());
-        assertEquals(config.getMapConfigs().size(), clonedConfig.getMapConfigs().size());
-        assertEquals(config.getListConfigs().size(), clonedConfig.getListConfigs().size());
-        assertEquals(config.getListenerConfigs().size(), clonedConfig.getListenerConfigs().size());
-        assertPropertiesEquals(config.getProperties(), clonedConfig.getProperties());
-    }
+        DynamicConfigurationAwareConfig dynamicConfig = new DynamicConfigurationAwareConfig(config, properties);
 
-    static Properties buildPropertiesWithDefaults() {
-        Properties defaults = new Properties();
-        defaults.setProperty("key1", "value1");
+        DynamicConfigurationAwareConfigConstructor constructor
+                = new DynamicConfigurationAwareConfigConstructor(DynamicConfigurationAwareConfig.class);
+        DynamicConfigurationAwareConfig clonedDynamicConfig
+                = (DynamicConfigurationAwareConfig) constructor.createNew(dynamicConfig);
 
-        Properties configProperties = new Properties(defaults);
-        configProperties.setProperty("key2", "value2");
-
-        return configProperties;
+        assertEquals(dynamicConfig.getInstanceName(), clonedDynamicConfig.getInstanceName());
+        assertEquals(dynamicConfig.getMapConfigs().size(), clonedDynamicConfig.getMapConfigs().size());
+        assertEquals(dynamicConfig.getListConfigs().size(), clonedDynamicConfig.getListConfigs().size());
+        assertEquals(dynamicConfig.getListenerConfigs().size(), clonedDynamicConfig.getListenerConfigs().size());
+        assertPropertiesEquals(dynamicConfig.getProperties(), clonedDynamicConfig.getProperties());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/FirewallingConnectionManagerConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/FirewallingConnectionManagerConstructorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.nio.tcp.FirewallingConnectionManager;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.FirewallingConnectionManagerConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class FirewallingConnectionManagerConstructorTest {
+
+    @Test
+    public void testConstructor() throws Exception {
+        ConnectionManager delegate = mock(ConnectionManager.class);
+        Address address = new Address("172.16.16.1", 4223);
+        Set<Address> blockedAddresses = Collections.singleton(address);
+
+        FirewallingConnectionManager connectionManager = new FirewallingConnectionManager(delegate, blockedAddresses);
+
+        FirewallingConnectionManagerConstructor constructor
+                = new FirewallingConnectionManagerConstructor(FirewallingConnectionManager.class);
+        FirewallingConnectionManager clonedConnectionManager
+                = (FirewallingConnectionManager) constructor.createNew(connectionManager);
+
+        assertEquals(delegate, getFieldValueReflectively(clonedConnectionManager, "delegate"));
+        assertEquals(blockedAddresses, getFieldValueReflectively(clonedConnectionManager, "blockedAddresses"));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/FirewallingNodeContextConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/FirewallingNodeContextConstructorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.instance.FirewallingNodeContext;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.FirewallingNodeContextConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class FirewallingNodeContextConstructorTest {
+
+    @Test
+    public void testConstructor() {
+        FirewallingNodeContext nodeContext = new FirewallingNodeContext();
+
+        FirewallingNodeContextConstructor constructor = new FirewallingNodeContextConstructor(FirewallingNodeContext.class);
+        FirewallingNodeContext clonedFirewallingNodeContext = (FirewallingNodeContext) constructor.createNew(nodeContext);
+
+        assertNotNull(clonedFirewallingNodeContext);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/HazelcastPropertiesConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/HazelcastPropertiesConstructorTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.HazelcastPropertiesConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class HazelcastPropertiesConstructorTest {
+
+    @Test
+    public void testConstructor() {
+        Config config = new Config()
+                .setProperty("myProperty", "myValue");
+        HazelcastProperties properties = new HazelcastProperties(config);
+
+        HazelcastPropertiesConstructor constructor = new HazelcastPropertiesConstructor(HazelcastProperties.class);
+        HazelcastProperties clonedProperties = (HazelcastProperties) constructor.createNew(properties);
+
+        assertEquals(properties.get("myProperty"), clonedProperties.get("myProperty"));
+        assertEquals(properties.get("invalid"), clonedProperties.get("invalid"));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/HeapDataConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/HeapDataConstructorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.serialization.impl.HeapData;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.HeapDataConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class HeapDataConstructorTest {
+
+    @Test
+    public void testConstructor() {
+        SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+        int original = 42;
+        Data data = serializationService.toData(original);
+
+        HeapDataConstructor constructor = new HeapDataConstructor(HeapData.class);
+        Data clonedData = (Data) constructor.createNew(data);
+
+        assertEquals(data.toByteArray(), clonedData.toByteArray());
+        assertEquals(data.getType(), clonedData.getType());
+        assertEquals(data.totalSize(), clonedData.totalSize());
+        assertEquals(data.dataSize(), clonedData.dataSize());
+        assertEquals(data.getHeapCost(), clonedData.getHeapCost());
+        assertEquals(data.getPartitionHash(), clonedData.getPartitionHash());
+        assertEquals(data.hasPartitionHash(), clonedData.hasPartitionHash());
+        assertEquals(data.hash64(), clonedData.hash64());
+        assertEquals(data.isPortable(), clonedData.isPortable());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/InternalPartitionImplConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/InternalPartitionImplConstructorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.internal.partition.InternalPartition;
+import com.hazelcast.internal.partition.impl.InternalPartitionImpl;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.InternalPartitionImplConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class InternalPartitionImplConstructorTest {
+
+    @Test
+    public void testConstructor() throws Exception {
+        Address address = new Address("172.16.16.1", 4223);
+        Address[] addresses = new Address[]{new Address("127.0.0.1", 2342)};
+        InternalPartition partition = new InternalPartitionImpl(42, null, address, addresses);
+
+        InternalPartitionImplConstructor constructor = new InternalPartitionImplConstructor(InternalPartitionImpl.class);
+        InternalPartition clonedPartition = (InternalPartition) constructor.createNew(partition);
+
+        assertEquals(partition.getPartitionId(), clonedPartition.getPartitionId());
+        assertEquals(partition.getOwnerOrNull(), clonedPartition.getOwnerOrNull());
+        assertEquals(partition.getReplicaAddress(0), clonedPartition.getReplicaAddress(0));
+        assertEquals(partition.getReplicaIndex(addresses[0]), clonedPartition.getReplicaIndex(addresses[0]));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MemberImplConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MemberImplConstructorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.MemberImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.MemberImplConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MemberImplConstructorTest extends HazelcastTestSupport {
+
+    @Test
+    public void testConstructor() {
+        HazelcastInstance hz = createHazelcastInstance();
+        MemberImpl memberImpl = (MemberImpl) hz.getCluster().getLocalMember();
+
+        MemberImplConstructor constructor = new MemberImplConstructor(MemberImpl.class);
+        MemberImpl clonedMemberImpl = (MemberImpl) constructor.createNew(memberImpl);
+
+        assertEquals(memberImpl.localMember(), clonedMemberImpl.localMember());
+        assertEquals(memberImpl.isLiteMember(), clonedMemberImpl.isLiteMember());
+        assertEquals(memberImpl.getAddress(), clonedMemberImpl.getAddress());
+        assertEquals(memberImpl.getSocketAddress(), clonedMemberImpl.getSocketAddress());
+        assertEquals(memberImpl.getUuid(), clonedMemberImpl.getUuid());
+        assertEquals(memberImpl.getAttributes(), clonedMemberImpl.getAttributes());
+        assertEquals(memberImpl.getVersion(), clonedMemberImpl.getVersion());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MemberVersionConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MemberVersionConstructorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.MemberVersionConstructor;
+import com.hazelcast.version.MemberVersion;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MemberVersionConstructorTest {
+
+    @Test
+    public void testConstructor() {
+        MemberVersion memberVersion = new MemberVersion(3, 7, 4);
+
+        MemberVersionConstructor constructor = new MemberVersionConstructor(MemberVersion.class);
+        MemberVersion clonedMemberVersion = (MemberVersion) constructor.createNew(memberVersion);
+
+        assertEquals(memberVersion.getMajor(), clonedMemberVersion.getMajor());
+        assertEquals(memberVersion.getMinor(), clonedMemberVersion.getMinor());
+        assertEquals(memberVersion.getPatch(), clonedMemberVersion.getPatch());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MergePolicyProviderConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MergePolicyProviderConstructorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.merge.policy.CacheMergePolicyProvider;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.starter.HazelcastStarter;
+import com.hazelcast.test.starter.constructor.MergePolicyProviderConstructor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.test.starter.HazelcastStarterUtils.assertInstanceOfByClassName;
+import static com.hazelcast.test.starter.ReflectionUtils.getDelegateFromMock;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class MergePolicyProviderConstructorTest extends HazelcastTestSupport {
+
+    private HazelcastInstance hz;
+
+    @Before
+    public void setUp() {
+        Config config = new Config();
+        hz = HazelcastStarter.newHazelcastInstance("3.11-SNAPSHOT", config, false);
+    }
+
+    @After
+    public void tearDown() {
+        hz.shutdown();
+    }
+
+    @Test
+    public void testConstructor() throws Exception {
+        NodeEngine nodeEngine = getNodeEngineImpl(hz);
+        CacheService service = nodeEngine.getService(CacheService.SERVICE_NAME);
+        CacheMergePolicyProvider mergePolicyProvider = service.getMergePolicyProvider();
+
+        Object delegate = getDelegateFromMock(service);
+        Object mergePolicyProviderProxy = getFieldValueReflectively(delegate, "mergePolicyProvider");
+
+        MergePolicyProviderConstructor constructor = new MergePolicyProviderConstructor(CacheMergePolicyProvider.class);
+        CacheMergePolicyProvider clonedMergePolicyProvider
+                = (CacheMergePolicyProvider) constructor.createNew(mergePolicyProviderProxy);
+
+        // invalid merge policy
+        assertInvalidCacheMergePolicy(mergePolicyProvider);
+        assertInvalidCacheMergePolicy(clonedMergePolicyProvider);
+        // legacy merge policy
+        assertCacheMergePolicy(mergePolicyProvider, "com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy");
+        assertCacheMergePolicy(clonedMergePolicyProvider, "com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy");
+        // unified merge policy
+        assertCacheMergePolicy(mergePolicyProvider, "com.hazelcast.spi.merge.PutIfAbsentMergePolicy");
+        assertCacheMergePolicy(clonedMergePolicyProvider, "com.hazelcast.spi.merge.PutIfAbsentMergePolicy");
+    }
+
+    private static void assertInvalidCacheMergePolicy(CacheMergePolicyProvider mergePolicyProvider) {
+        try {
+            mergePolicyProvider.getMergePolicy("invalid");
+            fail("Expected: InvalidConfigurationException: Invalid cache merge policy: invalid");
+        } catch (InvalidConfigurationException expected) {
+        }
+    }
+
+    private static void assertCacheMergePolicy(CacheMergePolicyProvider mergePolicyProvider, String mergePolicyClassname) {
+        Object mergePolicy = mergePolicyProvider.getMergePolicy(mergePolicyClassname);
+        assertInstanceOfByClassName(mergePolicyClassname, mergePolicy);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MultiMapRecordConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MultiMapRecordConstructorTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.multimap.impl.MultiMapRecord;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.MultiMapRecordConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MultiMapRecordConstructorTest {
+
+    @Test
+    public void testConstructor() {
+        MultiMapRecord multiMapRecord = new MultiMapRecord(23, "myValue");
+
+        MultiMapRecordConstructor constructor = new MultiMapRecordConstructor(MultiMapRecord.class);
+        MultiMapRecord clonedMultiMapRecord = (MultiMapRecord) constructor.createNew(multiMapRecord);
+
+        assertEquals(multiMapRecord.getRecordId(), clonedMultiMapRecord.getRecordId());
+        assertEquals(multiMapRecord.getObject(), clonedMultiMapRecord.getObject());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/ScheduledTaskHandlerImplConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/ScheduledTaskHandlerImplConstructorTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor.test;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
+import com.hazelcast.scheduledexecutor.impl.ScheduledTaskHandlerImpl;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.constructor.ScheduledTaskHandlerImplConstructor;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ScheduledTaskHandlerImplConstructorTest {
+
+    @Test
+    public void testConstructor() throws Exception {
+        String schedulerName = "myScheduler";
+        String taskName = "myTask";
+        int partitionId = 23;
+        Address address = new Address("172.16.16.1", 4223);
+
+        ScheduledTaskHandler handlerWithAddress = ScheduledTaskHandlerImpl.of(address, schedulerName, taskName);
+        ScheduledTaskHandler handlerWithPartitionId = ScheduledTaskHandlerImpl.of(partitionId, schedulerName, taskName);
+
+        ScheduledTaskHandlerImplConstructor constructor = new ScheduledTaskHandlerImplConstructor(ScheduledTaskHandlerImpl.class);
+        ScheduledTaskHandler clonedHandlerWithAddress = (ScheduledTaskHandler) constructor.createNew(handlerWithAddress);
+        ScheduledTaskHandler clonedHandlerWithPartitionId = (ScheduledTaskHandler) constructor.createNew(handlerWithPartitionId);
+
+        assertThatScheduledTaskHandlerAreEqual(handlerWithAddress, clonedHandlerWithAddress);
+        assertThatScheduledTaskHandlerAreEqual(handlerWithPartitionId, clonedHandlerWithPartitionId);
+    }
+
+    private static void assertThatScheduledTaskHandlerAreEqual(ScheduledTaskHandler expected, ScheduledTaskHandler actual) {
+        assertEquals(expected.getAddress(), actual.getAddress());
+        assertEquals(expected.getSchedulerName(), actual.getSchedulerName());
+        assertEquals(expected.getTaskName(), actual.getTaskName());
+        assertEquals(expected.getPartitionId(), actual.getPartitionId());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/HazelcastVersionLocatorTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.test.starter.test;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import com.google.common.io.Files;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.SlowTest;
@@ -31,8 +30,8 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 
 import java.io.File;
-import java.io.IOException;
 
+import static com.google.common.io.Files.toByteArray;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -42,25 +41,28 @@ public class HazelcastVersionLocatorTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
+    private HashFunction md5Hash = Hashing.md5();
+
     @Test
-    public void testDownloadVersion() throws IOException {
+    public void testDownloadVersion() throws Exception {
         File[] files = HazelcastVersionLocator.locateVersion("3.6", folder.getRoot(), true);
-        HashFunction md5Hash = Hashing.md5();
 
-        byte[] memberBytes = Files.toByteArray(files[0]);
+        assertHash(files[0], "89563f7dab02bd5f592082697c24d167", "OS member");
+
+        assertHash(files[1], "66615c68c2708036a6030114a1b87f2b", "OS member tests");
+
+        assertHash(files[2], "fd6022e35908b42d24fe10a9c9fdaad5", "OS client");
+
+        assertHash(files[3], "c5718ba5c280339fff9b54ecb5e61549", "EE member");
+
+        assertHash(files[4], "c5df750fdab71a650fb56c41742806ff", "EE member tests");
+
+        assertHash(files[5], "b1cf93ec4bb9bcda8809b81349f48cb3", "EE client");
+    }
+
+    private void assertHash(File file, String expectedHash, String label) throws Exception {
+        byte[] memberBytes = toByteArray(file);
         HashCode memberHash = md5Hash.hashBytes(memberBytes);
-        assertEquals("89563f7dab02bd5f592082697c24d167", memberHash.toString());
-
-        byte[] clientBytes = Files.toByteArray(files[1]);
-        HashCode clientHash = md5Hash.hashBytes(clientBytes);
-        assertEquals("fd6022e35908b42d24fe10a9c9fdaad5", clientHash.toString());
-
-        byte[] eeMemberBytes = Files.toByteArray(files[2]);
-        HashCode eeMemberHash = md5Hash.hashBytes(eeMemberBytes);
-        assertEquals("c5718ba5c280339fff9b54ecb5e61549", eeMemberHash.toString());
-
-        byte[] eeClientBytes = Files.toByteArray(files[3]);
-        HashCode eeClientHash = md5Hash.hashBytes(eeClientBytes);
-        assertEquals("b1cf93ec4bb9bcda8809b81349f48cb3", eeClientHash.toString());
+        assertEquals("Expected hash of Hazelcast " + label + " JAR to be " + expectedHash, expectedHash, memberHash.toString());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/PatchLevelCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/PatchLevelCompatibilityTest.java
@@ -16,61 +16,80 @@
 
 package com.hazelcast.test.starter.test;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.starter.HazelcastStarter;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category(SlowTest.class)
+@Category(NightlyTest.class)
 public class PatchLevelCompatibilityTest {
+
+    private HazelcastInstance[] instances;
+
+    @After
+    public void tearDown() {
+        if (instances != null) {
+            for (HazelcastInstance hz: instances) {
+                if (hz != null) {
+                    hz.shutdown();
+                }
+            }
+        }
+    }
 
     @Test
     public void testAll_V37_Versions() {
-        String[] versions = new String[]{"3.7", "3.7.1", "3.7.2", "3.7.3", "3.7.4", "3.7.5", "3.7.6", "3.7.7"};
-        HazelcastInstance[] instances = new HazelcastInstance[versions.length];
-        for (int i = 0; i < versions.length; i++) {
-            instances[i] = HazelcastStarter.newHazelcastInstance(versions[i]);
-        }
-        assertClusterSizeEventually(versions.length, instances[0]);
-        for (HazelcastInstance hz : instances) {
-            hz.shutdown();
-        }
+        String[] versions = new String[]{"3.7", "3.7.1", "3.7.2", "3.7.3", "3.7.4", "3.7.5", "3.7.6", "3.7.7", "3.7.8"};
+        testAllGivenVersions(versions);
     }
 
     @Test
     public void testAll_V38_Versions() {
-        String[] versions = new String[]{"3.8", "3.8.1", "3.8.2"};
-        HazelcastInstance[] instances = new HazelcastInstance[versions.length];
-        for (int i = 0; i < versions.length; i++) {
-            instances[i] = HazelcastStarter.newHazelcastInstance(versions[i]);
-        }
-        assertClusterSizeEventually(versions.length, instances[0]);
-        for (HazelcastInstance hz : instances) {
-            hz.shutdown();
-        }
+        String[] versions = new String[]{"3.8", "3.8.1", "3.8.2", "3.8.3", "3.8.4", "3.8.5", "3.8.6", "3.8.7", "3.8.8", "3.8.9"};
+        testAllGivenVersions(versions);
+    }
+
+    @Test
+    public void testAll_V39_Versions() {
+        String[] versions = new String[]{"3.9", "3.9.1", "3.9.2", "3.9.3", "3.9.4"};
+        testAllGivenVersions(versions);
+    }
+
+    @Test
+    public void testAll_V310_Versions() {
+        String[] versions = new String[]{"3.10", "3.10.1", "3.10.2", "3.10.3", "3.10.4"};
+        testAllGivenVersions(versions);
     }
 
     @Test
     public void testMap_whenMixed_V37_Cluster() {
-        HazelcastInstance hz374 = HazelcastStarter.newHazelcastInstance("3.7.4");
-        HazelcastInstance hz375 = HazelcastStarter.newHazelcastInstance("3.7.5");
+        String[] versions = new String[]{"3.7.4", "3.7.5"};
+        testAllGivenVersions(versions);
 
-        IMap<Integer, String> map374 = hz374.getMap("myMap");
+        IMap<Integer, String> map374 = instances[0].getMap("myMap");
         map374.put(42, "GUI = Cheating!");
 
-        IMap<Integer, String> myMap = hz375.getMap("myMap");
-        String ancientWisdom = myMap.get(42);
+        IMap<Integer, String> map375 = instances[1].getMap("myMap");
+        assertEquals("GUI = Cheating!", map375.get(42));
+    }
 
-        assertEquals("GUI = Cheating!", ancientWisdom);
-        hz374.shutdown();
-        hz375.shutdown();
+    private void testAllGivenVersions(String[] versions) {
+        Config config = smallInstanceConfig();
+        instances = new HazelcastInstance[versions.length];
+        for (int i = 0; i < versions.length; i++) {
+            instances[i] = HazelcastStarter.newHazelcastInstance(versions[i], config, false);
+        }
+        assertClusterSizeEventually(versions.length, instances[0]);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/ReflectionUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/ReflectionUtilsTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.test.starter.test;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.starter.ReflectionUtils;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -28,6 +29,7 @@ import java.util.Map;
 
 import static com.hazelcast.test.starter.ReflectionUtils.getAllFieldsByName;
 import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+import static com.hazelcast.test.starter.ReflectionUtils.isInstanceOf;
 import static com.hazelcast.test.starter.ReflectionUtils.setFieldValueReflectively;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -39,6 +41,16 @@ import static org.junit.Assert.assertTrue;
 public class ReflectionUtilsTest {
 
     private ReflectionTestClass testClass = new ReflectionTestClass();
+
+    @Test
+    public void testGetClass() {
+        assertEquals(ReflectionTestClass.class, ReflectionUtils.getClass(testClass));
+    }
+
+    @Test
+    public void testIsInstanceOf() {
+        assertTrue("Expected testClass to be instanceOf ReflectionTestClass", isInstanceOf(testClass, ReflectionTestClass.class));
+    }
 
     @Test
     public void testGetFieldValueReflectively() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/util/RootCauseMatcher.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/RootCauseMatcher.java
@@ -81,7 +81,7 @@ public class RootCauseMatcher extends TypeSafeMatcher<Throwable> {
         super.describeMismatchSafely(getRootCause(item), mismatchDescription);
     }
 
-    private Throwable getRootCause(Throwable item) {
+    public static Throwable getRootCause(Throwable item) {
         while (item.getCause() != null) {
             item = item.getCause();
         }


### PR DESCRIPTION
* Added new constructor classes for `HazelcastStarter`
* Added new answer classes for `HazelcastStarter`
* Improved `ReflectionUtils` for `HazelcastStarter`
* Added download of test JARs to `HazelcastVersionLocator`
* Improved `HazelcastStarter` for `SplitBrainTestSupport` and `Node` access
* Fixed `HazelcastInstanceImpl` casting in cache tests