### PR TITLE
Enhancement/setexpirypolicy cache

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -396,12 +396,12 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
     private void setExpiryPolicyAndWaitForCompletion(List<Data>[] keysByPartition, ExpiryPolicy expiryPolicy) {
         List<Future> futures = new ArrayList<Future>(keysByPartition.length);
 
-        Data expiryPolicyData = toData(expiryPolicy);
+        Data policyData = toData(expiryPolicy);
         for (int partitionId = 0; partitionId < keysByPartition.length; partitionId++) {
             List<Data> keys = keysByPartition[partitionId];
             if (keys != null) {
                 int completionId = nextCompletionId();
-                ClientMessage request = CacheSetExpiryPolicyCodec.encodeRequest(nameWithPrefix, keys, expiryPolicyData, completionId);
+                ClientMessage request = CacheSetExpiryPolicyCodec.encodeRequest(nameWithPrefix, keys, policyData, completionId);
                 futures.add(invoke(request, partitionId, completionId));
             }
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -50,6 +50,7 @@ import java.util.concurrent.Future;
 
 import static com.hazelcast.cache.impl.CacheProxyUtil.NULL_KEY_IS_NOT_ALLOWED;
 import static com.hazelcast.cache.impl.CacheProxyUtil.validateNotNull;
+import static com.hazelcast.cache.impl.operation.MutableOperation.IGNORE_COMPLETION;
 import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.ExceptionUtil.rethrowAllowedTypeFirst;
@@ -402,8 +403,8 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
             List<Data> keys = keysByPartition[partitionId];
             if (keys != null) {
                 int completionId = nextCompletionId();
-                ClientMessage request = CacheSetExpiryPolicyCodec.encodeRequest(nameWithPrefix, keys, policyData, completionId);
-                futures.add(invoke(request, partitionId, completionId));
+                ClientMessage request = CacheSetExpiryPolicyCodec.encodeRequest(nameWithPrefix, keys, policyData);
+                futures.add(invoke(request, partitionId, IGNORE_COMPLETION));
             }
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientCacheProxy.java
@@ -280,7 +280,7 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
     }
 
     @Override
-    public void setExpiryPolicy(Set<K> keys, ExpiryPolicy policy) {
+    public void setExpiryPolicy(Set<? extends K> keys, ExpiryPolicy policy) {
         ensureOpen();
         checkNotNull(keys);
         checkNotNull(policy);
@@ -331,7 +331,7 @@ abstract class AbstractClientCacheProxy<K, V> extends AbstractClientInternalCach
         }
     }
 
-    private List<Data>[] groupKeysToPartitions(Set<K> keys) {
+    private List<Data>[] groupKeysToPartitions(Set<? extends K> keys) {
         List<Data>[] keysByPartition = new List[partitionCount];
         ClientPartitionService partitionService = getContext().getPartitionService();
         for (K key: keys) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/ClientCacheProxy.java
@@ -483,6 +483,11 @@ public class ClientCacheProxy<K, V> extends AbstractClientCacheProxy<K, V>
     }
 
     @Override
+    public void setExpiryPolicy(K key, ExpiryPolicy expiryPolicy) {
+        setExpiryPolicy(Collections.singleton(key), expiryPolicy);
+    }
+
+    @Override
     public String addPartitionLostListener(CachePartitionLostListener listener) {
         EventHandler<ClientMessage> handler = new ClientCachePartitionLostEventHandler(listener);
         injectDependencies(listener);

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheEntryView.java
@@ -60,4 +60,11 @@ public interface CacheEntryView<K, V> extends EvictableEntryView<K, V> {
      * @return the count of how many time this cache entry has been accessed
      */
     long getAccessHit();
+
+    /**
+     * Gets the expiry policy associated with this entry if any
+     *
+     * @return expiry policy associated with this entry or {@code null}
+     */
+    Object getExpiryPolicy();
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheEntryView.java
@@ -62,9 +62,9 @@ public interface CacheEntryView<K, V> extends EvictableEntryView<K, V> {
     long getAccessHit();
 
     /**
-     * Gets the expiry policy associated with this entry if any
+     * Gets the expiry policy associated with this entry if there is one.
      *
-     * @return expiry policy associated with this entry or {@code null}
+     * @return the expiry policy associated with this entry or {@code null} if there is none
      */
     Object getExpiryPolicy();
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheEvictionPolicyComparator.java
@@ -18,8 +18,6 @@ package com.hazelcast.cache;
 
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
 
-import javax.cache.expiry.ExpiryPolicy;
-
 /**
  * Cache specific {@link EvictionPolicyComparator} for comparing
  * {@link CacheEntryView}s to be evicted.

--- a/hazelcast/src/main/java/com/hazelcast/cache/CacheEvictionPolicyComparator.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/CacheEvictionPolicyComparator.java
@@ -18,6 +18,8 @@ package com.hazelcast.cache;
 
 import com.hazelcast.internal.eviction.EvictionPolicyComparator;
 
+import javax.cache.expiry.ExpiryPolicy;
+
 /**
  * Cache specific {@link EvictionPolicyComparator} for comparing
  * {@link CacheEntryView}s to be evicted.

--- a/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
@@ -143,7 +143,7 @@ public interface ICache<K, V>
      * @throws  NullPointerException if {@code keys} or {@code expiryPolicy} is null.
      * @since 3.11
      */
-    void setExpiryPolicy(Set<K> keys, ExpiryPolicy expiryPolicy);
+    void setExpiryPolicy(Set<? extends K> keys, ExpiryPolicy expiryPolicy);
 
     /**
      * Asynchronously retrieves the mapped value of the given key using a custom

--- a/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
@@ -114,6 +114,37 @@ import java.util.Set;
 public interface ICache<K, V>
         extends javax.cache.Cache<K, V>, PrefixedDistributedObject {
 
+
+    /**
+     * Associates the specified key with the given {@link javax.cache.expiry.ExpiryPolicy}.
+     * {@code expiryPolicy} takes precedence for this particular {@code key} against any cache wide expiry policy.
+     * If {@code key} does not exist or is already expired, this call has no effect.
+     *
+     * Note: This operation does not change current time-to-live duration of the entry. The new expiry policy is used
+     * to calculate time-to-live duration only after the expiry policy is triggered after custom expiry policy is set.
+     *
+     * @param   key The key that is associated with the specified expiry policy.
+     * @param   expiryPolicy custom expiry policy for this operation
+     * @throws  NullPointerException if {@code keys} or {@code expiryPolicy} is null.
+     * @since 3.11
+     */
+    void setExpiryPolicy(K key, ExpiryPolicy expiryPolicy);
+
+    /**
+     * Associates the specified key with the given {@link javax.cache.expiry.ExpiryPolicy}.
+     * {@code expiryPolicy} takes precedence for these particular {@code keys} against any cache wide expiry policy.
+     * If some keys in {@code keys} do not exist or are already expired, this call has no effect for those.
+     *
+     * Note: This operation does not change current time-to-live duration of the entry. The new expiry policy is used
+     * to calculate time-to-live duration only after the expiry policy is triggered after custom expiry policy is set.
+     *
+     * @param   keys The keys that are associated with the specified expiry policy.
+     * @param   expiryPolicy custom expiry policy for this operation
+     * @throws  NullPointerException if {@code keys} or {@code expiryPolicy} is null.
+     * @since 3.11
+     */
+    void setExpiryPolicy(Set<K> keys, ExpiryPolicy expiryPolicy);
+
     /**
      * Asynchronously retrieves the mapped value of the given key using a custom
      * {@link javax.cache.expiry.ExpiryPolicy}. If no mapping exists <tt>null</tt> is returned.

--- a/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/ICache.java
@@ -120,8 +120,8 @@ public interface ICache<K, V>
      * {@code expiryPolicy} takes precedence for this particular {@code key} against any cache wide expiry policy.
      * If {@code key} does not exist or is already expired, this call has no effect.
      *
-     * Note: This operation does not change current time-to-live duration of the entry. The new expiry policy is used
-     * to calculate time-to-live duration only after the expiry policy is triggered after custom expiry policy is set.
+     * Note: New time-to-live duration is calculated using newly added entry policy's getExpiryForUpdate method
+     * immediately after this operation succeeds.
      *
      * @param   key The key that is associated with the specified expiry policy.
      * @param   expiryPolicy custom expiry policy for this operation
@@ -135,8 +135,8 @@ public interface ICache<K, V>
      * {@code expiryPolicy} takes precedence for these particular {@code keys} against any cache wide expiry policy.
      * If some keys in {@code keys} do not exist or are already expired, this call has no effect for those.
      *
-     * Note: This operation does not change current time-to-live duration of the entry. The new expiry policy is used
-     * to calculate time-to-live duration only after the expiry policy is triggered after custom expiry policy is set.
+     * Note: New time-to-live duration is calculated using newly added entry policy's getExpiryForUpdate method
+     * immediately after this operation succeeds.
      *
      * @param   keys The keys that are associated with the specified expiry policy.
      * @param   expiryPolicy custom expiry policy for this operation

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
@@ -230,7 +230,7 @@ abstract class AbstractCacheProxy<K, V>
     }
 
     @Override
-    public void setExpiryPolicy(Set<K> keys, ExpiryPolicy expiryPolicy) {
+    public void setExpiryPolicy(Set<? extends K> keys, ExpiryPolicy expiryPolicy) {
         ensureOpen();
         validateNotNull(keys);
         validateNotNull(expiryPolicy);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.impl;
 
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.InternalCompletableFuture;
@@ -56,6 +57,7 @@ import static java.util.Collections.emptyMap;
  * @see com.hazelcast.cache.impl.CacheProxy
  * @see com.hazelcast.cache.ICache
  */
+@SuppressWarnings("checkstyle:methodcount")
 abstract class AbstractCacheProxy<K, V>
         extends AbstractInternalCacheProxy<K, V> {
 
@@ -231,6 +233,10 @@ abstract class AbstractCacheProxy<K, V>
 
     @Override
     public void setExpiryPolicy(Set<? extends K> keys, ExpiryPolicy expiryPolicy) {
+        if (isClusterVersionLessThan(Versions.V3_11)) {
+            throw new UnsupportedOperationException("setExpiryPolicy operation is available"
+                    + "when cluster version is 3.11 or higher");
+        }
         ensureOpen();
         validateNotNull(keys);
         validateNotNull(expiryPolicy);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheProxy.java
@@ -238,7 +238,7 @@ abstract class AbstractCacheProxy<K, V>
         try {
             int partitionCount = partitionService.getPartitionCount();
             List<Data>[] keysPerPartition = groupDataToPartitions(keys, partitionCount);
-            setTTLAllPartitionsAndWaitForCompletion(keysPerPartition, expiryPolicy);
+            setTTLAllPartitionsAndWaitForCompletion(keysPerPartition, serializationService.toData(expiryPolicy));
         } catch (Exception e) {
             rethrow(e);
         }
@@ -333,7 +333,7 @@ abstract class AbstractCacheProxy<K, V>
         }
     }
 
-    private void setTTLAllPartitionsAndWaitForCompletion(List<Data>[] keysPerPartition, ExpiryPolicy expiryPolicy) {
+    private void setTTLAllPartitionsAndWaitForCompletion(List<Data>[] keysPerPartition, Data expiryPolicy) {
         List<Future> futures = new ArrayList<Future>(keysPerPartition.length);
         for (int partitionId = 0; partitionId < keysPerPartition.length; partitionId++) {
             List<Data> keys = keysPerPartition[partitionId];

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -706,11 +706,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         Object inMemoryExpiryPolicy;
         switch (cacheConfig.getInMemoryFormat()) {
             case OBJECT:
-                if (expiryPolicy instanceof Data) {
-                    inMemoryExpiryPolicy = dataToValue((Data) expiryPolicy);
-                } else {
-                    inMemoryExpiryPolicy = expiryPolicy;
-                }
+                inMemoryExpiryPolicy = toValue(expiryPolicy);
                 break;
             case BINARY:
             case NATIVE:

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -62,6 +62,7 @@ import com.hazelcast.cache.impl.operation.CacheRemoveBackupOperation;
 import com.hazelcast.cache.impl.operation.CacheRemoveOperation;
 import com.hazelcast.cache.impl.operation.CacheReplaceOperation;
 import com.hazelcast.cache.impl.operation.CacheReplicationOperation;
+import com.hazelcast.cache.impl.operation.CacheSetExpiryPolicyOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperationFactory;
 import com.hazelcast.cache.impl.operation.OnJoinCacheOperation;
@@ -158,8 +159,9 @@ public final class CacheDataSerializerHook
     public static final int MERGE_FACTORY = 64;
     public static final int MERGE = 65;
     public static final int ADD_CACHE_CONFIG_OPERATION = 66;
+    public static final int SET_EXPIRY_POLICY = 67;
 
-    private static final int LEN = ADD_CACHE_CONFIG_OPERATION + 1;
+    private static final int LEN = SET_EXPIRY_POLICY + 1;
 
     public int getFactoryId() {
         return F_ID;
@@ -502,6 +504,12 @@ public final class CacheDataSerializerHook
                         return new AddCacheConfigOperation();
                     }
                 };
+        constructors[SET_EXPIRY_POLICY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheSetExpiryPolicyOperation();
+            }
+        };
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheDataSerializerHook.java
@@ -62,6 +62,7 @@ import com.hazelcast.cache.impl.operation.CacheRemoveBackupOperation;
 import com.hazelcast.cache.impl.operation.CacheRemoveOperation;
 import com.hazelcast.cache.impl.operation.CacheReplaceOperation;
 import com.hazelcast.cache.impl.operation.CacheReplicationOperation;
+import com.hazelcast.cache.impl.operation.CacheSetExpiryPolicyBackupOperation;
 import com.hazelcast.cache.impl.operation.CacheSetExpiryPolicyOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperationFactory;
@@ -160,8 +161,9 @@ public final class CacheDataSerializerHook
     public static final int MERGE = 65;
     public static final int ADD_CACHE_CONFIG_OPERATION = 66;
     public static final int SET_EXPIRY_POLICY = 67;
+    public static final int SET_EXPIRY_POLICY_BACKUP = 68;
 
-    private static final int LEN = SET_EXPIRY_POLICY + 1;
+    private static final int LEN = SET_EXPIRY_POLICY_BACKUP + 1;
 
     public int getFactoryId() {
         return F_ID;
@@ -508,6 +510,12 @@ public final class CacheDataSerializerHook
             @Override
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new CacheSetExpiryPolicyOperation();
+            }
+        };
+        constructors[SET_EXPIRY_POLICY_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new CacheSetExpiryPolicyBackupOperation();
             }
         };
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryViews.java
@@ -61,9 +61,18 @@ public final class CacheEntryViews {
                                                              record.getCreationTime(),
                                                              record.getExpirationTime(),
                                                              record.getLastAccessTime(),
-                                                             record.getAccessHit());
+                                                             record.getAccessHit(),
+                                                             (Data) record.getExpiryPolicy());
         return entryView;
     }
+
+    public static CacheEntryView<Data, Data> createEntryView(Data key, CacheRecord record) {
+        if (record == null) {
+            throw new IllegalArgumentException("Empty record");
+        }
+        return createDefaultEntryView(key, (Data) record.getValue(), record);
+    }
+
 
     /**
      * Creates a {@link LazyCacheEntryView} instance.
@@ -79,7 +88,8 @@ public final class CacheEntryViews {
                                                           record.getCreationTime(),
                                                           record.getExpirationTime(),
                                                           record.getLastAccessTime(),
-                                                          record.getAccessHit());
+                                                          record.getAccessHit(),
+                                                          record.getExpiryPolicy());
         return entryView;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryViews.java
@@ -56,21 +56,22 @@ public final class CacheEntryViews {
      *                  expiration time and access hit
      * @return the {@link DefaultCacheEntryView} instance
      */
-    public static CacheEntryView<Data, Data> createDefaultEntryView(Data key, Data value, CacheRecord record) {
+    public static CacheEntryView<Data, Data> createDefaultEntryView(Data key, Data value, Data expiryPolicy,
+                                                                    CacheRecord<Object, Data> record) {
         CacheEntryView entryView = new DefaultCacheEntryView(key, value,
                                                              record.getCreationTime(),
                                                              record.getExpirationTime(),
                                                              record.getLastAccessTime(),
                                                              record.getAccessHit(),
-                                                             (Data) record.getExpiryPolicy());
+                                                             expiryPolicy);
         return entryView;
     }
 
-    public static CacheEntryView<Data, Data> createEntryView(Data key, CacheRecord record) {
+    public static CacheEntryView<Data, Data> createEntryView(Data key, Data expiryPolicy, CacheRecord record) {
         if (record == null) {
             throw new IllegalArgumentException("Empty record");
         }
-        return createDefaultEntryView(key, (Data) record.getValue(), record);
+        return createDefaultEntryView(key, (Data) record.getValue(), expiryPolicy, record);
     }
 
 
@@ -83,13 +84,13 @@ public final class CacheEntryViews {
      *                  expiration time and access hit
      * @return the {@link LazyCacheEntryView} instance
      */
-    public static CacheEntryView<Data, Data> createLazyEntryView(Data key, Data value, CacheRecord record) {
+    public static CacheEntryView<Data, Data> createLazyEntryView(Data key, Data value, Data expiryPolicy, CacheRecord record) {
         CacheEntryView entryView = new LazyCacheEntryView(key, value,
                                                           record.getCreationTime(),
                                                           record.getExpirationTime(),
                                                           record.getLastAccessTime(),
                                                           record.getAccessHit(),
-                                                          record.getExpiryPolicy());
+                                                          expiryPolicy);
         return entryView;
     }
 
@@ -103,16 +104,16 @@ public final class CacheEntryViews {
      * @param cacheEntryViewType    the type of the {@link CacheEntryView} represented as {@link CacheEntryViewType}
      * @return the {@link CacheEntryView} instance
      */
-    public static CacheEntryView<Data, Data> createEntryView(Data key, Data value, CacheRecord record,
+    public static CacheEntryView<Data, Data> createEntryView(Data key, Data value, Data expiryPolicy, CacheRecord record,
                                                              CacheEntryViewType cacheEntryViewType) {
         if (cacheEntryViewType == null) {
             throw new IllegalArgumentException("Empty cache entry view type");
         }
         switch (cacheEntryViewType) {
             case DEFAULT:
-                return createDefaultEntryView(key, value, record);
+                return createDefaultEntryView(key, value, expiryPolicy, record);
             case LAZY:
-                return createLazyEntryView(key, value, record);
+                return createLazyEntryView(key, value, expiryPolicy, record);
             default:
                 throw new IllegalArgumentException("Invalid cache entry view type: " + cacheEntryViewType);
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContext.java
@@ -37,6 +37,7 @@ public class CacheEventContext {
     private String origin;
     private int orderKey;
     private int completionId;
+    private Data expiryPolicy;
 
     public CacheEventContext() { }
 
@@ -126,6 +127,15 @@ public class CacheEventContext {
 
     public CacheEventContext setAccessHit(long accessHit) {
         this.accessHit = accessHit;
+        return this;
+    }
+
+    public Data getExpiryPolicy() {
+        return expiryPolicy;
+    }
+
+    public CacheEventContext setExpiryPolicy(Data expiryPolicy) {
+        this.expiryPolicy = expiryPolicy;
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContextUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContextUtil.java
@@ -75,7 +75,7 @@ public final class CacheEventContextUtil {
     public static CacheEventContext createCacheUpdatedEvent(Data dataKey, Data dataValue, Data dataOldValue,
                                                             long creationTime, long expirationTime,
                                                             long lastAccessTime, long accessHit,
-                                                            String origin, int completionId) {
+                                                            String origin, int completionId, Data expiryPolicy) {
         CacheEventContext cacheEventContext =
                 createBaseEventContext(CacheEventType.UPDATED, dataKey, dataValue,
                                        expirationTime, origin, completionId);
@@ -84,15 +84,8 @@ public final class CacheEventContextUtil {
         cacheEventContext.setCreationTime(creationTime);
         cacheEventContext.setLastAccessTime(lastAccessTime);
         cacheEventContext.setAccessHit(accessHit);
+        cacheEventContext.setExpiryPolicy(expiryPolicy);
         return cacheEventContext;
-    }
-
-    public static CacheEventContext createCacheUpdatedEvent(Data dataKey, Data dataValue, Data dataOldValue,
-                                                            long creationTime, long expirationTime,
-                                                            long lastAccessTime, long accessHit,
-                                                            String origin, int completionId, Data expiryPolicy) {
-        return createCacheUpdatedEvent(dataKey, dataValue, dataOldValue, creationTime, expirationTime, lastAccessTime,
-                accessHit, origin, completionId).setExpiryPolicy(expiryPolicy);
     }
 
     public static CacheEventContext createCacheUpdatedEvent(Data dataKey, Data dataValue, Data dataOldValue,

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContextUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEventContextUtil.java
@@ -89,10 +89,18 @@ public final class CacheEventContextUtil {
 
     public static CacheEventContext createCacheUpdatedEvent(Data dataKey, Data dataValue, Data dataOldValue,
                                                             long creationTime, long expirationTime,
-                                                            long lastAccessTime, long accessHit) {
+                                                            long lastAccessTime, long accessHit,
+                                                            String origin, int completionId, Data expiryPolicy) {
+        return createCacheUpdatedEvent(dataKey, dataValue, dataOldValue, creationTime, expirationTime, lastAccessTime,
+                accessHit, origin, completionId).setExpiryPolicy(expiryPolicy);
+    }
+
+    public static CacheEventContext createCacheUpdatedEvent(Data dataKey, Data dataValue, Data dataOldValue,
+                                                            long creationTime, long expirationTime,
+                                                            long lastAccessTime, long accessHit, Data expiryPolicy) {
         return createCacheUpdatedEvent(dataKey, dataValue, dataOldValue,
                                        creationTime, expirationTime, lastAccessTime, accessHit,
-                                       null, MutableOperation.IGNORE_COMPLETION);
+                                       null, MutableOperation.IGNORE_COMPLETION, expiryPolicy);
     }
 
     public static CacheEventContext createCacheRemovedEvent(Data dataKey, Data dataValue,

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheMergeRunnable.java
@@ -99,7 +99,8 @@ class CacheMergeRunnable extends AbstractMergeRunnable<Data, Data, ICacheRecordS
                     record.getCreationTime(),
                     record.getExpirationTime(),
                     record.getLastAccessTime(),
-                    record.getAccessHit());
+                    record.getAccessHit(),
+                    toData(record.getExpiryPolicy()));
 
             consumer.accept(partitionId, new CacheLegacyMergeOperation(name, key, entryView, mergePolicy));
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
@@ -64,6 +64,10 @@ public interface CacheOperationProvider {
                                                  List<CacheMergeTypes>[] mergingEntries,
                                                  SplitBrainMergePolicy<Data, CacheMergeTypes> policy);
 
+    Operation createSetExpiryPolicyOperation(List<Data> keys, ExpiryPolicy expiryPolicy, int completionId);
+
+    Operation createSetExpiryPolicyOperation(List<Data> keys, ExpiryPolicy expiryPolicy);
+
     OperationFactory createGetAllOperationFactory(Set<Data> keySet, ExpiryPolicy policy);
 
     OperationFactory createLoadAllOperationFactory(Set<Data> keySet, boolean replaceExistingValues);
@@ -73,4 +77,5 @@ public interface CacheOperationProvider {
     OperationFactory createRemoveAllOperationFactory(Set<Data> keySet, Integer completionId);
 
     OperationFactory createSizeOperationFactory();
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
@@ -64,9 +64,9 @@ public interface CacheOperationProvider {
                                                  List<CacheMergeTypes>[] mergingEntries,
                                                  SplitBrainMergePolicy<Data, CacheMergeTypes> policy);
 
-    Operation createSetExpiryPolicyOperation(List<Data> keys, ExpiryPolicy expiryPolicy, int completionId);
+    Operation createSetExpiryPolicyOperation(List<Data> keys, Data expiryPolicy, int completionId);
 
-    Operation createSetExpiryPolicyOperation(List<Data> keys, ExpiryPolicy expiryPolicy);
+    Operation createSetExpiryPolicyOperation(List<Data> keys, Data expiryPolicy);
 
     OperationFactory createGetAllOperationFactory(Set<Data> keySet, ExpiryPolicy policy);
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheOperationProvider.java
@@ -64,8 +64,6 @@ public interface CacheOperationProvider {
                                                  List<CacheMergeTypes>[] mergingEntries,
                                                  SplitBrainMergePolicy<Data, CacheMergeTypes> policy);
 
-    Operation createSetExpiryPolicyOperation(List<Data> keys, Data expiryPolicy, int completionId);
-
     Operation createSetExpiryPolicyOperation(List<Data> keys, Data expiryPolicy);
 
     OperationFactory createGetAllOperationFactory(Set<Data> keySet, ExpiryPolicy policy);

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheProxy.java
@@ -48,6 +48,7 @@ import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.EntryProcessorResult;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -349,6 +350,11 @@ public class CacheProxy<K, V> extends AbstractCacheProxy<K, V>
     public Iterator<Entry<K, V>> iterator(int fetchSize, int partitionId, boolean prefetchValues) {
         ensureOpen();
         return new CachePartitionIterator<K, V>(this, fetchSize, partitionId, prefetchValues);
+    }
+
+    @Override
+    public void setExpiryPolicy(K key, ExpiryPolicy expiryPolicy) {
+        setExpiryPolicy(Collections.singleton(key), expiryPolicy);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
@@ -135,12 +135,12 @@ public class DefaultOperationProvider implements CacheOperationProvider {
     }
 
     @Override
-    public Operation createSetExpiryPolicyOperation(List<Data> keys, ExpiryPolicy expiryPolicy, int completionId) {
+    public Operation createSetExpiryPolicyOperation(List<Data> keys, Data expiryPolicy, int completionId) {
         return new CacheSetExpiryPolicyOperation(nameWithPrefix, keys, expiryPolicy, completionId);
     }
 
     @Override
-    public Operation createSetExpiryPolicyOperation(List<Data> keys, ExpiryPolicy expiryPolicy) {
+    public Operation createSetExpiryPolicyOperation(List<Data> keys, Data expiryPolicy) {
         return new CacheSetExpiryPolicyOperation(nameWithPrefix, keys, expiryPolicy);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
@@ -135,11 +135,6 @@ public class DefaultOperationProvider implements CacheOperationProvider {
     }
 
     @Override
-    public Operation createSetExpiryPolicyOperation(List<Data> keys, Data expiryPolicy, int completionId) {
-        return new CacheSetExpiryPolicyOperation(nameWithPrefix, keys, expiryPolicy, completionId);
-    }
-
-    @Override
     public Operation createSetExpiryPolicyOperation(List<Data> keys, Data expiryPolicy) {
         return new CacheSetExpiryPolicyOperation(nameWithPrefix, keys, expiryPolicy);
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DefaultOperationProvider.java
@@ -34,6 +34,7 @@ import com.hazelcast.cache.impl.operation.CachePutOperation;
 import com.hazelcast.cache.impl.operation.CacheRemoveAllOperationFactory;
 import com.hazelcast.cache.impl.operation.CacheRemoveOperation;
 import com.hazelcast.cache.impl.operation.CacheReplaceOperation;
+import com.hazelcast.cache.impl.operation.CacheSetExpiryPolicyOperation;
 import com.hazelcast.cache.impl.operation.CacheSizeOperationFactory;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.nio.serialization.Data;
@@ -131,6 +132,16 @@ public class DefaultOperationProvider implements CacheOperationProvider {
                                                         List<CacheMergeTypes>[] mergingEntries,
                                                         SplitBrainMergePolicy<Data, CacheMergeTypes> policy) {
         return new CacheMergeOperationFactory(name, partitions, mergingEntries, policy);
+    }
+
+    @Override
+    public Operation createSetExpiryPolicyOperation(List<Data> keys, ExpiryPolicy expiryPolicy, int completionId) {
+        return new CacheSetExpiryPolicyOperation(nameWithPrefix, keys, expiryPolicy, completionId);
+    }
+
+    @Override
+    public Operation createSetExpiryPolicyOperation(List<Data> keys, ExpiryPolicy expiryPolicy) {
+        return new CacheSetExpiryPolicyOperation(nameWithPrefix, keys, expiryPolicy);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -28,6 +28,7 @@ import com.hazelcast.spi.merge.SplitBrainMergeTypes.CacheMergeTypes;
 
 import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.processor.EntryProcessor;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
@@ -269,6 +270,16 @@ public interface ICacheRecordStore {
      * <tt>null</tt> if there was no mapping for the key.
      */
     Object getAndReplace(Data key, Object value, ExpiryPolicy expiryPolicy, String caller, int completionId);
+
+
+    /**
+     * Sets expiry policy for the records with given keys if and only if there is a
+     * value currently mapped by the key
+     *
+     * @param keys          keys for the entries
+     * @param expiryPolicy  custom expiry policy or null to use configured default value
+     */
+    void setExpiryPolicy(Collection<Data> keys, ExpiryPolicy expiryPolicy, int completionId);
 
     /**
      * Determines if this store contains an entry for the specified key.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -279,7 +279,9 @@ public interface ICacheRecordStore {
      * @param keys          keys for the entries
      * @param expiryPolicy  custom expiry policy or null to use configured default value
      */
-    void setExpiryPolicy(Collection<Data> keys, ExpiryPolicy expiryPolicy, int completionId);
+    void setExpiryPolicy(Collection<Data> keys, Object expiryPolicy, int completionId);
+
+    Object getExpiryPolicy(Data key);
 
     /**
      * Determines if this store contains an entry for the specified key.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -279,7 +279,7 @@ public interface ICacheRecordStore {
      * @param keys          keys for the entries
      * @param expiryPolicy  custom expiry policy or null to use configured default value
      */
-    void setExpiryPolicy(Collection<Data> keys, Object expiryPolicy, String source, int completionId);
+    void setExpiryPolicy(Collection<Data> keys, Object expiryPolicy, String source);
 
     Object getExpiryPolicy(Data key);
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -279,7 +279,7 @@ public interface ICacheRecordStore {
      * @param keys          keys for the entries
      * @param expiryPolicy  custom expiry policy or null to use configured default value
      */
-    void setExpiryPolicy(Collection<Data> keys, Object expiryPolicy, int completionId);
+    void setExpiryPolicy(Collection<Data> keys, Object expiryPolicy, String source, int completionId);
 
     Object getExpiryPolicy(Data key);
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
@@ -18,11 +18,12 @@ package com.hazelcast.cache.impl.merge.entry;
 
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.version.Version;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 
@@ -30,7 +31,7 @@ import java.io.IOException;
  * Default heap based implementation of {@link com.hazelcast.cache.CacheEntryView}.
  */
 public class DefaultCacheEntryView
-        implements CacheEntryView<Data, Data>, IdentifiedDataSerializable {
+        implements CacheEntryView<Data, Data>, IdentifiedDataSerializable, Versioned {
 
     private Data key;
     private Data value;
@@ -85,6 +86,11 @@ public class DefaultCacheEntryView
         return accessHit;
     }
 
+    /**
+     * Gets the expiry policy associated with this entry if any
+     *
+     * @return expiry policy associated with this entry or {@code null}
+     */
     @Override
     public Data getExpiryPolicy() {
         return expiryPolicy;
@@ -98,7 +104,7 @@ public class DefaultCacheEntryView
         out.writeLong(accessHit);
         out.writeData(key);
         out.writeData(value);
-        if (out.getVersion().isGreaterOrEqual(Version.of("3.11"))) {
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             out.writeData(expiryPolicy);
         }
     }
@@ -111,7 +117,7 @@ public class DefaultCacheEntryView
         accessHit = in.readLong();
         key = in.readData();
         value = in.readData();
-        if (in.getVersion().isGreaterOrEqual(Version.of("3.11"))) {
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             expiryPolicy = in.readData();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 
@@ -37,18 +38,21 @@ public class DefaultCacheEntryView
     private long expirationTime;
     private long lastAccessTime;
     private long accessHit;
+    private Data expiryPolicy;
 
     public DefaultCacheEntryView() {
     }
 
     public DefaultCacheEntryView(Data key, Data value, long creationTime,
-                                 long expirationTime, long lastAccessTime, long accessHit) {
+                                 long expirationTime, long lastAccessTime, long accessHit,
+                                 Data expiryPolicy) {
         this.key = key;
         this.value = value;
         this.creationTime = creationTime;
         this.expirationTime = expirationTime;
         this.lastAccessTime = lastAccessTime;
         this.accessHit = accessHit;
+        this.expiryPolicy = expiryPolicy;
     }
 
     @Override
@@ -82,6 +86,11 @@ public class DefaultCacheEntryView
     }
 
     @Override
+    public Data getExpiryPolicy() {
+        return expiryPolicy;
+    }
+
+    @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeLong(creationTime);
         out.writeLong(expirationTime);
@@ -89,6 +98,9 @@ public class DefaultCacheEntryView
         out.writeLong(accessHit);
         out.writeData(key);
         out.writeData(value);
+        if (out.getVersion().isGreaterOrEqual(Version.of("3.11"))) {
+            out.writeData(expiryPolicy);
+        }
     }
 
     @Override
@@ -99,6 +111,9 @@ public class DefaultCacheEntryView
         accessHit = in.readLong();
         key = in.readData();
         value = in.readData();
+        if (in.getVersion().isGreaterOrEqual(Version.of("3.11"))) {
+            expiryPolicy = in.readData();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/LazyCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/LazyCacheEntryView.java
@@ -19,8 +19,6 @@ package com.hazelcast.cache.impl.merge.entry;
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.spi.serialization.SerializationService;
 
-import javax.cache.expiry.ExpiryPolicy;
-
 /**
  * An implementation of {@link com.hazelcast.cache.CacheEntryView}
  * for converting key and value to object when they are touched as lazy.
@@ -75,11 +73,11 @@ public class LazyCacheEntryView<K, V>
     }
 
     @Override
-    public ExpiryPolicy getExpiryPolicy() {
+    public Object getExpiryPolicy() {
         if (serializationService != null) {
             expiryPolicy = serializationService.toObject(expiryPolicy);
         }
-        return (ExpiryPolicy) expiryPolicy;
+        return expiryPolicy;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/LazyCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/LazyCacheEntryView.java
@@ -19,6 +19,8 @@ package com.hazelcast.cache.impl.merge.entry;
 import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.spi.serialization.SerializationService;
 
+import javax.cache.expiry.ExpiryPolicy;
+
 /**
  * An implementation of {@link com.hazelcast.cache.CacheEntryView}
  * for converting key and value to object when they are touched as lazy.
@@ -73,11 +75,11 @@ public class LazyCacheEntryView<K, V>
     }
 
     @Override
-    public Object getExpiryPolicy() {
+    public ExpiryPolicy getExpiryPolicy() {
         if (serializationService != null) {
             expiryPolicy = serializationService.toObject(expiryPolicy);
         }
-        return expiryPolicy;
+        return (ExpiryPolicy) expiryPolicy;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/LazyCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/LazyCacheEntryView.java
@@ -28,6 +28,7 @@ public class LazyCacheEntryView<K, V>
 
     private Object key;
     private Object value;
+    private Object expiryPolicy;
     private long creationTime;
     private long expirationTime;
     private long lastAccessTime;
@@ -35,13 +36,13 @@ public class LazyCacheEntryView<K, V>
     private SerializationService serializationService;
 
     public LazyCacheEntryView(Object key, Object value, long creationTime,
-                              long expirationTime, long lastAccessTime, long accessHit) {
+                              long expirationTime, long lastAccessTime, long accessHit, Object expiryPolicy) {
         // `null` `serializationService` means, use raw type without any conversion
-        this(key, value, creationTime, expirationTime, lastAccessTime, accessHit, null);
+        this(key, value, creationTime, expirationTime, lastAccessTime, accessHit, expiryPolicy, null);
     }
 
     public LazyCacheEntryView(Object key, Object value, long creationTime,
-                              long expirationTime, long lastAccessTime, long accessHit,
+                              long expirationTime, long lastAccessTime, long accessHit, Object expiryPolicy,
                               SerializationService serializationService) {
         this.key = key;
         this.value = value;
@@ -49,6 +50,7 @@ public class LazyCacheEntryView<K, V>
         this.expirationTime = expirationTime;
         this.lastAccessTime = lastAccessTime;
         this.accessHit = accessHit;
+        this.expiryPolicy = expiryPolicy;
         this.serializationService = serializationService;
     }
 
@@ -68,6 +70,14 @@ public class LazyCacheEntryView<K, V>
             value = serializationService.toObject(value);
         }
         return (V) value;
+    }
+
+    @Override
+    public Object getExpiryPolicy() {
+        if (serializationService != null) {
+            expiryPolicy = serializationService.toObject(expiryPolicy);
+        }
+        return expiryPolicy;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheOperation.java
@@ -182,10 +182,15 @@ public abstract class CacheOperation extends AbstractNamedOperation
         NodeEngine nodeEngine = getNodeEngine();
         SerializationService serializationService = nodeEngine.getSerializationService();
         Data dataValue = toHeapData(serializationService.toData(record.getValue()));
-        publishWanUpdate(dataKey, dataValue, record);
+        Data dataExpiryPolicy = toHeapData(serializationService.toData(record.getExpiryPolicy()));
+        publishWanUpdate(dataKey, dataValue, dataExpiryPolicy, record);
     }
 
     protected final void publishWanUpdate(Data dataKey, Data dataValue, CacheRecord record) {
+        publishWanUpdate(dataKey, dataValue, null, record);
+    }
+
+    protected final void publishWanUpdate(Data dataKey, Data dataValue, Data dataExpiryPolicy, CacheRecord record) {
         assert dataValue != null;
 
         if (!recordStore.isWanReplicationEnabled() || record == null) {
@@ -193,7 +198,7 @@ public abstract class CacheOperation extends AbstractNamedOperation
         }
 
         CacheEntryView<Data, Data> entryView = createDefaultEntryView(toHeapData(dataKey),
-                toHeapData(dataValue), record);
+                toHeapData(dataValue), toHeapData(dataExpiryPolicy), record);
         wanEventPublisher.publishWanUpdate(name, entryView);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheOperation.java
@@ -182,12 +182,18 @@ public abstract class CacheOperation extends AbstractNamedOperation
         NodeEngine nodeEngine = getNodeEngine();
         SerializationService serializationService = nodeEngine.getSerializationService();
         Data dataValue = toHeapData(serializationService.toData(record.getValue()));
-        Data dataExpiryPolicy = toHeapData(serializationService.toData(record.getExpiryPolicy()));
-        publishWanUpdate(dataKey, dataValue, dataExpiryPolicy, record);
+        publishWanUpdate(dataKey, dataValue, record);
     }
 
     protected final void publishWanUpdate(Data dataKey, Data dataValue, CacheRecord record) {
-        publishWanUpdate(dataKey, dataValue, null, record);
+        if (!recordStore.isWanReplicationEnabled() || record == null) {
+            return;
+        }
+        NodeEngine nodeEngine = getNodeEngine();
+        SerializationService serializationService = nodeEngine.getSerializationService();
+
+        Data dataExpiryPolicy = toHeapData(serializationService.toData(record.getExpiryPolicy()));
+        publishWanUpdate(dataKey, dataValue, dataExpiryPolicy, record);
     }
 
     protected final void publishWanUpdate(Data dataKey, Data dataValue, Data dataExpiryPolicy, CacheRecord record) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyBackupOperation.java
@@ -17,14 +17,11 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
-import com.hazelcast.cache.impl.CacheEntryViews;
 import com.hazelcast.cache.impl.record.CacheRecord;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.BackupOperation;
-import com.hazelcast.spi.ServiceNamespaceAware;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +29,7 @@ import java.util.List;
 
 public class CacheSetExpiryPolicyBackupOperation
         extends CacheOperation
-        implements BackupOperation, IdentifiedDataSerializable, ServiceNamespaceAware {
+        implements BackupOperation {
 
     private List<Data> keys;
     private Data expiryPolicy;
@@ -61,7 +58,7 @@ public class CacheSetExpiryPolicyBackupOperation
         if (recordStore.isWanReplicationEnabled()) {
             for (Data key : keys) {
                 CacheRecord record = recordStore.getRecord(key);
-                wanEventPublisher.publishWanUpdate(name, CacheEntryViews.createEntryView(key, expiryPolicy, record));
+                publishWanUpdate(key, record);
             }
         }
     }
@@ -90,7 +87,7 @@ public class CacheSetExpiryPolicyBackupOperation
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         int s = in.readInt();
-        keys = new ArrayList<Data>();
+        keys = new ArrayList<Data>(s);
         while (s-- > 0) {
             keys.add(in.readData());
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyOperation.java
@@ -29,7 +29,6 @@ import com.hazelcast.spi.ServiceNamespaceAware;
 import com.hazelcast.spi.impl.AbstractNamedOperation;
 import com.hazelcast.spi.impl.MutatingOperation;
 
-import javax.cache.expiry.ExpiryPolicy;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,20 +42,20 @@ public class CacheSetExpiryPolicyOperation extends AbstractNamedOperation
     private transient int partitionId;
 
     private List<Data> keys;
-    private ExpiryPolicy expiryPolicy;
+    private Data expiryPolicy;
     private int completionId;
 
     public CacheSetExpiryPolicyOperation() {
 
     }
 
-    public CacheSetExpiryPolicyOperation(String name, List<Data> keys, ExpiryPolicy expiryPolicy) {
+    public CacheSetExpiryPolicyOperation(String name, List<Data> keys, Data expiryPolicy) {
         super(name);
         this.keys = keys;
         this.expiryPolicy = expiryPolicy;
     }
 
-    public CacheSetExpiryPolicyOperation(String name, List<Data> keys, ExpiryPolicy expiryPolicy, int completionId) {
+    public CacheSetExpiryPolicyOperation(String name, List<Data> keys, Data expiryPolicy, int completionId) {
         this(name, keys, expiryPolicy);
         this.completionId = completionId;
     }
@@ -114,7 +113,7 @@ public class CacheSetExpiryPolicyOperation extends AbstractNamedOperation
             out.writeData(key);
         }
         out.writeInt(completionId);
-        out.writeObject(expiryPolicy);
+        out.writeData(expiryPolicy);
     }
 
     @Override
@@ -126,6 +125,6 @@ public class CacheSetExpiryPolicyOperation extends AbstractNamedOperation
             keys.add(in.readData());
         }
         completionId = in.readInt();
-        expiryPolicy = in.readObject();
+        expiryPolicy = in.readData();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyOperation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
-import com.hazelcast.cache.impl.CacheEntryViews;
 import com.hazelcast.cache.impl.record.CacheRecord;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -60,7 +59,7 @@ public class CacheSetExpiryPolicyOperation extends CacheOperation
         if (recordStore.isWanReplicationEnabled()) {
             for (Data key : keys) {
                 CacheRecord record = recordStore.getRecord(key);
-                wanEventPublisher.publishWanUpdate(name, CacheEntryViews.createEntryView(key, expiryPolicy, record));
+                publishWanUpdate(key, record);
             }
         }
     }
@@ -89,7 +88,7 @@ public class CacheSetExpiryPolicyOperation extends CacheOperation
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         int s = in.readInt();
-        keys = new ArrayList<Data>();
+        keys = new ArrayList<Data>(s);
         while (s-- > 0) {
             keys.add(in.readData());
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheSetExpiryPolicyOperation.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache.impl.operation;
+
+import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.cache.impl.ICacheRecordStore;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.PartitionAwareOperation;
+import com.hazelcast.spi.ServiceNamespace;
+import com.hazelcast.spi.ServiceNamespaceAware;
+import com.hazelcast.spi.impl.AbstractNamedOperation;
+import com.hazelcast.spi.impl.MutatingOperation;
+
+import javax.cache.expiry.ExpiryPolicy;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CacheSetExpiryPolicyOperation extends AbstractNamedOperation
+        implements IdentifiedDataSerializable, PartitionAwareOperation, ServiceNamespaceAware, MutableOperation,
+        MutatingOperation {
+
+    private transient ICacheService service;
+    private transient ICacheRecordStore recordStore;
+    private transient int partitionId;
+
+    private List<Data> keys;
+    private ExpiryPolicy expiryPolicy;
+    private int completionId;
+
+    public CacheSetExpiryPolicyOperation() {
+
+    }
+
+    public CacheSetExpiryPolicyOperation(String name, List<Data> keys, ExpiryPolicy expiryPolicy) {
+        super(name);
+        this.keys = keys;
+        this.expiryPolicy = expiryPolicy;
+    }
+
+    public CacheSetExpiryPolicyOperation(String name, List<Data> keys, ExpiryPolicy expiryPolicy, int completionId) {
+        this(name, keys, expiryPolicy);
+        this.completionId = completionId;
+    }
+
+    @Override
+    public void beforeRun() throws Exception {
+        super.beforeRun();
+        service = getService();
+        partitionId = getPartitionId();
+        recordStore = service.getRecordStore(name, partitionId);
+    }
+
+    @Override
+    public void run() throws Exception {
+        if (recordStore == null) {
+            return;
+        }
+        recordStore.setExpiryPolicy(keys, expiryPolicy, completionId);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return CacheDataSerializerHook.SET_EXPIRY_POLICY;
+    }
+
+    @Override
+    public int getId() {
+        return CacheDataSerializerHook.SET_EXPIRY_POLICY;
+    }
+
+    @Override
+    public int getCompletionId() {
+        return completionId;
+    }
+
+    @Override
+    public void setCompletionId(int completionId) {
+        this.completionId = completionId;
+    }
+
+    @Override
+    public ServiceNamespace getServiceNamespace() {
+        ICacheRecordStore store = recordStore;
+        if (store == null) {
+            store = service.getOrCreateRecordStore(name, partitionId);
+        }
+        return store.getObjectNamespace();
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        out.writeInt(keys.size());
+        for (Data key: keys) {
+            out.writeData(key);
+        }
+        out.writeInt(completionId);
+        out.writeObject(expiryPolicy);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int s = in.readInt();
+        keys = new ArrayList<Data>();
+        while (s-- > 0) {
+            keys.add(in.readData());
+        }
+        completionId = in.readInt();
+        expiryPolicy = in.readObject();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.version.Version;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import javax.cache.expiry.ExpiryPolicy;
 import java.io.IOException;
 
 /**
@@ -35,7 +36,11 @@ import java.io.IOException;
  */
 public abstract class AbstractCacheRecord<V, E> implements CacheRecord<V, E>, IdentifiedDataSerializable {
 
-    protected static final Version EXPIRY_POLICY_VERSION = Versions.V3_11;
+    /**
+     * Represents when {@link com.hazelcast.cache.ICache#setExpiryPolicy(Object, ExpiryPolicy)} is added.
+     * The constant is used in selective serialization of {@link CacheRecord}s.
+     */
+    public static final Version EXPIRY_POLICY_VERSION = Versions.V3_11;
 
     protected long creationTime = TIME_NOT_AVAILABLE;
     protected volatile long expirationTime = TIME_NOT_AVAILABLE;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
@@ -22,6 +22,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import javax.cache.expiry.ExpiryPolicy;
 import java.io.IOException;
 
 /**
@@ -37,6 +38,7 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, Identifi
     protected volatile long expirationTime = TIME_NOT_AVAILABLE;
     protected volatile long accessTime = TIME_NOT_AVAILABLE;
     protected volatile int accessHit;
+    protected volatile ExpiryPolicy expiryPolicy;
 
     protected AbstractCacheRecord() {
     }
@@ -86,6 +88,16 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, Identifi
     }
 
     @Override
+    public void setExpiryPolicy(ExpiryPolicy expiryPolicy) {
+        this.expiryPolicy = expiryPolicy;
+    }
+
+    @Override
+    public ExpiryPolicy getExpiryPolicy() {
+        return expiryPolicy;
+    }
+
+    @Override
     @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
             justification = "CacheRecord can be accessed by only its own partition thread.")
     public void incrementAccessHit() {
@@ -108,6 +120,7 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, Identifi
         out.writeLong(expirationTime);
         out.writeLong(accessTime);
         out.writeInt(accessHit);
+        out.writeObject(expiryPolicy);
     }
 
     @Override
@@ -116,6 +129,7 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, Identifi
         expirationTime = in.readLong();
         accessTime = in.readLong();
         accessHit = in.readInt();
+        expiryPolicy = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
@@ -17,13 +17,13 @@
 package com.hazelcast.cache.impl.record;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.version.Version;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
-import javax.cache.expiry.ExpiryPolicy;
 import java.io.IOException;
 
 /**
@@ -35,7 +35,7 @@ import java.io.IOException;
  */
 public abstract class AbstractCacheRecord<V, E> implements CacheRecord<V, E>, IdentifiedDataSerializable {
 
-    protected static final Version EXPIRY_POLICY_VERSION = Version.of("3.11");
+    protected static final Version EXPIRY_POLICY_VERSION = Versions.V3_11;
 
     protected long creationTime = TIME_NOT_AVAILABLE;
     protected volatile long expirationTime = TIME_NOT_AVAILABLE;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/AbstractCacheRecord.java
@@ -33,15 +33,14 @@ import java.io.IOException;
  *
  * @param <V> the type of the value stored by this {@link AbstractCacheRecord}
  */
-public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, IdentifiedDataSerializable {
+public abstract class AbstractCacheRecord<V, E> implements CacheRecord<V, E>, IdentifiedDataSerializable {
 
-    private static final Version EXPIRY_POLICY_VERSION = Version.of("3.11");
+    protected static final Version EXPIRY_POLICY_VERSION = Version.of("3.11");
 
     protected long creationTime = TIME_NOT_AVAILABLE;
     protected volatile long expirationTime = TIME_NOT_AVAILABLE;
     protected volatile long accessTime = TIME_NOT_AVAILABLE;
     protected volatile int accessHit;
-    protected volatile Object expiryPolicy;
 
     protected AbstractCacheRecord() {
     }
@@ -91,16 +90,6 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, Identifi
     }
 
     @Override
-    public void setExpiryPolicy(Object expiryPolicy) {
-        this.expiryPolicy = expiryPolicy;
-    }
-
-    @Override
-    public Object getExpiryPolicy() {
-        return expiryPolicy;
-    }
-
-    @Override
     @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
             justification = "CacheRecord can be accessed by only its own partition thread.")
     public void incrementAccessHit() {
@@ -123,9 +112,6 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, Identifi
         out.writeLong(expirationTime);
         out.writeLong(accessTime);
         out.writeInt(accessHit);
-        if (out.getVersion().isGreaterOrEqual(EXPIRY_POLICY_VERSION)) {
-            out.writeObject(expiryPolicy);
-        }
     }
 
     @Override
@@ -134,9 +120,6 @@ public abstract class AbstractCacheRecord<V> implements CacheRecord<V>, Identifi
         expirationTime = in.readLong();
         accessTime = in.readLong();
         accessHit = in.readInt();
-        if (in.getVersion().isGreaterOrEqual(EXPIRY_POLICY_VERSION)) {
-            expiryPolicy = in.readObject();
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheDataRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheDataRecord.java
@@ -26,9 +26,10 @@ import java.io.IOException;
 /**
  * Implementation of {@link com.hazelcast.cache.impl.record.CacheRecord} where value has an internal serialized format.
  */
-public class CacheDataRecord extends AbstractCacheRecord<Data> {
+public class CacheDataRecord extends AbstractCacheRecord<Data, Data> {
 
     private Data value;
+    private Data expiryPolicy;
 
     // Deserialization constructor
     public CacheDataRecord() {
@@ -50,15 +51,31 @@ public class CacheDataRecord extends AbstractCacheRecord<Data> {
     }
 
     @Override
+    public void setExpiryPolicy(Data expiryPolicy) {
+        this.expiryPolicy = expiryPolicy;
+    }
+
+    @Override
+    public Data getExpiryPolicy() {
+        return expiryPolicy;
+    }
+
+    @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
         out.writeData(value);
+        if (out.getVersion().isGreaterOrEqual(EXPIRY_POLICY_VERSION)) {
+            out.writeData(expiryPolicy);
+        }
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
         value = in.readData();
+        if (in.getVersion().isGreaterOrEqual(EXPIRY_POLICY_VERSION)) {
+            expiryPolicy = in.readData();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheObjectRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheObjectRecord.java
@@ -20,14 +20,16 @@ import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 
+import javax.cache.expiry.ExpiryPolicy;
 import java.io.IOException;
 
 /**
  * Implementation of {@link com.hazelcast.cache.impl.record.CacheRecord} which has an internal object format.
  */
-public class CacheObjectRecord extends AbstractCacheRecord<Object> {
+public class CacheObjectRecord extends AbstractCacheRecord<Object, ExpiryPolicy> {
 
     protected Object value;
+    protected ExpiryPolicy expiryPolicy;
 
     public CacheObjectRecord() {
     }
@@ -48,15 +50,31 @@ public class CacheObjectRecord extends AbstractCacheRecord<Object> {
     }
 
     @Override
+    public void setExpiryPolicy(ExpiryPolicy expiryPolicy) {
+        this.expiryPolicy = expiryPolicy;
+    }
+
+    @Override
+    public ExpiryPolicy getExpiryPolicy() {
+        return expiryPolicy;
+    }
+
+    @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         super.writeData(out);
         out.writeObject(value);
+        if (out.getVersion().isGreaterOrEqual(EXPIRY_POLICY_VERSION)) {
+            out.writeObject(expiryPolicy);
+        }
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         super.readData(in);
         value = in.readObject();
+        if (in.getVersion().isGreaterOrEqual(EXPIRY_POLICY_VERSION)) {
+            expiryPolicy = in.readObject();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
@@ -78,13 +78,13 @@ public interface CacheRecord<V> extends Expirable, Evictable<V> {
      * Sets the expiry policy for this record.
      * @param expiryPolicy
      */
-    void setExpiryPolicy(ExpiryPolicy expiryPolicy);
+    void setExpiryPolicy(Object expiryPolicy);
 
     /**
      * Gets the expiryPolicy associated with this record.
      *
      * @return
      */
-    ExpiryPolicy getExpiryPolicy();
+    Object getExpiryPolicy();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
@@ -18,8 +18,7 @@ package com.hazelcast.cache.impl.record;
 
 import com.hazelcast.internal.eviction.Evictable;
 import com.hazelcast.internal.eviction.Expirable;
-
-import javax.cache.expiry.ExpiryPolicy;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 /**
  * <p>
@@ -29,7 +28,7 @@ import javax.cache.expiry.ExpiryPolicy;
  *
  * @param <V> the type of the value stored by this {@link CacheRecord}
  */
-public interface CacheRecord<V, E> extends Expirable, Evictable<V> {
+public interface CacheRecord<V, E> extends Expirable, Evictable<V>, Versioned {
 
     /**
      * Represents invalid (not set) time for creation time, expiration time, access time, etc...
@@ -82,7 +81,6 @@ public interface CacheRecord<V, E> extends Expirable, Evictable<V> {
 
     /**
      * Gets the expiryPolicy associated with this record.
-     *
      * @return
      */
     E getExpiryPolicy();

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
@@ -29,7 +29,7 @@ import javax.cache.expiry.ExpiryPolicy;
  *
  * @param <V> the type of the value stored by this {@link CacheRecord}
  */
-public interface CacheRecord<V> extends Expirable, Evictable<V> {
+public interface CacheRecord<V, E> extends Expirable, Evictable<V> {
 
     /**
      * Represents invalid (not set) time for creation time, expiration time, access time, etc...
@@ -78,13 +78,13 @@ public interface CacheRecord<V> extends Expirable, Evictable<V> {
      * Sets the expiry policy for this record.
      * @param expiryPolicy
      */
-    void setExpiryPolicy(Object expiryPolicy);
+    void setExpiryPolicy(E expiryPolicy);
 
     /**
      * Gets the expiryPolicy associated with this record.
      *
      * @return
      */
-    Object getExpiryPolicy();
+    E getExpiryPolicy();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecord.java
@@ -19,6 +19,8 @@ package com.hazelcast.cache.impl.record;
 import com.hazelcast.internal.eviction.Evictable;
 import com.hazelcast.internal.eviction.Expirable;
 
+import javax.cache.expiry.ExpiryPolicy;
+
 /**
  * <p>
  * An expirable and evictable data object which represents a cache entry.
@@ -71,5 +73,18 @@ public interface CacheRecord<V> extends Expirable, Evictable<V> {
      * Resets the access hit count of this {@link Evictable} to <code>0</code>.
      */
     void resetAccessHit();
+
+    /**
+     * Sets the expiry policy for this record.
+     * @param expiryPolicy
+     */
+    void setExpiryPolicy(ExpiryPolicy expiryPolicy);
+
+    /**
+     * Gets the expiryPolicy associated with this record.
+     *
+     * @return
+     */
+    ExpiryPolicy getExpiryPolicy();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -28,6 +28,7 @@ import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
+import javax.cache.expiry.ExpiryPolicy;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -148,7 +149,7 @@ public class CacheRecordHashMap
         }
 
         @Override
-        public Object getExpiryPolicy() {
+        public ExpiryPolicy getExpiryPolicy() {
             return serializationService.toObject(value.getExpiryPolicy());
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -148,6 +148,11 @@ public class CacheRecordHashMap
         }
 
         @Override
+        public Object getExpiryPolicy() {
+            return serializationService.toObject(value.getExpiryPolicy());
+        }
+
+        @Override
         public long getCreationTime() {
             return value.getCreationTime();
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -316,6 +316,12 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
                 return new com.hazelcast.client.impl.protocol.task.cache.CachePutAllMessageTask(clientMessage, node, connection);
             }
         };
+        factories[com.hazelcast.client.impl.protocol.codec.CacheSetExpiryPolicyCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            @Override
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new com.hazelcast.client.impl.protocol.task.cache.CacheSetExpiryPolicyMessageTask(clientMessage, node, connection);
+            }
+        };
         factories[com.hazelcast.client.impl.protocol.codec.CacheLoadAllCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
                 return new com.hazelcast.client.impl.protocol.task.cache.CacheLoadAllMessageTask(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSetExpiryPolicyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSetExpiryPolicyMessageTask.java
@@ -24,7 +24,6 @@ import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.CachePermission;
 import com.hazelcast.spi.Operation;
 
-import javax.cache.expiry.ExpiryPolicy;
 import java.security.Permission;
 
 public class CacheSetExpiryPolicyMessageTask extends AbstractCacheMessageTask<CacheSetExpiryPolicyCodec.RequestParameters> {
@@ -36,7 +35,7 @@ public class CacheSetExpiryPolicyMessageTask extends AbstractCacheMessageTask<Ca
     @Override
     protected Operation prepareOperation() {
         return getOperationProvider(parameters.name)
-                .createSetExpiryPolicyOperation(parameters.keys, parameters.expiryPolicy, parameters.completionId);
+                .createSetExpiryPolicyOperation(parameters.keys, parameters.expiryPolicy);
     }
 
     @Override
@@ -66,6 +65,6 @@ public class CacheSetExpiryPolicyMessageTask extends AbstractCacheMessageTask<Ca
 
     @Override
     public Permission getRequiredPermission() {
-        return new CachePermission(parameters.name, ActionConstants.ACTION_MODIFY);
+        return new CachePermission(parameters.name, ActionConstants.ACTION_REMOVE);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSetExpiryPolicyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSetExpiryPolicyMessageTask.java
@@ -35,9 +35,8 @@ public class CacheSetExpiryPolicyMessageTask extends AbstractCacheMessageTask<Ca
 
     @Override
     protected Operation prepareOperation() {
-        ExpiryPolicy expiryPolicy = serializationService.toObject(parameters.expiryPolicy);
         return getOperationProvider(parameters.name)
-                .createSetExpiryPolicyOperation(parameters.keys, expiryPolicy, parameters.completionId);
+                .createSetExpiryPolicyOperation(parameters.keys, parameters.expiryPolicy, parameters.completionId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSetExpiryPolicyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheSetExpiryPolicyMessageTask.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task.cache;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.CacheSetExpiryPolicyCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.security.permission.ActionConstants;
+import com.hazelcast.security.permission.CachePermission;
+import com.hazelcast.spi.Operation;
+
+import javax.cache.expiry.ExpiryPolicy;
+import java.security.Permission;
+
+public class CacheSetExpiryPolicyMessageTask extends AbstractCacheMessageTask<CacheSetExpiryPolicyCodec.RequestParameters> {
+
+    public CacheSetExpiryPolicyMessageTask(ClientMessage message, Node node, Connection connection) {
+        super(message, node, connection);
+    }
+
+    @Override
+    protected Operation prepareOperation() {
+        ExpiryPolicy expiryPolicy = serializationService.toObject(parameters.expiryPolicy);
+        return getOperationProvider(parameters.name)
+                .createSetExpiryPolicyOperation(parameters.keys, expiryPolicy, parameters.completionId);
+    }
+
+    @Override
+    protected CacheSetExpiryPolicyCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return CacheSetExpiryPolicyCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return CacheSetExpiryPolicyCodec.encodeResponse();
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return parameters.name;
+    }
+
+    @Override
+    public String getMethodName() {
+        return "setExpiryPolicy";
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return new Object[]{parameters.keys, parameters.expiryPolicy};
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return new CachePermission(parameters.name, ActionConstants.ACTION_MODIFY);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/DataStructureAdapter.java
@@ -119,6 +119,8 @@ public interface DataStructureAdapter<K, V> {
 
     void destroy();
 
+    void setExpiryPolicy(Set<K> keys, ExpiryPolicy expiryPolicy);
+
     LocalMapStats getLocalMapStats();
 
     /**
@@ -166,7 +168,8 @@ public interface DataStructureAdapter<K, V> {
         CLOSE("close"),
         DESTROY("destroy"),
         GET_LOCAL_MAP_STATS("getLocalMapStats"),
-        SET_TTL("setTTL", Object.class, long.class, TimeUnit.class);
+        SET_TTL("setTTL", Object.class, long.class, TimeUnit.class),
+        SET_EXPIRY_POLICY("setExpiryPolicy", Set.class, ExpiryPolicy.class);
 
         private final String methodName;
         private final Class<?>[] parameterTypes;

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ICacheDataStructureAdapter.java
@@ -258,6 +258,11 @@ public class ICacheDataStructureAdapter<K, V> implements DataStructureAdapter<K,
     }
 
     @Override
+    public void setExpiryPolicy(Set<K> keys, ExpiryPolicy expiryPolicy) {
+        cache.setExpiryPolicy(keys, expiryPolicy);
+    }
+
+    @Override
     @MethodNotAvailable
     public LocalMapStats getLocalMapStats() {
         throw new MethodNotAvailableException();

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/IMapDataStructureAdapter.java
@@ -258,6 +258,12 @@ public class IMapDataStructureAdapter<K, V> implements DataStructureAdapter<K, V
     }
 
     @Override
+    @MethodNotAvailable
+    public void setExpiryPolicy(Set<K> keys, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
     public LocalMapStats getLocalMapStats() {
         return map.getLocalMapStats();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/ReplicatedMapDataStructureAdapter.java
@@ -284,6 +284,12 @@ public class ReplicatedMapDataStructureAdapter<K, V> implements DataStructureAda
 
     @Override
     @MethodNotAvailable
+    public void setExpiryPolicy(Set<K> keys, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
     public LocalMapStats getLocalMapStats() {
         throw new MethodNotAvailableException();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/adapter/TransactionalMapDataStructureAdapter.java
@@ -291,6 +291,12 @@ public class TransactionalMapDataStructureAdapter<K, V> implements DataStructure
 
     @Override
     @MethodNotAvailable
+    public void setExpiryPolicy(Set<K> keys, ExpiryPolicy expiryPolicy) {
+        throw new MethodNotAvailableException();
+    }
+
+    @Override
+    @MethodNotAvailable
     public LocalMapStats getLocalMapStats() {
         throw new MethodNotAvailableException();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
@@ -132,6 +132,7 @@ public class GetCacheEntryRequest implements ConsoleRequest {
         private long creationTime;
         private long lastAccessTime;
         private long accessHit;
+        private Object expiryPolicy;
 
         public CacheBrowserEntryView() {
         }
@@ -144,6 +145,7 @@ public class GetCacheEntryRequest implements ConsoleRequest {
             this.creationTime = record.getCreationTime();
             this.lastAccessTime = record.getLastAccessTime();
             this.accessHit = record.getAccessHit();
+            this.expiryPolicy = record.getExpiryPolicy();
         }
 
         @Override
@@ -174,6 +176,11 @@ public class GetCacheEntryRequest implements ConsoleRequest {
         @Override
         public long getAccessHit() {
             return accessHit;
+        }
+
+        @Override
+        public Object getExpiryPolicy() {
+            return expiryPolicy;
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
+import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.processor.EntryProcessor;
 import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.MutableEntry;
@@ -132,7 +133,7 @@ public class GetCacheEntryRequest implements ConsoleRequest {
         private long creationTime;
         private long lastAccessTime;
         private long accessHit;
-        private Object expiryPolicy;
+        private ExpiryPolicy expiryPolicy;
 
         public CacheBrowserEntryView() {
         }
@@ -140,7 +141,7 @@ public class GetCacheEntryRequest implements ConsoleRequest {
         CacheBrowserEntryView(CacheEntryProcessorEntry entry) {
             this.value = entry.getValue();
 
-            CacheRecord record = entry.getRecord();
+            CacheRecord<Object, ExpiryPolicy> record = entry.getRecord();
             this.expirationTime = record.getExpirationTime();
             this.creationTime = record.getCreationTime();
             this.lastAccessTime = record.getLastAccessTime();
@@ -179,7 +180,7 @@ public class GetCacheEntryRequest implements ConsoleRequest {
         }
 
         @Override
-        public Object getExpiryPolicy() {
+        public ExpiryPolicy getExpiryPolicy() {
             return expiryPolicy;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
@@ -200,6 +200,7 @@ public class GetCacheEntryRequest implements ConsoleRequest {
             out.writeLong(creationTime);
             out.writeLong(lastAccessTime);
             out.writeLong(accessHit);
+            out.writeObject(expiryPolicy);
         }
 
         @Override
@@ -209,6 +210,7 @@ public class GetCacheEntryRequest implements ConsoleRequest {
             creationTime = in.readLong();
             lastAccessTime = in.readLong();
             accessHit = in.readLong();
+            expiryPolicy = in.readObject();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/GetCacheEntryRequest.java
@@ -29,6 +29,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.processor.EntryProcessor;
@@ -36,6 +37,7 @@ import javax.cache.processor.EntryProcessorException;
 import javax.cache.processor.MutableEntry;
 import java.io.IOException;
 
+import static com.hazelcast.cache.impl.record.AbstractCacheRecord.EXPIRY_POLICY_VERSION;
 import static com.hazelcast.util.JsonUtil.getString;
 
 /**
@@ -127,7 +129,7 @@ public class GetCacheEntryRequest implements ConsoleRequest {
         }
     }
 
-    public static class CacheBrowserEntryView implements CacheEntryView<Object, Object>, IdentifiedDataSerializable {
+    public static class CacheBrowserEntryView implements CacheEntryView<Object, Object>, IdentifiedDataSerializable, Versioned {
         private Object value;
         private long expirationTime;
         private long creationTime;
@@ -201,7 +203,9 @@ public class GetCacheEntryRequest implements ConsoleRequest {
             out.writeLong(creationTime);
             out.writeLong(lastAccessTime);
             out.writeLong(accessHit);
-            out.writeObject(expiryPolicy);
+            if (out.getVersion().isGreaterOrEqual(EXPIRY_POLICY_VERSION)) {
+                out.writeObject(expiryPolicy);
+            }
         }
 
         @Override
@@ -211,7 +215,9 @@ public class GetCacheEntryRequest implements ConsoleRequest {
             creationTime = in.readLong();
             lastAccessTime = in.readLong();
             accessHit = in.readLong();
-            expiryPolicy = in.readObject();
+            if (in.getVersion().isGreaterOrEqual(EXPIRY_POLICY_VERSION)) {
+                expiryPolicy = in.readObject();
+            }
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/FutureUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/FutureUtil.java
@@ -324,6 +324,13 @@ public final class FutureUtil {
     }
 
     @PrivateApi
+    public static List<Throwable> waitUntilAllResponded(Collection<? extends Future> futures) {
+        CollectAllExceptionHandler collector = new CollectAllExceptionHandler(futures.size());
+        waitForever(futures, collector);
+        return collector.getThrowables();
+    }
+
+    @PrivateApi
     public static void waitWithDeadline(Collection<? extends Future> futures, long timeout, TimeUnit timeUnit,
                                         ExceptionHandler exceptionHandler) {
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheBasicAbstractTest.java
@@ -878,8 +878,6 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         ICache<Integer, String> cache = createCache(cacheConfig);
         cache.put(1, "value");
         cache.setExpiryPolicy(1, TouchedExpiryPolicy.factoryOf(modifiedDuration).create());
-        //touch the entry for the new policy to take effect
-        cache.get(1);
 
         sleepAtLeastMillis(UPDATED_TTL + 1);
 
@@ -895,8 +893,6 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         ICache<Integer, String> cache = createCache();
         cache.put(1, "value");
         cache.setExpiryPolicy(1, TouchedExpiryPolicy.factoryOf(modifiedDuration).create());
-        //touch the entry for the new policy to take effect
-        cache.get(1);
 
         sleepAtLeastMillis(TTL + 1);
 
@@ -910,8 +906,6 @@ public abstract class CacheBasicAbstractTest extends CacheTestSupport {
         cache.put(1, "value");
         Duration expiryDuration = new Duration(TimeUnit.MILLISECONDS, TTL);
         cache.setExpiryPolicy(1, TouchedExpiryPolicy.factoryOf(expiryDuration).create());
-        //touch the entry for the new policy to take effect
-        cache.get(1);
 
         cache.setExpiryPolicy(1, TouchedExpiryPolicy.factoryOf(Duration.ETERNAL).create());
         cache.get(1);

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheEntryViewsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheEntryViewsTest.java
@@ -29,6 +29,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.cache.expiry.EternalExpiryPolicy;
+import javax.cache.expiry.ExpiryPolicy;
+
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -50,10 +53,13 @@ public class CacheEntryViewsTest extends HazelcastTestSupport {
     private void doCacheEntryViewTest(CacheEntryViews.CacheEntryViewType cacheEntryViewType) {
         String key = "testKey";
         String value = "testValue";
+        ExpiryPolicy expiryPolicy = new EternalExpiryPolicy();
         CacheObjectRecord record = new CacheObjectRecord(value, System.currentTimeMillis(), 1234L);
+        record.setExpiryPolicy(new EternalExpiryPolicy());
         CacheEntryView cacheEntryView =
                 CacheEntryViews.createEntryView(serializationService.toData(key),
                         serializationService.toData(value),
+                        serializationService.toData(expiryPolicy),
                         record,
                         cacheEntryViewType);
 
@@ -62,6 +68,7 @@ public class CacheEntryViewsTest extends HazelcastTestSupport {
         assertEquals(record.getAccessHit(), cacheEntryView.getAccessHit());
         assertEquals(record.getExpirationTime(), cacheEntryView.getExpirationTime());
         assertEquals(record.getLastAccessTime(), cacheEntryView.getLastAccessTime());
+        assertInstanceOf(EternalExpiryPolicy.class, serializationService.toObject(cacheEntryView.getExpiryPolicy()));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheExpiryPolicyBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheExpiryPolicyBackupTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cache;
+
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.ICacheRecordStore;
+import com.hazelcast.cache.impl.ICacheService;
+import com.hazelcast.config.CacheSimpleConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.cache.expiry.EternalExpiryPolicy;
+import javax.cache.expiry.ExpiryPolicy;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class CacheExpiryPolicyBackupTest extends HazelcastTestSupport {
+
+    private static final int NINSTANCES = 3;
+    private static final int ENTRIES = 100;
+    private TestHazelcastInstanceFactory factory;
+    private HazelcastInstance[] instances;
+    private String cacheName;
+
+    @Before
+    public void setUp() {
+        cacheName = randomName();
+        factory = createHazelcastInstanceFactory(NINSTANCES);
+        instances = new HazelcastInstance[NINSTANCES];
+        for (int i = 0; i < instances.length; i++) {
+            instances[i] = factory.newHazelcastInstance(getConfig());
+        }
+    }
+
+    @After
+    public void tearDown() {
+        factory.shutdownAll();
+    }
+
+    @Override
+    public Config getConfig() {
+        CacheSimpleConfig cacheConfig = new CacheSimpleConfig();
+        cacheConfig.setName(cacheName);
+        cacheConfig.setBackupCount(NINSTANCES - 1);
+        return new Config().addCacheConfig(cacheConfig);
+    }
+
+    private void assertExpiryPolicyInAllNodes(ExpiryPolicy expiryPolicy, Collection<String> keys) {
+        for (int i = 0; i < instances.length; i++) {
+            Node node = getNode(instances[i]);
+
+            CacheService cacheService = node.getNodeEngine().getService(ICacheService.SERVICE_NAME);
+            SerializationService serializationService = node.getSerializationService();
+            InternalPartitionService partitionService = node.getPartitionService();
+            for (String key: keys) {
+                Data dataKey = serializationService.toData(key);
+                int partitionId = partitionService.getPartitionId(dataKey);
+
+                ICacheRecordStore recordStore = cacheService.getRecordStore("/hz/" + cacheName, partitionId);
+                ExpiryPolicy actual = serializationService.toObject(recordStore.getExpiryPolicy(dataKey));
+
+                assertEquals(expiryPolicy, actual);
+            }
+        }
+    }
+
+    @Test
+    public void testSetExpiryPolicyBackupOperation() {
+        HazelcastInstance instance = instances[0];
+        ICache<String, String> cache = instance.getCacheManager().getCache(cacheName);
+        Set<String> keys = new HashSet<String>();
+
+        for (int i = 0; i < ENTRIES; i++) {
+            cache.put("key" + i, "value");
+            keys.add("key" + i);
+        }
+
+        ExpiryPolicy expiryPolicy = EternalExpiryPolicy.factoryOf().create();
+        cache.setExpiryPolicy(keys, expiryPolicy);
+
+        assertExpiryPolicyInAllNodes(expiryPolicy, keys);
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/cache/CacheExpiryPolicyBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/CacheExpiryPolicyBackupTest.java
@@ -26,11 +26,16 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import javax.cache.expiry.EternalExpiryPolicy;
 import javax.cache.expiry.ExpiryPolicy;
@@ -40,6 +45,8 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 
+@Category({QuickTest.class, ParallelTest.class})
+@RunWith(HazelcastSerialClassRunner.class)
 public class CacheExpiryPolicyBackupTest extends HazelcastTestSupport {
 
     private static final int NINSTANCES = 3;
@@ -64,11 +71,15 @@ public class CacheExpiryPolicyBackupTest extends HazelcastTestSupport {
     }
 
     @Override
-    public Config getConfig() {
+    protected Config getConfig() {
+        return new Config().addCacheConfig(getCacheConfig());
+    }
+
+    protected CacheSimpleConfig getCacheConfig() {
         CacheSimpleConfig cacheConfig = new CacheSimpleConfig();
         cacheConfig.setName(cacheName);
         cacheConfig.setBackupCount(NINSTANCES - 1);
-        return new Config().addCacheConfig(cacheConfig);
+        return cacheConfig;
     }
 
     private void assertExpiryPolicyInAllNodes(ExpiryPolicy expiryPolicy, Collection<String> keys) {
@@ -101,7 +112,7 @@ public class CacheExpiryPolicyBackupTest extends HazelcastTestSupport {
             keys.add("key" + i);
         }
 
-        ExpiryPolicy expiryPolicy = EternalExpiryPolicy.factoryOf().create();
+        ExpiryPolicy expiryPolicy = new EternalExpiryPolicy();
         cache.setExpiryPolicy(keys, expiryPolicy);
 
         assertExpiryPolicyInAllNodes(expiryPolicy, keys);

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/AbstractCacheEvictionPolicyComparatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/AbstractCacheEvictionPolicyComparatorTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
+import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.spi.CachingProvider;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -97,6 +98,7 @@ public abstract class AbstractCacheEvictionPolicyComparatorTest extends Hazelcas
             assertTrue(e2.getCreationTime() > 0);
             assertEquals(CacheRecord.TIME_NOT_AVAILABLE, e2.getLastAccessTime());
             assertEquals(0, e2.getAccessHit());
+            assertEquals(e1.getExpiryPolicy(), e2.getExpiryPolicy());
 
             callCounter.incrementAndGet();
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTest.java
@@ -41,4 +41,16 @@ public class CacheRecordStoreTest
         putAndGetFromCacheRecordStore(cacheRecordStore, InMemoryFormat.OBJECT);
     }
 
+    @Test
+    public void putObjectAndGetObjectExpiryPolicyFromCacheRecordStore() {
+        ICacheRecordStore cacheRecordStore = createCacheRecordStore(InMemoryFormat.OBJECT);
+        putAndSetExpiryPolicyFromRecordStore(cacheRecordStore, InMemoryFormat.OBJECT);
+    }
+
+    @Test
+    public void putObjectAndGetDataExpiryPolicyFromCacheRecordStore() {
+        ICacheRecordStore cacheRecordStore = createCacheRecordStore(InMemoryFormat.BINARY);
+        putAndSetExpiryPolicyFromRecordStore(cacheRecordStore, InMemoryFormat.BINARY);
+    }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
@@ -127,7 +127,7 @@ public abstract class CacheRecordStoreTestSupport
             Data keyData = serializationService.toData(i);
 
             cacheRecordStore.put(keyData, "value-" + i, null, null, -1);
-            cacheRecordStore.setExpiryPolicy(Collections.singleton(keyData), policyData, -1);
+            cacheRecordStore.setExpiryPolicy(Collections.singleton(keyData), policyData, null, -1);
         }
 
         if (inMemoryFormat == InMemoryFormat.BINARY || inMemoryFormat == InMemoryFormat.NATIVE) {

--- a/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
@@ -33,6 +33,12 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import org.junit.After;
 import org.junit.Before;
 
+import javax.cache.expiry.Duration;
+import javax.cache.expiry.ExpiryPolicy;
+import javax.cache.expiry.TouchedExpiryPolicy;
+
+import java.util.Collections;
+
 import static org.junit.Assert.assertTrue;
 
 public abstract class CacheRecordStoreTestSupport
@@ -110,6 +116,35 @@ public abstract class CacheRecordStoreTestSupport
         } else {
             throw new IllegalArgumentException("Unsupported in-memory format: " + inMemoryFormat);
         }
+    }
+
+    protected void putAndSetExpiryPolicyFromRecordStore(ICacheRecordStore cacheRecordStore, InMemoryFormat inMemoryFormat) {
+        SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+        ExpiryPolicy expiryPolicy = TouchedExpiryPolicy.factoryOf(Duration.ETERNAL).create();
+        Data policyData = serializationService.toData(expiryPolicy);
+
+        for (int i = 0; i < CACHE_RECORD_COUNT; i++) {
+            Data keyData = serializationService.toData(i);
+
+            cacheRecordStore.put(keyData, "value-" + i, null, null, -1);
+            cacheRecordStore.setExpiryPolicy(Collections.singleton(keyData), policyData, -1);
+        }
+
+        if (inMemoryFormat == InMemoryFormat.BINARY || inMemoryFormat == InMemoryFormat.NATIVE) {
+            for (int i = 0; i < CACHE_RECORD_COUNT; i++) {
+                assertTrue(Data.class.isAssignableFrom(
+                        cacheRecordStore.getExpiryPolicy(serializationService.toData(i)).getClass()));
+            }
+        } else if (inMemoryFormat == InMemoryFormat.OBJECT) {
+            for (int i = 0; i < CACHE_RECORD_COUNT; i++) {
+                assertTrue(ExpiryPolicy.class.isAssignableFrom(
+                        cacheRecordStore.getExpiryPolicy(serializationService.toData(i)).getClass()));
+            }
+        } else {
+            throw new IllegalArgumentException("Unsupported in-memory format: " + inMemoryFormat);
+        }
+
+
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/recordstore/CacheRecordStoreTestSupport.java
@@ -120,14 +120,14 @@ public abstract class CacheRecordStoreTestSupport
 
     protected void putAndSetExpiryPolicyFromRecordStore(ICacheRecordStore cacheRecordStore, InMemoryFormat inMemoryFormat) {
         SerializationService serializationService = new DefaultSerializationServiceBuilder().build();
-        ExpiryPolicy expiryPolicy = TouchedExpiryPolicy.factoryOf(Duration.ETERNAL).create();
+        ExpiryPolicy expiryPolicy = new TouchedExpiryPolicy(Duration.ETERNAL);
         Data policyData = serializationService.toData(expiryPolicy);
 
         for (int i = 0; i < CACHE_RECORD_COUNT; i++) {
             Data keyData = serializationService.toData(i);
 
             cacheRecordStore.put(keyData, "value-" + i, null, null, -1);
-            cacheRecordStore.setExpiryPolicy(Collections.singleton(keyData), policyData, null, -1);
+            cacheRecordStore.setExpiryPolicy(Collections.singleton(keyData), policyData, null);
         }
 
         if (inMemoryFormat == InMemoryFormat.BINARY || inMemoryFormat == InMemoryFormat.NATIVE) {

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityFileGenerator.java
@@ -4074,7 +4074,7 @@ public class BinaryCompatibilityFileGenerator {
 
 
 {
-    ClientMessage clientMessage = CacheSetExpiryPolicyCodec.encodeRequest(    aString ,    datas ,    aData ,    anInt   );
+    ClientMessage clientMessage = CacheSetExpiryPolicyCodec.encodeRequest(    aString ,    datas ,    aData   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityNullFileGenerator.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/BinaryCompatibilityNullFileGenerator.java
@@ -4074,7 +4074,7 @@ public class BinaryCompatibilityNullFileGenerator {
 
 
 {
-    ClientMessage clientMessage = CacheSetExpiryPolicyCodec.encodeRequest(   aString ,   datas ,   aData ,   anInt   );
+    ClientMessage clientMessage = CacheSetExpiryPolicyCodec.encodeRequest(   aString ,   datas ,   aData   );
      outputStream.writeInt(clientMessage.getFrameLength());
      outputStream.write(clientMessage.buffer().byteArray(), 0 , clientMessage.getFrameLength());
 }

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityNullTest.java
@@ -4427,12 +4427,11 @@ public class EncodeDecodeCompatibilityNullTest {
             assertTrue(isEqual(aLong, params.nextSeq));
 }
 {
-    ClientMessage clientMessage = CacheSetExpiryPolicyCodec.encodeRequest(    aString ,    datas ,    aData ,    anInt   );
+    ClientMessage clientMessage = CacheSetExpiryPolicyCodec.encodeRequest(    aString ,    datas ,    aData   );
     CacheSetExpiryPolicyCodec.RequestParameters params = CacheSetExpiryPolicyCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(datas, params.keys));
             assertTrue(isEqual(aData, params.expiryPolicy));
-            assertTrue(isEqual(anInt, params.completionId));
 }
 {
     ClientMessage clientMessage = CacheSetExpiryPolicyCodec.encodeResponse( );

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/EncodeDecodeCompatibilityTest.java
@@ -4312,12 +4312,11 @@ public class EncodeDecodeCompatibilityTest {
             assertTrue(isEqual(aLong, params.nextSeq));
 }
 {
-    ClientMessage clientMessage = CacheSetExpiryPolicyCodec.encodeRequest(    aString ,    datas ,    aData ,    anInt   );
+    ClientMessage clientMessage = CacheSetExpiryPolicyCodec.encodeRequest(    aString ,    datas ,    aData   );
     CacheSetExpiryPolicyCodec.RequestParameters params = CacheSetExpiryPolicyCodec.decodeRequest(ClientMessage.createForDecode(clientMessage.buffer(), 0));
             assertTrue(isEqual(aString, params.name));
             assertTrue(isEqual(datas, params.keys));
             assertTrue(isEqual(aData, params.expiryPolicy));
-            assertTrue(isEqual(anInt, params.completionId));
 }
 {
     ClientMessage clientMessage = CacheSetExpiryPolicyCodec.encodeResponse( );

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
@@ -34,7 +34,6 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
 import org.junit.Test;
 
-import javax.cache.expiry.EternalExpiryPolicy;
 import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.processor.EntryProcessorResult;
 import java.util.ArrayList;
@@ -896,7 +895,6 @@ public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSu
         assertNearCacheInvalidations(context, DEFAULT_RECORD_COUNT);
         String message = format("Invalidation is not working on %s()", method.getMethodName());
         assertNearCacheSizeEventually(context, 0, message);
-        String newValuePrefix = "newValue-";
         if (method == DataStructureMethods.SET_TTL) {
             newValuePrefix = "value-";
         }

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.7.0-2</client.protocol.version>
+        <client.protocol.version>1.7.0-3</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>1.6</jdk.version>


### PR DESCRIPTION
This PR adds `setExpiryPolicy` calls to `ICache` interface.
It is ICache only, should not make any changes to JCache.

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/2200