### PR TITLE
Java 9 - PowerMock support

### DIFF
--- a/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/HazelcastManifestTransformerTest.java
+++ b/hazelcast-build-utils/src/test/java/com/hazelcast/buildutils/HazelcastManifestTransformerTest.java
@@ -39,8 +39,8 @@ import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.nio.IOUtil.getFileFromResources;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyByte;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -89,13 +89,12 @@ public class HazelcastManifestTransformerTest {
     }
 
     @Test
-    @SuppressWarnings("Since15")
     public void testTransformation() throws Exception {
         transformer.processResource(null, is, Collections.<Relocator>emptyList());
         transformer.modifyOutputStream(os);
 
         verify(os).putNextEntry(any(JarEntry.class));
-        verify(os, atLeastOnce()).write(anyByte());
+        verify(os, atLeastOnce()).write(anyInt());
         verify(os, atLeastOnce()).flush();
         verifyNoMoreInteractions(os);
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -355,6 +355,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         final DiscoveryService discoveryService = mock(DiscoveryService.class);
+        when(discoveryService.discoverNodes()).thenReturn(null);
         DiscoveryServiceProvider discoveryServiceProvider = new DiscoveryServiceProvider() {
             public DiscoveryService newDiscoveryService(DiscoveryServiceSettings arg0) {
                 return discoveryService;

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStream.java
@@ -30,6 +30,10 @@ import static com.hazelcast.nio.Bits.NULL_ARRAY_LENGTH;
 
 public class ObjectDataInputStream extends VersionedObjectDataInput implements Closeable {
 
+    private static final int BITS_IN_BYTE = 8;
+    private static final int MASK_INT_LAST_BYTE = 0xFF;
+    private static final int MASK_INT_LAST_BUT_ONE_BYTE = 0xFF00;
+
     private final InternalSerializationService serializationService;
     private final DataInputStream dataInput;
     private final ByteOrder byteOrder;
@@ -103,7 +107,9 @@ public class ObjectDataInputStream extends VersionedObjectDataInput implements C
 
     @Override
     public int readUnsignedShort() throws IOException {
-        return readShort();
+        int v = dataInput.readUnsignedShort();
+        return bigEndian() ? v
+                : ((v & MASK_INT_LAST_BUT_ONE_BYTE) >> BITS_IN_BYTE | (v & MASK_INT_LAST_BYTE) << BITS_IN_BYTE);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioThreadAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioThreadAbstractTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.networking.nio;
 
+import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelErrorHandler;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
@@ -39,8 +40,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -169,7 +171,7 @@ public abstract class NioThreadAbstractTest extends HazelcastTestSupport {
             }
         });
 
-        verify(errorHandler).onError(any(NioChannel.class), any(OutOfMemoryError.class));
+        verify(errorHandler).onError((Channel) isNull(), any(OutOfMemoryError.class));
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
@@ -26,10 +26,10 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
-import java.lang.reflect.Field;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Random;
@@ -41,7 +41,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
@@ -53,7 +52,8 @@ public class ObjectDataInputStreamFinalMethodsTest {
 
     private InternalSerializationService mockSerializationService;
     private ObjectDataInputStream in;
-    private DataInputStream dataInputSpy;
+    private ObjectDataInputStream inMockedDis;
+    private DataInputStream mockedDis;
     private InitableByteArrayInputStream inputStream;
     private ByteOrder byteOrder;
 
@@ -66,78 +66,74 @@ public class ObjectDataInputStreamFinalMethodsTest {
         inputStream = new InitableByteArrayInputStream(INIT_DATA);
         in = new ObjectDataInputStream(inputStream, mockSerializationService);
 
-        Field field = ObjectDataInputStream.class.getDeclaredField("dataInput");
-        field.setAccessible(true);
-        DataInputStream dataInput = (DataInputStream) field.get(in);
-
-        dataInputSpy = spy(dataInput);
-
-        field.set(in, dataInputSpy);
+        mockedDis = mock(DataInputStream.class);
+        inMockedDis = new ObjectDataInputStream(inputStream, mockSerializationService);
+        Whitebox.setInternalState(inMockedDis, DataInputStream.class, mockedDis);
     }
 
     @Test
     public void testRead() throws Exception {
-        in.read();
-        verify(dataInputSpy).readByte();
+        inMockedDis.read();
+        verify(mockedDis).readByte();
     }
 
     @Test
     public void testReadB() throws Exception {
         byte[] someInput = new byte[0];
-        in.read(someInput);
-        verify(dataInputSpy).read(someInput);
+        inMockedDis.read(someInput);
+        verify(mockedDis).read(someInput);
     }
 
     @Test
     public void testReadForBOffLen() throws Exception {
         byte[] someInput = new byte[1];
-        in.read(someInput, 0, 1);
-        verify(dataInputSpy).read(someInput, 0, 1);
+        inMockedDis.read(someInput, 0, 1);
+        verify(mockedDis).read(someInput, 0, 1);
     }
 
     @Test
     public void testReadFullyB() throws Exception {
         byte[] someInput = new byte[1];
-        in.readFully(someInput);
-        verify(dataInputSpy).readFully(someInput);
+        inMockedDis.readFully(someInput);
+        verify(mockedDis).readFully(someInput);
     }
 
     @Test
     public void testReadFullyForBOffLen() throws Exception {
         byte[] someInput = new byte[1];
-        in.readFully(someInput, 0, 1);
-        verify(dataInputSpy).readFully(someInput, 0, 1);
+        inMockedDis.readFully(someInput, 0, 1);
+        verify(mockedDis).readFully(someInput, 0, 1);
     }
 
     @Test
     public void testSkipBytes() throws Exception {
         int someInput = new Random().nextInt();
-        in.skipBytes(someInput);
-        verify(dataInputSpy).skipBytes(someInput);
+        inMockedDis.skipBytes(someInput);
+        verify(mockedDis).skipBytes(someInput);
     }
 
     @Test
     public void testReadBoolean() throws Exception {
-        in.readBoolean();
-        verify(dataInputSpy).readBoolean();
+        inMockedDis.readBoolean();
+        verify(mockedDis).readBoolean();
     }
 
     @Test
     public void testReadByte() throws Exception {
-        in.readByte();
-        verify(dataInputSpy).readByte();
+        inMockedDis.readByte();
+        verify(mockedDis).readByte();
     }
 
     @Test
     public void testReadUnsignedByte() throws Exception {
-        in.readUnsignedByte();
-        verify(dataInputSpy).readUnsignedByte();
+        inMockedDis.readUnsignedByte();
+        verify(mockedDis).readUnsignedByte();
     }
 
     @Test
     public void testReadUnsignedShort() throws Exception {
-        in.readUnsignedShort();
-        verify(dataInputSpy).readUnsignedShort();
+        inMockedDis.readUnsignedShort();
+        verify(mockedDis).readUnsignedShort();
     }
 
     @Test
@@ -305,14 +301,14 @@ public class ObjectDataInputStreamFinalMethodsTest {
 
     @Test
     public void testReadLine() throws Exception {
-        in.readLine();
-        verify(dataInputSpy).readLine();
+        inMockedDis.readLine();
+        verify(mockedDis).readLine();
     }
 
     @Test
     public void testReadObject() throws Exception {
-        in.readObject();
-        verify(mockSerializationService).readObject(in);
+        inMockedDis.readObject();
+        verify(mockSerializationService).readObject(inMockedDis);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreFailureConsistencyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreFailureConsistencyTest.java
@@ -43,8 +43,8 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.config.RingbufferConfig.DEFAULT_CAPACITY;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -141,7 +141,8 @@ public class RingbufferStoreFailureConsistencyTest extends HazelcastTestSupport 
     public void testAddAllAsync_PrimaryAndBackupIsConsistentAfterStoreFailure() throws Exception {
         long primaryTailSequenceBeforeAddingAll = ringbufferPrimary.tailSequence();
         long seqFirstItem = ringbufferPrimary.tailSequence() + 1;
-        doThrow(new IllegalStateException("Expected test exception")).when(store).storeAll(eq(seqFirstItem), any(String[].class));
+        doThrow(new IllegalStateException("Expected test exception")).when(store).storeAll(eq(seqFirstItem),
+                (String[]) any(Object[].class));
 
         ICompletableFuture<Long> result = ringbufferPrimary.addAllAsync(newArrayList(ONE, TWO, THREE), OverflowPolicy.FAIL);
         try {

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/DiscoverySpiTest.java
@@ -393,7 +393,9 @@ public class DiscoverySpiTest extends HazelcastTestSupport {
 
         DiscoveryServiceProvider discoveryServiceProvider = new DiscoveryServiceProvider() {
             public DiscoveryService newDiscoveryService(DiscoveryServiceSettings arg0) {
-                return mock(DiscoveryService.class);
+                DiscoveryService mocked = mock(DiscoveryService.class);
+                when(mocked.discoverNodes()).thenReturn(null);
+                return mocked;
             }
         };
         config.getNetworkConfig().getJoin().getDiscoveryConfig().setDiscoveryServiceProvider(discoveryServiceProvider);

--- a/hazelcast/src/test/java/com/hazelcast/util/AddressUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/AddressUtilTest.java
@@ -46,10 +46,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 /**
@@ -248,7 +247,7 @@ public class AddressUtilTest extends HazelcastTestSupport {
 
         when(inet6Address.getAddress()).thenReturn(address);
         when(inet6Address.isSiteLocalAddress()).thenReturn(true);
-        when(Inet6Address.getByAddress(anyString(), eq(address), eq(Integer.parseInt(scope))))
+        when(Inet6Address.getByAddress(nullable(String.class), eq(address), eq(Integer.parseInt(scope))))
                 .thenReturn((Inet6Address) expected);
 
         InetAddress actual = AddressUtil.getInetAddressFor(inet6Address, scope);
@@ -289,7 +288,7 @@ public class AddressUtilTest extends HazelcastTestSupport {
         PowerMockito.mockStatic(NetworkInterface.class);
         PowerMockito.mockStatic(Inet6Address.class);
         PowerMockito.when(NetworkInterface.getNetworkInterfaces()).thenReturn(networkInterfaceEnumeration);
-        when(Inet6Address.getByAddress(anyString(), any(byte[].class), anyInt()))
+        when(Inet6Address.getByAddress(nullable(String.class), nullable(byte[].class), anyInt()))
                 .thenReturn((Inet6Address) expected);
         when(networkInterface.getInetAddresses()).thenReturn(inetAddressEnumeration);
         when(possibleAddress.isLinkLocalAddress()).thenReturn(true);

--- a/pom.xml
+++ b/pom.xml
@@ -83,8 +83,8 @@
 
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>1.10.19</mockito.version>
-        <powermock.version>1.6.6</powermock.version>
+        <mockito.version>2.19.0</mockito.version>
+        <powermock.version>2.0.0-beta.5</powermock.version>
         <jmh.version>1.16</jmh.version>
         <bytebuddy.version>1.6.12</bytebuddy.version>
         <commons-lang3.version>3.4</commons-lang3.version>
@@ -1153,15 +1153,16 @@
             <scope>test</scope>
             <optional>true</optional>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
@@ -1171,6 +1172,7 @@
             <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>


### PR DESCRIPTION
This PR upgrades PowerMock and Mockito to their 2.y lines.  PowerMock 1.x tests don't work on Java 9. They fail on
```
java.lang.IllegalAccessError: class jdk.internal.reflect.ConstructorAccessorImpl loaded by org/powermock/core/classloader/MockClassLoader cannot access jdk/internal/reflect superclass jdk.internal.reflect.MagicAccessorImpl
```

The Java 9+ is supported in PowerMock 2.x, but there is no final release yet. The latest release is from September 2017 - `2.0.0-beta5` which requires Mockito 2.10+.
(details in https://github.com/powermock/powermock/issues/783)

This PR contains 2 commits:
* the first fixes reading unsigned shorts in ObjectDataInputStream class (issue discovered during testing PowerMock update)
* the second upgrades libraries and fixes mocks usage; There are some slight differences between Mockito 1 and 2.