### PR TITLE
Fix exceptions thrown to the user

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/InvalidConfigurationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InvalidConfigurationException.java
@@ -16,12 +16,14 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.core.HazelcastException;
+
 /**
  * A InvalidConfigurationException is thrown when there is an Invalid Configuration.
  * Invalid Configuration can be a wrong XML Config or logical config errors that are found
  * at real time.
  */
-public class InvalidConfigurationException extends RuntimeException {
+public class InvalidConfigurationException extends HazelcastException {
 
     /**
      * Creates a InvalidConfigurationException with the given message.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/proxyservice/impl/ProxyRegistry.java
@@ -17,12 +17,14 @@
 package com.hazelcast.spi.impl.proxyservice.impl;
 
 import com.hazelcast.core.DistributedObject;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.RemoteService;
+import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.eventservice.InternalEventService;
 import com.hazelcast.util.EmptyStatement;
 
@@ -50,7 +52,29 @@ public final class ProxyRegistry {
     ProxyRegistry(ProxyServiceImpl proxyService, String serviceName) {
         this.proxyService = proxyService;
         this.serviceName = serviceName;
-        this.service = proxyService.nodeEngine.getService(serviceName);
+        this.service = getService(proxyService.nodeEngine, serviceName);
+    }
+
+    /**
+     * Returns the service for the given {@code serviceName} or throws an
+     * exception. This method never returns {@code null}.
+     *
+     * @param nodeEngine  the node engine
+     * @param serviceName the remote service name
+     * @return the service instance
+     * @throws HazelcastException                  if there is no service with the given name
+     * @throws HazelcastInstanceNotActiveException if this instance is shutting down
+     */
+    private RemoteService getService(NodeEngineImpl nodeEngine, String serviceName) {
+        try {
+            return nodeEngine.getService(serviceName);
+        } catch (HazelcastException e) {
+            if (!nodeEngine.isRunning()) {
+                throw new HazelcastInstanceNotActiveException(e.getMessage());
+            } else {
+                throw e;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Retrieving a service instance while shutting down the node throws a
RetryableHazelcastException. This may make sense for most cases like
running an operation as the operation can then be retried. In some cases
like creating a proxy, this exception is thrown directly to user code.
In this case, the code is not retriable as the node will shut down and
will never be able to create a proxy.

We fix this issue by catching the exception thrown when retrieving the
service instance and rethrowing it as
HazelcastInstanceNotActiveException. This is what most of the proxy code
throws in case the instance is not active.

The alternative fix which might have been more suitable would have been
for the getService call to throw a HazelcastInstanceNotActiveException
and for the callers to rethrow a retryable exception in case a retry was
needed. Unfortunately, we have several issues with this solution:
- NodeEngine.getService is part of SPI and the javadoc states that it
throws a HazelcastException if a service is not available
- HazelcastInstanceNotActiveException does not extend HazelcastException
and we cannot make it extend it since it extends IllegalStateException
already
- changing the exception thrown from the getService method would require
extensive changes to the code calling this method (checking each call
and determining if we can retry). This is not an issue in itself but it
should have been done from the beginning. Now we cannot change the
exception because of the above two points.

Also, changed the parent class for InvalidConfigurationException to
HazelcastException as we advertise HazelcastException to be a base class
for hazelcast exceptions. The InvalidConfigurationException still
extends RuntimeException so this is acceptable.

Fixes: https://github.com/hazelcast/hazelcast/issues/13225