### PR TITLE
Cleanup in ManagementCenterConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
@@ -23,13 +23,16 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 public class ManagementCenterConfig {
 
-    static final int UPDATE_INTERVAL = 3;
+    /**
+     * The default interval for sending member information to the management center.
+     */
+    public static final int UPDATE_INTERVAL_SECONDS = 3;
 
     private boolean enabled;
 
     private String url;
 
-    private int updateInterval = UPDATE_INTERVAL;
+    private int updateInterval = UPDATE_INTERVAL_SECONDS;
 
     private MCMutualAuthConfig mutualAuthConfig;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -2268,7 +2268,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
 
         Node intervalNode = attrs.getNamedItem("update-interval");
         int interval = intervalNode != null ? getIntegerValue("update-interval",
-                getTextContent(intervalNode)) : ManagementCenterConfig.UPDATE_INTERVAL;
+                getTextContent(intervalNode)) : ManagementCenterConfig.UPDATE_INTERVAL_SECONDS;
 
         ManagementCenterConfig managementCenterConfig = config.getManagementCenterConfig();
         managementCenterConfig.setEnabled(enabled);


### PR DESCRIPTION
* PrepareStateThread has been dropped. Preparation of the state to
send to the MC is done by the StateSendThread. There is no point
in having another thread to prepare the state and to stick it into
an AtomicReference so that another thread can send it.

* made some fields private

* removed duplicate default UPDATE setting from the ManagementCenterService;
instead now the ManagementCenterService.UPDATE_INTERVAL_SECONDS is used.