### PR TITLE
 Fixed TransactionalMapProxy with Near Cache

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -48,7 +48,8 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
- * Proxy implementation of {@link com.hazelcast.core.TransactionalMap} interface.
+ * Proxy implementation of {@link com.hazelcast.core.TransactionalMap}
+ * interface.
  */
 public class TransactionalMapProxy extends TransactionalMapProxySupport implements TransactionalMap {
 
@@ -63,12 +64,13 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkTransactionState();
         checkNotNull(key, "key can't be null");
 
-        Data keyData = ss.toData(key, partitionStrategy);
-        TxnValueWrapper valueWrapper = txMap.get(keyData);
+        Data dataKey = ss.toData(key, partitionStrategy);
+
+        TxnValueWrapper valueWrapper = txMap.get(dataKey);
         if (valueWrapper != null) {
             return (valueWrapper.type != Type.REMOVED);
         }
-        return containsKeyInternal(keyData, key);
+        return containsKeyInternal(key, dataKey);
     }
 
     @Override
@@ -100,14 +102,13 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkTransactionState();
         checkNotNull(key, "key can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
-        Data keyData = nearCacheKey instanceof Data ? (Data) nearCacheKey : ss.toData(key, partitionStrategy);
+        Data dataKey = ss.toData(key, partitionStrategy);
 
-        TxnValueWrapper currentValue = txMap.get(keyData);
+        TxnValueWrapper currentValue = txMap.get(dataKey);
         if (currentValue != null) {
             return checkIfRemoved(currentValue);
         }
-        return toObjectIfNeeded(getInternal(nearCacheKey, keyData));
+        return toObjectIfNeeded(getInternal(key, dataKey));
     }
 
     @Override
@@ -115,14 +116,14 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkTransactionState();
         checkNotNull(key, "key can't be null");
 
-        Data keyData = ss.toData(key, partitionStrategy);
+        Data dataKey = ss.toData(key, partitionStrategy);
 
-        TxnValueWrapper currentValue = txMap.get(keyData);
+        TxnValueWrapper currentValue = txMap.get(dataKey);
         if (currentValue != null) {
             return checkIfRemoved(currentValue);
         }
 
-        return toObjectIfNeeded(getForUpdateInternal(keyData));
+        return toObjectIfNeeded(getForUpdateInternal(dataKey));
     }
 
     @Override
@@ -136,18 +137,17 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(key, "key can't be null");
         checkNotNull(value, "value can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
+        Data dataKey = ss.toData(key, partitionStrategy);
         try {
-            Data keyData = ss.toData(nearCacheKey, partitionStrategy);
-            Object valueBeforeTxn = toObjectIfNeeded(putInternal(keyData, ss.toData(value), ttl, timeUnit));
+            Object valueBeforeTxn = toObjectIfNeeded(putInternal(dataKey, ss.toData(value), ttl, timeUnit));
 
-            TxnValueWrapper currentValue = txMap.get(keyData);
+            TxnValueWrapper currentValue = txMap.get(dataKey);
             Type type = valueBeforeTxn == null ? Type.NEW : Type.UPDATED;
             TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
-            txMap.put(keyData, wrapper);
+            txMap.put(dataKey, wrapper);
             return currentValue == null ? valueBeforeTxn : checkIfRemoved(currentValue);
         } finally {
-            invalidateNearCache(nearCacheKey);
+            invalidateNearCache(key, dataKey);
         }
     }
 
@@ -157,15 +157,14 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(key, "key can't be null");
         checkNotNull(value, "value can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
+        Data dataKey = ss.toData(key, partitionStrategy);
         try {
-            Data keyData = ss.toData(nearCacheKey, partitionStrategy);
-            Data dataBeforeTxn = putInternal(keyData, ss.toData(value), -1, MILLISECONDS);
+            Data dataBeforeTxn = putInternal(dataKey, ss.toData(value), -1, MILLISECONDS);
             Type type = dataBeforeTxn == null ? Type.NEW : Type.UPDATED;
             TxnValueWrapper wrapper = new TxnValueWrapper(value, type);
-            txMap.put(keyData, wrapper);
+            txMap.put(dataKey, wrapper);
         } finally {
-            invalidateNearCache(nearCacheKey);
+            invalidateNearCache(key, dataKey);
         }
     }
 
@@ -175,27 +174,26 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(key, "key can't be null");
         checkNotNull(value, "value can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
+        Data dataKey = ss.toData(key, partitionStrategy);
         try {
-            Data keyData = ss.toData(nearCacheKey, partitionStrategy);
-            TxnValueWrapper wrapper = txMap.get(keyData);
+            TxnValueWrapper wrapper = txMap.get(dataKey);
             boolean haveTxnPast = wrapper != null;
             if (haveTxnPast) {
                 if (wrapper.type != Type.REMOVED) {
                     return wrapper.value;
                 }
-                putInternal(keyData, ss.toData(value), -1, MILLISECONDS);
-                txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
+                putInternal(dataKey, ss.toData(value), -1, MILLISECONDS);
+                txMap.put(dataKey, new TxnValueWrapper(value, Type.NEW));
                 return null;
             } else {
-                Data oldValue = putIfAbsentInternal(keyData, ss.toData(value));
+                Data oldValue = putIfAbsentInternal(dataKey, ss.toData(value));
                 if (oldValue == null) {
-                    txMap.put(keyData, new TxnValueWrapper(value, Type.NEW));
+                    txMap.put(dataKey, new TxnValueWrapper(value, Type.NEW));
                 }
                 return toObjectIfNeeded(oldValue);
             }
         } finally {
-            invalidateNearCache(nearCacheKey);
+            invalidateNearCache(key, dataKey);
         }
     }
 
@@ -205,28 +203,26 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(key, "key can't be null");
         checkNotNull(value, "value can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
+        Data dataKey = ss.toData(key, partitionStrategy);
         try {
-            Data keyData = ss.toData(nearCacheKey, partitionStrategy);
-
-            TxnValueWrapper wrapper = txMap.get(keyData);
+            TxnValueWrapper wrapper = txMap.get(dataKey);
             boolean haveTxnPast = wrapper != null;
             if (haveTxnPast) {
                 if (wrapper.type == Type.REMOVED) {
                     return null;
                 }
-                putInternal(keyData, ss.toData(value), -1, MILLISECONDS);
-                txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
+                putInternal(dataKey, ss.toData(value), -1, MILLISECONDS);
+                txMap.put(dataKey, new TxnValueWrapper(value, Type.UPDATED));
                 return wrapper.value;
             } else {
-                Data oldValue = replaceInternal(keyData, ss.toData(value));
+                Data oldValue = replaceInternal(dataKey, ss.toData(value));
                 if (oldValue != null) {
-                    txMap.put(keyData, new TxnValueWrapper(value, Type.UPDATED));
+                    txMap.put(dataKey, new TxnValueWrapper(value, Type.UPDATED));
                 }
                 return toObjectIfNeeded(oldValue);
             }
         } finally {
-            invalidateNearCache(nearCacheKey);
+            invalidateNearCache(key, dataKey);
         }
     }
 
@@ -237,28 +233,26 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(oldValue, "oldValue can't be null");
         checkNotNull(newValue, "newValue can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
+        Data dataKey = ss.toData(key, partitionStrategy);
         try {
-            Data keyData = ss.toData(nearCacheKey, partitionStrategy);
-
-            TxnValueWrapper wrapper = txMap.get(keyData);
+            TxnValueWrapper wrapper = txMap.get(dataKey);
             boolean haveTxnPast = wrapper != null;
             if (haveTxnPast) {
                 if (!wrapper.value.equals(oldValue)) {
                     return false;
                 }
-                putInternal(keyData, ss.toData(newValue), -1, MILLISECONDS);
-                txMap.put(keyData, new TxnValueWrapper(wrapper.value, Type.UPDATED));
+                putInternal(dataKey, ss.toData(newValue), -1, MILLISECONDS);
+                txMap.put(dataKey, new TxnValueWrapper(wrapper.value, Type.UPDATED));
                 return true;
             } else {
-                boolean success = replaceIfSameInternal(keyData, ss.toData(oldValue), ss.toData(newValue));
+                boolean success = replaceIfSameInternal(dataKey, ss.toData(oldValue), ss.toData(newValue));
                 if (success) {
-                    txMap.put(keyData, new TxnValueWrapper(newValue, Type.UPDATED));
+                    txMap.put(dataKey, new TxnValueWrapper(newValue, Type.UPDATED));
                 }
                 return success;
             }
         } finally {
-            invalidateNearCache(nearCacheKey);
+            invalidateNearCache(key, dataKey);
         }
     }
 
@@ -268,16 +262,14 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(key, "key can't be null");
         checkNotNull(value, "value can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
+        Data dataKey = ss.toData(key, partitionStrategy);
         try {
-            Data keyData = ss.toData(nearCacheKey, partitionStrategy);
-
-            TxnValueWrapper wrapper = txMap.get(keyData);
+            TxnValueWrapper wrapper = txMap.get(dataKey);
             // wrapper is null which means this entry is not touched by transaction
             if (wrapper == null) {
-                boolean removed = removeIfSameInternal(keyData, value);
+                boolean removed = removeIfSameInternal(dataKey, value);
                 if (removed) {
-                    txMap.put(keyData, new TxnValueWrapper(value, Type.REMOVED));
+                    txMap.put(dataKey, new TxnValueWrapper(value, Type.REMOVED));
                 }
                 return removed;
             }
@@ -290,13 +282,12 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
                 return false;
             }
             // wrapper value is equal to passed value, we call removeInternal just to add delete log
-            removeInternal(keyData);
-            txMap.put(keyData, new TxnValueWrapper(value, Type.REMOVED));
+            removeInternal(dataKey);
+            txMap.put(dataKey, new TxnValueWrapper(value, Type.REMOVED));
+            return true;
         } finally {
-            invalidateNearCache(nearCacheKey);
+            invalidateNearCache(key, dataKey);
         }
-
-        return true;
     }
 
     @Override
@@ -304,18 +295,17 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkTransactionState();
         checkNotNull(key, "key can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
+        Data dataKey = ss.toData(key, partitionStrategy);
         try {
-            Data keyData = ss.toData(nearCacheKey, partitionStrategy);
-            Object valueBeforeTxn = toObjectIfNeeded(removeInternal(keyData));
+            Object valueBeforeTxn = toObjectIfNeeded(removeInternal(dataKey));
 
             TxnValueWrapper wrapper = null;
-            if (valueBeforeTxn != null || txMap.containsKey(keyData)) {
-                wrapper = txMap.put(keyData, new TxnValueWrapper(valueBeforeTxn, Type.REMOVED));
+            if (valueBeforeTxn != null || txMap.containsKey(dataKey)) {
+                wrapper = txMap.put(dataKey, new TxnValueWrapper(valueBeforeTxn, Type.REMOVED));
             }
             return wrapper == null ? valueBeforeTxn : checkIfRemoved(wrapper);
         } finally {
-            invalidateNearCache(nearCacheKey);
+            invalidateNearCache(key, dataKey);
         }
     }
 
@@ -324,15 +314,14 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkTransactionState();
         checkNotNull(key, "key can't be null");
 
-        Object nearCacheKey = toNearCacheKeyWithStrategy(key);
+        Data dataKey = ss.toData(key, partitionStrategy);
         try {
-            Data keyData = ss.toData(key, partitionStrategy);
-            Data data = removeInternal(keyData);
-            if (data != null || txMap.containsKey(keyData)) {
-                txMap.put(keyData, new TxnValueWrapper(toObjectIfNeeded(data), Type.REMOVED));
+            Data data = removeInternal(dataKey);
+            if (data != null || txMap.containsKey(dataKey)) {
+                txMap.put(dataKey, new TxnValueWrapper(toObjectIfNeeded(data), Type.REMOVED));
             }
         } finally {
-            invalidateNearCache(nearCacheKey);
+            invalidateNearCache(key, dataKey);
         }
     }
 
@@ -364,15 +353,15 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
                 // meanwhile remove keys which are not in txMap
                 returningKeySet.remove(toObjectIfNeeded(entry.getKey()));
             } else {
-                Data keyData = entry.getKey();
+                Data dataKey = entry.getKey();
 
                 if (predicate == TruePredicate.INSTANCE) {
-                    returningKeySet.add(toObjectIfNeeded(keyData));
+                    returningKeySet.add(toObjectIfNeeded(dataKey));
                 } else {
-                    cachedQueryEntry.init(ss, keyData, entry.getValue().value, extractors);
+                    cachedQueryEntry.init(ss, dataKey, entry.getValue().value, extractors);
                     // apply predicate on txMap
                     if (predicate.apply(cachedQueryEntry)) {
-                        returningKeySet.add(toObjectIfNeeded(keyData));
+                        returningKeySet.add(toObjectIfNeeded(dataKey));
                     }
                 }
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -49,7 +49,8 @@ import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 /**
- * Base class contains proxy helper methods for {@link com.hazelcast.map.impl.tx.TransactionalMapProxy}
+ * Base class contains proxy helper methods for
+ * {@link com.hazelcast.map.impl.tx.TransactionalMapProxy}.
  */
 public abstract class TransactionalMapProxySupport extends TransactionalDistributedObject<MapService> {
 
@@ -86,7 +87,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
     }
 
     @Override
-    public String getName() {
+    public final String getName() {
         return name;
     }
 
@@ -95,19 +96,19 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         return SERVICE_NAME;
     }
 
-    boolean isEquals(Object value1, Object value2) {
+    final boolean isEquals(Object value1, Object value2) {
         return recordComparator.isEqual(value1, value2);
     }
 
-    void checkTransactionState() {
+    final void checkTransactionState() {
         if (!tx.getState().equals(Transaction.State.ACTIVE)) {
             throw new TransactionNotActiveException("Transaction is not active!");
         }
     }
 
-    boolean containsKeyInternal(Data dataKey, Object objectKey) {
+    final boolean containsKeyInternal(Object key, Data dataKey) {
         if (nearCacheEnabled) {
-            Object nearCacheKey = serializeKeys ? dataKey : objectKey;
+            Object nearCacheKey = toNearCacheKeyWithStrategy(key, dataKey);
             Object cachedValue = getCachedValue(nearCacheKey, false);
             if (cachedValue != NOT_CACHED) {
                 return cachedValue != null;
@@ -125,17 +126,18 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         }
     }
 
-    Object getInternal(Object nearCacheKey, Data keyData) {
+    final Object getInternal(Object key, Data dataKey) {
         if (nearCacheEnabled) {
+            Object nearCacheKey = toNearCacheKeyWithStrategy(key, dataKey);
             Object value = getCachedValue(nearCacheKey, true);
             if (value != NOT_CACHED) {
                 return value;
             }
         }
 
-        MapOperation operation = operationProvider.createGetOperation(name, keyData);
+        MapOperation operation = operationProvider.createGetOperation(name, dataKey);
         operation.setThreadId(ThreadUtil.getThreadId());
-        int partitionId = partitionService.getPartitionId(keyData);
+        int partitionId = partitionService.getPartitionId(dataKey);
         try {
             Future future = operationService.createInvocationBuilder(SERVICE_NAME, operation, partitionId)
                     .setResultDeserialized(false)
@@ -146,27 +148,124 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         }
     }
 
-    final Object toNearCacheKeyWithStrategy(Object key) {
-        if (!nearCacheEnabled) {
-            return key;
-        }
-
-        return serializeKeys ? ss.toData(key, partitionStrategy) : key;
+    final Object getForUpdateInternal(Data key) {
+        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis(), true);
+        addUnlockTransactionRecord(key, versionedValue.version);
+        return versionedValue.value;
     }
 
-    final void invalidateNearCache(Object nearCacheKey) {
-        if (!nearCacheEnabled) {
-            return;
+    final int sizeInternal() {
+        try {
+            OperationFactory sizeOperationFactory = operationProvider.createMapSizeOperationFactory(name);
+            Map<Integer, Object> results = operationService.invokeOnAllPartitions(SERVICE_NAME, sizeOperationFactory);
+            int total = 0;
+            for (Object result : results.values()) {
+                Integer size = getNodeEngine().toObject(result);
+                total += size;
+            }
+            return total;
+        } catch (Throwable t) {
+            throw rethrow(t);
         }
-        if (nearCacheKey == null) {
+    }
+
+    final Data putInternal(Data key, Data value, long ttl, TimeUnit timeUnit) {
+        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
+        long timeInMillis = getTimeInMillis(ttl, timeUnit);
+        MapOperation operation = operationProvider.createTxnSetOperation(name, key, value, versionedValue.version, timeInMillis);
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
+        return versionedValue.value;
+    }
+
+    final Data putIfAbsentInternal(Data key, Data value) {
+        boolean unlockImmediately = !valueMap.containsKey(key);
+        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
+        if (versionedValue.value != null) {
+            if (unlockImmediately) {
+                unlock(key, versionedValue);
+                return versionedValue.value;
+            }
+            addUnlockTransactionRecord(key, versionedValue.version);
+            return versionedValue.value;
+        }
+
+        MapOperation operation = operationProvider.createTxnSetOperation(name, key, value, versionedValue.version, -1);
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
+        return versionedValue.value;
+    }
+
+    final Data replaceInternal(Data key, Data value) {
+        boolean unlockImmediately = !valueMap.containsKey(key);
+        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
+        if (versionedValue.value == null) {
+            if (unlockImmediately) {
+                unlock(key, versionedValue);
+                return null;
+            }
+            addUnlockTransactionRecord(key, versionedValue.version);
+            return null;
+        }
+        MapOperation operation = operationProvider.createTxnSetOperation(name, key, value, versionedValue.version, -1);
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
+        return versionedValue.value;
+    }
+
+    final boolean replaceIfSameInternal(Data key, Object oldValue, Data newValue) {
+        boolean unlockImmediately = !valueMap.containsKey(key);
+        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
+        if (!isEquals(oldValue, versionedValue.value)) {
+            if (unlockImmediately) {
+                unlock(key, versionedValue);
+                return false;
+            }
+            addUnlockTransactionRecord(key, versionedValue.version);
+            return false;
+        }
+        MapOperation operation = operationProvider.createTxnSetOperation(name, key, newValue, versionedValue.version, -1);
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
+        return true;
+    }
+
+    final Data removeInternal(Data key) {
+        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
+        MapOperation operation = operationProvider.createTxnDeleteOperation(name, key, versionedValue.version);
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
+        return versionedValue.value;
+    }
+
+    final boolean removeIfSameInternal(Data key, Object value) {
+        boolean unlockImmediately = !valueMap.containsKey(key);
+        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
+        if (!isEquals(versionedValue.value, value)) {
+            if (unlockImmediately) {
+                unlock(key, versionedValue);
+                return false;
+            }
+            addUnlockTransactionRecord(key, versionedValue.version);
+            return false;
+        }
+        MapOperation operation = operationProvider.createTxnDeleteOperation(name, key, versionedValue.version);
+        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
+        return true;
+    }
+
+    final void invalidateNearCache(Object key, Data dataKey) {
+        if (!nearCacheEnabled || key == null) {
             return;
         }
         NearCache<Object, Object> nearCache = mapNearCacheManager.getNearCache(name);
         if (nearCache == null) {
             return;
         }
-
+        Object nearCacheKey = toNearCacheKeyWithStrategy(key, dataKey);
         nearCache.invalidate(nearCacheKey);
+    }
+
+    private Object toNearCacheKeyWithStrategy(Object key, Data dataKey) {
+        if (!nearCacheEnabled) {
+            return null;
+        }
+        return serializeKeys ? dataKey : ss.toObject(key);
     }
 
     private Object getCachedValue(Object nearCacheKey, boolean deserializeValue) {
@@ -185,109 +284,6 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
 
         mapServiceContext.interceptAfterGet(name, value);
         return deserializeValue ? ss.toObject(value) : value;
-    }
-
-    Object getForUpdateInternal(Data key) {
-        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis(), true);
-        addUnlockTransactionRecord(key, versionedValue.version);
-        return versionedValue.value;
-    }
-
-    int sizeInternal() {
-        try {
-            OperationFactory sizeOperationFactory = operationProvider.createMapSizeOperationFactory(name);
-            Map<Integer, Object> results = operationService.invokeOnAllPartitions(SERVICE_NAME, sizeOperationFactory);
-            int total = 0;
-            for (Object result : results.values()) {
-                Integer size = getNodeEngine().toObject(result);
-                total += size;
-            }
-            return total;
-        } catch (Throwable t) {
-            throw rethrow(t);
-        }
-    }
-
-    Data putInternal(Data key, Data value, long ttl, TimeUnit timeUnit) {
-        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
-        long timeInMillis = getTimeInMillis(ttl, timeUnit);
-        MapOperation operation = operationProvider.createTxnSetOperation(name, key, value, versionedValue.version, timeInMillis);
-        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
-        return versionedValue.value;
-    }
-
-    Data putIfAbsentInternal(Data key, Data value) {
-        boolean unlockImmediately = !valueMap.containsKey(key);
-        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
-        if (versionedValue.value != null) {
-            if (unlockImmediately) {
-                unlock(key, versionedValue);
-                return versionedValue.value;
-            }
-            addUnlockTransactionRecord(key, versionedValue.version);
-            return versionedValue.value;
-        }
-
-        MapOperation operation = operationProvider.createTxnSetOperation(name, key, value, versionedValue.version, -1);
-        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
-        return versionedValue.value;
-    }
-
-    Data replaceInternal(Data key, Data value) {
-        boolean unlockImmediately = !valueMap.containsKey(key);
-        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
-        if (versionedValue.value == null) {
-            if (unlockImmediately) {
-                unlock(key, versionedValue);
-                return null;
-            }
-            addUnlockTransactionRecord(key, versionedValue.version);
-            return null;
-        }
-        MapOperation operation = operationProvider.createTxnSetOperation(name, key, value, versionedValue.version, -1);
-        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
-        return versionedValue.value;
-    }
-
-    boolean replaceIfSameInternal(Data key, Object oldValue, Data newValue) {
-        boolean unlockImmediately = !valueMap.containsKey(key);
-        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
-        if (!isEquals(oldValue, versionedValue.value)) {
-            if (unlockImmediately) {
-                unlock(key, versionedValue);
-                return false;
-            }
-            addUnlockTransactionRecord(key, versionedValue.version);
-            return false;
-        }
-        MapOperation operation = operationProvider.createTxnSetOperation(name, key, newValue, versionedValue.version, -1);
-        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key), operation, versionedValue.version, tx.getOwnerUuid()));
-        return true;
-    }
-
-    Data removeInternal(Data key) {
-        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
-        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key),
-                operationProvider.createTxnDeleteOperation(name, key, versionedValue.version),
-                versionedValue.version, tx.getOwnerUuid()));
-        return versionedValue.value;
-    }
-
-    boolean removeIfSameInternal(Data key, Object value) {
-        boolean unlockImmediately = !valueMap.containsKey(key);
-        VersionedValue versionedValue = lockAndGet(key, tx.getTimeoutMillis());
-        if (!isEquals(versionedValue.value, value)) {
-            if (unlockImmediately) {
-                unlock(key, versionedValue);
-                return false;
-            }
-            addUnlockTransactionRecord(key, versionedValue.version);
-            return false;
-        }
-        tx.add(new MapTransactionLogRecord(name, key, getPartitionId(key),
-                operationProvider.createTxnDeleteOperation(name, key, versionedValue.version),
-                versionedValue.version, tx.getOwnerUuid()));
-        return true;
     }
 
     private void unlock(Data key, VersionedValue versionedValue) {
@@ -327,8 +323,8 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
             return versionedValue;
         }
         boolean blockReads = tx.getTransactionType() == TransactionType.ONE_PHASE;
-        MapOperation operation = operationProvider.createTxnLockAndGetOperation(name, key, timeout, timeout,
-                tx.getOwnerUuid(), shouldLoad, blockReads);
+        MapOperation operation = operationProvider.createTxnLockAndGetOperation(name, key, timeout, timeout, tx.getOwnerUuid(),
+                shouldLoad, blockReads);
         operation.setThreadId(ThreadUtil.getThreadId());
         try {
             int partitionId = partitionService.getPartitionId(key);


### PR DESCRIPTION
The Near Cache key for a `TransactionalMapProxy` was not deserialized when it was in binary format, which happens when a Hazelcast client is used.

Another problem was that the Near Cache key was created first, even if it was not used at all. Especially with this fix, we might run into an unused deserialization, when no Near Cache was configured.

The order of read-only calls is:
* read value from internal TX map (always binary key)
* read value from Near Cache (binary/object key)
* read value from remote (always binary key)

The Near Cache key creation has been moved behind the internal TX map lookup. This prevents the key creation if it's not used at all. It uses the original and binary key, to prevent a duplicated (de)serialization.

The order of write/remove calls is:
* remove the value (always binary key)
* invalidate the Near Cache (binary/object key)

The Near Cache key creation has been moved to the invalidation method, so behind all checks if the Near Cache is enabled. This prevents the key creation if it's not used at all.

Fixes https://github.com/hazelcast/hazelcast/issues/13371