### PR TITLE
Add an assume to PhoneHomeTest.testShutdown

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -38,7 +38,6 @@ import org.junit.runner.RunWith;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;

--- a/hazelcast/src/test/java/com/hazelcast/map/MapSetTTLBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapSetTTLBackupTest.java
@@ -106,7 +106,7 @@ public class MapSetTTLBackupTest extends HazelcastTestSupport {
         final String mapName = randomMapName();
         HazelcastInstance instance = instances[0];
 
-        putKeys(instance, mapName, 1,0, 100);
+        putKeys(instance, mapName, 1, 0, 100);
         setTTL(instance, mapName, 0, 100, 0, TimeUnit.SECONDS);
         sleepAtLeastMillis(1100);
         for (int i = 0; i < NINSTANCE; i++) {

--- a/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/PhoneHomeTest.java
@@ -34,12 +34,14 @@ import java.lang.management.OperatingSystemMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.util.Map;
 
+import static java.lang.System.getenv;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -129,6 +131,8 @@ public class PhoneHomeTest extends HazelcastTestSupport {
 
     @Test
     public void testShutdown() {
+        assumeFalse("Skipping. The PhoneHome is disabled by the Environment variable",
+                "false".equals(getenv("HZ_PHONE_HOME_ENABLED")));
         Config config = new Config()
                 .setProperty(GroupProperty.PHONE_HOME_ENABLED.getName(), "true");
 


### PR DESCRIPTION
To pass the `PhoneHomeTest`, the feature must not be disabled by `HZ_PHONE_HOME_ENABLED` environment variable.