### PR TITLE
Fix and cleanup of TestTaskExecutorUtil and TestBackupUtils

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/backup/AbstractBackupAccessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/backup/AbstractBackupAccessor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.backup;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.partition.InternalPartition;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.partition.IPartition;
+
+import java.util.Arrays;
+
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+
+/**
+ * Base class for {@link BackupAccessor} implementations.
+ *
+ * @param <K> type of keys
+ * @param <V> type of values
+ */
+abstract class AbstractBackupAccessor<K, V> implements BackupAccessor<K, V> {
+
+    final HazelcastInstance[] cluster;
+    final int replicaIndex;
+
+    AbstractBackupAccessor(HazelcastInstance[] cluster, int replicaIndex) {
+        if (cluster == null || cluster.length == 0) {
+            throw new IllegalArgumentException("Cluster has to have at least 1 member.");
+        }
+        if (replicaIndex < 1 || replicaIndex > IPartition.MAX_BACKUP_COUNT) {
+            throw new IllegalArgumentException("Cannot access replica index " + replicaIndex);
+        }
+        this.cluster = cluster;
+        this.replicaIndex = replicaIndex;
+    }
+
+    HazelcastInstance getHazelcastInstance(IPartition partition) {
+        Address replicaAddress = partition.getReplicaAddress(replicaIndex);
+        if (replicaAddress == null) {
+            // there is no owner of this replica (yet?)
+            return null;
+        }
+
+        HazelcastInstance hz = getInstanceWithAddress(replicaAddress);
+        if (hz == null) {
+            throw new IllegalStateException("Partition " + partition + " with replica index " + replicaIndex
+                    + " is mapped to " + replicaAddress + " but there is no member with this address in the cluster."
+                    + " List of known members: " + Arrays.toString(cluster));
+        }
+        return hz;
+    }
+
+    InternalPartition getPartitionForKey(K key) {
+        // to determine partition we can use any instance (let's pick the first one)
+        HazelcastInstance instance = cluster[0];
+        InternalPartitionService partitionService = getNode(instance).getPartitionService();
+        int partitionId = partitionService.getPartitionId(key);
+        return partitionService.getPartition(partitionId);
+    }
+
+    HazelcastInstance getInstanceWithAddress(Address address) {
+        for (HazelcastInstance hz : cluster) {
+            if (hz.getCluster().getLocalMember().getAddress().equals(address)) {
+                return hz;
+            }
+        }
+        throw new IllegalStateException("Address " + address + " not found in the cluster");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/backup/AbstractClassLoaderAwareCallable.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/backup/AbstractClassLoaderAwareCallable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.backup;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Base class for {@link Callable} classes which need a special TCCL to be set.
+ *
+ * @param <V> the result type of method {@code call}
+ */
+abstract class AbstractClassLoaderAwareCallable<V> implements Callable<V> {
+
+    private final ClassLoader classLoader = AbstractClassLoaderAwareCallable.class.getClassLoader();
+
+    @Override
+    public final V call() throws Exception {
+        Thread thread = Thread.currentThread();
+        ClassLoader contextClassLoader = thread.getContextClassLoader();
+        try {
+            thread.setContextClassLoader(classLoader);
+            return callInternal();
+        } finally {
+            thread.setContextClassLoader(contextClassLoader);
+        }
+    }
+
+    abstract V callInternal() throws Exception;
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/backup/BackupAccessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/backup/BackupAccessor.java
@@ -17,7 +17,7 @@
 package com.hazelcast.test.backup;
 
 /**
- * Access backup records in a given replica.
+ * Accesses backup records in a given replica.
  * <p>
  * All accessors use a partition thread to access values data hence
  * they are safe to use with HD-backed data structures.
@@ -31,17 +31,17 @@ package com.hazelcast.test.backup;
 public interface BackupAccessor<K, V> {
 
     /**
-     * Number of existing backup entries in a given structure and replica index
+     * Number of existing backup entries in a given structure and replica index.
      *
      * @return number of backup entries
      */
     int size();
 
     /**
-     * Reads backup value
+     * Returns the backup value for the given key.
      *
      * @param key key of the backup entry to get
-     * @return backup value or null
+     * @return backup value or {@code null}
      */
     V get(K key);
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/backup/CacheBackupAccessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/backup/CacheBackupAccessor.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.backup;
+
+import com.hazelcast.cache.HazelcastCacheManager;
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.CacheService;
+import com.hazelcast.cache.impl.HazelcastServerCacheManager;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.cache.impl.ICacheRecordStore;
+import com.hazelcast.cache.impl.record.CacheRecord;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.partition.InternalPartition;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import javax.cache.expiry.ExpiryPolicy;
+import javax.cache.spi.CachingProvider;
+import java.util.Map;
+
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+import static com.hazelcast.test.TestTaskExecutorUtil.runOnPartitionThread;
+
+/**
+ * Implementation of {@link BackupAccessor} for {@link ICache}.
+ *
+ * @param <K> type of keys
+ * @param <V> type of values
+ */
+class CacheBackupAccessor<K, V> extends AbstractBackupAccessor<K, V> implements BackupAccessor<K, V> {
+
+    private final String cacheName;
+
+    CacheBackupAccessor(HazelcastInstance[] cluster, String cacheName, int replicaIndex) {
+        super(cluster, replicaIndex);
+        this.cacheName = cacheName;
+    }
+
+    @Override
+    public int size() {
+        InternalPartitionService partitionService = getNode(cluster[0]).getPartitionService();
+        IPartition[] partitions = partitionService.getPartitions();
+        int count = 0;
+        for (IPartition partition : partitions) {
+            Address replicaAddress = partition.getReplicaAddress(replicaIndex);
+            if (replicaAddress == null) {
+                continue;
+            }
+
+            HazelcastInstance hz = getInstanceWithAddress(replicaAddress);
+            CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(hz);
+            HazelcastCacheManager cacheManager = (HazelcastServerCacheManager) provider.getCacheManager();
+
+            NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+            CacheService cacheService = nodeEngine.getService(CacheService.SERVICE_NAME);
+            String cacheNameWithPrefix = cacheManager.getCacheNameWithPrefix(cacheName);
+            int partitionId = partition.getPartitionId();
+
+            count += runOnPartitionThread(hz, new SizeCallable(cacheService, cacheNameWithPrefix, partitionId), partitionId);
+        }
+        return count;
+    }
+
+    @Override
+    public V get(K key) {
+        IPartition partition = getPartitionForKey(key);
+        HazelcastInstance hz = getHazelcastInstance(partition);
+
+        Node node = getNode(hz);
+        SerializationService serializationService = node.getSerializationService();
+        CacheService cacheService = node.getNodeEngine().getService(CacheService.SERVICE_NAME);
+        String cacheNameWithPrefix = getCacheNameWithPrefix(hz, cacheName);
+        int partitionId = partition.getPartitionId();
+
+        return runOnPartitionThread(hz, new GetValueCallable(serializationService, cacheService, cacheNameWithPrefix, partitionId,
+                key), partitionId);
+    }
+
+    ExpiryPolicy getExpiryPolicy(K key) {
+        InternalPartition partition = getPartitionForKey(key);
+        HazelcastInstance hz = getHazelcastInstance(partition);
+
+        Node node = getNode(hz);
+        SerializationService serializationService = node.getSerializationService();
+        CacheService cacheService = node.getNodeEngine().getService(CacheService.SERVICE_NAME);
+        String cacheNameWithPrefix = getCacheNameWithPrefix(hz, cacheName);
+        int partitionId = partition.getPartitionId();
+
+        return runOnPartitionThread(hz, new GetExpiryPolicyCallable(serializationService, cacheService, cacheNameWithPrefix,
+                partitionId, key), partitionId);
+    }
+
+    private static String getCacheNameWithPrefix(HazelcastInstance hz, String cacheName) {
+        CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(hz);
+        HazelcastCacheManager cacheManager = (HazelcastServerCacheManager) provider.getCacheManager();
+        return cacheManager.getCacheNameWithPrefix(cacheName);
+    }
+
+    private static class SizeCallable extends AbstractClassLoaderAwareCallable<Integer> {
+
+        private final CacheService cacheService;
+        private final String cacheNameWithPrefix;
+        private final int partitionId;
+
+        SizeCallable(CacheService cacheService, String cacheNameWithPrefix, int partitionId) {
+            this.cacheService = cacheService;
+            this.cacheNameWithPrefix = cacheNameWithPrefix;
+            this.partitionId = partitionId;
+        }
+
+        @Override
+        public Integer callInternal() {
+            ICacheRecordStore recordStore = cacheService.getRecordStore(cacheNameWithPrefix, partitionId);
+            if (recordStore == null) {
+                return 0;
+            }
+            return recordStore.size();
+        }
+    }
+
+    private class GetValueCallable extends AbstractClassLoaderAwareCallable<V> {
+
+        private final SerializationService serializationService;
+        private final CacheService cacheService;
+        private final String cacheNameWithPrefix;
+        private final int partitionId;
+        private final K key;
+
+        GetValueCallable(SerializationService serializationService, CacheService cacheService, String cacheNameWithPrefix,
+                         int partitionId, K key) {
+            this.serializationService = serializationService;
+            this.cacheService = cacheService;
+            this.cacheNameWithPrefix = cacheNameWithPrefix;
+            this.partitionId = partitionId;
+            this.key = key;
+        }
+
+        @Override
+        public V callInternal() {
+            ICacheRecordStore recordStore = cacheService.getRecordStore(cacheNameWithPrefix, partitionId);
+            if (recordStore == null) {
+                return null;
+            }
+            Data keyData = serializationService.toData(key);
+            Map<Data, CacheRecord> records = recordStore.getReadOnlyRecords();
+            CacheRecord cacheRecord = records.get(keyData);
+            if (cacheRecord == null) {
+                return null;
+            }
+            Object value = cacheRecord.getValue();
+            return serializationService.toObject(value);
+        }
+    }
+
+    private class GetExpiryPolicyCallable extends AbstractClassLoaderAwareCallable<ExpiryPolicy> {
+
+        private final SerializationService serializationService;
+        private final CacheService cacheService;
+        private final String cacheNameWithPrefix;
+        private final int partitionId;
+        private final K key;
+
+        GetExpiryPolicyCallable(SerializationService serializationService, CacheService cacheService, String cacheNameWithPrefix,
+                                int partitionId, K key) {
+            this.serializationService = serializationService;
+            this.cacheService = cacheService;
+            this.cacheNameWithPrefix = cacheNameWithPrefix;
+            this.partitionId = partitionId;
+            this.key = key;
+        }
+
+        @Override
+        public ExpiryPolicy callInternal() {
+            ICacheRecordStore recordStore = cacheService.getRecordStore(cacheNameWithPrefix, partitionId);
+            if (recordStore == null) {
+                return null;
+            }
+            Data keyData = serializationService.toData(key);
+            CacheRecord cacheRecord = recordStore.getReadOnlyRecords().get(keyData);
+            if (cacheRecord == null) {
+                return null;
+            }
+            Object expiryPolicy = cacheRecord.getExpiryPolicy();
+            return serializationService.toObject(expiryPolicy);
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/backup/MapBackupAccessor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/backup/MapBackupAccessor.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.backup;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.PartitionContainer;
+import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.serialization.SerializationService;
+
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
+import static com.hazelcast.test.HazelcastTestSupport.getNodeEngineImpl;
+import static com.hazelcast.test.TestTaskExecutorUtil.runOnPartitionThread;
+
+/**
+ * Implementation of {@link BackupAccessor} for {@link IMap}.
+ *
+ * @param <K> type of keys
+ * @param <V> type of values
+ */
+class MapBackupAccessor<K, V> extends AbstractBackupAccessor<K, V> implements BackupAccessor<K, V> {
+
+    private final String mapName;
+
+    MapBackupAccessor(HazelcastInstance[] cluster, String mapName, int replicaIndex) {
+        super(cluster, replicaIndex);
+        this.mapName = mapName;
+    }
+
+    @Override
+    public int size() {
+        InternalPartitionService partitionService = getNode(cluster[0]).getPartitionService();
+        IPartition[] partitions = partitionService.getPartitions();
+        int count = 0;
+        for (IPartition partition : partitions) {
+            Address replicaAddress = partition.getReplicaAddress(replicaIndex);
+            if (replicaAddress == null) {
+                continue;
+            }
+            HazelcastInstance hz = getInstanceWithAddress(replicaAddress);
+            NodeEngineImpl nodeEngine = getNodeEngineImpl(hz);
+            MapService mapService = nodeEngine.getService(MapService.SERVICE_NAME);
+
+            MapServiceContext context = mapService.getMapServiceContext();
+            int partitionId = partition.getPartitionId();
+            PartitionContainer partitionContainer = context.getPartitionContainer(partitionId);
+
+            count += runOnPartitionThread(hz, new SizeCallable(partitionContainer), partitionId);
+        }
+        return count;
+    }
+
+    @Override
+    public V get(K key) {
+        IPartition partition = getPartitionForKey(key);
+        HazelcastInstance hz = getHazelcastInstance(partition);
+
+        Node node = getNode(hz);
+        SerializationService serializationService = node.getSerializationService();
+        MapService mapService = node.getNodeEngine().getService(MapService.SERVICE_NAME);
+        MapServiceContext context = mapService.getMapServiceContext();
+        int partitionId = partition.getPartitionId();
+        PartitionContainer partitionContainer = context.getPartitionContainer(partitionId);
+
+        return runOnPartitionThread(hz, new GetValueCallable(serializationService, partitionContainer, key), partitionId);
+    }
+
+    private class SizeCallable extends AbstractClassLoaderAwareCallable<Integer> {
+
+        private final PartitionContainer partitionContainer;
+
+        SizeCallable(PartitionContainer partitionContainer) {
+            this.partitionContainer = partitionContainer;
+        }
+
+        @Override
+        public Integer callInternal() {
+            RecordStore recordStore = partitionContainer.getExistingRecordStore(mapName);
+            if (recordStore == null) {
+                return 0;
+            }
+            return recordStore.size();
+        }
+    }
+
+    private class GetValueCallable extends AbstractClassLoaderAwareCallable<V> {
+
+        private final SerializationService serializationService;
+        private final PartitionContainer partitionContainer;
+        private final K key;
+
+        GetValueCallable(SerializationService serializationService, PartitionContainer partitionContainer, K key) {
+            this.serializationService = serializationService;
+            this.partitionContainer = partitionContainer;
+            this.key = key;
+        }
+
+        @Override
+        public V callInternal() {
+            RecordStore recordStore = partitionContainer.getExistingRecordStore(mapName);
+            if (recordStore == null) {
+                return null;
+            }
+            Data keyData = serializationService.toData(key);
+            Object o = recordStore.get(keyData, true, null);
+            if (o == null) {
+                return null;
+            }
+            return serializationService.toObject(o);
+        }
+    }
+}


### PR DESCRIPTION
### Fix and cleanup of TestTaskExecutorUtil

Fixed wrong method call for thread interruption in `TestTaskExecutorUtil`.

### Improved TestBackupUtils

Prepared `TestBackupUtils` for `HazelcastStarter`, by setting the correct classloader for the partition specific tasks.

Without the fix a `Callable` from the `TestBackupUtils` is executed with the `HazelcastAPIDelegatingClassloader` when sent to a proxied Hazelcast instance. This causes very weird classloading issues, when the executed test code is trying to create proxy classes to access the proxied Hazelcast internals from the "normal" classloader (which is not being set in the partition thread).

#### Exception examples:
```
java.lang.ExceptionInInitializerError
    at sun.reflect.GeneratedSerializationConstructorAccessor35.newInstance(Unknown Source)
        (...)
    at org.mockito.Mockito.mock(Mockito.java:1843)
    at com.hazelcast.test.starter.answer.ServiceAnswer.getICacheRecordStore(ServiceAnswer.java:117)
    at com.hazelcast.test.starter.answer.ServiceAnswer.run(ServiceAnswer.java:67)
    at com.hazelcast.test.starter.answer.AbstractAnswer.answer(AbstractAnswer.java:82)
        (...)
    at com.hazelcast.cache.impl.EnterpriseCacheService$MockitoMock$611800888.getRecordStore(Unknown Source)
    at com.hazelcast.test.backup.TestBackupUtils$CacheBackupAccessor$2.call(TestBackupUtils.java:249)
    at com.hazelcast.test.TestTaskExecutorUtil$PartitionSpecificRunnableWithResultQueue.run(TestTaskExecutorUtil.java:104)
        (...)
Caused by: java.lang.NoSuchMethodException: com.hazelcast.cache.impl.ICacheRecordStore.setExpiryPolicy(java.util.Collection, java.lang.Object, java.lang.String)
    at java.lang.Class.getDeclaredMethod(Class.java:2130)
    at com.hazelcast.cache.impl.ICacheRecordStore$MockitoMock$1308572499.<clinit>(Unknown Source)
    ... 34 more
```
```
java.lang.ExceptionInInitializerError
	at sun.reflect.GeneratedSerializationConstructorAccessor62.newInstance(Unknown Source)
        (...)
	at org.mockito.Mockito.mock(Mockito.java:1843)
	at com.hazelcast.test.starter.answer.PartitionContainerAnswer.getRecordStore(PartitionContainerAnswer.java:51)
	at com.hazelcast.test.starter.answer.PartitionContainerAnswer.run(PartitionContainerAnswer.java:38)
	at com.hazelcast.test.starter.answer.AbstractAnswer.answer(AbstractAnswer.java:82)
        (...)
	at com.hazelcast.map.impl.PartitionContainer$MockitoMock$929214215.getExistingRecordStore(Unknown Source)
	at com.hazelcast.test.backup.MapBackupAccessor$GetValueCallable.callInternal(MapBackupAccessor.java:122)
        (...)
Caused by: java.lang.NoSuchMethodException: com.hazelcast.map.impl.recordstore.RecordStore.putFromLoad(com.hazelcast.nio.serialization.Data, java.lang.Object, com.hazelcast.nio.Address)
	at java.lang.Class.getDeclaredMethod(Class.java:2130)
	at com.hazelcast.map.impl.recordstore.RecordStore$MockitoMock$1771714397.<clinit>(Unknown Source)
	... 35 more
```
```
Caused by: java.lang.ClassCastException: Cannot cast com.hazelcast.map.impl.PartitionContainer$MockitoMock$244612770 to com.hazelcast.map.impl.PartitionContainer
    at java.lang.Class.cast(Class.java:3369)
    at org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker.ensureMockIsAssignableToMockedType(SubclassByteBuddyMockMaker.java:87)
```

Pulled out from https://github.com/hazelcast/hazelcast/pull/13293