### PR TITLE
Increase timings to min chance of hiccup failure & moved to slow test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.Preconditions;
 import org.junit.Before;
@@ -1215,13 +1216,16 @@ public class BasicMapTest extends HazelcastTestSupport {
     }
 
     @Test
+    @Category(SlowTest.class)
     public void testExtendTTLOfAKeyBeforeItExpires() {
         final IMap<String, String> map = getInstance().getMap("testSetTTLExtend");
-        map.put("key", "value", 1, TimeUnit.SECONDS);
+        map.put("key", "value", 10, TimeUnit.SECONDS);
+
+        sleepAtLeastMillis(SECONDS.toMillis(1));
         //Make the entry eternal
         map.setTTL("key", 0, TimeUnit.DAYS);
 
-        sleepAtLeastMillis(1200);
+        sleepAtLeastMillis(SECONDS.toMillis(15));
 
         assertEquals("value", map.get("key"));
     }


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2248

Build env noise:
```
Hiccups measured while running test 'testExtendTTLOfAKeyBeforeItExpires(com.hazelcast.map.HDBasicMapTest):'
11:39:15, accumulated pauses: 3135 ms, max pause: 1185 ms, pauses over 1000 ms: 1
11:39:20, accumulated pauses: 3574 ms, max pause: 1515 ms, pauses over 1000 ms: 2
11:39:25, accumulated pauses: 1887 ms, max pause: 546 ms, pauses over 1000 ms: 0
```