### PR TITLE
Preparing Merkle tree IMap integration in OS

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -33,8 +33,10 @@ import com.hazelcast.map.impl.query.PartitionScanRunner;
 import com.hazelcast.map.impl.query.QueryRunner;
 import com.hazelcast.map.impl.query.ResultProcessorRegistry;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
+import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordComparator;
 import com.hazelcast.map.impl.recordstore.RecordStore;
+import com.hazelcast.map.impl.recordstore.RecordStoreMutationObserver;
 import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.nio.serialization.Data;
@@ -190,4 +192,17 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     String addLocalListenerAdapter(ListenerAdapter listenerAdaptor, String mapName);
 
     IndexCopyBehavior getIndexCopyBehavior();
+
+    /**
+     * Returns the collection of the {@link RecordStoreMutationObserver}s
+     * for the given map's partition that need to be added in record
+     * store construction time in order to ensure no {@link RecordStore}
+     * mutations are missed.
+     *
+     * @param mapName The name of the map
+     * @param partitionId The partition
+     *
+     * @return The collection of the observers
+     */
+    Collection<RecordStoreMutationObserver<Record>> createRecordStoreMutationObservers(String mapName, int partitionId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeRecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeRecordStoreMutationObserver.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.recordstore;
+
+import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.nio.serialization.Data;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+class CompositeRecordStoreMutationObserver<R extends Record> implements RecordStoreMutationObserver<R> {
+
+    private final Collection<RecordStoreMutationObserver<R>> mutationObservers = new
+            LinkedList<RecordStoreMutationObserver<R>>();
+
+    CompositeRecordStoreMutationObserver(Collection<RecordStoreMutationObserver<R>> mutationObservers) {
+        this.mutationObservers.addAll(mutationObservers);
+    }
+
+    @Override
+    public void onClear() {
+        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+            mutationObserver.onClear();
+        }
+    }
+
+    @Override
+    public void onPutRecord(Data key, R record) {
+        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+            mutationObserver.onPutRecord(key, record);
+        }
+    }
+
+    @Override
+    public void onReplicationPutRecord(Data key, R record) {
+        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+            mutationObserver.onReplicationPutRecord(key, record);
+        }
+    }
+
+    @Override
+    public void onUpdateRecord(Data key, R record, Object newValue) {
+        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+            mutationObserver.onUpdateRecord(key, record, newValue);
+        }
+    }
+
+    @Override
+    public void onRemoveRecord(Data key, R record) {
+        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+            mutationObserver.onRemoveRecord(key, record);
+        }
+    }
+
+    @Override
+    public void onEvictRecord(Data key, R record) {
+        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+            mutationObserver.onEvictRecord(key, record);
+        }
+    }
+
+    @Override
+    public void onDestroy(boolean internal) {
+        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+            mutationObserver.onDestroy(internal);
+        }
+    }
+
+    @Override
+    public void onReset() {
+        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+            mutationObserver.onReset();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalUpdaterRecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalUpdaterRecordStoreMutationObserver.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.recordstore;
+
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.journal.MapEventJournal;
+import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.ObjectNamespace;
+
+public class EventJournalUpdaterRecordStoreMutationObserver implements RecordStoreMutationObserver {
+    private final MapEventJournal eventJournal;
+    private final int partitionId;
+    private final EventJournalConfig eventJournalConfig;
+    private final ObjectNamespace objectNamespace;
+
+    public EventJournalUpdaterRecordStoreMutationObserver(MapEventJournal eventJournal, MapContainer mapContainer,
+                                                          int partitionId) {
+        this.eventJournal = eventJournal;
+        this.partitionId = partitionId;
+        this.eventJournalConfig = mapContainer.getEventJournalConfig();
+        this.objectNamespace = mapContainer.getObjectNamespace();
+    }
+
+    @Override
+    public void onClear() {
+        // NOP
+    }
+
+    @Override
+    public void onPutRecord(Data key, Record record) {
+        eventJournal.writeAddEvent(eventJournalConfig, objectNamespace, partitionId, record.getKey(), record.getValue());
+    }
+
+    @Override
+    public void onReplicationPutRecord(Data key, Record record) {
+        // NOP
+    }
+
+    @Override
+    public void onUpdateRecord(Data key, Record record, Object newValue) {
+        eventJournal.writeUpdateEvent(eventJournalConfig, objectNamespace, partitionId,
+                record.getKey(), record.getValue(), newValue);
+    }
+
+    @Override
+    public void onRemoveRecord(Data key, Record record) {
+        eventJournal.writeRemoveEvent(eventJournalConfig, objectNamespace, partitionId, record.getKey(), record.getValue());
+    }
+
+    @Override
+    public void onEvictRecord(Data key, Record record) {
+        eventJournal.writeEvictEvent(eventJournalConfig, objectNamespace, partitionId, record.getKey(), record.getValue());
+    }
+
+    @Override
+    public void onDestroy(boolean internal) {
+        if (!internal) {
+            eventJournal.destroy(objectNamespace, partitionId);
+        }
+    }
+
+    @Override
+    public void onReset() {
+        // NOP
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreMutationObserver.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.recordstore;
+
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.nio.serialization.Data;
+
+/**
+ * Interface for observing {@link RecordStore} mutations
+ *
+ * @param <R> The type of the records in the observed {@link RecordStore}
+ */
+public interface RecordStoreMutationObserver<R extends Record> {
+    /**
+     * Called if the observed {@link RecordStore} is cleared
+     */
+    void onClear();
+
+    /**
+     * Called when a new record is added to the {@link RecordStore}
+     *
+     * @param key    The key of the record
+     * @param record The record
+     */
+    void onPutRecord(Data key, R record);
+
+    /**
+     * Called when a new record is added to the {@link RecordStore} due
+     * to replication
+     *
+     * @param key    The key of the record
+     * @param record The record
+     */
+    void onReplicationPutRecord(Data key, R record);
+
+    /**
+     * Called when a new record is updated in the observed {@link RecordStore}
+     *
+     * @param key      The key of the record
+     * @param record   The record
+     * @param newValue The new value of the record
+     */
+    void onUpdateRecord(Data key, R record, Object newValue);
+
+    /**
+     * Called when a record is removed from the observed {@link RecordStore}
+     *
+     * @param key    The key of the record
+     * @param record The record
+     */
+    void onRemoveRecord(Data key, R record);
+
+    /**
+     * Called when a record is evicted from the observed {@link RecordStore}
+     *
+     * @param key    The key of the record
+     * @param record The record
+     */
+    void onEvictRecord(Data key, R record);
+
+    /**
+     * Called when the observed {@link RecordStore} is being destroyed.
+     * The observer should release all resources. The implementations of
+     * this method should be idempotent.
+     *
+     * @param internal is only data bound to the {@link MapService} being destroyed
+     */
+    void onDestroy(boolean internal);
+
+    /**
+     * Called when the observed {@link RecordStore} is being reset.
+     */
+    void onReset();
+}


### PR DESCRIPTION
The Merkle tree integration is done at RecordStore level via an observer, which captures all mutating interactions with the RecordStore.
The goal with this abstraction is to keep the RecordStore and the Merkle tree uncoupled.
The actual integration is done in EE, this PR is only about introducing the abstraction.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2274