### PR TITLE
Use assert eventually for a latch based test that failed due to noise

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/QueueListenerTest.java
@@ -114,7 +114,7 @@ public class QueueListenerTest extends HazelcastTestSupport {
         for (int i = 0; i < TOTAL_QUEUE_PUT / 4; i++) {
             queue.put(i);
         }
-        assertTrue(countdownItemListener.added.await(3, TimeUnit.SECONDS));
+        assertOpenEventually(countdownItemListener.added);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/13415

I noticed the following (build 16328):

```
Hiccups measured while running test 'testItemListener_addedToQueueConfig_Issue366(com.hazelcast.collection.impl.queue.QueueListenerTest):'
08:00:40, accumulated pauses: 1260 ms, max pause: 304 ms, pauses over 1000 ms: 0
08:00:45, accumulated pauses: 1021 ms, max pause: 264 ms, pauses over 1000 ms: 0
```

And also, all tests took >3 seconds to complete (successfully). 
```
<testcase name="testConfigListenerRegistration" classname="com.hazelcast.collection.impl.queue.QueueListenerTest" time="3.439"/>
  <testcase name="testListener_withEvictionViaTTL" classname="com.hazelcast.collection.impl.queue.QueueListenerTest" time="3.455"/>
  <testcase name="testListeners" classname="com.hazelcast.collection.impl.queue.QueueListenerTest" time="3.484"/>
  <testcase name="testItemListener_addedToQueueConfig_Issue366" classname="com.hazelcast.collection.impl.queue.QueueListenerTest" time="7.481">
```

**vs**

Normal run (build 16329):
```  
<testcase name="testListener_withEvictionViaTTL" classname="com.hazelcast.collection.impl.queue.QueueListenerTest" time="0.108"/>
  <testcase name="testConfigListenerRegistration" classname="com.hazelcast.collection.impl.queue.QueueListenerTest" time="0.122"/>
  <testcase name="testListeners" classname="com.hazelcast.collection.impl.queue.QueueListenerTest" time="0.186"/>
  <testcase name="testItemListener_addedToQueueConfig_Issue366" classname="com.hazelcast.collection.impl.queue.QueueListenerTest" time="0.794"/>
```

Switching to an `assertOpenEventually`