### PR TITLE
Fixed Maven Shading for Hazelcast client module

### DIFF
--- a/hazelcast-client/pom.xml
+++ b/hazelcast-client/pom.xml
@@ -131,6 +131,38 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${project.build.finalName}</finalName>
+                            <createSourcesJar>true</createSourcesJar>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                            <shadeTestJar>true</shadeTestJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.eclipsesource.minimal-json:minimal-json</include>
+                                    <include>com.hazelcast:hazelcast-client-protocol</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.eclipsesource.json</pattern>
+                                    <shadedPattern>com.hazelcast.com.eclipsesource.json</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/HazelcastCloudDiscovery.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/HazelcastCloudDiscovery.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.client.spi.impl.discovery;
 
-import com.hazelcast.com.eclipsesource.json.Json;
-import com.hazelcast.com.eclipsesource.json.JsonValue;
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonValue;
 import com.hazelcast.client.util.AddressHelper;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.AddressUtil;


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast/pull/13367 seems to the wrong fix. The core module uses the normal JSON imports and has the shading plugin in its `pom.xml`. So we should use the same approach on the client module.