### PR TITLE
Initialize query cache config only once at construction phase

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheConfigurator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheConfigurator.java
@@ -50,8 +50,14 @@ public class ClientQueryCacheConfigurator extends AbstractQueryCacheConfigurator
     }
 
     @Override
-    public QueryCacheConfig getOrNull(String mapName, String cacheName) {
-        return clientConfig.getOrNullQueryCacheConfig(mapName, cacheName);
+    public QueryCacheConfig getOrNull(String mapName, String cacheName, String cacheId) {
+        QueryCacheConfig config = clientConfig.getOrNullQueryCacheConfig(mapName, cacheName);
+        if (config != null) {
+            setPredicateImpl(config);
+            setEntryListener(mapName, cacheId, config);
+        }
+
+        return config;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheConfigurator.java
@@ -40,7 +40,7 @@ public interface QueryCacheConfigurator {
      * @param cacheName query cache name.
      * @return {@link QueryCacheConfig} for the requested {@code cacheName}.
      */
-    QueryCacheConfig getOrNull(String mapName, String cacheName);
+    QueryCacheConfig getOrNull(String mapName, String cacheName, String cacheId);
 
     /**
      * Removes corresponding configuration for the supplied {@code cacheName}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
@@ -77,7 +77,7 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
             if (queryCacheConfig == null) {
                 return NULL_QUERY_CACHE;
             }
-            queryCache = createUnderlyingQueryCache(request, cacheId);
+            queryCache = createUnderlyingQueryCache(request, cacheId, queryCacheConfig);
             // this is users listener which can be given as a parameter
             // when calling `IMap.getQueryCache` method
             addListener(mapName, cacheId);
@@ -103,9 +103,11 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
     /**
      * This is the cache which we store all key-value pairs.
      */
-    private InternalQueryCache createUnderlyingQueryCache(QueryCacheRequest request, String cacheId) {
+    private InternalQueryCache createUnderlyingQueryCache(QueryCacheRequest request,
+                                                          String cacheId, QueryCacheConfig queryCacheConfig) {
         SubscriberContext subscriberContext = context.getSubscriberContext();
         QueryCacheFactory queryCacheFactory = subscriberContext.getQueryCacheFactory();
+        request.withQueryCacheConfig(queryCacheConfig);
         return queryCacheFactory.create(request, cacheId);
     }
 
@@ -134,7 +136,7 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
         QueryCacheConfig queryCacheConfig;
 
         if (predicate == null) {
-            queryCacheConfig = getOrNullQueryCacheConfig(mapName, request.getCacheName());
+            queryCacheConfig = getOrNullQueryCacheConfig(mapName, request.getCacheName(), cacheId);
         } else {
             queryCacheConfig = getOrCreateQueryCacheConfig(mapName, request.getCacheName(), cacheId);
             queryCacheConfig.setIncludeValue(request.isIncludeValue());
@@ -157,9 +159,9 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
         return queryCacheConfigurator.getOrCreateConfiguration(mapName, cacheName, cacheId);
     }
 
-    private QueryCacheConfig getOrNullQueryCacheConfig(String mapName, String cacheName) {
+    private QueryCacheConfig getOrNullQueryCacheConfig(String mapName, String cacheName, String cacheId) {
         QueryCacheConfigurator queryCacheConfigurator = subscriberContext.geQueryCacheConfigurator();
-        return queryCacheConfigurator.getOrNull(mapName, cacheName);
+        return queryCacheConfigurator.getOrNull(mapName, cacheName, cacheId);
     }
 
     private void removeQueryCacheConfig(String mapName, String cacheName) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.querycache.subscriber;
 
+import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.Member;
@@ -72,8 +73,9 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 @SuppressWarnings("checkstyle:methodcount")
 class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
-    public DefaultQueryCache(String cacheId, String cacheName, IMap delegate, QueryCacheContext context) {
-        super(cacheId, cacheName, delegate, context);
+    public DefaultQueryCache(String cacheId, String cacheName, QueryCacheConfig queryCacheConfig,
+                             IMap delegate, QueryCacheContext context) {
+        super(cacheId, cacheName, queryCacheConfig, delegate, context);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheConfigurator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheConfigurator.java
@@ -49,7 +49,7 @@ public class NodeQueryCacheConfigurator extends AbstractQueryCacheConfigurator {
 
         QueryCacheConfig queryCacheConfig = findQueryCacheConfigFromMapConfig(mapConfig, cacheName);
 
-        if (null != queryCacheConfig) {
+        if (queryCacheConfig != null) {
             setPredicateImpl(queryCacheConfig);
             setEntryListener(mapName, cacheId, queryCacheConfig);
             return queryCacheConfig;
@@ -61,13 +61,20 @@ public class NodeQueryCacheConfigurator extends AbstractQueryCacheConfigurator {
     }
 
     @Override
-    public QueryCacheConfig getOrNull(String mapName, String cacheName) {
+    public QueryCacheConfig getOrNull(String mapName, String cacheName, String cacheId) {
         MapConfig mapConfig = config.getMapConfigOrNull(mapName);
-        if (null == mapConfig) {
+        if (mapConfig == null) {
             return null;
         }
 
-        return findQueryCacheConfigFromMapConfig(mapConfig, cacheName);
+        QueryCacheConfig queryCacheConfig = findQueryCacheConfigFromMapConfig(mapConfig, cacheName);
+        if (queryCacheConfig != null) {
+            setPredicateImpl(queryCacheConfig);
+            setEntryListener(mapName, cacheId, queryCacheConfig);
+            return queryCacheConfig;
+        }
+
+        return queryCacheConfig;
     }
 
     private QueryCacheConfig findQueryCacheConfigFromMapConfig(MapConfig mapConfig, String cacheName) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheFactory.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.querycache.subscriber;
 
+import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.util.ConcurrencyUtil;
@@ -45,8 +46,9 @@ public class QueryCacheFactory {
             String cacheName = request.getCacheName();
             IMap delegate = request.getMap();
             QueryCacheContext context = request.getContext();
+            QueryCacheConfig queryCacheConfig = request.getQueryCacheConfig();
 
-            return new DefaultQueryCache(cacheId, cacheName, delegate, context);
+            return new DefaultQueryCache(cacheId, cacheName, queryCacheConfig, delegate, context);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRequest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.querycache.subscriber;
 
+import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.listener.MapListener;
@@ -32,12 +33,13 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 public class QueryCacheRequest {
 
     private IMap map;
-    private Predicate predicate;
-    private Boolean includeValue;
-    private MapListener listener;
-    private QueryCacheContext context;
     private String mapName;
     private String cacheName;
+    private Predicate predicate;
+    private MapListener listener;
+    private Boolean includeValue;
+    private QueryCacheContext context;
+    private QueryCacheConfig queryCacheConfig;
 
     QueryCacheRequest() {
     }
@@ -79,6 +81,11 @@ public class QueryCacheRequest {
         return this;
     }
 
+    public QueryCacheRequest withQueryCacheConfig(QueryCacheConfig queryCacheConfig) {
+        this.queryCacheConfig = checkNotNull(queryCacheConfig, "queryCacheConfig can not be null");
+        return this;
+    }
+
     public IMap getMap() {
         return map;
     }
@@ -105,5 +112,9 @@ public class QueryCacheRequest {
 
     public QueryCacheContext getContext() {
         return context;
+    }
+
+    public QueryCacheConfig getQueryCacheConfig() {
+        return queryCacheConfig;
     }
 }


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/13402

- [ ] needs port for 3.11