### PR TITLE
Tmp fix HazelcastCloudDiscovery imports

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/HazelcastCloudDiscovery.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/HazelcastCloudDiscovery.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.client.spi.impl.discovery;
 
-import com.hazelcast.com.eclipsesource.json.Json;
-import com.hazelcast.com.eclipsesource.json.JsonValue;
+import com.eclipsesource.json.Json;
+import com.eclipsesource.json.JsonValue;
 import com.hazelcast.client.util.AddressHelper;
 import com.hazelcast.nio.Address;
 import com.hazelcast.util.AddressUtil;


### PR DESCRIPTION
This allows people to compile Hazelcast from intellij
and not just from the commandline.

A proper fix needs to be found, but it won't block
engineers using Intellij any longer.