### PR TITLE
[Java 9] Add modulepath specific tests - testing Hazelcast in modularized environment.

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -314,4 +314,8 @@
             files="[\\/]src[\\/]test[\\/]"/>
     <suppress checks="" files="src[\\/]test[\\/]java[\\/]com[\\/]hazelcast[\\/]client[\\/]protocol[\\/]compatibility[\\/]"/>
     <suppress checks="" files="src[\\/]test[\\/]java[\\/]com[\\/]hazelcast[\\/]nio[\\/]serialization[\\/]compatibility[\\/]"/>
+
+    <!-- module-info.java -->
+    <suppress checks="" files="[\\/]module-info"/>
+
 </suppressions>

--- a/modulepath-tests/pom.xml
+++ b/modulepath-tests/pom.xml
@@ -1,0 +1,101 @@
+<!--
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>modulepath-tests</name>
+    <artifactId>modulepath-tests</artifactId>
+    <description>Hazelcast modulepath tests</description>
+    <packaging>jar</packaging>
+
+    <parent>
+        <groupId>com.hazelcast</groupId>
+        <artifactId>hazelcast-root</artifactId>
+        <version>3.11-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>9</maven.compiler.source>
+        <maven.compiler.target>9</maven.compiler.target>
+
+        <!-- needed for CheckStyle -->
+        <main.basedir>${project.parent.basedir}</main.basedir>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.7.0</version>
+                <configuration combine.self="override">
+                    <release>9</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+                <configuration combine.self="override">
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
+            </plugin>
+
+            <!-- Disable spotbugs as we have nothing to analyze yet (which makes the plugin unhappy). -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${maven.spotbugs.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/modulepath-tests/src/main/java/module-info.java
+++ b/modulepath-tests/src/main/java/module-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/**
- * <p>This package contains the serverside client functionality</p>
- */
-package com.hazelcast.client;
+open module com.hazelcast.tests {
+    requires com.hazelcast.core;
+    requires com.hazelcast.client;
+}

--- a/modulepath-tests/src/test/java/com/hazelcast/test/modulepath/SmokeModulePathTest.java
+++ b/modulepath-tests/src/test/java/com/hazelcast/test/modulepath/SmokeModulePathTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.modulepath;
+
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+
+/**
+ * Basic test which checks if correct Hazelcast modules are on the modulepath. It also checks that Hazelcast members and clients
+ * are able to start and form a cluster.
+ */
+public class SmokeModulePathTest {
+
+    @After
+    public void after() {
+        HazelcastClient.shutdownAll();
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    /**
+     * Verify the Hazelcast JARs are on the modulepath.
+     */
+    @Test
+    public void testModulePath() {
+        String modulePath = System.getProperty("jdk.module.path");
+        assertNotNull("Module path was expected", modulePath);
+        assertTrue("Module path should contain hazelcast JAR",
+                modulePath.matches(".*hazelcast-[1-9][\\p{Alnum}\\-_\\.]+\\.jar.*"));
+        assertTrue("Module path should contain hazelcast-client JAR",
+                modulePath.matches(".*hazelcast-client-[\\p{Alnum}\\-_\\.]+\\.jar.*"));
+    }
+
+    /**
+     * Verify the Hazelcast modules with correct names are used.
+     */
+    @Test
+    public void testModuleNames() {
+        Set<String> hazelcastModuleNames = ModuleLayer.boot().modules().stream().map(Module::getName)
+                .filter(s -> s.contains("hazelcast")).collect(Collectors.toSet());
+        assertThat(hazelcastModuleNames, hasItems("com.hazelcast.core", "com.hazelcast.client", "com.hazelcast.tests"));
+    }
+
+    /**
+     * Verify Hazelcast members are able to start and form cluster. It also verifies the client is able to join and work with
+     * the cluster.
+     */
+    @Test
+    public void testCluster() {
+        Config config = new Config();
+
+        NetworkConfig networkConfig = config.getNetworkConfig();
+        networkConfig.getInterfaces().addInterface("127.0.0.1");
+        networkConfig.getJoin().getMulticastConfig().setEnabled(false);
+        networkConfig.getJoin().getTcpIpConfig().setEnabled(true).addMember("127.0.0.1");
+
+        HazelcastInstance hz1 = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance hz2 = Hazelcast.newHazelcastInstance(config);
+        hz1.getMap("test").put("a", "b");
+        assertClusterSize(2, hz1, hz2);
+        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        assertEquals("b", client.getMap("test").get("a"));
+    }
+
+    public static void assertClusterSize(int expectedSize, HazelcastInstance... instances) {
+        for (int i = 0; i < instances.length; i++) {
+            int clusterSize = getClusterSize(instances[i]);
+            if (expectedSize != clusterSize) {
+                fail(format("Cluster size is not correct. Expected: %d, actual: %d, instance index: %d", expectedSize,
+                        clusterSize, i));
+            }
+        }
+    }
+
+    private static int getClusterSize(HazelcastInstance instance) {
+        Set<Member> members = instance.getCluster().getMembers();
+        return members == null ? 0 : members.size();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1009,7 +1009,7 @@
         <profile>
             <id>jdk-9</id>
             <activation>
-                <jdk>1.9</jdk>
+                <jdk>[9,)</jdk>
             </activation>
             <build>
                 <plugins>
@@ -1021,8 +1021,12 @@
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <useFile>false</useFile>
                             <trimStackTrace>false</trimStackTrace>
+                            <!--
+                            The jdk.xml.internal package export is added to workaround Powermock issue https://github.com/powermock/powermock/issues/905 in tests.
+                             -->
                             <argLine>
                                 ${vmHeapSettings}
+                                --add-exports java.xml/jdk.xml.internal=ALL-UNNAMED
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
@@ -1046,6 +1050,9 @@
                     </plugin>
                 </plugins>
             </build>
+            <modules>
+                <module>modulepath-tests</module>
+            </modules>
         </profile>
 
         <profile>


### PR DESCRIPTION
This PR introduces a new Maven module which is intended for testing Hazelcast in modularized environment (Java 9+).

The module is only compiled and tested if the `jdk-9` profile is enabled. So it's used automatically when a Java 9 version or newer is used by the Maven. It'll also automatically verify that the packages in the core and in the client stay distinct (i.e. no overlaps).