### PR TITLE
Remove group property "hazelcast.mc.max.visible.instance.count"

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
@@ -2501,13 +2501,6 @@
             <xs:enumeration value="hazelcast.phone.home.enabled"/>
             <xs:enumeration value="hazelcast.map.max.backup.count"/>
             <xs:enumeration value="hazelcast.max.wait.seconds.before.join"/>
-            <xs:enumeration value="hazelcast.mc.max.visible.instance.count">
-                <xs:annotation>
-                    <xs:documentation>
-                        Deprecated as of version 3.10, subject to remove in a future release.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:enumeration>
             <xs:enumeration value="hazelcast.logging.type"/>
             <xs:enumeration value="hazelcast.compatibility.3.6.client"/>
         </xs:restriction>

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -76,7 +76,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.spi.properties.GroupProperty.MC_MAX_VISIBLE_INSTANCE_COUNT;
 import static com.hazelcast.util.SetUtil.createHashSet;
 
 /**
@@ -88,7 +87,6 @@ public class TimedMemberStateFactory {
     private static final int PARTITION_SAFETY_CHECK_PERIOD = 60;
 
     protected final HazelcastInstanceImpl instance;
-    private final int maxVisibleInstanceCount;
     private final boolean cacheServiceEnabled;
 
     private volatile boolean memberStateSafe = true;
@@ -96,11 +94,10 @@ public class TimedMemberStateFactory {
     public TimedMemberStateFactory(HazelcastInstanceImpl instance) {
         this.instance = instance;
 
-        if (instance.node.getProperties().get(MC_MAX_VISIBLE_INSTANCE_COUNT.getName()) != null) {
-            instance.node.loggingService.getLogger(getClass()).warning(MC_MAX_VISIBLE_INSTANCE_COUNT.getName()
-                    + " property is deprecated and will be removed in a future release.");
+        if (instance.node.getProperties().get("hazelcast.mc.max.visible.instance.count") != null) {
+            instance.node.loggingService.getLogger(getClass())
+                    .warning("hazelcast.mc.max.visible.instance.count property is removed.");
         }
-        maxVisibleInstanceCount = instance.node.getProperties().getInteger(MC_MAX_VISIBLE_INSTANCE_COUNT);
         cacheServiceEnabled = isCacheServiceEnabled();
     }
 
@@ -232,29 +229,27 @@ public class TimedMemberStateFactory {
         int count = 0;
         Config config = instance.getConfig();
         for (StatisticsAwareService service : services) {
-            if (count < maxVisibleInstanceCount) {
-                if (service instanceof MapService) {
-                    count = handleMap(memberState, count, config, ((MapService) service).getStats());
-                } else if (service instanceof MultiMapService) {
-                    count = handleMultimap(memberState, count, config, ((MultiMapService) service).getStats());
-                } else if (service instanceof QueueService) {
-                    count = handleQueue(memberState, count, config, ((QueueService) service).getStats());
-                } else if (service instanceof TopicService) {
-                    count = handleTopic(memberState, count, config, ((TopicService) service).getStats());
-                } else if (service instanceof ReliableTopicService) {
-                    count = handleReliableTopic(memberState, count, config,
-                            ((ReliableTopicService) service).getStats());
-                } else if (service instanceof DistributedExecutorService) {
-                    count = handleExecutorService(memberState, count, config,
-                            ((DistributedExecutorService) service).getStats());
-                } else if (service instanceof ReplicatedMapService) {
-                    count = handleReplicatedMap(memberState, count, config, ((ReplicatedMapService) service).getStats());
-                } else if (service instanceof PNCounterService) {
-                    count = handlePNCounter(memberState, count, config, ((PNCounterService) service).getStats());
-                } else if (service instanceof FlakeIdGeneratorService) {
-                    count = handleFlakeIdGenerator(memberState, count, config,
-                            ((FlakeIdGeneratorService) service).getStats());
-                }
+            if (service instanceof MapService) {
+                count = handleMap(memberState, count, config, ((MapService) service).getStats());
+            } else if (service instanceof MultiMapService) {
+                count = handleMultimap(memberState, count, config, ((MultiMapService) service).getStats());
+            } else if (service instanceof QueueService) {
+                count = handleQueue(memberState, count, config, ((QueueService) service).getStats());
+            } else if (service instanceof TopicService) {
+                count = handleTopic(memberState, count, config, ((TopicService) service).getStats());
+            } else if (service instanceof ReliableTopicService) {
+                count = handleReliableTopic(memberState, count, config,
+                        ((ReliableTopicService) service).getStats());
+            } else if (service instanceof DistributedExecutorService) {
+                count = handleExecutorService(memberState, count, config,
+                        ((DistributedExecutorService) service).getStats());
+            } else if (service instanceof ReplicatedMapService) {
+                count = handleReplicatedMap(memberState, count, config, ((ReplicatedMapService) service).getStats());
+            } else if (service instanceof PNCounterService) {
+                count = handlePNCounter(memberState, count, config, ((PNCounterService) service).getStats());
+            } else if (service instanceof FlakeIdGeneratorService) {
+                count = handleFlakeIdGenerator(memberState, count, config,
+                        ((FlakeIdGeneratorService) service).getStats());
             }
         }
 
@@ -267,7 +262,7 @@ public class TimedMemberStateFactory {
         if (cacheServiceEnabled) {
             ICacheService cacheService = getCacheService();
             for (CacheConfig cacheConfig : cacheService.getCacheConfigs()) {
-                if (cacheConfig.isStatisticsEnabled() && count < maxVisibleInstanceCount) {
+                if (cacheConfig.isStatisticsEnabled()) {
                     CacheStatistics statistics = cacheService.getStatistics(cacheConfig.getNameWithPrefix());
                     //Statistics can be null for a short period of time since config is created at first then stats map
                     //is filled.git
@@ -283,9 +278,7 @@ public class TimedMemberStateFactory {
             Map<String, LocalFlakeIdGeneratorStats> flakeIdstats) {
         for (Map.Entry<String, LocalFlakeIdGeneratorStats> entry : flakeIdstats.entrySet()) {
             String name = entry.getKey();
-            if (count >= maxVisibleInstanceCount) {
-                break;
-            } else if (config.findFlakeIdGeneratorConfig(name).isStatisticsEnabled()) {
+            if (config.findFlakeIdGeneratorConfig(name).isStatisticsEnabled()) {
                 LocalFlakeIdGeneratorStats stats = entry.getValue();
                 memberState.putLocalFlakeIdStats(name, stats);
                 ++count;
@@ -299,9 +292,7 @@ public class TimedMemberStateFactory {
 
         for (Map.Entry<String, LocalExecutorStats> entry : executorServices.entrySet()) {
             String name = entry.getKey();
-            if (count >= maxVisibleInstanceCount) {
-                break;
-            } else if (config.findExecutorConfig(name).isStatisticsEnabled()) {
+            if (config.findExecutorConfig(name).isStatisticsEnabled()) {
                 LocalExecutorStats stats = entry.getValue();
                 memberState.putLocalExecutorStats(name, stats);
                 ++count;
@@ -313,9 +304,7 @@ public class TimedMemberStateFactory {
     private int handleMultimap(MemberStateImpl memberState, int count, Config config, Map<String, LocalMultiMapStats> multiMaps) {
         for (Map.Entry<String, LocalMultiMapStats> entry : multiMaps.entrySet()) {
             String name = entry.getKey();
-            if (count >= maxVisibleInstanceCount) {
-                break;
-            } else if (config.findMultiMapConfig(name).isStatisticsEnabled()) {
+            if (config.findMultiMapConfig(name).isStatisticsEnabled()) {
                 LocalMultiMapStats stats = entry.getValue();
                 memberState.putLocalMultiMapStats(name, stats);
                 ++count;
@@ -328,9 +317,7 @@ public class TimedMemberStateFactory {
             config, Map<String, LocalReplicatedMapStats> replicatedMaps) {
         for (Map.Entry<String, LocalReplicatedMapStats> entry : replicatedMaps.entrySet()) {
             String name = entry.getKey();
-            if (count >= maxVisibleInstanceCount) {
-                break;
-            } else if (config.findReplicatedMapConfig(name).isStatisticsEnabled()) {
+            if (config.findReplicatedMapConfig(name).isStatisticsEnabled()) {
                 LocalReplicatedMapStats stats = entry.getValue();
                 memberState.putLocalReplicatedMapStats(name, stats);
                 ++count;
@@ -343,9 +330,7 @@ public class TimedMemberStateFactory {
                                 Map<String, LocalPNCounterStats> counters) {
         for (Map.Entry<String, LocalPNCounterStats> entry : counters.entrySet()) {
             String name = entry.getKey();
-            if (count >= maxVisibleInstanceCount) {
-                break;
-            } else if (config.findPNCounterConfig(name).isStatisticsEnabled()) {
+            if (config.findPNCounterConfig(name).isStatisticsEnabled()) {
                 LocalPNCounterStats stats = entry.getValue();
                 memberState.putLocalPNCounterStats(name, stats);
                 ++count;
@@ -357,9 +342,7 @@ public class TimedMemberStateFactory {
     private int handleReliableTopic(MemberStateImpl memberState, int count, Config config, Map<String, LocalTopicStats> topics) {
         for (Map.Entry<String, LocalTopicStats> entry : topics.entrySet()) {
             String name = entry.getKey();
-            if (count >= maxVisibleInstanceCount) {
-                break;
-            } else if (config.findReliableTopicConfig(name).isStatisticsEnabled()) {
+            if (config.findReliableTopicConfig(name).isStatisticsEnabled()) {
                 LocalTopicStats stats = entry.getValue();
                 memberState.putLocalReliableTopicStats(name, stats);
                 ++count;
@@ -371,9 +354,7 @@ public class TimedMemberStateFactory {
     private int handleTopic(MemberStateImpl memberState, int count, Config config, Map<String, LocalTopicStats> topics) {
         for (Map.Entry<String, LocalTopicStats> entry : topics.entrySet()) {
             String name = entry.getKey();
-            if (count >= maxVisibleInstanceCount) {
-                break;
-            } else if (config.findTopicConfig(name).isStatisticsEnabled()) {
+            if (config.findTopicConfig(name).isStatisticsEnabled()) {
                 LocalTopicStats stats = entry.getValue();
                 memberState.putLocalTopicStats(name, stats);
                 ++count;
@@ -385,9 +366,7 @@ public class TimedMemberStateFactory {
     private int handleQueue(MemberStateImpl memberState, int count, Config config, Map<String, LocalQueueStats> queues) {
         for (Map.Entry<String, LocalQueueStats> entry : queues.entrySet()) {
             String name = entry.getKey();
-            if (count >= maxVisibleInstanceCount) {
-                break;
-            } else if (config.findQueueConfig(name).isStatisticsEnabled()) {
+            if (config.findQueueConfig(name).isStatisticsEnabled()) {
                 LocalQueueStats stats = entry.getValue();
                 memberState.putLocalQueueStats(name, stats);
                 ++count;
@@ -399,9 +378,7 @@ public class TimedMemberStateFactory {
     private int handleMap(MemberStateImpl memberState, int count, Config config, Map<String, LocalMapStats> maps) {
         for (Map.Entry<String, LocalMapStats> entry : maps.entrySet()) {
             String name = entry.getKey();
-            if (count >= maxVisibleInstanceCount) {
-                break;
-            } else if (config.findMapConfig(name).isStatisticsEnabled()) {
+            if (config.findMapConfig(name).isStatisticsEnabled()) {
                 LocalMapStats stats = entry.getValue();
                 memberState.putLocalMapStats(name, stats);
                 ++count;

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -550,13 +550,6 @@ public final class GroupProperty {
     public static final HazelcastProperty JMX_UPDATE_INTERVAL_SECONDS
             = new HazelcastProperty("hazelcast.jmx.update.interval.seconds", 5, SECONDS);
 
-    /**
-     * @deprecated as of 3.10
-     * This will be removed in future versions.
-     */
-    @Deprecated
-    public static final HazelcastProperty MC_MAX_VISIBLE_INSTANCE_COUNT
-            = new HazelcastProperty("hazelcast.mc.max.visible.instance.count", Integer.MAX_VALUE);
     public static final HazelcastProperty MC_MAX_VISIBLE_SLOW_OPERATION_COUNT
             = new HazelcastProperty("hazelcast.mc.max.visible.slow.operations.count", 10);
     public static final HazelcastProperty MC_URL_CHANGE_ENABLED

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.management;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -48,23 +47,6 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
         hz.getReliableTopic("trial").publish("Hello");
         hz.getReplicatedMap("trial").put(3, 3);
         hz.getExecutorService("trial");
-
-        TimedMemberState timedMemberState = factory.createTimedMemberState();
-        assertEquals("dev", timedMemberState.clusterName);
-    }
-
-    @Test
-    public void testMaxVisibleInstanceCount() {
-        Config config = new Config();
-        config.setProperty(GroupProperty.MC_MAX_VISIBLE_INSTANCE_COUNT.getName(), "3");
-        HazelcastInstance hz = createHazelcastInstance(config);
-        TimedMemberStateFactory factory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
-
-        hz.getMap("trial").put(1, 1);
-        hz.getMultiMap("trial").put(2, 2);
-        hz.getQueue("trial").offer(3);
-        hz.getTopic("trial").publish("Hello");
-        hz.getReliableTopic("trial").publish("Hello");
 
         TimedMemberState timedMemberState = factory.createTimedMemberState();
         assertEquals("dev", timedMemberState.clusterName);


### PR DESCRIPTION
It was deprecated in 3.10 and set to be removed in 3.11. A warning is
displayed if user specifies a value for it.