### PR TITLE
Provide a way to force service name serialization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheMergeOperation.java
@@ -18,13 +18,18 @@ package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.core.Member;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.impl.operationservice.TargetAware;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.CacheMergeTypes;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,13 +43,14 @@ import static com.hazelcast.util.MapUtil.createHashMap;
  *
  * @since 3.10
  */
-public class CacheMergeOperation extends CacheOperation implements BackupAwareOperation {
+public class CacheMergeOperation extends CacheOperation implements BackupAwareOperation, TargetAware {
 
     private List<CacheMergeTypes> mergingEntries;
     private SplitBrainMergePolicy<Data, CacheMergeTypes> mergePolicy;
 
     private transient boolean hasBackups;
     private transient Map<Data, CacheRecord> backupRecords;
+    private transient Address target;
 
     public CacheMergeOperation() {
     }
@@ -100,6 +106,22 @@ public class CacheMergeOperation extends CacheOperation implements BackupAwareOp
     @Override
     public Operation getBackupOperation() {
         return new CachePutAllBackupOperation(name, backupRecords);
+    }
+
+    @Override
+    public void setTarget(Address address) {
+        this.target = address;
+    }
+
+    @Override
+    protected boolean requiresExplicitServiceName() {
+        // RU_COMPAT_3_10
+        Member member = getNodeEngine().getClusterService().getMember(target);
+        if (member == null) {
+            return false;
+        }
+        Version memberVersion = member.getVersion().asVersion();
+        return memberVersion.isLessThan(Versions.V3_11);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -34,8 +34,7 @@ import static com.hazelcast.util.MapUtil.createHashMap;
  *
  * @see com.hazelcast.cache.impl.operation.CacheLoadAllOperation
  */
-public class CachePutAllBackupOperation
-        extends CacheOperation implements BackupOperation {
+public class CachePutAllBackupOperation extends CacheOperation implements BackupOperation {
 
     private Map<Data, CacheRecord> cacheRecords;
 
@@ -60,6 +59,17 @@ public class CachePutAllBackupOperation
                 publishWanUpdate(entry.getKey(), record);
             }
         }
+    }
+
+    @Override
+    protected boolean requiresExplicitServiceName() {
+        // RU_COMPAT_3_10
+        // We are not checking target member version here since this requires
+        // the operation to be target-aware and that breaks the multi-member
+        // broadcast serialization optimization in OperationBackupHandler. It's
+        // cheaper just to transfer an additional service name string than
+        // serializing the operation for each member individually.
+        return true;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CachePutAllBackupOperation.java
@@ -18,10 +18,12 @@ package com.hazelcast.cache.impl.operation;
 
 import com.hazelcast.cache.impl.CacheDataSerializerHook;
 import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.Map;
@@ -67,9 +69,11 @@ public class CachePutAllBackupOperation extends CacheOperation implements Backup
         // We are not checking target member version here since this requires
         // the operation to be target-aware and that breaks the multi-member
         // broadcast serialization optimization in OperationBackupHandler. It's
-        // cheaper just to transfer an additional service name string than
-        // serializing the operation for each member individually.
-        return true;
+        // cheaper just to transfer an additional service name string in
+        // mixed-version clusters than serializing the operation for each member
+        // individually.
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
+        return clusterVersion.isUnknownOrLessThan(Versions.V3_11);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/Operation.java
@@ -640,6 +640,16 @@ public abstract class Operation implements DataSerializable {
         // It is used to return deserialization exceptions to the caller.
         out.writeLong(callId);
 
+        // Adjust the flags and the service name if an explicit service name is
+        // required.
+        if (!isFlagSet(BITMASK_SERVICE_NAME_SET) && requiresExplicitServiceName()) {
+            String explicitServiceName = getServiceName();
+            if (explicitServiceName != null) {
+                this.serviceName = explicitServiceName;
+                setFlag(true, BITMASK_SERVICE_NAME_SET);
+            }
+        }
+
         // write state next, so that it is first available on reading.
         out.writeShort(flags);
 
@@ -716,6 +726,22 @@ public abstract class Operation implements DataSerializable {
         }
 
         readInternal(in);
+    }
+
+    /**
+     * Returns {@code true} to force the explicit service name serialization
+     * for this operation, {@code false} otherwise.
+     * <p>
+     * Usually, the method should be overridden if {@link #getServiceName} is
+     * also overridden, but it was not overridden in the previous HZ version,
+     * i.e. the service name was provided using an explicit external call to
+     * {@link #setServiceName}. This mechanism is required to maintain the
+     * backward compatibility of the serialized representation of the operation
+     * since the service name is not serialized if it matches the one returned
+     * by {@link #getServiceName}.
+     */
+    protected boolean requiresExplicitServiceName() {
+        return false;
     }
 
     protected void writeInternal(ObjectDataOutput out) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationBackupHandler.java
@@ -281,6 +281,7 @@ final class OperationBackupHandler {
         // if getServiceName() method is overridden to return the same name
         // then this will have no effect.
         backupOp.setServiceName(op.getServiceName());
+        backupOp.setNodeEngine(nodeEngine);
         return backupOp;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -55,6 +55,7 @@ public final class Backup extends Operation implements BackupOperation, AllowedD
     private Data backupOpData;
 
     private transient Throwable validationFailure;
+    private transient boolean backupOperationInitialized;
 
     public Backup() {
     }
@@ -132,7 +133,8 @@ public final class Backup extends Operation implements BackupOperation, AllowedD
     }
 
     private void ensureBackupOperationInitialized() {
-        if (backupOp.getNodeEngine() == null) {
+        if (!backupOperationInitialized) {
+            backupOperationInitialized = true;
             backupOp.setNodeEngine(getNodeEngine());
             backupOp.setPartitionId(getPartitionId());
             backupOp.setReplicaIndex(getReplicaIndex());

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 
 import static org.junit.Assert.assertEquals;
@@ -52,7 +51,7 @@ public class OperationSerializationTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_partitionId() throws IOException {
+    public void test_partitionId() {
         test_partitionId(0, false);
         test_partitionId(100, false);
         test_partitionId(-1, false);
@@ -72,7 +71,7 @@ public class OperationSerializationTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_replicaIndex() throws IOException {
+    public void test_replicaIndex() {
         test_replicaIndex(0, false);
         test_replicaIndex(1, true);
         test_replicaIndex(3, true);
@@ -89,7 +88,7 @@ public class OperationSerializationTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void test_callTimeout() throws IOException {
+    public void test_callTimeout() {
         test_callTimeout(0, false);
         test_callTimeout(100, false);
         test_callTimeout(-1, false);
@@ -205,6 +204,17 @@ public class OperationSerializationTest extends HazelcastTestSupport {
         assertTrue("service name should be set", copy.isFlagSet(Operation.BITMASK_SERVICE_NAME_SET));
     }
 
+    @Test
+    public void test_serviceName_whenOverridesGetServiceNameAndRequiresExplicitServiceName_thenSerialized() {
+        OperationWithExplicitServiceNameAndOverride op = new OperationWithExplicitServiceNameAndOverride();
+        assertNull(op.getRawServiceName());
+        assertFalse("service name should not be set", op.isFlagSet(Operation.BITMASK_SERVICE_NAME_SET));
+
+        Operation copy = copy(op);
+        assertEquals(DUMMY_SERVICE_NAME, copy.getRawServiceName());
+        assertTrue("service name should be set", copy.isFlagSet(Operation.BITMASK_SERVICE_NAME_SET));
+    }
+
     private Operation copy(Operation op) {
         try {
             BufferObjectDataOutput out = serializationService.createObjectDataOutput(1000);
@@ -251,4 +261,26 @@ public class OperationSerializationTest extends HazelcastTestSupport {
             return DUMMY_SERVICE_NAME;
         }
     }
+
+    private static class OperationWithExplicitServiceNameAndOverride extends Operation {
+
+        public OperationWithExplicitServiceNameAndOverride() {
+        }
+
+        @Override
+        public void run() throws Exception {
+        }
+
+        @Override
+        protected boolean requiresExplicitServiceName() {
+            return true;
+        }
+
+        @Override
+        public String getServiceName() {
+            return DUMMY_SERVICE_NAME;
+        }
+
+    }
+
 }


### PR DESCRIPTION
Consider an operation that doesn't override its getServiceName, i.e the
service name is provided by an explicit external call to setServiceName.
The operation is already released as a part of an official HZ release.
If, in the next version, one decided to override getServiceName to
provide the same service name, the serialized representation of the
operation is no longer compatible with the previous version since the
service name is not serialized if it matches the one returned by
getServiceName.

This change provides a way to work around this issue and fixes several
affected operations.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2198