### PR TITLE
Send license information to Management Center

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/LicenseInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/LicenseInfo.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.monitor.impl;
+package com.hazelcast.internal.management;
 
 import com.eclipsesource.json.JsonObject;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -191,6 +191,7 @@ public class TimedMemberStateFactory {
         createMemState(memberState, services);
 
         createNodeState(memberState);
+        createLicenseInfo(memberState);
         createHotRestartState(memberState);
         createClusterHotRestartStatus(memberState);
         createWanSyncState(memberState);
@@ -218,6 +219,9 @@ public class TimedMemberStateFactory {
         NodeStateImpl nodeState = new NodeStateImpl(cluster.getClusterState(), node.getState(),
                 cluster.getClusterVersion(), node.getVersion());
         memberState.setNodeState(nodeState);
+    }
+
+    protected void createLicenseInfo(MemberStateImpl memberState) {
     }
 
     private void createWanSyncState(MemberStateImpl memberState) {

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LicenseInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LicenseInfo.java
@@ -18,6 +18,9 @@ package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;
 
+/**
+ * Value object for sending license information to Management Center.
+ */
 public class LicenseInfo {
     private final int allowedNumberOfNodes;
     private final int type;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LicenseInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LicenseInfo.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.monitor.impl;
 
 import com.eclipsesource.json.JsonObject;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LicenseInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LicenseInfo.java
@@ -1,0 +1,29 @@
+package com.hazelcast.monitor.impl;
+
+import com.eclipsesource.json.JsonObject;
+
+public class LicenseInfo {
+    private final int allowedNumberOfNodes;
+    private final int type;
+    private final String companyName;
+    private final String email;
+    private final long expiryDate;
+
+    public LicenseInfo(int allowedNumberOfNodes, int type, String companyName, String email, long expiryDate) {
+        this.allowedNumberOfNodes = allowedNumberOfNodes;
+        this.type = type;
+        this.companyName = companyName;
+        this.email = email;
+        this.expiryDate = expiryDate;
+    }
+
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject();
+        root.add("allowedNumberOfNodes", allowedNumberOfNodes);
+        root.add("type", type);
+        root.add("companyName", companyName);
+        root.add("email", email);
+        root.add("expiryDate", expiryDate);
+        return root;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LicenseInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LicenseInfo.java
@@ -17,6 +17,26 @@ public class LicenseInfo {
         this.expiryDate = expiryDate;
     }
 
+    public int getAllowedNumberOfNodes() {
+        return allowedNumberOfNodes;
+    }
+
+    public int getType() {
+        return type;
+    }
+
+    public String getCompanyName() {
+        return companyName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public long getExpiryDate() {
+        return expiryDate;
+    }
+
     public JsonObject toJson() {
         JsonObject root = new JsonObject();
         root.add("allowedNumberOfNodes", allowedNumberOfNodes);

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
@@ -77,6 +77,7 @@ public class MemberStateImpl implements MemberState {
     private HotRestartState hotRestartState = new HotRestartStateImpl();
     private ClusterHotRestartStatusDTO clusterHotRestartStatus = new ClusterHotRestartStatusDTO();
     private WanSyncState wanSyncState = new WanSyncStateImpl();
+    private LicenseInfo licenseInfo;
 
     public MemberStateImpl() {
     }
@@ -282,6 +283,14 @@ public class MemberStateImpl implements MemberState {
         this.clientStats = clientStats;
     }
 
+    public LicenseInfo getLicenseInfo() {
+        return licenseInfo;
+    }
+
+    public void setLicenseInfo(LicenseInfo licenseInfo) {
+        this.licenseInfo = licenseInfo;
+    }
+
     @Override
     public JsonObject toJson() {
         final JsonObject root = new JsonObject();
@@ -323,6 +332,9 @@ public class MemberStateImpl implements MemberState {
             clientStatsObject.add(entry.getKey(), entry.getValue());
         }
         root.add("clientStats", clientStatsObject);
+        if (licenseInfo != null) {
+            root.add("licenseInfo", licenseInfo.toJson());
+        }
         return root;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/MemberStateImpl.java
@@ -20,6 +20,7 @@ import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
 import com.hazelcast.internal.management.JsonSerializable;
+import com.hazelcast.internal.management.LicenseInfo;
 import com.hazelcast.internal.management.dto.ClientEndPointDTO;
 import com.hazelcast.internal.management.dto.ClusterHotRestartStatusDTO;
 import com.hazelcast.internal.management.dto.MXBeansDTO;

--- a/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/TimedMemberStateIntegrationTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -102,5 +103,14 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
 
         TimedMemberState timedMemberState = factory.createTimedMemberState();
         assertEquals(enabled, timedMemberState.sslEnabled);
+    }
+
+    @Test
+    public void testLicenseInfoIsNull() {
+        HazelcastInstance hz = createHazelcastInstance();
+        TimedMemberStateFactory factory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
+
+        TimedMemberState timedMemberState = factory.createTimedMemberState();
+        assertNull(timedMemberState.memberState.getLicenseInfo());
     }
 }


### PR DESCRIPTION
Goal is to show information about the cluster license on MC UI. For this, we're sending the license information to MC. 

Since, OSS clusters don't have licenses, it is sent as `null` for OSS clusters. The field is added in OSS project but filled in the EE project because the object structure needs to be the same for both OSS and EE cluster. We extract license information in EE code because we don't have the required dependency to license extractor in the OSS project.