### PR TITLE
Fixed backup test utils for HazelcastStarter

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorSplitBrainTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.cardinality;
 
-import com.hazelcast.cardinality.impl.CardinalityEstimatorProxy;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -142,10 +141,8 @@ public class CardinalityEstimatorSplitBrainTest extends SplitBrainTestSupport {
 
         estimatorB1 = instances[0].getCardinalityEstimator(estimatorNameB);
 
-        int partitionId = ((CardinalityEstimatorProxy) estimatorA1).getPartitionId();
-        backupEstimateA = getBackupEstimate(getFirstBackupInstance(instances, partitionId), estimatorNameA);
-        partitionId = ((CardinalityEstimatorProxy) estimatorB1).getPartitionId();
-        backupEstimateB = getBackupEstimate(getFirstBackupInstance(instances, partitionId), estimatorNameB);
+        backupEstimateA = getBackupEstimate(instances, estimatorA1);
+        backupEstimateB = getBackupEstimate(instances, estimatorB1);
 
         if (mergePolicyClass == DiscardMergePolicy.class) {
             onAfterMergeDiscardMergePolicy();

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorTestUtil.java
@@ -22,11 +22,28 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.test.HazelcastTestSupport;
 
+import static com.hazelcast.test.HazelcastTestSupport.getFirstBackupInstance;
 import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+import static com.hazelcast.test.HazelcastTestSupport.getPartitionIdViaReflection;
 
 final class CardinalityEstimatorTestUtil {
 
     private CardinalityEstimatorTestUtil() {
+    }
+
+    /**
+     * Returns the backup instance of an {@link CardinalityEstimator} by a given cardinality estimator instance.
+     * <p>
+     * Note: Returns the backups from the first replica index.
+     *
+     * @param instances            the {@link HazelcastInstance} array to gather the data from
+     * @param cardinalityEstimator the {@link CardinalityEstimator} to retrieve the backup from
+     * @return the backup estimation
+     */
+    static long getBackupEstimate(HazelcastInstance[] instances, CardinalityEstimator cardinalityEstimator) {
+        int partitionId = getPartitionIdViaReflection(cardinalityEstimator);
+        HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
+        return getBackupEstimate(backupInstance, cardinalityEstimator.getName());
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/CollectionTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/CollectionTestUtil.java
@@ -28,6 +28,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IList;
 import com.hazelcast.core.IQueue;
 import com.hazelcast.core.ISet;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastTestSupport;
 
@@ -39,13 +40,30 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 
+import static com.hazelcast.test.HazelcastTestSupport.getFirstBackupInstance;
 import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+import static com.hazelcast.test.HazelcastTestSupport.getPartitionIdViaReflection;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 
 public final class CollectionTestUtil {
 
     private CollectionTestUtil() {
+    }
+
+    /**
+     * Returns the backup instance of an {@link IList} by a given list instance.
+     * <p>
+     * Note: Returns the backups from the first replica index.
+     *
+     * @param instances the {@link HazelcastInstance} array to gather the data from
+     * @param list      the {@link IList} to retrieve the backup from
+     * @return a {@link List} with the backup items
+     */
+    public static <E> List<E> getBackupList(HazelcastInstance[] instances, IList list) {
+        int partitionId = getPartitionIdViaReflection(list);
+        HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
+        return getBackupList(backupInstance, list.getName());
     }
 
     /**
@@ -59,7 +77,8 @@ public final class CollectionTestUtil {
      * @return a {@link List} with the backup items
      */
     public static <E> List<E> getBackupList(HazelcastInstance backupInstance, String listName) {
-        CollectionService service = getNodeEngineImpl(backupInstance).getService(ListService.SERVICE_NAME);
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(backupInstance);
+        CollectionService service = nodeEngine.getService(ListService.SERVICE_NAME);
         CollectionContainer collectionContainer = service.getContainerMap().get(listName);
         if (collectionContainer == null) {
             return emptyList();
@@ -68,12 +87,27 @@ public final class CollectionTestUtil {
         Map<Long, CollectionItem> map = collectionContainer.getMap();
 
         List<E> backupList = new ArrayList<E>(map.size());
-        SerializationService serializationService = getNodeEngineImpl(backupInstance).getSerializationService();
+        SerializationService serializationService = nodeEngine.getSerializationService();
         for (CollectionItem collectionItem : map.values()) {
             E value = serializationService.toObject(collectionItem.getValue());
             backupList.add(value);
         }
         return backupList;
+    }
+
+    /**
+     * Returns the backup instance of an {@link IQueue} by a given queue instance.
+     * <p>
+     * Note: Returns the backups from the first replica index.
+     *
+     * @param instances the {@link HazelcastInstance} array to gather the data from
+     * @param queue     the {@link IQueue} to retrieve the backup from
+     * @return a {@link Queue} with the backup items
+     */
+    public static <E> Queue<E> getBackupQueue(HazelcastInstance[] instances, IQueue queue) {
+        int partitionId = getPartitionIdViaReflection(queue);
+        HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
+        return getBackupQueue(backupInstance, queue.getName());
     }
 
     /**
@@ -84,15 +118,16 @@ public final class CollectionTestUtil {
      *
      * @param backupInstance the {@link HazelcastInstance} to retrieve the backups from
      * @param queueName      the queue name
-     * @return a {@link List} with the backup items
+     * @return a {@link Queue} with the backup items
      */
     public static <E> Queue<E> getBackupQueue(HazelcastInstance backupInstance, String queueName) {
-        QueueService service = getNodeEngineImpl(backupInstance).getService(QueueService.SERVICE_NAME);
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(backupInstance);
+        QueueService service = nodeEngine.getService(QueueService.SERVICE_NAME);
         QueueContainer container = service.getOrCreateContainer(queueName, true);
         Map<Long, QueueItem> map = container.getBackupMap();
 
         Queue<E> backupQueue = new LinkedList<E>();
-        SerializationService serializationService = getNodeEngineImpl(backupInstance).getSerializationService();
+        SerializationService serializationService = nodeEngine.getSerializationService();
         for (QueueItem queueItem : map.values()) {
             E value = serializationService.toObject(queueItem.getData());
             backupQueue.add(value);
@@ -101,17 +136,33 @@ public final class CollectionTestUtil {
     }
 
     /**
-     * Returns all backup items of an {@link ISet} by a given queue name.
+     * Returns the backup instance of an {@link ISet} by a given set instance.
+     * <p>
+     * Note: Returns the backups from the first replica index.
+     *
+     * @param instances the {@link HazelcastInstance} array to gather the data from
+     * @param set       the {@link ISet} to retrieve the backup from
+     * @return a {@link Set} with the backup items
+     */
+    public static <E> Set<E> getBackupSet(HazelcastInstance[] instances, ISet set) {
+        int partitionId = getPartitionIdViaReflection(set);
+        HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
+        return getBackupSet(backupInstance, set.getName());
+    }
+
+    /**
+     * Returns all backup items of an {@link ISet} by a given set name.
      * <p>
      * Note: You have to provide the {@link HazelcastInstance} you want to retrieve the backups from.
      * Use {@link HazelcastTestSupport#getBackupInstance} to retrieve the backup instance for a given replica index.
      *
      * @param backupInstance the {@link HazelcastInstance} to retrieve the backups from
      * @param setName        the set name
-     * @return a {@link List} with the backup items
+     * @return a {@link Set} with the backup items
      */
     public static <E> Set<E> getBackupSet(HazelcastInstance backupInstance, String setName) {
-        CollectionService service = getNodeEngineImpl(backupInstance).getService(SetService.SERVICE_NAME);
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(backupInstance);
+        CollectionService service = nodeEngine.getService(SetService.SERVICE_NAME);
         CollectionContainer collectionContainer = service.getContainerMap().get(setName);
         if (collectionContainer == null) {
             return emptySet();
@@ -120,7 +171,7 @@ public final class CollectionTestUtil {
         Map<Long, CollectionItem> map = collectionContainer.getMap();
 
         Set<E> backupSet = new HashSet<E>();
-        SerializationService serializationService = getNodeEngineImpl(backupInstance).getSerializationService();
+        SerializationService serializationService = nodeEngine.getSerializationService();
         for (CollectionItem collectionItem : map.values()) {
             E value = serializationService.toObject(collectionItem.getValue());
             backupSet.add(value);

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/list/ListSplitBrainTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.collection.impl.list;
 
-import com.hazelcast.collection.impl.collection.AbstractCollectionProxyImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -135,9 +134,7 @@ public class ListSplitBrainTest extends SplitBrainTestSupport {
         // wait until merge completes
         mergeLifecycleListener.await();
 
-        int partitionId = ((AbstractCollectionProxyImpl) listA1).getPartitionId();
-        HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
-        backupList = getBackupList(backupInstance, listNameA);
+        backupList = getBackupList(instances, listA1);
 
         listB1 = instances[0].getList(listNameB);
 

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueSplitBrainTest.java
@@ -154,9 +154,7 @@ public class QueueSplitBrainTest extends SplitBrainTestSupport {
         queueStoreA.purgeValuesWithPrefix("lostItem");
         queueStoreB.purgeValuesWithPrefix("lostItem");
 
-        int partitionId = ((QueueProxySupport) queueA1).getPartitionId();
-        HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
-        backupQueue = getBackupQueue(backupInstance, queueNameA);
+        backupQueue = getBackupQueue(instances, queueA1);
 
         queueB1 = instances[0].getQueue(queueNameB);
 

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/set/SetSplitBrainTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.collection.impl.set;
 
-import com.hazelcast.collection.impl.collection.AbstractCollectionProxyImpl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.core.HazelcastInstance;
@@ -135,9 +134,7 @@ public class SetSplitBrainTest extends SplitBrainTestSupport {
         // wait until merge completes
         mergeLifecycleListener.await();
 
-        int partitionId = ((AbstractCollectionProxyImpl) setA1).getPartitionId();
-        HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
-        backupSet = getBackupSet(backupInstance, setNameA);
+        backupSet = getBackupSet(instances, setA1);
 
         setB1 = instances[0].getSet(setNameB);
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/ConcurrencyTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/ConcurrencyTestUtil.java
@@ -17,10 +17,8 @@
 package com.hazelcast.concurrent;
 
 import com.hazelcast.concurrent.atomiclong.AtomicLongContainer;
-import com.hazelcast.concurrent.atomiclong.AtomicLongProxy;
 import com.hazelcast.concurrent.atomiclong.AtomicLongService;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceContainer;
-import com.hazelcast.concurrent.atomicreference.AtomicReferenceProxy;
 import com.hazelcast.concurrent.atomicreference.AtomicReferenceService;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
@@ -33,15 +31,15 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.test.HazelcastTestSupport.getFirstBackupInstance;
 import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+import static com.hazelcast.test.HazelcastTestSupport.getPartitionIdViaReflection;
 
-@SuppressWarnings("WeakerAccess")
 public final class ConcurrencyTestUtil {
 
     private ConcurrencyTestUtil() {
     }
 
     /**
-     * Returns the backup instance of an {@link IAtomicLong} by a given atomic long name.
+     * Returns the backup instance of an {@link IAtomicLong} by a given atomic long instance.
      * <p>
      * Note: Returns the backups from the first replica index.
      *
@@ -50,7 +48,7 @@ public final class ConcurrencyTestUtil {
      * @return the backup {@link AtomicLong}
      */
     public static AtomicLong getAtomicLongBackup(HazelcastInstance[] instances, IAtomicLong atomicLong) {
-        int partitionId = ((AtomicLongProxy) atomicLong).getPartitionId();
+        int partitionId = getPartitionIdViaReflection(atomicLong);
         HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
         return getAtomicLongBackup(backupInstance, atomicLong.getName());
     }
@@ -82,7 +80,7 @@ public final class ConcurrencyTestUtil {
      */
     public static <E> AtomicReference<E> getAtomicReferenceBackup(HazelcastInstance[] instances,
                                                                   IAtomicReference<E> atomicReference) {
-        int partitionId = ((AtomicReferenceProxy) atomicReference).getPartitionId();
+        int partitionId = getPartitionIdViaReflection(atomicReference);
         HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
         return getAtomicReferenceBackup(backupInstance, atomicReference.getName());
     }

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/RingbufferTestUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/RingbufferTestUtil.java
@@ -18,8 +18,8 @@ package com.hazelcast.ringbuffer;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.ringbuffer.impl.RingbufferContainer;
-import com.hazelcast.ringbuffer.impl.RingbufferProxy;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.test.HazelcastTestSupport;
 
@@ -30,6 +30,7 @@ import java.util.List;
 import static com.hazelcast.ringbuffer.impl.RingbufferService.getRingbufferNamespace;
 import static com.hazelcast.test.HazelcastTestSupport.getFirstBackupInstance;
 import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+import static com.hazelcast.test.HazelcastTestSupport.getPartitionIdViaReflection;
 import static java.util.Collections.emptyList;
 
 final class RingbufferTestUtil {
@@ -47,7 +48,7 @@ final class RingbufferTestUtil {
      * @return a {@link Collection} with the backup items
      */
     static Collection<Object> getBackupRingbuffer(HazelcastInstance[] instances, Ringbuffer ringbuffer) {
-        int partitionId = ((RingbufferProxy) ringbuffer).getPartitionId();
+        int partitionId = getPartitionIdViaReflection(ringbuffer);
         HazelcastInstance backupInstance = getFirstBackupInstance(instances, partitionId);
         return getBackupRingbuffer(backupInstance, partitionId, ringbuffer.getName());
     }
@@ -64,14 +65,15 @@ final class RingbufferTestUtil {
      * @return a {@link Collection} with the backup items
      */
     static Collection<Object> getBackupRingbuffer(HazelcastInstance backupInstance, int partitionId, String ringbufferName) {
-        RingbufferService service = getNodeEngineImpl(backupInstance).getService(RingbufferService.SERVICE_NAME);
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(backupInstance);
+        RingbufferService service = nodeEngine.getService(RingbufferService.SERVICE_NAME);
         RingbufferContainer container = service.getContainerOrNull(partitionId, getRingbufferNamespace(ringbufferName));
         if (container == null) {
             return emptyList();
         }
 
+        SerializationService serializationService = nodeEngine.getSerializationService();
         List<Object> backupRingbuffer = new ArrayList<Object>((int) container.size());
-        SerializationService serializationService = getNodeEngineImpl(backupInstance).getSerializationService();
         for (long sequence = container.headSequence(); sequence <= container.tailSequence(); sequence++) {
             backupRingbuffer.add(serializationService.toObject(container.readAsData(sequence)));
         }


### PR DESCRIPTION
Proxied Hazelcast instances from `HazelcastStarter` cannot easily use casting to get access to implementation details. A good workaround is to use reflection.

This PR prepares the split-brain tests to use a reflective way to verify the backups of a data structure.

Pulled out from https://github.com/hazelcast/hazelcast/pull/13293