### PR TITLE
Exclude from parallel timeout-test to keep noise to the min

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientTimeoutTest.java
@@ -24,7 +24,6 @@ import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Test;
@@ -37,7 +36,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 @RunWith(HazelcastParallelClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class})
 public class ClientTimeoutTest {
 
     private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/13303