### PR TITLE
Added framelength to Packet.toString.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -253,9 +253,10 @@ public final class Packet extends HeapData implements OutboundFrame {
 
     @Override
     public String toString() {
-        final Type type = getPacketType();
+        Type type = getPacketType();
         return "Packet{"
                 + "partitionId=" + partitionId
+                + ", frameLength=" + getFrameLength()
                 + ", conn=" + conn
                 + ", rawFlags=" + Integer.toBinaryString(flags)
                 + ", isUrgent=" + isUrgent()


### PR DESCRIPTION
This is useful for debugging since the size of the frame is
very useful information to have.