### PR TITLE
Provide WAN replication publisher state through JMX

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/WanPublisherMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/WanPublisherMBean.java
@@ -47,6 +47,9 @@ public class WanPublisherMBean extends HazelcastMBean<WanReplicationService> {
     @ManagedDescription("State of the WAN replication publisher")
     public String getState() {
         final Map<String, LocalWanStats> wanStats = managedObject.getStats();
+        if (wanStats == null) {
+            return "";
+        }
         final LocalWanStats wanReplicationStats = wanStats.get(wanReplicationName);
         final Map<String, LocalWanPublisherStats> wanDelegatingPublisherStats = wanReplicationStats.getLocalWanPublisherStats();
         final LocalWanPublisherStats wanPublisherStats = wanDelegatingPublisherStats.get(targetGroupName);

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/WanPublisherMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/WanPublisherMBean.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.jmx;
+
+import com.hazelcast.monitor.LocalWanPublisherStats;
+import com.hazelcast.monitor.LocalWanStats;
+import com.hazelcast.wan.WanReplicationService;
+
+import java.util.Map;
+
+/**
+ * Management bean for a single WAN replication publisher. Since OS and EE
+ * WAN publishers do not share a single common interface, we need to access
+ * them through the WAN replication service until such an interface is introduced.
+ */
+@ManagedDescription("WanReplicationPublisher")
+public class WanPublisherMBean extends HazelcastMBean<WanReplicationService> {
+    private final String wanReplicationName;
+    private final String targetGroupName;
+
+    public WanPublisherMBean(WanReplicationService wanReplicationService,
+                             String wanReplicationName,
+                             String targetGroupName,
+                             ManagementService service) {
+        super(wanReplicationService, service);
+        this.wanReplicationName = wanReplicationName;
+        this.targetGroupName = targetGroupName;
+        this.objectName = service.createObjectName("WanReplicationPublisher",
+                wanReplicationName + "." + targetGroupName);
+    }
+
+    @ManagedAnnotation("state")
+    @ManagedDescription("State of the WAN replication publisher")
+    public String getState() {
+        final Map<String, LocalWanStats> wanStats = managedObject.getStats();
+        final LocalWanStats wanReplicationStats = wanStats.get(wanReplicationName);
+        final Map<String, LocalWanPublisherStats> wanDelegatingPublisherStats = wanReplicationStats.getLocalWanPublisherStats();
+        final LocalWanPublisherStats wanPublisherStats = wanDelegatingPublisherStats.get(targetGroupName);
+        return wanPublisherStats.getPublisherState().name();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/MBeanDataHolder.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/MBeanDataHolder.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.fail;
 /**
  * Holds the Hazelcast instance and MBean server and provides some utility functions for accessing the MBeans.
  */
-final class MBeanDataHolder {
+public final class MBeanDataHolder {
 
     private HazelcastInstance hz;
     private MBeanServer mbs;
@@ -47,7 +47,7 @@ final class MBeanDataHolder {
     /**
      * Initialize with new hazelcast instance and MBean server
      */
-    MBeanDataHolder(TestHazelcastInstanceFactory factory) {
+    public MBeanDataHolder(TestHazelcastInstanceFactory factory) {
         Config config = new Config();
         config.setInstanceName("hz:\",=*?" + ID_GEN.getAndIncrement());
         config.setProperty(GroupProperty.ENABLE_JMX.getName(), "true");
@@ -55,7 +55,12 @@ final class MBeanDataHolder {
         mbs = ManagementFactory.getPlatformMBeanServer();
     }
 
-    void assertMBeanExistEventually(final String type, final String name) {
+    public MBeanDataHolder(HazelcastInstance instance) {
+        hz = instance;
+        mbs = ManagementFactory.getPlatformMBeanServer();
+    }
+
+    public void assertMBeanExistEventually(final String type, final String name) {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -69,7 +74,7 @@ final class MBeanDataHolder {
         });
     }
 
-    void assertMBeanNotExistEventually(final String type, final String name) {
+    public void assertMBeanNotExistEventually(final String type, final String name) {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -101,7 +106,7 @@ final class MBeanDataHolder {
      * @param attributeName Name of attribute to query, e.g. "size"
      * @return Value to get
      */
-    Object getMBeanAttribute(final String type, final String objectName, String attributeName) throws Exception {
+    public Object getMBeanAttribute(final String type, final String objectName, String attributeName) throws Exception {
         return mbs.getAttribute(getObjectName(type, objectName), attributeName);
     }
 
@@ -116,8 +121,8 @@ final class MBeanDataHolder {
      *                      May be null for methods without parameters.
      * @return Value to get
      */
-    Object invokeMBeanOperation(final String type, final String objectName, String operationName, Object[] params,
-                                String[] signature) throws Exception {
+    public Object invokeMBeanOperation(final String type, final String objectName, String operationName, Object[] params,
+                                       String[] signature) throws Exception {
         return mbs.invoke(getObjectName(type, objectName), operationName, params, signature);
     }
 


### PR DESCRIPTION
We provide the WAN replication publisher state through JMX. The managed
bean is somewhat different from the existing mbeans:
- there can be many WAN publisher mbeans (unlike mbeans for some
services)
- a single WAN publisher is identified with a composite identifier - WAN
 replication name + target cluster group name. This is different from
other mbeans with a single type (e.g. lock mbeans) which have only one
identifier

An another complication is that the OS and EE WAN publisher don't have a
 common interface. To avoid introducing such and interface and introduce
larger refactoring, we will expose the WAN publisher mbean in such a
way as if there was a common interface and internally hide the
complexity. Later on, we can clean it up and introduce the common WAN
publisher interface for OS and EE. The only issue is that the MBean
managed object class name may change at that point.

EE (test): https://github.com/hazelcast/hazelcast-enterprise/pull/2219