### PR TITLE
Adding data structure config at runtime should not fail unless equal …

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -1134,8 +1134,10 @@ public class DynamicConfigurationAwareConfig extends Config {
         }
 
         Map<String, MerkleTreeConfig> staticConfigs = staticConfig.getMapMerkleTreeConfigs();
-        checkStaticConfigurationDoesNotExist(staticConfigs, mapName, merkleTreeConfig);
-        configurationService.broadcastConfig(merkleTreeConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfigs, mapName, merkleTreeConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(merkleTreeConfig);
+        }
         return this;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -98,7 +98,7 @@ public class DynamicConfigurationAwareConfig extends Config {
             return staticConfig.getMapConfigs();
         }
     };
-  
+
     private final ConfigSupplier<EventJournalConfig> mapEventJournalConfigSupplier =
         new ConfigSupplier<EventJournalConfig>() {
             @Override
@@ -117,7 +117,7 @@ public class DynamicConfigurationAwareConfig extends Config {
                 return staticConfig.getMapEventJournalConfigs();
             }
         };
-  
+
     private final ConfigSupplier<EventJournalConfig> cacheEventJournalConfigSupplier = new
             ConfigSupplier<EventJournalConfig>() {
                 @Override
@@ -136,7 +136,7 @@ public class DynamicConfigurationAwareConfig extends Config {
                     return staticConfig.getCacheEventJournalConfigs();
                 }
             };
-  
+
     private final ConfigSupplier<MerkleTreeConfig> mapMerkleTreeConfigSupplier =
             new ConfigSupplier<MerkleTreeConfig>() {
                 @Override
@@ -292,7 +292,7 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     private <T> boolean checkStaticConfigDoesNotExist(Map<String, T> staticConfigurations, String configName, T newConfig) {
         Object existingConfiguration = staticConfigurations.get(configName);
-        if (existingConfiguration != null && !existingConfiguration.equals(newConfig)) {
+        if (existingConfiguration != null) {
             throw new ConfigurationException("Cannot add a new dynamic configuration " + newConfig
                 + " as static configuration already contains " + existingConfiguration);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -268,7 +268,7 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     private <T> void checkStaticConfigurationDoesNotExist(Map<String, T> staticConfigurations, String configName, T newConfig) {
         Object existingConfiguration = staticConfigurations.get(configName);
-        if (existingConfiguration != null) {
+        if (existingConfiguration != null && existingConfiguration.equals(newConfig)) {
             throw new ConfigurationException("Cannot add a new dynamic configuration " + newConfig
                     + " as static configuration already contains " + existingConfiguration);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -268,7 +268,7 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     private <T> void checkStaticConfigurationDoesNotExist(Map<String, T> staticConfigurations, String configName, T newConfig) {
         Object existingConfiguration = staticConfigurations.get(configName);
-        if (existingConfiguration != null && existingConfiguration.equals(newConfig)) {
+        if (existingConfiguration != null && !existingConfiguration.equals(newConfig)) {
             throw new ConfigurationException("Cannot add a new dynamic configuration " + newConfig
                     + " as static configuration already contains " + existingConfiguration);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -117,7 +117,7 @@ public class DynamicConfigurationAwareConfig extends Config {
                 return staticConfig.getMapEventJournalConfigs();
             }
         };
-
+  
     private final ConfigSupplier<EventJournalConfig> cacheEventJournalConfigSupplier = new
             ConfigSupplier<EventJournalConfig>() {
                 @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -292,7 +292,7 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     private <T> boolean checkStaticConfigDoesNotExist(Map<String, T> staticConfigurations, String configName, T newConfig) {
         Object existingConfiguration = staticConfigurations.get(configName);
-        if (existingConfiguration != null) {
+        if (existingConfiguration != null && !existingConfiguration.equals(newConfig)) {
             throw new ConfigurationException("Cannot add a new dynamic configuration " + newConfig
                 + " as static configuration already contains " + existingConfiguration);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -117,7 +117,7 @@ public class DynamicConfigurationAwareConfig extends Config {
                 return staticConfig.getMapEventJournalConfigs();
             }
         };
-  
+
     private final ConfigSupplier<EventJournalConfig> cacheEventJournalConfigSupplier = new
             ConfigSupplier<EventJournalConfig>() {
                 @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -16,6 +16,10 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
+import static com.hazelcast.internal.dynamicconfig.AggregatingMap.aggregate;
+import static com.hazelcast.internal.dynamicconfig.search.ConfigSearch.supplierFor;
+import static com.hazelcast.spi.properties.GroupProperty.SEARCH_DYNAMIC_CONFIG_FIRST;
+
 import com.hazelcast.config.AtomicLongConfig;
 import com.hazelcast.config.AtomicReferenceConfig;
 import com.hazelcast.config.CRDTReplicationConfig;
@@ -64,8 +68,6 @@ import com.hazelcast.internal.dynamicconfig.search.Searcher;
 import com.hazelcast.security.SecurityService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.StringUtil;
-
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
@@ -74,10 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentMap;
-
-import static com.hazelcast.internal.dynamicconfig.AggregatingMap.aggregate;
-import static com.hazelcast.internal.dynamicconfig.search.ConfigSearch.supplierFor;
-import static com.hazelcast.spi.properties.GroupProperty.SEARCH_DYNAMIC_CONFIG_FIRST;
+import javax.annotation.Nonnull;
 
 @SuppressWarnings({"unchecked", "checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
 public class DynamicConfigurationAwareConfig extends Config {
@@ -99,41 +98,41 @@ public class DynamicConfigurationAwareConfig extends Config {
         }
     };
     private final ConfigSupplier<EventJournalConfig> mapEventJournalConfigSupplier =
-            new ConfigSupplier<EventJournalConfig>() {
-                @Override
-                public EventJournalConfig getDynamicConfig(@Nonnull ConfigurationService configurationService,
-                                                           @Nonnull String name) {
-                    return configurationService.findMapEventJournalConfig(name);
-                }
+        new ConfigSupplier<EventJournalConfig>() {
+            @Override
+            public EventJournalConfig getDynamicConfig(@Nonnull ConfigurationService configurationService,
+                @Nonnull String name) {
+                return configurationService.findMapEventJournalConfig(name);
+            }
 
-                @Override
-                public EventJournalConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
-                    return staticConfig.getMapEventJournalConfig(name);
-                }
+            @Override
+            public EventJournalConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
+                return staticConfig.getMapEventJournalConfig(name);
+            }
 
-                @Override
-                public Map<String, EventJournalConfig> getStaticConfigs(@Nonnull Config staticConfig) {
-                    return staticConfig.getMapEventJournalConfigs();
-                }
-            };
+            @Override
+            public Map<String, EventJournalConfig> getStaticConfigs(@Nonnull Config staticConfig) {
+                return staticConfig.getMapEventJournalConfigs();
+            }
+        };
     private final ConfigSupplier<EventJournalConfig> cacheEventJournalConfigSupplier = new
-            ConfigSupplier<EventJournalConfig>() {
-                @Override
-                public EventJournalConfig getDynamicConfig(@Nonnull ConfigurationService configurationService,
-                                                           @Nonnull String name) {
-                    return configurationService.findCacheEventJournalConfig(name);
-                }
+        ConfigSupplier<EventJournalConfig>() {
+            @Override
+            public EventJournalConfig getDynamicConfig(@Nonnull ConfigurationService configurationService,
+                @Nonnull String name) {
+                return configurationService.findCacheEventJournalConfig(name);
+            }
 
-                @Override
-                public EventJournalConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
-                    return staticConfig.getCacheEventJournalConfig(name);
-                }
+            @Override
+            public EventJournalConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
+                return staticConfig.getCacheEventJournalConfig(name);
+            }
 
-                @Override
-                public Map<String, EventJournalConfig> getStaticConfigs(@Nonnull Config staticConfig) {
-                    return staticConfig.getCacheEventJournalConfigs();
-                }
-            };
+            @Override
+            public Map<String, EventJournalConfig> getStaticConfigs(@Nonnull Config staticConfig) {
+                return staticConfig.getCacheEventJournalConfigs();
+            }
+        };
 
     private final Config staticConfig;
     private final ConfigPatternMatcher configPatternMatcher;
@@ -261,17 +260,21 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addMapConfig(MapConfig mapConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getMapConfigs(), mapConfig.getName(), mapConfig);
-        configurationService.broadcastConfig(mapConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getMapConfigs(),
+            mapConfig.getName(), mapConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(mapConfig);
+        }
         return this;
     }
 
-    private <T> void checkStaticConfigurationDoesNotExist(Map<String, T> staticConfigurations, String configName, T newConfig) {
+    private <T> boolean checkStaticConfigDoesNotExist(Map<String, T> staticConfigurations, String configName, T newConfig) {
         Object existingConfiguration = staticConfigurations.get(configName);
         if (existingConfiguration != null && !existingConfiguration.equals(newConfig)) {
             throw new ConfigurationException("Cannot add a new dynamic configuration " + newConfig
-                    + " as static configuration already contains " + existingConfiguration);
+                + " as static configuration already contains " + existingConfiguration);
         }
+        return existingConfiguration == null;
     }
 
     @Override
@@ -312,8 +315,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addCacheConfig(CacheSimpleConfig cacheConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getCacheConfigs(), cacheConfig.getName(), cacheConfig);
-        configurationService.broadcastConfig(cacheConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getCacheConfigs(),
+            cacheConfig.getName(), cacheConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(cacheConfig);
+        }
         return this;
     }
 
@@ -346,8 +352,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addQueueConfig(QueueConfig queueConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getQueueConfigs(), queueConfig.getName(), queueConfig);
-        configurationService.broadcastConfig(queueConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getQueueConfigs(),
+            queueConfig.getName(), queueConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(queueConfig);
+        }
         return this;
     }
 
@@ -379,8 +388,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addLockConfig(LockConfig lockConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getLockConfigs(), lockConfig.getName(), lockConfig);
-        configurationService.broadcastConfig(lockConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getLockConfigs(),
+            lockConfig.getName(), lockConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(lockConfig);
+        }
         return this;
     }
 
@@ -412,8 +424,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addListConfig(ListConfig listConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getListConfigs(), listConfig.getName(), listConfig);
-        configurationService.broadcastConfig(listConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getListConfigs(),
+            listConfig.getName(), listConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(listConfig);
+        }
         return this;
     }
 
@@ -446,8 +461,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addSetConfig(SetConfig setConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getSetConfigs(), setConfig.getName(), setConfig);
-        configurationService.broadcastConfig(setConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getSetConfigs(),
+            setConfig.getName(), setConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(setConfig);
+        }
         return this;
     }
 
@@ -479,8 +497,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addMultiMapConfig(MultiMapConfig multiMapConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getMultiMapConfigs(), multiMapConfig.getName(), multiMapConfig);
-        configurationService.broadcastConfig(multiMapConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getMultiMapConfigs(),
+            multiMapConfig.getName(), multiMapConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(multiMapConfig);
+        }
         return this;
     }
 
@@ -513,9 +534,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addReplicatedMapConfig(ReplicatedMapConfig replicatedMapConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getReplicatedMapConfigs(), replicatedMapConfig.getName(),
-                replicatedMapConfig);
-        configurationService.broadcastConfig(replicatedMapConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getReplicatedMapConfigs(),
+            replicatedMapConfig.getName(), replicatedMapConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(replicatedMapConfig);
+        }
         return this;
     }
 
@@ -548,9 +571,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addRingBufferConfig(RingbufferConfig ringbufferConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getRingbufferConfigs(), ringbufferConfig.getName(),
-                ringbufferConfig);
-        configurationService.broadcastConfig(ringbufferConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getRingbufferConfigs(),
+            ringbufferConfig.getName(), ringbufferConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(ringbufferConfig);
+        }
         return this;
     }
 
@@ -579,8 +604,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addAtomicLongConfig(AtomicLongConfig atomicLongConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getAtomicLongConfigs(), atomicLongConfig.getName(), atomicLongConfig);
-        configurationService.broadcastConfig(atomicLongConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getAtomicLongConfigs(),
+            atomicLongConfig.getName(), atomicLongConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(atomicLongConfig);
+        }
         return this;
     }
 
@@ -613,9 +641,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addAtomicReferenceConfig(AtomicReferenceConfig atomicReferenceConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getAtomicReferenceConfigs(), atomicReferenceConfig.getName(),
-                atomicReferenceConfig);
-        configurationService.broadcastConfig(atomicReferenceConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getAtomicReferenceConfigs(),
+            atomicReferenceConfig.getName(), atomicReferenceConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(atomicReferenceConfig);
+        }
         return this;
     }
 
@@ -648,9 +678,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addCountDownLatchConfig(CountDownLatchConfig countDownLatchConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getCountDownLatchConfigs(), countDownLatchConfig.getName(),
-                countDownLatchConfig);
-        configurationService.broadcastConfig(countDownLatchConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getCountDownLatchConfigs(),
+            countDownLatchConfig.getName(), countDownLatchConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(countDownLatchConfig);
+        }
         return this;
     }
 
@@ -687,9 +719,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addTopicConfig(TopicConfig topicConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getTopicConfigs(), topicConfig.getName(),
-                topicConfig);
-        configurationService.broadcastConfig(topicConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getTopicConfigs(),
+            topicConfig.getName(), topicConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(topicConfig);
+        }
         return this;
     }
 
@@ -730,9 +764,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addReliableTopicConfig(ReliableTopicConfig reliableTopicConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getReliableTopicConfigs(), reliableTopicConfig.getName(),
-                reliableTopicConfig);
-        configurationService.broadcastConfig(reliableTopicConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getReliableTopicConfigs(),
+            reliableTopicConfig.getName(), reliableTopicConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(reliableTopicConfig);
+        }
         return this;
     }
 
@@ -757,9 +793,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addExecutorConfig(ExecutorConfig executorConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getExecutorConfigs(), executorConfig.getName(),
-                executorConfig);
-        configurationService.broadcastConfig(executorConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getExecutorConfigs(),
+            executorConfig.getName(), executorConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(executorConfig);
+        }
         return this;
     }
 
@@ -792,9 +830,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addDurableExecutorConfig(DurableExecutorConfig durableExecutorConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getDurableExecutorConfigs(), durableExecutorConfig.getName(),
-                durableExecutorConfig);
-        configurationService.broadcastConfig(durableExecutorConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getDurableExecutorConfigs(),
+            durableExecutorConfig.getName(), durableExecutorConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(durableExecutorConfig);
+        }
         return this;
     }
 
@@ -836,9 +876,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addScheduledExecutorConfig(ScheduledExecutorConfig scheduledExecutorConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getScheduledExecutorConfigs(), scheduledExecutorConfig.getName(),
-                scheduledExecutorConfig);
-        configurationService.broadcastConfig(scheduledExecutorConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getScheduledExecutorConfigs(),
+            scheduledExecutorConfig.getName(), scheduledExecutorConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(scheduledExecutorConfig);
+        }
         return this;
     }
 
@@ -859,15 +901,17 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     private CardinalityEstimatorConfig getCardinalityEstimatorConfigInternal(String name, String fallbackName) {
         return (CardinalityEstimatorConfig) configSearcher.getConfig(name, fallbackName,
-                supplierFor(CardinalityEstimatorConfig.class));
+            supplierFor(CardinalityEstimatorConfig.class));
     }
 
 
     @Override
     public Config addCardinalityEstimatorConfig(CardinalityEstimatorConfig cardinalityEstimatorConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getCardinalityEstimatorConfigs(),
-                cardinalityEstimatorConfig.getName(), cardinalityEstimatorConfig);
-        configurationService.broadcastConfig(cardinalityEstimatorConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getCardinalityEstimatorConfigs(),
+            cardinalityEstimatorConfig.getName(), cardinalityEstimatorConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(cardinalityEstimatorConfig);
+        }
         return this;
     }
 
@@ -900,8 +944,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addPNCounterConfig(PNCounterConfig pnCounterConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getPNCounterConfigs(), pnCounterConfig.getName(), pnCounterConfig);
-        configurationService.broadcastConfig(pnCounterConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getPNCounterConfigs(),
+            pnCounterConfig.getName(), pnCounterConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(pnCounterConfig);
+        }
         return this;
     }
 
@@ -934,9 +981,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addSemaphoreConfig(SemaphoreConfig semaphoreConfig) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getSemaphoreConfigsAsMap(),
-                semaphoreConfig.getName(), semaphoreConfig);
-        configurationService.broadcastConfig(semaphoreConfig);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getSemaphoreConfigsAsMap(),
+            semaphoreConfig.getName(), semaphoreConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(semaphoreConfig);
+        }
         return this;
     }
 
@@ -1015,15 +1064,19 @@ public class DynamicConfigurationAwareConfig extends Config {
             throw new IllegalArgumentException("Event journal config should have non-empty map name and/or cache name");
         }
 
+        boolean staticConfigDoesNotExist = false;
         if (!StringUtil.isNullOrEmpty(mapName)) {
             Map<String, EventJournalConfig> staticConfigs = staticConfig.getMapEventJournalConfigs();
-            checkStaticConfigurationDoesNotExist(staticConfigs, mapName, eventJournalConfig);
+            staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfigs, mapName, eventJournalConfig);
         }
         if (!StringUtil.isNullOrEmpty(cacheName)) {
             Map<String, EventJournalConfig> staticConfigs = staticConfig.getCacheEventJournalConfigs();
-            checkStaticConfigurationDoesNotExist(staticConfigs, cacheName, eventJournalConfig);
+            staticConfigDoesNotExist = staticConfigDoesNotExist
+                | checkStaticConfigDoesNotExist(staticConfigs, cacheName, eventJournalConfig);
         }
-        configurationService.broadcastConfig(eventJournalConfig);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(eventJournalConfig);
+        }
         return this;
     }
 
@@ -1060,8 +1113,11 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config addFlakeIdGeneratorConfig(FlakeIdGeneratorConfig config) {
-        checkStaticConfigurationDoesNotExist(staticConfig.getFlakeIdGeneratorConfigs(), config.getName(), config);
-        configurationService.broadcastConfig(config);
+        boolean staticConfigDoesNotExist = checkStaticConfigDoesNotExist(staticConfig.getFlakeIdGeneratorConfigs(),
+            config.getName(), config);
+        if (staticConfigDoesNotExist) {
+            configurationService.broadcastConfig(config);
+        }
         return this;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
+import static org.junit.Assert.assertEquals;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.ListenerConfig;
@@ -33,8 +34,6 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
@@ -16,9 +16,7 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
-import static org.junit.Assert.assertEquals;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MultiMapConfig;
@@ -34,6 +32,8 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
@@ -17,8 +17,8 @@
 package com.hazelcast.internal.dynamicconfig;
 
 import static org.junit.Assert.assertEquals;
+
 import com.hazelcast.config.Config;
-import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MultiMapConfig;
@@ -155,24 +155,6 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
             mapConfig = instance.getConfig().findMapConfig(prefixWithWildcard + randomSuffix);
             assertEquals(TestConfigUtils.NON_DEFAULT_BACKUP_COUNT, mapConfig.getBackupCount());
         }
-    }
-
-    @Test(expected = ConfigurationException.class)
-    public void map_whenConflictingWithStaticConfig_thenThrowConfigurationException() {
-        String mapName = randomMapName();
-        int initialClusterSize = 1;
-
-        Config config = new Config();
-        MapConfig mapConfig = new MapConfig(mapName);
-        config.addMapConfig(mapConfig);
-
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(initialClusterSize);
-        HazelcastInstance[] instances = factory.newInstances(config);
-        HazelcastInstance i1 = instances[0];
-
-        mapConfig = new MapConfig(mapName);
-        config = i1.getConfig();
-        config.addMapConfig(mapConfig);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
@@ -223,7 +223,7 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         config.addMapConfig(getMapConfigWithTTL(mapName, 20));
 
         HazelcastInstance hz = createHazelcastInstance(config);
-        hz.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 50));
+        hz.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 20));
     }
 
     @Test(expected = HazelcastException.class)
@@ -233,7 +233,7 @@ public class DynamicConfigSmokeTest extends HazelcastTestSupport {
         config.addMapConfig(getMapConfigWithTTL(mapName, 20));
 
         HazelcastInstance hz = createHazelcastInstance(config);
-        hz.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 20));
+        hz.getConfig().addMapConfig(getMapConfigWithTTL(mapName, 50));
     }
 
     private MapConfig getMapConfigWithTTL(String mapName, int ttl) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSmokeTest.java
@@ -16,9 +16,8 @@
 
 package com.hazelcast.internal.dynamicconfig;
 
-import static org.junit.Assert.assertEquals;
-
 import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MultiMapConfig;
@@ -34,6 +33,8 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})


### PR DESCRIPTION
Adding data structure config at runtime should not fail unless equal config exists as static config 
Fixes #13158