### PR TITLE
Increase call timeout in a test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutSlowTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutSlowTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi.impl.operationservice.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.SlowTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({SlowTest.class, ParallelTest.class})
+public class OperationServiceImpl_timeoutSlowTest extends HazelcastTestSupport {
+
+    @Test
+    public void testOperationTimeoutForLongRunningRemoteOperation() throws Exception {
+        // this timeout makes the test slow. however we cannot shorten it too much
+        // as otherwise it becomes to sensitive on environmental hiccups
+        int callTimeoutMillis = 15000;
+        Config config = new Config().setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + callTimeoutMillis);
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+
+        // invoke on the "remote" member
+        Address remoteAddress = getNode(hz2).getThisAddress();
+        OperationService operationService = getNode(hz1).getNodeEngine().getOperationService();
+        ICompletableFuture<Boolean> future = operationService
+                .invokeOnTarget(null, new OperationServiceImpl_timeoutTest.SleepingOperation(callTimeoutMillis * 5), remoteAddress);
+
+        // wait more than operation timeout
+        sleepAtLeastMillis(callTimeoutMillis * 3);
+        assertTrue(future.get());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_timeoutTest.java
@@ -186,26 +186,6 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testOperationTimeoutForLongRunningRemoteOperation() throws Exception {
-        int callTimeoutMillis = 6000;
-        Config config = new Config().setProperty(OPERATION_CALL_TIMEOUT_MILLIS.getName(), "" + callTimeoutMillis);
-
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
-        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
-
-        // invoke on the "remote" member
-        Address remoteAddress = getNode(hz2).getThisAddress();
-        OperationService operationService = getNode(hz1).getNodeEngine().getOperationService();
-        ICompletableFuture<Boolean> future = operationService
-                .invokeOnTarget(null, new SleepingOperation(callTimeoutMillis * 5), remoteAddress);
-
-        // wait more than operation timeout
-        sleepAtLeastMillis(callTimeoutMillis * 3);
-        assertTrue(future.get());
-    }
-
-    @Test
     public void testOperationTimeoutForLongRunningLocalOperation() throws Exception {
         int callTimeoutMillis = 500;
         Config config = new Config();
@@ -225,7 +205,7 @@ public class OperationServiceImpl_timeoutTest extends HazelcastTestSupport {
         assertTrue(future.get());
     }
 
-    private static class SleepingOperation extends Operation {
+    public static class SleepingOperation extends Operation {
         private long sleepTime;
 
         public SleepingOperation() {


### PR DESCRIPTION
There were spurious failures due gc pauses. The original timeout 6s
was insufficient as there were multiple pauses close to 5.
```
10:04:20, accumulated pauses: 1085 ms, max pause: 138 ms, pauses over 1000 ms: 0
10:04:25, accumulated pauses: 2667 ms, max pause: 2000 ms, pauses over 1000 ms: 1
10:04:30, accumulated pauses: 4911 ms, max pause: 4562 ms, pauses over 1000 ms: 1
10:04:35, accumulated pauses: 4290 ms, max pause: 2537 ms, pauses over 1000 ms: 2
10:04:40, accumulated pauses: 704 ms, max pause: 146 ms, pauses over 1000 ms: 0
10:04:45, accumulated pauses: 1287 ms, max pause: 229 ms, pauses over 1000 ms: 0
10:04:50, accumulated pauses: 505 ms, max pause: 37 ms, pauses over 1000 ms: 0
```

Increased timeout makes the test slow hence moving to SlowTest category

Fixes #7940