### PR TITLE
Cancel scheduled replicated map entries to prevent memory leaks.

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapTest.java
@@ -543,6 +543,25 @@ public class ClientReplicatedMapTest extends HazelcastTestSupport {
         assertAllTtlSchedulersEmpty(node.getReplicatedMap(mapName));
     }
 
+    @Test
+    public void remove_empties_internal_ttl_schedulers() {
+        String mapName = "test";
+        HazelcastInstance node = hazelcastFactory.newHazelcastInstance(config);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        ReplicatedMap map = client.getReplicatedMap(mapName);
+
+        for (int i = 0; i < 1000; i++) {
+            map.put(i, i, 100, TimeUnit.DAYS);
+        }
+
+        for (int i = 0; i < 1000; i++) {
+            map.remove(i);
+        }
+
+        assertAllTtlSchedulersEmpty(node.getReplicatedMap(mapName));
+    }
+
     private static void assertAllTtlSchedulersEmpty(ReplicatedMap map) {
         String mapName = map.getName();
         ReplicatedMapProxy replicatedMapProxy = (ReplicatedMapProxy) map;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractBaseReplicatedRecordStore.java
@@ -42,17 +42,19 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public abstract class AbstractBaseReplicatedRecordStore<K, V> implements ReplicatedRecordStore {
 
-    protected final AtomicReference<InternalReplicatedMapStorage<K, V>> storageRef;
-    protected final ReplicatedMapService replicatedMapService;
-    protected final ReplicatedMapConfig replicatedMapConfig;
-    protected final NodeEngine nodeEngine;
-    protected final SerializationService serializationService;
-    protected final IPartitionService partitionService;
-    protected final AtomicBoolean isLoaded = new AtomicBoolean(false);
-    protected final EntryTaskScheduler<Object, Object> ttlEvictionScheduler;
-    protected final EventService eventService;
-    protected final String name;
     protected int partitionId;
+
+    protected final String name;
+    protected final NodeEngine nodeEngine;
+    protected final EventService eventService;
+    protected final IPartitionService partitionService;
+    protected final ReplicatedMapConfig replicatedMapConfig;
+    protected final SerializationService serializationService;
+    protected final ReplicatedMapService replicatedMapService;
+    protected final AtomicReference<InternalReplicatedMapStorage<K, V>> storageRef;
+    protected final AtomicBoolean isLoaded = new AtomicBoolean(false);
+
+    private final EntryTaskScheduler<Object, Object> ttlEvictionScheduler;
 
     protected AbstractBaseReplicatedRecordStore(String name, ReplicatedMapService replicatedMapService, int partitionId) {
         this.name = name;
@@ -103,6 +105,7 @@ public abstract class AbstractBaseReplicatedRecordStore<K, V> implements Replica
         if (storage != null) {
             storage.clear();
         }
+        ttlEvictionScheduler.cancelAll();
     }
 
     protected InternalReplicatedMapStorage<K, V> clearInternal() {

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/AbstractReplicatedRecordStore.java
@@ -90,6 +90,7 @@ public abstract class AbstractReplicatedRecordStore<K, V> extends AbstractBaseRe
         if (replicatedMapConfig.isStatisticsEnabled()) {
             getStats().incrementRemoves(Clock.currentTimeMillis() - time);
         }
+        cancelTtlEntry(marshalledKey);
         return unmarshalledOldValue;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTtlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapTtlTest.java
@@ -129,6 +129,39 @@ public class ReplicatedMapTtlTest extends ReplicatedMapAbstractTest {
         assertAllTtlSchedulersEmpty(map);
     }
 
+    @Test
+    public void remove_empties_internal_ttl_schedulers() {
+        HazelcastInstance node = createHazelcastInstance();
+        String mapName = "test";
+        ReplicatedMap map = node.getReplicatedMap(mapName);
+
+        for (int i = 0; i < 1000; i++) {
+            map.put(i, i, 100, TimeUnit.DAYS);
+        }
+
+        for (int i = 0; i < 1000; i++) {
+            map.remove(i);
+        }
+
+        assertAllTtlSchedulersEmpty(map);
+    }
+
+    @Test
+    public void service_reset_empties_internal_ttl_schedulers() {
+        HazelcastInstance node = createHazelcastInstance();
+        String mapName = "test";
+        ReplicatedMap map = node.getReplicatedMap(mapName);
+
+        for (int i = 0; i < 1000; i++) {
+            map.put(i, i, 100, TimeUnit.DAYS);
+        }
+
+        ReplicatedMapService service = getNodeEngineImpl(node).getService(ReplicatedMapService.SERVICE_NAME);
+        service.reset();
+
+        assertAllTtlSchedulersEmpty(map);
+    }
+
     private static void assertAllTtlSchedulersEmpty(ReplicatedMap map) {
         String mapName = map.getName();
         ReplicatedMapProxy replicatedMapProxy = (ReplicatedMapProxy) map;


### PR DESCRIPTION
This cancelation is done in two cases:
				 - upon removal of entry
				 - upon reset of replicated-map service


follow-up PR that fixes https://github.com/hazelcast/hazelcast/issues/13409 