### PR TITLE
MapSetTTLBackupTest timing issue fix

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/MapSetTTLBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapSetTTLBackupTest.java
@@ -106,11 +106,11 @@ public class MapSetTTLBackupTest extends HazelcastTestSupport {
         final String mapName = randomMapName();
         HazelcastInstance instance = instances[0];
 
-        putKeys(instance, mapName, 1, 0, 100);
-        setTTL(instance, mapName, 0, 100, 0, TimeUnit.SECONDS);
-        sleepAtLeastMillis(1100);
+        putKeys(instance, mapName, 10, 0, 20);
+        setTTL(instance, mapName, 0, 20, 0, TimeUnit.SECONDS);
+        sleepAtLeastMillis(10100);
         for (int i = 0; i < NINSTANCE; i++) {
-            assertKeys(instances[i], mapName, 0, 100);
+            assertKeys(instances[i], mapName, 0, 20);
         }
     }
 


### PR DESCRIPTION
In the original test, by the time `setTTL` operation runs some of the entries are already expired due to short initial TTL.
This PR increases the initial TTL and decreases the number of entries. We still need to wait initial TTL amount of time to make sure the entries are not evicted at the end of TTL duration.

Fixes https://github.com/hazelcast/hazelcast/issues/13333