### PR TITLE
MapInterceptor improvements

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/MapInterceptor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/MapInterceptor.java
@@ -21,47 +21,53 @@ import com.hazelcast.nio.serialization.BinaryInterface;
 import java.io.Serializable;
 
 /**
- * MapInterceptor is used to intercept changes to the map, allowing access to the values before and
- * after adding them to the map.
- *
- * MapInterceptors are chained when added to the map, which means that when an interceptor is added
- * on node initialization, it could be added twice. To prevent this, make sure to implement the
- * hashCode method to return the same value for every instance of the class.
- *
- * Serialized instances of this interface are used in client-member communication, so changing an implementation's binary format
- * will render it incompatible with its previous versions.
+ * MapInterceptor is used to intercept changes to the map, allowing access to
+ * the values before and after adding them to the map.
+ * <p>
+ * MapInterceptors are chained when added to the map, which means that when an
+ * interceptor is added on node initialization, it could be added twice. To
+ * prevent this, make sure to implement the hashCode method to return the same
+ * value for every instance of the class.
+ * <p>
+ * Serialized instances of this interface are used in client-member
+ * communication, so changing an implementation's binary format will render it
+ * incompatible with its previous versions.
  */
 @BinaryInterface
 public interface MapInterceptor extends Serializable {
 
     /**
-     * Intercept the get operation before returning value.
-     * Return another object to change the return value of get(..)
-     * Returning null will cause the get(..) operation to return the original value,
-     * so return null if you do not want to change anything.
-     * <p/>
-     * Mutations made to the value do not affect the stored value. They do affect the returned value.
+     * Intercepts the get operation before returning value.
+     * <p>
+     * Returns another object to change the return value of get(...) operations.
+     * Returning {@code null} will cause the get(...) operation to return the
+     * original value, so return {@code null} if you do not want to change
+     * anything.
+     * <p>
+     * Mutations made to the value do not affect the stored value. They do
+     * affect the returned value.
      *
-     * @param value the original value to be returned as the result of get(..) operation
-     * @return the new value that will be returned by the get(..) operation
+     * @param value the original value to be returned as the result of get(...)
+     *              operation
+     * @return the new value that will be returned by the get(...) operation
      */
     Object interceptGet(Object value);
 
     /**
-     * Called after the get(..) operation is completed.
-     * <p/>
+     * Called after the get(...) operation is completed.
+     * <p>
      * Mutations made to value do not affect the stored value.
      *
-     * @param value the value returned as the result of the get(..) operation
+     * @param value the value returned as the result of the get(...) operation
      */
     void afterGet(Object value);
 
     /**
-     * Intercept the put operation before modifying the map data.
-     * Return the object to be put into the map.
-     * Returning null will cause the put(..) operation to operate as expected, namely no interception.
-     * Throwing an exception will cancel the put operation.
-     * <p/>
+     * Intercepts the put operation before modifying the map data.
+     * <p>
+     * Returns the object to be put into the map. Returning {@code null} will
+     * cause the put(...) operation to operate as expected, namely no
+     * interception. Throwing an exception will cancel the put operation.
      *
      * @param oldValue the value currently in map
      * @param newValue the new value to be put into the map
@@ -70,18 +76,17 @@ public interface MapInterceptor extends Serializable {
     Object interceptPut(Object oldValue, Object newValue);
 
     /**
-     * Called after the put(..) operation is completed.
-     * <p/>
+     * Called after the put(...) operation is completed.
      *
-     * @param value the value returned as the result of the put(..) operation
+     * @param value the value returned as the result of the put(...) operation
      */
     void afterPut(Object value);
 
     /**
-     * Intercept remove operation before removing the data.
-     * Return the object to be returned as the result of the remove operation.
+     * Intercepts the remove operation before removing the data.
+     * <p>
+     * Returns the object to be returned as the result of the remove operation.
      * Throwing an exception will cancel the remove operation.
-     * <p/>
      *
      * @param removedValue the existing value to be removed
      * @return the value to be returned as the result of remove operation
@@ -89,11 +94,10 @@ public interface MapInterceptor extends Serializable {
     Object interceptRemove(Object removedValue);
 
     /**
-     * Called after the remove(..) operation is completed.
-     * <p/>
+     * Called after the remove(...) operation is completed.
      *
-     * @param value the value returned as the result of the remove(..) operation
+     * @param oldValue the value returned as the result of the remove(...)
+     *                 operation
      */
-    void afterRemove(Object value);
-
+    void afterRemove(Object oldValue);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -618,8 +618,8 @@ class MapServiceContextImpl implements MapServiceContext {
         InterceptorRegistry interceptorRegistry = mapContainer.getInterceptorRegistry();
         List<MapInterceptor> interceptors = interceptorRegistry.getInterceptors();
         if (!interceptors.isEmpty()) {
+            value = toObject(value);
             for (MapInterceptor interceptor : interceptors) {
-                value = toObject(value);
                 interceptor.afterRemove(value);
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/EmbeddedMapInterceptorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EmbeddedMapInterceptorTest.java
@@ -18,56 +18,66 @@ package com.hazelcast.map;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
+import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import com.hazelcast.util.StringUtil;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.util.StringUtil.LOCALE_INTERNAL;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
 
+    private static final String[] CITIES = {"NEW YORK", "ISTANBUL", "TOKYO", "LONDON", "PARIS", "CAIRO", "HONG KONG"};
+
     private final String mapName = "testMapInterceptor";
+    private final Map<HazelcastInstance, SimpleInterceptor> interceptorMap = new HashMap<HazelcastInstance, SimpleInterceptor>();
 
-    /**
-     * Simulates initialisation code deployed on every member of the cluster. They
-     * all add an interceptor because the same code is deployed everywhere.
-     *
-     * @param nodeFactory Use this to create the instance
-     * @return The instance started
-     */
-    public HazelcastInstance startNode(TestHazelcastInstanceFactory nodeFactory) {
-        Config cfg = new Config();
-        cfg.getMapConfig("default").setInMemoryFormat(InMemoryFormat.OBJECT);
-        HazelcastInstance instance = nodeFactory.newHazelcastInstance(cfg);
-        IMap<Object, Object> map = instance.getMap(mapName);
-        SimpleInterceptor interceptor = new SimpleInterceptor();
-        map.addInterceptor(interceptor);
-        return instance;
-    }
+    private TestHazelcastInstanceFactory factory;
+    private HazelcastInstance hz1;
+    private HazelcastInstance hz2;
+    private IMap<Object, Object> map1;
+    private IMap<Object, Object> map2;
+    private SimpleInterceptor interceptor1;
+    private SimpleInterceptor interceptor2;
 
-    public void putAll(IMap<Integer, String> map, String... cities) {
-        for (int i = 1; i < cities.length; i++) {
-            map.put(i, cities[i]);
-        }
-    }
+    private String key;
+    private String value;
+    private String expectedValueAfterPut;
+    private String expectedValueAfterGet;
 
-    public void assertGet(IMap<Integer, String> map, String postfix, String... cities) {
-        for (int i = 1; i < cities.length; i++) {
-            assertEquals(cities[i] + postfix, map.get(i));
-        }
+    @Before
+    public void setUp() {
+        factory = createHazelcastInstanceFactory(2);
+        hz1 = startNodeWithInterceptor(factory);
+        hz2 = startNodeWithInterceptor(factory);
+
+        map1 = hz1.getMap(mapName);
+        map2 = hz2.getMap(mapName);
+        interceptor1 = interceptorMap.get(hz1);
+        interceptor2 = interceptorMap.get(hz2);
+
+        key = generateKeyOwnedBy(hz1);
+        value = randomString();
+        expectedValueAfterPut = value.toUpperCase(LOCALE_INTERNAL);
+        expectedValueAfterGet = expectedValueAfterPut + "-foo";
     }
 
     /**
@@ -75,19 +85,10 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
      */
     @Test
     public void testChainingOfSameInterceptor() {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        putAll(map1, CITIES);
 
-        HazelcastInstance i1 = startNode(nodeFactory);
-        HazelcastInstance i2 = startNode(nodeFactory);
-
-        final IMap<Integer, String> map1 = i1.getMap(mapName);
-        final IMap<Integer, String> map2 = i2.getMap(mapName);
-
-        String[] cities = {"NEW YORK", "ISTANBULL", "TOKYO", "LONDON", "PARIS", "CAIRO", "HONG KONG"};
-        putAll(map1, cities);
-
-        assertGet(map1, "-foo", cities);
-        assertGet(map2, "-foo", cities);
+        assertGet(map1, "-foo", CITIES);
+        assertGet(map2, "-foo", CITIES);
     }
 
     /**
@@ -95,136 +96,226 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
      */
     @Test
     public void testStoppingNodeLeavesInterceptor() {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
+        putAll(map1, CITIES);
 
-        HazelcastInstance i1 = startNode(nodeFactory);
-        HazelcastInstance i2 = startNode(nodeFactory);
+        // terminate one node
+        hz2.shutdown();
 
-        final IMap<Integer, String> map1 = i1.getMap(mapName);
-        final IMap<Integer, String> map2 = i2.getMap(mapName);
+        assertGet(map1, "-foo", CITIES);
 
-        String[] cities = {"NEW YORK", "ISTANBULL", "TOKYO", "LONDON", "PARIS", "CAIRO", "HONG KONG"};
-        putAll(map1, cities);
+        // adding the node back in
+        hz2 = startNodeWithInterceptor(factory);
+        map2 = hz2.getMap(mapName);
 
-        //Now terminate one node
-        i2.shutdown();
-
-        assertGet(map1, "-foo", cities);
-
-        //Now adding the node back in
-        i2 = startNode(nodeFactory);
-        IMap<Integer, String> map2b = i2.getMap(mapName);
-
-        assertGet(map1, "-foo", cities);
-        assertGet(map2b, "-foo", cities);
-    }
-
-
-    @Test
-    public void testPutInterceptedValuePropagatesToBackupCorrectly() throws Exception {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
-        HazelcastInstance h1 = startNode(nodeFactory);
-        HazelcastInstance h2 = startNode(nodeFactory);
-        IMap<Object, Object> map1 = h1.getMap(mapName);
-        IMap<Object, Object> map2 = h2.getMap(mapName);
-        String key = generateKeyOwnedBy(h1);
-        map1.put(key, key);
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
-        h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
+        assertGet(map1, "-foo", CITIES);
+        assertGet(map2, "-foo", CITIES);
     }
 
     @Test
-    public void testPutIfAbsentInterceptedValuePropagatesToBackupCorrectly() throws Exception {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
-        HazelcastInstance h1 = startNode(nodeFactory);
-        HazelcastInstance h2 = startNode(nodeFactory);
-        IMap<Object, Object> map1 = h1.getMap(mapName);
-        IMap<Object, Object> map2 = h2.getMap(mapName);
-        String key = generateKeyOwnedBy(h1);
-        map1.putIfAbsent(key, key);
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
-        h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
+    public void testGetInterceptedValue() {
+        // no value is set yet
+        assertNull("Expected no value", map1.get(key));
+        assertNull("Expected no value", interceptor1.getValue);
+        assertNull("Expected no value after get", interceptor1.afterGetValue);
+        assertNoInteractionWith(interceptor2);
+        interceptor1.reset();
+        interceptor2.reset();
+
+        map1.put(key, value);
+        interceptor1.reset();
+        interceptor2.reset();
+
+        // multiple get calls
+        for (int i = 0; i < 5; i++) {
+            assertEquals("Expected the intercepted value", expectedValueAfterGet, map1.get(key));
+            assertTrueEventually(new AssertTask() {
+                @Override
+                public void run() {
+                    assertEquals("Expected the uppercase value", expectedValueAfterPut, interceptor1.getValue);
+                    assertEquals("Expected the intercepted value after get", expectedValueAfterGet, interceptor1.afterGetValue);
+                    assertNoInteractionWith(interceptor2);
+                }
+            });
+            interceptor1.reset();
+            interceptor2.reset();
+        }
     }
 
     @Test
-    public void testPutTransientInterceptedValuePropagatesToBackupCorrectly() throws Exception {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
-        HazelcastInstance h1 = startNode(nodeFactory);
-        HazelcastInstance h2 = startNode(nodeFactory);
-        IMap<Object, Object> map1 = h1.getMap(mapName);
-        IMap<Object, Object> map2 = h2.getMap(mapName);
-        String key = generateKeyOwnedBy(h1);
-        map1.putTransient(key, key, 1, TimeUnit.MINUTES);
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
-        h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
+    public void testPutInterceptedValuePropagatesToBackupCorrectly() {
+        map1.put(key, value);
+        testInterceptedValuePropagatesToBackupCorrectly();
     }
 
     @Test
-    public void testReplaceInterceptedValuePropagatesToBackupCorrectly() throws Exception {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
-        HazelcastInstance h1 = startNode(nodeFactory);
-        HazelcastInstance h2 = startNode(nodeFactory);
-        IMap<Object, Object> map1 = h1.getMap(mapName);
-        IMap<Object, Object> map2 = h2.getMap(mapName);
-        String key = generateKeyOwnedBy(h1);
-        map1.put(key, key);
-        map1.replace(key, key);
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
-        h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
+    public void testPutIfAbsentInterceptedValuePropagatesToBackupCorrectly() {
+        map1.putIfAbsent(key, value);
+        testInterceptedValuePropagatesToBackupCorrectly();
     }
 
     @Test
-    public void testReplaceIfSameInterceptedValuePropagatesToBackupCorrectly() throws Exception {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
-        HazelcastInstance h1 = startNode(nodeFactory);
-        HazelcastInstance h2 = startNode(nodeFactory);
-        IMap<Object, Object> map1 = h1.getMap(mapName);
-        IMap<Object, Object> map2 = h2.getMap(mapName);
-        String key = generateKeyOwnedBy(h1);
-        map1.put(key, key);
-        map1.replace(key, key, key);
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
-        h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
+    public void testPutTransientInterceptedValuePropagatesToBackupCorrectly() {
+        map1.putTransient(key, value, 1, TimeUnit.MINUTES);
+        testInterceptedValuePropagatesToBackupCorrectly();
     }
 
     @Test
-    public void testSetInterceptedValuePropagatesToBackupCorrectly() throws Exception {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
-        HazelcastInstance h1 = startNode(nodeFactory);
-        HazelcastInstance h2 = startNode(nodeFactory);
-        IMap<Object, Object> map1 = h1.getMap(mapName);
-        IMap<Object, Object> map2 = h2.getMap(mapName);
-        String key = generateKeyOwnedBy(h1);
-        map1.set(key, key);
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
-        h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
+    public void testTryPutInterceptedValuePropagatesToBackupCorrectly() {
+        map1.tryPut(key, value, 5, TimeUnit.SECONDS);
+        testInterceptedValuePropagatesToBackupCorrectly();
     }
 
     @Test
-    public void testTryPutInterceptedValuePropagatesToBackupCorrectly() throws Exception {
-        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(3);
-        HazelcastInstance h1 = startNode(nodeFactory);
-        HazelcastInstance h2 = startNode(nodeFactory);
-        IMap<Object, Object> map1 = h1.getMap(mapName);
-        IMap<Object, Object> map2 = h2.getMap(mapName);
-        String key = generateKeyOwnedBy(h1);
-        map1.tryPut(key, key, 5, TimeUnit.SECONDS);
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map1.get(key));
-        h1.getLifecycleService().shutdown();
-        assertEquals(key.toUpperCase(StringUtil.LOCALE_INTERNAL) + "-foo", map2.get(key));
+    public void testSetInterceptedValuePropagatesToBackupCorrectly() {
+        map1.set(key, value);
+        testInterceptedValuePropagatesToBackupCorrectly();
     }
 
+    private void testInterceptedValuePropagatesToBackupCorrectly() {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertNull("Expected no old value", interceptor1.putOldValue);
+                assertEquals("Expected unmodified new value", value, interceptor1.putNewValue);
+                assertEquals("Expected new uppercase value after put", expectedValueAfterPut, interceptor1.afterPutValue);
+                assertNoInteractionWith(interceptor2);
+            }
+        });
+        assertEquals("Expected the intercepted value", expectedValueAfterGet, map1.get(key));
+
+        hz1.getLifecycleService().shutdown();
+        assertEquals("Expected the intercepted value after backup promotion", expectedValueAfterGet, map2.get(key));
+    }
+
+    @Test
+    public void testReplaceInterceptedValuePropagatesToBackupCorrectly() {
+        final String oldValue = "oldValue";
+        final String oldValueAfterPut = oldValue.toUpperCase(LOCALE_INTERNAL);
+        final String oldValueAfterGet = oldValueAfterPut + "-foo";
+
+        map1.put(key, oldValue);
+        assertEquals("Expected the intercepted old value", oldValueAfterGet, map1.get(key));
+        interceptor1.reset();
+        interceptor2.reset();
+
+        map1.replace(key, value);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals("Expected uppercase old value", oldValueAfterPut, interceptor1.putOldValue);
+                assertEquals("Expected unmodified new value", value, interceptor1.putNewValue);
+                assertEquals("Expected new uppercase value after put", expectedValueAfterPut, interceptor1.afterPutValue);
+                assertNoInteractionWith(interceptor2);
+            }
+        });
+        assertEquals("Expected the intercepted value", expectedValueAfterGet, map1.get(key));
+
+        hz1.getLifecycleService().shutdown();
+        assertEquals("Expected the intercepted value after backup promotion", expectedValueAfterGet, map2.get(key));
+    }
+
+    @Test
+    public void testReplaceIfSameInterceptedValuePropagatesToBackupCorrectly() {
+        final String oldValue = "oldValue";
+        final String oldValueAfterPut = oldValue.toUpperCase(LOCALE_INTERNAL);
+        final String oldValueAfterGet = oldValueAfterPut + "-foo";
+
+        map1.put(key, oldValue);
+        assertEquals("Expected the intercepted old value", oldValueAfterGet, map1.get(key));
+        interceptor1.reset();
+        interceptor2.reset();
+
+        map1.replace(key, oldValueAfterPut, value);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals("Expected uppercase old value", oldValueAfterPut, interceptor1.putOldValue);
+                assertEquals("Expected unmodified new value", value, interceptor1.putNewValue);
+                assertEquals("Expected new uppercase value after put", expectedValueAfterPut, interceptor1.afterPutValue);
+                assertNoInteractionWith(interceptor2);
+            }
+        });
+        assertEquals("Expected the intercepted value", expectedValueAfterGet, map1.get(key));
+
+        hz1.getLifecycleService().shutdown();
+        assertEquals("Expected the intercepted value after backup promotion", expectedValueAfterGet, map2.get(key));
+    }
+
+    @Test
+    public void testRemoveInterceptedValuePropagatesToBackupCorrectly() {
+        map1.put(key, value);
+        assertEquals("Expected the intercepted value", expectedValueAfterGet, map1.get(key));
+        interceptor1.reset();
+        interceptor2.reset();
+
+        map1.remove(key);
+        assertEquals("Expected the uppercase removed value", expectedValueAfterPut, interceptor1.removedValue);
+        assertEquals("Expected the uppercase value after remove", expectedValueAfterPut, interceptor1.afterRemoveValue);
+        assertNoInteractionWith(interceptor2);
+        assertNull("Expected the value to be removed", map1.get(key));
+
+        hz1.getLifecycleService().shutdown();
+        assertNull("Expected the value to be removed after backup promotion", map2.get(key));
+    }
+
+    /**
+     * Starts a Hazelcast instance with a {@link SimpleInterceptor}.
+     *
+     * @param nodeFactory use this to create the instance
+     * @return the started instance
+     */
+    private HazelcastInstance startNodeWithInterceptor(TestHazelcastInstanceFactory nodeFactory) {
+        MapConfig mapConfig = new MapConfig("default")
+                .setInMemoryFormat(InMemoryFormat.OBJECT);
+        Config config = new Config()
+                .addMapConfig(mapConfig);
+
+        HazelcastInstance instance = nodeFactory.newHazelcastInstance(config);
+        IMap<Object, Object> map = instance.getMap(mapName);
+
+        SimpleInterceptor interceptor = new SimpleInterceptor();
+        interceptorMap.put(instance, interceptor);
+        map.addInterceptor(interceptor);
+
+        return instance;
+    }
+
+    private static void putAll(IMap<Object, Object> map, String... cities) {
+        for (int i = 1; i < cities.length; i++) {
+            map.put(i, cities[i]);
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static void assertGet(IMap<Object, Object> map, String postfix, String... cities) {
+        for (int i = 1; i < cities.length; i++) {
+            assertEquals(cities[i] + postfix, map.get(i));
+        }
+    }
+
+    private static void assertNoInteractionWith(SimpleInterceptor interceptor) {
+        assertNull("Expected no getValue on the interceptor", interceptor.getValue);
+        assertNull("Expected no afterGetValue on the interceptor", interceptor.afterGetValue);
+        assertNull("Expected no putOldValue on the interceptor", interceptor.putOldValue);
+        assertNull("Expected no putNewValue on the interceptor", interceptor.putNewValue);
+        assertNull("Expected no afterPutValue on the interceptor", interceptor.afterPutValue);
+        assertNull("Expected no removedValue on the interceptor", interceptor.removedValue);
+        assertNull("Expected no afterRemoveValue on the interceptor", interceptor.afterRemoveValue);
+    }
 
     static class SimpleInterceptor implements MapInterceptor, Serializable {
 
+        volatile Object getValue;
+        volatile Object afterGetValue;
+        volatile Object putOldValue;
+        volatile Object putNewValue;
+        volatile Object afterPutValue;
+        volatile Object removedValue;
+        volatile Object afterRemoveValue;
+
         @Override
         public Object interceptGet(Object value) {
+            getValue = value;
             if (value == null) {
                 return null;
             }
@@ -233,29 +324,45 @@ public class EmbeddedMapInterceptorTest extends HazelcastTestSupport {
 
         @Override
         public void afterGet(Object value) {
+            afterGetValue = value;
         }
 
         @Override
         public Object interceptPut(Object oldValue, Object newValue) {
-            return newValue.toString().toUpperCase(StringUtil.LOCALE_INTERNAL);
+            putOldValue = oldValue;
+            putNewValue = newValue;
+            return newValue.toString().toUpperCase(LOCALE_INTERNAL);
         }
 
         @Override
         public void afterPut(Object value) {
+            afterPutValue = value;
         }
 
         @Override
         public Object interceptRemove(Object removedValue) {
+            this.removedValue = removedValue;
             return removedValue;
         }
 
         @Override
-        public void afterRemove(Object value) {
+        public void afterRemove(Object oldValue) {
+            afterRemoveValue = oldValue;
         }
 
         @Override
         public int hashCode() {
             return 123456;
+        }
+
+        void reset() {
+            getValue = null;
+            afterGetValue = null;
+            putOldValue = null;
+            putNewValue = null;
+            afterPutValue = null;
+            removedValue = null;
+            afterRemoveValue = null;
         }
     }
 }


### PR DESCRIPTION
* Improved JavaDoc of `MapInterceptor`
* Fixed multiple deserializations on `MapInterceptor.interceptAfterRemove()`
* Improved `MapInterceptor` tests
  * added missing test for `map.remove()`
  * added missing assertions for intercepted values
  * improved assertion messages

Adds a missing test for https://github.com/hazelcast/hazelcast/pull/13340