### PR TITLE
Fix handling of local Node ID overflow [backport of #13330]

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/flakeidgen/impl/FlakeIdGenerator_NodeIdOverflowIntegrationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/flakeidgen/impl/FlakeIdGenerator_NodeIdOverflowIntegrationTest.java
@@ -92,8 +92,8 @@ public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
         gen.newId();
     }
 
-    private void assignOverflowedNodeId(HazelcastInstance instance2) {
-        MemberImpl member = (MemberImpl) instance2.getCluster().getLocalMember();
+    private void assignOverflowedNodeId(HazelcastInstance instance) {
+        MemberImpl member = (MemberImpl) instance.getCluster().getLocalMember();
         member.setMemberListJoinVersion(100000);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/flakeidgen/impl/FlakeIdGenerator_NodeIdOverflowIntegrationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/flakeidgen/impl/FlakeIdGenerator_NodeIdOverflowIntegrationTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.flakeidgen.impl;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
@@ -28,6 +29,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -44,6 +46,16 @@ public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
     public ExpectedException exception = ExpectedException.none();
 
     private TestHazelcastFactory factory = new TestHazelcastFactory();
+    private HazelcastInstance instance2;
+    private HazelcastInstance instance1;
+
+    @Before
+    public void before() {
+        Config cfg = new Config();
+        cfg.getFlakeIdGeneratorConfig("gen").setPrefetchCount(1);
+        instance1 = factory.newHazelcastInstance(cfg);
+        instance2 = factory.newHazelcastInstance(cfg);
+    }
 
     @After
     public void after() {
@@ -51,7 +63,7 @@ public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
     }
 
     @Test
-    public void when_memberOutOfRangeNodeId_then_theOtherMemberUsed() throws Exception {
+    public void when_memberOutOfRangeNodeId_then_theOtherMemberUsed() {
         // Design of this test: we create two members. To one of them, out-of-range memberListJoinVersion
         // is assigned. This causes the client message to fail and the client will retry with another member
         // and will never again try the failed member.
@@ -59,8 +71,6 @@ public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
         // Probability of initially choosing a good member and not going through the process of choosing another
         // one is 50%. To avoid false success, we retry 10 times, which gives the probability of false success
         // of 0.1%.
-        HazelcastInstance instance1 = factory.newHazelcastInstance();
-        HazelcastInstance instance2 = factory.newHazelcastInstance();
         assignOverflowedNodeId(instance2);
 
         ClientConfig clientConfig = new ClientConfig();
@@ -79,8 +89,6 @@ public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
 
     @Test
     public void when_allMembersOutOfRangeNodeId_then_error() {
-        HazelcastInstance instance1 = factory.newHazelcastInstance();
-        HazelcastInstance instance2 = factory.newHazelcastInstance();
         assignOverflowedNodeId(instance1);
         assignOverflowedNodeId(instance2);
 
@@ -92,8 +100,8 @@ public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
         gen.newId();
     }
 
-    private void assignOverflowedNodeId(HazelcastInstance instance) {
-        MemberImpl member = (MemberImpl) instance.getCluster().getLocalMember();
+    private static void assignOverflowedNodeId(HazelcastInstance instance2) {
+        MemberImpl member = (MemberImpl) instance2.getCluster().getLocalMember();
         member.setMemberListJoinVersion(100000);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/impl/FlakeIdGeneratorProxy.java
@@ -224,12 +224,7 @@ public class FlakeIdGeneratorProxy
             newNodeId += nodeIdOffset;
             nextNodeIdUpdate = nanoTime + NODE_ID_UPDATE_INTERVAL_NS;
             if (newNodeId != nodeId) {
-                // we ignore possible double initialization
                 nodeId = newNodeId;
-                this.nodeId = newNodeId;
-                if (logger.isFineEnabled()) {
-                    logger.fine("Node ID assigned to '" + name + "': " + nodeId);
-                }
 
                 // If our node ID is out of range, assign NODE_ID_OUT_OF_RANGE to nodeId
                 if ((nodeId & -1 << BITS_NODE_ID) != 0) {
@@ -237,6 +232,12 @@ public class FlakeIdGeneratorProxy
                     logger.severe("Node ID is out of range (" + nodeId + "), this member won't be able to generate IDs. "
                             + "Cluster restart is recommended.");
                     nodeId = NODE_ID_OUT_OF_RANGE;
+                }
+
+                // we ignore possible double initialization
+                this.nodeId = nodeId;
+                if (logger.isFineEnabled()) {
+                    logger.fine("Node ID assigned to '" + name + "': " + nodeId);
                 }
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_NodeIdOverflowIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/flakeidgen/impl/FlakeIdGenerator_NodeIdOverflowIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.flakeidgen.impl;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
@@ -25,6 +26,7 @@ import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -39,6 +41,16 @@ public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
     public ExpectedException exception = ExpectedException.none();
 
     private TestHazelcastInstanceFactory factory = new TestHazelcastInstanceFactory();
+    private HazelcastInstance instance2;
+    private HazelcastInstance instance1;
+
+    @Before
+    public void before() {
+        Config cfg = new Config();
+        cfg.getFlakeIdGeneratorConfig("gen").setPrefetchCount(1);
+        instance1 = factory.newHazelcastInstance(cfg);
+        instance2 = factory.newHazelcastInstance(cfg);
+    }
 
     @After
     public void after() {
@@ -46,20 +58,18 @@ public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
     }
 
     @Test
-    public void when_memberOutOfRangeNodeId_then_theOtherMemberUsed() throws Exception {
-        HazelcastInstance instance1 = factory.newHazelcastInstance();
-        HazelcastInstance instance2 = factory.newHazelcastInstance();
+    public void when_memberOutOfRangeNodeId_then_theOtherMemberUsed() {
         assignOutOfRangeNodeId(instance2);
 
         // let's use the instance with out-of-range node ID to generate IDs, it should succeed
         FlakeIdGenerator gen = instance2.getFlakeIdGenerator("gen");
-        gen.newId();
+        for (int i = 0; i < 100; i++) {
+            gen.newId();
+        }
     }
 
     @Test
     public void when_allMembersOutOfRangeNodeId_then_error() {
-        HazelcastInstance instance1 = factory.newHazelcastInstance();
-        HazelcastInstance instance2 = factory.newHazelcastInstance();
         assignOutOfRangeNodeId(instance1);
         assignOutOfRangeNodeId(instance2);
 
@@ -70,8 +80,8 @@ public class FlakeIdGenerator_NodeIdOverflowIntegrationTest {
         gen.newId();
     }
 
-    private void assignOutOfRangeNodeId(HazelcastInstance instance2) {
-        MemberImpl member = (MemberImpl) instance2.getCluster().getLocalMember();
+    private static void assignOutOfRangeNodeId(HazelcastInstance instance) {
+        MemberImpl member = (MemberImpl) instance.getCluster().getLocalMember();
         member.setMemberListJoinVersion(100000);
     }
 }


### PR DESCRIPTION
If local Node ID was overflowed the `FlakeIdGeneratorProxy.getNodeId`
was supposed to return -2 (`NODE_ID_OUT_OF_RANGE`). There is an
optimization in it which caches the nodeId value. However, it cached the
overflowed nodeId, not -2. So on subsequent call it returned overflowed
id, on which the `newIdBaseLocal` failed with `AssertionError: nodeId
out of range: NNN`.

The fix is to assign correct value to `FlakeIdGeneratorProxy.nodeId`.

The test supposed to detect this didn't due to a bug that the non-smart 
client always chose port 5001 (the `instance1`) and never went to 
`instance2`. So the false success probability of 0.1% was actually 100%.