### PR TITLE
Call primary or backup map wan publisher from MapEventPublisherImpl#publishWanEvent

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -119,7 +119,11 @@ public class MapEventPublisherImpl implements MapEventPublisher {
     protected void publishWanEvent(String mapName, ReplicationEventObject event) {
         MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
         WanReplicationPublisher wanReplicationPublisher = mapContainer.getWanReplicationPublisher();
-        wanReplicationPublisher.publishReplicationEvent(SERVICE_NAME, event);
+        if (isOwnedPartition(event.getKey())) {
+            wanReplicationPublisher.publishReplicationEvent(SERVICE_NAME, event);
+        } else {
+            wanReplicationPublisher.publishReplicationEventBackup(SERVICE_NAME, event);
+        }
     }
 
     private boolean isOwnedPartition(Data dataKey) {


### PR DESCRIPTION
WanReplicationPublisher#publishReplicationEvent unconditionally publishes the event as primary. It can't decide whether the event is backup or not, since the method is invoked during migration as well, in which case InternalPartition#isLocal() cannot be relied upon.

Partially fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2189
EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/2190