### PR TITLE
move client statistic properties to client property

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientStatisticsCodec;
 import com.hazelcast.client.spi.impl.ClientInvocation;
+import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.core.ClientType;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
@@ -34,7 +35,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.UsernamePasswordCredentials;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.spi.properties.HazelcastProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,19 +48,6 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * it will be scheduled for periodic statistics collection and sent.
  */
 public class Statistics {
-    /**
-     * Use to enable the client statistics collection.
-     * <p>
-     * The default is false.
-     */
-    public static final HazelcastProperty ENABLED = new HazelcastProperty("hazelcast.client.statistics.enabled", false);
-
-    /**
-     * The period in seconds the statistics run.
-     */
-    public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty("hazelcast.client.statistics.period.seconds", 3,
-            SECONDS);
-
     private static final String NEAR_CACHE_CATEGORY_PREFIX = "nc.";
     private static final String FEATURE_SUPPORTED_SINCE_VERSION_STRING = "3.9";
     private static final int FEATURE_SUPPORTED_SINCE_VERSION = BuildInfo.calculateVersion(FEATURE_SUPPORTED_SINCE_VERSION_STRING);
@@ -83,7 +70,7 @@ public class Statistics {
 
     public Statistics(final HazelcastClientInstanceImpl clientInstance) {
         this.properties = clientInstance.getProperties();
-        this.enabled = properties.getBoolean(ENABLED);
+        this.enabled = properties.getBoolean(ClientProperty.STATISTICS_ENABLED);
         this.client = clientInstance;
         this.enterprise = BuildInfoProvider.getBuildInfo().isEnterprise();
         this.metricsRegistry = clientInstance.getMetricsRegistry();
@@ -97,10 +84,10 @@ public class Statistics {
             return;
         }
 
-        long periodSeconds = properties.getSeconds(PERIOD_SECONDS);
+        long periodSeconds = properties.getSeconds(ClientProperty.STATISTICS_PERIOD_SECONDS);
         if (periodSeconds <= 0) {
-            long defaultValue = Long.parseLong(PERIOD_SECONDS.getDefaultValue());
-            logger.warning("Provided client statistics " + PERIOD_SECONDS.getName()
+            long defaultValue = Long.parseLong(ClientProperty.STATISTICS_PERIOD_SECONDS.getDefaultValue());
+            logger.warning("Provided client statistics " + ClientProperty.STATISTICS_PERIOD_SECONDS.getName()
                     + " can not be less than or equal to 0. You provided " + periodSeconds
                     + " seconds as the configuration. Client will use the default value of " + defaultValue + " instead.");
             periodSeconds = defaultValue;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
@@ -190,6 +190,22 @@ public final class ClientProperty {
     public static final HazelcastProperty HAZELCAST_CLOUD_DISCOVERY_TOKEN =
             new HazelcastProperty("hazelcast.client.cloud.discovery.token");
 
+    /**
+     * Use to enable the client statistics collection.
+     * <p>
+     * The default is false.
+     */
+    public static final HazelcastProperty STATISTICS_ENABLED = new
+            HazelcastProperty("hazelcast.client.statistics.enabled", false);
+
+    /**
+     * The period in seconds the statistics run.
+     */
+    public static final HazelcastProperty STATISTICS_PERIOD_SECONDS = new
+            HazelcastProperty("hazelcast.client.statistics.period.seconds", 3,
+            SECONDS);
+
+
     private ClientProperty() {
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.statistics.Statistics;
+import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.CacheConfig;
@@ -33,6 +34,9 @@ import com.hazelcast.core.ICacheManager;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
+
+
+
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -240,8 +244,8 @@ public class ClientStatisticsTest extends ClientTestSupport {
         final ClientEngineImpl clientEngine = getClientEngineImpl(hazelcastInstance);
 
         ClientConfig clientConfig = new ClientConfig();
-        clientConfig.setProperty(Statistics.ENABLED.getName(), "false");
-        clientConfig.setProperty(Statistics.PERIOD_SECONDS.getName(), Integer.toString(STATS_PERIOD_SECONDS));
+        clientConfig.setProperty(ClientProperty.STATISTICS_ENABLED.getName(), "false");
+        clientConfig.setProperty(ClientProperty.STATISTICS_PERIOD_SECONDS.getName(), Integer.toString(STATS_PERIOD_SECONDS));
 
         hazelcastFactory.newHazelcastClient(clientConfig);
 
@@ -274,8 +278,8 @@ public class ClientStatisticsTest extends ClientTestSupport {
 
     private HazelcastClientInstanceImpl createHazelcastClient() {
         ClientConfig clientConfig = new ClientConfig()
-                .setProperty(Statistics.ENABLED.getName(), "true")
-                .setProperty(Statistics.PERIOD_SECONDS.getName(), Integer.toString(STATS_PERIOD_SECONDS))
+                .setProperty(ClientProperty.STATISTICS_ENABLED.getName(), "true")
+                .setProperty(ClientProperty.STATISTICS_PERIOD_SECONDS.getName(), Integer.toString(STATS_PERIOD_SECONDS))
                 // add IMap and ICache with Near Cache config
                 .addNearCacheConfig(new NearCacheConfig(MAP_NAME))
                 .addNearCacheConfig(new NearCacheConfig(CACHE_NAME));


### PR DESCRIPTION
This PR moves client statistic properties to clientProperty. I believe this makes it easier for users to see the properties.