### PR TITLE
[BACKPORT] Use user code deployment for custom attribute extractors

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -131,7 +131,8 @@ public class MapContainer {
         this.queryEntryFactory = new QueryEntryFactory(mapConfig.getCacheDeserializedValues());
         this.objectNamespace = MapService.getObjectNamespace(name);
         initWanReplication(nodeEngine);
-        this.extractors = new Extractors(mapConfig.getMapAttributeConfigs(), config.getClassLoader());
+        ClassLoader classloader = mapServiceContext.getNodeEngine().getConfigClassLoader();
+        this.extractors = new Extractors(mapConfig.getMapAttributeConfigs(), classloader);
         if (shouldUseGlobalIndex(mapConfig)) {
             this.globalIndexes = new Indexes((InternalSerializationService) serializationService,
                     mapServiceContext.getIndexProvider(mapConfig), extractors,

--- a/hazelcast/src/test/java/usercodedeployment/CapitalizatingFirstnameExtractor.java
+++ b/hazelcast/src/test/java/usercodedeployment/CapitalizatingFirstnameExtractor.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package usercodedeployment;
+
+import com.hazelcast.query.extractor.ValueCollector;
+import com.hazelcast.query.extractor.ValueExtractor;
+
+public class CapitalizatingFirstnameExtractor extends ValueExtractor<Person, Object> {
+    @Override
+    public void extract(Person target, Object argument, ValueCollector collector) {
+        collector.addObject(target.getName().toUpperCase());
+    }
+}

--- a/hazelcast/src/test/java/usercodedeployment/Person.java
+++ b/hazelcast/src/test/java/usercodedeployment/Person.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package usercodedeployment;
+
+import java.io.Serializable;
+
+public class Person implements Serializable {
+    public final String name;
+
+    public Person(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "Person{"
+                + "name='" + name
+                + '\'' + '}';
+    }
+}


### PR DESCRIPTION
Backport of #13401, Fixes #13400

The original issue:
Extractors were constructed using the classloader which was configured
by the user (=it's null in most of cases).

However this bypass the classloader for dynamic class loading.

(cherry picked from commit b29a430)