### PR TITLE
Refactored some CheckStyle suppressions to annotation based style

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -170,18 +170,6 @@
     <!-- Instance -->
     <suppress checks="Javadoc(Method|Type|Variable)" files="com[\\/]hazelcast[\\/]instance[\\/]"/>
 
-    <!-- SPI -->
-    <suppress checks="MethodCount|NPathComplexity|MagicNumber" files="com[\\/]hazelcast[\\/]spi[\\/]Operation"/>
-    <suppress checks="MethodCount|ClassFanOutComplexity" files="com[\\/]hazelcast[\\/]spi[\\/]impl[\\/]NodeEngineImpl"/>
-    <suppress checks="ReturnCount" files="com[\\/]hazelcast[\\/]spi[\\/]impl[\\/]SpiPortableHook"/>
-    <!-- since these classes need to manage services, it is fine to have lots of dependencies in them -->
-    <suppress checks="ClassDataAbstractionCoupling"
-              files="com[\\/]hazelcast[\\/]spi[\\/]impl[\\/]servicemanager[\\/]impl[\\/]ServiceManager"/>
-    <suppress checks="MethodCount|ClassFanOutComplexity|ClassDataAbstractionCoupling"
-              files="com[\\/]hazelcast[\\/]spi[\\/]impl[\\/]operationservice[\\/]impl[\\/]OperationServiceImpl"/>
-    <suppress checks="ClassDataAbstractionCoupling|MethodCount"
-              files="com[\\/]hazelcast[\\/]spi[\\/]impl[\\/]eventservice[\\/]impl[\\/]EventServiceImpl"/>
-
     <!-- Transaction -->
     <suppress checks="Javadoc(Method|Type)" files="com[\\/]hazelcast[\\/]transaction[\\/]"/>
 
@@ -209,12 +197,8 @@
     <!-- Multimap -->
     <suppress checks="Javadoc(Method|Type)" files="com[\\/]hazelcast[\\/]multimap[\\/]"/>
 
-    <!-- Aggregations -->
-    <suppress checks="ClassDataAbstractionCoupling" files="com[\\/]hazelcast[\\/]mapreduce[\\/]aggregation[\\/]Aggregations"/>
-
     <!-- NIO -->
     <suppress checks="Javadoc(Method|Type|Variable)" files="com[\\/]hazelcast[\\/]nio[\\/]"/>
-    <suppress checks="MethodCount|MagicNumber" files="com[\\/]hazelcast[\\/]nio[\\/]Bits"/>
     <suppress checks="ExecutableStatementCount|ClassDataAbstractionCoupling|ClassFanOutComplexity"
               files="com[\\/]hazelcast[\\/]nio[\\/]tcp[\\/]TcpIpConnectionManager"/>
     <suppress checks="NPathComplexity" files="com[\\/]hazelcast[\\/]nio[\\/]tcp[\\/]spinning[\\/]SpinningSocketReader"/>

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/Aggregations.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/Aggregations.java
@@ -58,6 +58,7 @@ import java.util.Set;
  * @deprecated Use fast-aggregations {@link com.hazelcast.aggregation.Aggregators}
  */
 @Deprecated
+@SuppressWarnings("checkstyle:classdataabstractioncoupling")
 public final class Aggregations {
 
     private Aggregations() {

--- a/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Bits.java
@@ -29,7 +29,7 @@ import static com.hazelcast.internal.memory.impl.EndiannessUtil.BYTE_ARRAY_ACCES
 /**
  * Access and manipulate bits, bytes, primitives...
  */
-@SuppressWarnings({"checkstyle:magicnumber", "MagicNumber"})
+@SuppressWarnings({"checkstyle:magicnumber", "checkstyle:methodcount"})
 @PrivateApi
 public final class Bits {
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -48,6 +48,7 @@ import static com.hazelcast.util.StringUtil.timeToString;
  * is going to be executed; this logic will be placed in the
  * {@link Operation#run()} method.
  */
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:magicnumber"})
 public abstract class Operation implements DataSerializable {
 
     /**
@@ -633,6 +634,7 @@ public abstract class Operation implements DataSerializable {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public final void writeData(ObjectDataOutput out) throws IOException {
         // THIS HAS TO BE THE FIRST VALUE IN THE STREAM! DO NOT CHANGE!
         // It is used to return deserialization exceptions to the caller.
@@ -675,6 +677,7 @@ public abstract class Operation implements DataSerializable {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
     public final void readData(ObjectDataInput in) throws IOException {
         // THIS HAS TO BE THE FIRST VALUE IN THE STREAM! DO NOT CHANGE!
         // It is used to return deserialization exceptions to the caller.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -95,7 +95,7 @@ import static java.lang.System.currentTimeMillis;
  * But the crucial thing is that we don't want to leak concrete dependencies to the outside. For example
  * we don't leak {@link com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl} to the outside.
  */
-@SuppressWarnings("checkstyle:classdataabstractioncoupling")
+@SuppressWarnings({"checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity", "checkstyle:methodcount"})
 public class NodeEngineImpl implements NodeEngine {
 
     private static final String JET_SERVICE_NAME = "hz:impl:jetService";

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiPortableHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiPortableHook.java
@@ -49,6 +49,7 @@ public final class SpiPortableHook implements PortableHook {
     @Override
     public PortableFactory createFactory() {
         return new PortableFactory() {
+            @SuppressWarnings("checkstyle:returncount")
             public Portable create(int classId) {
                 switch (classId) {
                     case USERNAME_PWD_CRED:

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -91,7 +91,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
  * and we don't wait for the response before publishing the next event. The previously published
  * event can be retransmitted causing it to be received by the target node at a later time.
  */
-@SuppressWarnings("checkstyle:classfanoutcomplexity")
+@SuppressWarnings({"checkstyle:classfanoutcomplexity", "checkstyle:methodcount"})
 public class EventServiceImpl implements InternalEventService, MetricsProvider {
 
     public static final String SERVICE_NAME = "hz:core:eventService";

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -94,6 +94,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * @see PartitionInvocation
  * @see TargetInvocation
  */
+@SuppressWarnings({"checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity", "checkstyle:methodcount"})
 public final class OperationServiceImpl implements InternalOperationService, MetricsProvider, LiveOperationsTracker {
 
     private static final int ASYNC_QUEUE_CAPACITY = 100000;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/servicemanager/impl/ServiceManagerImpl.java
@@ -84,7 +84,7 @@ import java.util.concurrent.ConcurrentMap;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
-@SuppressWarnings("checkstyle:classfanoutcomplexity")
+@SuppressWarnings({"checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity"})
 public final class ServiceManagerImpl implements ServiceManager {
 
     private static final String PROVIDER_ID = "com.hazelcast.spi.impl.servicemanager.RemoteServiceDescriptorProvider";


### PR DESCRIPTION
Some classes already had mixed suppression styles, e.g. `Bits`. Other suppressions like `NPathComplexity` should not be applied on a whole class.

In general it makes more sense to see the CheckStyle suppressions directly in the code, so they can be considered when refactoring a class. The `suppressions.xml` is easily forgotten when changing code.