### PR TITLE
Simplify the check in isAfterVectorClock

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/VectorClock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/VectorClock.java
@@ -101,7 +101,7 @@ public class VectorClock implements IdentifiedDataSerializable {
             }
         }
         // there is at least one local timestamp greater or local vector clock has additional timestamps
-        return anyTimestampGreater || !other.replicaTimestamps.keySet().containsAll(replicaTimestamps.keySet());
+        return anyTimestampGreater || other.replicaTimestamps.size() < replicaTimestamps.size();
     }
 
     /**


### PR DESCRIPTION
If we reach here it is guaranteed that replicaTimstamps has all
the keys that other.replicaTimestamps has. We can simply check if
number of keys in replicaTimestamps is greater than the number of
keys in other.replicaTimestamps instead of containsAll