### PR TITLE
Shutdown joining member when initial cluster version is not valid

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -81,6 +81,7 @@ import static com.hazelcast.spi.ExecutionService.SYSTEM_EXECUTOR;
 import static com.hazelcast.util.Preconditions.checkFalse;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.checkTrue;
+import static java.lang.String.format;
 
 @SuppressWarnings({"checkstyle:methodcount", "checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity"})
 public class ClusterServiceImpl implements ClusterService, ConnectionListener, ManagedService,
@@ -378,7 +379,15 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
 
             checkMemberUpdateContainsLocalMember(membersView, targetUuid);
 
-            initialClusterState(clusterState, clusterVersion);
+            try {
+                initialClusterState(clusterState, clusterVersion);
+            } catch (VersionMismatchException e) {
+                // node should shutdown since it cannot handle the cluster version
+                // it is safe to do so here because no operations have been executed yet
+                logger.severe(format("This member will shutdown because it cannot join the cluster: %s", e.getMessage()));
+                node.shutdown(true);
+                return false;
+            }
             setClusterId(clusterId);
             ClusterClockImpl clusterClock = getClusterClock();
             clusterClock.setClusterStartTime(clusterStartTime);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -115,7 +115,7 @@ public class ClusterStateManager {
                         + initialState);
                 return;
             }
-            // no need to validate again
+            validateNodeCompatibleWith(version);
             logger.fine("Setting initial cluster state: " + initialState + " and version: " + version);
             setClusterStateAndVersion(initialState, version, true);
         } finally {


### PR DESCRIPTION
The local member should be validating the initial cluster version
as is already done each time cluster version changes.