### PR TITLE
[BACKPORT] DefaultSerializationServiceBuilder no longer ignores useNativeByteOrder

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/SerializationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SerializationConfig.java
@@ -368,7 +368,7 @@ public class SerializationConfig {
     }
 
     /**
-     * Not that configuring use native byte order as enabled will override the byte order set by this method.
+     * Note that configuring use native byte order as enabled will override the byte order set by this method.
      *
      * @param byteOrder that serialization will use
      * @return configured {@link com.hazelcast.config.SerializerConfig} for chaining

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilder.java
@@ -56,6 +56,8 @@ import static java.nio.ByteOrder.nativeOrder;
 @SuppressWarnings({"checkstyle:methodcount"})
 public class DefaultSerializationServiceBuilder implements SerializationServiceBuilder {
 
+    static final ByteOrder DEFAULT_BYTE_ORDER = BIG_ENDIAN;
+
     // System property to override configured byte order for tests
     private static final String BYTE_ORDER_OVERRIDE_PROPERTY = "hazelcast.serialization.byteOrder";
     private static final int DEFAULT_OUT_BUFFER_SIZE = 4 * 1024;
@@ -78,7 +80,7 @@ public class DefaultSerializationServiceBuilder implements SerializationServiceB
     protected ManagedContext managedContext;
 
     protected boolean useNativeByteOrder;
-    protected ByteOrder byteOrder = BIG_ENDIAN;
+    protected ByteOrder byteOrder = DEFAULT_BYTE_ORDER;
 
     protected boolean enableCompression;
     protected boolean enableSharedObject;
@@ -339,7 +341,10 @@ public class DefaultSerializationServiceBuilder implements SerializationServiceB
         overrideByteOrder();
 
         if (byteOrder == null) {
-            byteOrder = useNativeByteOrder ? nativeOrder() : BIG_ENDIAN;
+            byteOrder = DEFAULT_BYTE_ORDER;
+        }
+        if (useNativeByteOrder) {
+            byteOrder = nativeOrder();
         }
         return byteOrder == nativeOrder() && allowUnsafe && GlobalMemoryAccessorRegistry.MEM_AVAILABLE
                 ? new UnsafeInputOutputFactory()

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilderTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 
 import java.nio.ByteOrder;
 
+import static com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder.DEFAULT_BYTE_ORDER;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -87,6 +88,20 @@ public class DefaultSerializationServiceBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void test_exceptionThrown_whenInitialOutputBufferSizeNegative() {
         getSerializationServiceBuilder().setInitialOutputBufferSize(-1);
+    }
+
+    @Test
+    public void test_nullByteOrder() {
+        InternalSerializationService serializationService = getSerializationServiceBuilder()
+                .setByteOrder(null).build();
+        assertEquals(DEFAULT_BYTE_ORDER, serializationService.getByteOrder());
+    }
+
+    @Test
+    public void test_useNativeByteOrder() {
+        ByteOrder nativeOrder = ByteOrder.nativeOrder();
+        InternalSerializationService serializationService = getSerializationServiceBuilder().setUseNativeByteOrder(true).build();
+        assertEquals(nativeOrder, serializationService.getByteOrder());
     }
 
     protected SerializationServiceBuilder getSerializationServiceBuilder() {


### PR DESCRIPTION
Previously this flag was ignored because byteOrder was already
initialized to a non-null value.

Backport of #13411 