### PR TITLE
IMap: add max-idle support per entry

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/NearCachedClientMapProxy.java
@@ -224,11 +224,12 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected ICompletableFuture<V> putAsyncInternal(long ttl, TimeUnit timeunit, Object key, Object value) {
+    protected ICompletableFuture<V> putAsyncInternal(long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit,
+                                                     Object key, Object value) {
         key = toNearCacheKey(key);
         ICompletableFuture<V> future;
         try {
-            future = super.putAsyncInternal(ttl, timeunit, key, value);
+            future = super.putAsyncInternal(ttl, timeunit, maxIdle, maxIdleUnit, key, value);
         } finally {
             invalidateNearCache(key);
         }
@@ -236,11 +237,12 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected ICompletableFuture<Void> setAsyncInternal(long ttl, TimeUnit timeunit, Object key, Object value) {
+    protected ICompletableFuture<Void> setAsyncInternal(long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit,
+                                                        Object key, Object value) {
         key = toNearCacheKey(key);
         ICompletableFuture<Void> future;
         try {
-            future = super.setAsyncInternal(ttl, timeunit, key, value);
+            future = super.setAsyncInternal(ttl, timeunit, maxIdle, maxIdleUnit, key, value);
         } finally {
             invalidateNearCache(key);
         }
@@ -272,11 +274,12 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected boolean tryPutInternal(long timeout, TimeUnit timeunit, Object key, Object value) {
+    protected boolean tryPutInternal(long timeout, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit,
+                                     Object key, Object value) {
         key = toNearCacheKey(key);
         boolean putInternal;
         try {
-            putInternal = super.tryPutInternal(timeout, timeunit, key, value);
+            putInternal = super.tryPutInternal(timeout, timeunit, maxIdle, maxIdleUnit, key, value);
         } finally {
             invalidateNearCache(key);
         }
@@ -284,11 +287,11 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected V putInternal(long ttl, TimeUnit timeunit, Object key, Object value) {
+    protected V putInternal(long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit, Object key, Object value) {
         key = toNearCacheKey(key);
         V previousValue;
         try {
-            previousValue = super.putInternal(ttl, timeunit, key, value);
+            previousValue = super.putInternal(ttl, ttlUnit, maxIdle, maxIdleUnit, key, value);
         } finally {
             invalidateNearCache(key);
         }
@@ -296,21 +299,23 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected void putTransientInternal(long ttl, TimeUnit timeunit, Object key, Object value) {
+    protected void putTransientInternal(long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit,
+                                        Object key, Object value) {
         key = toNearCacheKey(key);
         try {
-            super.putTransientInternal(ttl, timeunit, key, value);
+            super.putTransientInternal(ttl, timeunit, maxIdle, maxIdleUnit, key, value);
         } finally {
             invalidateNearCache(key);
         }
     }
 
     @Override
-    protected V putIfAbsentInternal(long ttl, TimeUnit timeunit, Object key, Object value) {
+    protected V putIfAbsentInternal(long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit,
+                                    Object key, Object value) {
         key = toNearCacheKey(key);
         V previousValue;
         try {
-            previousValue = super.putIfAbsentInternal(ttl, timeunit, key, value);
+            previousValue = super.putIfAbsentInternal(ttl, timeunit, maxIdle, maxIdleUnit, key, value);
         } finally {
             invalidateNearCache(key);
         }
@@ -342,10 +347,10 @@ public class NearCachedClientMapProxy<K, V> extends ClientMapProxy<K, V> {
     }
 
     @Override
-    protected void setInternal(long ttl, TimeUnit timeunit, Object key, Object value) {
+    protected void setInternal(long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit, Object key, Object value) {
         key = toNearCacheKey(key);
         try {
-            super.setInternal(ttl, timeunit, key, value);
+            super.setInternal(ttl, timeunit, maxIdle, maxIdleUnit, key, value);
         } finally {
             invalidateNearCache(key);
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -98,9 +98,9 @@ public class ClientMapBasicTest extends AbstractClientMapTest {
         final IMap<String, String> map = client.getMap(randomString());
 
         map.put("key", "value");
-        map.setTTL("key", 100, TimeUnit.MILLISECONDS);
+        map.setTTL("key", 1000, TimeUnit.MILLISECONDS);
 
-        sleepAtLeastMillis(100);
+        sleepAtLeastMillis(1000);
 
         assertNull(map.get("key"));
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutIfAbsentMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutIfAbsentMessageTask.java
@@ -26,6 +26,8 @@ import com.hazelcast.spi.Operation;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+
 public class MapPutIfAbsentMessageTask
         extends AbstractMapPutMessageTask<MapPutIfAbsentCodec.RequestParameters> {
 
@@ -46,7 +48,7 @@ public class MapPutIfAbsentMessageTask
     protected Operation prepareOperation() {
         MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
         MapOperation op = operationProvider.createPutIfAbsentOperation(parameters.name, parameters.key,
-                parameters.value, parameters.ttl);
+                parameters.value, parameters.ttl, parameters.maxIdleExist ? parameters.maxIdle : DEFAULT_MAX_IDLE);
         op.setThreadId(parameters.threadId);
         return op;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutMessageTask.java
@@ -26,6 +26,8 @@ import com.hazelcast.spi.Operation;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+
 public class MapPutMessageTask
         extends AbstractMapPutMessageTask<MapPutCodec.RequestParameters> {
 
@@ -37,7 +39,7 @@ public class MapPutMessageTask
     protected Operation prepareOperation() {
         MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
         MapOperation op = operationProvider.createPutOperation(parameters.name, parameters.key,
-                parameters.value, parameters.ttl);
+                parameters.value, parameters.ttl, parameters.maxIdleExist ? parameters.maxIdle : DEFAULT_MAX_IDLE);
         op.setThreadId(parameters.threadId);
         return op;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutTransientMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutTransientMessageTask.java
@@ -26,6 +26,8 @@ import com.hazelcast.spi.Operation;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+
 public class MapPutTransientMessageTask
         extends AbstractMapPutMessageTask<MapPutTransientCodec.RequestParameters> {
 
@@ -37,7 +39,7 @@ public class MapPutTransientMessageTask
     protected Operation prepareOperation() {
         MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
         MapOperation op = operationProvider.createPutTransientOperation(parameters.name, parameters.key,
-                parameters.value, parameters.ttl);
+                parameters.value, parameters.ttl, parameters.maxIdleExist ? parameters.maxIdle : DEFAULT_MAX_IDLE);
         op.setThreadId(parameters.threadId);
         return op;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSetMessageTask.java
@@ -26,6 +26,8 @@ import com.hazelcast.spi.Operation;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+
 public class MapSetMessageTask
         extends AbstractMapPutMessageTask<MapSetCodec.RequestParameters> {
 
@@ -37,7 +39,7 @@ public class MapSetMessageTask
     protected Operation prepareOperation() {
         MapOperationProvider operationProvider = getMapOperationProvider(parameters.name);
         MapOperation op = operationProvider.createSetOperation(parameters.name, parameters.key,
-                parameters.value, parameters.ttl);
+                parameters.value, parameters.ttl, parameters.maxIdleExist ? parameters.maxIdle : DEFAULT_MAX_IDLE);
         op.setThreadId(parameters.threadId);
         return op;
     }

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
@@ -112,4 +112,6 @@ public interface EntryView<K, V> {
      * @return the last set time to live in milliseconds.
      */
     long getTtl();
+
+    long getMaxIdle();
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
@@ -113,5 +113,10 @@ public interface EntryView<K, V> {
      */
     long getTtl();
 
+    /**
+     * Returns the last set max idle time in milliseconds.
+     *
+     * @return the last set max idle time in milliseconds.
+     */
     long getMaxIdle();
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -760,13 +760,99 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * @param key      the key of the map entry
      * @param value    the new value of the map entry
      * @param ttl      maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
-     * @param timeunit time unit for the TTL
+     * @param ttlUnit time unit for the TTL
      * @return ICompletableFuture from which the old value of the key can be retrieved
      * @throws NullPointerException if the specified key or value is null
      * @see ICompletableFuture
      * @see #setAsync(Object, Object, long, TimeUnit)
      */
-    ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit timeunit);
+    ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit ttlUnit);
+
+    /**
+     * Asynchronously puts the given key and value into this map with a given TTL (time to live) value.
+     * <p>
+     * The entry will expire and get evicted after the TTL. If the TTL is 0,
+     * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <pre>
+     *   ICompletableFuture future = map.putAsync(key, value, ttl, timeunit);
+     *   // do some other stuff, when ready get the result
+     *   Object oldValue = future.get();
+     * </pre>
+     * ICompletableFuture.get() will block until the actual map.put() completes.
+     * If your application requires a timely response,
+     * then you can use Future.get(timeout, timeunit).
+     * <pre>
+     *   try {
+     *     ICompletableFuture future = map.putAsync(key, newValue, ttl, timeunit);
+     *     Object oldValue = future.get(40, TimeUnit.MILLISECOND);
+     *   } catch (TimeoutException t) {
+     *     // time wasn't enough
+     *   }
+     * </pre>
+     * The client can schedule an {@link ExecutionCallback} to be invoked upon
+     * completion of the {@code ICompletableFuture} via {@link ICompletableFuture#andThen(ExecutionCallback)} or
+     * {@link ICompletableFuture#andThen(ExecutionCallback, Executor)}:
+     * <pre>{@code
+     *   // assuming an IMap<String, String>
+     *   ICompletableFuture<String> future = map.putAsync("a", "b", 5, TimeUnit.MINUTES);
+     *   future.andThen(new ExecutionCallback<String>() {
+     *     public void onResponse(String response) {
+     *       // do something with old value returned by put operation
+     *     }
+     *
+     *     public void onFailure(Throwable t) {
+     *       // handle failure
+     *     }
+     *   });
+     * }</pre>
+     * ExecutionException is never thrown.
+     * <p>
+     * <b>Warning 1:</b>
+     * <p>
+     * This method uses {@code hashCode} and {@code equals} of the binary form of
+     * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
+     * defined in the {@code key}'s class.
+     * <p>
+     * <b>Warning 2:</b>
+     * <p>
+     * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
+     * <p>
+     * <p><b>Note:</b>
+     * Use {@link #setAsync(Object, Object, long, TimeUnit)} if you don't need the return value, it's slightly
+     * more efficient.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
+     * @param key         the key of the map entry
+     * @param value       the new value of the map entry
+     * @param ttl         maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
+     * @param ttlUnit     time unit for the TTL
+     * @param maxIdle     maximum time for this entry to stay idle in the map.
+     *                    (0 means infinite, negative means map config default)
+     * @param maxIdleUnit time unit for the Max-Idle
+     * @return ICompletableFuture from which the old value of the key can be retrieved
+     * @throws NullPointerException if the specified key or value is null
+     * @see ICompletableFuture
+     * @see #setAsync(Object, Object, long, TimeUnit)
+     */
+    ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit);
 
     /**
      * Asynchronously puts the given key and value.
@@ -900,13 +986,90 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * @param key      the key of the map entry
      * @param value    the new value of the map entry
      * @param ttl      maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
-     * @param timeunit time unit for the TTL
+     * @param ttlUnit  time unit for the TTL
      * @return ICompletableFuture on which client code can block waiting for the operation to complete
      * or provide an {@link ExecutionCallback} to be invoked upon set operation completion
      * @throws NullPointerException if the specified key or value is null
      * @see ICompletableFuture
      */
-    ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit timeunit);
+    ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit ttlUnit);
+
+    /**
+     * Asynchronously puts an entry into this map with a given TTL (time to live) value,
+     * without returning the old value (which is more efficient than {@code put()}).
+     * <p>
+     * The entry will expire and get evicted after the TTL. If the TTL is 0,
+     * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <pre>
+     *   ICompletableFuture&lt;Void&gt; future = map.setAsync(key, value, ttl, timeunit);
+     *   // do some other stuff, when you want to make sure set operation is complete:
+     *   future.get();
+     * </pre>
+     * ICompletableFuture.get() will block until the actual map set operation completes.
+     * If your application requires a timely response,
+     * then you can use {@link ICompletableFuture#get(long, TimeUnit)}.
+     * <pre>
+     *   try {
+     *     ICompletableFuture<Void> future = map.setAsync(key, newValue, ttl, timeunit);
+     *     future.get(40, TimeUnit.MILLISECOND);
+     *   } catch (TimeoutException t) {
+     *     // time wasn't enough
+     *   }
+     * </pre>
+     * You can also schedule an {@link ExecutionCallback} to be invoked upon
+     * completion of the {@code ICompletableFuture} via {@link ICompletableFuture#andThen(ExecutionCallback)} or
+     * {@link ICompletableFuture#andThen(ExecutionCallback, Executor)}:
+     * <pre>
+     *   ICompletableFuture&lt;Void&gt; future = map.setAsync("a", "b", 5, TimeUnit.MINUTES);
+     *   future.andThen(new ExecutionCallback&lt;String&gt;() {
+     *     public void onResponse(Void response) {
+     *       // Set operation was completed
+     *     }
+     *
+     *     public void onFailure(Throwable t) {
+     *       // handle failure
+     *     }
+     *   });
+     * </pre>
+     * ExecutionException is never thrown.
+     * <p>
+     * <b>Warning 1:</b>
+     * <p>
+     * This method uses {@code hashCode} and {@code equals} of the binary form of
+     * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
+     * defined in the {@code key}'s class.
+     * <p>
+     * <b>Warning 2:</b>
+     * <p>
+     * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller..
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
+     * @param key         the key of the map entry
+     * @param value       the new value of the map entry
+     * @param ttl         maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
+     * @param ttlUnit     time unit for the TTL
+     * @param maxIdle     maximum time for this entry to stay idle in the map.
+     *                    (0 means infinite, negative means map config default)
+     * @param maxIdleUnit time unit for the Max-Idle
+     * @return ICompletableFuture on which client code can block waiting for the operation to complete
+     * or provide an {@link ExecutionCallback} to be invoked upon set operation completion
+     * @throws NullPointerException if the specified key or value is null
+     * @see ICompletableFuture
+     */
+    ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit);
 
     /**
      * Asynchronously removes the given key, returning an {@link ICompletableFuture} on which
@@ -1059,11 +1222,66 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * @param key      key of the entry
      * @param value    value of the entry
      * @param ttl      maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
-     * @param timeunit time unit for the TTL
+     * @param ttlUnit  time unit for the TTL
      * @return old value of the entry
      * @throws NullPointerException if the specified key or value is null
      */
-    V put(K key, V value, long ttl, TimeUnit timeunit);
+    V put(K key, V value, long ttl, TimeUnit ttlUnit);
+
+    /**
+     * Puts an entry into this map with a given TTL (time to live) value.
+     * <p>
+     * The entry will expire and get evicted after the TTL. If the TTL is 0,
+     * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <p>
+     * <b>Warning 1:</b>
+     * <p>
+     * This method uses {@code hashCode} and {@code equals} of the binary form of
+     * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
+     * defined in the {@code key}'s class.
+     * <p>
+     * <b>Warning 2:</b>
+     * <p>
+     * This method returns a clone of the previous value, not the original (identically equal) value
+     * previously put into the map.
+     * <p>
+     * <b>Warning 3:</b>
+     * <p>
+     * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
+     * <p>
+     * <p><b>Note:</b>
+     * Use {@link #set(Object, Object, long, TimeUnit)} if you don't need the return value, it's slightly more efficient.
+     * <p>
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
+     * @param key         key of the entry
+     * @param value       value of the entry
+     * @param ttl         maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
+     * @param ttlUnit     time unit for the TTL
+     * @param maxIdle     maximum time for this entry to stay idle in the map.
+     *                    (0 means infinite, negative means map config default)
+     * @param maxIdleUnit time unit for the Max-Idle
+     * @return old value of the entry
+     * @throws NullPointerException if the specified key or value is null
+     */
+    V put(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit);
 
     /**
      * Same as {@link #put(K, V, long, java.util.concurrent.TimeUnit)}
@@ -1087,10 +1305,40 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * @param key      key of the entry
      * @param value    value of the entry
      * @param ttl      maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
-     * @param timeunit time unit for the TTL
+     * @param ttlUnit  time unit for the TTL
      * @throws NullPointerException if the specified key or value is null
      */
-    void putTransient(K key, V value, long ttl, TimeUnit timeunit);
+    void putTransient(K key, V value, long ttl, TimeUnit ttlUnit);
+
+    /**
+     * Same as {@link #put(K, V, long, java.util.concurrent.TimeUnit)}
+     * except that the map store, if defined, will not be called to
+     * load/store/persist the entry.
+     * <p>
+     * The entry will expire and get evicted after the TTL. If the TTL is 0,
+     * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <p>
+     * <b>Warning 1:</b>
+     * <p>
+     * This method uses {@code hashCode} and {@code equals} of the binary form of
+     * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
+     * defined in the {@code key}'s class.
+     * <p>
+     * <b>Warning 2:</b>
+     * <p>
+     * Time resolution for TTL is seconds. The given TTL value is rounded to next closest second value.
+     *
+     * @param key         key of the entry
+     * @param value       value of the entry
+     * @param ttl         maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
+     * @param ttlUnit     time unit for the TTL
+     * @param maxIdle     maximum time for this entry to stay idle in the map.
+     *                    (0 means infinite, negative means map config default)
+     * @param maxIdleUnit time unit for the Max-Idle
+     * @throws NullPointerException if the specified key or value is null
+     */
+    void putTransient(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit);
 
     /**
      * {@inheritDoc}
@@ -1171,12 +1419,64 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * @param key      key of the entry
      * @param value    value of the entry
      * @param ttl      maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
-     * @param timeunit time unit for the TTL
+     * @param ttlUnit time unit for the TTL
      * @return old value of the entry
      * @throws NullPointerException if the specified key or value is null
      */
-    V putIfAbsent(K key, V value, long ttl, TimeUnit timeunit);
+    V putIfAbsent(K key, V value, long ttl, TimeUnit ttlUnit);
 
+    /**
+     * Puts an entry into this map with a given TTL (time to live) value,
+     * if the specified key is not already associated with a value.
+     * <p>
+     * The entry will expire and get evicted after the TTL. If the TTL is 0,
+     * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <p>
+     * <b>Warning 1:</b>
+     * <p>
+     * This method uses {@code hashCode} and {@code equals} of the binary form of
+     * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
+     * defined in the {@code key}'s class.
+     * <p>
+     * <b>Warning 2:</b>
+     * <p>
+     * This method returns a clone of the previous value, not the original (identically equal) value
+     * previously put into the map.
+     * <p>
+     * <b>Warning 3:</b>
+     * <p>
+     * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If no value is found with {@code key} in memory,
+     * {@link MapLoader#load(Object)} is invoked to load the value from
+     * the map store backing the map. Exceptions thrown by load fail
+     * the operation and are propagated to the caller.
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
+     * @param key         key of the entry
+     * @param value       value of the entry
+     * @param ttl         maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
+     * @param ttlUnit     time unit for the TTL
+     * @param maxIdle     maximum time for this entry to stay idle in the map.
+     *                    (0 means infinite, negative means map config default)
+     * @param maxIdleUnit time unit for the Max-Idle
+     * @return old value of the entry
+     * @throws NullPointerException if the specified key or value is null
+     */
+    V putIfAbsent(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit);
     /**
      * {@inheritDoc}
      * <p>
@@ -1312,10 +1612,52 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * @param key      key of the entry
      * @param value    value of the entry
      * @param ttl      maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
-     * @param timeunit time unit for the TTL
+     * @param ttlUnit  time unit for the TTL
      * @throws NullPointerException if the specified key or value is null
      */
-    void set(K key, V value, long ttl, TimeUnit timeunit);
+    void set(K key, V value, long ttl, TimeUnit ttlUnit);
+
+    /**
+     * Puts an entry into this map with a given TTL (time to live) value,
+     * without returning the old value (which is more efficient than {@code put()}).
+     * <p>
+     * The entry will expire and get evicted after the TTL. If the TTL is 0,
+     * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <p>
+     * <b>Warning 1:</b>
+     * <p>
+     * This method uses {@code hashCode} and {@code equals} of the binary form of
+     * the {@code key}, not the actual implementations of {@code hashCode} and {@code equals}
+     * defined in the {@code key}'s class.
+     * <p>
+     * <b>Warning 2:</b>
+     * <p>
+     * Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
+     *
+     * <p><b>Interactions with the map store</b>
+     * <p>
+     * If write-through persistence mode is configured, before the value
+     * is stored in memory, {@link MapStore#store(Object, Object)} is
+     * called to write the value into the map store. Exceptions thrown
+     * by the store fail the operation and are propagated to the caller.
+     * <p>
+     * If write-behind persistence mode is configured with
+     * write-coalescing turned off,
+     * {@link com.hazelcast.map.ReachedMaxSizeException} may be thrown
+     * if the write-behind queue has reached its per-node maximum
+     * capacity.
+     *
+     * @param key         key of the entry
+     * @param value       value of the entry
+     * @param ttl         maximum time for this entry to stay in the map (0 means infinite, negative means map config default)
+     * @param ttlUnit     time unit for the TTL
+     * @param maxIdle     maximum time for this entry to stay idle in the map.
+     *                    (0 means infinite, negative means map config default)
+     * @param maxIdleUnit time unit for the Max-Idle
+     * @throws NullPointerException if the specified key or value is null
+     */
+    void set(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit);
 
     /**
      * Acquires the lock for the specified key.

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -769,10 +769,14 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit ttlUnit);
 
     /**
-     * Asynchronously puts the given key and value into this map with a given TTL (time to live) value.
+     * Asynchronously puts the given key and value into this map with a given TTL (time to live) value and max idle time value.
      * <p>
      * The entry will expire and get evicted after the TTL. If the TTL is 0,
      * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <p>
+     * The entry will expire and get evicted after the Max Idle time. If the MaxIdle is 0,
+     * then the entry lives forever. If the MaxIdle is negative, then the MaxIdle
      * from the map configuration will be used (default: forever).
      * <pre>
      *   ICompletableFuture future = map.putAsync(key, value, ttl, timeunit);
@@ -927,6 +931,10 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * The entry will expire and get evicted after the TTL. If the TTL is 0,
      * then the entry lives forever. If the TTL is negative, then the TTL
      * from the map configuration will be used (default: forever).
+     * <p>
+     * The entry will expire and get evicted after the Max Idle time. If the MaxIdle is 0,
+     * then the entry lives forever. If the MaxIdle is negative, then the MaxIdle
+     * from the map configuration will be used (default: forever).
      * <pre>
      *   ICompletableFuture&lt;Void&gt; future = map.setAsync(key, value, ttl, timeunit);
      *   // do some other stuff, when you want to make sure set operation is complete:
@@ -995,11 +1003,15 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit ttlUnit);
 
     /**
-     * Asynchronously puts an entry into this map with a given TTL (time to live) value,
+     * Asynchronously puts an entry into this map with a given TTL (time to live) value and max idle time value.
      * without returning the old value (which is more efficient than {@code put()}).
      * <p>
      * The entry will expire and get evicted after the TTL. If the TTL is 0,
      * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <p>
+     * The entry will expire and get evicted after the Max Idle time. If the MaxIdle is 0,
+     * then the entry lives forever. If the MaxIdle is negative, then the MaxIdle
      * from the map configuration will be used (default: forever).
      * <pre>
      *   ICompletableFuture&lt;Void&gt; future = map.setAsync(key, value, ttl, timeunit);
@@ -1229,10 +1241,14 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     V put(K key, V value, long ttl, TimeUnit ttlUnit);
 
     /**
-     * Puts an entry into this map with a given TTL (time to live) value.
+     * Puts an entry into this map with a given TTL (time to live) value and max idle time value.
      * <p>
      * The entry will expire and get evicted after the TTL. If the TTL is 0,
      * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <p>
+     * The entry will expire and get evicted after the Max Idle time. If the MaxIdle is 0,
+     * then the entry lives forever. If the MaxIdle is negative, then the MaxIdle
      * from the map configuration will be used (default: forever).
      * <p>
      * <b>Warning 1:</b>
@@ -1317,6 +1333,10 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
      * <p>
      * The entry will expire and get evicted after the TTL. If the TTL is 0,
      * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <p>
+     * The entry will expire and get evicted after the Max Idle time. If the MaxIdle is 0,
+     * then the entry lives forever. If the MaxIdle is negative, then the MaxIdle
      * from the map configuration will be used (default: forever).
      * <p>
      * <b>Warning 1:</b>
@@ -1426,11 +1446,15 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     V putIfAbsent(K key, V value, long ttl, TimeUnit ttlUnit);
 
     /**
-     * Puts an entry into this map with a given TTL (time to live) value,
+     * Puts an entry into this map with a given TTL (time to live) value and max idle time value.
      * if the specified key is not already associated with a value.
      * <p>
      * The entry will expire and get evicted after the TTL. If the TTL is 0,
      * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <p>
+     * The entry will expire and get evicted after the Max Idle time. If the MaxIdle is 0,
+     * then the entry lives forever. If the MaxIdle is negative, then the MaxIdle
      * from the map configuration will be used (default: forever).
      * <p>
      * <b>Warning 1:</b>
@@ -1618,11 +1642,15 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, LegacyAsyncMap<K, V> {
     void set(K key, V value, long ttl, TimeUnit ttlUnit);
 
     /**
-     * Puts an entry into this map with a given TTL (time to live) value,
+     * Puts an entry into this map with a given TTL (time to live) value and max idle time value.
      * without returning the old value (which is more efficient than {@code put()}).
      * <p>
      * The entry will expire and get evicted after the TTL. If the TTL is 0,
      * then the entry lives forever. If the TTL is negative, then the TTL
+     * from the map configuration will be used (default: forever).
+     * <p>
+     * The entry will expire and get evicted after the Max Idle time. If the MaxIdle is 0,
+     * then the entry lives forever. If the MaxIdle is negative, then the MaxIdle
      * from the map configuration will be used (default: forever).
      * <p>
      * <b>Warning 1:</b>

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -54,6 +54,7 @@ public final class EntryViews {
                 .withLastAccessTime(record.getLastAccessTime())
                 .withLastUpdateTime(record.getLastUpdateTime())
                 .withTtl(record.getTtl())
+                .withMaxIdle(record.getMaxIdle())
                 .withCreationTime(record.getCreationTime())
                 .withExpirationTime(record.getExpirationTime())
                 .withLastStoredTime(record.getLastStoredTime());
@@ -67,6 +68,7 @@ public final class EntryViews {
                 .withLastAccessTime(record.getLastAccessTime())
                 .withLastUpdateTime(record.getLastUpdateTime())
                 .withTtl(record.getTtl())
+                .withMaxIdle(record.getMaxIdle())
                 .withCreationTime(record.getCreationTime())
                 .withExpirationTime(record.getExpirationTime())
                 .withLastStoredTime(record.getLastStoredTime());
@@ -82,6 +84,7 @@ public final class EntryViews {
                 .setLastAccessTime(record.getLastAccessTime())
                 .setLastUpdateTime(record.getLastUpdateTime())
                 .setTtl(record.getTtl())
+                .setMaxIdle(record.getMaxIdle())
                 .setCreationTime(record.getCreationTime())
                 .setExpirationTime(record.getExpirationTime())
                 .setLastStoredTime(record.getLastStoredTime());
@@ -96,6 +99,7 @@ public final class EntryViews {
                 .setLastAccessTime(entryView.getLastAccessTime())
                 .setLastUpdateTime(entryView.getLastUpdateTime())
                 .setTtl(entryView.getTtl())
+                .setMaxIdle(entryView.getMaxIdle())
                 .setCreationTime(entryView.getCreationTime())
                 .setHits(entryView.getHits())
                 .setExpirationTime(entryView.getExpirationTime())

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
@@ -44,6 +44,7 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
     private long lastUpdateTime;
     private long version;
     private long ttl;
+    private long maxIdle;
 
     private SerializationService serializationService;
     private MapMergePolicy mergePolicy;
@@ -185,6 +186,16 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
 
     public LazyEntryView<K, V> setTtl(long ttl) {
         this.ttl = ttl;
+        return this;
+    }
+
+    @Override
+    public long getMaxIdle() {
+        return maxIdle;
+    }
+
+    public LazyEntryView<K, V> setMaxIdle(long maxIdle) {
+        this.maxIdle = maxIdle;
         return this;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/NullEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/NullEntryView.java
@@ -87,4 +87,8 @@ class NullEntryView<K, V> implements EntryView<K, V> {
         return 0;
     }
 
+    @Override
+    public long getMaxIdle() {
+        return 0;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
@@ -22,8 +22,11 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
+
+import static com.hazelcast.internal.cluster.Versions.V3_11;
 
 /**
  * SimpleEntryView is an implementation of {@link com.hazelcast.core.EntryView} and also it is writable.
@@ -33,7 +36,8 @@ import java.io.IOException;
  */
 @BinaryInterface
 @SuppressWarnings("checkstyle:methodcount")
-public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSerializable {
+public class SimpleEntryView<K, V>
+        implements EntryView<K, V>, IdentifiedDataSerializable, Versioned {
 
     private K key;
     private V value;
@@ -255,7 +259,10 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         // writes the deprecated evictionCriteriaNumber to the data output (client protocol compatibility)
         out.writeLong(0);
         out.writeLong(ttl);
-        out.writeLong(maxIdle);
+        //RU_COMPAT_3_10
+        if (out.getVersion().isGreaterOrEqual(V3_11)) {
+            out.writeLong(maxIdle);
+        }
     }
 
     @Override
@@ -273,7 +280,10 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         // reads the deprecated evictionCriteriaNumber from the data input (client protocol compatibility)
         in.readLong();
         ttl = in.readLong();
-        maxIdle = in.readLong();
+        //RU_COMPAT_3_10
+        if (in.getVersion().isGreaterOrEqual(V3_11)) {
+            maxIdle = in.readLong();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
@@ -47,6 +47,7 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
     private long lastUpdateTime;
     private long version;
     private long ttl;
+    private long maxIdle;
 
     public SimpleEntryView(K key, V value) {
         this.key = key;
@@ -210,6 +211,20 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         return this;
     }
 
+    @Override
+    public long getMaxIdle() {
+        return maxIdle;
+    }
+
+    public void setMaxIdle(long maxIdle) {
+        this.maxIdle = maxIdle;
+    }
+
+    public SimpleEntryView<K, V> withMaxIdle(long maxIdle) {
+        this.maxIdle = maxIdle;
+        return this;
+    }
+
     /**
      * Needed for client protocol compatibility.
      */
@@ -240,6 +255,7 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         // writes the deprecated evictionCriteriaNumber to the data output (client protocol compatibility)
         out.writeLong(0);
         out.writeLong(ttl);
+        out.writeLong(maxIdle);
     }
 
     @Override
@@ -257,6 +273,7 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         // reads the deprecated evictionCriteriaNumber from the data input (client protocol compatibility)
         in.readLong();
         ttl = in.readLong();
+        maxIdle = in.readLong();
     }
 
     @Override
@@ -306,6 +323,9 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         if (ttl != that.ttl) {
             return false;
         }
+        if (maxIdle != that.maxIdle) {
+            return false;
+        }
         if (key != null ? !key.equals(that.key) : that.key != null) {
             return false;
         }
@@ -325,6 +345,7 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         result = 31 * result + (int) (lastUpdateTime ^ (lastUpdateTime >>> 32));
         result = 31 * result + (int) (version ^ (version >>> 32));
         result = 31 * result + (int) (ttl ^ (ttl >>> 32));
+        result = 31 * result + (int) (maxIdle ^ (maxIdle >>> 32));
         return result;
     }
 
@@ -342,6 +363,7 @@ public class SimpleEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
                 + ", lastUpdateTime=" + lastUpdateTime
                 + ", version=" + version
                 + ", ttl=" + ttl
+                + ", maxIdle=" + maxIdle
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.EntryView;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.impl.Versioned;
 
@@ -34,7 +33,6 @@ import static com.hazelcast.internal.cluster.Versions.V3_11;
  * @param <K> the type of key.
  * @param <V> the type of value.
  */
-@BinaryInterface
 @SuppressWarnings("checkstyle:methodcount")
 public class SimpleEntryView<K, V>
         implements EntryView<K, V>, IdentifiedDataSerializable, Versioned {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -24,6 +24,7 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
 
 import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
 import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 
 public abstract class BasePutOperation extends LockAwareOperation implements BackupAwareOperation {
@@ -34,11 +35,11 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
     protected transient boolean putTransient;
 
     public BasePutOperation(String name, Data dataKey, Data value) {
-        super(name, dataKey, value, DEFAULT_TTL);
+        super(name, dataKey, value, DEFAULT_TTL, DEFAULT_MAX_IDLE);
     }
 
-    public BasePutOperation(String name, Data dataKey, Data value, long ttl) {
-        super(name, dataKey, value, ttl);
+    public BasePutOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
+        super(name, dataKey, value, ttl, maxIdle);
     }
 
     public BasePutOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DefaultMapOperationProvider.java
@@ -51,8 +51,8 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createPutOperation(String name, Data key, Data value, long ttl) {
-        return new PutOperation(name, key, value, ttl);
+    public MapOperation createPutOperation(String name, Data key, Data value, long ttl, long maxIdle) {
+        return new PutOperation(name, key, value, ttl, maxIdle);
     }
 
     @Override
@@ -61,18 +61,18 @@ public class DefaultMapOperationProvider implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createSetOperation(String name, Data dataKey, Data value, long ttl) {
-        return new SetOperation(name, dataKey, value, ttl);
+    public MapOperation createSetOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
+        return new SetOperation(name, dataKey, value, ttl, maxIdle);
     }
 
     @Override
-    public MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl) {
-        return new PutIfAbsentOperation(name, key, value, ttl);
+    public MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl, long maxIdle) {
+        return new PutIfAbsentOperation(name, key, value, ttl, maxIdle);
     }
 
     @Override
-    public MapOperation createPutTransientOperation(String name, Data key, Data value, long ttl) {
-        return new PutTransientOperation(name, key, value, ttl);
+    public MapOperation createPutTransientOperation(String name, Data key, Data value, long ttl, long maxIdle) {
+        return new PutTransientOperation(name, key, value, ttl, maxIdle);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EntryOperator.java
@@ -51,6 +51,7 @@ import static com.hazelcast.core.EntryEventType.UPDATED;
 import static com.hazelcast.internal.util.ToHeapDataConverter.toHeapData;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.wan.impl.CallerProvenance.NOT_WAN;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
 import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 
 /**
@@ -284,7 +285,7 @@ public final class EntryOperator {
         if (backup) {
             recordStore.putBackup(dataKey, newValue, NOT_WAN);
         } else {
-            recordStore.setWithUncountedAccess(dataKey, newValue, DEFAULT_TTL);
+            recordStore.setWithUncountedAccess(dataKey, newValue, DEFAULT_TTL, DEFAULT_MAX_IDLE);
             if (mapOperation.isPostProcessing(recordStore)) {
                 Record record = recordStore.getRecord(dataKey);
                 newValue = record == null ? null : record.getValue();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LockAwareOperation.java
@@ -30,12 +30,12 @@ public abstract class LockAwareOperation extends KeyBasedMapOperation implements
         super(name, dataKey);
     }
 
-    protected LockAwareOperation(String name, Data dataKey, long ttl) {
-        super(name, dataKey, ttl);
+    protected LockAwareOperation(String name, Data dataKey, long ttl, long maxIdle) {
+        super(name, dataKey, ttl, maxIdle);
     }
 
-    protected LockAwareOperation(String name, Data dataKey, Data dataValue, long ttl) {
-        super(name, dataKey, dataValue, ttl);
+    protected LockAwareOperation(String name, Data dataKey, Data dataValue, long ttl, long maxIdle) {
+        super(name, dataKey, dataValue, ttl, maxIdle);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProvider.java
@@ -36,15 +36,15 @@ import java.util.Set;
  */
 public interface MapOperationProvider {
 
-    MapOperation createPutOperation(String name, Data key, Data value, long ttl);
+    MapOperation createPutOperation(String name, Data key, Data value, long ttl, long maxIdle);
 
     MapOperation createTryPutOperation(String name, Data dataKey, Data value, long timeout);
 
-    MapOperation createSetOperation(String name, Data dataKey, Data value, long ttl);
+    MapOperation createSetOperation(String name, Data dataKey, Data value, long ttl, long maxIdle);
 
-    MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl);
+    MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl, long maxIdle);
 
-    MapOperation createPutTransientOperation(String name, Data key, Data value, long ttl);
+    MapOperation createPutTransientOperation(String name, Data key, Data value, long ttl, long maxIdle);
 
     MapOperation createSetTTLOperation(String name, Data key, long ttl);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapOperationProviderDelegator.java
@@ -41,8 +41,8 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
     abstract MapOperationProvider getDelegate();
 
     @Override
-    public MapOperation createPutOperation(String name, Data key, Data value, long ttl) {
-        return getDelegate().createPutOperation(name, key, value, ttl);
+    public MapOperation createPutOperation(String name, Data key, Data value, long ttl, long maxIdle) {
+        return getDelegate().createPutOperation(name, key, value, ttl, maxIdle);
     }
 
     @Override
@@ -51,18 +51,18 @@ abstract class MapOperationProviderDelegator implements MapOperationProvider {
     }
 
     @Override
-    public MapOperation createSetOperation(String name, Data dataKey, Data value, long ttl) {
-        return getDelegate().createSetOperation(name, dataKey, value, ttl);
+    public MapOperation createSetOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
+        return getDelegate().createSetOperation(name, dataKey, value, ttl, maxIdle);
     }
 
     @Override
-    public MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl) {
-        return getDelegate().createPutIfAbsentOperation(name, key, value, ttl);
+    public MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl, long maxIdle) {
+        return getDelegate().createPutIfAbsentOperation(name, key, value, ttl, maxIdle);
     }
 
     @Override
-    public MapOperation createPutTransientOperation(String name, Data key, Data value, long ttl) {
-        return getDelegate().createPutTransientOperation(name, key, value, ttl);
+    public MapOperation createPutTransientOperation(String name, Data key, Data value, long ttl, long maxIdle) {
+        return getDelegate().createPutTransientOperation(name, key, value, ttl, maxIdle);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -43,7 +43,9 @@ import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
 /**
  * Replicates all IMap-states of this partition to a replica partition.
  */
-public class MapReplicationOperation extends Operation implements IdentifiedDataSerializable, Versioned, TargetAware {
+public class MapReplicationOperation
+        extends Operation
+        implements IdentifiedDataSerializable, Versioned, TargetAware {
 
     // keep these fields `protected`, extended in another context.
     protected final MapReplicationStateHolder mapReplicationStateHolder = new MapReplicationStateHolder(this);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -58,6 +58,7 @@ import static com.hazelcast.internal.cluster.Versions.V3_10;
 import static com.hazelcast.internal.cluster.Versions.V3_9;
 import static com.hazelcast.map.impl.record.Records.applyRecordInfo;
 import static com.hazelcast.map.impl.record.Records.getValueOrCachedValue;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
 import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 import static com.hazelcast.util.MapUtil.createHashMap;
 
@@ -188,7 +189,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
                 for (RecordReplicationInfo recordReplicationInfo : recordReplicationInfos) {
                     Data key = recordReplicationInfo.getKey();
                     final Data value = recordReplicationInfo.getValue();
-                    Record newRecord = recordStore.createRecord(value, DEFAULT_TTL, Clock.currentTimeMillis());
+                    Record newRecord = recordStore.createRecord(value, DEFAULT_TTL, DEFAULT_MAX_IDLE, Clock.currentTimeMillis());
                     applyRecordInfo(newRecord, recordReplicationInfo);
                     recordStore.putRecord(key, newRecord);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryOperation.java
@@ -75,7 +75,6 @@ public class PartitionWideEntryOperation extends MapOperation
     public void run() {
         responses = new MapEntries(recordStore.size());
         operator = operator(this, entryProcessor, getPredicate());
-
         Iterator<Record> iterator = recordStore.iterator(Clock.currentTimeMillis(), false);
         while (iterator.hasNext()) {
             Record record = iterator.next();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import static com.hazelcast.core.EntryEventType.ADDED;
 import static com.hazelcast.core.EntryEventType.UPDATED;
 import static com.hazelcast.map.impl.record.Records.buildRecordInfo;
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
 import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_TTL;
 
 /**
@@ -120,9 +121,9 @@ public class PutAllOperation extends MapOperation
      */
     private Object putToRecordStore(Data dataKey, Data dataValue) {
         if (hasMapListener) {
-            return recordStore.put(dataKey, dataValue, DEFAULT_TTL);
+            return recordStore.put(dataKey, dataValue, DEFAULT_TTL, DEFAULT_MAX_IDLE);
         }
-        recordStore.set(dataKey, dataValue, DEFAULT_TTL);
+        recordStore.set(dataKey, dataValue, DEFAULT_TTL, DEFAULT_MAX_IDLE);
         return null;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutBackupOperation.java
@@ -64,8 +64,8 @@ public final class PutBackupOperation extends KeyBasedMapOperation implements Ba
     @Override
     public void run() {
         ttl = recordInfo != null ? recordInfo.getTtl() : ttl;
-
-        Record record = recordStore.putBackup(dataKey, dataValue, ttl, putTransient, getCallerProvenance());
+        maxIdle = recordInfo != null ? recordInfo.getMaxIdle() : maxIdle;
+        final Record record = recordStore.putBackup(dataKey, dataValue, ttl, maxIdle, putTransient, getCallerProvenance());
 
         if (recordInfo != null) {
             Records.applyRecordInfo(record, recordInfo);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutIfAbsentOperation.java
@@ -24,8 +24,8 @@ public class PutIfAbsentOperation extends BasePutOperation implements MutatingOp
 
     private boolean successful;
 
-    public PutIfAbsentOperation(String name, Data dataKey, Data value, long ttl) {
-        super(name, dataKey, value, ttl);
+    public PutIfAbsentOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
+        super(name, dataKey, value, ttl, maxIdle);
     }
 
     public PutIfAbsentOperation() {
@@ -33,7 +33,7 @@ public class PutIfAbsentOperation extends BasePutOperation implements MutatingOp
 
     @Override
     public void run() {
-        final Object oldValue = recordStore.putIfAbsent(dataKey, dataValue, ttl, getCallerAddress());
+        final Object oldValue = recordStore.putIfAbsent(dataKey, dataValue, ttl, maxIdle, getCallerAddress());
         dataOldValue = mapServiceContext.toData(oldValue);
         successful = dataOldValue == null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutOperation.java
@@ -25,13 +25,13 @@ public class PutOperation extends BasePutOperation implements MutatingOperation 
     public PutOperation() {
     }
 
-    public PutOperation(String name, Data dataKey, Data value, long ttl) {
-        super(name, dataKey, value, ttl);
+    public PutOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
+        super(name, dataKey, value, ttl, maxIdle);
     }
 
     @Override
     public void run() {
-        dataOldValue = mapServiceContext.toData(recordStore.put(dataKey, dataValue, ttl));
+        dataOldValue = mapServiceContext.toData(recordStore.put(dataKey, dataValue, ttl, maxIdle));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutTransientOperation.java
@@ -25,13 +25,13 @@ public class PutTransientOperation extends BasePutOperation implements MutatingO
     public PutTransientOperation() {
     }
 
-    public PutTransientOperation(String name, Data dataKey, Data value, long ttl) {
-        super(name, dataKey, value, ttl);
+    public PutTransientOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
+        super(name, dataKey, value, ttl, maxIdle);
     }
 
     @Override
     public void run() {
-        dataOldValue = mapServiceContext.toData(recordStore.putTransient(dataKey, dataValue, ttl));
+        dataOldValue = mapServiceContext.toData(recordStore.putTransient(dataKey, dataValue, ttl, maxIdle));
         putTransient = true;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetOperation.java
@@ -30,13 +30,13 @@ public class SetOperation extends BasePutOperation implements MutatingOperation 
     public SetOperation() {
     }
 
-    public SetOperation(String name, Data dataKey, Data value, long ttl) {
-        super(name, dataKey, value, ttl);
+    public SetOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
+        super(name, dataKey, value, ttl, maxIdle);
     }
 
     @Override
     public void run() {
-        Object oldValue = recordStore.set(dataKey, dataValue, ttl);
+        Object oldValue = recordStore.set(dataKey, dataValue, ttl, maxIdle);
         newRecord = oldValue == null;
 
         if (recordStore.hasQueryCache()) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTTLBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTTLBackupOperation.java
@@ -21,6 +21,8 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+
 public class SetTTLBackupOperation extends KeyBasedMapOperation implements BackupOperation {
 
     public SetTTLBackupOperation() {
@@ -28,7 +30,7 @@ public class SetTTLBackupOperation extends KeyBasedMapOperation implements Backu
     }
 
     public SetTTLBackupOperation(String name, Data dataKey, long ttl) {
-        super(name, dataKey, ttl);
+        super(name, dataKey, ttl, DEFAULT_MAX_IDLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTTLOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/SetTTLOperation.java
@@ -23,6 +23,8 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
+import static com.hazelcast.map.impl.recordstore.RecordStore.DEFAULT_MAX_IDLE;
+
 public class SetTTLOperation extends LockAwareOperation implements BackupAwareOperation, MutatingOperation {
 
     public SetTTLOperation() {
@@ -30,7 +32,7 @@ public class SetTTLOperation extends LockAwareOperation implements BackupAwareOp
     }
 
     public SetTTLOperation(String name, Data dataKey, long ttl) {
-        super(name, dataKey, ttl);
+        super(name, dataKey, ttl, DEFAULT_MAX_IDLE);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/TryPutOperation.java
@@ -32,7 +32,7 @@ public class TryPutOperation extends BasePutOperation implements MutatingOperati
 
     @Override
     public void run() {
-        recordStore.put(dataKey, dataValue, ttl);
+        recordStore.put(dataKey, dataValue, ttl, maxIdle);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WANAwareOperationProvider.java
@@ -53,9 +53,9 @@ public class WANAwareOperationProvider extends MapOperationProviderDelegator {
     }
 
     @Override
-    public MapOperation createPutOperation(String name, Data key, Data value, long ttl) {
+    public MapOperation createPutOperation(String name, Data key, Data value, long ttl, long maxIdle) {
         checkWanReplicationQueues(name);
-        return getDelegate().createPutOperation(name, key, value, ttl);
+        return getDelegate().createPutOperation(name, key, value, ttl, maxIdle);
     }
 
     @Override
@@ -65,21 +65,21 @@ public class WANAwareOperationProvider extends MapOperationProviderDelegator {
     }
 
     @Override
-    public MapOperation createSetOperation(String name, Data dataKey, Data value, long ttl) {
+    public MapOperation createSetOperation(String name, Data dataKey, Data value, long ttl, long maxIdle) {
         checkWanReplicationQueues(name);
-        return getDelegate().createSetOperation(name, dataKey, value, ttl);
+        return getDelegate().createSetOperation(name, dataKey, value, ttl, maxIdle);
     }
 
     @Override
-    public MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl) {
+    public MapOperation createPutIfAbsentOperation(String name, Data key, Data value, long ttl, long maxIdle) {
         checkWanReplicationQueues(name);
-        return getDelegate().createPutIfAbsentOperation(name, key, value, ttl);
+        return getDelegate().createPutIfAbsentOperation(name, key, value, ttl, maxIdle);
     }
 
     @Override
-    public MapOperation createPutTransientOperation(String name, Data key, Data value, long ttl) {
+    public MapOperation createPutTransientOperation(String name, Data key, Data value, long ttl, long maxIdle) {
         checkWanReplicationQueues(name);
-        return getDelegate().createPutTransientOperation(name, key, value, ttl);
+        return getDelegate().createPutTransientOperation(name, key, value, ttl, maxIdle);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -123,11 +123,16 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public V put(K key, V value, long ttl, TimeUnit timeunit) {
+        return put(key, value, ttl, timeunit, -1, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public V put(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
-        Data result = putInternal(key, valueData, ttl, timeunit);
+        Data result = putInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit);
         return toObject(result);
     }
 
@@ -147,21 +152,31 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public V putIfAbsent(K key, V value, long ttl, TimeUnit timeunit) {
+        return putIfAbsent(key, value, ttl, timeunit, -1, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
-        Data result = putIfAbsentInternal(key, valueData, ttl, timeunit);
+        Data result = putIfAbsentInternal(key, valueData, ttl, timeunit, maxIdle, maxIdleUnit);
         return toObject(result);
     }
 
     @Override
     public void putTransient(K key, V value, long ttl, TimeUnit timeunit) {
+        putTransient(key, value, ttl, timeunit, -1, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void putTransient(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
-        putTransientInternal(key, valueData, ttl, timeunit);
+        putTransientInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit);
     }
 
     @Override
@@ -190,12 +205,17 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     @Override
-    public void set(K key, V value, long ttl, TimeUnit timeunit) {
+    public void set(K key, V value, long ttl, TimeUnit ttlUnit) {
+        set(key, value, ttl, ttlUnit, -1, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void set(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
-        setInternal(key, valueData, ttl, timeunit);
+        setInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit);
     }
 
     @Override
@@ -299,11 +319,18 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        return putAsync(key, value, ttl, timeunit, -1, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public ICompletableFuture<V> putAsync(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
-        return new DelegatingFuture<V>(putAsyncInternal(key, valueData, ttl, timeunit), serializationService);
+        return new DelegatingFuture<V>(
+                putAsyncInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit),
+                serializationService);
     }
 
     @Override
@@ -313,11 +340,18 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
 
     @Override
     public ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit timeunit) {
+        return setAsync(key, value, ttl, timeunit, -1, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public ICompletableFuture<Void> setAsync(K key, V value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(value, NULL_VALUE_IS_NOT_ALLOWED);
 
         Data valueData = toData(value);
-        return new DelegatingFuture<Void>(setAsyncInternal(key, valueData, ttl, timeunit), serializationService);
+        return new DelegatingFuture<Void>(
+                setAsyncInternal(key, valueData, ttl, ttlUnit, maxIdle, maxIdleUnit),
+                serializationService);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -384,10 +384,11 @@ abstract class MapProxySupport<K, V>
         }
     }
 
-    protected Data putInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected Data putInternal(Object key, Data value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         Data keyData = toDataWithStrategy(key);
-        long timeInMillis = getTimeInMillis(ttl, timeunit);
-        MapOperation operation = operationProvider.createPutOperation(name, keyData, value, timeInMillis);
+        long timeInMillis = getTimeInMillis(ttl, ttlUnit);
+        long maxIdleInMillis = getTimeInMillis(maxIdle, maxIdleUnit);
+        MapOperation operation = operationProvider.createPutOperation(name, keyData, value, timeInMillis, maxIdleInMillis);
         return (Data) invokeOperation(keyData, operation);
     }
 
@@ -398,17 +399,21 @@ abstract class MapProxySupport<K, V>
         return (Boolean) invokeOperation(keyData, operation);
     }
 
-    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
         Data keyData = toDataWithStrategy(key);
         long timeInMillis = getTimeInMillis(ttl, timeunit);
-        MapOperation operation = operationProvider.createPutIfAbsentOperation(name, keyData, value, timeInMillis);
+        long maxIdleInMillis = getTimeInMillis(maxIdle, maxIdleUnit);
+        MapOperation operation = operationProvider
+                .createPutIfAbsentOperation(name, keyData, value, timeInMillis, maxIdleInMillis);
         return (Data) invokeOperation(keyData, operation);
     }
 
-    protected void putTransientInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected void putTransientInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
         Data keyData = toDataWithStrategy(key);
         long timeInMillis = getTimeInMillis(ttl, timeunit);
-        MapOperation operation = operationProvider.createPutTransientOperation(name, keyData, value, timeInMillis);
+        long maxIdleInMillis = getTimeInMillis(maxIdle, maxIdleUnit);
+        MapOperation operation = operationProvider
+                .createPutTransientOperation(name, keyData, value, timeInMillis, maxIdleInMillis);
         invokeOperation(keyData, operation);
     }
 
@@ -438,10 +443,12 @@ abstract class MapProxySupport<K, V>
         }
     }
 
-    protected InternalCompletableFuture<Data> putAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected InternalCompletableFuture<Data> putAsyncInternal(Object key, Data value, long ttl, TimeUnit ttlUnit,
+                                                               long maxIdle, TimeUnit maxIdleUnit) {
         Data keyData = toDataWithStrategy(key);
         int partitionId = partitionService.getPartitionId(keyData);
-        MapOperation operation = operationProvider.createPutOperation(name, keyData, value, getTimeInMillis(ttl, timeunit));
+        MapOperation operation = operationProvider.createPutOperation(name, keyData, value,
+                getTimeInMillis(ttl, ttlUnit), getTimeInMillis(maxIdle, maxIdleUnit));
         operation.setThreadId(getThreadId());
         try {
             long startTimeNanos = System.nanoTime();
@@ -456,10 +463,12 @@ abstract class MapProxySupport<K, V>
         }
     }
 
-    protected InternalCompletableFuture<Data> setAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected InternalCompletableFuture<Data> setAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit,
+                                                               long maxIdle, TimeUnit maxIdleUnit) {
         Data keyData = toDataWithStrategy(key);
         int partitionId = partitionService.getPartitionId(keyData);
-        MapOperation operation = operationProvider.createSetOperation(name, keyData, value, getTimeInMillis(ttl, timeunit));
+        MapOperation operation = operationProvider.createSetOperation(name, keyData, value,
+                getTimeInMillis(ttl, timeunit), getTimeInMillis(maxIdle, maxIdleUnit));
         operation.setThreadId(getThreadId());
         try {
             return operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId);
@@ -482,9 +491,10 @@ abstract class MapProxySupport<K, V>
 
     // WARNING: when UpdateEvent is fired it does *NOT* contain the oldValue
     // see this: https://github.com/hazelcast/hazelcast/pull/6088#issuecomment-136025968
-    protected void setInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected void setInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
         Data keyData = toDataWithStrategy(key);
-        MapOperation operation = operationProvider.createSetOperation(name, keyData, value, timeunit.toMillis(ttl));
+        MapOperation operation = operationProvider.createSetOperation(name, keyData, value,
+                getTimeInMillis(ttl, timeunit), getTimeInMillis(maxIdle, maxIdleUnit));
         invokeOperation(keyData, operation);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -399,18 +399,18 @@ abstract class MapProxySupport<K, V>
         return (Boolean) invokeOperation(keyData, operation);
     }
 
-    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
+    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         Data keyData = toDataWithStrategy(key);
-        long timeInMillis = getTimeInMillis(ttl, timeunit);
+        long timeInMillis = getTimeInMillis(ttl, ttlUnit);
         long maxIdleInMillis = getTimeInMillis(maxIdle, maxIdleUnit);
         MapOperation operation = operationProvider
                 .createPutIfAbsentOperation(name, keyData, value, timeInMillis, maxIdleInMillis);
         return (Data) invokeOperation(keyData, operation);
     }
 
-    protected void putTransientInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
+    protected void putTransientInternal(Object key, Data value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         Data keyData = toDataWithStrategy(key);
-        long timeInMillis = getTimeInMillis(ttl, timeunit);
+        long timeInMillis = getTimeInMillis(ttl, ttlUnit);
         long maxIdleInMillis = getTimeInMillis(maxIdle, maxIdleUnit);
         MapOperation operation = operationProvider
                 .createPutTransientOperation(name, keyData, value, timeInMillis, maxIdleInMillis);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -158,10 +158,10 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Data putInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected Data putInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.putInternal(key, value, ttl, timeunit);
+            return super.putInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
@@ -188,40 +188,42 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.putIfAbsentInternal(key, value, ttl, timeunit);
+            return super.putIfAbsentInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
     }
 
     @Override
-    protected void putTransientInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected void putTransientInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            super.putTransientInternal(key, value, ttl, timeunit);
+            super.putTransientInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
     }
 
     @Override
-    protected InternalCompletableFuture<Data> putAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected InternalCompletableFuture<Data> putAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit,
+                                                               long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.putAsyncInternal(key, value, ttl, timeunit);
+            return super.putAsyncInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
     }
 
     @Override
-    protected InternalCompletableFuture<Data> setAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected InternalCompletableFuture<Data> setAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit,
+                                                               long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.setAsyncInternal(key, value, ttl, timeunit);
+            return super.setAsyncInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
@@ -248,10 +250,10 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected void setInternal(Object key, Data value, long ttl, TimeUnit timeunit) {
+    protected void setInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            super.setInternal(key, value, ttl, timeunit);
+            super.setInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/NearCachedMapProxyImpl.java
@@ -158,10 +158,10 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Data putInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
+    protected Data putInternal(Object key, Data value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.putInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
+            return super.putInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
@@ -188,42 +188,42 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
+    protected Data putIfAbsentInternal(Object key, Data value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.putIfAbsentInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
+            return super.putIfAbsentInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
     }
 
     @Override
-    protected void putTransientInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
+    protected void putTransientInternal(Object key, Data value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            super.putTransientInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
+            super.putTransientInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
     }
 
     @Override
-    protected InternalCompletableFuture<Data> putAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit,
+    protected InternalCompletableFuture<Data> putAsyncInternal(Object key, Data value, long ttl, TimeUnit ttlUnit,
                                                                long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.putAsyncInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
+            return super.putAsyncInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
     }
 
     @Override
-    protected InternalCompletableFuture<Data> setAsyncInternal(Object key, Data value, long ttl, TimeUnit timeunit,
+    protected InternalCompletableFuture<Data> setAsyncInternal(Object key, Data value, long ttl, TimeUnit ttlUnit,
                                                                long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            return super.setAsyncInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
+            return super.setAsyncInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }
@@ -250,10 +250,10 @@ public class NearCachedMapProxyImpl<K, V> extends MapProxyImpl<K, V> {
     }
 
     @Override
-    protected void setInternal(Object key, Data value, long ttl, TimeUnit timeunit, long maxIdle, TimeUnit maxIdleUnit) {
+    protected void setInternal(Object key, Data value, long ttl, TimeUnit ttlUnit, long maxIdle, TimeUnit maxIdleUnit) {
         key = toNearCacheKeyWithStrategy(key);
         try {
-            super.setInternal(key, value, ttl, timeunit, maxIdle, maxIdleUnit);
+            super.setInternal(key, value, ttl, ttlUnit, maxIdle, maxIdleUnit);
         } finally {
             invalidateNearCache(key);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
@@ -19,8 +19,11 @@ package com.hazelcast.map.impl.record;
 import com.hazelcast.nio.serialization.Data;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.util.JVMUtil.REFERENCE_COST_IN_BYTES;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * @param <V> the type of the value of Record.
@@ -28,18 +31,27 @@ import static com.hazelcast.util.JVMUtil.REFERENCE_COST_IN_BYTES;
 @SuppressWarnings("VolatileLongOrDoubleField")
 public abstract class AbstractRecord<V> implements Record<V> {
 
-    private static final int NUMBER_OF_LONGS = 6;
+    private static final int NUMBER_OF_LONGS = 2;
+    private static final int NUMBER_OF_INTS = 4;
+
+    /**
+     * Base time to be used for storing time values as diffs (int) rather than full blown epoch based vals (long)
+     * This allows for a space in seconds, of roughly 68 years.
+     */
+    private static final long CREATION_DATE_BASE = System.currentTimeMillis();
+
 
     protected Data key;
     protected long version;
-    protected long ttl;
-    protected long creationTime;
+    protected int ttl;
+    protected int maxIdle;
+    private int creationTime = NOT_AVAILABLE;
 
     @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
             justification = "Record can be accessed by only its own partition thread.")
     protected volatile long hits;
-    protected volatile long lastAccessTime;
-    protected volatile long lastUpdateTime;
+    private volatile int lastAccessTime = NOT_AVAILABLE;
+    private volatile int lastUpdateTime = NOT_AVAILABLE;
 
     AbstractRecord() {
     }
@@ -61,37 +73,56 @@ public abstract class AbstractRecord<V> implements Record<V> {
 
     @Override
     public void setTtl(long ttl) {
-        this.ttl = ttl;
+        long ttlSeconds = MILLISECONDS.toSeconds(ttl);
+        if (ttlSeconds == 0 && ttl != 0) {
+            ttlSeconds = 1;
+        }
+
+        this.ttl =  ttlSeconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) ttlSeconds;
+    }
+
+    @Override
+    public long getMaxIdle() {
+        return SECONDS.toMillis(maxIdle);
+    }
+
+    @Override
+    public void setMaxIdle(long maxIdle) {
+        long maxIdleSeconds = MILLISECONDS.toSeconds(maxIdle);
+        if (maxIdleSeconds == 0 && maxIdle != 0) {
+            maxIdleSeconds = 1;
+        }
+        this.maxIdle = maxIdleSeconds > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) maxIdleSeconds;
     }
 
     @Override
     public long getLastAccessTime() {
-        return lastAccessTime;
+        return recomputeWithBaseTime(lastAccessTime);
     }
 
     @Override
     public void setLastAccessTime(long lastAccessTime) {
-        this.lastAccessTime = lastAccessTime;
+        this.lastAccessTime = stripBaseTime(lastAccessTime);
     }
 
     @Override
     public long getLastUpdateTime() {
-        return lastUpdateTime;
+        return recomputeWithBaseTime(lastUpdateTime);
     }
 
     @Override
     public void setLastUpdateTime(long lastUpdateTime) {
-        this.lastUpdateTime = lastUpdateTime;
+        this.lastUpdateTime = stripBaseTime(lastUpdateTime);
     }
 
     @Override
     public long getCreationTime() {
-        return creationTime;
+        return recomputeWithBaseTime(creationTime);
     }
 
     @Override
     public void setCreationTime(long creationTime) {
-        this.creationTime = creationTime;
+        this.creationTime = stripBaseTime(creationTime);
     }
 
     @Override
@@ -106,13 +137,13 @@ public abstract class AbstractRecord<V> implements Record<V> {
 
     @Override
     public long getCost() {
-        return REFERENCE_COST_IN_BYTES + NUMBER_OF_LONGS * LONG_SIZE_IN_BYTES;
+        return REFERENCE_COST_IN_BYTES + (NUMBER_OF_LONGS * LONG_SIZE_IN_BYTES) + (NUMBER_OF_INTS * INT_SIZE_IN_BYTES);
     }
 
     @Override
     public void onUpdate(long now) {
         version++;
-        lastUpdateTime = now;
+        lastUpdateTime = stripBaseTime(now);
     }
 
     @Override
@@ -123,7 +154,7 @@ public abstract class AbstractRecord<V> implements Record<V> {
     @Override
     public void onAccess(long now) {
         hits++;
-        lastAccessTime = now;
+        lastAccessTime = stripBaseTime(now);
     }
 
     @Override
@@ -177,16 +208,19 @@ public abstract class AbstractRecord<V> implements Record<V> {
         if (this == o) {
             return true;
         }
-
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
         AbstractRecord<?> that = (AbstractRecord<?>) o;
+
         if (version != that.version) {
             return false;
         }
         if (ttl != that.ttl) {
+            return false;
+        }
+        if (maxIdle != that.maxIdle) {
             return false;
         }
         if (creationTime != that.creationTime) {
@@ -209,10 +243,31 @@ public abstract class AbstractRecord<V> implements Record<V> {
         int result = key.hashCode();
         result = 31 * result + (int) (version ^ (version >>> 32));
         result = 31 * result + (int) (ttl ^ (ttl >>> 32));
-        result = 31 * result + (int) (creationTime ^ (creationTime >>> 32));
+        result = 31 * result + (int) (maxIdle ^ (maxIdle >>> 32));
+        result = 31 * result + creationTime;
         result = 31 * result + (int) (hits ^ (hits >>> 32));
-        result = 31 * result + (int) (lastAccessTime ^ (lastAccessTime >>> 32));
-        result = 31 * result + (int) (lastUpdateTime ^ (lastUpdateTime >>> 32));
+        result = 31 * result + lastAccessTime;
+        result = 31 * result + lastUpdateTime;
         return result;
+    }
+
+    protected long recomputeWithBaseTime(int value) {
+        if (value == NOT_AVAILABLE) {
+            return 0L;
+        }
+
+        long exploded = SECONDS.toMillis(value);
+        return exploded + CREATION_DATE_BASE;
+    }
+
+    protected int stripBaseTime(long value) {
+        int diff = NOT_AVAILABLE;
+        if (value > 0) {
+            diff = (int) MILLISECONDS.toSeconds(value - CREATION_DATE_BASE);
+            // overflow - should not happen, 2^31 seconds ~ 70 years
+            assert diff >= 0 : "Diff is not supposed to overflow " + diff + " Value: " + value + " Base: " + CREATION_DATE_BASE;
+        }
+
+        return diff;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
@@ -28,11 +28,11 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 /**
  * @param <V> the type of the value of Record.
  */
-@SuppressWarnings("VolatileLongOrDoubleField")
+@SuppressWarnings({ "checkstyle:methodcount", "VolatileLongOrDoubleField" })
 public abstract class AbstractRecord<V> implements Record<V> {
 
     private static final int NUMBER_OF_LONGS = 2;
-    private static final int NUMBER_OF_INTS = 4;
+    private static final int NUMBER_OF_INTS = 5;
 
     /**
      * Base time to be used for storing time values as diffs (int) rather than full blown epoch based vals (long)
@@ -45,13 +45,13 @@ public abstract class AbstractRecord<V> implements Record<V> {
     protected long version;
     protected int ttl;
     protected int maxIdle;
-    private int creationTime = NOT_AVAILABLE;
 
     @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
             justification = "Record can be accessed by only its own partition thread.")
     protected volatile long hits;
     private volatile int lastAccessTime = NOT_AVAILABLE;
     private volatile int lastUpdateTime = NOT_AVAILABLE;
+    private int creationTime = NOT_AVAILABLE;
 
     AbstractRecord() {
     }
@@ -68,7 +68,7 @@ public abstract class AbstractRecord<V> implements Record<V> {
 
     @Override
     public long getTtl() {
-        return ttl;
+        return ttl == Integer.MAX_VALUE ? Long.MAX_VALUE : SECONDS.toMillis(ttl);
     }
 
     @Override
@@ -83,7 +83,7 @@ public abstract class AbstractRecord<V> implements Record<V> {
 
     @Override
     public long getMaxIdle() {
-        return SECONDS.toMillis(maxIdle);
+        return maxIdle == Integer.MAX_VALUE ? Long.MAX_VALUE : SECONDS.toMillis(maxIdle);
     }
 
     @Override
@@ -240,10 +240,10 @@ public abstract class AbstractRecord<V> implements Record<V> {
 
     @Override
     public int hashCode() {
-        int result = key.hashCode();
+        int result = key != null ? key.hashCode() : 0;
         result = 31 * result + (int) (version ^ (version >>> 32));
-        result = 31 * result + (int) (ttl ^ (ttl >>> 32));
-        result = 31 * result + (int) (maxIdle ^ (maxIdle >>> 32));
+        result = 31 * result + ttl;
+        result = 31 * result + maxIdle;
         result = 31 * result + creationTime;
         result = 31 * result + (int) (hits ^ (hits >>> 32));
         result = 31 * result + lastAccessTime;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecordWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecordWithStats.java
@@ -18,48 +18,48 @@ package com.hazelcast.map.impl.record;
 
 import com.hazelcast.util.Clock;
 
-import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
+import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
 
 /**
  * @param <V> type of {@link AbstractRecord}
  */
 abstract class AbstractRecordWithStats<V> extends AbstractRecord<V> {
 
-    protected long lastStoredTime;
-    protected long expirationTime;
+    protected int lastStoredTime;
+    protected int expirationTime;
 
     AbstractRecordWithStats() {
     }
 
     @Override
     public final void onStore() {
-        lastStoredTime = Clock.currentTimeMillis();
+        lastStoredTime = stripBaseTime(Clock.currentTimeMillis());
     }
 
     @Override
     public long getCost() {
-        final int numberOfLongFields = 2;
-        return super.getCost() + numberOfLongFields * LONG_SIZE_IN_BYTES;
+        final int numberOfIntFields = 2;
+        return super.getCost() + numberOfIntFields * INT_SIZE_IN_BYTES;
     }
 
     @Override
     public long getExpirationTime() {
-        return expirationTime;
+        return recomputeWithBaseTime(expirationTime);
     }
 
     @Override
     public void setExpirationTime(long expirationTime) {
-        this.expirationTime = expirationTime;
+        this.expirationTime = stripBaseTime(expirationTime);
     }
 
     @Override
     public long getLastStoredTime() {
-        return lastStoredTime;
+        return recomputeWithBaseTime(lastStoredTime);
     }
 
     @Override
     public void setLastStoredTime(long lastStoredTime) {
-        this.lastStoredTime = lastStoredTime;
+        this.lastStoredTime = stripBaseTime(lastStoredTime);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/DataRecordFactory.java
@@ -42,12 +42,16 @@ public class DataRecordFactory implements RecordFactory<Data> {
         assert value != null : "value can not be null";
 
         final Data data = serializationService.toData(value, partitionStrategy);
+        Record<Data> record;
         switch (cacheDeserializedValues) {
             case NEVER:
-                return statisticsEnabled ? new DataRecordWithStats(data) : new DataRecord(data);
+                record = statisticsEnabled ? new DataRecordWithStats(data) : new DataRecord(data);
+                break;
             default:
-                return statisticsEnabled ? new CachedDataRecordWithStats(data) : new CachedDataRecord(data);
+                record = statisticsEnabled ? new CachedDataRecordWithStats(data) : new CachedDataRecord(data);
         }
+
+        return record;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/ObjectRecordFactory.java
@@ -35,7 +35,8 @@ public class ObjectRecordFactory implements RecordFactory<Object> {
         assert value != null : "value can not be null";
 
         Object objectValue = serializationService.toObject(value);
-        return statisticsEnabled ? new ObjectRecordWithStats(objectValue) : new ObjectRecord(objectValue);
+        Record<Object> record = statisticsEnabled ? new ObjectRecordWithStats(objectValue) : new ObjectRecord(objectValue);
+        return record;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/Record.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/Record.java
@@ -32,6 +32,8 @@ public interface Record<V> {
 
     Data getKey();
 
+    void setKey(Data key);
+
     V getValue();
 
     void setValue(V value);
@@ -77,6 +79,10 @@ public interface Record<V> {
     long getTtl();
 
     void setTtl(long ttl);
+
+    long getMaxIdle();
+
+    void setMaxIdle(long maxIdle);
 
     long getLastAccessTime();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/RecordInfo.java
@@ -31,6 +31,7 @@ import static com.hazelcast.map.impl.record.Record.NOT_AVAILABLE;
 public class RecordInfo implements IdentifiedDataSerializable {
     protected long version;
     protected long ttl;
+    protected long maxIdle;
     protected long creationTime;
     protected long lastAccessTime;
     protected long lastUpdateTime;
@@ -46,6 +47,7 @@ public class RecordInfo implements IdentifiedDataSerializable {
         this.version = recordInfo.version;
         this.hits = recordInfo.hits;
         this.ttl = recordInfo.ttl;
+        this.maxIdle = recordInfo.maxIdle;
         this.creationTime = recordInfo.creationTime;
         this.lastAccessTime = recordInfo.lastAccessTime;
         this.lastUpdateTime = recordInfo.lastUpdateTime;
@@ -77,6 +79,14 @@ public class RecordInfo implements IdentifiedDataSerializable {
 
     public void setTtl(long ttl) {
         this.ttl = ttl;
+    }
+
+    public long getMaxIdle() {
+        return maxIdle;
+    }
+
+    public void setMaxIdle(long maxIdle) {
+        this.maxIdle = maxIdle;
     }
 
     public long getCreationTime() {
@@ -127,6 +137,7 @@ public class RecordInfo implements IdentifiedDataSerializable {
         out.writeLong(creationTime);
         out.writeLong(lastAccessTime);
         out.writeLong(lastUpdateTime);
+        out.writeLong(maxIdle);
 
         boolean statsEnabled = !(lastStoredTime == NOT_AVAILABLE && expirationTime == NOT_AVAILABLE);
         out.writeBoolean(statsEnabled);
@@ -144,6 +155,7 @@ public class RecordInfo implements IdentifiedDataSerializable {
         creationTime = in.readLong();
         lastAccessTime = in.readLong();
         lastUpdateTime = in.readLong();
+        maxIdle = in.readLong();
 
         boolean statsEnabled = in.readBoolean();
         lastStoredTime = statsEnabled ? in.readLong() : NOT_AVAILABLE;
@@ -157,6 +169,7 @@ public class RecordInfo implements IdentifiedDataSerializable {
                 + "creationTime=" + creationTime
                 + ", version=" + version
                 + ", ttl=" + ttl
+                + ", maxIdle=" + maxIdle
                 + ", lastAccessTime=" + lastAccessTime
                 + ", lastUpdateTime=" + lastUpdateTime
                 + ", hits=" + hits

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/Records.java
@@ -33,6 +33,7 @@ public final class Records {
         record.setVersion(replicationInfo.getVersion());
         record.setHits(replicationInfo.getHits());
         record.setTtl(replicationInfo.getTtl());
+        record.setMaxIdle(replicationInfo.getMaxIdle());
         record.setCreationTime(replicationInfo.getCreationTime());
         record.setLastAccessTime(replicationInfo.getLastAccessTime());
         record.setLastUpdateTime(replicationInfo.getLastUpdateTime());
@@ -49,6 +50,7 @@ public final class Records {
         info.setLastAccessTime(record.getLastAccessTime());
         info.setLastUpdateTime(record.getLastUpdateTime());
         info.setTtl(record.getTtl());
+        info.setMaxIdle(record.getMaxIdle());
         info.setExpirationTime(record.getExpirationTime());
         info.setLastStoredTime(record.getLastStoredTime());
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -43,7 +43,7 @@ import com.hazelcast.wan.impl.CallerProvenance;
 import javax.annotation.Nonnull;
 import java.util.Collection;
 
-import static com.hazelcast.map.impl.ExpirationTimeSetter.setTTLAndUpdateExpiryTime;
+import static com.hazelcast.map.impl.ExpirationTimeSetter.setExpirationTimes;
 
 
 /**
@@ -107,12 +107,12 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
     }
 
     @Override
-    public Record createRecord(Object value, long ttlMillis, long now) {
+    public Record createRecord(Object value, long ttlMillis, long maxIdle, long now) {
         Record record = recordFactory.newRecord(value);
         record.setCreationTime(now);
         record.setLastUpdateTime(now);
 
-        setTTLAndUpdateExpiryTime(ttlMillis, record, mapContainer.getMapConfig(), true);
+        setExpirationTimes(ttlMillis, maxIdle, record, mapContainer.getMapConfig(), true);
         updateStatsOnPut(false, now);
         return record;
     }
@@ -238,4 +238,5 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
         stats.setLastAccessTime(now);
         stats.increaseHits();
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecord.java
@@ -106,6 +106,11 @@ public class LazyEntryViewFromRecord<R extends Record> extends SampleableConcurr
         return record.getTtl();
     }
 
+    @Override
+    public long getMaxIdle() {
+        return record.getMaxIdle();
+    }
+
     public Record getRecord() {
         return record;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -50,6 +50,11 @@ public interface RecordStore<R extends Record> {
      */
     long DEFAULT_TTL = -1L;
 
+    /**
+     * Default Max Idle value of a record.
+     */
+    long DEFAULT_MAX_IDLE = -1L;
+
     LocalRecordStoreStats getLocalRecordStoreStats();
 
     String getName();
@@ -58,15 +63,15 @@ public interface RecordStore<R extends Record> {
      * @return oldValue only if it exists in memory, otherwise just returns
      * null and doesn't try to load it from {@link com.hazelcast.core.MapLoader}
      */
-    Object set(Data dataKey, Object value, long ttl);
+    Object set(Data dataKey, Object value, long ttl, long maxIdle);
 
     /**
      * @return oldValue if it exists in memory otherwise tries to load oldValue
      * by using {@link com.hazelcast.core.MapLoader}
      */
-    Object put(Data dataKey, Object dataValue, long ttl);
+    Object put(Data dataKey, Object dataValue, long ttl, long maxIdle);
 
-    Object putIfAbsent(Data dataKey, Object value, long ttl, Address callerAddress);
+    Object putIfAbsent(Data dataKey, Object value, long ttl, long maxIdle, Address callerAddress);
 
     /**
      * @param key        the key
@@ -80,17 +85,18 @@ public interface RecordStore<R extends Record> {
      * @param key          the key to be processed.
      * @param value        the value to be processed.
      * @param ttl          milliseconds. Check out {@link com.hazelcast.map.impl.proxy.MapProxySupport#putInternal}
+     * @param maxIdle      milliseconds. Check out {@link com.hazelcast.map.impl.proxy.MapProxySupport#putInternal}
      * @param putTransient {@code true} if putting transient entry, otherwise {@code false}
      * @param provenance   origin of call to this method.
      * @return previous record if exists otherwise null.
      */
-    R putBackup(Data key, Object value, long ttl, boolean putTransient, CallerProvenance provenance);
+    R putBackup(Data key, Object value, long ttl, long maxIdle, boolean putTransient, CallerProvenance provenance);
 
     /**
-     * Does exactly the same thing as {@link #set(Data, Object, long)} except the invocation is not counted as
+     * Does exactly the same thing as {@link #set(Data, Object, long, long)} except the invocation is not counted as
      * a read access while updating the access statics.
      */
-    boolean setWithUncountedAccess(Data dataKey, Object value, long ttl);
+    boolean setWithUncountedAccess(Data dataKey, Object value, long ttl, long maxIdle);
 
     /**
      * @param key        the key to be removed
@@ -165,7 +171,7 @@ public interface RecordStore<R extends Record> {
      */
     boolean replace(Data dataKey, Object expect, Object update);
 
-    Object putTransient(Data dataKey, Object value, long ttl);
+    Object putTransient(Data dataKey, Object value, long ttl, long maxIdle);
 
     /**
      * Puts key-value pair to map which is the result of a load from map store operation.
@@ -405,7 +411,7 @@ public interface RecordStore<R extends Record> {
 
     Storage createStorage(RecordFactory<R> recordFactory, InMemoryFormat memoryFormat);
 
-    Record createRecord(Object value, long ttlMillis, long now);
+    Record createRecord(Object value, long ttlMillis, long maxIdle, long now);
 
     Record loadRecordOrNull(Data key, boolean backup, Address callerAddress);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/StorageImpl.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.map.impl.EntryCostEstimator;
 import com.hazelcast.map.impl.iterator.MapEntriesWithCursor;
 import com.hazelcast.map.impl.iterator.MapKeysWithCursor;
-import com.hazelcast.map.impl.record.AbstractRecord;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordFactory;
 import com.hazelcast.nio.serialization.Data;
@@ -74,7 +73,7 @@ public class StorageImpl<R extends Record> implements Storage<Data, R> {
     @Override
     public void put(Data key, R record) {
 
-        ((AbstractRecord) record).setKey(key);
+        record.setKey(key);
 
         R previousRecord = records.put(key, record);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -211,7 +211,8 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
     Data putInternal(Data key, Data value, long ttl, TimeUnit timeUnit) {
         VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
         long timeInMillis = getTimeInMillis(ttl, timeUnit);
-        MapOperation operation = operationProvider.createTxnSetOperation(name, key, value, versionedValue.version, timeInMillis);
+        MapOperation operation = operationProvider.createTxnSetOperation(name, key, value, versionedValue.version,
+                timeInMillis);
         tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
         return versionedValue.value;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnLockAndGetOperation.java
@@ -42,7 +42,7 @@ public class TxnLockAndGetOperation extends LockAwareOperation implements Mutati
 
     public TxnLockAndGetOperation(String name, Data dataKey, long timeout, long ttl, String ownerUuid,
                                   boolean shouldLoad, boolean blockReads) {
-        super(name, dataKey, ttl);
+        super(name, dataKey, ttl, -1);
         this.ownerUuid = ownerUuid;
         this.shouldLoad = shouldLoad;
         this.blockReads = blockReads;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -78,7 +78,7 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
                 dataOldValue = record == null ? null : mapServiceContext.toData(record.getValue());
             }
             eventType = record == null ? EntryEventType.ADDED : EntryEventType.UPDATED;
-            recordStore.set(dataKey, dataValue, ttl);
+            recordStore.set(dataKey, dataValue, ttl, maxIdle);
             shouldBackup = true;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockBackupOperation.java
@@ -36,7 +36,7 @@ public class TxnUnlockBackupOperation extends KeyBasedMapOperation implements Ba
     }
 
     public TxnUnlockBackupOperation(String name, Data dataKey, String ownerUuid) {
-        super(name, dataKey, -1);
+        super(name, dataKey, -1, -1);
         this.ownerUuid = ownerUuid;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnUnlockOperation.java
@@ -41,7 +41,7 @@ public class TxnUnlockOperation extends LockAwareOperation implements MapTxnOper
     }
 
     public TxnUnlockOperation(String name, Data dataKey, long version) {
-        super(name, dataKey, -1);
+        super(name, dataKey, -1, -1);
         this.version = version;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedMapEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedMapEntryView.java
@@ -21,11 +21,15 @@ import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.replicatedmap.impl.operation.ReplicatedMapDataSerializerHook;
 
 import java.io.IOException;
 
-public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSerializable {
+import static com.hazelcast.internal.cluster.Versions.V3_11;
+
+public class ReplicatedMapEntryView<K, V>
+        implements EntryView, IdentifiedDataSerializable, Versioned {
 
     private static final int NOT_AVAILABLE = -1;
 
@@ -145,7 +149,10 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         out.writeLong(lastAccessTime);
         out.writeLong(lastUpdateTime);
         out.writeLong(ttl);
-        out.writeLong(maxIdle);
+        //RU_COMPAT_3_10
+        if (out.getVersion().isGreaterOrEqual(V3_11)) {
+            out.writeLong(maxIdle);
+        }
     }
 
     @Override
@@ -157,7 +164,10 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         lastAccessTime = in.readLong();
         lastUpdateTime = in.readLong();
         ttl = in.readLong();
-        maxIdle = in.readLong();
+        //RU_COMPAT_3_10
+        if (in.getVersion().isGreaterOrEqual(V3_11)) {
+            maxIdle = in.readLong();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedMapEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedMapEntryView.java
@@ -36,6 +36,7 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
     private long lastAccessTime;
     private long lastUpdateTime;
     private long ttl;
+    private long maxIdle;
 
     public ReplicatedMapEntryView() {
     }
@@ -125,6 +126,11 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         return ttl;
     }
 
+    @Override
+    public long getMaxIdle() {
+        return maxIdle;
+    }
+
     public ReplicatedMapEntryView<K, V> setTtl(long ttl) {
         this.ttl = ttl;
         return this;
@@ -139,6 +145,7 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         out.writeLong(lastAccessTime);
         out.writeLong(lastUpdateTime);
         out.writeLong(ttl);
+        out.writeLong(maxIdle);
     }
 
     @Override
@@ -150,6 +157,7 @@ public class ReplicatedMapEntryView<K, V> implements EntryView, IdentifiedDataSe
         lastAccessTime = in.readLong();
         lastUpdateTime = in.readLong();
         ttl = in.readLong();
+        maxIdle = in.readLong();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
@@ -46,6 +46,7 @@ public class MapMergingEntryImpl implements MapMergeTypes, SerializationServiceA
     private long lastUpdateTime = -1;
     private long version = -1;
     private long ttl = -1;
+    private long maxIdle = -1;
 
     private transient SerializationService serializationService;
 
@@ -177,6 +178,11 @@ public class MapMergingEntryImpl implements MapMergeTypes, SerializationServiceA
     }
 
     @Override
+    public long getMaxIdle() {
+        return maxIdle;
+    }
+
+    @Override
     public void setSerializationService(SerializationService serializationService) {
         this.serializationService = serializationService;
     }
@@ -194,6 +200,7 @@ public class MapMergingEntryImpl implements MapMergeTypes, SerializationServiceA
         out.writeLong(lastUpdateTime);
         out.writeLong(version);
         out.writeLong(ttl);
+        out.writeLong(maxIdle);
     }
 
     @Override
@@ -209,6 +216,7 @@ public class MapMergingEntryImpl implements MapMergeTypes, SerializationServiceA
         lastUpdateTime = in.readLong();
         version = in.readLong();
         ttl = in.readLong();
+        maxIdle = in.readLong();
     }
 
     @Override
@@ -259,6 +267,9 @@ public class MapMergingEntryImpl implements MapMergeTypes, SerializationServiceA
         if (ttl != that.ttl) {
             return false;
         }
+        if (maxIdle != that.maxIdle) {
+            return false;
+        }
         if (key != null ? !key.equals(that.key) : that.key != null) {
             return false;
         }
@@ -278,6 +289,7 @@ public class MapMergingEntryImpl implements MapMergeTypes, SerializationServiceA
         result = 31 * result + (int) (lastUpdateTime ^ (lastUpdateTime >>> 32));
         result = 31 * result + (int) (version ^ (version >>> 32));
         result = 31 * result + (int) (ttl ^ (ttl >>> 32));
+        result = 31 * result + (int) (maxIdle ^ (maxIdle >>> 32));
         return result;
     }
 
@@ -295,6 +307,7 @@ public class MapMergingEntryImpl implements MapMergeTypes, SerializationServiceA
                 + ", lastUpdateTime=" + lastUpdateTime
                 + ", version=" + version
                 + ", ttl=" + ttl
+                + ", maxIdle=" + maxIdle
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
@@ -186,6 +186,11 @@ public class MapMergingEntryImpl
         return maxIdle;
     }
 
+    public MapMergingEntryImpl setMaxIdle(long maxIdle) {
+        this.maxIdle = maxIdle;
+        return this;
+    }
+
     @Override
     public void setSerializationService(SerializationService serializationService) {
         this.serializationService = serializationService;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
@@ -21,11 +21,14 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.spi.serialization.SerializationServiceAware;
 
 import java.io.IOException;
+
+import static com.hazelcast.internal.cluster.Versions.V3_11;
 
 /**
  * Implementation of {@link MapMergeTypes}.
@@ -33,7 +36,8 @@ import java.io.IOException;
  * @since 3.10
  */
 @SuppressWarnings({"WeakerAccess", "checkstyle:methodcount"})
-public class MapMergingEntryImpl implements MapMergeTypes, SerializationServiceAware, IdentifiedDataSerializable {
+public class MapMergingEntryImpl
+        implements MapMergeTypes, SerializationServiceAware, IdentifiedDataSerializable, Versioned {
 
     private Data value;
     private Data key;
@@ -200,7 +204,10 @@ public class MapMergingEntryImpl implements MapMergeTypes, SerializationServiceA
         out.writeLong(lastUpdateTime);
         out.writeLong(version);
         out.writeLong(ttl);
-        out.writeLong(maxIdle);
+        //RU_COMPAT_3_10
+        if (out.getVersion().isGreaterOrEqual(V3_11)) {
+            out.writeLong(maxIdle);
+        }
     }
 
     @Override
@@ -216,7 +223,10 @@ public class MapMergingEntryImpl implements MapMergeTypes, SerializationServiceA
         lastUpdateTime = in.readLong();
         version = in.readLong();
         ttl = in.readLong();
-        maxIdle = in.readLong();
+        //RU_COMPAT_3_10
+        if (in.getVersion().isGreaterOrEqual(V3_11)) {
+            maxIdle = in.readLong();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MergingValueFactory.java
@@ -100,6 +100,7 @@ public final class MergingValueFactory {
                 .setLastAccessTime(entryView.getLastAccessTime())
                 .setHits(entryView.getHits())
                 .setTtl(entryView.getTtl())
+                .setMaxIdle(entryView.getMaxIdle())
                 .setVersion(entryView.getVersion())
                 .setCost(entryView.getCost());
     }
@@ -116,6 +117,7 @@ public final class MergingValueFactory {
                 .setLastUpdateTime(record.getLastUpdateTime())
                 .setHits(record.getHits())
                 .setTtl(record.getTtl())
+                .setMaxIdle(record.getMaxIdle())
                 .setVersion(record.getVersion())
                 .setCost(record.getCost());
     }
@@ -132,6 +134,7 @@ public final class MergingValueFactory {
                 .setLastUpdateTime(record.getLastUpdateTime())
                 .setHits(record.getHits())
                 .setTtl(record.getTtl())
+                .setMaxIdle(record.getMaxIdle())
                 .setVersion(record.getVersion())
                 .setCost(record.getCost());
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingMaxIdle.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/MergingMaxIdle.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.merge;
+
+import com.hazelcast.spi.annotation.Beta;
+
+/**
+ * Represents a read-only view of a MaxIdle for the merging process after a split-brain.
+ *
+ * @param <V> the type of the value
+ * @since 3.10
+ */
+@Beta
+public interface MergingMaxIdle<V> extends MergingValue<V> {
+
+    /**
+     * Returns the MaxIdle of the merge data.
+     *
+     * @return the MaxIdle of the merge data
+     */
+    long getMaxIdle();
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/merge/SplitBrainMergeTypes.java
@@ -45,8 +45,8 @@ public class SplitBrainMergeTypes {
      */
     @Beta
     public interface MapMergeTypes extends MergingEntry<Data, Data>, MergingCreationTime<Data>, MergingHits<Data>,
-            MergingLastAccessTime<Data>, MergingLastUpdateTime<Data>, MergingTTL<Data>, MergingCosts<Data>, MergingVersion<Data>,
-            MergingExpirationTime<Data>, MergingLastStoredTime<Data> {
+            MergingLastAccessTime<Data>, MergingLastUpdateTime<Data>, MergingTTL<Data>, MergingMaxIdle<Data>, MergingCosts<Data>,
+            MergingVersion<Data>, MergingExpirationTime<Data>, MergingLastStoredTime<Data> {
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/MapMessageEncodeDecodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/MapMessageEncodeDecodeTest.java
@@ -55,8 +55,8 @@ public class MapMessageEncodeDecodeTest {
 
     @Test
     public void shouldEncodeDecodeCorrectly_PUT() {
-        final int calculatedSize = MapPutCodec.RequestParameters.calculateDataSize(NAME, DATA, DATA, THE_LONG, THE_LONG);
-        ClientMessage cmEncode = MapPutCodec.encodeRequest(NAME, DATA, DATA, THE_LONG, THE_LONG);
+        final int calculatedSize = MapPutCodec.RequestParameters.calculateDataSize(NAME, DATA, DATA, THE_LONG, THE_LONG, THE_LONG);
+        ClientMessage cmEncode = MapPutCodec.encodeRequest(NAME, DATA, DATA, THE_LONG, THE_LONG, THE_LONG);
         cmEncode.setVersion((short) 3).addFlag(ClientMessage.BEGIN_AND_END_FLAGS)
                 .setCorrelationId(Long.MAX_VALUE).setPartitionId(77);
 
@@ -77,6 +77,7 @@ public class MapMessageEncodeDecodeTest {
         assertEquals(DATA, decodeParams.value);
         assertEquals(THE_LONG, decodeParams.threadId);
         assertEquals(THE_LONG, decodeParams.ttl);
+        assertEquals(THE_LONG, decodeParams.maxIdle);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityFileGenerator.java
@@ -16,40 +16,57 @@
 
 package com.hazelcast.client.protocol.compatibility;
 
-import com.hazelcast.client.impl.MemberImpl;
-import com.hazelcast.client.impl.client.DistributedObjectInfo;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.*;
-import com.hazelcast.core.Member;
-import com.hazelcast.internal.serialization.impl.HeapData;
-import com.hazelcast.map.impl.SimpleEntryView;
-import com.hazelcast.map.impl.querycache.event.DefaultQueryCacheEventData;
-import com.hazelcast.map.impl.querycache.event.QueryCacheEventData;
-import com.hazelcast.mapreduce.JobPartitionState;
-import com.hazelcast.mapreduce.impl.task.JobPartitionStateImpl;
-import com.hazelcast.nio.Address;
-import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
-import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.transaction.impl.xa.SerializableXID;
 
 import java.io.DataOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.lang.reflect.Array;
-import java.net.UnknownHostException;
-import javax.transaction.xa.Xid;
-import java.util.AbstractMap;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
-import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aBoolean;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aByte;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aData;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aListOfEntry;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aListOfStringToByteArrEntry;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aListOfStringToLong;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aListOfStringToString;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aLong;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aMember;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aNamePartitionSequenceList;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aPartitionTable;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aPartitionUuidList;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aQueryCacheEventData;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aString;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.aUUID;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.anAddress;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.anEntryView;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.anInt;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.anXid;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.arrLongs;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.cacheEntryListenerConfigs;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.cacheEventDatas;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.datas;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.distributedObjectInfos;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.evictionConfig;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.hotRestartConfig;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.jobPartitionStates;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.listenerConfigs;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.longs;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.mapAttributeConfigs;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.mapIndexConfigs;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.mapStoreConfig;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.members;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.nearCacheConfig;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.queryCacheConfigs;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.queryCacheEventDatas;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.queueStoreConfig;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.ringbufferStore;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.strings;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.taskHandlers;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.timedExpiryPolicyFactoryConfig;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.uuids;
+import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.wanReplicationRef;
 
 
 public class BinaryCompatibilityFileGenerator {
@@ -300,7 +317,7 @@ public class BinaryCompatibilityFileGenerator {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
@@ -432,7 +449,7 @@ public class BinaryCompatibilityFileGenerator {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
@@ -444,7 +461,7 @@ public class BinaryCompatibilityFileGenerator {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
@@ -456,7 +473,7 @@ public class BinaryCompatibilityFileGenerator {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
@@ -468,7 +485,7 @@ public class BinaryCompatibilityFileGenerator {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityNullFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityNullFileGenerator.java
@@ -300,7 +300,7 @@ public class BinaryCompatibilityNullFileGenerator {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong ,   aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
@@ -432,7 +432,7 @@ public class BinaryCompatibilityNullFileGenerator {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong ,   aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
@@ -444,7 +444,7 @@ public class BinaryCompatibilityNullFileGenerator {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong ,   aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
@@ -456,7 +456,7 @@ public class BinaryCompatibilityNullFileGenerator {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong ,   aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }
@@ -468,7 +468,7 @@ public class BinaryCompatibilityNullFileGenerator {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(   aString ,   aData ,   aData ,   aLong ,   aLong ,   aLong   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_0.java
@@ -141,13 +141,13 @@ public class ClientCompatibilityNullTest_1_0 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
 
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
@@ -155,7 +155,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -271,7 +271,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -339,7 +339,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -397,11 +397,16 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -571,11 +576,16 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -587,11 +597,16 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -602,11 +617,16 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -618,11 +638,16 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -764,7 +789,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -808,7 +833,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -852,7 +877,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -896,7 +921,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -940,14 +965,14 @@ public class ClientCompatibilityNullTest_1_0 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
 
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(null,key));
                 }
 
 
 
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -956,14 +981,14 @@ public class ClientCompatibilityNullTest_1_0 {
             }
 
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
 
 
 
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1021,7 +1046,7 @@ public class ClientCompatibilityNullTest_1_0 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1725,7 +1750,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -1769,7 +1794,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -2195,7 +2220,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2295,7 +2320,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2507,7 +2532,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2894,7 +2919,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -3996,7 +4021,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4040,7 +4065,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4084,7 +4109,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4128,7 +4153,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4236,7 +4261,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4940,7 +4965,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
 
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -4982,7 +5007,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -4990,7 +5015,7 @@ public class ClientCompatibilityNullTest_1_0 {
                 }
 
 
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5002,7 +5027,7 @@ public class ClientCompatibilityNullTest_1_0 {
 
 
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5010,7 +5035,7 @@ public class ClientCompatibilityNullTest_1_0 {
                 }
 
 
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5415,7 +5440,7 @@ public class ClientCompatibilityNullTest_1_0 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5697,14 +5722,14 @@ public class ClientCompatibilityNullTest_1_0 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
 
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
 
 
 
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_1.java
@@ -141,13 +141,13 @@ public class ClientCompatibilityNullTest_1_1 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
 
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
@@ -155,7 +155,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -271,7 +271,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -339,7 +339,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -397,11 +397,16 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -571,11 +576,16 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -587,11 +597,16 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -602,11 +617,16 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -618,11 +638,16 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -764,7 +789,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -808,7 +833,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -852,7 +877,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -896,7 +921,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -940,14 +965,14 @@ public class ClientCompatibilityNullTest_1_1 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
 
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(null,key));
                 }
 
 
 
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -956,14 +981,14 @@ public class ClientCompatibilityNullTest_1_1 {
             }
 
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
 
 
 
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1021,7 +1046,7 @@ public class ClientCompatibilityNullTest_1_1 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1755,7 +1780,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -1799,7 +1824,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -2225,7 +2250,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2325,7 +2350,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2537,7 +2562,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2924,7 +2949,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -4026,7 +4051,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4070,7 +4095,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4114,7 +4139,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4158,7 +4183,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4266,7 +4291,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4970,7 +4995,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
 
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5012,7 +5037,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5020,7 +5045,7 @@ public class ClientCompatibilityNullTest_1_1 {
                 }
 
 
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5032,7 +5057,7 @@ public class ClientCompatibilityNullTest_1_1 {
 
 
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5040,7 +5065,7 @@ public class ClientCompatibilityNullTest_1_1 {
                 }
 
 
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5445,7 +5470,7 @@ public class ClientCompatibilityNullTest_1_1 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5742,14 +5767,14 @@ public class ClientCompatibilityNullTest_1_1 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
 
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
 
 
 
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_2.java
@@ -141,13 +141,13 @@ public class ClientCompatibilityNullTest_1_2 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
 
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
@@ -155,7 +155,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -271,7 +271,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -339,7 +339,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -397,11 +397,16 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -571,11 +576,16 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -587,11 +597,16 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -602,11 +617,16 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -618,11 +638,16 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -749,7 +774,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -793,7 +818,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -837,7 +862,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -881,7 +906,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -925,14 +950,14 @@ public class ClientCompatibilityNullTest_1_2 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
 
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(null,key));
                 }
 
 
 
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -941,14 +966,14 @@ public class ClientCompatibilityNullTest_1_2 {
             }
 
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
 
 
 
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1006,7 +1031,7 @@ public class ClientCompatibilityNullTest_1_2 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1735,7 +1760,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -1779,7 +1804,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -2185,7 +2210,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2285,7 +2310,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2497,7 +2522,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2884,7 +2909,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -3956,7 +3981,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4000,7 +4025,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4044,7 +4069,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4088,7 +4113,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4196,7 +4221,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4900,7 +4925,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
 
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -4942,7 +4967,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -4950,7 +4975,7 @@ public class ClientCompatibilityNullTest_1_2 {
                 }
 
 
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -4962,7 +4987,7 @@ public class ClientCompatibilityNullTest_1_2 {
 
 
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -4970,7 +4995,7 @@ public class ClientCompatibilityNullTest_1_2 {
                 }
 
 
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5375,7 +5400,7 @@ public class ClientCompatibilityNullTest_1_2 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5672,14 +5697,14 @@ public class ClientCompatibilityNullTest_1_2 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
 
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
 
 
 
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_3.java
@@ -131,13 +131,13 @@ public class ClientCompatibilityNullTest_1_3 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
 
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
@@ -145,7 +145,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -261,7 +261,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -329,7 +329,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -387,11 +387,16 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -561,11 +566,16 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -577,11 +587,16 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -592,11 +607,16 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -608,11 +628,16 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -739,7 +764,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -783,7 +808,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -827,7 +852,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -871,7 +896,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -915,14 +940,14 @@ public class ClientCompatibilityNullTest_1_3 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
 
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(null,key));
                 }
 
 
 
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -931,14 +956,14 @@ public class ClientCompatibilityNullTest_1_3 {
             }
 
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
 
 
 
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -996,7 +1021,7 @@ public class ClientCompatibilityNullTest_1_3 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1725,7 +1750,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -1769,7 +1794,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -2175,7 +2200,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2275,7 +2300,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2487,7 +2512,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2874,7 +2899,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -3946,7 +3971,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -3990,7 +4015,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4034,7 +4059,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4078,7 +4103,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4186,7 +4211,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4890,7 +4915,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
 
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -4932,7 +4957,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -4940,7 +4965,7 @@ public class ClientCompatibilityNullTest_1_3 {
                 }
 
 
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -4952,7 +4977,7 @@ public class ClientCompatibilityNullTest_1_3 {
 
 
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -4960,7 +4985,7 @@ public class ClientCompatibilityNullTest_1_3 {
                 }
 
 
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5365,7 +5390,7 @@ public class ClientCompatibilityNullTest_1_3 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5662,14 +5687,14 @@ public class ClientCompatibilityNullTest_1_3 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
 
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
 
 
 
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_4.java
@@ -131,13 +131,13 @@ public class ClientCompatibilityNullTest_1_4 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
 
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
@@ -145,7 +145,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -261,7 +261,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -329,7 +329,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -387,11 +387,16 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -561,11 +566,16 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -577,11 +587,16 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -592,11 +607,16 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -608,11 +628,16 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -739,7 +764,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -783,7 +808,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -827,7 +852,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -871,7 +896,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -910,14 +935,14 @@ public class ClientCompatibilityNullTest_1_4 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
 
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(null,key));
                 }
 
 
 
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -926,14 +951,14 @@ public class ClientCompatibilityNullTest_1_4 {
             }
 
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
 
 
 
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -991,7 +1016,7 @@ public class ClientCompatibilityNullTest_1_4 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1611,14 +1636,14 @@ public class ClientCompatibilityNullTest_1_4 {
     class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
 
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(null,key));
                 }
 
 
 
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -1627,14 +1652,14 @@ public class ClientCompatibilityNullTest_1_4 {
             }
 
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
 
 
 
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1881,7 +1906,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -1925,7 +1950,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -2331,7 +2356,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2431,7 +2456,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2643,7 +2668,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -3030,7 +3055,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -4102,7 +4127,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4146,7 +4171,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4190,7 +4215,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4234,7 +4259,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4342,7 +4367,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -5046,7 +5071,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
 
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5083,7 +5108,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5091,7 +5116,7 @@ public class ClientCompatibilityNullTest_1_4 {
                 }
 
 
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5103,7 +5128,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5111,7 +5136,7 @@ public class ClientCompatibilityNullTest_1_4 {
                 }
 
 
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5516,7 +5541,7 @@ public class ClientCompatibilityNullTest_1_4 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5600,7 +5625,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5608,7 +5633,7 @@ public class ClientCompatibilityNullTest_1_4 {
                 }
 
 
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5620,7 +5645,7 @@ public class ClientCompatibilityNullTest_1_4 {
 
 
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5628,7 +5653,7 @@ public class ClientCompatibilityNullTest_1_4 {
                 }
 
 
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5913,14 +5938,14 @@ public class ClientCompatibilityNullTest_1_4 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
 
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
 
 
 
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_5.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_5.java
@@ -131,13 +131,13 @@ public class ClientCompatibilityNullTest_1_5 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
 
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
@@ -145,7 +145,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -256,7 +256,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -324,7 +324,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -419,7 +419,7 @@ public class ClientCompatibilityNullTest_1_5 {
     class ClientAddPartitionListenerCodecHandler extends ClientAddPartitionListenerCodec.AbstractEventHandler {
 
 
-            public void  handlePartitionsEventV15(java.util.Collection<java.util.Map.Entry<com.hazelcast.nio.Address,java.util.List<java.lang.Integer>>> partitions, int partitionStateVersion) {
+            public void  handlePartitionsEventV15(Collection<Map.Entry<Address,List<Integer>>> partitions, int partitionStateVersion) {
                    
  assertTrue(isEqual(aPartitionTable,partitions));
  assertTrue(isEqual(anInt,partitionStateVersion));
@@ -439,11 +439,16 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -613,11 +618,16 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -629,11 +639,16 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -644,11 +659,16 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -660,11 +680,16 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -791,7 +816,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -835,7 +860,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -879,7 +904,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -923,7 +948,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -962,14 +987,14 @@ public class ClientCompatibilityNullTest_1_5 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
 
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(null,key));
                 }
 
 
 
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -978,14 +1003,14 @@ public class ClientCompatibilityNullTest_1_5 {
             }
 
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
 
 
 
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1043,7 +1068,7 @@ public class ClientCompatibilityNullTest_1_5 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1663,14 +1688,14 @@ public class ClientCompatibilityNullTest_1_5 {
     class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
 
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(null,key));
                 }
 
 
 
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -1679,14 +1704,14 @@ public class ClientCompatibilityNullTest_1_5 {
             }
 
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
 
 
 
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1985,7 +2010,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -2029,7 +2054,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -2435,7 +2460,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2535,7 +2560,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2747,7 +2772,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -3134,7 +3159,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -4206,7 +4231,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4250,7 +4275,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4294,7 +4319,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4338,7 +4363,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4446,7 +4471,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -5150,7 +5175,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
 
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5187,7 +5212,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5195,7 +5220,7 @@ public class ClientCompatibilityNullTest_1_5 {
                 }
 
 
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5207,7 +5232,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5215,7 +5240,7 @@ public class ClientCompatibilityNullTest_1_5 {
                 }
 
 
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5620,7 +5645,7 @@ public class ClientCompatibilityNullTest_1_5 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5704,7 +5729,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5712,7 +5737,7 @@ public class ClientCompatibilityNullTest_1_5 {
                 }
 
 
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5724,7 +5749,7 @@ public class ClientCompatibilityNullTest_1_5 {
 
 
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5732,7 +5757,7 @@ public class ClientCompatibilityNullTest_1_5 {
                 }
 
 
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -6054,14 +6079,14 @@ public class ClientCompatibilityNullTest_1_5 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
 
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
 
 
 
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_6.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityNullTest_1_6.java
@@ -131,13 +131,13 @@ public class ClientCompatibilityNullTest_1_6 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
 
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
@@ -145,7 +145,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -256,7 +256,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -324,7 +324,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -419,7 +419,7 @@ public class ClientCompatibilityNullTest_1_6 {
     class ClientAddPartitionListenerCodecHandler extends ClientAddPartitionListenerCodec.AbstractEventHandler {
 
 
-            public void  handlePartitionsEventV15(java.util.Collection<java.util.Map.Entry<com.hazelcast.nio.Address,java.util.List<java.lang.Integer>>> partitions, int partitionStateVersion) {
+            public void  handlePartitionsEventV15(Collection<Map.Entry<Address,List<Integer>>> partitions, int partitionStateVersion) {
                    
  assertTrue(isEqual(aPartitionTable,partitions));
  assertTrue(isEqual(anInt,partitionStateVersion));
@@ -452,11 +452,16 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -626,11 +631,16 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -642,11 +652,16 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -657,11 +672,16 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -673,11 +693,16 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
     int length = inputStream.readInt();
@@ -804,7 +829,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -848,7 +873,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -892,7 +917,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -936,7 +961,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -975,14 +1000,14 @@ public class ClientCompatibilityNullTest_1_6 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
 
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(null,key));
                 }
 
 
 
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -991,14 +1016,14 @@ public class ClientCompatibilityNullTest_1_6 {
             }
 
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
 
 
 
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1056,7 +1081,7 @@ public class ClientCompatibilityNullTest_1_6 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1676,14 +1701,14 @@ public class ClientCompatibilityNullTest_1_6 {
     class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
 
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(null,key));
                 }
 
 
 
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -1692,14 +1717,14 @@ public class ClientCompatibilityNullTest_1_6 {
             }
 
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
 
 
 
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1993,7 +2018,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -2037,7 +2062,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -2456,7 +2481,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2556,7 +2581,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2768,7 +2793,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -3155,7 +3180,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -4240,7 +4265,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4284,7 +4309,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4328,7 +4353,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4372,7 +4397,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -4480,7 +4505,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -5198,7 +5223,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
 
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5235,7 +5260,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5243,7 +5268,7 @@ public class ClientCompatibilityNullTest_1_6 {
                 }
 
 
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5255,7 +5280,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5263,7 +5288,7 @@ public class ClientCompatibilityNullTest_1_6 {
                 }
 
 
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5668,7 +5693,7 @@ public class ClientCompatibilityNullTest_1_6 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5752,7 +5777,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5760,7 +5785,7 @@ public class ClientCompatibilityNullTest_1_6 {
                 }
 
 
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -5772,7 +5797,7 @@ public class ClientCompatibilityNullTest_1_6 {
 
 
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5780,7 +5805,7 @@ public class ClientCompatibilityNullTest_1_6 {
                 }
 
 
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -6097,14 +6122,14 @@ public class ClientCompatibilityNullTest_1_6 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
 
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
 
 
 
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_0.java
@@ -143,18 +143,18 @@ public class ClientCompatibilityTest_1_0 {
 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
             @Override
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
             @Override
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -273,7 +273,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -342,7 +342,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -401,11 +401,16 @@ public class ClientCompatibilityTest_1_0 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -586,11 +591,16 @@ public class ClientCompatibilityTest_1_0 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -603,11 +613,16 @@ public class ClientCompatibilityTest_1_0 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -619,11 +634,16 @@ public class ClientCompatibilityTest_1_0 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -636,11 +656,16 @@ public class ClientCompatibilityTest_1_0 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -784,7 +809,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -823,7 +848,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -862,7 +887,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -901,7 +926,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -945,12 +970,12 @@ public class ClientCompatibilityTest_1_0 {
 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -958,12 +983,12 @@ public class ClientCompatibilityTest_1_0 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1022,7 +1047,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1760,7 +1785,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -1799,7 +1824,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -2246,7 +2271,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2348,7 +2373,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2569,7 +2594,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2976,7 +3001,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -4130,7 +4155,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4169,7 +4194,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4208,7 +4233,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4247,7 +4272,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4354,7 +4379,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -5091,7 +5116,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5131,14 +5156,14 @@ public class ClientCompatibilityTest_1_0 {
 {
     class CacheAddInvalidationListenerCodecHandler extends CacheAddInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -5147,14 +5172,14 @@ public class ClientCompatibilityTest_1_0 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5582,7 +5607,7 @@ public class ClientCompatibilityTest_1_0 {
 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5877,12 +5902,12 @@ public class ClientCompatibilityTest_1_0 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
             @Override
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_1.java
@@ -143,18 +143,18 @@ public class ClientCompatibilityTest_1_1 {
 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
             @Override
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
             @Override
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -273,7 +273,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -342,7 +342,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -401,11 +401,16 @@ public class ClientCompatibilityTest_1_1 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -586,11 +591,16 @@ public class ClientCompatibilityTest_1_1 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -603,11 +613,16 @@ public class ClientCompatibilityTest_1_1 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -619,11 +634,16 @@ public class ClientCompatibilityTest_1_1 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -636,11 +656,16 @@ public class ClientCompatibilityTest_1_1 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -784,7 +809,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -823,7 +848,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -862,7 +887,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -901,7 +926,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -945,12 +970,12 @@ public class ClientCompatibilityTest_1_1 {
 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -958,12 +983,12 @@ public class ClientCompatibilityTest_1_1 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1022,7 +1047,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1792,7 +1817,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -1831,7 +1856,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -2278,7 +2303,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2380,7 +2405,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2601,7 +2626,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -3008,7 +3033,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -4162,7 +4187,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4201,7 +4226,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4240,7 +4265,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4279,7 +4304,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4386,7 +4411,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -5123,7 +5148,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5163,14 +5188,14 @@ public class ClientCompatibilityTest_1_1 {
 {
     class CacheAddInvalidationListenerCodecHandler extends CacheAddInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -5179,14 +5204,14 @@ public class ClientCompatibilityTest_1_1 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5614,7 +5639,7 @@ public class ClientCompatibilityTest_1_1 {
 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5925,12 +5950,12 @@ public class ClientCompatibilityTest_1_1 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
             @Override
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_2.java
@@ -143,18 +143,18 @@ public class ClientCompatibilityTest_1_2 {
 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
             @Override
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
             @Override
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -273,7 +273,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -342,7 +342,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -401,11 +401,16 @@ public class ClientCompatibilityTest_1_2 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -586,11 +591,16 @@ public class ClientCompatibilityTest_1_2 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -603,11 +613,16 @@ public class ClientCompatibilityTest_1_2 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -619,11 +634,16 @@ public class ClientCompatibilityTest_1_2 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -636,11 +656,16 @@ public class ClientCompatibilityTest_1_2 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -769,7 +794,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -808,7 +833,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -847,7 +872,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -886,7 +911,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -930,12 +955,12 @@ public class ClientCompatibilityTest_1_2 {
 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -943,12 +968,12 @@ public class ClientCompatibilityTest_1_2 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1007,7 +1032,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1772,7 +1797,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -1811,7 +1836,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -2238,7 +2263,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2340,7 +2365,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2561,7 +2586,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2968,7 +2993,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -4092,7 +4117,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4131,7 +4156,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4170,7 +4195,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4209,7 +4234,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4316,7 +4341,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -5053,7 +5078,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5093,14 +5118,14 @@ public class ClientCompatibilityTest_1_2 {
 {
     class CacheAddInvalidationListenerCodecHandler extends CacheAddInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -5109,14 +5134,14 @@ public class ClientCompatibilityTest_1_2 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5544,7 +5569,7 @@ public class ClientCompatibilityTest_1_2 {
 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5855,12 +5880,12 @@ public class ClientCompatibilityTest_1_2 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
             @Override
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_3.java
@@ -133,18 +133,18 @@ public class ClientCompatibilityTest_1_3 {
 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
             @Override
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
             @Override
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -263,7 +263,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -332,7 +332,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -391,11 +391,16 @@ public class ClientCompatibilityTest_1_3 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -576,11 +581,16 @@ public class ClientCompatibilityTest_1_3 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -593,11 +603,16 @@ public class ClientCompatibilityTest_1_3 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -609,11 +624,16 @@ public class ClientCompatibilityTest_1_3 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -626,11 +646,16 @@ public class ClientCompatibilityTest_1_3 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -759,7 +784,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -798,7 +823,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -837,7 +862,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -876,7 +901,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -920,12 +945,12 @@ public class ClientCompatibilityTest_1_3 {
 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -933,12 +958,12 @@ public class ClientCompatibilityTest_1_3 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -997,7 +1022,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1762,7 +1787,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -1801,7 +1826,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -2228,7 +2253,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2330,7 +2355,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2551,7 +2576,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2958,7 +2983,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -4082,7 +4107,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4121,7 +4146,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4160,7 +4185,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4199,7 +4224,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4306,7 +4331,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -5043,7 +5068,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5083,14 +5108,14 @@ public class ClientCompatibilityTest_1_3 {
 {
     class CacheAddInvalidationListenerCodecHandler extends CacheAddInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -5099,14 +5124,14 @@ public class ClientCompatibilityTest_1_3 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5534,7 +5559,7 @@ public class ClientCompatibilityTest_1_3 {
 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5845,12 +5870,12 @@ public class ClientCompatibilityTest_1_3 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
             @Override
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_4.java
@@ -133,18 +133,18 @@ public class ClientCompatibilityTest_1_4 {
 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
             @Override
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
             @Override
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -263,7 +263,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -332,7 +332,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -391,11 +391,16 @@ public class ClientCompatibilityTest_1_4 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -576,11 +581,16 @@ public class ClientCompatibilityTest_1_4 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -593,11 +603,16 @@ public class ClientCompatibilityTest_1_4 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -609,11 +624,16 @@ public class ClientCompatibilityTest_1_4 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -626,11 +646,16 @@ public class ClientCompatibilityTest_1_4 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -759,7 +784,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -798,7 +823,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -837,7 +862,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -876,7 +901,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -915,12 +940,12 @@ public class ClientCompatibilityTest_1_4 {
 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -928,12 +953,12 @@ public class ClientCompatibilityTest_1_4 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -992,7 +1017,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1649,12 +1674,12 @@ public class ClientCompatibilityTest_1_4 {
 {
     class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -1662,12 +1687,12 @@ public class ClientCompatibilityTest_1_4 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1920,7 +1945,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -1959,7 +1984,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -2386,7 +2411,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2488,7 +2513,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2709,7 +2734,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -3116,7 +3141,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -4240,7 +4265,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4279,7 +4304,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4318,7 +4343,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4357,7 +4382,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4464,7 +4489,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -5201,7 +5226,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5236,14 +5261,14 @@ public class ClientCompatibilityTest_1_4 {
 {
     class CacheAddInvalidationListenerCodecHandler extends CacheAddInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -5252,14 +5277,14 @@ public class ClientCompatibilityTest_1_4 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5687,7 +5712,7 @@ public class ClientCompatibilityTest_1_4 {
 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5772,14 +5797,14 @@ public class ClientCompatibilityTest_1_4 {
 {
     class CacheAddNearCacheInvalidationListenerCodecHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -5788,14 +5813,14 @@ public class ClientCompatibilityTest_1_4 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -6093,12 +6118,12 @@ public class ClientCompatibilityTest_1_4 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
             @Override
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_5.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_5.java
@@ -133,18 +133,18 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
             @Override
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
             @Override
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -258,7 +258,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -327,7 +327,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -426,7 +426,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ClientAddPartitionListenerCodecHandler extends ClientAddPartitionListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionsEventV15(java.util.Collection<java.util.Map.Entry<com.hazelcast.nio.Address,java.util.List<java.lang.Integer>>> partitions, int partitionStateVersion) {
+            public void  handlePartitionsEventV15(Collection<Map.Entry<Address,List<Integer>>> partitions, int partitionStateVersion) {
                    
  assertTrue(isEqual(aPartitionTable,partitions));
  assertTrue(isEqual(anInt,partitionStateVersion));
@@ -445,11 +445,16 @@ public class ClientCompatibilityTest_1_5 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -630,11 +635,16 @@ public class ClientCompatibilityTest_1_5 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -647,11 +657,16 @@ public class ClientCompatibilityTest_1_5 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -663,11 +678,16 @@ public class ClientCompatibilityTest_1_5 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -680,11 +700,16 @@ public class ClientCompatibilityTest_1_5 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -813,7 +838,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -852,7 +877,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -891,7 +916,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -930,7 +955,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -969,12 +994,12 @@ public class ClientCompatibilityTest_1_5 {
 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -982,12 +1007,12 @@ public class ClientCompatibilityTest_1_5 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1046,7 +1071,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1703,12 +1728,12 @@ public class ClientCompatibilityTest_1_5 {
 {
     class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -1716,12 +1741,12 @@ public class ClientCompatibilityTest_1_5 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -2029,7 +2054,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -2068,7 +2093,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -2495,7 +2520,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2597,7 +2622,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2818,7 +2843,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -3225,7 +3250,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -4349,7 +4374,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4388,7 +4413,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4427,7 +4452,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4466,7 +4491,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4573,7 +4598,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -5310,7 +5335,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5345,14 +5370,14 @@ public class ClientCompatibilityTest_1_5 {
 {
     class CacheAddInvalidationListenerCodecHandler extends CacheAddInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -5361,14 +5386,14 @@ public class ClientCompatibilityTest_1_5 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5796,7 +5821,7 @@ public class ClientCompatibilityTest_1_5 {
 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5881,14 +5906,14 @@ public class ClientCompatibilityTest_1_5 {
 {
     class CacheAddNearCacheInvalidationListenerCodecHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -5897,14 +5922,14 @@ public class ClientCompatibilityTest_1_5 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -6241,12 +6266,12 @@ public class ClientCompatibilityTest_1_5 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
             @Override
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_6.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ClientCompatibilityTest_1_6.java
@@ -133,18 +133,18 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
             @Override
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
             @Override
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -258,7 +258,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -327,7 +327,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -426,7 +426,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ClientAddPartitionListenerCodecHandler extends ClientAddPartitionListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionsEventV15(java.util.Collection<java.util.Map.Entry<com.hazelcast.nio.Address,java.util.List<java.lang.Integer>>> partitions, int partitionStateVersion) {
+            public void  handlePartitionsEventV15(Collection<Map.Entry<Address,List<Integer>>> partitions, int partitionStateVersion) {
                    
  assertTrue(isEqual(aPartitionTable,partitions));
  assertTrue(isEqual(anInt,partitionStateVersion));
@@ -459,11 +459,16 @@ public class ClientCompatibilityTest_1_6 {
 
 
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -644,11 +649,16 @@ public class ClientCompatibilityTest_1_6 {
 
 
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -661,11 +671,16 @@ public class ClientCompatibilityTest_1_6 {
 
 
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -677,11 +692,16 @@ public class ClientCompatibilityTest_1_6 {
 
 
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -694,11 +714,16 @@ public class ClientCompatibilityTest_1_6 {
 
 
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 
 }
 {
@@ -827,7 +852,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -866,7 +891,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -905,7 +930,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -944,7 +969,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -983,12 +1008,12 @@ public class ClientCompatibilityTest_1_6 {
 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -996,12 +1021,12 @@ public class ClientCompatibilityTest_1_6 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1060,7 +1085,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1717,12 +1742,12 @@ public class ClientCompatibilityTest_1_6 {
 {
     class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -1730,12 +1755,12 @@ public class ClientCompatibilityTest_1_6 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -2038,7 +2063,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -2077,7 +2102,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -2518,7 +2543,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2620,7 +2645,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2841,7 +2866,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -3248,7 +3273,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -4386,7 +4411,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4425,7 +4450,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4464,7 +4489,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4503,7 +4528,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -4610,7 +4635,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -5362,7 +5387,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -5397,14 +5422,14 @@ public class ClientCompatibilityTest_1_6 {
 {
     class CacheAddInvalidationListenerCodecHandler extends CacheAddInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -5413,14 +5438,14 @@ public class ClientCompatibilityTest_1_6 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -5848,7 +5873,7 @@ public class ClientCompatibilityTest_1_6 {
 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -5933,14 +5958,14 @@ public class ClientCompatibilityTest_1_6 {
 {
     class CacheAddNearCacheInvalidationListenerCodecHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -5949,14 +5974,14 @@ public class ClientCompatibilityTest_1_6 {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -6288,12 +6313,12 @@ public class ClientCompatibilityTest_1_6 {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
             @Override
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityNullTest.java
@@ -117,13 +117,13 @@ public class EncodeDecodeCompatibilityNullTest {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
 
 
-                public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+                public void  handleMemberEventV10(Member member, int eventType) {
                        
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
                 }
 
-                public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+                public void  handleMemberListEventV10(Collection<Member> members) {
                        
  assertTrue(isEqual(members,members));
                 }
@@ -131,7 +131,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+                public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                        
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -207,7 +207,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+                public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                        
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -254,7 +254,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+                public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -315,7 +315,7 @@ public class EncodeDecodeCompatibilityNullTest {
     class ClientAddPartitionListenerCodecHandler extends ClientAddPartitionListenerCodec.AbstractEventHandler {
 
 
-                public void  handlePartitionsEventV15(java.util.Collection<java.util.Map.Entry<com.hazelcast.nio.Address,java.util.List<java.lang.Integer>>> partitions, int partitionStateVersion) {
+                public void  handlePartitionsEventV15(Collection<Map.Entry<Address,List<Integer>>> partitions, int partitionStateVersion) {
                        
  assertTrue(isEqual(aPartitionTable,partitions));
  assertTrue(isEqual(anInt,partitionStateVersion));
@@ -337,13 +337,14 @@ public class EncodeDecodeCompatibilityNullTest {
     ClientCreateProxiesCodec.ResponseParameters params = ClientCreateProxiesCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
 }
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     MapPutCodec.RequestParameters params = MapPutCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(aData, params.key));
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+            assertTrue(isEqual(aLong, params.maxIdle));
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    null   );
@@ -471,13 +472,14 @@ public class EncodeDecodeCompatibilityNullTest {
             assertTrue(isEqual(aBoolean, params.response));
 }
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     MapTryPutCodec.RequestParameters params = MapTryPutCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(aData, params.key));
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.timeout));
+            assertTrue(isEqual(aLong, params.maxIdle));
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
@@ -485,26 +487,28 @@ public class EncodeDecodeCompatibilityNullTest {
             assertTrue(isEqual(aBoolean, params.response));
 }
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     MapPutTransientCodec.RequestParameters params = MapPutTransientCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(aData, params.key));
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+            assertTrue(isEqual(aLong, params.maxIdle));
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     MapPutTransientCodec.ResponseParameters params = MapPutTransientCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
 }
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     MapPutIfAbsentCodec.RequestParameters params = MapPutIfAbsentCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(aData, params.key));
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+            assertTrue(isEqual(aLong, params.maxIdle));
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    null   );
@@ -512,13 +516,14 @@ public class EncodeDecodeCompatibilityNullTest {
             assertTrue(isEqual(null, params.response));
 }
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     MapSetCodec.RequestParameters params = MapSetCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(aData, params.key));
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+            assertTrue(isEqual(aLong, params.maxIdle));
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
@@ -621,7 +626,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -661,7 +666,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -701,7 +706,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -740,7 +745,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -773,14 +778,14 @@ public class EncodeDecodeCompatibilityNullTest {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
 
                     @Override
-                    public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                    public void  handleIMapInvalidationEventV10(Data key) {
                            
  assertTrue(isEqual(null,key));
                     }
 
 
 
-                public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+                public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -789,14 +794,14 @@ public class EncodeDecodeCompatibilityNullTest {
                 }
 
                     @Override
-                    public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                    public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                            
  assertTrue(isEqual(datas,keys));
                     }
 
 
 
-                public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+                public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                        
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -840,7 +845,7 @@ public class EncodeDecodeCompatibilityNullTest {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-                public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+                public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                        
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1277,14 +1282,14 @@ public class EncodeDecodeCompatibilityNullTest {
     class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
 
                     @Override
-                    public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                    public void  handleIMapInvalidationEventV10(Data key) {
                            
  assertTrue(isEqual(null,key));
                     }
 
 
 
-                public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+                public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -1293,14 +1298,14 @@ public class EncodeDecodeCompatibilityNullTest {
                 }
 
                     @Override
-                    public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                    public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                            
  assertTrue(isEqual(datas,keys));
                     }
 
 
 
-                public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+                public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                        
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1529,7 +1534,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -1567,7 +1572,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -1867,7 +1872,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+                public void  handleItemEventV10(Data item, String uuid, int eventType) {
                        
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -1937,7 +1942,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+                public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                        
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2084,7 +2089,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+                public void  handleItemEventV10(Data item, String uuid, int eventType) {
                        
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -2353,7 +2358,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+                public void  handleItemEventV10(Data item, String uuid, int eventType) {
                        
  assertTrue(isEqual(null,item));
  assertTrue(isEqual(aString,uuid));
@@ -3099,7 +3104,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -3137,7 +3142,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -3175,7 +3180,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -3212,7 +3217,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -3291,7 +3296,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+                public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                        
  assertTrue(isEqual(null,key));
  assertTrue(isEqual(null,value));
@@ -3897,7 +3902,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
 
-                public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+                public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                        
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -3927,7 +3932,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
                     @Override
-                    public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                    public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                            
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -3935,7 +3940,7 @@ public class EncodeDecodeCompatibilityNullTest {
                     }
 
 
-                public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+                public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -3947,7 +3952,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
                     @Override
-                    public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                    public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                            
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -3955,7 +3960,7 @@ public class EncodeDecodeCompatibilityNullTest {
                     }
 
 
-                public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+                public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -4263,7 +4268,7 @@ public class EncodeDecodeCompatibilityNullTest {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
 
 
-                public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+                public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                        
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -4329,7 +4334,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
                     @Override
-                    public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                    public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                            
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -4337,7 +4342,7 @@ public class EncodeDecodeCompatibilityNullTest {
                     }
 
 
-                public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+                public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(null,key));
@@ -4349,7 +4354,7 @@ public class EncodeDecodeCompatibilityNullTest {
 
 
                     @Override
-                    public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                    public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                            
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -4357,7 +4362,7 @@ public class EncodeDecodeCompatibilityNullTest {
                     }
 
 
-                public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+                public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -4596,14 +4601,14 @@ public class EncodeDecodeCompatibilityNullTest {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
 
-                public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+                public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                        
  assertTrue(isEqual(aQueryCacheEventData,data));
                 }
 
 
 
-                public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+                public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                        
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityTest.java
@@ -116,18 +116,18 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ClientAddMembershipListenerCodecHandler extends ClientAddMembershipListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMemberEventV10(com.hazelcast.core.Member member, int eventType) {
+            public void  handleMemberEventV10(Member member, int eventType) {
                    
  assertTrue(isEqual(aMember,member));
  assertTrue(isEqual(anInt,eventType));
             }
             @Override
-            public void  handleMemberListEventV10(java.util.Collection<com.hazelcast.core.Member> members) {
+            public void  handleMemberListEventV10(Collection<Member> members) {
                    
  assertTrue(isEqual(members,members));
             }
             @Override
-            public void  handleMemberAttributeChangeEventV10(java.lang.String uuid, java.lang.String key, int operationType, java.lang.String value) {
+            public void  handleMemberAttributeChangeEventV10(String uuid, String key, int operationType, String value) {
                    
  assertTrue(isEqual(aString,uuid));
  assertTrue(isEqual(aString,key));
@@ -201,7 +201,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ClientAddPartitionLostListenerCodecHandler extends ClientAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, com.hazelcast.nio.Address source) {
+            public void  handlePartitionLostEventV10(int partitionId, int lostBackupCount, Address source) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(anInt,lostBackupCount));
@@ -246,7 +246,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ClientAddDistributedObjectListenerCodecHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleDistributedObjectEventV10(java.lang.String name, java.lang.String serviceName, java.lang.String eventType) {
+            public void  handleDistributedObjectEventV10(String name, String serviceName, String eventType) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aString,serviceName));
@@ -306,7 +306,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ClientAddPartitionListenerCodecHandler extends ClientAddPartitionListenerCodec.AbstractEventHandler {
             @Override
-            public void  handlePartitionsEventV15(java.util.Collection<java.util.Map.Entry<com.hazelcast.nio.Address,java.util.List<java.lang.Integer>>> partitions, int partitionStateVersion) {
+            public void  handlePartitionsEventV15(Collection<Map.Entry<Address,List<Integer>>> partitions, int partitionStateVersion) {
                    
  assertTrue(isEqual(aPartitionTable,partitions));
  assertTrue(isEqual(anInt,partitionStateVersion));
@@ -328,13 +328,14 @@ public class EncodeDecodeCompatibilityTest {
     ClientCreateProxiesCodec.ResponseParameters params = ClientCreateProxiesCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
 }
 {
-    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     MapPutCodec.RequestParameters params = MapPutCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(aData, params.key));
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+            assertTrue(isEqual(aLong, params.maxIdle));
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    aData   );
@@ -462,13 +463,14 @@ public class EncodeDecodeCompatibilityTest {
             assertTrue(isEqual(aBoolean, params.response));
 }
 {
-    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapTryPutCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     MapTryPutCodec.RequestParameters params = MapTryPutCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(aData, params.key));
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.timeout));
+            assertTrue(isEqual(aLong, params.maxIdle));
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
@@ -476,26 +478,28 @@ public class EncodeDecodeCompatibilityTest {
             assertTrue(isEqual(aBoolean, params.response));
 }
 {
-    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutTransientCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     MapPutTransientCodec.RequestParameters params = MapPutTransientCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(aData, params.key));
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+            assertTrue(isEqual(aLong, params.maxIdle));
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     MapPutTransientCodec.ResponseParameters params = MapPutTransientCodec.decodeResponse(ClientMessage.createForDecode(clientMessage.buffer(), 0));
 }
 {
-    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapPutIfAbsentCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     MapPutIfAbsentCodec.RequestParameters params = MapPutIfAbsentCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(aData, params.key));
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+            assertTrue(isEqual(aLong, params.maxIdle));
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    aData   );
@@ -503,13 +507,14 @@ public class EncodeDecodeCompatibilityTest {
             assertTrue(isEqual(aData, params.response));
 }
 {
-    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong   );
+    ClientMessage clientMessage = MapSetCodec.encodeRequest(    aString ,    aData ,    aData ,    aLong ,    aLong ,    aLong   );
     MapSetCodec.RequestParameters params = MapSetCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(aData, params.key));
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+            assertTrue(isEqual(aLong, params.maxIdle));
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
@@ -606,7 +611,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class MapAddEntryListenerToKeyWithPredicateCodecHandler extends MapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -640,7 +645,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class MapAddEntryListenerWithPredicateCodecHandler extends MapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -674,7 +679,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class MapAddEntryListenerToKeyCodecHandler extends MapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -707,7 +712,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class MapAddEntryListenerCodecHandler extends MapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -739,12 +744,12 @@ public class EncodeDecodeCompatibilityTest {
 {
     class MapAddNearCacheEntryListenerCodecHandler extends MapAddNearCacheEntryListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -752,12 +757,12 @@ public class EncodeDecodeCompatibilityTest {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -800,7 +805,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class MapAddPartitionLostListenerCodecHandler extends MapAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleMapPartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleMapPartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -1236,12 +1241,12 @@ public class EncodeDecodeCompatibilityTest {
 {
     class MapAddNearCacheInvalidationListenerCodecHandler extends MapAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleIMapInvalidationEventV10(com.hazelcast.nio.serialization.Data key) {
+                public void  handleIMapInvalidationEventV10(Data key) {
                        
  assertTrue(isEqual(aData,key));
                 }
             @Override
-            public void  handleIMapInvalidationEventV14(com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleIMapInvalidationEventV14(Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
@@ -1249,12 +1254,12 @@ public class EncodeDecodeCompatibilityTest {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleIMapBatchInvalidationEventV10(java.util.Collection<com.hazelcast.nio.serialization.Data> keys) {
+                public void  handleIMapBatchInvalidationEventV10(Collection<Data> keys) {
                        
  assertTrue(isEqual(datas,keys));
                 }
             @Override
-            public void  handleIMapBatchInvalidationEventV14(java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleIMapBatchInvalidationEventV14(Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
@@ -1477,7 +1482,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class MultiMapAddEntryListenerToKeyCodecHandler extends MultiMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -1509,7 +1514,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class MultiMapAddEntryListenerCodecHandler extends MultiMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -1807,7 +1812,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class QueueAddListenerCodecHandler extends QueueAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -1875,7 +1880,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class TopicAddMessageListenerCodecHandler extends TopicAddMessageListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleTopicEventV10(com.hazelcast.nio.serialization.Data item, long publishTime, java.lang.String uuid) {
+            public void  handleTopicEventV10(Data item, long publishTime, String uuid) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aLong,publishTime));
@@ -2020,7 +2025,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ListAddListenerCodecHandler extends ListAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -2287,7 +2292,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class SetAddListenerCodecHandler extends SetAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleItemEventV10(com.hazelcast.nio.serialization.Data item, java.lang.String uuid, int eventType) {
+            public void  handleItemEventV10(Data item, String uuid, int eventType) {
                    
  assertTrue(isEqual(aData,item));
  assertTrue(isEqual(aString,uuid));
@@ -3027,7 +3032,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ReplicatedMapAddEntryListenerToKeyWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerToKeyWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -3059,7 +3064,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ReplicatedMapAddEntryListenerWithPredicateCodecHandler extends ReplicatedMapAddEntryListenerWithPredicateCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -3091,7 +3096,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ReplicatedMapAddEntryListenerToKeyCodecHandler extends ReplicatedMapAddEntryListenerToKeyCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -3122,7 +3127,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ReplicatedMapAddEntryListenerCodecHandler extends ReplicatedMapAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -3195,7 +3200,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ReplicatedMapAddNearCacheEntryListenerCodecHandler extends ReplicatedMapAddNearCacheEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleEntryEventV10(com.hazelcast.nio.serialization.Data key, com.hazelcast.nio.serialization.Data value, com.hazelcast.nio.serialization.Data oldValue, com.hazelcast.nio.serialization.Data mergingValue, int eventType, java.lang.String uuid, int numberOfAffectedEntries) {
+            public void  handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid, int numberOfAffectedEntries) {
                    
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aData,value));
@@ -3799,7 +3804,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class CacheAddEntryListenerCodecHandler extends CacheAddEntryListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCacheEventV10(int type, java.util.Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
+            public void  handleCacheEventV10(int type, Collection<com.hazelcast.cache.impl.CacheEventData> keys, int completionId) {
                    
  assertTrue(isEqual(anInt,type));
  assertTrue(isEqual(cacheEventDatas,keys));
@@ -3826,14 +3831,14 @@ public class EncodeDecodeCompatibilityTest {
 {
     class CacheAddInvalidationListenerCodecHandler extends CacheAddInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -3842,14 +3847,14 @@ public class EncodeDecodeCompatibilityTest {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -4156,7 +4161,7 @@ public class EncodeDecodeCompatibilityTest {
 {
     class CacheAddPartitionLostListenerCodecHandler extends CacheAddPartitionLostListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleCachePartitionLostEventV10(int partitionId, java.lang.String uuid) {
+            public void  handleCachePartitionLostEventV10(int partitionId, String uuid) {
                    
  assertTrue(isEqual(anInt,partitionId));
  assertTrue(isEqual(aString,uuid));
@@ -4219,14 +4224,14 @@ public class EncodeDecodeCompatibilityTest {
 {
     class CacheAddNearCacheInvalidationListenerCodecHandler extends CacheAddNearCacheInvalidationListenerCodec.AbstractEventHandler {
                 @Override
-                public void  handleCacheInvalidationEventV10(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid) {
+                public void  handleCacheInvalidationEventV10(String name, Data key, String sourceUuid) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
  assertTrue(isEqual(aString,sourceUuid));
                 }
             @Override
-            public void  handleCacheInvalidationEventV14(java.lang.String name, com.hazelcast.nio.serialization.Data key, java.lang.String sourceUuid, java.util.UUID partitionUuid, long sequence) {
+            public void  handleCacheInvalidationEventV14(String name, Data key, String sourceUuid, java.util.UUID partitionUuid, long sequence) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(aData,key));
@@ -4235,14 +4240,14 @@ public class EncodeDecodeCompatibilityTest {
  assertTrue(isEqual(aLong,sequence));
             }
                 @Override
-                public void  handleCacheBatchInvalidationEventV10(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids) {
+                public void  handleCacheBatchInvalidationEventV10(String name, Collection<Data> keys, Collection<String> sourceUuids) {
                        
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
  assertTrue(isEqual(strings,sourceUuids));
                 }
             @Override
-            public void  handleCacheBatchInvalidationEventV14(java.lang.String name, java.util.Collection<com.hazelcast.nio.serialization.Data> keys, java.util.Collection<java.lang.String> sourceUuids, java.util.Collection<java.util.UUID> partitionUuids, java.util.Collection<java.lang.Long> sequences) {
+            public void  handleCacheBatchInvalidationEventV14(String name, Collection<Data> keys, Collection<String> sourceUuids, Collection<java.util.UUID> partitionUuids, Collection<Long> sequences) {
                    
  assertTrue(isEqual(aString,name));
  assertTrue(isEqual(datas,keys));
@@ -4481,12 +4486,12 @@ public class EncodeDecodeCompatibilityTest {
 {
     class ContinuousQueryAddListenerCodecHandler extends ContinuousQueryAddListenerCodec.AbstractEventHandler {
             @Override
-            public void  handleQueryCacheSingleEventV10(com.hazelcast.map.impl.querycache.event.QueryCacheEventData data) {
+            public void  handleQueryCacheSingleEventV10(QueryCacheEventData data) {
                    
  assertTrue(isEqual(aQueryCacheEventData,data));
             }
             @Override
-            public void  handleQueryCacheBatchEventV10(java.util.Collection<com.hazelcast.map.impl.querycache.event.QueryCacheEventData> events, java.lang.String source, int partitionId) {
+            public void  handleQueryCacheBatchEventV10(Collection<QueryCacheEventData> events, String source, int partitionId) {
                    
  assertTrue(isEqual(queryCacheEventDatas,events));
  assertTrue(isEqual(aString,source));

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_0.java
@@ -329,13 +329,19 @@ public class ServerCompatibilityNullTest_1_0 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -509,13 +515,19 @@ public class ServerCompatibilityNullTest_1_0 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -527,13 +539,19 @@ public class ServerCompatibilityNullTest_1_0 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -545,13 +563,19 @@ public class ServerCompatibilityNullTest_1_0 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -563,13 +587,19 @@ public class ServerCompatibilityNullTest_1_0 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_1.java
@@ -329,13 +329,19 @@ public class ServerCompatibilityNullTest_1_1 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -509,13 +515,19 @@ public class ServerCompatibilityNullTest_1_1 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -527,13 +539,19 @@ public class ServerCompatibilityNullTest_1_1 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -545,13 +563,19 @@ public class ServerCompatibilityNullTest_1_1 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -563,13 +587,19 @@ public class ServerCompatibilityNullTest_1_1 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_2.java
@@ -329,13 +329,19 @@ public class ServerCompatibilityNullTest_1_2 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -509,13 +515,19 @@ public class ServerCompatibilityNullTest_1_2 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -527,13 +539,19 @@ public class ServerCompatibilityNullTest_1_2 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -545,13 +563,19 @@ public class ServerCompatibilityNullTest_1_2 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -563,13 +587,19 @@ public class ServerCompatibilityNullTest_1_2 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_3.java
@@ -319,13 +319,19 @@ public class ServerCompatibilityNullTest_1_3 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -499,13 +505,19 @@ public class ServerCompatibilityNullTest_1_3 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -517,13 +529,19 @@ public class ServerCompatibilityNullTest_1_3 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -535,13 +553,19 @@ public class ServerCompatibilityNullTest_1_3 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -553,13 +577,19 @@ public class ServerCompatibilityNullTest_1_3 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_4.java
@@ -319,13 +319,19 @@ public class ServerCompatibilityNullTest_1_4 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -499,13 +505,19 @@ public class ServerCompatibilityNullTest_1_4 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -517,13 +529,19 @@ public class ServerCompatibilityNullTest_1_4 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -535,13 +553,19 @@ public class ServerCompatibilityNullTest_1_4 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -553,13 +577,19 @@ public class ServerCompatibilityNullTest_1_4 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_5.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_5.java
@@ -364,13 +364,19 @@ public class ServerCompatibilityNullTest_1_5 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -544,13 +550,19 @@ public class ServerCompatibilityNullTest_1_5 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -562,13 +574,19 @@ public class ServerCompatibilityNullTest_1_5 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -580,13 +598,19 @@ public class ServerCompatibilityNullTest_1_5 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -598,13 +622,19 @@ public class ServerCompatibilityNullTest_1_5 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_6.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityNullTest_1_6.java
@@ -378,13 +378,19 @@ public class ServerCompatibilityNullTest_1_6 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -558,13 +564,19 @@ public class ServerCompatibilityNullTest_1_6 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -576,13 +588,19 @@ public class ServerCompatibilityNullTest_1_6 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -594,13 +612,19 @@ public class ServerCompatibilityNullTest_1_6 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    null   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -612,13 +636,19 @@ public class ServerCompatibilityNullTest_1_6 {
             assertTrue(isEqual(aData, params.value));
             assertTrue(isEqual(aLong, params.threadId));
             assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_0.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_0.java
@@ -334,13 +334,19 @@ public class ServerCompatibilityTest_1_0 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -514,13 +520,19 @@ public class ServerCompatibilityTest_1_0 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -532,13 +544,19 @@ public class ServerCompatibilityTest_1_0 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -550,13 +568,19 @@ public class ServerCompatibilityTest_1_0 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -568,13 +592,19 @@ public class ServerCompatibilityTest_1_0 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.0) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_1.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_1.java
@@ -334,13 +334,19 @@ public class ServerCompatibilityTest_1_1 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -514,13 +520,19 @@ public class ServerCompatibilityTest_1_1 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -532,13 +544,19 @@ public class ServerCompatibilityTest_1_1 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -550,13 +568,19 @@ public class ServerCompatibilityTest_1_1 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -568,13 +592,19 @@ public class ServerCompatibilityTest_1_1 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.1) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_2.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_2.java
@@ -334,13 +334,19 @@ public class ServerCompatibilityTest_1_2 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -514,13 +520,19 @@ public class ServerCompatibilityTest_1_2 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -532,13 +544,19 @@ public class ServerCompatibilityTest_1_2 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -550,13 +568,19 @@ public class ServerCompatibilityTest_1_2 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -568,13 +592,19 @@ public class ServerCompatibilityTest_1_2 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.2) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_3.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_3.java
@@ -324,13 +324,19 @@ public class ServerCompatibilityTest_1_3 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -504,13 +510,19 @@ public class ServerCompatibilityTest_1_3 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -522,13 +534,19 @@ public class ServerCompatibilityTest_1_3 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -540,13 +558,19 @@ public class ServerCompatibilityTest_1_3 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -558,13 +582,19 @@ public class ServerCompatibilityTest_1_3 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.3) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_4.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_4.java
@@ -324,13 +324,19 @@ public class ServerCompatibilityTest_1_4 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -504,13 +510,19 @@ public class ServerCompatibilityTest_1_4 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -522,13 +534,19 @@ public class ServerCompatibilityTest_1_4 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -540,13 +558,19 @@ public class ServerCompatibilityTest_1_4 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -558,13 +582,19 @@ public class ServerCompatibilityTest_1_4 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.4) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_5.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_5.java
@@ -370,13 +370,19 @@ public class ServerCompatibilityTest_1_5 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -550,13 +556,19 @@ public class ServerCompatibilityTest_1_5 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -568,13 +580,19 @@ public class ServerCompatibilityTest_1_5 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -586,13 +604,19 @@ public class ServerCompatibilityTest_1_5 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -604,13 +628,19 @@ public class ServerCompatibilityTest_1_5 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.5) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_6.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ServerCompatibilityTest_1_6.java
@@ -384,13 +384,19 @@ public class ServerCompatibilityTest_1_6 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -564,13 +570,19 @@ public class ServerCompatibilityTest_1_6 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.timeout));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapTryPutCodec.encodeResponse(    aBoolean   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -582,13 +594,19 @@ public class ServerCompatibilityTest_1_6 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutTransientCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -600,13 +618,19 @@ public class ServerCompatibilityTest_1_6 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapPutIfAbsentCodec.encodeResponse(    aData   );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();
@@ -618,13 +642,19 @@ public class ServerCompatibilityTest_1_6 {
                 assertTrue(isEqual(aData, params.value));
                 assertTrue(isEqual(aLong, params.threadId));
                 assertTrue(isEqual(aLong, params.ttl));
+                assertFalse(params.maxIdleExist);
 }
 {
     ClientMessage clientMessage = MapSetCodec.encodeResponse( );
     int length = inputStream.readInt();
-    byte[] bytes = new byte[length];
+    // Since the test is generated for protocol version (1.6) which is earlier than latest change in the message
+    // (version 1.7), only the bytes after frame length fields are compared
+    int frameLength = clientMessage.getFrameLength();
+    assertTrue(frameLength >= length);
+    inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+    byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
     inputStream.read(bytes);
-    assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
 }
 {
      int length = inputStream.readInt();

--- a/hazelcast/src/test/java/com/hazelcast/map/BackupExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BackupExpirationTest.java
@@ -163,7 +163,7 @@ public class BackupExpirationTest extends HazelcastTestSupport {
             RecordStore recordStore = mapServiceContext.getRecordStore(0, MAP_NAME);
 
             Data dataKey = ss.toData(1);
-            recordStore.put(dataKey, "value", 100);
+            recordStore.put(dataKey, "value", 100, -1);
             sleepSeconds(1);
             recordStore.get(dataKey, false, null);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -62,6 +62,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -694,6 +695,8 @@ public class BasicMapTest extends HazelcastTestSupport {
 
         IMap<Integer, Integer> map = instance.getMap("testEntryView");
         long time1 = Clock.currentTimeMillis();
+        sleepSeconds(1);
+
         map.put(1, 1);
         map.put(1, 1);
         map.get(1);
@@ -702,10 +705,16 @@ public class BasicMapTest extends HazelcastTestSupport {
         map.get(2);
         map.put(3, 3);
         map.put(3, 3);
+
         long time2 = Clock.currentTimeMillis();
+        sleepSeconds(1);
         map.get(3);
         map.get(3);
+        sleepSeconds(1);
+
         long time3 = Clock.currentTimeMillis();
+        sleepSeconds(1);
+        map.get(2);
         map.put(2, 22);
 
         EntryView<Integer, Integer> entryView1 = map.getEntryView(1);
@@ -721,7 +730,7 @@ public class BasicMapTest extends HazelcastTestSupport {
         assertEqualsStringFormat("Expected entryView3.getValue() to be %d, but was %d", 3, entryView3.getValue());
 
         assertEqualsStringFormat("Expected entryView1.getHits() to be %d, but were %d", 2L, entryView1.getHits());
-        assertEqualsStringFormat("Expected entryView2.getHits() to be %d, but were %d", 3L, entryView2.getHits());
+        assertEqualsStringFormat("Expected entryView2.getHits() to be %d, but were %d", 4L, entryView2.getHits());
         assertEqualsStringFormat("Expected entryView3.getHits() to be %d, but were %d", 3L, entryView3.getHits());
 
         assertEqualsStringFormat("Expected entryView1.getVersion() to be %d, but was %d", 1L, entryView1.getVersion());
@@ -733,12 +742,17 @@ public class BasicMapTest extends HazelcastTestSupport {
         assertBetween("entryView3.getCreationTime()", entryView3.getCreationTime(), time1, time2);
 
         assertBetween("entryView1.getLastAccessTime()", entryView1.getLastAccessTime(), time1, time2);
-        assertGreaterOrEquals("entryView2.getLastAccessTime()", entryView2.getLastAccessTime(), time3);
-        assertBetween("entryView3.getLastAccessTime()", entryView3.getLastAccessTime(), time2, time3);
+        assertGreaterOrEquals("entryView2.getLastAccessTime()",
+                MILLISECONDS.toSeconds(entryView2.getLastAccessTime()), MILLISECONDS.toSeconds(time3));
+        assertBetween("entryView3.getLastAccessTime()", MILLISECONDS.toSeconds(entryView3.getLastAccessTime()),
+                MILLISECONDS.toSeconds(time2), MILLISECONDS.toSeconds(time3));
 
-        assertBetween("entryView1.getLastUpdateTime()", entryView1.getLastUpdateTime(), time1, time2);
-        assertGreaterOrEquals("entryView2.getLastUpdateTime()", entryView2.getLastUpdateTime(), time3);
-        assertBetween("entryView3.getLastUpdateTime()", entryView3.getLastUpdateTime(), time1, time2);
+        assertBetween("entryView1.getLastUpdateTime()", MILLISECONDS.toSeconds(entryView1.getLastUpdateTime()),
+                MILLISECONDS.toSeconds(time1), MILLISECONDS.toSeconds(time2));
+        assertGreaterOrEquals("entryView2.getLastUpdateTime()", MILLISECONDS.toSeconds(entryView2.getLastUpdateTime()),
+                MILLISECONDS.toSeconds(time3));
+        assertBetween("entryView3.getLastUpdateTime()", MILLISECONDS.toSeconds(entryView3.getLastUpdateTime()),
+                MILLISECONDS.toSeconds(time1), MILLISECONDS.toSeconds(time2));
     }
 
     @Test
@@ -1210,7 +1224,7 @@ public class BasicMapTest extends HazelcastTestSupport {
         map.put("key", "value");
         map.setTTL("key", 1, TimeUnit.SECONDS);
 
-        sleepAtLeastMillis(1000);
+        sleepAtLeastMillis(2000);
 
         assertNull(map.get("key"));
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryCostEstimatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryCostEstimatorTest.java
@@ -40,11 +40,11 @@ public class EntryCostEstimatorTest
         extends HazelcastTestSupport {
 
     protected TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-    // the JVM-independent portion of the cost of Integer key + Long value record is 124 bytes
+    // the JVM-independent portion of the cost of Integer key + Long value record is 100 bytes
     // (without taking into account 8 references to key, record and value objects)
-    private static final int JVM_INDEPENDENT_ENTRY_COST_IN_BYTES = 124;
+    private static final int JVM_INDEPENDENT_ENTRY_COST_IN_BYTES = 104;
     // JVM-dependent total cost of entry
-    private static final int ENTRY_COST_IN_BYTES = JVM_INDEPENDENT_ENTRY_COST_IN_BYTES + 7 * REFERENCE_COST_IN_BYTES;
+    private static final int ENTRY_COST_IN_BYTES = JVM_INDEPENDENT_ENTRY_COST_IN_BYTES + 9 * REFERENCE_COST_IN_BYTES;
 
     @Test
     public void smoke() {

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryCostEstimatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryCostEstimatorTest.java
@@ -44,7 +44,7 @@ public class EntryCostEstimatorTest
     // (without taking into account 8 references to key, record and value objects)
     private static final int JVM_INDEPENDENT_ENTRY_COST_IN_BYTES = 124;
     // JVM-dependent total cost of entry
-    private static final int ENTRY_COST_IN_BYTES = JVM_INDEPENDENT_ENTRY_COST_IN_BYTES + 9 * REFERENCE_COST_IN_BYTES;
+    private static final int ENTRY_COST_IN_BYTES = JVM_INDEPENDENT_ENTRY_COST_IN_BYTES + 7 * REFERENCE_COST_IN_BYTES;
 
     @Test
     public void smoke() {

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryCostEstimatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryCostEstimatorTest.java
@@ -40,7 +40,7 @@ public class EntryCostEstimatorTest
         extends HazelcastTestSupport {
 
     protected TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-    // the JVM-independent portion of the cost of Integer key + Long value record is 100 bytes
+    // the JVM-independent portion of the cost of Integer key + Long value record is 104 bytes
     // (without taking into account 8 references to key, record and value objects)
     private static final int JVM_INDEPENDENT_ENTRY_COST_IN_BYTES = 104;
     // JVM-dependent total cost of entry

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -182,7 +182,7 @@ public class EvictionTest extends HazelcastTestSupport {
     public void testIssue455ZeroTTLShouldPreventEviction() {
         GroupConfig groupConfig = new GroupConfig()
                 .setName("testIssue455ZeroTTLShouldPreventEviction");
-        MapConfig mapConfig = new MapConfig("testIssue455ZeroTTLShouldPreventEviction")
+        MapConfig mapConfig = newMapConfig("testIssue455ZeroTTLShouldPreventEviction")
                 .setNearCacheConfig(new NearCacheConfig());
         Config config = getConfig()
                 .setGroupConfig(groupConfig)
@@ -201,7 +201,7 @@ public class EvictionTest extends HazelcastTestSupport {
     public void testIssue585ZeroTTLShouldPreventEvictionWithSet() {
         GroupConfig groupConfig = new GroupConfig()
                 .setName("testIssue585ZeroTTLShouldPreventEvictionWithSet");
-        MapConfig mapConfig = new MapConfig("testIssue585ZeroTTLShouldPreventEvictionWithSet")
+        MapConfig mapConfig = newMapConfig("testIssue585ZeroTTLShouldPreventEvictionWithSet")
                 .setNearCacheConfig(new NearCacheConfig());
         Config config = getConfig()
                 .setGroupConfig(groupConfig)
@@ -237,7 +237,7 @@ public class EvictionTest extends HazelcastTestSupport {
     public void testIssue304EvictionDespitePut() {
         GroupConfig groupConfig = new GroupConfig()
                 .setName("testIssue304EvictionDespitePut");
-        MapConfig mapConfig = new MapConfig("testIssue304EvictionDespitePut")
+        MapConfig mapConfig = newMapConfig("testIssue304EvictionDespitePut")
                 .setMaxIdleSeconds(5);
         Config config = getConfig()
                 .setGroupConfig(groupConfig)
@@ -273,7 +273,7 @@ public class EvictionTest extends HazelcastTestSupport {
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig()
                 .setMaxSizePolicy(MaxSizeConfig.MaxSizePolicy.PER_NODE)
                 .setSize(size);
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setEvictionPolicy(EvictionPolicy.LRU)
                 .setEvictionPercentage(25)
                 .setMaxSizeConfig(maxSizeConfig);
@@ -327,7 +327,7 @@ public class EvictionTest extends HazelcastTestSupport {
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig()
                 .setMaxSizePolicy(PER_PARTITION)
                 .setSize(size);
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setEvictionPolicy(EvictionPolicy.LRU)
                 .setEvictionPercentage(25)
                 .setMaxSizeConfig(maxSizeConfig);
@@ -379,7 +379,7 @@ public class EvictionTest extends HazelcastTestSupport {
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig()
                 .setMaxSizePolicy(PER_PARTITION)
                 .setSize(size);
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setEvictionPolicy(EvictionPolicy.LRU)
                 .setEvictionPercentage(50)
                 .setMinEvictionCheckMillis(0)
@@ -410,7 +410,7 @@ public class EvictionTest extends HazelcastTestSupport {
         MaxSizeConfig max = new MaxSizeConfig()
                 .setMaxSizePolicy(MaxSizeConfig.MaxSizePolicy.PER_NODE)
                 .setSize(size);
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setStatisticsEnabled(false)
                 .setEvictionPolicy(EvictionPolicy.LRU)
                 .setEvictionPercentage(10)
@@ -460,7 +460,7 @@ public class EvictionTest extends HazelcastTestSupport {
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig()
                 .setMaxSizePolicy(PER_NODE)
                 .setSize(mapMaxSize);
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setStatisticsEnabled(disableStats)
                 .setEvictionPolicy(LFU)
                 .setMinEvictionCheckMillis(0)
@@ -488,7 +488,7 @@ public class EvictionTest extends HazelcastTestSupport {
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig()
                 .setMaxSizePolicy(MaxSizeConfig.MaxSizePolicy.PER_NODE)
                 .setSize(size);
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setEvictionPolicy(EvictionPolicy.LFU)
                 .setEvictionPercentage(90)
                 .setMaxSizeConfig(maxSizeConfig);
@@ -528,7 +528,7 @@ public class EvictionTest extends HazelcastTestSupport {
                     }
                 });
 
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setTimeToLiveSeconds(1)
                 .addEntryListenerConfig(entryListenerConfig);
         Config config = getConfig()
@@ -556,7 +556,7 @@ public class EvictionTest extends HazelcastTestSupport {
         int maxIdleSeconds = 1;
         int size = 100;
 
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setMaxIdleSeconds(maxIdleSeconds);
         Config config = getConfig()
                 .addMapConfig(mapConfig);
@@ -573,7 +573,7 @@ public class EvictionTest extends HazelcastTestSupport {
 
     @Test
     public void testZeroResetsTTL() throws Exception {
-        MapConfig mapConfig = new MapConfig("testZeroResetsTTL")
+        MapConfig mapConfig = newMapConfig("testZeroResetsTTL")
                 .setTimeToLiveSeconds(5);
         Config config = getConfig()
                 .addMapConfig(mapConfig);
@@ -607,7 +607,7 @@ public class EvictionTest extends HazelcastTestSupport {
         int numOfEntries = 1000;
         String name = "expired_entries_removed_after_migration";
 
-        MapConfig mapConfig = new MapConfig(name)
+        MapConfig mapConfig = newMapConfig(name)
                 .setMaxIdleSeconds(20);
         Config config = getConfig()
                 .setProperty(PROP_TASK_PERIOD_SECONDS, "1")
@@ -670,7 +670,7 @@ public class EvictionTest extends HazelcastTestSupport {
         String mapName = randomMapName();
         int waitSeconds = 2;
 
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setMaxIdleSeconds(30);
         Config config = getConfig()
                 .addMapConfig(mapConfig);
@@ -704,7 +704,7 @@ public class EvictionTest extends HazelcastTestSupport {
         String mapName = randomMapName();
         int entryCount = 10;
 
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setTimeToLiveSeconds(3);
         Config config = getConfig()
                 .addMapConfig(mapConfig);
@@ -897,7 +897,7 @@ public class EvictionTest extends HazelcastTestSupport {
         map.put(1, 1, 100, TimeUnit.MILLISECONDS);
         map.put(2, 1, 100, TimeUnit.MILLISECONDS);
         map.put(3, 1, 100, TimeUnit.MILLISECONDS);
-        sleepSeconds(1);
+        sleepSeconds(2);
         return map;
     }
 
@@ -940,7 +940,7 @@ public class EvictionTest extends HazelcastTestSupport {
     private IMap<Integer, Integer> createMapWithReadBackupDataEnabled(int maxIdleSeconds) {
         String mapName = randomMapName();
 
-        MapConfig mapConfig = new MapConfig(mapName)
+        MapConfig mapConfig = newMapConfig(mapName)
                 .setMaxIdleSeconds(maxIdleSeconds)
                 .setReadBackupData(true);
         Config config = getConfig()
@@ -1009,10 +1009,11 @@ public class EvictionTest extends HazelcastTestSupport {
         // 1. put a key to expire
         map.put(key, 1, 3, TimeUnit.SECONDS);
 
-        HazelcastInstance joinerNode = factory.newHazelcastInstance(config);
-
         // 2. wait for expiration on owner node
         assertOpenEventually(evictedEntryCounterLatch, 240);
+
+        HazelcastInstance joinerNode = factory.newHazelcastInstance(config);
+        waitAllForSafeState(factory.getAllHazelcastInstances());
 
         // 3. shutdown owner
         initialNode.shutdown();
@@ -1075,7 +1076,7 @@ public class EvictionTest extends HazelcastTestSupport {
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig()
                 .setSize(maxSize)
                 .setMaxSizePolicy(PER_NODE);
-        MapConfig mapConfig = new MapConfig("test")
+        MapConfig mapConfig = newMapConfig("test")
                 .setEvictionPolicy(RANDOM)
                 .setMaxSizeConfig(maxSizeConfig);
         Config config = getConfig()
@@ -1098,7 +1099,7 @@ public class EvictionTest extends HazelcastTestSupport {
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig()
                 .setSize(1)
                 .setMaxSizePolicy(PER_PARTITION);
-        MapConfig mapConfig = new MapConfig("test")
+        MapConfig mapConfig = newMapConfig("test")
                 .setEvictionPolicy(LFU)
                 .setMaxSizeConfig(maxSizeConfig);
         Config config = getConfig()
@@ -1136,7 +1137,7 @@ public class EvictionTest extends HazelcastTestSupport {
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig()
                 .setSize(90)
                 .setMaxSizePolicy(FREE_HEAP_PERCENTAGE);
-        MapConfig mapConfig = new MapConfig("test")
+        MapConfig mapConfig = newMapConfig("test")
                 .setEvictionPolicy(LFU)
                 .setMaxSizeConfig(maxSizeConfig);
         // don't use getConfig(), this test is OSS specific
@@ -1181,10 +1182,14 @@ public class EvictionTest extends HazelcastTestSupport {
         return instance.getMap(randomMapName());
     }
 
+    protected MapConfig newMapConfig(String mapName) {
+        return new MapConfig(mapName);
+    }
+
     private Config newConfig(String mapName, int maxSize, MaxSizeConfig.MaxSizePolicy maxSizePolicy) {
         MaxSizeConfig maxSizeConfig = new MaxSizeConfig(maxSize, maxSizePolicy);
 
-        MapConfig mapConfig = new MapConfig(mapName + "*")
+        MapConfig mapConfig = newMapConfig(mapName + "*")
                 .setMaxSizeConfig(maxSizeConfig)
                 .setEvictionPolicy(EvictionPolicy.LRU)
                 .setMinEvictionCheckMillis(0);
@@ -1194,7 +1199,7 @@ public class EvictionTest extends HazelcastTestSupport {
     }
 
     private Config newConfigWithTTL(String mapName, int ttlSeconds) {
-        MapConfig mapConfig = new MapConfig(mapName + "*")
+        MapConfig mapConfig = newMapConfig(mapName + "*")
                 .setTimeToLiveSeconds(ttlSeconds);
 
         return getConfig()

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -87,11 +87,32 @@ public class EvictionTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testTTL_entryShouldNotBeReachableAfterMaxIdle() {
+        IMap<Integer, String> map = createSimpleMap();
+
+        map.put(1, "value0", 0, TimeUnit.SECONDS, 1, TimeUnit.SECONDS);
+        sleepSeconds(1);
+
+        assertFalse(map.containsKey(1));
+    }
+
+    @Test
     public void testTTL_zeroIsInfinity() {
         IMap<Integer, String> map = createSimpleMap();
 
         map.put(1, "value0", 2, TimeUnit.SECONDS);
         map.put(1, "value1", 0, TimeUnit.SECONDS);
+        sleepSeconds(3);
+
+        assertTrue(map.containsKey(1));
+    }
+
+    @Test
+    public void testMaxIdle_zeroIsInfinity() {
+        IMap<Integer, String> map = createSimpleMap();
+
+        map.put(1, "value0", 0, TimeUnit.SECONDS, 1, TimeUnit.SECONDS);
+        map.put(1, "value1", 0, TimeUnit.SECONDS, 0, TimeUnit.SECONDS);
         sleepSeconds(3);
 
         assertTrue(map.containsKey(1));

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
@@ -226,7 +226,6 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
         // lastAccessTime is zero after put, we can find expiration by this calculation
         long expectedExpirationTime = delayToExpiration + entryView.getCreationTime();
-        System.out.println(lastAccessTime + " " + delayToExpiration);
         assertEquals(expectedExpirationTime, entryView.getExpirationTime());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
@@ -56,6 +56,33 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testExpirationTime_withTTL_withShorterMaxIdle() {
+        IMap<Integer, Integer> map = createMap();
+
+        map.put(1, 1, ONE_MINUTE_IN_MILLIS, MILLISECONDS, 3, SECONDS);
+
+        EntryView<Integer, Integer> entryView = map.getEntryView(1);
+        long creationTime = entryView.getCreationTime();
+
+        long expectedExpirationTime = creationTime + SECONDS.toMillis(3);
+        assertEquals(expectedExpirationTime, entryView.getExpirationTime());
+    }
+
+    @Test
+    public void testExpirationTime_withShorterTTL_andMaxIdle() {
+        IMap<Integer, Integer> map = createMap();
+
+        map.put(1, 1, 2, SECONDS, 10, SECONDS);
+
+        EntryView<Integer, Integer> entryView = map.getEntryView(1);
+        long creationTime = entryView.getCreationTime();
+
+        long expectedExpirationTime = creationTime + SECONDS.toMillis(2);
+        assertEquals(expectedExpirationTime, entryView.getExpirationTime());
+    }
+
+
+    @Test
     public void testExpirationTime_withZeroTTL() {
         IMap<Integer, Integer> map = createMap();
 
@@ -138,6 +165,34 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
         long expirationTime = entryView.getExpirationTime();
 
         long expectedExpirationTime = creationTime + TimeUnit.SECONDS.toMillis(10);
+        assertEquals(expectedExpirationTime, expirationTime);
+    }
+
+    @Test
+    public void testExpirationTime_withMaxIdleTime_withEntryCustomMaxIdle() {
+        IMap<Integer, Integer> map = createMapWithMaxIdleSeconds(10);
+
+        map.put(1, 1, -1, MILLISECONDS, 2, SECONDS);
+
+        EntryView<Integer, Integer> entryView = map.getEntryView(1);
+        long creationTime = entryView.getCreationTime();
+        long expirationTime = entryView.getExpirationTime();
+
+        long expectedExpirationTime = creationTime + TimeUnit.SECONDS.toMillis(2);
+        assertEquals(expectedExpirationTime, expirationTime);
+    }
+
+    @Test
+    public void testExpirationTime_withMaxIdleTime_withEntryCustomMaxIdleGreaterThanConfig() {
+        IMap<Integer, Integer> map = createMapWithMaxIdleSeconds(10);
+
+        map.put(1, 1, -1, MILLISECONDS, 2, MINUTES);
+
+        EntryView<Integer, Integer> entryView = map.getEntryView(1);
+        long creationTime = entryView.getCreationTime();
+        long expirationTime = entryView.getExpirationTime();
+
+        long expectedExpirationTime = creationTime + TimeUnit.MINUTES.toMillis(2);
         assertEquals(expectedExpirationTime, expirationTime);
     }
 
@@ -274,6 +329,7 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
     @SuppressWarnings("SameParameterValue")
     private static long getExpirationTime(IMap<Integer, Integer> map, int key) {
         EntryView<Integer, Integer> entryView = map.getEntryView(key);
+        System.out.println(entryView.toString());
         return entryView.getExpirationTime();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ExpirationTimeTest.java
@@ -155,7 +155,6 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
         EntryView<Integer, Integer> entryView = map.getEntryView(1);
         long lastAccessTime = entryView.getLastAccessTime();
-
         long expectedExpirationTime = lastAccessTime + TimeUnit.SECONDS.toMillis(10);
         assertEquals(expectedExpirationTime, entryView.getExpirationTime());
     }
@@ -172,6 +171,7 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
         // lastAccessTime is zero after put, we can find expiration by this calculation
         long expectedExpirationTime = delayToExpiration + entryView.getCreationTime();
+        System.out.println(lastAccessTime + " " + delayToExpiration);
         assertEquals(expectedExpirationTime, entryView.getExpirationTime());
     }
 
@@ -220,7 +220,7 @@ public class ExpirationTimeTest extends HazelcastTestSupport {
 
         map.put(1, 1, 100, SECONDS);
         long expirationTimeAfterPut = getExpirationTime(map, 1);
-        sleepAtLeastMillis(3);
+        sleepAtLeastMillis(1000);
 
         map.replace(1, 1, 2);
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/SimpleEntryViewTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/SimpleEntryViewTest.java
@@ -57,6 +57,7 @@ public class SimpleEntryViewTest extends HazelcastTestSupport {
                 + ", lastUpdateTime=" + entryView.getLastUpdateTime()
                 + ", version=" + entryView.getVersion()
                 + ", ttl=" + entryView.getTtl()
+                + ", maxIdle=" + entryView.getMaxIdle()
                 + '}';
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/AbstractRecordTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.Clock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -66,7 +67,7 @@ public class AbstractRecordTest {
 
         recordOtherCreationTime = new ObjectRecord(VALUE);
         recordOtherCreationTime.setKey(KEY);
-        recordOtherCreationTime.setCreationTime(152344145);
+        recordOtherCreationTime.setCreationTime(Clock.currentTimeMillis());
 
         recordOtherHits = new ObjectRecord(VALUE);
         recordOtherHits.setKey(KEY);
@@ -74,11 +75,11 @@ public class AbstractRecordTest {
 
         recordOtherLastAccessTime = new ObjectRecord(VALUE);
         recordOtherLastAccessTime.setKey(KEY);
-        recordOtherLastAccessTime.setLastAccessTime(354712354);
+        recordOtherLastAccessTime.setLastAccessTime(Clock.currentTimeMillis());
 
         recordOtherLastUpdateTime = new ObjectRecord(VALUE);
         recordOtherLastUpdateTime.setKey(KEY);
-        recordOtherLastUpdateTime.setLastUpdateTime(124241425);
+        recordOtherLastUpdateTime.setLastUpdateTime(Clock.currentTimeMillis() + 10000);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordWithStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/ObjectRecordWithStatsTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.Clock;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -62,7 +63,7 @@ public class ObjectRecordWithStatsTest {
 
         recordOtherExpirationTime = new ObjectRecordWithStats(VALUE);
         recordOtherExpirationTime.setKey(key);
-        recordOtherExpirationTime.setExpirationTime(2342);
+        recordOtherExpirationTime.setExpirationTime(Clock.currentTimeMillis());
 
         recordOtherKeyAndValue = new ObjectRecordWithStats();
         recordOtherKeyAndValue.setKey(otherKey);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/RecordsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/RecordsTest.java
@@ -121,10 +121,12 @@ public class RecordsTest extends HazelcastTestSupport {
         Record record = new DataRecordWithStats();
         Records.applyRecordInfo(record, recordInfo);
 
-        assertEquals(now, record.getCreationTime());
-        assertEquals(now, record.getCreationTime());
-        assertEquals(now, record.getLastAccessTime());
-        assertEquals(now, record.getLastUpdateTime());
+        // The creation time of the record is based on base offset (classloading time) + delta of (now - base)
+        // This info is stored as seconds, so the ms resolution is lost. Therefore the times retrieved from the Record
+        // will always be slightly elevated (depends on the classloading time).
+        assertEquals(now, record.getCreationTime(), 1);
+        assertEquals(now, record.getLastAccessTime(), 1);
+        assertEquals(now, record.getLastUpdateTime(), 1);
         assertEquals(123, record.getVersion());
         assertEquals(12, record.getHits());
         assertEquals(now, record.getExpirationTime());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/record/RecordsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/record/RecordsTest.java
@@ -124,13 +124,13 @@ public class RecordsTest extends HazelcastTestSupport {
         // The creation time of the record is based on base offset (classloading time) + delta of (now - base)
         // This info is stored as seconds, so the ms resolution is lost. Therefore the times retrieved from the Record
         // will always be slightly elevated (depends on the classloading time).
-        assertEquals(now, record.getCreationTime(), 1);
-        assertEquals(now, record.getLastAccessTime(), 1);
-        assertEquals(now, record.getLastUpdateTime(), 1);
+        assertEquals(now, record.getCreationTime(), 1000);
+        assertEquals(now, record.getLastAccessTime(), 1000);
+        assertEquals(now, record.getLastUpdateTime(), 1000);
         assertEquals(123, record.getVersion());
         assertEquals(12, record.getHits());
-        assertEquals(now, record.getExpirationTime());
-        assertEquals(now, record.getLastStoredTime());
+        assertEquals(now, record.getExpirationTime(), 1000);
+        assertEquals(now, record.getLastStoredTime(), 1000);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
 @Category({QuickTest.class, ParallelTest.class})
 public class LazyEntryViewFromRecordTest {
 
-    private static final int ENTRY_VIEW_COST_IN_BYTES = 97 + 4 * REFERENCE_COST_IN_BYTES;
+    private static final int ENTRY_VIEW_COST_IN_BYTES = 89 + 4 * REFERENCE_COST_IN_BYTES;
 
     private final String key = "key";
     private final String value = "value";

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecordTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
 @Category({QuickTest.class, ParallelTest.class})
 public class LazyEntryViewFromRecordTest {
 
-    private static final int ENTRY_VIEW_COST_IN_BYTES = 89 + 4 * REFERENCE_COST_IN_BYTES;
+    private static final int ENTRY_VIEW_COST_IN_BYTES = 77 + 4 * REFERENCE_COST_IN_BYTES;
 
     private final String key = "key";
     private final String value = "value";

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/LegacyMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/LegacyMapSplitBrainTest.java
@@ -245,13 +245,13 @@ public class LegacyMapSplitBrainTest extends SplitBrainTestSupport {
         mapA1.put("key1", "value1");
 
         // prevent updating at the same time
-        sleepAtLeastMillis(100);
+        sleepAtLeastMillis(1000);
 
         mapA2.put("key1", "LatestUpdatedValue1");
         mapA2.put("key2", "value2");
 
         // prevent updating at the same time
-        sleepAtLeastMillis(100);
+        sleepAtLeastMillis(1000);
 
         mapA1.put("key2", "LatestUpdatedValue2");
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
@@ -265,7 +265,7 @@ public class MapSplitBrainTest extends SplitBrainTestSupport {
         assertEquals("value1", mapA1.get("key1"));
 
         // prevent updating at the same time
-        sleepAtLeastMillis(100);
+        sleepAtLeastMillis(1000);
 
         mapA2.put("key1", "LatestAccessedValue1");
         // access to record
@@ -276,7 +276,7 @@ public class MapSplitBrainTest extends SplitBrainTestSupport {
         assertEquals("value2", mapA2.get("key2"));
 
         // prevent updating at the same time
-        sleepAtLeastMillis(100);
+        sleepAtLeastMillis(1000);
 
         mapA1.put("key2", "LatestAccessedValue2");
         // access to record

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/MapSplitBrainTest.java
@@ -301,13 +301,13 @@ public class MapSplitBrainTest extends SplitBrainTestSupport {
         mapA1.put("key1", "value1");
 
         // prevent updating at the same time
-        sleepAtLeastMillis(100);
+        sleepAtLeastMillis(1000);
 
         mapA2.put("key1", "LatestUpdatedValue1");
         mapA2.put("key2", "value2");
 
         // prevent updating at the same time
-        sleepAtLeastMillis(100);
+        sleepAtLeastMillis(1000);
 
         mapA1.put("key2", "LatestUpdatedValue2");
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_asyncInvokeOnPartitionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_asyncInvokeOnPartitionTest.java
@@ -68,7 +68,7 @@ public class OperationServiceImpl_asyncInvokeOnPartitionTest extends HazelcastTe
             Data sourceKey = nodeEngine.toData(entry.getKey());
             Data key = generateKey_FallsToSamePartitionThread_ButDifferentPartition(nodeEngine, sourceKey);
             Data val = nodeEngine.toData(randomString());
-            PutOperation op = new PutOperation((String) entry.getValue(), key, val, -1);
+            PutOperation op = new PutOperation((String) entry.getValue(), key, val, -1, -1);
             int partitionId = nodeEngine.getPartitionService().getPartitionId(key);
             operationService.asyncInvokeOnPartition(MapService.SERVICE_NAME, op, partitionId,
                     new ExecutionCallback<Object>() {

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.7.0-3</client.protocol.version>
+        <client.protocol.version>1.7.0-4</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
Introduces support for Max Idle per entry on IMap.
The behavior mimics TTL support per entry, and alters slightly the storage layout of the Record to save on memory costs.

Depends on https://github.com/hazelcast/hazelcast-client-protocol/pull/149
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2309

**IMPORTANT NOTE:** 
This change, introduces an additional field in the Record layout. To keep the record footprint small or smaller, the date fields were altered to an int datatype, holding only the delta between a known base time (produced on class loading). The side effect is that the millisecond resolution of the timestamps is now lost, to allow for a bigger second based resolution ~70 years vs ~25 days. 

**New Record sizes:**
OffHeap: 60bytes (before 60 bytes)
OnHeap: - 20 bytes per Record (with stats)

@Serdaro if this gets merged in 3.11 we need to mention that the timestamps retrieved from the IMap entries are now rounded up to the seconds.