### PR TITLE
[FORWARD-PORT] Add stop state to WAN publisher

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -1266,9 +1266,9 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         String nodeName = cleanNodeName(child);
                         if ("properties".equals(nodeName)) {
                             handleProperties(child, publisherBuilder);
-                        } else if ("queue-full-behavior".equals(nodeName)) {
-                            publisherBuilder.addPropertyValue(xmlToJavaName(nodeName), getTextContent(child));
-                        } else if ("queue-capacity".equals(nodeName)) {
+                        } else if ("queue-full-behavior".equals(nodeName)
+                                || "initial-publisher-state".equals(nodeName)
+                                || "queue-capacity".equals(nodeName)) {
                             publisherBuilder.addPropertyValue(xmlToJavaName(nodeName), getTextContent(child));
                         } else if ("aws".equals(nodeName)) {
                             handleAws(child, publisherBuilder);

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
@@ -2702,6 +2702,24 @@
                         <xs:element name="queue-full-behavior" type="wan-queue-full-behavior" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="queue-capacity" type="parameterized-positive-integer" default="10000" minOccurs="0"
                                     maxOccurs="1"/>
+                        <xs:element name="initial-publisher-state" type="initial-publisher-state" minOccurs="0" maxOccurs="1"
+                                    default="REPLICATING">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Defines the initial state in which a WAN publisher is started.
+                                    - REPLICATING (default):
+                                    State where both enqueuing new events is allowed, enqueued events are replicated to the target cluster
+                                    and WAN sync is enabled.
+                                    - PAUSED:
+                                    State where new events are enqueued but they are not dequeued. Some events which have been dequeued before
+                                    the state was switched may still be replicated to the target cluster but further events will not be
+                                    replicated. WAN sync is enabled.
+                                    - STOPPED:
+                                    State where neither new events are enqueued nor dequeued. As with the PAUSED state, some events might
+                                    still be replicated after the publisher has switched to this state. WAN sync is enabled.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
                         <xs:element name="aws" type="aws" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
@@ -3750,12 +3768,24 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="initial-publisher-state-format-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="REPLICATING"/>
+            <xs:enumeration value="PAUSED"/>
+            <xs:enumeration value="STOPPED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="wan-ack-type">
         <xs:union memberTypes="wan-ack-type-format-enum non-space-string"/>
     </xs:simpleType>
 
     <xs:simpleType name="wan-queue-full-behavior">
         <xs:union memberTypes="wan-queue-full-behavior-format-enum non-space-string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="initial-publisher-state">
+        <xs:union memberTypes="initial-publisher-state-format-enum non-space-string"/>
     </xs:simpleType>
 
     <xs:complexType name="crdt-replication">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -87,6 +87,7 @@ import com.hazelcast.config.WANQueueFullBehavior;
 import com.hazelcast.config.WanAcknowledgeType;
 import com.hazelcast.config.WanConsumerConfig;
 import com.hazelcast.config.WanPublisherConfig;
+import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.EntryListener;
@@ -914,6 +915,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("tokyo", publisherConfig.getGroupName());
         assertEquals("com.hazelcast.enterprise.wan.replication.WanBatchReplication", publisherConfig.getClassName());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, publisherConfig.getQueueFullBehavior());
+        assertEquals(WanPublisherState.STOPPED, publisherConfig.getInitialPublisherState());
         assertEquals(1000, publisherConfig.getQueueCapacity());
         Map<String, Comparable> publisherProps = publisherConfig.getProperties();
         assertEquals("50", publisherProps.get("batch.size"));

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -61,6 +61,7 @@
                 <hz:wan-publisher group-name="tokyo" class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">
                     <hz:queue-full-behavior>THROW_EXCEPTION</hz:queue-full-behavior>
                     <hz:queue-capacity>1000</hz:queue-capacity>
+                    <hz:initial-publisher-state>STOPPED</hz:initial-publisher-state>
                     <hz:properties>
                         <hz:property name="batch.size">50</hz:property>
                         <hz:property name="batch.max.delay.millis">3000</hz:property>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -659,10 +659,11 @@ public class ConfigXmlGenerator {
             gen.open("wan-replication", "name", wan.getName());
             for (WanPublisherConfig p : wan.getWanPublisherConfigs()) {
                 gen.open("wan-publisher", "group-name", p.getGroupName())
-                        .node("class-name", p.getClassName())
-                        .node("queue-full-behavior", p.getQueueFullBehavior())
-                        .node("queue-capacity", p.getQueueCapacity())
-                        .appendProperties(p.getProperties());
+                   .node("class-name", p.getClassName())
+                   .node("queue-full-behavior", p.getQueueFullBehavior())
+                   .node("initial-publisher-state", p.getInitialPublisherState())
+                   .node("queue-capacity", p.getQueueCapacity())
+                   .appendProperties(p.getProperties());
                 awsConfigXmlGenerator(gen, p.getAwsConfig());
                 discoveryStrategyConfigXmlGenerator(gen, p.getDiscoveryConfig());
                 gen.close();
@@ -671,10 +672,10 @@ public class ConfigXmlGenerator {
             WanConsumerConfig consumerConfig = wan.getWanConsumerConfig();
             if (consumerConfig != null) {
                 gen.open("wan-consumer")
-                        .node("class-name", classNameOrImplClass(consumerConfig.getClassName(),
-                                consumerConfig.getImplementation()))
-                        .appendProperties(consumerConfig.getProperties())
-                        .close();
+                   .node("class-name", classNameOrImplClass(consumerConfig.getClassName(),
+                           consumerConfig.getImplementation()))
+                   .appendProperties(consumerConfig.getProperties())
+                   .close();
             }
             gen.close();
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/WANQueueFullBehavior.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WANQueueFullBehavior.java
@@ -56,9 +56,9 @@ public enum WANQueueFullBehavior {
     }
 
     /**
-     * Returns the EntryEventType as an enum.
+     * Returns the WANQueueFullBehavior as an enum.
      *
-     * @return the EntryEventType as an enum
+     * @return the WANQueueFullBehavior as an enum
      */
     public static WANQueueFullBehavior getByType(final int id) {
         for (WANQueueFullBehavior behavior : values()) {

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherState.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherState.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Defines the state in which a WAN publisher can be in if it is not shutting
+ * down.
+ */
+public enum WanPublisherState {
+    /**
+     * State where both enqueuing new events is allowed, enqueued events are
+     * replicated to the target cluster and WAN sync is enabled.
+     * The publisher is most often in REPLICATING state when the target cluster
+     * is operational.
+     */
+    REPLICATING((byte) 0, true, true),
+    /**
+     * State where new events are enqueued but they are not dequeued. Some events
+     * which have been dequeued before the state was switched may still be
+     * replicated to the target cluster but further events will not be
+     * replicated. WAN sync is enabled.
+     * For instance, this state may be useful if you know that the target cluster
+     * is temporarily unavailable (is under maintenance) and that the WAN queues
+     * can hold as many events as is necessary to reconcile the state between
+     * two clusters once the target cluster becomes available.
+     */
+    PAUSED((byte) 1, true, false),
+    /**
+     * State where neither new events are enqueued nor dequeued. As with the
+     * {@link #PAUSED} state, some events might still be replicated after the
+     * publisher has switched to this state. WAN sync is enabled.
+     * For instance, this state may be useful if you know that the target cluster
+     * is being shut down, decomissioned and being put out of use and that it
+     * will never come back. In such cases, you may additionally clear the WAN
+     * queues to release the consumed heap after the publisher has been switched
+     * into this state.
+     * An another example would be starting a publisher in STOPPED state. This
+     * may be the case where you know that the target cluster is not initially
+     * available and will be unavailable for a definite period but at some point
+     * it will become available. Once it becomes available, you can then switch
+     * the publisher state to REPLICATING to begin replicating to that cluster.
+     *
+     * @see com.hazelcast.wan.WanReplicationService#clearQueues(String, String)
+     */
+    STOPPED((byte) 2, false, false);
+
+    private static final WanPublisherState[] STATE_VALUES = values();
+    private final boolean enqueueNewEvents;
+    private final boolean replicateEnqueuedEvents;
+    private final byte id;
+
+    WanPublisherState(byte id,
+                      boolean enqueueNewEvents,
+                      boolean replicateEnqueuedEvents) {
+        this.id = id;
+        this.enqueueNewEvents = enqueueNewEvents;
+        this.replicateEnqueuedEvents = replicateEnqueuedEvents;
+    }
+
+    /**
+     * Returns the WanPublisherState as an enum.
+     */
+    public static WanPublisherState getByType(final byte id) {
+        for (WanPublisherState state : STATE_VALUES) {
+            if (state.id == id) {
+                return state;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if this state allows enqueueing new events,
+     * {@code false} otherwise.
+     */
+    public boolean isEnqueueNewEvents() {
+        return enqueueNewEvents;
+    }
+
+    /**
+     * Returns {@code true} if this state allows dequeueing and replicating
+     * events, {@code false} otherwise.
+     */
+    public boolean isReplicateEnqueuedEvents() {
+        return replicateEnqueuedEvents;
+    }
+
+    /**
+     * Returns the ID of the WAN publisher state.
+     */
+    public byte getId() {
+        return id;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -661,6 +661,10 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         } else if ("queue-full-behavior".equals(targetChildName)) {
             String queueFullBehavior = getTextContent(targetChild);
             publisherConfig.setQueueFullBehavior(WANQueueFullBehavior.valueOf(upperCaseInternal(queueFullBehavior)));
+        } else if ("initial-publisher-state".equals(targetChildName)) {
+            String initialPublisherState = getTextContent(targetChild);
+            publisherConfig.setInitialPublisherState(
+                    WanPublisherState.valueOf(upperCaseInternal(initialPublisherState)));
         } else if ("queue-capacity".equals(targetChildName)) {
             int queueCapacity = getIntegerValue("queue-capacity", getTextContent(targetChild));
             publisherConfig.setQueueCapacity(queueCapacity);

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
@@ -43,6 +43,7 @@ import static com.hazelcast.util.MapUtil.createHashMap;
  * Management bean for {@link com.hazelcast.core.HazelcastInstance}
  */
 @ManagedDescription("HazelcastInstance")
+@SuppressWarnings("checkstyle:methodcount")
 public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
 
     private static final int INITIAL_CAPACITY = 3;

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
@@ -22,14 +22,18 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.monitor.LocalWanPublisherStats;
+import com.hazelcast.monitor.LocalWanStats;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.wan.WanReplicationService;
 
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
@@ -70,6 +74,29 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
         InternalOperationService operationService = node.nodeEngine.getOperationService();
         createMBeans(hazelcastInstance, managementService, node, executionService, operationService);
         registerMBeans();
+        registerWanPublisherMBeans(node.nodeEngine.getWanReplicationService());
+    }
+
+    /**
+     * Registers managed beans for all WAN publishers, if any.
+     *
+     * @param wanReplicationService the WAN replication service
+     */
+    private void registerWanPublisherMBeans(WanReplicationService wanReplicationService) {
+        final Map<String, LocalWanStats> wanStats = wanReplicationService.getStats();
+        if (wanStats == null) {
+            return;
+        }
+
+        for (Entry<String, LocalWanStats> replicationStatsEntry : wanStats.entrySet()) {
+            final String wanReplicationName = replicationStatsEntry.getKey();
+            final LocalWanStats localWanStats = replicationStatsEntry.getValue();
+            final Map<String, LocalWanPublisherStats> publisherStats = localWanStats.getLocalWanPublisherStats();
+
+            for (String targetGroupName : publisherStats.keySet()) {
+                register(new WanPublisherMBean(wanReplicationService, wanReplicationName, targetGroupName, service));
+            }
+        }
     }
 
     private void createMBeans(HazelcastInstanceImpl hazelcastInstance, ManagementService managementService, Node node,

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/WanPublisherMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/WanPublisherMBean.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.jmx;
+
+import com.hazelcast.monitor.LocalWanPublisherStats;
+import com.hazelcast.monitor.LocalWanStats;
+import com.hazelcast.wan.WanReplicationService;
+
+import java.util.Map;
+
+/**
+ * Management bean for a single WAN replication publisher. Since OS and EE
+ * WAN publishers do not share a single common interface, we need to access
+ * them through the WAN replication service until such an interface is introduced.
+ */
+@ManagedDescription("WanReplicationPublisher")
+public class WanPublisherMBean extends HazelcastMBean<WanReplicationService> {
+    private final String wanReplicationName;
+    private final String targetGroupName;
+
+    public WanPublisherMBean(WanReplicationService wanReplicationService,
+                             String wanReplicationName,
+                             String targetGroupName,
+                             ManagementService service) {
+        super(wanReplicationService, service);
+        this.wanReplicationName = wanReplicationName;
+        this.targetGroupName = targetGroupName;
+        this.objectName = service.createObjectName("WanReplicationPublisher",
+                wanReplicationName + "." + targetGroupName);
+    }
+
+    @ManagedAnnotation("state")
+    @ManagedDescription("State of the WAN replication publisher")
+    public String getState() {
+        final Map<String, LocalWanStats> wanStats = managedObject.getStats();
+        if (wanStats == null) {
+            return "";
+        }
+        final LocalWanStats wanReplicationStats = wanStats.get(wanReplicationName);
+        final Map<String, LocalWanPublisherStats> wanDelegatingPublisherStats = wanReplicationStats.getLocalWanPublisherStats();
+        final LocalWanPublisherStats wanPublisherStats = wanDelegatingPublisherStats.get(targetGroupName);
+        return wanPublisherStats.getPublisherState().name();
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
@@ -17,6 +17,7 @@
 
 package com.hazelcast.monitor;
 
+import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.internal.management.JsonSerializable;
 import com.hazelcast.wan.impl.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;
 
@@ -57,11 +58,12 @@ public interface LocalWanPublisherStats extends JsonSerializable {
     int getOutboundQueueSize();
 
     /**
-     * Returns if the wan replication on this member is paused
+     * Returns the current {@link WanPublisherState} of this publisher.
      *
-     * @return true the wan replication on this member is paused
+     * @see com.hazelcast.wan.WanReplicationService#pause(String, String)
+     * @see com.hazelcast.wan.WanReplicationService#stop(String, String)
      */
-    boolean isPaused();
+    WanPublisherState getPublisherState();
 
     /**
      * Returns the counter for the successfully transfered map WAN events.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
@@ -18,6 +18,7 @@
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.monitor.LocalWanPublisherStats;
 import com.hazelcast.wan.impl.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;
 
@@ -37,7 +38,7 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
             newUpdater(LocalWanPublisherStatsImpl.class, "totalPublishedEventCount");
 
     private volatile boolean connected;
-    private volatile boolean paused;
+    private volatile WanPublisherState state;
     private volatile int outboundQueueSize;
     private volatile long totalPublishLatency;
     private volatile long totalPublishedEventCount;
@@ -63,12 +64,12 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
     }
 
     @Override
-    public boolean isPaused() {
-        return paused;
+    public WanPublisherState getPublisherState() {
+        return state;
     }
 
-    public void setPaused(boolean paused) {
-        this.paused = paused;
+    public void setState(WanPublisherState state) {
+        this.state = state;
     }
 
     @Override
@@ -111,7 +112,8 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
         root.add("totalPublishLatencies", totalPublishLatency);
         root.add("totalPublishedEventCount", totalPublishedEventCount);
         root.add("outboundQueueSize", outboundQueueSize);
-        root.add("paused", paused);
+        root.add("paused", !state.isReplicateEnqueuedEvents());
+        root.add("stopped", !state.isEnqueueNewEvents());
         return root;
     }
 
@@ -121,7 +123,15 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
         totalPublishLatency = getLong(json, "totalPublishLatencies", -1);
         totalPublishedEventCount = getLong(json, "totalPublishedEventCount", -1);
         outboundQueueSize = getInt(json, "outboundQueueSize", -1);
-        paused = getBoolean(json, "paused");
+        final boolean paused = getBoolean(json, "paused");
+        final boolean stopped = getBoolean(json, "stopped");
+        if (stopped) {
+            state = WanPublisherState.STOPPED;
+        } else if (paused) {
+            state = WanPublisherState.PAUSED;
+        } else {
+            state = WanPublisherState.REPLICATING;
+        }
     }
 
     @Override
@@ -131,7 +141,7 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
                 + ", totalPublishLatency=" + totalPublishLatency
                 + ", totalPublishedEventCount=" + totalPublishedEventCount
                 + ", outboundQueueSize=" + outboundQueueSize
-                + ", paused=" + paused
+                + ", state=" + state
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -52,20 +52,34 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
     void shutdown();
 
     /**
-     * Pauses wan replication to target group for the called node
+     * Pauses WAN replication for the given {@code wanReplicationName} and
+     * {@code targetGroupName} on this hazelcast instance.
      *
-     * @param name name of WAN replication configuration
-     * @param targetGroupName name of wan target cluster config
+     * @param wanReplicationName name of WAN replication configuration
+     * @param targetGroupName    WAN target cluster group name
+     * @throws UnsupportedOperationException if called on an OS instance
      */
-    void pause(String name, String targetGroupName);
+    void pause(String wanReplicationName, String targetGroupName);
 
     /**
-     * Resumes wan replication to target group for the called node.
+     * Stops WAN replication for the given {@code wanReplicationName} and
+     * {@code targetGroupName} on this hazelcast instance.
      *
-     * @param name name of WAN replication configuration
-     * @param targetGroupName name of wan target cluster config
+     * @param wanReplicationName name of WAN replication configuration
+     * @param targetGroupName    WAN target cluster group name
+     * @throws UnsupportedOperationException if called on an OS instance
      */
-    void resume(String name, String targetGroupName);
+    void stop(String wanReplicationName, String targetGroupName);
+
+    /**
+     * Resumes WAN replication for the given {@code wanReplicationName} and
+     * {@code targetGroupName} on this hazelcast instance.
+     *
+     * @param wanReplicationName name of WAN replication configuration
+     * @param targetGroupName    WAN target cluster group name
+     * @throws UnsupportedOperationException if called on an OS instance
+     */
+    void resume(String wanReplicationName, String targetGroupName);
 
     void checkWanReplicationQueues(String name);
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -107,13 +107,18 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
-    public void pause(String name, String targetGroupName) {
-        throw new UnsupportedOperationException("Pausing wan replication is not supported.");
+    public void pause(String wanReplicationName, String targetGroupName) {
+        throw new UnsupportedOperationException("Pausing WAN replication is not supported.");
     }
 
     @Override
-    public void resume(String name, String targetGroupName) {
-        throw new UnsupportedOperationException("Resuming wan replication is not supported");
+    public void stop(String wanReplicationName, String targetGroupName) {
+        throw new UnsupportedOperationException("Stopping WAN replication is not supported");
+    }
+
+    @Override
+    public void resume(String wanReplicationName, String targetGroupName) {
+        throw new UnsupportedOperationException("Resuming WAN replication is not supported");
     }
 
     @Override

--- a/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
@@ -2441,6 +2441,24 @@
             </xs:element>
             <xs:element name="queue-capacity" type="xs:integer" default="10000" minOccurs="0" maxOccurs="1"/>
             <xs:element name="queue-full-behavior" type="wan-queue-full-behavior" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="initial-publisher-state" type="initial-publisher-state" minOccurs="0" maxOccurs="1"
+                        default="REPLICATING">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines the initial state in which a WAN publisher is started.
+                        - REPLICATING (default):
+                        State where both enqueuing new events is allowed, enqueued events are replicated to the target cluster
+                        and WAN sync is enabled.
+                        - PAUSED:
+                        State where new events are enqueued but they are not dequeued. Some events which have been dequeued before
+                        the state was switched may still be replicated to the target cluster but further events will not be
+                        replicated. WAN sync is enabled.
+                        - STOPPED:
+                        State where neither new events are enqueued nor dequeued. As with the PAUSED state, some events might
+                        still be replicated after the publisher has switched to this state. WAN sync is enabled.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="aws" type="aws" minOccurs="0" maxOccurs="1"/>
             <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
             <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
@@ -3941,4 +3959,11 @@
             </xs:annotation>
         </xs:attribute>
     </xs:complexType>
+    <xs:simpleType name="initial-publisher-state">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="REPLICATING"/>
+            <xs:enumeration value="PAUSED"/>
+            <xs:enumeration value="STOPPED"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -185,6 +185,18 @@
         - THROW_EXCEPTION:
             The WAN queue size is checked before each supported mutating operation. If one of the queues of the target
             cluster is full, WANReplicationQueueFullException is thrown and the operation is not allowed.
+        * <initial-publisher-state>:
+        Defines the initial state in which a WAN publisher is started.
+        - REPLICATING (default):
+            State where both enqueuing new events is allowed, enqueued events are replicated to the target cluster
+            and WAN sync is enabled.
+        - PAUSED:
+            State where new events are enqueued but they not are dequeued. Some events which have been dequeued before
+            the state was switched may still be replicated to the target cluster but further events will not be
+            replicated. WAN sync is enabled.
+        - STOPPED:
+            State where neither new events are enqueued nor dequeued. As with the PAUSED state, some events might
+            still be replicated after the publisher has switched to this state. WAN sync is enabled.
         * <aws>:
             Set its "enabled" attribute to true for discovery within Amazon EC2. It has the following sub-elements:
             - <access-key>:
@@ -236,6 +248,7 @@
             <class-name>com.hazelcast.enterprise.wan.replication.WanBatchReplication</class-name>
             <queue-capacity>15000</queue-capacity>
             <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>
+            <initial-publisher-state>REPLICATING</initial-publisher-state>
             <properties>
                 <property name="endpoints">10.3.5.1:5701,10.3.5.2:5701</property>
                 <property name="batch.size">1000</property>

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1024,6 +1024,7 @@ class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.getGroupName(), c2.getGroupName())
                     && nullSafeEqual(c1.getQueueCapacity(), c2.getQueueCapacity())
                     && nullSafeEqual(c1.getQueueFullBehavior(), c2.getQueueFullBehavior())
+                    && nullSafeEqual(c1.getInitialPublisherState(), c2.getInitialPublisherState())
                     && new AwsConfigChecker().check(c1.getAwsConfig(), c2.getAwsConfig())
                     && new DiscoveryConfigChecker().check(c1.getDiscoveryConfig(), c2.getDiscoveryConfig())
                     && nullSafeEqual(c1.getClassName(), c2.getClassName())

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1121,6 +1121,7 @@ public class ConfigXmlGeneratorTest {
                 .setGroupName("dummyGroup")
                 .setClassName("dummyClass")
                 .setAwsConfig(getDummyAwsConfig())
+                .setInitialPublisherState(WanPublisherState.STOPPED)
                 .setDiscoveryConfig(getDummyDiscoveryConfig());
         wanConfig.setWanPublisherConfigs(Collections.singletonList(publisherConfig));
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1388,6 +1388,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "      <wan-publisher group-name=\"ankara\">\n"
                 + "         <class-name>com.hazelcast.wan.custom.WanPublisher</class-name>\n"
                 + "         <queue-full-behavior>THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE</queue-full-behavior>\n"
+                + "         <initial-publisher-state>STOPPED</initial-publisher-state>\n"
                 + "      </wan-publisher>\n"
                 + "      <wan-consumer>\n"
                 + "         <class-name>com.hazelcast.wan.custom.WanConsumer</class-name>\n"
@@ -1408,6 +1409,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("istanbul", publisherConfig1.getGroupName());
         assertEquals("com.hazelcast.wan.custom.WanPublisher", publisherConfig1.getClassName());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, publisherConfig1.getQueueFullBehavior());
+        assertEquals(WanPublisherState.REPLICATING, publisherConfig1.getInitialPublisherState());
         assertEquals(21, publisherConfig1.getQueueCapacity());
         Map<String, Comparable> pubProperties = publisherConfig1.getProperties();
         assertEquals("prop.publisher", pubProperties.get("custom.prop.publisher"));
@@ -1420,6 +1422,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         WanPublisherConfig publisherConfig2 = publisherConfigs.get(1);
         assertEquals("ankara", publisherConfig2.getGroupName());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, publisherConfig2.getQueueFullBehavior());
+        assertEquals(WanPublisherState.STOPPED, publisherConfig2.getInitialPublisherState());
 
         WanConsumerConfig consumerConfig = wanConfig.getWanConsumerConfig();
         assertEquals("com.hazelcast.wan.custom.WanConsumer", consumerConfig.getClassName());

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MBeanDataHolder.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MBeanDataHolder.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.fail;
 /**
  * Holds the Hazelcast instance and MBean server and provides some utility functions for accessing the MBeans.
  */
-final class MBeanDataHolder {
+public final class MBeanDataHolder {
 
     private static final AtomicInteger ID_GEN = new AtomicInteger(0);
 
@@ -48,7 +48,7 @@ final class MBeanDataHolder {
     /**
      * Initialize with new hazelcast instance and MBean server
      */
-    MBeanDataHolder(TestHazelcastInstanceFactory factory) {
+    public MBeanDataHolder(TestHazelcastInstanceFactory factory) {
         Config config = new Config();
         config.setInstanceName("hz:\",=*?" + ID_GEN.getAndIncrement());
         config.setProperty(GroupProperty.ENABLE_JMX.getName(), "true");
@@ -56,7 +56,12 @@ final class MBeanDataHolder {
         mbs = ManagementFactory.getPlatformMBeanServer();
     }
 
-    void assertMBeanExistEventually(final String type, final String name) {
+    public MBeanDataHolder(HazelcastInstance instance) {
+        hz = instance;
+        mbs = ManagementFactory.getPlatformMBeanServer();
+    }
+
+    public void assertMBeanExistEventually(final String type, final String name) {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -70,7 +75,7 @@ final class MBeanDataHolder {
         });
     }
 
-    void assertMBeanNotExistEventually(final String type, final String name) {
+    public void assertMBeanNotExistEventually(final String type, final String name) {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -102,7 +107,7 @@ final class MBeanDataHolder {
      * @param attributeName Name of attribute to query, e.g. "size"
      * @return Value to get
      */
-    Object getMBeanAttribute(final String type, final String objectName, String attributeName) throws Exception {
+    public Object getMBeanAttribute(final String type, final String objectName, String attributeName) throws Exception {
         return mbs.getAttribute(getObjectName(type, objectName), attributeName);
     }
 
@@ -117,8 +122,8 @@ final class MBeanDataHolder {
      *                      May be null for methods without parameters.
      * @return Value to get
      */
-    Object invokeMBeanOperation(final String type, final String objectName, String operationName, Object[] params,
-                                String[] signature) throws Exception {
+    public Object invokeMBeanOperation(final String type, final String objectName, String operationName, Object[] params,
+                                       String[] signature) throws Exception {
         return mbs.invoke(getObjectName(type, objectName), operationName, params, signature);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.monitor.impl;
 
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -37,6 +38,7 @@ public class LocalWanPublisherStatsTest {
         localWanPublisherStats.setConnected(true);
         localWanPublisherStats.setOutboundQueueSize(100);
         localWanPublisherStats.incrementPublishedEventCount(10);
+        localWanPublisherStats.setState(WanPublisherState.REPLICATING);
 
         JsonObject serialized = localWanPublisherStats.toJson();
 

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalWanStatsImplTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
+import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.monitor.LocalWanPublisherStats;
 import com.hazelcast.monitor.LocalWanStats;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -41,11 +42,13 @@ public class LocalWanStatsImplTest {
         tokyo.setConnected(true);
         tokyo.incrementPublishedEventCount(10);
         tokyo.setOutboundQueueSize(100);
+        tokyo.setState(WanPublisherState.REPLICATING);
 
         LocalWanPublisherStatsImpl singapore = new LocalWanPublisherStatsImpl();
         singapore.setConnected(true);
         singapore.setOutboundQueueSize(200);
         singapore.incrementPublishedEventCount(20);
+        singapore.setState(WanPublisherState.REPLICATING);
 
         LocalWanStatsImpl localWanStats = new LocalWanStatsImpl();
         Map<String, LocalWanPublisherStats> localWanPublisherStatsMap = new HashMap<String, LocalWanPublisherStats>();

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -62,6 +62,7 @@
             <class-name>com.hazelcast.enterprise.wan.replication.WanBatchReplication</class-name>
             <queue-capacity>1000</queue-capacity>
             <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>
+            <initial-publisher-state>REPLICATING</initial-publisher-state>
             <properties>
                 <property name="batch.size">50</property>
                 <property name="batch.max.delay.millis">3000</property>
@@ -76,6 +77,7 @@
         <wan-publisher group-name="istanbul">
             <class-name>com.hazelcast.wan.custom.WanPublisher</class-name>
             <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>
+            <initial-publisher-state>STOPPED</initial-publisher-state>
             <queue-capacity>10000</queue-capacity>
             <aws enabled="false" connection-timeout-seconds="10">
                 <access-key>sample-access-key</access-key>


### PR DESCRIPTION
The stop state allows the user to stop adding events to the WAN queues
in addition to the paused state where events are added but not polled.
The publisher may now also be started in STOPPED or PAUSED state.

Forward port of https://github.com/hazelcast/hazelcast/pull/13219
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2194