### PR TITLE
Fix broken ClientInvocationFuture from completeExceptionally changes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocationFuture.java
@@ -63,8 +63,8 @@ public class ClientInvocationFuture extends AbstractInvocationFuture<ClientMessa
     }
 
     @Override
-    protected Throwable unwrap(AltResult result) {
-        return result.getCause();
+    protected Throwable prepareError(AltResult result) {
+        return new ExecutionException(result.getCause());
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationFutureTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientInvocationFutureTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl;
+
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientInvocationFutureTest
+        extends ClientTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testChainedExecution_onResponse() {
+        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        InternalCompletableFuture<Double> future = (InternalCompletableFuture<Double>)
+                client.getExecutorService("MyTest")
+                      .submit(new ValidCallable());
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Double> value = new AtomicReference<Double>();
+
+        future.andThen(new ExecutionCallback<Double>() {
+            @Override
+            public void onResponse(Double response) {
+                value.set(response);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+            }
+        });
+
+        assertOpenEventually(latch);
+        assertEquals(value.get(), 2d, 0);
+    }
+
+    @Test
+    public void testChainedExecution_onFailure() {
+        hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        InternalCompletableFuture<Double> future = (InternalCompletableFuture<Double>)
+                client.getExecutorService("MyTest")
+                      .submit(new FailingCallable());
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+
+        future.andThen(new ExecutionCallback<Double>() {
+            @Override
+            public void onResponse(Double response) {
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                error.set(t);
+                latch.countDown();
+            }
+        });
+
+        assertOpenEventually(latch);
+        assertNotNull(error.get());
+        assertEquals(error.get().getClass(), ExecutionException.class);
+        assertEquals(error.get().getCause().getClass(), IllegalStateException.class);
+        assertEquals(error.get().getCause().getMessage(), "Failed");
+    }
+
+    private static class FailingCallable
+            implements Callable<Double>, Serializable {
+
+        @Override
+        public Double call()
+                throws Exception {
+            throw new IllegalStateException("Failed");
+        }
+    }
+
+    private static class ValidCallable
+            implements Callable<Double>, Serializable {
+
+        @Override
+        public Double call()
+                throws Exception {
+            return 2d;
+        }
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractInvocationFuture.java
@@ -252,7 +252,7 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
                     try {
                         Object value = resolve(state);
                         if (value instanceof AltResult) {
-                            Throwable error = unwrap((AltResult) value);
+                            Throwable error = prepareError((AltResult) value);
                             callback.onFailure(error);
                         } else {
                             callback.onResponse((V) value);
@@ -269,7 +269,7 @@ public abstract class AbstractInvocationFuture<V> implements InternalCompletable
     }
 
     // this method should not be needed; but there is a difference between client and server how it handles async throwables
-    protected Throwable unwrap(AltResult result) {
+    protected Throwable prepareError(AltResult result) {
         Throwable throwable = result.cause;
 
         if (throwable instanceof ExecutionException && throwable.getCause() != null) {


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2266

Before it was handled here https://github.com/tkountis/hazelcast/commit/4c71d9e7f4f53dd12fbbb7fb22a50c4005c76bd1#diff-4631ea079bffbdeb27eb4a729d030d21L71

Backported the same unit-test to 3.10.4 https://github.com/hazelcast/hazelcast/pull/13461