### PR TITLE
Cleanup of Node field access

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -102,45 +102,38 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
     @SuppressWarnings("checkstyle:visibilitymodifier")
     public final Node node;
 
-    final ILogger logger;
-
-    final String name;
-
-    final ManagementService managementService;
-
-    final LifecycleServiceImpl lifecycleService;
-
-    final ManagedContext managedContext;
-
     final ConcurrentMap<String, Object> userContext = new ConcurrentHashMap<String, Object>();
 
+    final ILogger logger;
+    final String name;
+    final ManagementService managementService;
+    final LifecycleServiceImpl lifecycleService;
+    final ManagedContext managedContext;
     final HazelcastInstanceCacheManager hazelcastCacheManager;
 
     @SuppressWarnings("checkstyle:executablestatementcount")
-    protected HazelcastInstanceImpl(String name, Config config, NodeContext nodeContext)
-            throws Exception {
+    protected HazelcastInstanceImpl(String name, Config config, NodeContext nodeContext) {
         this.name = name;
         this.lifecycleService = new LifecycleServiceImpl(this);
 
         ManagedContext configuredManagedContext = config.getManagedContext();
-        managedContext = new HazelcastManagedContext(this, configuredManagedContext);
+        this.managedContext = new HazelcastManagedContext(this, configuredManagedContext);
 
-        //we are going to copy the user-context map of the Config so that each HazelcastInstance will get its own
-        //user-context map instance instead of having a shared map instance. So changes made to the user-context map
-        //in one HazelcastInstance will not reflect on other the user-context of other HazelcastInstances.
-        userContext.putAll(config.getUserContext());
-        node = createNode(config, nodeContext);
+        // we are going to copy the user-context map of the Config so that each HazelcastInstance will get its own
+        // user-context map instance instead of having a shared map instance. So changes made to the user-context map
+        // in one HazelcastInstance will not reflect on other the user-context of other HazelcastInstances
+        this.userContext.putAll(config.getUserContext());
+        this.node = createNode(config, nodeContext);
 
         try {
-            logger = node.getLogger(getClass().getName());
+            this.logger = node.getLogger(getClass().getName());
 
             node.start();
-
             if (!node.isRunning()) {
                 throw new IllegalStateException("Node failed to start!");
             }
 
-            managementService = new ManagementService(this);
+            this.managementService = new ManagementService(this);
             initManagedContext(configuredManagedContext);
 
             this.hazelcastCacheManager = new HazelcastInstanceCacheManager(this);
@@ -150,8 +143,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
             }
         } catch (Throwable e) {
             try {
-                // Terminate the node by terminating node engine,
-                // connection manager, multicast service, operation threads, etc... if they exist
+                // terminate the node by terminating the NodeEngine, ConnectionManager, services, operation threads etc.
                 node.shutdown(true);
             } catch (Throwable ignored) {
                 ignore(ignored);
@@ -250,7 +242,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
     @Override
     public <T> T executeTransaction(TransactionOptions options, TransactionalTask<T> task)
             throws TransactionException {
-        TransactionManagerService transactionManagerService = node.nodeEngine.getTransactionManagerService();
+        TransactionManagerService transactionManagerService = node.getNodeEngine().getTransactionManagerService();
         return transactionManagerService.executeTransaction(options, task);
     }
 
@@ -261,7 +253,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
 
     @Override
     public TransactionContext newTransactionContext(TransactionOptions options) {
-        TransactionManagerService transactionManagerService = node.nodeEngine.getTransactionManagerService();
+        TransactionManagerService transactionManagerService = node.getNodeEngine().getTransactionManagerService();
         return transactionManagerService.newTransactionContext(options);
     }
 
@@ -326,7 +318,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
 
     @Override
     public Cluster getCluster() {
-        return node.clusterService;
+        return node.getClusterService();
     }
 
     @Override
@@ -336,7 +328,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
 
     @Override
     public Collection<DistributedObject> getDistributedObjects() {
-        ProxyService proxyService = node.nodeEngine.getProxyService();
+        ProxyService proxyService = node.getNodeEngine().getProxyService();
         return proxyService.getAllDistributedObjects();
     }
 
@@ -352,12 +344,12 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
 
     @Override
     public PartitionService getPartitionService() {
-        return node.partitionService.getPartitionServiceProxy();
+        return node.getPartitionService().getPartitionServiceProxy();
     }
 
     @Override
     public QuorumService getQuorumService() {
-        return node.nodeEngine.getQuorumService();
+        return node.getNodeEngine().getQuorumService();
     }
 
     @Override
@@ -367,7 +359,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
 
     @Override
     public LoggingService getLoggingService() {
-        return node.loggingService;
+        return node.getLoggingService();
     }
 
     @Override
@@ -383,19 +375,19 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
     @Override
     @SuppressWarnings("unchecked")
     public <T extends DistributedObject> T getDistributedObject(String serviceName, String name) {
-        ProxyService proxyService = node.nodeEngine.getProxyService();
+        ProxyService proxyService = node.getNodeEngine().getProxyService();
         return (T) proxyService.getDistributedObject(serviceName, name);
     }
 
     @Override
     public String addDistributedObjectListener(DistributedObjectListener distributedObjectListener) {
-        final ProxyService proxyService = node.nodeEngine.getProxyService();
+        final ProxyService proxyService = node.getNodeEngine().getProxyService();
         return proxyService.addProxyListener(distributedObjectListener);
     }
 
     @Override
     public boolean removeDistributedObjectListener(String registrationId) {
-        final ProxyService proxyService = node.nodeEngine.getProxyService();
+        final ProxyService proxyService = node.getNodeEngine().getProxyService();
         return proxyService.removeProxyListener(registrationId);
     }
 
@@ -436,10 +428,9 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
         if (this == o) {
             return true;
         }
-        if (o == null || !(o instanceof HazelcastInstance)) {
+        if (!(o instanceof HazelcastInstance)) {
             return false;
         }
-
         HazelcastInstance that = (HazelcastInstance) o;
         return !(name != null ? !name.equals(that.getName()) : that.getName() != null);
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -49,6 +49,7 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
     public static final int NA_MEMBER_LIST_JOIN_VERSION = -1;
 
     private boolean localMember;
+
     private volatile int memberListJoinVersion = NA_MEMBER_LIST_JOIN_VERSION;
     private volatile HazelcastInstanceImpl instance;
     private volatile ILogger logger;
@@ -64,26 +65,25 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
         this(address, version, localMember, uuid, null, false);
     }
 
-    public MemberImpl(Address address, MemberVersion version, boolean localMember, String uuid,
-                      Map<String, Object> attributes, boolean liteMember) {
+    public MemberImpl(Address address, MemberVersion version, boolean localMember, String uuid, Map<String, Object> attributes,
+                      boolean liteMember) {
         super(address, version, uuid, attributes, liteMember);
         this.localMember = localMember;
     }
 
-    public MemberImpl(Address address, MemberVersion version, boolean localMember, String uuid,
-                      Map<String, Object> attributes, boolean liteMember,
-                      int memberListJoinVersion, HazelcastInstanceImpl instance) {
+    public MemberImpl(Address address, MemberVersion version, boolean localMember, String uuid, Map<String, Object> attributes,
+                      boolean liteMember, int memberListJoinVersion, HazelcastInstanceImpl instance) {
         super(address, version, uuid, attributes, liteMember);
         this.localMember = localMember;
-        this.instance = instance;
         this.memberListJoinVersion = memberListJoinVersion;
+        this.instance = instance;
     }
 
     public MemberImpl(MemberImpl member) {
         super(member);
         this.localMember = member.localMember;
-        this.instance = member.instance;
         this.memberListJoinVersion = member.memberListJoinVersion;
+        this.instance = member.instance;
     }
 
     @Override
@@ -255,6 +255,7 @@ public final class MemberImpl extends AbstractMember implements Member, Hazelcas
     }
 
     private class MemberAttributeOperationSupplier implements Supplier<Operation> {
+
         private final MemberAttributeOperationType operationType;
         private final String key;
         private final Object value;

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -55,6 +55,7 @@ import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.usercodedeployment.UserCodeDeploymentClassLoader;
 import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
 import com.hazelcast.logging.LoggingServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ClassLoaderUtil;
@@ -606,6 +607,10 @@ public class Node {
         joiner.reset();
     }
 
+    public LoggingService getLoggingService() {
+        return loggingService;
+    }
+
     public ILogger getLogger(String name) {
         return loggingService.getLogger(name);
     }
@@ -632,6 +637,10 @@ public class Node {
 
     public NodeEngineImpl getNodeEngine() {
         return nodeEngine;
+    }
+
+    public ClientEngineImpl getClientEngine() {
+        return clientEngine;
     }
 
     public NodeExtension getNodeExtension() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -20,6 +20,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
+import com.hazelcast.internal.partition.impl.PartitionReplicaStateChecker;
 import com.hazelcast.internal.partition.impl.PartitionStateManager;
 import com.hazelcast.internal.partition.operation.FetchPartitionStateOperation;
 import com.hazelcast.nio.Address;
@@ -89,9 +90,8 @@ public interface InternalPartitionService extends IPartitionService {
      * </ul>
      * If this instance is not the master, it will trigger the master to assign the partitions.
      *
-     * @throws HazelcastException if the partition state generator failed to arrange the partitions
      * @return {@link PartitionRuntimeState} if this node is the master and the partition table is initialized
-     *
+     * @throws HazelcastException if the partition state generator failed to arrange the partitions
      * @see PartitionStateManager#initializePartitionAssignments(java.util.Set)
      */
     PartitionRuntimeState firstArrangement();
@@ -118,4 +118,13 @@ public interface InternalPartitionService extends IPartitionService {
      * @return partition ID list assigned to given target if partitions are assigned already
      */
     List<Integer> getMemberPartitionsIfAssigned(Address target);
+
+    /**
+     * Returns the {@link PartitionServiceProxy} of the partition service..
+     *
+     * @return the {@link PartitionServiceProxy}
+     */
+    PartitionServiceProxy getPartitionServiceProxy();
+
+    PartitionReplicaStateChecker getPartitionReplicaStateChecker();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -1053,12 +1053,13 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         reset();
     }
 
-    @Override
     @Probe
+    @Override
     public long getMigrationQueueSize() {
         return migrationManager.getMigrationQueueSize();
     }
 
+    @Override
     public PartitionServiceProxy getPartitionServiceProxy() {
         return proxy;
     }
@@ -1156,6 +1157,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         return replicaManager;
     }
 
+    @Override
     public PartitionReplicaStateChecker getPartitionReplicaStateChecker() {
         return partitionReplicaStateChecker;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -120,7 +120,7 @@ public class MigrationManager {
 
     MigrationManager(Node node, InternalPartitionServiceImpl service, Lock partitionServiceLock) {
         this.node = node;
-        this.nodeEngine = node.nodeEngine;
+        this.nodeEngine = node.getNodeEngine();
         this.partitionService = service;
         this.logger = node.getLogger(getClass());
         this.partitionServiceLock = partitionServiceLock;

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/TestPartitionUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/TestPartitionUtils.java
@@ -53,7 +53,7 @@ public final class TestPartitionUtils {
     public static PartitionServiceState getPartitionServiceState(HazelcastInstance instance) {
         try {
             Node node = getNode(instance);
-            InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) node.getPartitionService();
+            InternalPartitionService partitionService = node.getPartitionService();
             return partitionService.getPartitionReplicaStateChecker().getPartitionServiceState();
         } catch (IllegalArgumentException e) {
             return PartitionServiceState.SAFE;


### PR DESCRIPTION
The direct access to `Node` fields is a problem for compatibility tests, which used proxied or mocked classes from another classloader. Method calls can be proxied or intercepted easily, access to fields is a real issue.

This PR fixes the most important `Node` access locations to enable the usage of Hazelcast instances in compatibility tests.

Pulled out from https://github.com/hazelcast/hazelcast/pull/13293