### PR TITLE
Map interceptor doesn't receive old value in afterRemove call.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -46,7 +46,7 @@ public abstract class BaseRemoveOperation extends LockAwareOperation implements 
 
     @Override
     public void afterRun() {
-        mapServiceContext.interceptAfterRemove(name, dataValue);
+        mapServiceContext.interceptAfterRemove(name, dataOldValue);
         mapEventPublisher.publishEvent(getCallerAddress(), name, EntryEventType.REMOVED, dataKey, dataOldValue, null);
         invalidateNearCache(dataKey);
         publishWanRemove(dataKey);


### PR DESCRIPTION
I attached an interceptor to a map but the afterRemove method receives null instead of the old value from the map. Problem originates in BaseRemoveOperation where the wrong value is passed to interceptAfterRemove.