### PR TITLE
Fixed tests with missing @RunWith or @Category annotations

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -19,19 +19,17 @@ package com.hazelcast.cluster;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JavaSerializationFilterConfig;
 import com.hazelcast.config.JoinConfig;
-import com.hazelcast.config.MulticastConfig;
-import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.internal.serialization.impl.SerializationConstants;
-import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.Packet;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import example.serialization.TestDeserialized;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -41,53 +39,61 @@ import java.net.InetAddress;
 import java.net.MulticastSocket;
 import java.nio.ByteBuffer;
 
+import static com.hazelcast.nio.IOUtil.closeResource;
 import static org.junit.Assert.assertFalse;
 
 /**
- * Tests if deserialization blacklisting works for MutlicastService.
+ * Tests if deserialization blacklisting works for MulticastService.
  */
+@RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class MulticastDeserializationTest {
 
     private static final int MULTICAST_PORT = 53535;
     private static final String MULTICAST_GROUP = "224.0.0.219";
-    // TTL==0 : Restricted to the same host. Won't be output by any interface.
+    // TTL = 0 : restricted to the same host, won't be output by any interface
     private static final int MULTICAST_TTL = 0;
 
-    @Before
     @After
-    public void killAllHazelcastInstances() throws IOException {
+    public void tearDown() {
         TestDeserialized.isDeserialized = false;
         HazelcastInstanceFactory.terminateAll();
     }
 
     /**
-     * <pre>
      * Given: Multicast is configured.
-     * When: DatagramPacket with a correct Packet comes. The Packet references Java serializer and the serialized object is not a Join message.
+     * When: DatagramPacket with a correct Packet comes. The Packet references
+     * Java serializer and the serialized object is not a Join message.
      * Then: The object from the Packet is not deserialized.
-     * </pre>
      */
     @Test
     public void test() throws Exception {
-        Config config = new Config();
-        JavaSerializationFilterConfig javaSerializationFilterConfig = new JavaSerializationFilterConfig();
-        javaSerializationFilterConfig.setDefaultsDisabled(true);
-        javaSerializationFilterConfig.getBlacklist().addClasses(TestDeserialized.class.getName());
-        config.getSerializationConfig().setJavaSerializationFilterConfig(javaSerializationFilterConfig);
-        NetworkConfig networkConfig = config.getNetworkConfig();
-        JoinConfig join = networkConfig.getJoin();
-        join.getTcpIpConfig().setEnabled(false);
-        MulticastConfig multicastConfig = join.getMulticastConfig();
-        multicastConfig.setMulticastPort(MULTICAST_PORT);
-        multicastConfig.setMulticastGroup(MULTICAST_GROUP);
-        multicastConfig.setMulticastTimeToLive(MULTICAST_TTL);
-        multicastConfig.setEnabled(true);
-
+        Config config = getConfig();
         Hazelcast.newHazelcastInstance(config);
+
         sendJoinDatagram(new TestDeserialized());
         Thread.sleep(500L);
         assertFalse("Untrusted deserialization is possible", TestDeserialized.isDeserialized);
+    }
+
+    private Config getConfig() {
+        JavaSerializationFilterConfig javaSerializationFilterConfig = new JavaSerializationFilterConfig()
+                .setDefaultsDisabled(true);
+        javaSerializationFilterConfig.getBlacklist()
+                .addClasses(TestDeserialized.class.getName());
+
+        Config config = new Config();
+        config.getSerializationConfig()
+                .setJavaSerializationFilterConfig(javaSerializationFilterConfig);
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getTcpIpConfig()
+                .setEnabled(false);
+        join.getMulticastConfig()
+                .setEnabled(true)
+                .setMulticastPort(MULTICAST_PORT)
+                .setMulticastGroup(MULTICAST_GROUP)
+                .setMulticastTimeToLive(MULTICAST_TTL);
+        return config;
     }
 
     private void sendJoinDatagram(Object object) throws IOException {
@@ -96,7 +102,7 @@ public class MulticastDeserializationTest {
         try {
             oos.writeObject(object);
         } finally {
-            IOUtil.closeResource(oos);
+            closeResource(oos);
         }
         byte[] data = bos.toByteArray();
         MulticastSocket multicastSocket = null;

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricsUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/MetricsUtilTest.java
@@ -17,8 +17,11 @@
 package com.hazelcast.internal.metrics;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
@@ -34,6 +37,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class MetricsUtilTest {
 
     @Rule
@@ -106,7 +110,7 @@ public class MetricsUtilTest {
         parseMetricName("[tag=value,tag2]");
     }
 
-    private Entry<String, String> entry(String key, String value) {
+    private static Entry<String, String> entry(String key, String value) {
         return new SimpleImmutableEntry<String, String>(key, value);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/ProbeBuilderImplTest.java
@@ -23,7 +23,12 @@ import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.metrics.ProbeUnit;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.util.HashSet;
 
@@ -31,6 +36,8 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class ProbeBuilderImplTest {
 
     @Probe
@@ -60,14 +67,14 @@ public class ProbeBuilderImplTest {
         builder.register(this, "probe1", ProbeLevel.INFO, ProbeUnit.COUNT,
                 new LongProbeFunction<ProbeBuilderImplTest>() {
                     @Override
-                    public long get(ProbeBuilderImplTest source) throws Exception {
+                    public long get(ProbeBuilderImplTest source) {
                         return source.probe1;
                     }
                 });
         builder.register(this, "secondProbe", ProbeLevel.INFO, ProbeUnit.BYTES,
                 new LongProbeFunction<ProbeBuilderImplTest>() {
                     @Override
-                    public long get(ProbeBuilderImplTest source) throws Exception {
+                    public long get(ProbeBuilderImplTest source) {
                         return source.probe2;
                     }
                 });


### PR DESCRIPTION
Tests need a `@Category` annotation, or they will never be executed. We should also provide the `@RunWith` to have control about the parallel/serial method execution.