### PR TITLE
During cluster-state change, trigger repartitioning only when needed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -392,10 +392,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             }
             if (node.isMaster()) {
                 if (partitionStateManager.isInitialized()) {
-                    final ClusterState clusterState = nodeEngine.getClusterService().getClusterState();
-                    if (clusterState.isMigrationAllowed()) {
-                        migrationManager.triggerControlTask();
-                    }
+                    migrationManager.triggerControlTask();
                 }
             }
         } finally {
@@ -449,7 +446,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
         lock.lock();
         try {
-            if (partitionStateManager.isInitialized()) {
+            if (partitionStateManager.isInitialized()
+                    && migrationManager.shouldTriggerRepartitioningWhenClusterStateAllowsMigration()) {
                 migrationManager.triggerControlTask();
             }
         } finally {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -116,6 +116,7 @@ public class MigrationManager {
     private final MigrationPlanner migrationPlanner;
     private final boolean fragmentedMigrationEnabled;
     private final long memberHeartbeatTimeoutMillis;
+    private boolean triggerRepartitioningWhenClusterStateAllowsMigration;
 
     MigrationManager(Node node, InternalPartitionServiceImpl service, Lock partitionServiceLock) {
         this.node = node;
@@ -612,6 +613,16 @@ public class MigrationManager {
     }
 
     /**
+     * Returns {@code true} if a repartitioning action occurred (member removal or addition)
+     * while migrations are not allowed by current cluster state
+     * (such as {@link ClusterState#NO_MIGRATION}, {@link ClusterState#PASSIVE}),
+     * {@code false} otherwise.
+     */
+    boolean shouldTriggerRepartitioningWhenClusterStateAllowsMigration() {
+        return triggerRepartitioningWhenClusterStateAllowsMigration;
+    }
+
+    /**
      * Invoked on the master node. Rearranges the partition table if there is no recent activity in the cluster after
      * this task has been scheduled, schedules migrations and syncs the partition state.
      * Also schedules a {@link ProcessShutdownRequestsTask}. Acquires partition service lock.
@@ -624,6 +635,11 @@ public class MigrationManager {
             }
             partitionServiceLock.lock();
             try {
+                triggerRepartitioningWhenClusterStateAllowsMigration = !isMigrationAllowedByClusterState();
+                if (triggerRepartitioningWhenClusterStateAllowsMigration && logger.isFineEnabled()) {
+                    logger.fine("Migrations are not allowed yet, "
+                            + "repartitioning will be triggered when cluster state allows migrations.");
+                }
                 Address[][] newState = repartition();
                 if (newState == null) {
                     return;


### PR DESCRIPTION
Currently, repartitioning is always triggered during cluster change,
regardless of whether or not it's needed. But since repartitioning algorithm
is not deterministic, it can create one or two migrations on every call.

This can cause redundant migrations and failures during Hot Restart validation.

Instead now, we set a flag when a repartitioning action (member add or remove) occurs,
and trigger repartitioning if that flag is set on cluster state change event.

Closes hazelcast/hazelcast-enterprise#2253