### PR TITLE
Clean for data-structure specific metrics.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.util.StringUtil.lowerCaseFirstChar;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -107,13 +108,18 @@ public class StatisticsAwareMetricsSet {
                     String name = entry.getKey();
 
                     NearCacheStats nearCacheStats = getNearCacheStats(localInstanceStats);
+                    String baseName = localInstanceStats.getClass().getSimpleName()
+                            .replace("Stats", "")
+                            .replace("Local", "")
+                            .replace("Impl", "");
+                    baseName = lowerCaseFirstChar(baseName);
                     if (nearCacheStats != null) {
                         metricsRegistry.scanAndRegister(nearCacheStats,
-                                localInstanceStats.getClass().getSimpleName() + "[" + name + "].nearcache");
+                                baseName + "[" + name + "].nearcache");
                     }
 
                     metricsRegistry.scanAndRegister(localInstanceStats,
-                            localInstanceStats.getClass().getSimpleName() + "[" + name + "]");
+                            baseName + "[" + name + "]");
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -180,7 +180,7 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
             throw new IllegalArgumentException("ExecutorService['" + name + "'] already exists!");
         }
 
-        metricsRegistry.scanAndRegister(executor, "executor.[" + name + "]");
+        metricsRegistry.scanAndRegister(executor, "internal-executor" + name + "]");
 
         return executor;
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/StringUtil.java
@@ -140,6 +140,27 @@ public final class StringUtil {
     }
 
     /**
+     * Converts the first character to lower case.
+     *
+     * Empty strings are ignored.
+     *
+     * @param s the given string
+     * @return the converted string.
+     */
+    public static String lowerCaseFirstChar(String s) {
+        if (s.isEmpty()) {
+            return s;
+        }
+
+        char first = s.charAt(0);
+        if (isLowerCase(first)) {
+            return s;
+        }
+
+        return toLowerCase(first) + s.substring(1);
+    }
+
+    /**
      * HC specific settings, operands etc. use this method.
      * Creates a lowercase string from the given string.
      *
@@ -242,6 +263,7 @@ public final class StringUtil {
      * (4) patch version, eg "0"
      * (5) 1st -qualifier, if exists
      * (6) -SNAPSHOT qualifier, if exists
+     *
      * @param version
      * @return
      */
@@ -316,7 +338,7 @@ public final class StringUtil {
             return null;
         }
         String[] splitWithEmptyValues = trim(input).split("\\s*,\\s*", -1);
-        return allowEmpty ? splitWithEmptyValues : subraction(splitWithEmptyValues, new String[] { "" });
+        return allowEmpty ? splitWithEmptyValues : subraction(splitWithEmptyValues, new String[]{""});
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DistributedDatastructuresMetricsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/DistributedDatastructuresMetricsTest.java
@@ -84,7 +84,7 @@ public class DistributedDatastructuresMetricsTest extends HazelcastTestSupport {
             map.removeAsync(key);
         }
 
-        assertHasStatsEventually("LocalMapStatsImpl[" + MAP_NAME + "]");
+        assertHasStatsEventually("map[" + MAP_NAME + "]");
     }
 
     @Test
@@ -107,7 +107,7 @@ public class DistributedDatastructuresMetricsTest extends HazelcastTestSupport {
         }
         latch.await();
 
-        assertHasStatsEventually("LocalExecutorStatsImpl[" + EXECUTOR_NAME + "]");
+        assertHasStatsEventually("executor[" + EXECUTOR_NAME + "]");
     }
 
     @Test
@@ -119,7 +119,7 @@ public class DistributedDatastructuresMetricsTest extends HazelcastTestSupport {
         }
         q.poll();
 
-        assertHasStatsEventually("LocalQueueStatsImpl[" + QUEUE_NAME + "]");
+        assertHasStatsEventually("queue[" + QUEUE_NAME + "]");
     }
 
     @Test
@@ -131,7 +131,7 @@ public class DistributedDatastructuresMetricsTest extends HazelcastTestSupport {
         }
         replicatedMap.remove(0);
 
-        assertHasStatsEventually("LocalReplicatedMapStatsImpl[" + REPLICATED_MAP_NAME + "]");
+        assertHasStatsEventually("replicatedMap[" + REPLICATED_MAP_NAME + "]");
     }
 
     @Test
@@ -142,7 +142,7 @@ public class DistributedDatastructuresMetricsTest extends HazelcastTestSupport {
             topic.publish(i);
         }
 
-        assertHasStatsEventually("LocalTopicStatsImpl[" + TOPIC_NAME + "]");
+        assertHasStatsEventually("topic[" + TOPIC_NAME + "]");
     }
 
     @Test
@@ -154,7 +154,7 @@ public class DistributedDatastructuresMetricsTest extends HazelcastTestSupport {
             map.get(i);
         }
 
-        assertHasStatsEventually("LocalMapStatsImpl[" + NEAR_CACHE_MAP_NAME + "].nearcache");
+        assertHasStatsEventually("map[" + NEAR_CACHE_MAP_NAME + "].nearcache");
     }
 
     private void assertHasStatsEventually(final String prefix) {

--- a/hazelcast/src/test/java/com/hazelcast/util/StringUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/StringUtilTest.java
@@ -96,6 +96,17 @@ public class StringUtilTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void test_lowerCaseFirstChar() {
+        assertEquals("", StringUtil.lowerCaseFirstChar(""));
+        assertEquals(".", StringUtil.lowerCaseFirstChar("."));
+        assertEquals(" ", StringUtil.lowerCaseFirstChar(" "));
+        assertEquals("a", StringUtil.lowerCaseFirstChar("a"));
+        assertEquals("a", StringUtil.lowerCaseFirstChar("A"));
+        assertEquals("aBC", StringUtil.lowerCaseFirstChar("ABC"));
+        assertEquals("abc", StringUtil.lowerCaseFirstChar("Abc"));
+    }
+
+    @Test
     public void testSplitByComma() throws Exception {
         assertNull(StringUtil.splitByComma(null, true));
         assertArrayEquals(arr(""), StringUtil.splitByComma("", true));


### PR DESCRIPTION
* Instead of the ugly LocalMapStatsImpl[foo].bar, it is now map[foo].bar.

* The internal executors have a metric prefix 'internal-executor' instead of
'executor' so they don't conflict with distributed executors.