### PR TITLE
Improve performance of MultiMap statistics #13007

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainer.java
@@ -16,6 +16,9 @@
 
 package com.hazelcast.multimap.impl;
 
+import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
+import static com.hazelcast.util.Clock.currentTimeMillis;
+import static com.hazelcast.util.MapUtil.createHashMap;
 import com.hazelcast.concurrent.lock.LockService;
 import com.hazelcast.concurrent.lock.LockStore;
 import com.hazelcast.nio.serialization.Data;
@@ -24,17 +27,14 @@ import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MultiMapMergeTypes;
 import com.hazelcast.spi.serialization.SerializationService;
-
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
-
-import static com.hazelcast.spi.impl.merge.MergingValueFactory.createMergingEntry;
-import static com.hazelcast.util.Clock.currentTimeMillis;
-import static com.hazelcast.util.MapUtil.createHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * MultiMap container which holds a map of {@link MultiMapValue}.
@@ -55,6 +55,8 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     // these fields are volatile since they can be read by other threads than the partition-thread
     private volatile long lastAccessTime;
     private volatile long lastUpdateTime;
+    private volatile long hits;
+    private AtomicInteger size;
 
     public MultiMapContainer(String name, MultiMapService service, int partitionId) {
         super(name, service.getNodeEngine());
@@ -64,6 +66,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
         this.lockStore = lockService == null ? null : lockService.createLockStore(partitionId, lockNamespace);
         this.creationTime = currentTimeMillis();
         this.objectNamespace = new DistributedObjectNamespace(MultiMapService.SERVICE_NAME, name);
+        this.size = new AtomicInteger(0);
     }
 
     public boolean canAcquireLock(Data dataKey, String caller, long threadId) {
@@ -107,12 +110,23 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     }
 
     public boolean delete(Data dataKey) {
-        return multiMapValues.remove(dataKey) != null;
+        MultiMapValue value = multiMapValues.remove(dataKey);
+        if (value != null) {
+            decrementSize(value.size());
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public Collection<MultiMapRecord> remove(Data dataKey, boolean copyOf) {
         MultiMapValue multiMapValue = multiMapValues.remove(dataKey);
-        return multiMapValue != null ? multiMapValue.getCollection(copyOf) : null;
+        if (multiMapValue != null) {
+            decrementSize(multiMapValue.size());
+            return multiMapValue.getCollection(copyOf);
+        } else {
+            return null;
+        }
     }
 
     public Set<Data> keySet() {
@@ -161,26 +175,26 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     }
 
     public int size() {
-        int size = 0;
-        for (MultiMapValue multiMapValue : multiMapValues.values()) {
-            size += multiMapValue.getCollection(false).size();
-        }
-        return size;
+        return size.get();
     }
 
     public int clear() {
+        int numOfEntriesDeleted = 0;
+        int numOfValuesDeleted = 0;
         Collection<Data> locks = lockStore != null ? lockStore.getLockedKeys() : Collections.<Data>emptySet();
-        Map<Data, MultiMapValue> lockedKeys = createHashMap(locks.size());
-        for (Data key : locks) {
-            MultiMapValue multiMapValue = multiMapValues.get(key);
-            if (multiMapValue != null) {
-                lockedKeys.put(key, multiMapValue);
+
+        for (Data key : multiMapValues.keySet()) {
+            if (!locks.contains(key)) {
+                MultiMapValue value = multiMapValues.remove(key);
+                if (value != null) {
+                    numOfEntriesDeleted++;
+                    numOfValuesDeleted += value.size();
+                }
             }
         }
-        int numberOfAffectedEntries = multiMapValues.size() - lockedKeys.size();
-        multiMapValues.clear();
-        multiMapValues.putAll(lockedKeys);
-        return numberOfAffectedEntries;
+
+        decrementSize(numOfValuesDeleted);
+        return numOfEntriesDeleted;
     }
 
     public void destroy() {
@@ -227,11 +241,11 @@ public class MultiMapContainer extends MultiMapContainerSupport {
      * Merges the given {@link MultiMapMergeContainer} via the given {@link SplitBrainMergePolicy}.
      *
      * @param mergeContainer the {@link MultiMapMergeContainer} instance to merge
-     * @param mergePolicy    the {@link SplitBrainMergePolicy} instance to apply
+     * @param mergePolicy the {@link SplitBrainMergePolicy} instance to apply
      * @return the used {@link MultiMapValue} if merge is applied, otherwise {@code null}
      */
     public MultiMapValue merge(MultiMapMergeContainer mergeContainer,
-                               SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy) {
+        SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy) {
         SerializationService serializationService = nodeEngine.getSerializationService();
         serializationService.getManagedContext().initialize(mergePolicy);
 
@@ -244,7 +258,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     }
 
     private MultiMapValue mergeNewValue(SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy,
-                                        MultiMapMergeTypes mergingEntry) {
+        MultiMapMergeTypes mergingEntry) {
         Collection<Object> newValues = mergePolicy.merge(mergingEntry, null);
         if (newValues != null && !newValues.isEmpty()) {
             MultiMapValue mergedValue = getOrCreateMultiMapValue(mergingEntry.getKey());
@@ -252,6 +266,7 @@ public class MultiMapContainer extends MultiMapContainerSupport {
             createNewMultiMapRecords(records, newValues);
             if (newValues.equals(mergingEntry.getValue())) {
                 setMergedStatistics(mergingEntry, mergedValue);
+                incrementSize(newValues.size());
             }
             return mergedValue;
         }
@@ -259,21 +274,24 @@ public class MultiMapContainer extends MultiMapContainerSupport {
     }
 
     private MultiMapValue mergeExistingValue(SplitBrainMergePolicy<Collection<Object>, MultiMapMergeTypes> mergePolicy,
-                                             MultiMapMergeTypes mergingEntry, MultiMapValue existingValue,
-                                             SerializationService ss) {
+        MultiMapMergeTypes mergingEntry, MultiMapValue existingValue,
+        SerializationService ss) {
         Collection<MultiMapRecord> existingRecords = existingValue.getCollection(false);
 
         Data dataKey = mergingEntry.getKey();
         MultiMapMergeTypes existingEntry = createMergingEntry(ss, this, dataKey, existingRecords, existingValue.getHits());
         Collection<Object> newValues = mergePolicy.merge(mergingEntry, existingEntry);
         if (newValues == null || newValues.isEmpty()) {
+            decrementSize(existingRecords.size());
             existingRecords.clear();
             multiMapValues.remove(dataKey);
         } else if (!newValues.equals(existingRecords)) {
+            decrementSize(existingRecords.size());
             existingRecords.clear();
             createNewMultiMapRecords(existingRecords, newValues);
             if (newValues.equals(mergingEntry.getValue())) {
                 setMergedStatistics(mergingEntry, existingValue);
+                incrementSize(newValues.size());
             }
         }
         return existingValue;
@@ -292,8 +310,44 @@ public class MultiMapContainer extends MultiMapContainerSupport {
 
     @SuppressWarnings("NonAtomicOperationOnVolatileField")
     private void setMergedStatistics(MultiMapMergeTypes mergingEntry, MultiMapValue multiMapValue) {
-        multiMapValue.setHits(mergingEntry.getHits());
+        updateHits(multiMapValue, mergingEntry.getHits());
         lastAccessTime = Math.max(lastAccessTime, mergingEntry.getLastAccessTime());
         lastUpdateTime = Math.max(lastUpdateTime, mergingEntry.getLastUpdateTime());
+    }
+
+    public long getHits() {
+        return hits;
+    }
+
+    @SuppressFBWarnings(value = "VO_VOLATILE_INCREMENT",
+        justification = "A value can be accessed by only its own partition thread.")
+    public void incrementHit(MultiMapValue value) {
+        if (value != null) {
+            value.incrementHit();
+            hits++;
+        }
+    }
+
+    public void updateHits(MultiMapValue value, long hits) {
+        this.hits = this.hits - value.getHits() + hits;
+        value.setHits(hits);
+    }
+
+    public void incrementSize(int by) {
+        while (true) {
+            int initValue = size.get();
+            if (size.compareAndSet(initValue, initValue + by)) {
+                break;
+            }
+        }
+    }
+
+    public void decrementSize(int by) {
+        while (true) {
+            int initValue = size.get();
+            if (size.compareAndSet(initValue, initValue - by)) {
+                break;
+            }
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainerSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainerSupport.java
@@ -60,8 +60,7 @@ abstract class MultiMapContainerSupport {
     }
 
     protected Collection<MultiMapRecord> getNewRecordsCollection() {
-        final MultiMapConfig.ValueCollectionType valueCollectionType = config.getValueCollectionType();
-        return createCollection(valueCollectionType);
+        return createCollection(config.getValueCollectionType());
     }
 
     public MultiMapValue getMultiMapValueOrNull(Data dataKey) {
@@ -207,11 +206,11 @@ abstract class MultiMapContainerSupport {
         return config;
     }
 
-    public void incSize(int by) {
+    private void incSize(int by) {
         size += by;
     }
 
-    public void decrSize(int by) {
+    private void decrSize(int by) {
         size -= by;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainerSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainerSupport.java
@@ -18,6 +18,7 @@ package com.hazelcast.multimap.impl;
 
 import static com.hazelcast.multimap.impl.ValueCollectionFactory.createCollection;
 import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
+
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
@@ -98,17 +99,17 @@ abstract class MultiMapContainerSupport {
 
     public boolean addValue(Data dataKey, MultiMapRecord value, int index) {
         MultiMapValue multiMapValue = getOrCreateMultiMapValue(dataKey);
-        boolean added;
         if (index < 0) {
-            added = multiMapValue.getCollection(false).add(value);
+            boolean added = multiMapValue.getCollection(false).add(value);
+            if (added) {
+                incSize(1);
+            }
+            return added;
         } else {
             ((List<MultiMapRecord>) multiMapValue.getCollection(false)).add(index, value);
-            added = true;
-        }
-        if (added) {
             incSize(1);
+            return true;
         }
-        return added;
     }
 
     public boolean removeValue(Data dataKey, long recordId) {
@@ -187,9 +188,8 @@ abstract class MultiMapContainerSupport {
         if (value != null) {
             decrSize(value.size());
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
     public Collection<MultiMapRecord> remove(Data dataKey, boolean copyOf) {
@@ -197,9 +197,8 @@ abstract class MultiMapContainerSupport {
         if (multiMapValue != null) {
             decrSize(multiMapValue.size());
             return multiMapValue.getCollection(copyOf);
-        } else {
-            return null;
         }
+        return null;
     }
 
     public MultiMapConfig getConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainerSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapContainerSupport.java
@@ -16,15 +16,16 @@
 
 package com.hazelcast.multimap.impl;
 
+import static com.hazelcast.multimap.impl.ValueCollectionFactory.createCollection;
+import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
-
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.ConcurrentMap;
-
-import static com.hazelcast.multimap.impl.ValueCollectionFactory.createCollection;
-import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
 
 /**
  * Contains various {@link com.hazelcast.multimap.impl.MultiMapContainer} support methods.
@@ -32,6 +33,7 @@ import static com.hazelcast.util.MapUtil.createConcurrentHashMap;
 abstract class MultiMapContainerSupport {
 
     protected final ConcurrentMap<Data, MultiMapValue> multiMapValues = createConcurrentHashMap(1000);
+    protected volatile int size;
 
     protected final String name;
     protected final NodeEngine nodeEngine;
@@ -49,13 +51,17 @@ abstract class MultiMapContainerSupport {
             return multiMapValue;
         }
         // create multiMapValue
-        final MultiMapConfig.ValueCollectionType valueCollectionType = config.getValueCollectionType();
-        final Collection<MultiMapRecord> collection = createCollection(valueCollectionType);
+        final Collection<MultiMapRecord> collection = getNewRecordsCollection();
         multiMapValue = new MultiMapValue(collection);
 
         multiMapValues.put(dataKey, multiMapValue);
 
         return multiMapValue;
+    }
+
+    protected Collection<MultiMapRecord> getNewRecordsCollection() {
+        final MultiMapConfig.ValueCollectionType valueCollectionType = config.getValueCollectionType();
+        return createCollection(valueCollectionType);
     }
 
     public MultiMapValue getMultiMapValueOrNull(Data dataKey) {
@@ -66,7 +72,146 @@ abstract class MultiMapContainerSupport {
         return multiMapValues;
     }
 
+    public void setValue(Data dataKey, MultiMapValue value) {
+        MultiMapValue prevValue = multiMapValues.put(dataKey, value);
+        if (prevValue != null) {
+            decrSize(prevValue.size());
+        }
+        incSize(value.size());
+    }
+
+    public boolean setValue(Data dataKey, Collection<MultiMapRecord> records) {
+        MultiMapValue multiMapValue = getOrCreateMultiMapValue(dataKey);
+        Collection<MultiMapRecord> mapRecords = multiMapValue.getCollection(false);
+        decrSize(mapRecords.size());
+        mapRecords.clear();
+
+        boolean added = mapRecords.addAll(records);
+        if (added) {
+            incSize(records.size());
+        }
+        return added;
+    }
+
+    public boolean addValue(Data dataKey, MultiMapRecord value) {
+        return addValue(dataKey, value, -1);
+    }
+
+    public boolean addValue(Data dataKey, MultiMapRecord value, int index) {
+        MultiMapValue multiMapValue = getOrCreateMultiMapValue(dataKey);
+        boolean added;
+        if (index < 0) {
+            added = multiMapValue.getCollection(false).add(value);
+        } else {
+            ((List<MultiMapRecord>) multiMapValue.getCollection(false)).add(index, value);
+            added = true;
+        }
+        if (added) {
+            incSize(1);
+        }
+        return added;
+    }
+
+    public boolean removeValue(Data dataKey, long recordId) {
+        MultiMapValue multiMapValue = getMultiMapValueOrNull(dataKey);
+        if (multiMapValue == null) {
+            return false;
+        }
+        Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
+        Iterator<MultiMapRecord> iterator = coll.iterator();
+        while (iterator.hasNext()) {
+            if (iterator.next().getRecordId() == recordId) {
+                iterator.remove();
+                decrSize(1);
+                if (coll.isEmpty()) {
+                    multiMapValues.remove(dataKey);
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public long removeValue(Data dataKey, MultiMapRecord record) {
+        MultiMapValue multiMapValue = getMultiMapValueOrNull(dataKey);
+        if (multiMapValue == null) {
+            return -1;
+        }
+        Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
+        Iterator<MultiMapRecord> iterator = coll.iterator();
+        while (iterator.hasNext()) {
+            MultiMapRecord multiMapRecord = iterator.next();
+            if (multiMapRecord.equals(record)) {
+                iterator.remove();
+                decrSize(1);
+                if (coll.isEmpty()) {
+                    multiMapValues.remove(dataKey);
+                }
+                return multiMapRecord.getRecordId();
+            }
+        }
+        return -1;
+    }
+
+    public List<MultiMapRecord> removeAllValues(Data dataKey, Collection<Long> recordIds) {
+        List<MultiMapRecord> removed = new LinkedList<MultiMapRecord>();
+        MultiMapValue multiMapValue = getOrCreateMultiMapValue(dataKey);
+        for (Long recordId : recordIds) {
+            if (!multiMapValue.containsRecordId(recordId)) {
+                return removed;
+            }
+        }
+
+        int numOfRecsRemoved = 0;
+        Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
+        for (Long recordId : recordIds) {
+            Iterator<MultiMapRecord> iterator = coll.iterator();
+            while (iterator.hasNext()) {
+                MultiMapRecord record = iterator.next();
+                if (record.getRecordId() == recordId) {
+                    iterator.remove();
+                    removed.add(record);
+                    ++numOfRecsRemoved;
+                    break;
+                }
+            }
+        }
+        decrSize(numOfRecsRemoved);
+        if (coll.isEmpty()) {
+            multiMapValues.remove(dataKey);
+        }
+        return removed;
+    }
+
+    public boolean delete(Data dataKey) {
+        MultiMapValue value = multiMapValues.remove(dataKey);
+        if (value != null) {
+            decrSize(value.size());
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public Collection<MultiMapRecord> remove(Data dataKey, boolean copyOf) {
+        MultiMapValue multiMapValue = multiMapValues.remove(dataKey);
+        if (multiMapValue != null) {
+            decrSize(multiMapValue.size());
+            return multiMapValue.getCollection(copyOf);
+        } else {
+            return null;
+        }
+    }
+
     public MultiMapConfig getConfig() {
         return config;
+    }
+
+    public void incSize(int by) {
+        size += by;
+    }
+
+    public void decrSize(int by) {
+        size -= by;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -322,11 +322,7 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
             for (Map.Entry<Data, MultiMapValue> multiMapValueEntry : collections.entrySet()) {
                 MultiMapValue multiMapValue = multiMapValueEntry.getValue();
-                MultiMapValue prevValue = container.getMultiMapValues().put(multiMapValueEntry.getKey(), multiMapValue);
-                if (prevValue != null) {
-                    container.decrementSize(prevValue.size());
-                }
-                container.incrementSize(multiMapValue.size());
+                container.setValue(multiMapValueEntry.getKey(), multiMapValue);
                 long recordId = getMaxRecordId(multiMapValue);
                 maxRecordId = max(maxRecordId, recordId);
             }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapValue.java
@@ -51,7 +51,7 @@ public class MultiMapValue {
         throw new IllegalArgumentException("No Matching CollectionProxyType!");
     }
 
-    void incrementHit() {
+    void incHits() {
         hits++;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapValue.java
@@ -51,7 +51,7 @@ public class MultiMapValue {
         throw new IllegalArgumentException("No Matching CollectionProxyType!");
     }
 
-    public void incrementHit() {
+    void incrementHit() {
         hits++;
     }
 
@@ -70,5 +70,9 @@ public class MultiMapValue {
             }
         }
         return false;
+    }
+
+    public int size() {
+        return collection.size();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/CountOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/CountOperation.java
@@ -42,7 +42,7 @@ public class CountOperation extends AbstractKeyBasedMultiMapOperation implements
         MultiMapContainer container = getOrCreateContainer();
         ((MultiMapService) getService()).getLocalMultiMapStatsImpl(name).incrementOtherOperations();
         MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
-        response = multiMapValue == null ? 0 : multiMapValue.getCollection(false).size();
+        response = multiMapValue == null ? 0 : multiMapValue.size();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/GetAllOperation.java
@@ -46,7 +46,7 @@ public class GetAllOperation extends AbstractKeyBasedMultiMapOperation implement
         MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
         Collection<MultiMapRecord> coll = null;
         if (multiMapValue != null) {
-            multiMapValue.incrementHit();
+            container.incrementHit(multiMapValue);
             coll = multiMapValue.getCollection(executedLocally());
         }
         response = new MultiMapResponse(coll, getValueCollectionType(container));

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
@@ -16,22 +16,20 @@
 
 package com.hazelcast.multimap.impl.operations;
 
+import static com.hazelcast.util.MapUtil.createHashMap;
+
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
 import com.hazelcast.multimap.impl.MultiMapRecord;
-import com.hazelcast.multimap.impl.MultiMapValue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-
-import static com.hazelcast.util.MapUtil.createHashMap;
 
 /**
  * Creates backups for merged {@link MultiMapRecord} after split-brain healing with a {@link SplitBrainMergePolicy}.
@@ -60,15 +58,7 @@ public class MergeBackupOperation extends AbstractMultiMapOperation implements B
             if (value.isEmpty()) {
                 container.remove(key, false);
             } else {
-                MultiMapValue containerValue = container.getOrCreateMultiMapValue(key);
-                Collection<MultiMapRecord> collection = containerValue.getCollection(false);
-                container.decrementSize(collection.size());
-                collection.clear();
-                if (!collection.addAll(value)) {
-                    response = false;
-                } else {
-                    container.incrementSize(value.size());
-                }
+                response = container.setValue(key, value);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/MergeBackupOperation.java
@@ -62,9 +62,12 @@ public class MergeBackupOperation extends AbstractMultiMapOperation implements B
             } else {
                 MultiMapValue containerValue = container.getOrCreateMultiMapValue(key);
                 Collection<MultiMapRecord> collection = containerValue.getCollection(false);
+                container.decrementSize(collection.size());
                 collection.clear();
                 if (!collection.addAll(value)) {
                     response = false;
+                } else {
+                    container.incrementSize(value.size());
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutBackupOperation.java
@@ -24,7 +24,6 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -61,6 +60,14 @@ public class PutBackupOperation extends AbstractKeyBasedMultiMapOperation implem
             } catch (IndexOutOfBoundsException e) {
                 response = e;
             }
+        }
+    }
+
+    @Override
+    public void afterRun() throws Exception {
+        super.afterRun();
+        if (Boolean.TRUE.equals(response)) {
+            getOrCreateContainerWithoutAccess().incrementSize(1);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/PutOperation.java
@@ -66,7 +66,9 @@ public class PutOperation extends AbstractBackupAwareMultiMapOperation implement
     @Override
     public void afterRun() throws Exception {
         if (Boolean.TRUE.equals(response)) {
-            getOrCreateContainer().update();
+            MultiMapContainer container = getOrCreateContainer();
+            container.update();
+            container.incrementSize(1);
             publishEvent(EntryEventType.ADDED, dataKey, value, null);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
@@ -18,16 +18,11 @@ package com.hazelcast.multimap.impl.operations;
 
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
-import com.hazelcast.multimap.impl.MultiMapRecord;
-import com.hazelcast.multimap.impl.MultiMapValue;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 
 public class RemoveBackupOperation extends AbstractKeyBasedMultiMapOperation implements BackupOperation {
 
@@ -43,32 +38,8 @@ public class RemoveBackupOperation extends AbstractKeyBasedMultiMapOperation imp
 
     @Override
     public void run() throws Exception {
-        response = false;
         MultiMapContainer container = getOrCreateContainerWithoutAccess();
-        MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
-        if (multiMapValue == null) {
-            return;
-        }
-        Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
-        Iterator<MultiMapRecord> iterator = coll.iterator();
-        while (iterator.hasNext()) {
-            if (iterator.next().getRecordId() == recordId) {
-                iterator.remove();
-                response = true;
-                if (coll.isEmpty()) {
-                    container.delete(dataKey);
-                }
-                break;
-            }
-        }
-    }
-
-    @Override
-    public void afterRun() throws Exception {
-        super.afterRun();
-        if (Boolean.TRUE.equals(response)) {
-            getOrCreateContainerWithoutAccess().decrementSize(1);
-        }
+        response = container.removeValue(dataKey, recordId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveBackupOperation.java
@@ -64,6 +64,14 @@ public class RemoveBackupOperation extends AbstractKeyBasedMultiMapOperation imp
     }
 
     @Override
+    public void afterRun() throws Exception {
+        super.afterRun();
+        if (Boolean.TRUE.equals(response)) {
+            getOrCreateContainerWithoutAccess().decrementSize(1);
+        }
+    }
+
+    @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeLong(recordId);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/operations/RemoveOperation.java
@@ -72,7 +72,9 @@ public class RemoveOperation extends AbstractBackupAwareMultiMapOperation implem
     @Override
     public void afterRun() throws Exception {
         if (Boolean.TRUE.equals(response)) {
-            getOrCreateContainer().update();
+            MultiMapContainer container = getOrCreateContainer();
+            container.update();
+            container.decrementSize(1);
             publishEvent(EntryEventType.REMOVED, dataKey, null, value);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionalMultiMapProxySupport.java
@@ -47,8 +47,8 @@ import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public abstract class TransactionalMultiMapProxySupport<K, V>
-        extends TransactionalDistributedObject<MultiMapService>
-        implements TransactionalMultiMap<K, V> {
+    extends TransactionalDistributedObject<MultiMapService>
+    implements TransactionalMultiMap<K, V> {
 
     private static final double TIMEOUT_EXTEND_MULTIPLIER = 1.5;
 
@@ -84,7 +84,7 @@ public abstract class TransactionalMultiMapProxySupport<K, V>
 
         try {
             Map<Integer, Object> results = operationService.invokeOnAllPartitions(MultiMapService.SERVICE_NAME,
-                    new MultiMapOperationFactory(name, MultiMapOperationFactory.OperationFactoryType.SIZE));
+                new MultiMapOperationFactory(name, MultiMapOperationFactory.OperationFactoryType.SIZE));
             int size = 0;
             for (Object obj : results.values()) {
                 if (obj == null) {
@@ -111,7 +111,7 @@ public abstract class TransactionalMultiMapProxySupport<K, V>
         }
     }
 
-    boolean putInternal(Data key, Data value) {
+    boolean  putInternal(Data key, Data value) {
         checkObjectNotNull(key);
         checkObjectNotNull(value);
 
@@ -219,7 +219,7 @@ public abstract class TransactionalMultiMapProxySupport<K, V>
             try {
                 int partitionId = partitionService.getPartitionId(key);
                 Future<MultiMapResponse> future = operationService
-                        .invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
+                    .invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
                 MultiMapResponse response = future.get();
                 coll = response.getRecordCollection(getNodeEngine());
             } catch (Throwable t) {
@@ -265,7 +265,7 @@ public abstract class TransactionalMultiMapProxySupport<K, V>
         try {
             int partitionId = partitionService.getPartitionId(key);
             Future<MultiMapResponse> future = operationService
-                    .invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
+                .invokeOnPartition(MultiMapService.SERVICE_NAME, operation, partitionId);
             return future.get();
         } catch (Throwable t) {
             throw rethrow(t);

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
@@ -25,9 +25,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-
 import java.io.IOException;
-import java.util.Collection;
 
 public class TxnPutBackupOperation extends AbstractKeyBasedMultiMapOperation implements BackupOperation {
 
@@ -47,17 +45,13 @@ public class TxnPutBackupOperation extends AbstractKeyBasedMultiMapOperation imp
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainerWithoutAccess();
         MultiMapValue multiMapValue = container.getOrCreateMultiMapValue(dataKey);
-        response = true;
         if (multiMapValue.containsRecordId(recordId)) {
             response = false;
             return;
         }
-        Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
+        response = true;
         MultiMapRecord record = new MultiMapRecord(recordId, isBinary() ? value : toObject(value));
-        boolean added = coll.add(record);
-        if (added) {
-            container.incrementSize(1);
-        }
+        container.addValue(dataKey, record);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutBackupOperation.java
@@ -54,7 +54,10 @@ public class TxnPutBackupOperation extends AbstractKeyBasedMultiMapOperation imp
         }
         Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
         MultiMapRecord record = new MultiMapRecord(recordId, isBinary() ? value : toObject(value));
-        coll.add(record);
+        boolean added = coll.add(record);
+        if (added) {
+            container.incrementSize(1);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
@@ -29,9 +29,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.MutatingOperation;
-
 import java.io.IOException;
-import java.util.Collection;
 
 public class TxnPutOperation extends AbstractKeyBasedMultiMapOperation implements BackupAwareOperation, MutatingOperation {
 
@@ -60,12 +58,8 @@ public class TxnPutOperation extends AbstractKeyBasedMultiMapOperation implement
         }
         response = true;
         container.update();
-        Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
         MultiMapRecord record = new MultiMapRecord(recordId, isBinary() ? value : toObject(value));
-        boolean added = coll.add(record);
-        if (added) {
-            container.incrementSize(1);
-        }
+        container.addValue(dataKey, record);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnPutOperation.java
@@ -62,7 +62,10 @@ public class TxnPutOperation extends AbstractKeyBasedMultiMapOperation implement
         container.update();
         Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
         MultiMapRecord record = new MultiMapRecord(recordId, isBinary() ? value : toObject(value));
-        coll.add(record);
+        boolean added = coll.add(record);
+        if (added) {
+            container.incrementSize(1);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllBackupOperation.java
@@ -53,7 +53,9 @@ public class TxnRemoveAllBackupOperation extends AbstractKeyBasedMultiMapOperati
                 return;
             }
         }
+
         response = true;
+        int numOfRecsRemoved = 0;
         Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
         for (Long recordId : recordIds) {
             Iterator<MultiMapRecord> iterator = coll.iterator();
@@ -61,13 +63,18 @@ public class TxnRemoveAllBackupOperation extends AbstractKeyBasedMultiMapOperati
                 MultiMapRecord record = iterator.next();
                 if (record.getRecordId() == recordId) {
                     iterator.remove();
+                    ++numOfRecsRemoved;
                     break;
                 }
             }
         }
+        if (numOfRecsRemoved > 0) {
+            container.decrementSize(numOfRecsRemoved);
+        }
         if (coll.isEmpty()) {
             container.delete(dataKey);
         }
+
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveAllOperation.java
@@ -91,6 +91,7 @@ public class TxnRemoveAllOperation extends AbstractKeyBasedMultiMapOperation imp
         MultiMapService service = getService();
         service.getLocalMultiMapStatsImpl(name).incrementRemoveLatencyNanos(elapsed);
         if (removed != null) {
+            getOrCreateContainer().decrementSize(removed.size());
             for (MultiMapRecord record : removed) {
                 publishEvent(EntryEventType.REMOVED, dataKey, null, record.getObject());
             }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
@@ -58,6 +58,7 @@ public class TxnRemoveBackupOperation extends AbstractKeyBasedMultiMapOperation 
         while (iterator.hasNext()) {
             if (iterator.next().getRecordId() == recordId) {
                 iterator.remove();
+                container.decrementSize(1);
                 break;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveBackupOperation.java
@@ -18,17 +18,12 @@ package com.hazelcast.multimap.impl.txn;
 
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
-import com.hazelcast.multimap.impl.MultiMapRecord;
-import com.hazelcast.multimap.impl.MultiMapValue;
 import com.hazelcast.multimap.impl.operations.AbstractKeyBasedMultiMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
-
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 
 public class TxnRemoveBackupOperation extends AbstractKeyBasedMultiMapOperation implements BackupOperation {
 
@@ -47,24 +42,7 @@ public class TxnRemoveBackupOperation extends AbstractKeyBasedMultiMapOperation 
     @Override
     public void run() throws Exception {
         MultiMapContainer container = getOrCreateContainerWithoutAccess();
-        MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
-        if (multiMapValue == null || !multiMapValue.containsRecordId(recordId)) {
-            response = false;
-            return;
-        }
-        response = true;
-        Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
-        Iterator<MultiMapRecord> iterator = coll.iterator();
-        while (iterator.hasNext()) {
-            if (iterator.next().getRecordId() == recordId) {
-                iterator.remove();
-                container.decrementSize(1);
-                break;
-            }
-        }
-        if (coll.isEmpty()) {
-            container.delete(dataKey);
-        }
+        response = container.removeValue(dataKey, recordId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
@@ -59,6 +59,7 @@ public class TxnRemoveOperation extends AbstractKeyBasedMultiMapOperation implem
             response = false;
             return;
         }
+
         response = true;
         container.update();
         Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
@@ -66,6 +67,7 @@ public class TxnRemoveOperation extends AbstractKeyBasedMultiMapOperation implem
         while (iter.hasNext()) {
             if (iter.next().getRecordId() == recordId) {
                 iter.remove();
+                container.decrementSize(1);
                 break;
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TxnRemoveOperation.java
@@ -19,9 +19,7 @@ package com.hazelcast.multimap.impl.txn;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.multimap.impl.MultiMapContainer;
 import com.hazelcast.multimap.impl.MultiMapDataSerializerHook;
-import com.hazelcast.multimap.impl.MultiMapRecord;
 import com.hazelcast.multimap.impl.MultiMapService;
-import com.hazelcast.multimap.impl.MultiMapValue;
 import com.hazelcast.multimap.impl.operations.AbstractKeyBasedMultiMapOperation;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -29,10 +27,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.MutatingOperation;
-
 import java.io.IOException;
-import java.util.Collection;
-import java.util.Iterator;
 
 public class TxnRemoveOperation extends AbstractKeyBasedMultiMapOperation implements BackupAwareOperation, MutatingOperation {
 
@@ -54,26 +49,7 @@ public class TxnRemoveOperation extends AbstractKeyBasedMultiMapOperation implem
     public void run() throws Exception {
         startTimeNanos = System.nanoTime();
         MultiMapContainer container = getOrCreateContainer();
-        MultiMapValue multiMapValue = container.getMultiMapValueOrNull(dataKey);
-        if (multiMapValue == null || !multiMapValue.containsRecordId(recordId)) {
-            response = false;
-            return;
-        }
-
-        response = true;
-        container.update();
-        Collection<MultiMapRecord> coll = multiMapValue.getCollection(false);
-        Iterator<MultiMapRecord> iter = coll.iterator();
-        while (iter.hasNext()) {
-            if (iter.next().getRecordId() == recordId) {
-                iter.remove();
-                container.decrementSize(1);
-                break;
-            }
-        }
-        if (coll.isEmpty()) {
-            container.delete(dataKey);
-        }
+        response = container.removeValue(dataKey, recordId);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapContainerStatisticsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapContainerStatisticsTest.java
@@ -154,32 +154,26 @@ public class MultiMapContainerStatisticsTest extends HazelcastTestSupport {
         //Test put operation
         assertSize(0);
         multiMap.put(key, "value1");
-        sleepMillis(10);
         assertSize(1);
 
         multiMap.put(key, "value2");
         multiMap.put(key, "value3");
-        sleepMillis(10);
         assertSize(3);
 
         //Test remove operation
         multiMap.remove(key, "value1");
-        sleepMillis(10);
         assertSize(2);
 
         multiMap.remove(key, "invalid_value");
-        sleepMillis(10);
         assertSize(2);
 
         //Test clear operation
         multiMap.lock(key);
         multiMap.clear();
-        sleepMillis(10);
         assertSize(2);
 
         multiMap.unlock(key);
         multiMap.clear();
-        sleepMillis(10);
         assertSize(0);
     }
 


### PR DESCRIPTION
As detailed in the issue, the `MultiMapService.createStats()` method was performing a full iteration on all the values contained in the MultiMap
The approach I've taken to resolve the issue is - I've added `hits` and `size` as instance variables to the `MultiMapContainer` class. We maintain the values of these variables as various operations are performed on the MultiMap.