### PR TITLE
Added HazelcastStarterConstructor annotation to HazelcastStarter

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarterConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarterConstructor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter;
+
+import com.hazelcast.test.starter.HazelcastProxyFactory.ProxyPolicy;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation for constructor classes for {@link HazelcastProxyFactory}.
+ * <p>
+ * The annotated classes have to be in the package
+ * {@code com.hazelcast.test.starter.constructor} to be registered.
+ */
+@Retention(value = RUNTIME)
+@Target(TYPE)
+public @interface HazelcastStarterConstructor {
+
+    /**
+     * The class names which this constructor class constructs.
+     *
+     * @return the supported class names
+     */
+    String[] classNames() default "";
+
+    /**
+     * The {@link ProxyPolicy} the supported classes should use.
+     * <p>
+     * Note: Classes which use {@link ProxyPolicy#NO_PROXY} have to implement
+     * {@link com.hazelcast.util.ConstructorFunction}. Classes which use
+     * {@link ProxyPolicy#SUBCLASS_PROXY} can be an empty class.
+     *
+     * @return the {@link ProxyPolicy} of the supported classes
+     */
+    ProxyPolicy proxyPolicy() default ProxyPolicy.NO_PROXY;
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarterUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastStarterUtils.java
@@ -23,6 +23,14 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static com.hazelcast.nio.IOUtil.closeResource;
 import static java.lang.String.format;
@@ -59,11 +67,11 @@ public class HazelcastStarterUtils {
     }
 
     /**
-     * Transfers the given throwable to the class loader hosting the
+     * Transfers the given {@link Throwable} to the classloader hosting the
      * compatibility tests.
      *
-     * @param throwable the throwable to transfer
-     * @return the transferred throwable
+     * @param throwable the Throwable to transfer
+     * @return the transferred Throwable
      */
     public static Throwable transferThrowable(Throwable throwable) {
         if (throwable.getClass().getClassLoader() == HazelcastStarterUtils.class.getClassLoader()) {
@@ -106,5 +114,26 @@ public class HazelcastStarterUtils {
      */
     public static void assertInstanceOfByClassName(String className, Object object) {
         assertEquals(className, object.getClass().getName());
+    }
+
+    /**
+     * Returns a {@link Collection} object for a given collection interface.
+     *
+     * @return a new Collection object of a class that is assignable from the given type
+     * @throws UnsupportedOperationException if the given interface is not implemented
+     */
+    public static Collection<Object> newCollectionFor(Class<?> type) {
+        if (Set.class.isAssignableFrom(type)) {
+            // original set might be ordered
+            return new LinkedHashSet<Object>();
+        } else if (List.class.isAssignableFrom(type)) {
+            return new ArrayList<Object>();
+        } else if (Queue.class.isAssignableFrom(type)) {
+            return new ConcurrentLinkedQueue<Object>();
+        } else if (Collection.class.isAssignableFrom(type)) {
+            return new LinkedList<Object>();
+        } else {
+            throw new UnsupportedOperationException("Cannot locate collection type for " + type);
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ProxyInvocationHandler.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ProxyInvocationHandler.java
@@ -24,9 +24,9 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
 
-import static com.hazelcast.test.starter.HazelcastProxyFactory.newCollectionFor;
 import static com.hazelcast.test.starter.HazelcastStarterUtils.debug;
 import static com.hazelcast.test.starter.HazelcastStarterUtils.isDebugEnabled;
+import static com.hazelcast.test.starter.HazelcastStarterUtils.newCollectionFor;
 import static com.hazelcast.test.starter.HazelcastStarterUtils.rethrowGuardianException;
 import static com.hazelcast.test.starter.HazelcastStarterUtils.transferThrowable;
 
@@ -40,8 +40,8 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        ClassLoader targetClassLoader = proxy.getClass().getClassLoader();
         debug("Proxy %s called. Method: %s", this, method);
+        ClassLoader targetClassLoader = proxy.getClass().getClassLoader();
         Class<?> delegateClass = delegate.getClass();
         Method methodDelegate = getMethodDelegate(method, delegateClass);
 

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/ReflectionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/ReflectionUtils.java
@@ -16,20 +16,71 @@
 
 package com.hazelcast.test.starter;
 
+import org.reflections.Reflections;
+import org.reflections.scanners.MethodAnnotationsScanner;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.util.Preconditions.checkHasText;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.net.URLClassLoader.newInstance;
 
 /**
  * Reflection utilities.
  */
+@SuppressWarnings("WeakerAccess")
 public final class ReflectionUtils {
 
     private ReflectionUtils() {
+    }
+
+    public static Reflections getReflectionsForTestPackage(String forPackage) {
+        try {
+            URL testClassesURL = new File("target/test-classes").toURI().toURL();
+            URLClassLoader classLoader = newInstance(new URL[]{testClassesURL}, ClasspathHelper.staticClassLoader());
+            return new Reflections(new ConfigurationBuilder()
+                    .addUrls(ClasspathHelper.forPackage(forPackage, classLoader))
+                    .addClassLoader(classLoader)
+                    .filterInputsBy(new FilterBuilder().includePackage(forPackage))
+                    .setScanners(
+                            new SubTypesScanner(false),
+                            new TypeAnnotationsScanner(),
+                            new MethodAnnotationsScanner()));
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Constructor<T> getConstructor(Class<?> constructorClass, Class<?>... parameterTypes) {
+        try {
+            Constructor<T> constructor = (Constructor<T>) constructorClass.getConstructor(parameterTypes);
+            constructor.setAccessible(true);
+            return constructor;
+        } catch (NoSuchMethodException ignored) {
+            try {
+                Constructor<T> constructor = (Constructor<T>) constructorClass.getDeclaredConstructor(parameterTypes);
+                constructor.setAccessible(true);
+                return constructor;
+            } catch (NoSuchMethodException e) {
+                throw new IllegalArgumentException("Could not find constructor " + constructorClass.getSimpleName() + "("
+                        + Arrays.toString(parameterTypes) + ")", e);
+            }
+        }
     }
 
     public static Object getFieldValueReflectively(Object arg, String fieldName) throws IllegalAccessException {

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractConfigConstructor.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.nio.ClassLoaderUtil;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.ProxyPolicy.RETURN_SAME;
+import static com.hazelcast.test.starter.HazelcastProxyFactory.shouldProxy;
+import static com.hazelcast.test.starter.HazelcastStarterUtils.debug;
+import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
+
+/**
+ * Abstract class for constructors of config classes.
+ */
+abstract class AbstractConfigConstructor extends AbstractStarterObjectConstructor {
+
+    AbstractConfigConstructor(Class<?> targetClass) {
+        super(targetClass);
+    }
+
+    @SuppressWarnings("unchecked")
+    static Object cloneConfig(Object thisConfigObject, ClassLoader classloader) throws Exception {
+        if (thisConfigObject == null) {
+            return null;
+        }
+
+        Class thisConfigClass = thisConfigObject.getClass();
+        if (shouldProxy(thisConfigClass, new Class[0]) == RETURN_SAME) {
+            return thisConfigObject;
+        }
+
+        Class<?> otherConfigClass = classloader.loadClass(thisConfigClass.getName());
+        if (isQuorumFunctionImplementation(thisConfigClass)) {
+            return cloneQuorumFunctionImplementation(thisConfigObject, otherConfigClass);
+        }
+
+        Object otherConfigObject = ClassLoaderUtil.newInstance(otherConfigClass.getClassLoader(), otherConfigClass.getName());
+        for (Method method : thisConfigClass.getMethods()) {
+            if (!isGetter(method)) {
+                continue;
+            }
+            Class returnType = method.getReturnType();
+            Class<?> otherReturnType;
+            try {
+                otherReturnType = getOtherReturnType(classloader, returnType);
+            } catch (ClassNotFoundException e) {
+                // new configuration option, return type was not found in target classloader
+                debug("Configuration option %s is not available in target classloader: %s", method.getName(), e.getMessage());
+                continue;
+            }
+
+            Method setter = getSetter(otherConfigClass, otherReturnType, createSetterName(method));
+            if (setter != null) {
+                if (Properties.class.isAssignableFrom(returnType)) {
+                    Properties original = (Properties) method.invoke(thisConfigObject, null);
+                    updateConfig(setter, otherConfigObject, copy(original));
+                } else if (Map.class.isAssignableFrom(returnType) || ConcurrentMap.class.isAssignableFrom(returnType)) {
+                    Map map = (Map) method.invoke(thisConfigObject, null);
+                    Map otherMap = ConcurrentMap.class.isAssignableFrom(returnType) ? new ConcurrentHashMap() : new HashMap();
+                    for (Object entry : map.entrySet()) {
+                        String key = (String) ((Map.Entry) entry).getKey();
+                        Object value = ((Map.Entry) entry).getValue();
+                        Object otherMapItem = cloneConfig(value, classloader);
+                        otherMap.put(key, otherMapItem);
+                    }
+                    updateConfig(setter, otherConfigObject, otherMap);
+                } else if (returnType.equals(List.class)) {
+                    List list = (List) method.invoke(thisConfigObject, null);
+                    List otherList = new ArrayList();
+                    for (Object item : list) {
+                        Object otherItem = cloneConfig(item, classloader);
+                        otherList.add(otherItem);
+                    }
+                    updateConfig(setter, otherConfigObject, otherList);
+                } else if (returnType.isEnum()) {
+                    Enum thisSubConfigObject = (Enum) method.invoke(thisConfigObject, null);
+                    Class otherEnumClass = classloader.loadClass(thisSubConfigObject.getClass().getName());
+                    Object otherEnumValue = Enum.valueOf(otherEnumClass, thisSubConfigObject.name());
+                    updateConfig(setter, otherConfigObject, otherEnumValue);
+                } else if (returnType.getName().startsWith("java") || returnType.isPrimitive()) {
+                    Object thisSubConfigObject = method.invoke(thisConfigObject, null);
+                    updateConfig(setter, otherConfigObject, thisSubConfigObject);
+                } else if (returnType.getName().startsWith("com.hazelcast.memory.MemorySize")) {
+                    // ignore
+                } else if (returnType.getName().startsWith("com.hazelcast")) {
+                    Object thisSubConfigObject = method.invoke(thisConfigObject, null);
+                    Object otherSubConfig = cloneConfig(thisSubConfigObject, classloader);
+                    updateConfig(setter, otherConfigObject, otherSubConfig);
+                }
+            }
+        }
+        return otherConfigObject;
+    }
+
+    private static boolean isGetter(Method method) {
+        if (!method.getName().startsWith("get") && !method.getName().startsWith("is")) {
+            return false;
+        }
+        if (method.getParameterTypes().length != 0) {
+            return false;
+        }
+        return !void.class.equals(method.getReturnType());
+    }
+
+    private static Class<?> getOtherReturnType(ClassLoader classloader, Class returnType) throws Exception {
+        String returnTypeName = returnType.getName();
+        if (returnTypeName.startsWith("com.hazelcast")) {
+            return classloader.loadClass(returnTypeName);
+        }
+        return returnType;
+    }
+
+    private static Method getSetter(Class<?> otherConfigClass, Class returnType, String setterName) {
+        try {
+            return otherConfigClass.getMethod(setterName, returnType);
+        } catch (NoSuchMethodException e) {
+            return null;
+        }
+    }
+
+    private static void updateConfig(Method setterMethod, Object otherConfigObject, Object value) {
+        try {
+            setterMethod.invoke(otherConfigObject, value);
+        } catch (IllegalAccessException e) {
+            debug("Could not update config via %s: %s", setterMethod.getName(), e.getMessage());
+        } catch (InvocationTargetException e) {
+            debug("Could not update config via %s: %s", setterMethod.getName(), e.getMessage());
+        } catch (IllegalArgumentException e) {
+            debug("Could not update config via %s: %s", setterMethod.getName(), e.getMessage());
+        }
+    }
+
+    private static String createSetterName(Method getter) {
+        if (getter.getName().startsWith("get")) {
+            return "s" + getter.getName().substring(1);
+        }
+        if (getter.getName().startsWith("is")) {
+            return "set" + getter.getName().substring(2);
+        }
+        throw new IllegalArgumentException("Unknown getter method name: " + getter.getName());
+    }
+
+    private static Properties copy(Properties original) {
+        if (original == null) {
+            return null;
+        }
+        Properties copy = new Properties();
+        for (String name : original.stringPropertyNames()) {
+            copy.setProperty(name, original.getProperty(name));
+        }
+        return copy;
+    }
+
+    /**
+     * Clones the built-in QuorumFunction implementations.
+     */
+    private static Object cloneQuorumFunctionImplementation(Object quorumFunction, Class<?> targetClass) throws Exception {
+        if (targetClass.getName().equals("com.hazelcast.quorum.impl.ProbabilisticQuorumFunction")) {
+            int size = (Integer) getFieldValueReflectively(quorumFunction, "quorumSize");
+            double suspicionThreshold = (Double) getFieldValueReflectively(quorumFunction, "suspicionThreshold");
+            int maxSampleSize = (Integer) getFieldValueReflectively(quorumFunction, "maxSampleSize");
+            long minStdDeviationMillis = (Long) getFieldValueReflectively(quorumFunction, "minStdDeviationMillis");
+            long acceptableHeartbeatPauseMillis = (Long) getFieldValueReflectively(quorumFunction,
+                    "acceptableHeartbeatPauseMillis");
+            long heartbeatIntervalMillis = (Long) getFieldValueReflectively(quorumFunction, "heartbeatIntervalMillis");
+
+            Constructor<?> constructor = targetClass.getConstructor(Integer.TYPE, Long.TYPE, Long.TYPE, Integer.TYPE, Long.TYPE,
+                    Double.TYPE);
+
+            return constructor.newInstance(size, heartbeatIntervalMillis, acceptableHeartbeatPauseMillis,
+                    maxSampleSize, minStdDeviationMillis, suspicionThreshold);
+        } else if (targetClass.getName().equals("com.hazelcast.quorum.impl.RecentlyActiveQuorumFunction")) {
+            int size = (Integer) getFieldValueReflectively(quorumFunction, "quorumSize");
+            int heartbeatToleranceMillis = (Integer) getFieldValueReflectively(quorumFunction, "heartbeatToleranceMillis");
+
+            Constructor<?> constructor = targetClass.getConstructor(Integer.TYPE, Integer.TYPE);
+            return constructor.newInstance(size, heartbeatToleranceMillis);
+        } else {
+            debug("Did not handle configured QuorumFunction implementation %s", targetClass.getName());
+            return null;
+        }
+    }
+
+    private static boolean isQuorumFunctionImplementation(Class<?> klass) throws Exception {
+        ClassLoader classLoader = klass.getClassLoader();
+        Class<?> quorumFunctionInterface = classLoader.loadClass("com.hazelcast.quorum.QuorumFunction");
+        return quorumFunctionInterface.isAssignableFrom(klass);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractStarterObjectConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AbstractStarterObjectConstructor.java
@@ -22,10 +22,14 @@ import static com.hazelcast.test.starter.HazelcastStarterUtils.rethrowGuardianEx
 import static com.hazelcast.test.starter.HazelcastStarterUtils.transferThrowable;
 
 /**
- * Abstract superclass for {@code ConstructorFunction}s which, given a target {@code Class}, create an {@code Object} of
- * target {@code Class} off an input {@code Object}. For example, assuming a {@code Config} instance in current classloader,
- * the appropriate {@code ConstructorFunction} would create a {@code Config} object representing the same configuration for
- * the classloader that loads Hazelcast version 3.8.
+ * Abstract superclass for {@link ConstructorFunction}s which, given a target
+ * {@link Class}, create an {@link Object} of target {@link Class} off an input
+ * {@link Object}.
+ * <p>
+ * For example, assuming a {@link com.hazelcast.config.Config} instance in the
+ * current classloader, the appropriate {@link ConstructorFunction} would
+ * create a {@link com.hazelcast.config.Config} object representing the same
+ * configuration for the classloader that loads Hazelcast version 3.8.
  */
 public abstract class AbstractStarterObjectConstructor implements ConstructorFunction<Object, Object> {
 

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AddressConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/AddressConstructor.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.test.starter.constructor;
 
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
 import java.lang.reflect.Constructor;
 
 import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.nio.Address"})
 public class AddressConstructor extends AbstractStarterObjectConstructor {
 
     public AddressConstructor(Class<?> targetClass) {

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/ConfigConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/ConfigConstructor.java
@@ -16,29 +16,16 @@
 
 package com.hazelcast.test.starter.constructor;
 
-import com.hazelcast.nio.ClassLoaderUtil;
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
-import static com.hazelcast.test.starter.HazelcastProxyFactory.ProxyPolicy.RETURN_SAME;
-import static com.hazelcast.test.starter.HazelcastProxyFactory.shouldProxy;
-import static com.hazelcast.test.starter.HazelcastStarterUtils.debug;
-import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 
 /**
  * Clones the configuration from {@code mainConfig} to a new configuration object loaded in the
  * target {@code classloader}. The returned configuration has its classloader set to the target classloader.
  */
-public class ConfigConstructor extends AbstractStarterObjectConstructor {
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.config.Config", "com.hazelcast.client.config.ClientConfig"})
+public class ConfigConstructor extends AbstractConfigConstructor {
 
     public ConfigConstructor(Class<?> targetClass) {
         super(targetClass);
@@ -52,182 +39,5 @@ public class ConfigConstructor extends AbstractStarterObjectConstructor {
         Method setClassLoaderMethod = targetClass.getMethod("setClassLoader", ClassLoader.class);
         setClassLoaderMethod.invoke(otherConfig, classloader);
         return otherConfig;
-    }
-
-    private static boolean isGetter(Method method) {
-        if (!method.getName().startsWith("get") && !method.getName().startsWith("is")) {
-            return false;
-        }
-        if (method.getParameterTypes().length != 0) {
-            return false;
-        }
-        return !void.class.equals(method.getReturnType());
-    }
-
-    private static Object cloneConfig(Object thisConfigObject, ClassLoader classloader) throws Exception {
-        if (thisConfigObject == null) {
-            return null;
-        }
-
-        Class thisConfigClass = thisConfigObject.getClass();
-        if (shouldProxy(thisConfigClass, new Class[0]) == RETURN_SAME) {
-            return thisConfigObject;
-        }
-
-        Class<?> otherConfigClass = classloader.loadClass(thisConfigClass.getName());
-        if (isQuorumFunctionImplementation(thisConfigClass)) {
-            return cloneQuorumFunctionImplementation(thisConfigObject, otherConfigClass);
-        }
-
-        Object otherConfigObject = ClassLoaderUtil.newInstance(otherConfigClass.getClassLoader(), otherConfigClass.getName());
-        for (Method method : thisConfigClass.getMethods()) {
-            if (!isGetter(method)) {
-                continue;
-            }
-            Class returnType = method.getReturnType();
-            Class<?> otherReturnType;
-            try {
-                otherReturnType = getOtherReturnType(classloader, returnType);
-            } catch (ClassNotFoundException e) {
-                // new configuration option, return type was not found in target classloader
-                debug("Configuration option %s is not available in target classloader: %s", method.getName(), e.getMessage());
-                continue;
-            }
-
-            Method setter = getSetter(otherConfigClass, otherReturnType, createSetterName(method));
-            if (setter != null) {
-                if (Properties.class.isAssignableFrom(returnType)) {
-                    Properties original = (Properties) method.invoke(thisConfigObject, null);
-                    updateConfig(setter, otherConfigObject, copy(original));
-                } else if (Map.class.isAssignableFrom(returnType) || ConcurrentMap.class.isAssignableFrom(returnType)) {
-                    Map map = (Map) method.invoke(thisConfigObject, null);
-                    Map otherMap = ConcurrentMap.class.isAssignableFrom(returnType) ? new ConcurrentHashMap() : new HashMap();
-                    for (Object entry : map.entrySet()) {
-                        String key = (String) ((Map.Entry) entry).getKey();
-                        Object value = ((Map.Entry) entry).getValue();
-                        Object otherMapItem = cloneConfig(value, classloader);
-                        otherMap.put(key, otherMapItem);
-                    }
-                    updateConfig(setter, otherConfigObject, otherMap);
-                } else if (returnType.equals(List.class)) {
-                    List list = (List) method.invoke(thisConfigObject, null);
-                    List otherList = new ArrayList();
-                    for (Object item : list) {
-                        Object otherItem = cloneConfig(item, classloader);
-                        otherList.add(otherItem);
-                    }
-                    updateConfig(setter, otherConfigObject, otherList);
-                } else if (returnType.isEnum()) {
-                    Enum thisSubConfigObject = (Enum) method.invoke(thisConfigObject, null);
-                    Class otherEnumClass = classloader.loadClass(thisSubConfigObject.getClass().getName());
-                    Object otherEnumValue = Enum.valueOf(otherEnumClass, thisSubConfigObject.name());
-                    updateConfig(setter, otherConfigObject, otherEnumValue);
-                } else if (returnType.getName().startsWith("java") || returnType.isPrimitive()) {
-                    Object thisSubConfigObject = method.invoke(thisConfigObject, null);
-                    updateConfig(setter, otherConfigObject, thisSubConfigObject);
-                } else if (returnType.getName().startsWith("com.hazelcast.memory.MemorySize")) {
-                    // ignore
-                } else if (returnType.getName().startsWith("com.hazelcast")) {
-                    Object thisSubConfigObject = method.invoke(thisConfigObject, null);
-                    Object otherSubConfig = cloneConfig(thisSubConfigObject, classloader);
-                    updateConfig(setter, otherConfigObject, otherSubConfig);
-                }
-            }
-        }
-        return otherConfigObject;
-    }
-
-    private static Class<?> getOtherReturnType(ClassLoader classloader, Class returnType) throws ClassNotFoundException {
-        String returnTypeName = returnType.getName();
-        if (returnTypeName.startsWith("com.hazelcast")) {
-            return classloader.loadClass(returnTypeName);
-        }
-        return returnType;
-    }
-
-    private static Method getSetter(Class<?> otherConfigClass, Class returnType, String setterName) {
-        try {
-            return otherConfigClass.getMethod(setterName, returnType);
-        } catch (NoSuchMethodException e) {
-            return null;
-        }
-    }
-
-    private static void updateConfig(Method setterMethod, Object otherConfigObject, Object value) {
-        try {
-            setterMethod.invoke(otherConfigObject, value);
-        } catch (IllegalAccessException e) {
-            debug("Could not update config via %s: %s", setterMethod.getName(), e.getMessage());
-        } catch (InvocationTargetException e) {
-            debug("Could not update config via %s: %s", setterMethod.getName(), e.getMessage());
-        } catch (IllegalArgumentException e) {
-            debug("Could not update config via %s: %s", setterMethod.getName(), e.getMessage());
-        }
-    }
-
-    private static String createSetterName(Method getter) {
-        if (getter.getName().startsWith("get")) {
-            return "s" + getter.getName().substring(1);
-        }
-        if (getter.getName().startsWith("is")) {
-            return "set" + getter.getName().substring(2);
-        }
-        throw new IllegalArgumentException("Unknown getter method name: " + getter.getName());
-    }
-
-    public static Object getValue(Object obj, String getter)
-            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Method method = obj.getClass().getMethod(getter, null);
-        return method.invoke(obj, null);
-    }
-
-    private static Properties copy(Properties original) {
-        if (original == null) {
-            return null;
-        }
-
-        Properties copy = new Properties();
-        for (String name : original.stringPropertyNames()) {
-            copy.setProperty(name, original.getProperty(name));
-        }
-        return copy;
-    }
-
-    // clones built-in QuorumFunction implementations
-    private static Object cloneQuorumFunctionImplementation(Object quorumFunction, Class<?> targetClass)
-            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException,
-            InstantiationException {
-
-        if (targetClass.getName().equals("com.hazelcast.quorum.impl.ProbabilisticQuorumFunction")) {
-            int size = (Integer) getFieldValueReflectively(quorumFunction, "quorumSize");
-            double suspicionThreshold = (Double) getFieldValueReflectively(quorumFunction, "suspicionThreshold");
-            int maxSampleSize = (Integer) getFieldValueReflectively(quorumFunction, "maxSampleSize");
-            long minStdDeviationMillis = (Long) getFieldValueReflectively(quorumFunction, "minStdDeviationMillis");
-            long acceptableHeartbeatPauseMillis = (Long) getFieldValueReflectively(quorumFunction,
-                    "acceptableHeartbeatPauseMillis");
-            long heartbeatIntervalMillis = (Long) getFieldValueReflectively(quorumFunction, "heartbeatIntervalMillis");
-
-
-            Constructor<?> ctor = targetClass.getConstructor(Integer.TYPE, Long.TYPE,
-                    Long.TYPE, Integer.TYPE, Long.TYPE, Double.TYPE);
-
-            return ctor.newInstance(size, heartbeatIntervalMillis, acceptableHeartbeatPauseMillis,
-                    maxSampleSize, minStdDeviationMillis, suspicionThreshold);
-        } else if (targetClass.getName().equals("com.hazelcast.quorum.impl.RecentlyActiveQuorumFunction")) {
-            int size = (Integer) getFieldValueReflectively(quorumFunction, "quorumSize");
-            int heartbeatToleranceMillis = (Integer) getFieldValueReflectively(quorumFunction, "heartbeatToleranceMillis");
-
-            Constructor<?> ctor = targetClass.getConstructor(Integer.TYPE, Integer.TYPE);
-            return ctor.newInstance(size, heartbeatToleranceMillis);
-        } else {
-            debug("Did not handle configured QuorumFunction implementation %s", targetClass.getName());
-            return null;
-        }
-    }
-
-    private static boolean isQuorumFunctionImplementation(Class<?> klass) throws ClassNotFoundException {
-        ClassLoader classLoader = klass.getClassLoader();
-        Class<?> quorumFunctionInterface = classLoader.loadClass("com.hazelcast.quorum.QuorumFunction");
-        return quorumFunctionInterface.isAssignableFrom(klass);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/DataAwareEntryEventConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/DataAwareEntryEventConstructor.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.test.starter.constructor;
 
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
 import java.lang.reflect.Constructor;
 
 import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
 import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.map.impl.DataAwareEntryEvent"})
 public class DataAwareEntryEventConstructor extends AbstractStarterObjectConstructor {
 
     public DataAwareEntryEventConstructor(Class<?> targetClass) {

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/EntryEventConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/EntryEventConstructor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.starter.constructor;
+
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
+import static com.hazelcast.test.starter.HazelcastProxyFactory.ProxyPolicy.SUBCLASS_PROXY;
+
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.core.EntryEvent"}, proxyPolicy = SUBCLASS_PROXY)
+public class EntryEventConstructor {
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/EnumConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/EnumConstructor.java
@@ -19,7 +19,8 @@ package com.hazelcast.test.starter.constructor;
 import java.lang.reflect.Method;
 
 /**
- * Construct enum instances using name() / valueOf() methods.
+ * Constructs enum instances using its {@link Enum#name()} and
+ * {@link Enum#valueOf(Class, String)} methods.
  */
 public class EnumConstructor extends AbstractStarterObjectConstructor {
 

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/GreaterLessPredicateConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/GreaterLessPredicateConstructor.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.test.starter.constructor;
 
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
 import java.lang.reflect.Constructor;
 
 import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
 import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.query.impl.predicates.GreaterLessPredicate"})
 public class GreaterLessPredicateConstructor extends AbstractStarterObjectConstructor {
 
     public GreaterLessPredicateConstructor(Class<?> targetClass) {

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/LifecycleEventConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/LifecycleEventConstructor.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.test.starter.constructor;
 
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
 import java.lang.reflect.Constructor;
 
 import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
 import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.core.LifecycleEvent"})
 public class LifecycleEventConstructor extends AbstractStarterObjectConstructor {
 
     public LifecycleEventConstructor(Class<?> targetClass) {
@@ -35,8 +38,8 @@ public class LifecycleEventConstructor extends AbstractStarterObjectConstructor 
 
         Object state = getFieldValueReflectively(delegate, "state");
         Object[] args = new Object[]{state};
-        Object[] proxiedArgs = proxyArgumentsIfNeeded(args, starterClassLoader);
 
+        Object[] proxiedArgs = proxyArgumentsIfNeeded(args, starterClassLoader);
         return constructor.newInstance(proxiedArgs);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/MapEventConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/MapEventConstructor.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.test.starter.constructor;
 
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
 import java.lang.reflect.Constructor;
 
 import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
 import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.core.MapEvent"})
 public class MapEventConstructor extends AbstractStarterObjectConstructor {
 
     public MapEventConstructor(Class<?> targetClass) {
@@ -42,7 +45,6 @@ public class MapEventConstructor extends AbstractStarterObjectConstructor {
         Object[] args = new Object[]{source, member, eventTypeId, numberOfKeysAffected};
 
         Object[] proxiedArgs = proxyArgumentsIfNeeded(args, starterClassLoader);
-
         return constructor.newInstance(proxiedArgs);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/VersionConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/VersionConstructor.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.test.starter.constructor;
 
+import com.hazelcast.test.starter.HazelcastStarterConstructor;
+
 import java.lang.reflect.Method;
 
 import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 
-/**
- * Constructor for {@link com.hazelcast.version.Version} class proxies
- */
+@HazelcastStarterConstructor(classNames = {"com.hazelcast.version.Version"})
 public class VersionConstructor extends AbstractStarterObjectConstructor {
 
     public VersionConstructor(Class<?> targetClass) {

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/ConfigConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/ConfigConstructorTest.java
@@ -21,7 +21,6 @@ import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.starter.constructor.ConfigConstructor;
@@ -31,11 +30,12 @@ import org.junit.runner.RunWith;
 
 import java.util.Properties;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertPropertiesEquals;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class ConfigConstructorTest extends HazelcastTestSupport {
+public class ConfigConstructorTest {
 
     @Test
     public void testConstructor() {
@@ -56,7 +56,7 @@ public class ConfigConstructorTest extends HazelcastTestSupport {
         assertPropertiesEquals(config.getProperties(), clonedConfig.getProperties());
     }
 
-    private Properties buildPropertiesWithDefaults() {
+    private static Properties buildPropertiesWithDefaults() {
         Properties defaults = new Properties();
         defaults.setProperty("key1", "value1");
 


### PR DESCRIPTION
This annotation marks `ConstructorFunction` classes for `HazelcastStarter`. They are registered via reflection, so we don't have to adjust the `HazelcastProxyFactory` each time, we add a new constructor class. This also gives us support for EE only constructor classes, which cannot be tested properly in OS.

Pulled out from https://github.com/hazelcast/hazelcast/pull/13293