### PR TITLE
Add merkle tree configuration

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -69,6 +69,7 @@ import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MemberAttributeConfig;
+import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NetworkConfig;
@@ -93,6 +94,7 @@ import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
+import com.hazelcast.util.Preconditions;
 import com.hazelcast.util.StringUtil;
 
 import java.io.File;
@@ -447,6 +449,34 @@ public class ClientDynamicClusterConfig extends Config {
 
     @Override
     public Config setCacheEventJournalConfigs(Map<String, EventJournalConfig> eventJournalConfigs) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public MerkleTreeConfig findMapMerkleTreeConfig(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public MerkleTreeConfig getMapMerkleTreeConfig(String name) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Config addMerkleTreeConfig(MerkleTreeConfig merkleTreeConfig) {
+        final String mapName = merkleTreeConfig.getMapName();
+        Preconditions.checkHasText(mapName, "Merkle tree config must define a map name");
+        // TODO add client invocation
+        return this;
+    }
+
+    @Override
+    public Map<String, MerkleTreeConfig> getMapMerkleTreeConfigs() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Config setMapMerkleTreeConfigs(Map<String, MerkleTreeConfig> merkleTreeConfigs) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -1298,7 +1298,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                 } else if ("discovery-strategies".equals(nodeName)) {
                     handleDiscoveryStrategies(child, publisherBuilder);
                 } else if ("wan-sync".equals(nodeName)) {
-                    createAndFillBeanBuilder(child, WanSyncConfig.class, "wanSync", publisherBuilder);
+                    createAndFillBeanBuilder(child, WanSyncConfig.class, "wanSyncConfig", publisherBuilder);
                 }
             }
             return childBeanDefinition;

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -65,6 +65,7 @@ import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.config.MemberGroupConfig;
 import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.config.NativeMemoryConfig;
@@ -104,6 +105,7 @@ import com.hazelcast.config.WanConsumerConfig;
 import com.hazelcast.config.WanPublisherConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
+import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.map.eviction.MapEvictionPolicy;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
@@ -192,6 +194,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private ManagedMap<String, AbstractBeanDefinition> scheduledExecutorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> mapEventJournalManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> cacheEventJournalManagedMap;
+        private ManagedMap<String, AbstractBeanDefinition> mapMerkleTreeManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> cardinalityEstimatorManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> wanReplicationManagedMap;
         private ManagedMap<String, AbstractBeanDefinition> jobTrackerManagedMap;
@@ -222,6 +225,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             this.scheduledExecutorManagedMap = createManagedMap("scheduledExecutorConfigs");
             this.mapEventJournalManagedMap = createManagedMap("mapEventJournalConfigs");
             this.cacheEventJournalManagedMap = createManagedMap("cacheEventJournalConfigs");
+            this.mapMerkleTreeManagedMap = createManagedMap("mapMerkleTreeConfigs");
             this.cardinalityEstimatorManagedMap = createManagedMap("cardinalityEstimatorConfigs");
             this.wanReplicationManagedMap = createManagedMap("wanReplicationConfigs");
             this.jobTrackerManagedMap = createManagedMap("jobTrackerConfigs");
@@ -261,6 +265,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                         handleScheduledExecutor(node);
                     } else if ("event-journal".equals(nodeName)) {
                         handleEventJournal(node);
+                    } else if ("merkle-tree".equals(nodeName)) {
+                        handleMerkleTree(node);
                     } else if ("cardinality-estimator".equals(nodeName)) {
                         handleCardinalityEstimator(node);
                     } else if ("queue".equals(nodeName)) {
@@ -841,6 +847,13 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             lockManagedMap.put(getAttribute(node, "name"), lockConfigBuilder.getBeanDefinition());
         }
 
+        public void handleMerkleTree(Node node) {
+            BeanDefinitionBuilder merkleTreeBuilder = createBeanBuilder(MerkleTreeConfig.class);
+            fillAttributeValues(node, merkleTreeBuilder);
+            String mapName = getAttribute(node, "map-name");
+            mapMerkleTreeManagedMap.put(mapName, merkleTreeBuilder.getBeanDefinition());
+        }
+
         public void handleEventJournal(Node node) {
             BeanDefinitionBuilder eventJournalBuilder = createBeanBuilder(EventJournalConfig.class);
             fillAttributeValues(node, eventJournalBuilder);
@@ -1248,59 +1261,69 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             for (Node n : childElements(node)) {
                 String nName = cleanNodeName(n);
                 if ("wan-publisher".equals(nName)) {
-                    BeanDefinitionBuilder publisherBuilder = createBeanBuilder(WanPublisherConfig.class);
-                    AbstractBeanDefinition childBeanDefinition = publisherBuilder.getBeanDefinition();
-                    fillAttributeValues(n, publisherBuilder, Collections.<String>emptyList());
-
-                    String className = getAttribute(n, "class-name");
-                    String implementation = getAttribute(n, "implementation");
-
-                    publisherBuilder.addPropertyValue("className", className);
-                    if (implementation != null) {
-                        publisherBuilder.addPropertyReference("implementation", implementation);
-                    }
-                    isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation'"
-                            + " attributes is required to create WanPublisherConfig!");
-                    for (Node child : childElements(n)) {
-
-                        String nodeName = cleanNodeName(child);
-                        if ("properties".equals(nodeName)) {
-                            handleProperties(child, publisherBuilder);
-                        } else if ("queue-full-behavior".equals(nodeName)
-                                || "initial-publisher-state".equals(nodeName)
-                                || "queue-capacity".equals(nodeName)) {
-                            publisherBuilder.addPropertyValue(xmlToJavaName(nodeName), getTextContent(child));
-                        } else if ("aws".equals(nodeName)) {
-                            handleAws(child, publisherBuilder);
-                        } else if ("discovery-strategies".equals(nodeName)) {
-                            handleDiscoveryStrategies(child, publisherBuilder);
-                        }
-                    }
-                    wanPublishers.add(childBeanDefinition);
+                    wanPublishers.add(handleWanPublisher(n));
                 } else if ("wan-consumer".equals(nName)) {
-                    BeanDefinitionBuilder consumerConfigBuilder = createBeanBuilder(WanConsumerConfig.class);
-
-                    String className = getAttribute(n, "class-name");
-                    String implementation = getAttribute(n, "implementation");
-                    boolean persistWanReplicatedData = getBooleanValue(getAttribute(n, "persist-wan-replicated-data"));
-
-                    consumerConfigBuilder.addPropertyValue("className", className);
-                    if (implementation != null) {
-                        consumerConfigBuilder.addPropertyReference("implementation", implementation);
-                    }
-                    consumerConfigBuilder.addPropertyValue("persistWanReplicatedData", persistWanReplicatedData);
-
-                    for (Node child : childElements(n)) {
-                        String nodeName = cleanNodeName(child);
-                        if ("properties".equals(nodeName)) {
-                            handleProperties(child, consumerConfigBuilder);
-                        }
-                    }
-                    replicationConfigBuilder.addPropertyValue("wanConsumerConfig", consumerConfigBuilder.getBeanDefinition());
+                    replicationConfigBuilder.addPropertyValue("wanConsumerConfig", handleWanConsumer(n));
                 }
             }
             replicationConfigBuilder.addPropertyValue("wanPublisherConfigs", wanPublishers);
             wanReplicationManagedMap.put(name, replicationConfigBuilder.getBeanDefinition());
+        }
+
+        private AbstractBeanDefinition handleWanPublisher(Node n) {
+            BeanDefinitionBuilder publisherBuilder = createBeanBuilder(WanPublisherConfig.class);
+            AbstractBeanDefinition childBeanDefinition = publisherBuilder.getBeanDefinition();
+            fillAttributeValues(n, publisherBuilder, Collections.<String>emptyList());
+
+            String className = getAttribute(n, "class-name");
+            String implementation = getAttribute(n, "implementation");
+
+            publisherBuilder.addPropertyValue("className", className);
+            if (implementation != null) {
+                publisherBuilder.addPropertyReference("implementation", implementation);
+            }
+            isTrue(className != null || implementation != null, "One of 'class-name' or 'implementation'"
+                    + " attributes is required to create WanPublisherConfig!");
+            for (Node child : childElements(n)) {
+
+                String nodeName = cleanNodeName(child);
+                if ("properties".equals(nodeName)) {
+                    handleProperties(child, publisherBuilder);
+                } else if ("queue-full-behavior".equals(nodeName)
+                        || "initial-publisher-state".equals(nodeName)
+                        || "queue-capacity".equals(nodeName)) {
+                    publisherBuilder.addPropertyValue(xmlToJavaName(nodeName), getTextContent(child));
+                } else if ("aws".equals(nodeName)) {
+                    handleAws(child, publisherBuilder);
+                } else if ("discovery-strategies".equals(nodeName)) {
+                    handleDiscoveryStrategies(child, publisherBuilder);
+                } else if ("wan-sync".equals(nodeName)) {
+                    createAndFillBeanBuilder(child, WanSyncConfig.class, "wanSync", publisherBuilder);
+                }
+            }
+            return childBeanDefinition;
+        }
+
+        private AbstractBeanDefinition handleWanConsumer(Node n) {
+            BeanDefinitionBuilder consumerConfigBuilder = createBeanBuilder(WanConsumerConfig.class);
+
+            String className = getAttribute(n, "class-name");
+            String implementation = getAttribute(n, "implementation");
+            boolean persistWanReplicatedData = getBooleanValue(getAttribute(n, "persist-wan-replicated-data"));
+
+            consumerConfigBuilder.addPropertyValue("className", className);
+            if (implementation != null) {
+                consumerConfigBuilder.addPropertyReference("implementation", implementation);
+            }
+            consumerConfigBuilder.addPropertyValue("persistWanReplicatedData", persistWanReplicatedData);
+
+            for (Node child : childElements(n)) {
+                String nodeName = cleanNodeName(child);
+                if ("properties".equals(nodeName)) {
+                    handleProperties(child, consumerConfigBuilder);
+                }
+            }
+            return consumerConfigBuilder.getBeanDefinition();
         }
 
         private void handlePartitionGroup(Node node) {

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
@@ -2414,14 +2414,16 @@
 
     <xs:complexType name="wan-sync">
         <xs:all>
-            <xs:element name="use-merkle-trees" type="parameterized-boolean" minOccurs="0" default="false">
+            <xs:element name="consistency-check-strategy" type="consistency-check-strategy" minOccurs="0" default="NONE">
                 <xs:annotation>
                     <xs:documentation>
-                        Boolean denoting if merkle trees should be used to optimise WAN sync.
-                        For the check procedure to work properly, the target cluster should
-                        support merkle trees and the data structures being synced should be
-                        configured with merkle trees enabled both on the source and target cluster.
-                        Default value is false.
+                        Sets the strategy for checking consistency of data between source and
+                        target cluster. Any inconsistency will not be reconciled, it will be
+                        merely reported via the usual mechanisms (e.g. statistics, diagnostics).
+                        The user must initiate WAN sync to reconcile there differences. For the
+                        check procedure to work properly, the target cluster should support the
+                        chosen strategy.
+                        Default value is NONE, which means the check is disabled.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -2436,7 +2438,8 @@
                         For the check procedure to work properly, the target cluster should
                         support merkle trees and the data structures being synced should be
                         configured with merkle trees enabled both on the source and target cluster.
-                        Default value is -1, which means the periodic check is disabled.
+                        Default value is 0, which means the periodic check is disabled.
+                        The period must not be negative.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -3946,6 +3949,13 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="consistency-check-strategy-format-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="MERKLE_TREES"/>
+        </xs:restriction>
+    </xs:simpleType>
+
     <xs:simpleType name="wan-ack-type">
         <xs:union memberTypes="wan-ack-type-format-enum non-space-string"/>
     </xs:simpleType>
@@ -3956,6 +3966,10 @@
 
     <xs:simpleType name="initial-publisher-state">
         <xs:union memberTypes="initial-publisher-state-format-enum non-space-string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="consistency-check-strategy">
+        <xs:union memberTypes="consistency-check-strategy-format-enum non-space-string"/>
     </xs:simpleType>
 
     <xs:complexType name="crdt-replication">

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
@@ -1211,6 +1211,64 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
+                        <xs:element name="merkle-tree" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Configuration for a merkle tree.
+                                        The merkle tree is a data structure used for efficient comparison of the
+                                        difference in the contents of large data structures. The precision of
+                                        such a comparison mechanism is defined by the depth of the merkle tree.
+                                        A larger depth means that a data synchronization mechanism will be able
+                                        to pinpoint a smaller subset of the data structure contents in which a
+                                        change occurred. This causes the synchronization mechanism to be more
+                                        efficient. On the other hand, a larger tree depth means the merkle tree
+                                        will consume more memory.
+                                        A smaller depth means the data synchronization mechanism will have to
+                                        transfer larger chunks of the data structure in which a possible change
+                                        happened. On the other hand, a shallower tree consumes less memory.
+                                        The depth must be between 2 and 27 (exclusive).
+                                        As the comparison mechanism is iterative, a larger depth will also prolong
+                                        the duration of the comparison mechanism. Care must be taken to not have
+                                        large tree depths if the latency of the comparison operation is high.
+                                        The default depth is 10.
+                                        This configuration is not tied to a specific data structure and can be
+                                        reused.
+                                        See https://en.wikipedia.org/wiki/Merkle_tree.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:attribute name="map-name" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the map to which this config applies.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="enabled" type="parameterized-boolean" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            True if the merkle tree is enabled, false otherwise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="depth" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The depth of the merkle tree.
+                                            A larger depth means that a data synchronization mechanism will be able
+                                            to pinpoint a smaller subset of the data structure contents in which a
+                                            change occurred. This causes the synchronization mechanism to be more
+                                            efficient. On the other hand, a larger tree depth means the merkle tree
+                                            will consume more memory.
+                                            A smaller depth means the data synchronization mechanism will have to
+                                            transfer larger chunks of the data structure in which a possible change
+                                            happened. On the other hand, a shallower tree consumes less memory.
+                                            The depth must be between 2 and 27 (exclusive). The default depth is 10.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
                         <xs:element name="multimap" minOccurs="0" maxOccurs="unbounded">
                             <xs:complexType>
                                 <xs:sequence>
@@ -2354,6 +2412,37 @@
         <xs:attribute name="discovery-strategy-factory" type="non-space-string" use="optional"/>
     </xs:complexType>
 
+    <xs:complexType name="wan-sync">
+        <xs:all>
+            <xs:element name="use-merkle-trees" type="parameterized-boolean" minOccurs="0" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        Boolean denoting if merkle trees should be used to optimise WAN sync.
+                        For the check procedure to work properly, the target cluster should
+                        support merkle trees and the data structures being synced should be
+                        configured with merkle trees enabled both on the source and target cluster.
+                        Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="consistency-check-period-millis" minOccurs="0" type="xs:long">
+                <xs:annotation>
+                    <xs:documentation>
+                        Period (in milliseconds) for checking consistency of data
+                        between source and target cluster.
+                        Any inconsistency will not be reconciled, it will be merely reported via
+                        the usual mechanisms (e.g. statistics, diagnostics). The user must
+                        initiate WAN sync to reconcile there differences.
+                        For the check procedure to work properly, the target cluster should
+                        support merkle trees and the data structures being synced should be
+                        configured with merkle trees enabled both on the source and target cluster.
+                        Default value is -1, which means the periodic check is disabled.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
     <xs:complexType name="merge-policy">
         <xs:annotation>
             <xs:documentation>
@@ -2713,6 +2802,13 @@
                         </xs:element>
                         <xs:element name="aws" type="aws" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="wan-sync" type="wan-sync" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Configuration for the WAN sync mechanism.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
                         <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
                     </xs:sequence>
                     <xs:attributeGroup ref="class-or-bean-name"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -994,7 +994,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("tokyo", publisherConfig.getGroupName());
         assertEquals("PublisherClassName", publisherConfig.getClassName());
 
-        final WanSyncConfig wanSyncConfig = publisherConfig.getWanSync();
+        final WanSyncConfig wanSyncConfig = publisherConfig.getWanSyncConfig();
         assertNotNull(wanSyncConfig);
         assertEquals(ConsistencyCheckStrategy.MERKLE_TREES, wanSyncConfig.getConsistencyCheckStrategy());
         assertEquals(12345, wanSyncConfig.getConsistencyCheckPeriodMillis());

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -25,6 +25,7 @@ import com.hazelcast.config.CacheSimpleConfig;
 import com.hazelcast.config.CardinalityEstimatorConfig;
 import com.hazelcast.config.ClassFilter;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.ConsistencyCheckStrategy;
 import com.hazelcast.config.CountDownLatchConfig;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
@@ -995,7 +996,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
 
         final WanSyncConfig wanSyncConfig = publisherConfig.getWanSync();
         assertNotNull(wanSyncConfig);
-        assertTrue(wanSyncConfig.isUseMerkleTrees());
+        assertEquals(ConsistencyCheckStrategy.MERKLE_TREES, wanSyncConfig.getConsistencyCheckStrategy());
         assertEquals(12345, wanSyncConfig.getConsistencyCheckPeriodMillis());
     }
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -117,6 +117,12 @@
                 </hz:wan-consumer>
             </hz:wan-replication>
             <hz:wan-replication name="testWan2">
+                <hz:wan-publisher group-name="tokyo" class-name="PublisherClassName">
+                    <hz:wan-sync>
+                        <hz:consistency-check-period-millis>12345</hz:consistency-check-period-millis>
+                        <hz:use-merkle-trees>true</hz:use-merkle-trees>
+                    </hz:wan-sync>
+                </hz:wan-publisher>
                 <hz:wan-consumer implementation="wanConsumer" persist-wan-replicated-data="false"/>
             </hz:wan-replication>
             <hz:wan-replication name="testWan3">
@@ -483,6 +489,8 @@
 
             <hz:event-journal map-name="mapName" cache-name="cacheName" enabled="true"
                               capacity="123" time-to-live-seconds="321"/>
+
+            <hz:merkle-tree map-name="mapName" enabled="true" depth="15"/>
 
             <hz:multimap name="testMultimap" value-collection-type="LIST" binary="false" statistics-enabled="false">
                 <hz:entry-listeners>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -119,8 +119,8 @@
             <hz:wan-replication name="testWan2">
                 <hz:wan-publisher group-name="tokyo" class-name="PublisherClassName">
                     <hz:wan-sync>
+                        <hz:consistency-check-strategy>MERKLE_TREES</hz:consistency-check-strategy>
                         <hz:consistency-check-period-millis>12345</hz:consistency-check-period-millis>
-                        <hz:use-merkle-trees>true</hz:use-merkle-trees>
                     </hz:wan-sync>
                 </hz:wan-publisher>
                 <hz:wan-consumer implementation="wanConsumer" persist-wan-replicated-data="false"/>

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -121,6 +121,8 @@ public class Config {
 
     private final Map<String, EventJournalConfig> cacheEventJournalConfigs = new ConcurrentHashMap<String, EventJournalConfig>();
 
+    private final Map<String, MerkleTreeConfig> mapMerkleTreeConfigs = new ConcurrentHashMap<String, MerkleTreeConfig>();
+
     private final Map<String, FlakeIdGeneratorConfig> flakeIdGeneratorConfigMap =
             new ConcurrentHashMap<String, FlakeIdGeneratorConfig>();
 
@@ -380,7 +382,7 @@ public class Config {
      * If there is no config found by the name, it will return the configuration
      * with the name {@code default}.
      * For non-default configurations and on-heap maps, it will also
-     * initialise the the Near Cache eviction if not previously set.
+     * initialise the Near Cache eviction if not previously set.
      *
      * @param name name of the map config
      * @return the map configuration
@@ -421,7 +423,7 @@ public class Config {
      * Returns the MapConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -549,7 +551,7 @@ public class Config {
      * Returns the CacheSimpleConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -661,7 +663,7 @@ public class Config {
      * Returns the QueueConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -773,7 +775,7 @@ public class Config {
      * Returns the LockConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -885,7 +887,7 @@ public class Config {
      * Returns the ListConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -997,7 +999,7 @@ public class Config {
      * Returns the SetConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -1109,7 +1111,7 @@ public class Config {
      * Returns the MultiMapConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -1221,7 +1223,7 @@ public class Config {
      * Returns the ReplicatedMapConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -1334,7 +1336,7 @@ public class Config {
      * Returns the RingbufferConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -1443,7 +1445,7 @@ public class Config {
      * Returns the AtomicLongConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -1551,7 +1553,7 @@ public class Config {
      * Returns the AtomicReferenceConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -1659,7 +1661,7 @@ public class Config {
      * Returns the CountDownLatchConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -1769,7 +1771,7 @@ public class Config {
      * Returns the TopicConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -1852,7 +1854,7 @@ public class Config {
      * Returns the ReliableTopicConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -2092,7 +2094,7 @@ public class Config {
      * Returns the ExecutorConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -2137,7 +2139,7 @@ public class Config {
      * Returns the DurableExecutorConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -2183,7 +2185,7 @@ public class Config {
      * Returns the ScheduledExecutorConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -2229,7 +2231,7 @@ public class Config {
      * Returns the CardinalityEstimatorConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -2275,7 +2277,7 @@ public class Config {
      * Returns the {@link PNCounterConfig} for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -2554,7 +2556,7 @@ public class Config {
      * Returns the SemaphoreConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -2724,7 +2726,7 @@ public class Config {
      * Returns the JobTrackerConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -2822,7 +2824,7 @@ public class Config {
      * Returns the QuorumConfig for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -3081,7 +3083,7 @@ public class Config {
      * Returns the map event journal config for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -3127,7 +3129,7 @@ public class Config {
      * Returns the cache event journal config for the given name, creating one
      * if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -3175,7 +3177,7 @@ public class Config {
      * means the configuration applies to maps and a non-empty value for
      * {@link EventJournalConfig#getCacheName()} means the configuration
      * applies to caches.
-     * The returned name may be a may be a pattern with which the configuration
+     * The returned name may be a pattern with which the configuration
      * will be obtained in the future.
      *
      * @param eventJournalConfig the event journal configuration
@@ -3197,6 +3199,95 @@ public class Config {
         if (!StringUtil.isNullOrEmpty(cacheName)) {
             cacheEventJournalConfigs.put(cacheName, eventJournalConfig);
         }
+        return this;
+    }
+
+    /**
+     * Returns a read-only map {@link MerkleTreeConfig} for the given name.
+     * <p>
+     * The name is matched by pattern to the configuration and by stripping the
+     * partition ID qualifier from the given {@code name}.
+     * If there is no config found by the name, it will return the configuration
+     * with the name {@code default}.
+     *
+     * @param name name of the map merkle tree config
+     * @return the map merkle tree configuration
+     * @throws ConfigurationException if ambiguous configurations are found
+     * @see StringPartitioningStrategy#getBaseName(java.lang.String)
+     * @see #setConfigPatternMatcher(ConfigPatternMatcher)
+     * @see #getConfigPatternMatcher()
+     */
+    public MerkleTreeConfig findMapMerkleTreeConfig(String name) {
+        name = getBaseName(name);
+        final MerkleTreeConfig config = lookupByPattern(configPatternMatcher, mapMerkleTreeConfigs, name);
+        if (config != null) {
+            return config.getAsReadOnly();
+        }
+        return getMapMerkleTreeConfig("default").getAsReadOnly();
+    }
+
+    /**
+     * Returns the map merkle tree config for the given name, creating one
+     * if necessary and adding it to the collection of known configurations.
+     * <p>
+     * The configuration is found by matching the configuration name
+     * pattern to the provided {@code name} without the partition qualifier
+     * (the part of the name after {@code '@'}).
+     * If no configuration matches, it will create one by cloning the
+     * {@code "default"} configuration and add it to the configuration
+     * collection.
+     * <p>
+     * If there is no default config as well, it will create one and disable
+     * the merkle tree by default.
+     * This method is intended to easily and fluently create and add
+     * configurations more specific than the default configuration without
+     * explicitly adding it by invoking
+     * {@link #addMerkleTreeConfig(MerkleTreeConfig)}.
+     * <p>
+     * Because it adds new configurations if they are not already present,
+     * this method is intended to be used before this config is used to
+     * create a hazelcast instance. Afterwards, newly added configurations
+     * may be ignored.
+     *
+     * @param name name of the map merkle tree config
+     * @return the map merkle tree configuration
+     * @throws ConfigurationException if ambiguous configurations are found
+     * @see StringPartitioningStrategy#getBaseName(java.lang.String)
+     * @see #setConfigPatternMatcher(ConfigPatternMatcher)
+     * @see #getConfigPatternMatcher()
+     */
+    public MerkleTreeConfig getMapMerkleTreeConfig(String name) {
+        name = getBaseName(name);
+        MerkleTreeConfig config = lookupByPattern(configPatternMatcher, mapMerkleTreeConfigs, name);
+        if (config != null) {
+            return config;
+        }
+        MerkleTreeConfig defConfig = mapMerkleTreeConfigs.get("default");
+        if (defConfig == null) {
+            defConfig = new MerkleTreeConfig().setMapName("default").setEnabled(false);
+            addMerkleTreeConfig(defConfig);
+        }
+        config = new MerkleTreeConfig(defConfig).setMapName(name);
+        addMerkleTreeConfig(config);
+        return config;
+    }
+
+    /**
+     * Adds the merkle tree configuration.
+     * The returned {@link MerkleTreeConfig#getMapName()} may be a
+     * pattern with which the configuration will be obtained in the future.
+     *
+     * @param merkleTreeConfig the merkle tree configuration
+     * @return this config instance
+     * @throws IllegalArgumentException if the {@link MerkleTreeConfig#getMapName()}
+     *                                  is empty
+     */
+    public Config addMerkleTreeConfig(MerkleTreeConfig merkleTreeConfig) {
+        final String mapName = merkleTreeConfig.getMapName();
+        if (StringUtil.isNullOrEmpty(mapName)) {
+            throw new IllegalArgumentException("Merkle tree config must define a map name");
+        }
+        mapMerkleTreeConfigs.put(mapName, merkleTreeConfig);
         return this;
     }
 
@@ -3239,7 +3330,7 @@ public class Config {
      * Returns the {@link FlakeIdGeneratorConfig} for the given name, creating
      * one if necessary and adding it to the collection of known configurations.
      * <p>
-     * The configuration is found by matching the the configuration name
+     * The configuration is found by matching the configuration name
      * pattern to the provided {@code name} without the partition qualifier
      * (the part of the name after {@code '@'}).
      * If no configuration matches, it will create one by cloning the
@@ -3361,6 +3452,34 @@ public class Config {
         this.cacheEventJournalConfigs.putAll(eventJournalConfigs);
         for (Entry<String, EventJournalConfig> entry : eventJournalConfigs.entrySet()) {
             entry.getValue().setCacheName(entry.getKey());
+        }
+        return this;
+    }
+
+    /**
+     * Returns the map of map merkle tree configurations, mapped by config
+     * name. The config name may be a pattern with which the configuration was
+     * initially obtained.
+     *
+     * @return the map merkle tree configurations mapped by config name
+     */
+    public Map<String, MerkleTreeConfig> getMapMerkleTreeConfigs() {
+        return mapMerkleTreeConfigs;
+    }
+
+    /**
+     * Sets the map of map merkle configurations, mapped by config name.
+     * The config name may be a pattern with which the configuration will be
+     * obtained in the future.
+     *
+     * @param merkleTreeConfigs the map merkle tree configuration map to set
+     * @return this config instance
+     */
+    public Config setMapMerkleTreeConfigs(Map<String, MerkleTreeConfig> merkleTreeConfigs) {
+        this.mapMerkleTreeConfigs.clear();
+        this.mapMerkleTreeConfigs.putAll(merkleTreeConfigs);
+        for (Entry<String, MerkleTreeConfig> entry : merkleTreeConfigs.entrySet()) {
+            entry.getValue().setMapName(entry.getKey());
         }
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -93,8 +93,10 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
     public static final int MERGE_POLICY_CONFIG = 51;
     public static final int COUNT_DOWN_LATCH_CONFIG = 52;
     public static final int PN_COUNTER_CONFIG = 53;
+    public static final int MERKLE_TREE_CONFIG = 54;
+    public static final int WAN_SYNC_CONFIG = 55;
 
-    private static final int LEN = PN_COUNTER_CONFIG + 1;
+    private static final int LEN = WAN_SYNC_CONFIG + 1;
 
     @Override
     public int getFactoryId() {
@@ -439,7 +441,20 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
                         return new PNCounterConfig();
                     }
                 };
-
+        constructors[MERKLE_TREE_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new MerkleTreeConfig();
+                    }
+                };
+        constructors[WAN_SYNC_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new WanSyncConfig();
+                    }
+                };
         return new ArrayDataSerializableFactory(constructors);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -697,7 +697,7 @@ public class ConfigXmlGenerator {
 
     private static void wanReplicationSyncGenerator(XmlGenerator gen, WanSyncConfig c) {
         gen.open("wan-sync")
-           .node("use-merkle-trees", c.isUseMerkleTrees())
+           .node("consistency-check-strategy", c.getConsistencyCheckStrategy())
            .node("consistency-check-period-millis", c.getConsistencyCheckPeriodMillis())
            .close();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -689,7 +689,7 @@ public class ConfigXmlGenerator {
            .node("initial-publisher-state", p.getInitialPublisherState())
            .node("queue-capacity", p.getQueueCapacity())
            .appendProperties(p.getProperties());
-        wanReplicationSyncGenerator(gen, p.getWanSync());
+        wanReplicationSyncGenerator(gen, p.getWanSyncConfig());
         awsConfigXmlGenerator(gen, p.getAwsConfig());
         discoveryStrategyConfigXmlGenerator(gen, p.getDiscoveryConfig());
         gen.close();

--- a/hazelcast/src/main/java/com/hazelcast/config/ConsistencyCheckStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConsistencyCheckStrategy.java
@@ -33,6 +33,7 @@ public enum ConsistencyCheckStrategy {
      */
     MERKLE_TREES((byte) 1);
 
+    private static final ConsistencyCheckStrategy[] VALUES = values();
     private final byte id;
 
     ConsistencyCheckStrategy(byte id) {
@@ -58,7 +59,7 @@ public enum ConsistencyCheckStrategy {
      * @throws IllegalArgumentException if no ConsistencyCheckStrategy was found
      */
     public static ConsistencyCheckStrategy getById(byte id) {
-        for (ConsistencyCheckStrategy type : values()) {
+        for (ConsistencyCheckStrategy type : VALUES) {
             if (type.id == id) {
                 return type;
             }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConsistencyCheckStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConsistencyCheckStrategy.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Strategy for checking the consistency of data between replicas.
+ *
+ * @since 3.11
+ */
+public enum ConsistencyCheckStrategy {
+    /**
+     * No consistency checks
+     */
+    NONE((byte) 0),
+    /**
+     * Uses merkle trees (if configured) for consistency checks.
+     *
+     * @see MerkleTreeConfig
+     */
+    MERKLE_TREES((byte) 1);
+
+    private final byte id;
+
+    ConsistencyCheckStrategy(byte id) {
+        this.id = id;
+    }
+
+    /**
+     * Gets the ID for this ConsistencyCheckStrategy.
+     * <p>
+     * This reason this ID is used instead of an the ordinal value is that the
+     * ordinal value is more prone to changes due to reordering.
+     *
+     * @return the ID
+     */
+    public byte getId() {
+        return id;
+    }
+
+    /**
+     * Returns the ConsistencyCheckStrategy for the given ID.
+     *
+     * @return the ConsistencyCheckStrategy for the given ID
+     * @throws IllegalArgumentException if no ConsistencyCheckStrategy was found
+     */
+    public static ConsistencyCheckStrategy getById(byte id) {
+        for (ConsistencyCheckStrategy type : values()) {
+            if (type.id == id) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Could not find a ConsistencyCheckStrategy with an ID:" + id);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/MerkleTreeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MerkleTreeConfig.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.spi.annotation.Beta;
+import com.hazelcast.util.StringUtil;
+
+import java.io.IOException;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * Configuration for a merkle tree.
+ * The merkle tree is a data structure used for efficient comparison of the
+ * difference in the contents of large data structures. The precision of
+ * such a comparison mechanism is defined by the depth of the merkle tree.
+ * <p>
+ * A larger depth means that a data synchronization mechanism will be able
+ * to pinpoint a smaller subset of the data structure contents in which a
+ * change occurred. This causes the synchronization mechanism to be more
+ * efficient. On the other hand, a larger tree depth means the merkle tree
+ * will consume more memory.
+ * <p>
+ * A smaller depth means the data synchronization mechanism will have to
+ * transfer larger chunks of the data structure in which a possible change
+ * happened. On the other hand, a shallower tree consumes less memory.
+ * The depth must be between {@value MIN_DEPTH} and {@value MAX_DEPTH}
+ * (exclusive). The default depth is {@value DEFAULT_DEPTH}.
+ * <p>
+ * As the comparison mechanism is iterative, a larger depth will also prolong
+ * the duration of the comparison mechanism. Care must be taken to not have
+ * large tree depths if the latency of the comparison operation is high.
+ * The default depth is {@value DEFAULT_DEPTH}.
+ * <p>
+ * This configuration is not tied to a specific data structure and can be
+ * reused.
+ *
+ * See https://en.wikipedia.org/wiki/Merkle_tree.
+ */
+@Beta
+public class MerkleTreeConfig implements IdentifiedDataSerializable {
+    /**
+     * Minimal depth of the merkle tree.
+     */
+    private static final int MIN_DEPTH = 2;
+    /**
+     * Maximal depth of the merkle tree.
+     */
+    private static final int MAX_DEPTH = 27;
+    /**
+     * Default depth of the merkle tree.
+     */
+    private static final int DEFAULT_DEPTH = 10;
+
+    private boolean enabled = true;
+    private int depth = DEFAULT_DEPTH;
+    private String mapName;
+
+    public MerkleTreeConfig() {
+    }
+
+    /**
+     * Clones a {@link MerkleTreeConfig}.
+     *
+     * @param config the merkle tree config to clone
+     * @throws NullPointerException if the config is null
+     */
+    public MerkleTreeConfig(MerkleTreeConfig config) {
+        checkNotNull(config, "config can't be null");
+        this.enabled = config.enabled;
+        this.mapName = config.mapName;
+        this.depth = config.depth;
+    }
+
+    @Override
+    public String toString() {
+        return "MerkleTreeConfig{"
+                + "enabled=" + enabled
+                + ", depth=" + depth
+                + ", mapName='" + mapName + '\''
+                + '}';
+    }
+
+    /**
+     * Returns an immutable version of this configuration.
+     *
+     * @return immutable version of this configuration
+     */
+    MerkleTreeConfig getAsReadOnly() {
+        return new MerkleTreeConfigReadOnly(this);
+    }
+
+    /**
+     * Returns the depth of the merkle tree.
+     * The default depth is {@value DEFAULT_DEPTH}.
+     */
+    public int getDepth() {
+        return depth;
+    }
+
+    /**
+     * Sets the depth of the merkle tree. The depth must be between
+     * {@value MAX_DEPTH} and {@value MIN_DEPTH} (exclusive).
+     *
+     * @param depth the depth of the merkle tree
+     * @return the updated config
+     * @throws ConfigurationException if the {@code depth} is greater than
+     *                                {@value MAX_DEPTH} or less than {@value MIN_DEPTH}
+     */
+    public MerkleTreeConfig setDepth(int depth) {
+        if (depth < MIN_DEPTH || depth > MAX_DEPTH) {
+            throw new IllegalArgumentException("Merkle tree depth " + depth + " is outside of the allowed range "
+                    + MIN_DEPTH + "-" + MAX_DEPTH + ". ");
+        }
+        this.depth = depth;
+        return this;
+    }
+
+    /**
+     * Returns if the merkle tree is enabled.
+     *
+     * @return {@code true} if the merkle tree is enabled, {@code false} otherwise
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enables or disables the merkle tree.
+     *
+     * @param enabled {@code true} if enabled, {@code false} otherwise.
+     * @return the updated config
+     */
+    public MerkleTreeConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Returns the map name to which this config applies.
+     *
+     * @return the map name
+     */
+    public String getMapName() {
+        return mapName;
+    }
+
+    /**
+     * Sets the map name to which this config applies. Map names
+     * are also matched by pattern and merkle with map name "default"
+     * applies to all maps that do not have more specific merkle tree configs.
+     *
+     * @param mapName the map name
+     * @return the merkle tree config
+     * @throws IllegalArgumentException if the {@code mapName} is {@code null} or empty.
+     */
+    public MerkleTreeConfig setMapName(String mapName) {
+        if (StringUtil.isNullOrEmpty(mapName)) {
+            throw new IllegalArgumentException("Merkle tree map name must not be empty.");
+        }
+        this.mapName = mapName;
+        return this;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.MERKLE_TREE_CONFIG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(mapName);
+        out.writeBoolean(enabled);
+        out.writeInt(depth);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        mapName = in.readUTF();
+        enabled = in.readBoolean();
+        depth = in.readInt();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MerkleTreeConfig that = (MerkleTreeConfig) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (depth != that.depth) {
+            return false;
+        }
+        return mapName != null ? mapName.equals(that.mapName) : that.mapName == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (enabled ? 1 : 0);
+        result = 31 * result + depth;
+        result = 31 * result + (mapName != null ? mapName.hashCode() : 0);
+        return result;
+    }
+
+    // not private for testing
+    @Beta
+    static class MerkleTreeConfigReadOnly extends MerkleTreeConfig {
+        MerkleTreeConfigReadOnly(MerkleTreeConfig config) {
+            super(config);
+        }
+
+        @Override
+        public MerkleTreeConfig setDepth(int depth) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public MerkleTreeConfig setEnabled(boolean enabled) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+
+        @Override
+        public MerkleTreeConfig setMapName(String mapName) {
+            throw new UnsupportedOperationException("This config is read-only");
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/MerkleTreeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MerkleTreeConfig.java
@@ -51,8 +51,10 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * <p>
  * This configuration is not tied to a specific data structure and can be
  * reused.
- *
+ * <p>
  * See https://en.wikipedia.org/wiki/Merkle_tree.
+ *
+ * @since 3.11
  */
 @Beta
 public class MerkleTreeConfig implements IdentifiedDataSerializable {

--- a/hazelcast/src/main/java/com/hazelcast/config/MerkleTreeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MerkleTreeConfig.java
@@ -49,9 +49,6 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * large tree depths if the latency of the comparison operation is high.
  * The default depth is {@value DEFAULT_DEPTH}.
  * <p>
- * This configuration is not tied to a specific data structure and can be
- * reused.
- * <p>
  * See https://en.wikipedia.org/wiki/Merkle_tree.
  *
  * @since 3.11

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -54,6 +54,25 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
     private Object implementation;
     private AwsConfig awsConfig = new AwsConfig();
     private DiscoveryConfig discoveryConfig = new DiscoveryConfig();
+    private WanSyncConfig wanSync = new WanSyncConfig();
+
+    /**
+     * Returns the config for the WAN sync mechanism.
+     */
+    public WanSyncConfig getWanSync() {
+        return wanSync;
+    }
+
+    /**
+     * Sets the config for the WAN sync mechanism.
+     *
+     * @param wanSync the WAN sync config
+     * @return this config
+     */
+    public WanPublisherConfig setWanSync(WanSyncConfig wanSync) {
+        this.wanSync = wanSync;
+        return this;
+    }
 
     /**
      * Returns the group name of this publisher. The group name is used for
@@ -270,6 +289,8 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
                 + "groupName='" + groupName + '\''
                 + ", queueCapacity=" + queueCapacity
                 + ", queueFullBehavior=" + queueFullBehavior
+                + ", initialPublisherState=" + initialPublisherState
+                + ", wanSync=" + wanSync
                 + ", properties=" + properties
                 + ", className='" + className + '\''
                 + ", implementation=" + implementation
@@ -302,8 +323,10 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
         out.writeUTF(className);
         out.writeObject(implementation);
 
+        // RU_COMPAT_3_10
         if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             out.writeByte(initialPublisherState.getId());
+            out.writeObject(wanSync);
         }
     }
 
@@ -319,8 +342,10 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
         className = in.readUTF();
         implementation = in.readObject();
 
+        // RU_COMPAT_3_10
         if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             initialPublisherState = WanPublisherState.getByType(in.readByte());
+            wanSync = in.readObject();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -54,23 +54,23 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
     private Object implementation;
     private AwsConfig awsConfig = new AwsConfig();
     private DiscoveryConfig discoveryConfig = new DiscoveryConfig();
-    private WanSyncConfig wanSync = new WanSyncConfig();
+    private WanSyncConfig wanSyncConfig = new WanSyncConfig();
 
     /**
      * Returns the config for the WAN sync mechanism.
      */
-    public WanSyncConfig getWanSync() {
-        return wanSync;
+    public WanSyncConfig getWanSyncConfig() {
+        return wanSyncConfig;
     }
 
     /**
      * Sets the config for the WAN sync mechanism.
      *
-     * @param wanSync the WAN sync config
+     * @param wanSyncConfig the WAN sync config
      * @return this config
      */
-    public WanPublisherConfig setWanSync(WanSyncConfig wanSync) {
-        this.wanSync = wanSync;
+    public WanPublisherConfig setWanSyncConfig(WanSyncConfig wanSyncConfig) {
+        this.wanSyncConfig = wanSyncConfig;
         return this;
     }
 
@@ -290,7 +290,7 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
                 + ", queueCapacity=" + queueCapacity
                 + ", queueFullBehavior=" + queueFullBehavior
                 + ", initialPublisherState=" + initialPublisherState
-                + ", wanSync=" + wanSync
+                + ", wanSyncConfig=" + wanSyncConfig
                 + ", properties=" + properties
                 + ", className='" + className + '\''
                 + ", implementation=" + implementation
@@ -326,7 +326,7 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
         // RU_COMPAT_3_10
         if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             out.writeByte(initialPublisherState.getId());
-            out.writeObject(wanSync);
+            out.writeObject(wanSyncConfig);
         }
     }
 
@@ -345,7 +345,7 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
         // RU_COMPAT_3_10
         if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             initialPublisherState = WanPublisherState.getByType(in.readByte());
-            wanSync = in.readObject();
+            wanSyncConfig = in.readObject();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanSyncConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanSyncConfig.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+/**
+ * Configuration object for the WAN sync mechanism.
+ *
+ * @see WanPublisherConfig
+ */
+public class WanSyncConfig implements IdentifiedDataSerializable {
+    private static final long DEFAULT_CONSISTENCY_CHECK_PERIOD_MILLIS = -1;
+    private static final boolean DEFAULT_USE_MERKLE_TREES = false;
+
+    private boolean useMerkleTrees = DEFAULT_USE_MERKLE_TREES;
+    private long consistencyCheckPeriodMillis = DEFAULT_CONSISTENCY_CHECK_PERIOD_MILLIS;
+
+    /**
+     * Returns if merkle trees should be used to optimise WAN sync.
+     * For the check procedure to work properly, the target cluster should
+     * support merkle trees and the data structures being synced should be
+     * configured with merkle trees enabled both on the source and target cluster.
+     * Default value is {@code false}.
+     *
+     * @return {@code true} if WAN sync should use merkle trees, {@code false}
+     * otherwise
+     * @see MerkleTreeConfig
+     */
+    public boolean isUseMerkleTrees() {
+        return useMerkleTrees;
+    }
+
+    /**
+     * Sets if merkle trees should be used to optimise WAN sync.
+     * For the check procedure to work properly, the target cluster should
+     * support merkle trees and the data structures being synced should be
+     * configured with merkle trees enabled both on the source and target cluster.
+     * Default value is {@code false}.
+     *
+     * @param useMerkleTrees if WAN sync should use merkle trees
+     * @see MerkleTreeConfig
+     */
+    public WanSyncConfig setUseMerkleTrees(boolean useMerkleTrees) {
+        this.useMerkleTrees = useMerkleTrees;
+        return this;
+    }
+
+    /**
+     * Returns the period (in milliseconds) for checking consistency of data
+     * between source and target cluster.
+     * Any inconsistency will not be reconciled, it will be merely reported via
+     * the usual mechanisms (e.g. statistics, diagnostics). The user must
+     * initiate WAN sync to reconcile there differences.
+     * For the check procedure to work properly, the target cluster should
+     * support merkle trees and the data structures being synced should be
+     * configured with merkle trees enabled both on the source and target cluster.
+     * Default value is {@code -1}, which means the periodic check is disabled.
+     */
+    public long getConsistencyCheckPeriodMillis() {
+        return consistencyCheckPeriodMillis;
+    }
+
+    /**
+     * Sets the period (in milliseconds) for checking consistency of data
+     * between source and target cluster.
+     * Any inconsistency will not be reconciled, it will be merely reported via
+     * the usual mechanisms (e.g. statistics, diagnostics). The user must
+     * initiate WAN sync to reconcile there differences.
+     * For the check procedure to work properly, the target cluster should
+     * support merkle trees and the data structures being synced should be
+     * configured with merkle trees enabled both on the source and target cluster.
+     * Default value is {@code -1}, which means the periodic check is disabled.
+     */
+    public void setConsistencyCheckPeriodMillis(long consistencyCheckPeriodMillis) {
+        this.consistencyCheckPeriodMillis = consistencyCheckPeriodMillis;
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.WAN_SYNC_CONFIG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeBoolean(useMerkleTrees);
+        out.writeLong(consistencyCheckPeriodMillis);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        useMerkleTrees = in.readBoolean();
+        consistencyCheckPeriodMillis = in.readLong();
+    }
+
+    @Override
+    public String toString() {
+        return "WanSyncConfig{"
+                + "useMerkleTrees=" + useMerkleTrees
+                + ", consistencyCheckPeriodMillis=" + consistencyCheckPeriodMillis
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -676,7 +676,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         } else if ("discovery-strategies".equals(targetChildName)) {
             handleDiscoveryStrategies(publisherConfig.getDiscoveryConfig(), targetChild);
         } else if ("wan-sync".equals(targetChildName)) {
-            handleWanSync(publisherConfig.getWanSync(), targetChild);
+            handleWanSync(publisherConfig.getWanSyncConfig(), targetChild);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -85,6 +85,7 @@ import static com.hazelcast.config.XmlElements.LOCK;
 import static com.hazelcast.config.XmlElements.MANAGEMENT_CENTER;
 import static com.hazelcast.config.XmlElements.MAP;
 import static com.hazelcast.config.XmlElements.MEMBER_ATTRIBUTES;
+import static com.hazelcast.config.XmlElements.MERKLE_TREE;
 import static com.hazelcast.config.XmlElements.MULTIMAP;
 import static com.hazelcast.config.XmlElements.NATIVE_MEMORY;
 import static com.hazelcast.config.XmlElements.NETWORK;
@@ -327,6 +328,8 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             handleScheduledExecutor(node);
         } else if (EVENT_JOURNAL.isEqual(nodeName)) {
             handleEventJournal(node);
+        } else if (MERKLE_TREE.isEqual(nodeName)) {
+            handleMerkleTree(node);
         } else if (SERVICES.isEqual(nodeName)) {
             handleServices(node);
         } else if (QUEUE.isEqual(nodeName)) {
@@ -672,6 +675,20 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             handleAWS(publisherConfig.getAwsConfig(), targetChild);
         } else if ("discovery-strategies".equals(targetChildName)) {
             handleDiscoveryStrategies(publisherConfig.getDiscoveryConfig(), targetChild);
+        } else if ("wan-sync".equals(targetChildName)) {
+            handleWanSync(publisherConfig.getWanSync(), targetChild);
+        }
+    }
+
+    private void handleWanSync(WanSyncConfig wanSyncConfig, Node node) {
+        for (Node child : childElements(node)) {
+            String nodeName = cleanNodeName(child);
+            String value = getTextContent(child).trim();
+            if ("use-merkle-trees".equals(nodeName)) {
+                wanSyncConfig.setUseMerkleTrees(getBooleanValue(value));
+            } else if ("consistency-check-period-millis".equalsIgnoreCase(nodeName)) {
+                wanSyncConfig.setConsistencyCheckPeriodMillis(getLongValue("consistency-check-period-millis", value));
+            }
         }
     }
 
@@ -2137,6 +2154,12 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         EventJournalConfig journalConfig = new EventJournalConfig();
         handleViaReflection(node, config, journalConfig);
         config.addEventJournalConfig(journalConfig);
+    }
+
+    private void handleMerkleTree(Node node) throws Exception {
+        MerkleTreeConfig merkleTreeConfig = new MerkleTreeConfig();
+        handleViaReflection(node, config, merkleTreeConfig);
+        config.addMerkleTreeConfig(merkleTreeConfig);
     }
 
     private void handleRingbuffer(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -684,8 +684,10 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             String value = getTextContent(child).trim();
-            if ("use-merkle-trees".equals(nodeName)) {
-                wanSyncConfig.setUseMerkleTrees(getBooleanValue(value));
+            if ("consistency-check-strategy".equals(nodeName)) {
+                String strategy = getTextContent(child);
+                wanSyncConfig.setConsistencyCheckStrategy(
+                        ConsistencyCheckStrategy.valueOf(upperCaseInternal(strategy)));
             } else if ("consistency-check-period-millis".equalsIgnoreCase(nodeName)) {
                 wanSyncConfig.setConsistencyCheckPeriodMillis(getLongValue("consistency-check-period-millis", value));
             }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlElements.java
@@ -32,6 +32,7 @@ enum XmlElements {
     DURABLE_EXECUTOR_SERVICE("durable-executor-service", true),
     SCHEDULED_EXECUTOR_SERVICE("scheduled-executor-service", true),
     EVENT_JOURNAL("event-journal", true),
+    MERKLE_TREE("merkle-tree", true),
     QUEUE("queue", true),
     MAP("map", true),
     CACHE("cache", true),

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/ConfigurationService.java
@@ -28,6 +28,7 @@ import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.PNCounterConfig;
 import com.hazelcast.config.QueueConfig;
@@ -235,6 +236,15 @@ public interface ConfigurationService {
     EventJournalConfig findMapEventJournalConfig(String name);
 
     /**
+     * Finds an existing map {@link MerkleTreeConfig}.
+     *
+     * @param name name of the config
+     * @return map {@link MerkleTreeConfig} or {@code null} when the requested
+     * configuration does not exist
+     */
+    MerkleTreeConfig findMapMerkleTreeConfig(String name);
+
+    /**
      * Finds existing FlakeIdGeneratorConfig config.
      *
      * @param name name of the config
@@ -395,6 +405,13 @@ public interface ConfigurationService {
      * @return registered MapEventJournal configurations
      */
     Map<String, EventJournalConfig> getMapEventJournalConfigs();
+
+    /**
+     * Returns a map of all registered IMap {@link MerkleTreeConfig}s.
+     *
+     * @return a map of registered IMap {@link MerkleTreeConfig}s
+     */
+    Map<String, MerkleTreeConfig> getMapMerkleTreeConfigs();
 
     /**
      * Returns all registered FlakeIdGenerator configurations.

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -38,6 +38,7 @@ import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MemberAttributeConfig;
+import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NetworkConfig;
@@ -132,6 +133,24 @@ public class DynamicConfigurationAwareConfig extends Config {
                 @Override
                 public Map<String, EventJournalConfig> getStaticConfigs(@Nonnull Config staticConfig) {
                     return staticConfig.getCacheEventJournalConfigs();
+                }
+            };
+    private final ConfigSupplier<MerkleTreeConfig> mapMerkleTreeConfigSupplier =
+            new ConfigSupplier<MerkleTreeConfig>() {
+                @Override
+                public MerkleTreeConfig getDynamicConfig(@Nonnull ConfigurationService configurationService,
+                                                           @Nonnull String name) {
+                    return configurationService.findMapMerkleTreeConfig(name);
+                }
+
+                @Override
+                public MerkleTreeConfig getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name) {
+                    return staticConfig.getMapMerkleTreeConfig(name);
+                }
+
+                @Override
+                public Map<String, MerkleTreeConfig> getStaticConfigs(@Nonnull Config staticConfig) {
+                    return staticConfig.getMapMerkleTreeConfigs();
                 }
             };
 
@@ -1034,6 +1053,45 @@ public class DynamicConfigurationAwareConfig extends Config {
 
     @Override
     public Config setCacheEventJournalConfigs(Map<String, EventJournalConfig> eventJournalConfigs) {
+        throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Override
+    public MerkleTreeConfig findMapMerkleTreeConfig(String name) {
+        return getMapMerkleTreeConfigInternal(name, "default");
+    }
+
+    @Override
+    public MerkleTreeConfig getMapMerkleTreeConfig(String name) {
+        return getMapMerkleTreeConfigInternal(name, name);
+    }
+
+    private MerkleTreeConfig getMapMerkleTreeConfigInternal(String name, String fallbackName) {
+        return (MerkleTreeConfig) configSearcher.getConfig(name, fallbackName, mapMerkleTreeConfigSupplier);
+    }
+
+    @Override
+    public Config addMerkleTreeConfig(MerkleTreeConfig merkleTreeConfig) {
+        final String mapName = merkleTreeConfig.getMapName();
+        if (StringUtil.isNullOrEmpty(mapName)) {
+            throw new IllegalArgumentException("Merkle tree config must define a map name");
+        }
+
+        Map<String, MerkleTreeConfig> staticConfigs = staticConfig.getMapMerkleTreeConfigs();
+        checkStaticConfigurationDoesNotExist(staticConfigs, mapName, merkleTreeConfig);
+        configurationService.broadcastConfig(merkleTreeConfig);
+        return this;
+    }
+
+    @Override
+    public Map<String, MerkleTreeConfig> getMapMerkleTreeConfigs() {
+        Map<String, MerkleTreeConfig> staticConfigs = staticConfig.getMapMerkleTreeConfigs();
+        Map<String, MerkleTreeConfig> dynamicConfigs = configurationService.getMapMerkleTreeConfigs();
+        return aggregate(staticConfigs, dynamicConfigs);
+    }
+
+    @Override
+    public Config setMapMerkleTreeConfigs(Map<String, MerkleTreeConfig> merkleTreeConfigs) {
         throw new UnsupportedOperationException("Unsupported operation");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/EmptyConfigurationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/EmptyConfigurationService.java
@@ -28,6 +28,7 @@ import com.hazelcast.config.FlakeIdGeneratorConfig;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.PNCounterConfig;
 import com.hazelcast.config.QueueConfig;
@@ -171,7 +172,17 @@ class EmptyConfigurationService implements ConfigurationService {
     }
 
     @Override
+    public MerkleTreeConfig findMapMerkleTreeConfig(String baseName) {
+        return null;
+    }
+
+    @Override
     public Map<String, EventJournalConfig> getMapEventJournalConfigs() {
+        return emptyMap();
+    }
+
+    @Override
+    public Map<String, MerkleTreeConfig> getMapMerkleTreeConfigs() {
         return emptyMap();
     }
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
@@ -2475,14 +2475,16 @@
     </xs:complexType>
     <xs:complexType name="wan-sync">
         <xs:all>
-            <xs:element name="use-merkle-trees" type="xs:boolean" minOccurs="0" default="false">
+            <xs:element name="consistency-check-strategy" type="consistency-check-strategy" minOccurs="0" default="NONE">
                 <xs:annotation>
                     <xs:documentation>
-                        Boolean denoting if merkle trees should be used to optimise WAN sync.
-                        For the check procedure to work properly, the target cluster should
-                        support merkle trees and the data structures being synced should be
-                        configured with merkle trees enabled both on the source and target cluster.
-                        Default value is false.
+                        Sets the strategy for checking consistency of data between source and
+                        target cluster. Any inconsistency will not be reconciled, it will be
+                        merely reported via the usual mechanisms (e.g. statistics, diagnostics).
+                        The user must initiate WAN sync to reconcile there differences. For the
+                        check procedure to work properly, the target cluster should support the
+                        chosen strategy.
+                        Default value is NONE, which means the check is disabled.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -2497,7 +2499,8 @@
                         For the check procedure to work properly, the target cluster should
                         support merkle trees and the data structures being synced should be
                         configured with merkle trees enabled both on the source and target cluster.
-                        Default value is -1, which means the periodic check is disabled.
+                        Default value is 0, which means the periodic check is disabled.
+                        The period must not be negative.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -4092,6 +4095,12 @@
             <xs:enumeration value="REPLICATING"/>
             <xs:enumeration value="PAUSED"/>
             <xs:enumeration value="STOPPED"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="consistency-check-strategy">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="MERKLE_TREES"/>
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
@@ -45,6 +45,7 @@
                 <xs:element name="scheduled-executor-service" type="scheduled-executor-service" minOccurs="0"
                             maxOccurs="unbounded"/>
                 <xs:element name="event-journal" type="event-journal" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="merkle-tree" type="merkle-tree" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="queue" type="queue" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="map" type="map" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="multimap" type="multimap" minOccurs="0" maxOccurs="unbounded"/>
@@ -2461,6 +2462,7 @@
             </xs:element>
             <xs:element name="aws" type="aws" minOccurs="0" maxOccurs="1"/>
             <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="wan-sync" type="wan-sync" minOccurs="0"/>
             <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="group-name" type="xs:string" use="required">
@@ -2470,6 +2472,36 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="wan-sync">
+        <xs:all>
+            <xs:element name="use-merkle-trees" type="xs:boolean" minOccurs="0" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        Boolean denoting if merkle trees should be used to optimise WAN sync.
+                        For the check procedure to work properly, the target cluster should
+                        support merkle trees and the data structures being synced should be
+                        configured with merkle trees enabled both on the source and target cluster.
+                        Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="consistency-check-period-millis" type="xs:int" minOccurs="0" default="-1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Period (in milliseconds) for checking consistency of data
+                        between source and target cluster.
+                        Any inconsistency will not be reconciled, it will be merely reported via
+                        the usual mechanisms (e.g. statistics, diagnostics). The user must
+                        initiate WAN sync to reconcile there differences.
+                        For the check procedure to work properly, the target cluster should
+                        support merkle trees and the data structures being synced should be
+                        configured with merkle trees enabled both on the source and target cluster.
+                        Default value is -1, which means the periodic check is disabled.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
     </xs:complexType>
     <xs:complexType name="wan-consumer">
         <xs:annotation>
@@ -3845,6 +3877,65 @@
             <xs:annotation>
                 <xs:documentation>
                     True if the event journal is enabled, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="merkle-tree">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration for a merkle tree.
+                The merkle tree is a data structure used for efficient comparison of the
+                difference in the contents of large data structures. The precision of
+                such a comparison mechanism is defined by the depth of the merkle tree.
+                A larger depth means that a data synchronization mechanism will be able
+                to pinpoint a smaller subset of the data structure contents in which a
+                change occurred. This causes the synchronization mechanism to be more
+                efficient. On the other hand, a larger tree depth means the merkle tree
+                will consume more memory.
+                A smaller depth means the data synchronization mechanism will have to
+                transfer larger chunks of the data structure in which a possible change
+                happened. On the other hand, a shallower tree consumes less memory.
+                The depth must be between 2 and 27 (exclusive).
+                As the comparison mechanism is iterative, a larger depth will also prolong
+                the duration of the comparison mechanism. Care must be taken to not have
+                large tree depths if the latency of the comparison operation is high.
+                The default depth is 10.
+                This configuration is not tied to a specific data structure and can be
+                reused.
+                See https://en.wikipedia.org/wiki/Merkle_tree.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="mapName" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the map to which this config applies.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="depth" type="xs:unsignedInt" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The depth of the merkle tree.
+                        A larger depth means that a data synchronization mechanism will be able
+                        to pinpoint a smaller subset of the data structure contents in which a
+                        change occurred. This causes the synchronization mechanism to be more
+                        efficient. On the other hand, a larger tree depth means the merkle tree
+                        will consume more memory.
+                        A smaller depth means the data synchronization mechanism will have to
+                        transfer larger chunks of the data structure in which a possible change
+                        happened. On the other hand, a shallower tree consumes less memory.
+                        The depth must be between 2 and 27 (exclusive). The default depth is 10.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    True if the merkle tree is enabled, false otherwise.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -239,6 +239,17 @@
         <time-to-live-seconds>0</time-to-live-seconds>
     </event-journal>
 
+    <!--
+       Configuration for a merkle tree.
+       The merkle tree is a data structure used for efficient comparison of the
+       difference in the contents of large data structures. The precision of
+       such a comparison mechanism is defined by the depth of the merkle tree.
+    -->
+    <merkle-tree enabled="false">
+        <mapName>mapName</mapName>
+        <depth>10</depth>
+    </merkle-tree>
+
     <multimap name="default">
         <backup-count>1</backup-count>
         <value-collection-type>SET</value-collection-type>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -205,17 +205,35 @@
                 The WAN queue size is checked before each supported mutating operation. If one of the queues of the target
                 cluster is full, WANReplicationQueueFullException is thrown and the operation is not allowed.
         * <initial-publisher-state>:
-            Defines the initial state in which a WAN publisher is started.
-            - REPLICATING (default):
-                State where both enqueuing new events is allowed, enqueued events are replicated to the target cluster
-                and WAN sync is enabled.
-            - PAUSED:
-                State where new events are enqueued but they not are dequeued. Some events which have been dequeued before
-                the state was switched may still be replicated to the target cluster but further events will not be
-                replicated. WAN sync is enabled.
-            - STOPPED:
-                State where neither new events are enqueued nor dequeued. As with the PAUSED state, some events might
-                still be replicated after the publisher has switched to this state. WAN sync is enabled.
+        Defines the initial state in which a WAN publisher is started.
+        - REPLICATING (default):
+            State where both enqueuing new events is allowed, enqueued events are replicated to the target cluster
+            and WAN sync is enabled.
+        - PAUSED:
+            State where new events are enqueued but they not are dequeued. Some events which have been dequeued before
+            the state was switched may still be replicated to the target cluster but further events will not be
+            replicated. WAN sync is enabled.
+        - STOPPED:
+            State where neither new events are enqueued nor dequeued. As with the PAUSED state, some events might
+            still be replicated after the publisher has switched to this state. WAN sync is enabled.
+        * <wan-sync>:
+        Configuration for the WAN sync mechanism. It has the following sub-elements:
+            - <use-merkle-trees>:
+                Boolean denoting if merkle trees should be used to optimise WAN sync.
+                For the check procedure to work properly, the target cluster should
+                support merkle trees and the data structures being synced should be
+                configured with merkle trees enabled both on the source and target cluster.
+                Default value is false.
+            - <consistency-check-period-millis>:
+                Period (in milliseconds) for checking consistency of data
+                between source and target cluster.
+                Any inconsistency will not be reconciled, it will be merely reported via
+                the usual mechanisms (e.g. statistics, diagnostics). The user must
+                initiate WAN sync to reconcile there differences.
+                For the check procedure to work properly, the target cluster should
+                support merkle trees and the data structures being synced should be
+                configured with merkle trees enabled both on the source and target cluster.
+                Default value is -1, which means the periodic check is disabled.
         * <aws>:
             Set its "enabled" attribute to true for discovery within Amazon EC2. It has the following sub-elements:
             - <access-key>:
@@ -268,6 +286,10 @@
             <queue-capacity>15000</queue-capacity>
             <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>
             <initial-publisher-state>REPLICATING</initial-publisher-state>
+            <wan-sync>
+                <use-merkle-trees>false</use-merkle-trees>
+                <consistency-check-period-millis>-1</consistency-check-period-millis>
+            </wan-sync>
             <properties>
                 <property name="endpoints">10.3.5.1:5701,10.3.5.2:5701</property>
                 <property name="batch.size">1000</property>
@@ -1450,6 +1472,38 @@
         <capacity>10000</capacity>
         <time-to-live-seconds>0</time-to-live-seconds>
     </event-journal>
+
+    <!--
+    ===== HAZELCAST MERKLE TREE CONFIGURATION =====
+
+    Configuration element's name is <merkle-tree>.
+    It has the following attributes and sub-elements:
+    * enabled:
+    	Specifies whether the merkle tree is enabled.
+    * <mapName>:
+    	Map name to which this configuration applies. This attribute's default value is "default".
+    	Configuration for the merkle tree with name "default" applies to all maps without
+    	configuration for a specific named map. In another words, if you specify the default
+    	merkle tree config as enabled then all maps which don't have specific merkle tree
+    	will be also enabled.
+    * <depth>:
+    	The depth of the merkle tree.
+    	 A larger depth means that a data synchronization mechanism will be able
+    	 to pinpoint a smaller subset of the data structure contents in which a
+    	 change occurred. This causes the synchronization mechanism to be more
+    	 efficient. On the other hand, a larger tree depth means the merkle tree
+    	 will consume more memory.
+    	 A smaller depth means the data synchronization mechanism will have to
+    	 transfer larger chunks of the data structure in which a possible change
+    	 happened. On the other hand, a shallower tree consumes less memory.
+    	 The depth must be between 2 and 27 (exclusive). The default depth is 10.
+
+     -->
+
+    <merkle-tree enabled="false">
+        <mapName>default</mapName>
+        <depth>10</depth>
+    </merkle-tree>
 
     <!--
         ===== HAZELCAST LIST CONFIGURATION =====

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -218,12 +218,14 @@
             still be replicated after the publisher has switched to this state. WAN sync is enabled.
         * <wan-sync>:
         Configuration for the WAN sync mechanism. It has the following sub-elements:
-            - <use-merkle-trees>:
-                Boolean denoting if merkle trees should be used to optimise WAN sync.
-                For the check procedure to work properly, the target cluster should
-                support merkle trees and the data structures being synced should be
-                configured with merkle trees enabled both on the source and target cluster.
-                Default value is false.
+            - <consistency-check-strategy>:
+                Sets the strategy for checking consistency of data between source and
+                target cluster. Any inconsistency will not be reconciled, it will be
+                merely reported via the usual mechanisms (e.g. statistics, diagnostics).
+                The user must initiate WAN sync to reconcile there differences. For the
+                check procedure to work properly, the target cluster should support the
+                chosen strategy.
+                Default value is NONE, which means the check is disabled.
             - <consistency-check-period-millis>:
                 Period (in milliseconds) for checking consistency of data
                 between source and target cluster.
@@ -233,7 +235,8 @@
                 For the check procedure to work properly, the target cluster should
                 support merkle trees and the data structures being synced should be
                 configured with merkle trees enabled both on the source and target cluster.
-                Default value is -1, which means the periodic check is disabled.
+                Default value is 0, which means the periodic check is disabled.
+                The period must not be negative.
         * <aws>:
             Set its "enabled" attribute to true for discovery within Amazon EC2. It has the following sub-elements:
             - <access-key>:
@@ -287,8 +290,8 @@
             <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>
             <initial-publisher-state>REPLICATING</initial-publisher-state>
             <wan-sync>
-                <use-merkle-trees>false</use-merkle-trees>
-                <consistency-check-period-millis>-1</consistency-check-period-millis>
+                <consistency-check-strategy>NONE</consistency-check-strategy>
+                <consistency-check-period-millis>0</consistency-check-period-millis>
             </wan-sync>
             <properties>
                 <property name="endpoints">10.3.5.1:5701,10.3.5.2:5701</property>

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1055,7 +1055,7 @@ class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.getInitialPublisherState(), c2.getInitialPublisherState())
                     && new AwsConfigChecker().check(c1.getAwsConfig(), c2.getAwsConfig())
                     && new DiscoveryConfigChecker().check(c1.getDiscoveryConfig(), c2.getDiscoveryConfig())
-                    && new WanSyncConfigChecker().check(c1.getWanSync(), c2.getWanSync())
+                    && new WanSyncConfigChecker().check(c1.getWanSyncConfig(), c2.getWanSyncConfig())
                     && nullSafeEqual(c1.getClassName(), c2.getClassName())
                     && nullSafeEqual(c1.getImplementation(), c2.getImplementation())
                     && nullSafeEqual(c1.getProperties(), c2.getProperties());

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -898,7 +898,7 @@ class ConfigCompatibilityChecker {
         @Override
         boolean check(WanSyncConfig c1, WanSyncConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
-                    && nullSafeEqual(c1.isUseMerkleTrees(), c2.isUseMerkleTrees())
+                    && nullSafeEqual(c1.getConsistencyCheckStrategy(), c2.getConsistencyCheckStrategy())
                     && nullSafeEqual(c1.getConsistencyCheckPeriodMillis(), c2.getConsistencyCheckPeriodMillis());
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
 import com.hazelcast.config.ConfigCompatibilityChecker.EventJournalConfigChecker;
+import com.hazelcast.config.ConfigCompatibilityChecker.MapMerkleTreeConfigChecker;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.quorum.QuorumType;
@@ -1123,6 +1124,9 @@ public class ConfigXmlGeneratorTest {
                 .setAwsConfig(getDummyAwsConfig())
                 .setInitialPublisherState(WanPublisherState.STOPPED)
                 .setDiscoveryConfig(getDummyDiscoveryConfig());
+        publisherConfig.getWanSync()
+                       .setUseMerkleTrees(true)
+                       .setConsistencyCheckPeriodMillis(12345);
         WanConsumerConfig wanConsumerConfig = new WanConsumerConfig()
                 .setClassName("dummyClass")
                 .setProperties(props)
@@ -1135,7 +1139,24 @@ public class ConfigXmlGeneratorTest {
         Config config = new Config().addWanReplicationConfig(wanConfig);
         Config xmlConfig = getNewConfigViaXMLGenerator(config);
 
-        ConfigCompatibilityChecker.checkWanConfigs(config.getWanReplicationConfigs(), xmlConfig.getWanReplicationConfigs());
+        ConfigCompatibilityChecker.checkWanConfigs(
+                config.getWanReplicationConfigs(),
+                xmlConfig.getWanReplicationConfigs());
+    }
+
+    @Test
+    public void testMapMerkleTree() {
+        String mapName = "mapName";
+        MerkleTreeConfig expectedConfig = new MerkleTreeConfig()
+                .setMapName(mapName)
+                .setEnabled(true)
+                .setDepth(10);
+        Config config = new Config().addMerkleTreeConfig(expectedConfig);
+        Config xmlConfig = getNewConfigViaXMLGenerator(config);
+
+        MerkleTreeConfig actualConfig = xmlConfig.getMapMerkleTreeConfig(mapName);
+        assertTrue(new MapMerkleTreeConfigChecker().check(expectedConfig, actualConfig));
+        assertEquals(expectedConfig, actualConfig);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1125,7 +1125,7 @@ public class ConfigXmlGeneratorTest {
                 .setInitialPublisherState(WanPublisherState.STOPPED)
                 .setDiscoveryConfig(getDummyDiscoveryConfig());
         publisherConfig.getWanSync()
-                       .setUseMerkleTrees(true)
+                       .setConsistencyCheckStrategy(ConsistencyCheckStrategy.MERKLE_TREES)
                        .setConsistencyCheckPeriodMillis(12345);
         WanConsumerConfig wanConsumerConfig = new WanConsumerConfig()
                 .setClassName("dummyClass")

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1124,7 +1124,7 @@ public class ConfigXmlGeneratorTest {
                 .setAwsConfig(getDummyAwsConfig())
                 .setInitialPublisherState(WanPublisherState.STOPPED)
                 .setDiscoveryConfig(getDummyDiscoveryConfig());
-        publisherConfig.getWanSync()
+        publisherConfig.getWanSyncConfig()
                        .setConsistencyCheckStrategy(ConsistencyCheckStrategy.MERKLE_TREES)
                        .setConsistencyCheckPeriodMillis(12345);
         WanConsumerConfig wanConsumerConfig = new WanConsumerConfig()

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1203,8 +1203,10 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertNotNull(publishers);
         assertEquals(1, publishers.size());
         WanPublisherConfig publisherConfig = publishers.get(0);
-        assertEquals(ConsistencyCheckStrategy.MERKLE_TREES, publisherConfig.getWanSync().getConsistencyCheckStrategy());
-        assertEquals(12345, publisherConfig.getWanSync().getConsistencyCheckPeriodMillis());
+        assertEquals(ConsistencyCheckStrategy.MERKLE_TREES, publisherConfig.getWanSyncConfig()
+                                                                           .getConsistencyCheckStrategy());
+        assertEquals(12345, publisherConfig.getWanSyncConfig()
+                                           .getConsistencyCheckPeriodMillis());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1187,7 +1187,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "        <wan-publisher group-name=\"nyc\">\n"
                 + "            <class-name>PublisherClassName</class-name>\n"
                 + "            <wan-sync>\n"
-                + "                <use-merkle-trees>true</use-merkle-trees>\n"
+                + "                <consistency-check-strategy>MERKLE_TREES</consistency-check-strategy>\n"
                 + "                <consistency-check-period-millis>12345</consistency-check-period-millis>\n"
                 + "            </wan-sync>\n"
                 + "        </wan-publisher>\n"
@@ -1203,7 +1203,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertNotNull(publishers);
         assertEquals(1, publishers.size());
         WanPublisherConfig publisherConfig = publishers.get(0);
-        assertTrue(publisherConfig.getWanSync().isUseMerkleTrees());
+        assertEquals(ConsistencyCheckStrategy.MERKLE_TREES, publisherConfig.getWanSync().getConsistencyCheckStrategy());
         assertEquals(12345, publisherConfig.getWanSync().getConsistencyCheckPeriodMillis());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -55,6 +55,7 @@ import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CACHE;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
+import static com.hazelcast.config.WANQueueFullBehavior.DISCARD_AFTER_MUTATION;
 import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
@@ -1126,6 +1127,87 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testWanReplicationConfig() {
+        String configName  = "test";
+        String xml = HAZELCAST_START_TAG
+                + "  <wan-replication name=\"" + configName + "\">\n"
+                + "        <wan-publisher group-name=\"nyc\">\n"
+                + "            <class-name>PublisherClassName</class-name>\n"
+                + "            <queue-capacity>15000</queue-capacity>\n"
+                + "            <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>\n"
+                + "            <initial-publisher-state>STOPPED</initial-publisher-state>\n"
+                + "            <properties>\n"
+                + "                <property name=\"propName1\">propValue1</property>\n"
+                + "            </properties>\n"
+                + "        </wan-publisher>\n"
+                + "        <wan-consumer>\n"
+                + "            <class-name>ConsumerClassName</class-name>\n"
+                + "            <properties>\n"
+                + "                <property name=\"propName1\">propValue1</property>\n"
+                + "            </properties>\n"
+                + "        </wan-consumer>\n"
+                + "    </wan-replication>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        WanReplicationConfig wanReplicationConfig = config.getWanReplicationConfig(configName);
+
+        assertEquals(configName, wanReplicationConfig.getName());
+
+        WanConsumerConfig consumerConfig = wanReplicationConfig.getWanConsumerConfig();
+        assertNotNull(consumerConfig);
+        assertEquals("ConsumerClassName", consumerConfig.getClassName());
+
+        Map<String, Comparable> properties = consumerConfig.getProperties();
+        assertNotNull(properties);
+        assertEquals(1, properties.size());
+        assertEquals("propValue1", properties.get("propName1"));
+
+        List<WanPublisherConfig> publishers = wanReplicationConfig.getWanPublisherConfigs();
+        assertNotNull(publishers);
+        assertEquals(1, publishers.size());
+        WanPublisherConfig publisherConfig = publishers.get(0);
+        assertEquals("PublisherClassName", publisherConfig.getClassName());
+        assertEquals("nyc", publisherConfig.getGroupName());
+        assertEquals(15000, publisherConfig.getQueueCapacity());
+        assertEquals(DISCARD_AFTER_MUTATION, publisherConfig.getQueueFullBehavior());
+        assertEquals(WanPublisherState.STOPPED, publisherConfig.getInitialPublisherState());
+
+        properties = publisherConfig.getProperties();
+        assertNotNull(properties);
+        assertEquals(1, properties.size());
+        assertEquals("propValue1", properties.get("propName1"));
+    }
+
+    @Test
+    public void testWanReplicationSyncConfig() {
+        String configName  = "test";
+        String xml = HAZELCAST_START_TAG
+                + "  <wan-replication name=\"" + configName + "\">\n"
+                + "        <wan-publisher group-name=\"nyc\">\n"
+                + "            <class-name>PublisherClassName</class-name>\n"
+                + "            <wan-sync>\n"
+                + "                <use-merkle-trees>true</use-merkle-trees>\n"
+                + "                <consistency-check-period-millis>12345</consistency-check-period-millis>\n"
+                + "            </wan-sync>\n"
+                + "        </wan-publisher>\n"
+                + "    </wan-replication>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        WanReplicationConfig wanReplicationConfig = config.getWanReplicationConfig(configName);
+
+        assertEquals(configName, wanReplicationConfig.getName());
+
+        List<WanPublisherConfig> publishers = wanReplicationConfig.getWanPublisherConfigs();
+        assertNotNull(publishers);
+        assertEquals(1, publishers.size());
+        WanPublisherConfig publisherConfig = publishers.get(0);
+        assertTrue(publisherConfig.getWanSync().isUseMerkleTrees());
+        assertEquals(12345, publisherConfig.getWanSync().getConsistencyCheckPeriodMillis());
+    }
+
+    @Test
     public void testMapEventJournalConfig() {
         String journalName = "mapName";
         String xml = HAZELCAST_START_TAG
@@ -1142,6 +1224,23 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(journalConfig.isEnabled());
         assertEquals(120, journalConfig.getCapacity());
         assertEquals(20, journalConfig.getTimeToLiveSeconds());
+    }
+
+    @Test
+    public void testMapMerkleTreeConfig() {
+        String mapName = "mapName";
+        String xml = HAZELCAST_START_TAG
+                + "<merkle-tree enabled=\"true\">\n"
+                + "    <mapName>" + mapName + "</mapName>\n"
+                + "    <depth>20</depth>\n"
+                + "</merkle-tree>"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        MerkleTreeConfig treeConfig = config.getMapMerkleTreeConfig(mapName);
+
+        assertTrue(treeConfig.isEnabled());
+        assertEquals(20, treeConfig.getDepth());
     }
 
     @Test

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -63,6 +63,10 @@
             <queue-capacity>1000</queue-capacity>
             <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>
             <initial-publisher-state>REPLICATING</initial-publisher-state>
+            <wan-sync>
+                <consistency-check-period-millis>10000</consistency-check-period-millis>
+                <use-merkle-trees>true</use-merkle-trees>
+            </wan-sync>
             <properties>
                 <property name="batch.size">50</property>
                 <property name="batch.max.delay.millis">3000</property>
@@ -808,4 +812,9 @@
         <quorum-type>READ_WRITE</quorum-type>
         <recently-active-quorum heartbeat-tolerance-millis="60000" />
     </quorum>
+
+    <merkle-tree enabled="true">
+        <mapName>default</mapName>
+        <depth>5</depth>
+    </merkle-tree>
 </hazelcast>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -64,8 +64,8 @@
             <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>
             <initial-publisher-state>REPLICATING</initial-publisher-state>
             <wan-sync>
+                <consistency-check-strategy>MERKLE_TREES</consistency-check-strategy>
                 <consistency-check-period-millis>10000</consistency-check-period-millis>
-                <use-merkle-trees>true</use-merkle-trees>
             </wan-sync>
             <properties>
                 <property name="batch.size">50</property>


### PR DESCRIPTION
Adds configuration for merkle trees as a new top-level config element.
Only map is now supported but we anticipate usage of merkle trees in
cache as well. Also, placing merkle tree configuration outside of WAN
config allows future usage outside of WAN context.

Todo:
- [ ] client invocation in `ClientDynamicClusterConfig#addMerkleTreeConfig`. It will be added as a separate PR because it will have to wait for the client protocol to be released.

### Chosen approach
Currently, the config is similar to event journal and client near cache config:
```
    <map name="myMap">
        <wan-replication-ref name="wanReplicationScheme">
            ...
        </wan-replication-ref>
        ...
    </map>

    <merkle-tree enabled="true">
        <mapName>default</mapName>
        <depth>5</depth>
    </merkle-tree>

    <merkle-tree enabled="true">
        <mapName>myMap</mapName>
        <depth>10</depth>
    </merkle-tree>

    <wan-replication name="wanReplicationScheme">
        <wan-publisher group-name="groupName">
            <class-name>...</class-name>
            <wan-sync>
                <consistency-check-strategy>MERKLE_TREES</consistency-check-strategy>
                <consistency-check-period-millis>10000</consistency-check-period-millis>
            </wan-sync>
            ...
        </wan-publisher>
    </wan-replication>
```
So when instantiating a map, the merkle tree config is matched by name.
The benefits of this approach:
- same for map and cache (when merkle trees will be implemented for cache)
- merkle trees are configured outside of WAN config as they might be used out of WAN context in the future
- if the user specifies he wants to use merkle trees in a WAN publisher, we can use the default merkle tree config and not require a separate `merkle-tree` tag

Downside of this approach
- we add a new top-level config. This is necessary because we are unable to change `CacheConfig`. Please read [this comment](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/129606857?focusedCommentId=131120305#comment-131120305)

### Alternative 1
```
    <map name="myMap">
        <wan-replication-ref name="wanReplicationScheme">
            ...
        </wan-replication-ref>
        ...
        <merkle-tree enabled="true">
            <depth>10</depth>
        </merkle-tree>
    </map>

    <map name="default">
        <wan-replication-ref name="wanReplicationScheme">
            ...
        </wan-replication-ref>
        ...
        <merkle-tree enabled="true">
            <depth>5</depth>
        </merkle-tree>
    </map>

    <wan-replication name="wanReplicationScheme">
        <wan-publisher group-name="groupName">
            <class-name>...</class-name>
            <wan-sync>
                <consistency-check-strategy>MERKLE_TREES</consistency-check-strategy>
                <consistency-check-period-millis>10000</consistency-check-period-millis>
            </wan-sync>
            ...
        </wan-publisher>
    </wan-replication>
```

The benefits of this approach:
- much cleaner when defining maps
- merkle trees are configured outside of WAN config as they might be used out of WAN context in the future
- if the user specifies he wants to use merkle trees in a WAN publisher, we can use the default merkle tree config and not require a separate `merkle-tree` tag

Downside of this approach
- not the same for map and cache (when we implement merkle trees for cache). Since we can't change `CacheConfig`, we will need to configure it outside of `<cache>`. Please read [this comment](https://hazelcast.atlassian.net/wiki/spaces/EN/pages/129606857?focusedCommentId=131120305#comment-131120305)

### Alternative 2
```
    <map name="myMap">
        ...
        <wan-replication-ref name="myMapReplication">
            ...
        </wan-replication-ref>
    </map>

    <map name="default">
        ...
        <wan-replication-ref name="defaultMapReplication">
            ...
        </wan-replication-ref>
    </map>

    <wan-replication name="myMapReplication">
        ...
        <merkle-tree enabled="true">
            <depth>10</depth>
        </merkle-tree>
        <wan-sync>
            <consistency-check-strategy>MERKLE_TREES</consistency-check-strategy>
            <consistency-check-period-millis>10000</consistency-check-period-millis>
        </wan-sync>
    </wan-replication>

    <wan-replication name="defaultMapReplication">
        ...
        <merkle-tree enabled="true">
            <depth>5</depth>
        </merkle-tree>
        <wan-sync>
            <consistency-check-strategy>MERKLE_TREES</consistency-check-strategy>
            <consistency-check-period-millis>10000</consistency-check-period-millis>
        </wan-sync>
    </wan-replication>
```
The benefits of this approach:
- merkle trees are used for WAN sync and they are configured in WAN config
- same for map and cache. We can freely change `wan-replication` and cache and map configs just refer to it via `wan-replication-ref`. So we avoid the problem of not being able to change `CacheConfig`.
- if the user specifies he wants to use merkle trees in a WAN publisher, we can use the default merkle tree config and not require a separate `merkle-tree` tag

Downside of this approach
- we might use merkle trees outside of WAN context in the future which then makes it extremely inadequate