### PR TITLE
Increase call timeout for long operation test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
@@ -1036,7 +1036,7 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
 
         Config config = new Config();
-        long callTimeoutMillis = 3000;
+        long callTimeoutMillis = 4000;
         config.setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), String.valueOf(callTimeoutMillis));
 
         HazelcastInstance hz1 = factory.newHazelcastInstance(config);


### PR DESCRIPTION
Operation heartbeat broadcast interval is calculated as:

max(1000, OPERATION_CALL_TIMEOUT_MILLIS / 4)

By increasing operation call timeout from 3s to 4s in the test we are
getting a sweet spot: highest number of heartbeats will be sent in the
shortest time. This should make the test more resistant to jittering
while not increasing the test duration significantly.