### PR TITLE
Added load event listening capability to client side added listener

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1757,7 +1757,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
 
         @Override
         public void handleEntryEventV10(Data key, Data value, Data oldValue, Data mergingValue, int eventType, String uuid,
-                           int numberOfAffectedEntries) {
+                                        int numberOfAffectedEntries) {
             Member member = getContext().getClusterService().getMember(uuid);
             listenerAdapter.onEvent(createIMapEvent(key, value, oldValue, mergingValue, eventType, numberOfAffectedEntries,
                     member));
@@ -1774,6 +1774,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
                 case EVICTED:
                 case EXPIRED:
                 case MERGED:
+                case LOADED:
                     return createEntryEvent(key, value, oldValue, mergingValue, eventType, member);
                 case EVICT_ALL:
                 case CLEAR_ALL:

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryLoadedListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryLoadedListenerTest.java
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MapLoader;
+import com.hazelcast.map.AbstractEntryProcessor;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.EntryLoadedListener;
+import com.hazelcast.map.listener.EntryUpdatedListener;
+import com.hazelcast.map.listener.MapListener;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.core.EntryEventType.LOADED;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientEntryLoadedListenerTest extends HazelcastTestSupport {
+
+    private static final TestHazelcastFactory FACTORY = new TestHazelcastFactory();
+
+    private static HazelcastInstance client;
+
+    @BeforeClass
+    public static void setUp() {
+        Config config = new Config();
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setEnabled(true);
+        mapStoreConfig.setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER);
+        mapStoreConfig.setClassName(TestMapLoader.class.getName());
+        config.getMapConfig("default").setMapStoreConfig(mapStoreConfig);
+
+        MapStoreConfig noInitialLoading = new MapStoreConfig();
+        noInitialLoading.setEnabled(true);
+        noInitialLoading.setClassName(TestMapLoaderWithoutInitialLoad.class.getName());
+        config.getMapConfig("noInitialLoading*").setMapStoreConfig(noInitialLoading);
+
+        FACTORY.newHazelcastInstance(config);
+        FACTORY.newHazelcastInstance(config);
+        client = FACTORY.newHazelcastClient();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        FACTORY.shutdownAll();
+    }
+
+    @Test
+    public void load_listener_notified_when_containsKey_loads_from_map_loader() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = client.getMap("noInitialLoading_test_containsKey");
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                loadEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.containsKey(1);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(1, loadEventCount.get());
+            }
+        }, 10);
+    }
+
+    @Test
+    public void load_listener_notified_when_putIfAbsent_loads_from_map_loader() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = client.getMap("noInitialLoading_test_putIfAbsent");
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                loadEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.putIfAbsent(1, 100);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(1, loadEventCount.get());
+            }
+        });
+    }
+
+    @Test
+    public void load_listener_notified_when_get_loads_from_map_loader() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = client.getMap("noInitialLoading_test_get");
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                loadEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.get(1);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(1, loadEventCount.get());
+            }
+        });
+    }
+
+    @Test
+    public void load_listener_notified_when_get_after_evict() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = client.getMap("noInitialLoading_load_listener_notified_when_get_after_evict");
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                loadEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.put(1, 1);
+        map.evict(1);
+        map.get(1);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(1, loadEventCount.get());
+            }
+        }, 5);
+    }
+
+    @Test
+    public void load_listener_notified_when_getAll_loads_from_map_loader() {
+        final Queue<EntryEvent> entryEvents = new ConcurrentLinkedQueue<EntryEvent>();
+
+        IMap<Integer, Integer> map = client.getMap("noInitialLoading_test_getAll");
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                entryEvents.add(event);
+            }
+        }, true);
+
+
+        final List<Integer> keyList = Arrays.asList(1, 2, 3, 4, 5);
+        map.getAll(new HashSet<Integer>(keyList));
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(keyList.size(), entryEvents.size());
+                for (EntryEvent entryEvent : entryEvents) {
+                    assertEquals(LOADED, entryEvent.getEventType());
+                }
+            }
+        });
+    }
+
+    @Test
+    public void load_listener_notified_when_read_only_entry_processor_loads_from_map_loader() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = client.getMap("noInitialLoading_test_read_only_ep");
+
+        map.addEntryListener(new EntryLoadedListener<Integer, Integer>() {
+            @Override
+            public void entryLoaded(EntryEvent<Integer, Integer> event) {
+                loadEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.executeOnKey(1, new Reader());
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(1, loadEventCount.get());
+            }
+        });
+    }
+
+    @Test
+    public void add_listener_not_notified_when_read_only_entry_processor_loads_from_map_loader() {
+        final AtomicInteger addEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = client.getMap("noInitialLoading_test_read_only_ep_not_notified");
+        map.addEntryListener(new EntryAddedListener<Integer, Integer>() {
+            @Override
+            public void entryAdded(EntryEvent<Integer, Integer> event) {
+                addEventCount.incrementAndGet();
+            }
+        }, true);
+
+        map.executeOnKey(1, new Reader());
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(0, addEventCount.get());
+            }
+        }, 3);
+    }
+
+    @Test
+    public void load_and_update_listener_notified_when_updater_entry_processor_loads_from_map_loader() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        final AtomicInteger updateEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = client.getMap("noInitialLoading_test_updater_ep");
+        map.addEntryListener(new LoadAndUpdateListener(loadEventCount, updateEventCount), true);
+
+        for (int i = 0; i < 10; i++) {
+            map.executeOnKey(i, new Updater());
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(10, loadEventCount.get());
+                assertEquals(10, updateEventCount.get());
+            }
+        });
+    }
+
+    @Test
+    public void load_listener_notified_but_add_listener_not_notified_after_loadAll() {
+        final AtomicInteger loadEventCount = new AtomicInteger();
+        final AtomicInteger addEventCount = new AtomicInteger();
+
+        IMap<Integer, Integer> map = client.getMap("load_listener_notified_but_add_listener_not_notified_after_loadAll");
+        map.clear();
+
+        MapListener listener = new LoadAndAddListener(loadEventCount, addEventCount);
+        map.addEntryListener(listener, true);
+
+        // add extra listeners
+        map.addEntryListener(new LoadAndAddListener(new AtomicInteger(), new AtomicInteger()), true);
+        map.addEntryListener(new LoadAndAddListener(new AtomicInteger(), new AtomicInteger()), true);
+
+        map.loadAll(true);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(5, loadEventCount.get());
+            }
+        });
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(0, addEventCount.get());
+            }
+        }, 3);
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(5, loadEventCount.get());
+            }
+        }, 3);
+    }
+
+    @Test
+    public void add_listener_notified_after_loadAll() {
+        final AtomicInteger addEventCount = new AtomicInteger();
+
+        IMap<Integer, Integer> map = client.getMap("add_listener_notified_after_loadAll");
+        map.clear();
+
+        MapListener listener = new AddListener(addEventCount);
+        map.addEntryListener(listener, true);
+
+        map.loadAll(true);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(5, addEventCount.get());
+            }
+        });
+    }
+
+    static class LoadAndAddListener implements EntryLoadedListener<Integer, Integer>,
+            EntryAddedListener<Integer, Integer> {
+
+        private final AtomicInteger loadEventCount;
+        private final AtomicInteger addEventCount;
+
+        public LoadAndAddListener(AtomicInteger loadEventCount, AtomicInteger addEventCount) {
+            this.loadEventCount = loadEventCount;
+            this.addEventCount = addEventCount;
+        }
+
+        @Override
+        public void entryLoaded(EntryEvent<Integer, Integer> event) {
+            loadEventCount.incrementAndGet();
+        }
+
+        @Override
+        public void entryAdded(EntryEvent<Integer, Integer> event) {
+            addEventCount.incrementAndGet();
+        }
+    }
+
+    static class LoadAndUpdateListener implements EntryLoadedListener<Integer, Integer>,
+            EntryUpdatedListener<Integer, Integer> {
+
+        private final AtomicInteger loadEventCount;
+        private final AtomicInteger updateEventCount;
+
+        public LoadAndUpdateListener(AtomicInteger loadEventCount, AtomicInteger updateEventCount) {
+            this.loadEventCount = loadEventCount;
+            this.updateEventCount = updateEventCount;
+        }
+
+        @Override
+        public void entryLoaded(EntryEvent<Integer, Integer> event) {
+            loadEventCount.incrementAndGet();
+        }
+
+        @Override
+        public void entryUpdated(EntryEvent<Integer, Integer> event) {
+            updateEventCount.incrementAndGet();
+        }
+    }
+
+    static class AddListener implements EntryAddedListener<Integer, Integer> {
+
+        private final AtomicInteger addEventCount;
+
+        public AddListener(AtomicInteger addEventCount) {
+            this.addEventCount = addEventCount;
+        }
+
+        @Override
+        public void entryAdded(EntryEvent<Integer, Integer> event) {
+            addEventCount.incrementAndGet();
+        }
+    }
+
+    public static class TestMapLoader implements MapLoader<Integer, Integer> {
+
+        AtomicInteger sequence = new AtomicInteger();
+
+        public TestMapLoader() {
+        }
+
+        @Override
+        public Integer load(Integer key) {
+            return sequence.incrementAndGet();
+        }
+
+        @Override
+        public Map<Integer, Integer> loadAll(Collection<Integer> keys) {
+            HashMap<Integer, Integer> map = new HashMap<Integer, Integer>();
+            for (Integer key : keys) {
+                map.put(key, sequence.incrementAndGet());
+            }
+            return map;
+        }
+
+        @Override
+        public Iterable<Integer> loadAllKeys() {
+            return Arrays.asList(1, 2, 3, 4, 5);
+        }
+    }
+
+    public static class TestMapLoaderWithoutInitialLoad extends TestMapLoader {
+
+        public TestMapLoaderWithoutInitialLoad() {
+        }
+
+        @Override
+        public Iterable<Integer> loadAllKeys() {
+            return Collections.emptyList();
+        }
+    }
+
+    public static class Updater extends AbstractEntryProcessor<Integer, Integer> {
+        @Override
+        public Object process(Map.Entry<Integer, Integer> entry) {
+            entry.setValue(entry.getValue() + 1);
+            return entry.getValue();
+        }
+    }
+
+    public static class Reader extends AbstractEntryProcessor<Integer, Integer> {
+        @Override
+        public Object process(Map.Entry<Integer, Integer> entry) {
+            return entry.getValue();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdapter.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.MapEvent;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryEvictedListener;
 import com.hazelcast.map.listener.EntryExpiredListener;
+import com.hazelcast.map.listener.EntryLoadedListener;
 import com.hazelcast.map.listener.EntryMergedListener;
 import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.map.listener.EntryUpdatedListener;
@@ -29,22 +30,23 @@ import com.hazelcast.map.listener.MapClearedListener;
 import com.hazelcast.map.listener.MapEvictedListener;
 
 /**
- *
- * Internal usage only adapter for {@link com.hazelcast.map.listener.MapListener}.
+ * Internal usage only adapter for {@link
+ * com.hazelcast.map.listener.MapListener}.
  *
  * The difference between this adapter and {@link EntryAdapter} is,
- * {@link EntryAdapter} is deprecated form of this one and it doesn't implement newly added listener interfaces.
- *
+ * {@link EntryAdapter} is deprecated form of this one and it doesn't
+ * implement newly added listener interfaces.
  *
  * @param <K> key of the map entry
  * @param <V> value of the map entry.
- *
  * @see com.hazelcast.map.listener.MapListener
  * @since 3.6
  */
 
-public class MapListenerAdapter<K, V> implements EntryAddedListener<K, V>, EntryUpdatedListener<K, V>,
-        EntryRemovedListener<K, V>, EntryEvictedListener<K, V>, EntryExpiredListener<K, V>, EntryMergedListener<K, V>,
+public class MapListenerAdapter<K, V> implements EntryAddedListener<K, V>,
+        EntryUpdatedListener<K, V>, EntryRemovedListener<K, V>,
+        EntryEvictedListener<K, V>, EntryExpiredListener<K, V>,
+        EntryMergedListener<K, V>, EntryLoadedListener<K, V>,
         MapClearedListener, MapEvictedListener {
 
     @Override
@@ -74,6 +76,11 @@ public class MapListenerAdapter<K, V> implements EntryAddedListener<K, V>, Entry
 
     @Override
     public void entryMerged(EntryEvent<K, V> event) {
+        onEntryEvent(event);
+    }
+
+    @Override
+    public void entryLoaded(EntryEvent<K, V> event) {
         onEntryEvent(event);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdaptors.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapListenerAdaptors.java
@@ -320,4 +320,8 @@ public final class MapListenerAdaptors {
         return new InternalMapListenerAdapter(mapListener);
     }
 
+    // only used for testing purposes
+    public static Map<EntryEventType, ConstructorFunction<MapListener, ListenerAdapter>> getConstructors() {
+        return CONSTRUCTORS;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -50,6 +50,7 @@ import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.event.AbstractFilteringStrategy.FILTER_DOES_NOT_MATCH;
 import static com.hazelcast.util.Clock.currentTimeMillis;
 import static com.hazelcast.util.CollectionUtil.isEmpty;
+import static java.util.Collections.singleton;
 
 public class MapEventPublisherImpl implements MapEventPublisher {
 
@@ -193,9 +194,9 @@ public class MapEventPublisherImpl implements MapEventPublisher {
             EventFilter filter = registration.getFilter();
             if (filter instanceof EventListenerFilter) {
                 if (filter.eval(ADDED.getType()) && !filter.eval(LOADED.getType())) {
-                    publishEvent(caller, mapName, ADDED, dataKey, dataOldValue, dataValue);
-                } else {
-                    publishEvent(caller, mapName, LOADED, dataKey, dataOldValue, dataValue);
+                    publishEvent(singleton(registration), caller, mapName, ADDED, dataKey, dataOldValue, dataValue, null);
+                } else if (filter.eval(LOADED.getType())) {
+                    publishEvent(singleton(registration), caller, mapName, LOADED, dataKey, dataOldValue, dataValue, null);
                 }
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/MapListenerAdapterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/MapListenerAdapterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.core.EntryEventType;
+import com.hazelcast.map.listener.MapListener;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.ConstructorFunction;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static com.hazelcast.map.impl.MapListenerAdaptors.getConstructors;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+@SuppressWarnings("ConstantConditions")
+public class MapListenerAdapterTest {
+
+    @Test
+    public void ensure_map_listener_adapter_implements_listeners_for_all_entry_event_types_except_invalidation() {
+        MapListenerAdapter mapListenerAdapterInstance = new MapListenerAdapter();
+        Map<EntryEventType, ConstructorFunction<MapListener, ListenerAdapter>> constructors = getConstructors();
+        for (Map.Entry<EntryEventType, ConstructorFunction<MapListener, ListenerAdapter>> entry : constructors.entrySet()) {
+            EntryEventType entryEventType = entry.getKey();
+            if (entryEventType == EntryEventType.INVALIDATION) {
+                // this event is used to listen near-cache invalidations.
+                continue;
+            }
+
+            assertNotNull("MapListenerAdapter misses an interface "
+                            + "to implement for entry-event-type=" + entryEventType,
+                    entry.getValue().createNew(mapListenerAdapterInstance));
+        }
+    }
+}


### PR DESCRIPTION
After merge, java client will also listen loaded event via EntryLoadedListener. This capability was missing. 

Thanks @lazerion for finding this.