### PR TITLE
Make `unit` mandatory in ProbeBuilder

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
@@ -56,9 +56,9 @@ public class Diagnostics {
             .setDeprecatedName("hazelcast.performance.metric.level");
 
     /**
-     * If metrics should be tracked on distributed data-structures like IMap, IQueue etc.
+     * If metrics should be tracked on distributed data structures like IMap, IQueue etc.
      * <p>
-     * By default these data-structures are not tracked, but in a future release this will probably be changed to {@code true}.
+     * By default, these data structures are not tracked, but in a future release this will probably be changed to {@code true}.
      */
     public static final HazelcastProperty METRICS_DISTRIBUTED_DATASTRUCTURES
             = new HazelcastProperty(PREFIX + ".metric.distributed.datastructures", false);

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagementService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/ManagementService.java
@@ -194,8 +194,7 @@ public class ManagementService implements DistributedObjectListener {
     }
 
     public static String quote(String text) {
-        return Pattern.compile("[:\",=*?]")
-                .matcher(text)
-                .find() ? ObjectName.quote(text) : text;
+        return Pattern.compile("[:\",=*?]").matcher(text).find() || text.indexOf('\n') >= 0
+                ? ObjectName.quote(text) : text;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/ProbeBuilder.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.metrics;
 
+import javax.annotation.Nonnull;
+
 /**
  * Immutable builder object to register Probes.
  */
@@ -34,10 +36,16 @@ public interface ProbeBuilder {
      * @param source the object to pass to probeFn
      * @param metricName the value of "metric" tag
      * @param level the ProbeLevel
+     * @param unit the unit
      * @param probeFn the probe function
      * @throws NullPointerException if any of the arguments is null
      */
-    <S> void register(S source, String metricName, ProbeLevel level, DoubleProbeFunction<S> probeFn);
+    <S> void register(
+            @Nonnull S source,
+            @Nonnull String metricName,
+            @Nonnull ProbeLevel level,
+            @Nonnull ProbeUnit unit,
+            @Nonnull DoubleProbeFunction<S> probeFn);
 
     /**
      * Registers a single probe.
@@ -47,10 +55,16 @@ public interface ProbeBuilder {
      * @param source the object to pass to probeFn
      * @param metricName the value of "metric" tag
      * @param level the ProbeLevel
+     * @param unit the unit
      * @param probeFn the probe function
      * @throws NullPointerException if any of the arguments is null
      */
-    <S> void register(S source, String metricName, ProbeLevel level, LongProbeFunction<S> probeFn);
+    <S> void register(
+            @Nonnull S source,
+            @Nonnull String metricName,
+            @Nonnull ProbeLevel level,
+            @Nonnull ProbeUnit unit,
+            @Nonnull LongProbeFunction<S> probeFn);
 
     /**
      * Scans the source object for any fields/methods that have been annotated
@@ -67,4 +81,10 @@ public interface ProbeBuilder {
      * on a field/method of unsupported type.
      */
     <S> void scanAndRegister(S source);
+
+    /**
+     * Returns the name for the metric.
+     */
+    String metricName();
 }
+

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImpl.java
@@ -21,6 +21,10 @@ import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.ProbeBuilder;
 import com.hazelcast.internal.metrics.ProbeFunction;
 import com.hazelcast.internal.metrics.ProbeLevel;
+import com.hazelcast.internal.metrics.ProbeUnit;
+
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 
 import static com.hazelcast.internal.metrics.MetricsUtil.containsSpecialCharacters;
 import static com.hazelcast.internal.metrics.MetricsUtil.escapeMetricNamePart;
@@ -41,6 +45,7 @@ public class ProbeBuilderImpl implements ProbeBuilder {
     }
 
     @Override
+    @CheckReturnValue
     public ProbeBuilderImpl withTag(String tag, String value) {
         assert containsSpecialCharacters(tag) : "tag contains special characters";
         return new ProbeBuilderImpl(
@@ -49,18 +54,39 @@ public class ProbeBuilderImpl implements ProbeBuilder {
                         + tag + '=' + escapeMetricNamePart(value));
     }
 
-    private String metricName() {
+    @Override
+    public String metricName() {
         return keyPrefix + ']';
     }
 
     @Override
-    public <S> void register(S source, String metricName, ProbeLevel level, DoubleProbeFunction<S> probe) {
-        metricsRegistry.register(source, withTag("metric", metricName).metricName(), level, probe);
+    public <S> void register(
+            @Nonnull S source,
+            @Nonnull String metricName,
+            @Nonnull ProbeLevel level,
+            @Nonnull ProbeUnit unit,
+            @Nonnull DoubleProbeFunction<S> probe
+    ) {
+        String name = this
+                .withTag("unit", unit.name().toLowerCase())
+                .withTag("metric", metricName)
+                .metricName();
+        metricsRegistry.register(source, name, level, probe);
     }
 
     @Override
-    public <S> void register(S source, String metricName, ProbeLevel level, LongProbeFunction<S> probe) {
-        metricsRegistry.register(source, withTag("metric", metricName).metricName(), level, probe);
+    public <S> void register(
+            @Nonnull S source,
+            @Nonnull String metricName,
+            @Nonnull ProbeLevel level,
+            @Nonnull ProbeUnit unit,
+            @Nonnull LongProbeFunction<S> probe
+    ) {
+        String name = this
+                .withTag("unit", unit.name().toLowerCase())
+                .withTag("metric", metricName)
+                .metricName();
+        metricsRegistry.register(source, name, level, probe);
     }
 
     <S> void register(S source, String metricName, ProbeLevel level, ProbeFunction probe) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -364,7 +364,7 @@ public class MigrationManager {
 
         MemberImpl member = node.getClusterService().getMember(destination);
         if (member == null) {
-            logger.warning("Destination " + destination + " is not member anymore");
+            logger.warning("Destination " + destination + " is not a member anymore");
             return false;
         }
 
@@ -954,13 +954,13 @@ public class MigrationManager {
             }
             if (migrationInfo.getSource() != null) {
                 if (node.getClusterService().getMember(migrationInfo.getSource()) == null) {
-                    logger.fine("Source is not member anymore. Ignoring " + migrationInfo);
+                    logger.fine("Source is not a member anymore. Ignoring " + migrationInfo);
                     triggerRepartitioningAfterMigrationFailure();
                     return null;
                 }
             }
             if (node.getClusterService().getMember(migrationInfo.getDestination()) == null) {
-                logger.fine("Destination is not member anymore. Ignoring " + migrationInfo);
+                logger.fine("Destination is not a member anymore. Ignoring " + migrationInfo);
                 triggerRepartitioningAfterMigrationFailure();
                 return null;
             }
@@ -1329,7 +1329,7 @@ public class MigrationManager {
 
             MemberImpl member = node.getClusterService().getMember(destination);
             if (member == null) {
-                logger.warning("Destination " + destination + " is not member anymore");
+                logger.warning("Destination " + destination + " is not a member anymore");
                 return false;
             }
             // RU_COMPAT_39

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalSubscribeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournalSubscribeOperation.java
@@ -48,7 +48,7 @@ public class MapEventJournalSubscribeOperation extends MapOperation implements P
         namespace = getServiceNamespace();
         if (!mapServiceContext.getEventJournal().hasEventJournal(namespace)) {
             throw new UnsupportedOperationException(
-                    "Cannot subscribe to event journal because it is either not configured or disabled for map " + name);
+                    "Cannot subscribe to event journal because it is either not configured or disabled for map '" + name + '\'');
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/OperationParker.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/OperationParker.java
@@ -37,7 +37,7 @@ public interface OperationParker {
      *
      * If wait time-outs, {@link BlockingOperation#onWaitExpire()} method is called.
      *
-     * This method should be called in the thread executes the actual {@link BlockingOperation} operation.
+     * This method should be called in the thread that executes the actual {@link BlockingOperation} operation.
      *
      *
      * @param op operation which will wait for notification

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionManagerServiceImpl.java
@@ -193,7 +193,7 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
         MemberImpl member = event.getMember();
         final String uuid = member.getUuid();
         if (nodeEngine.isRunning()) {
-            logger.info("Committing/rolling-back alive transactions of " + member + ", UUID: " + uuid);
+            logger.info("Committing/rolling-back live transactions of " + member.getAddress() + ", UUID: " + uuid);
             nodeEngine.getExecutionService().execute(ExecutionService.SYSTEM_EXECUTOR, new Runnable() {
                 @Override
                 public void run() {
@@ -201,7 +201,7 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
                 }
             });
         } else if (logger.isFinestEnabled()) {
-            logger.finest("Will not commit/roll-back transactions of " + member + ", UUID: " + uuid
+            logger.finest("Will not commit/roll-back transactions of " + member.getAddress() + ", UUID: " + uuid
                     + " because this member is not running");
         }
     }
@@ -280,7 +280,7 @@ public class TransactionManagerServiceImpl implements TransactionManagerService,
 
     @Override
     public void clientDisconnected(String clientUuid) {
-        logger.info("Committing/rolling-back alive transactions of client, UUID: " + clientUuid);
+        logger.info("Committing/rolling-back live transactions of client, UUID: " + clientUuid);
         finalizeTransactionsOf(clientUuid);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImplTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2017, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.metrics.ProbeLevel;
+import com.hazelcast.internal.metrics.ProbeUnit;
+import com.hazelcast.logging.Logger;
+import org.junit.Test;
+
+import java.util.HashSet;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+public class ProbeBuilderImplTest {
+
+    @Probe
+    private long probe1;
+
+    @Probe(name = "secondProbe", level = ProbeLevel.MANDATORY, unit = ProbeUnit.BYTES)
+    private long probe2;
+
+    @Test
+    public void test_scanAndRegister() {
+        MetricsRegistryImpl mr = new MetricsRegistryImpl(Logger.getLogger(MetricsRegistryImpl.class), ProbeLevel.INFO);
+        mr.newProbeBuilder()
+          .withTag("tag1", "value1")
+          .scanAndRegister(this);
+
+        assertEquals(new HashSet<String>(asList(
+                "[tag1=value1,unit=count,metric=probe1]",
+                "[tag1=value1,unit=bytes,metric=secondProbe]"
+        )), mr.getNames());
+    }
+
+    @Test
+    public void test_register() {
+
+    }
+}


### PR DESCRIPTION
`ProbeBuilder.scanAndRegister` always added the `unit` tag to metric
name. We add a mandatory `unit` parameter in `register` method giving
the same logic to this way of registering metrics.

Also contains some unrelated typo fixes.

A forward-port will come afterwards.