### PR TITLE
 Introduce GracefulShutdownAwareService

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -28,6 +28,7 @@ import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.config.UserCodeDeploymentConfig;
 import com.hazelcast.core.ClientListener;
 import com.hazelcast.core.DistributedObjectListener;
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.LifecycleEvent.LifecycleState;
 import com.hazelcast.core.LifecycleListener;
@@ -64,6 +65,8 @@ import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.security.SecurityService;
+import com.hazelcast.spi.ExecutionService;
+import com.hazelcast.spi.GracefulShutdownAwareService;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
 import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
@@ -75,6 +78,7 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.proxyservice.impl.ProxyServiceImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.Clock;
+import com.hazelcast.util.FutureUtil;
 import com.hazelcast.util.PhoneHome;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
@@ -82,11 +86,14 @@ import com.hazelcast.version.Version;
 import java.lang.reflect.Constructor;
 import java.nio.channels.ServerSocketChannel;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -424,8 +431,9 @@ public class Node {
 
         if (!terminate) {
             replicateCRDTs();
-            final int maxWaitSeconds = properties.getSeconds(GRACEFUL_SHUTDOWN_MAX_WAIT);
-            if (!partitionService.prepareToSafeShutdown(maxWaitSeconds, TimeUnit.SECONDS)) {
+            int maxWaitSeconds = properties.getSeconds(GRACEFUL_SHUTDOWN_MAX_WAIT);
+            boolean success = callGracefulShutdownAwareServices(maxWaitSeconds);
+            if (!success) {
                 logger.warning("Graceful shutdown could not be completed in " + maxWaitSeconds + " seconds!");
             }
         } else {
@@ -471,14 +479,38 @@ public class Node {
         replicationMigrationService.syncReplicateDirtyCRDTs();
     }
 
+    private boolean callGracefulShutdownAwareServices(final int maxWaitSeconds) {
+        ExecutorService executor = nodeEngine.getExecutionService().getExecutor(ExecutionService.ASYNC_EXECUTOR);
+        Collection<GracefulShutdownAwareService> services = nodeEngine.getServices(GracefulShutdownAwareService.class);
+        Collection<Future> futures = new ArrayList<Future>(services.size());
+
+        for (final GracefulShutdownAwareService service : services) {
+            Future future = executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    boolean success = service.onShutdown(maxWaitSeconds, TimeUnit.SECONDS);
+                    if (!success) {
+                        throw new HazelcastException("Graceful shutdown failed for " + service);
+                    }
+                }
+            });
+            futures.add(future);
+        }
+        try {
+            FutureUtil.waitWithDeadline(futures, maxWaitSeconds, TimeUnit.SECONDS, FutureUtil.RETHROW_EVERYTHING);
+            return true;
+        } catch (Exception e) {
+            logger.warning(e);
+            return false;
+        }
+    }
+
     @SuppressWarnings("checkstyle:npathcomplexity")
     private void shutdownServices(boolean terminate) {
         if (nodeExtension != null) {
             nodeExtension.beforeShutdown();
         }
-        if (phoneHome != null) {
-            phoneHome.shutdown();
-        }
+        phoneHome.shutdown();
         if (managementCenterService != null) {
             managementCenterService.shutdown();
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -35,7 +35,6 @@ import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.core.MigrationListener;
-import com.hazelcast.crdt.CRDTReplicationMigrationService;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.ascii.TextCommandServiceImpl;
 import com.hazelcast.internal.cluster.impl.ClusterJoinManager;
@@ -430,7 +429,6 @@ public class Node {
         }
 
         if (!terminate) {
-            replicateCRDTs();
             int maxWaitSeconds = properties.getSeconds(GRACEFUL_SHUTDOWN_MAX_WAIT);
             boolean success = callGracefulShutdownAwareServices(maxWaitSeconds);
             if (!success) {
@@ -467,16 +465,6 @@ public class Node {
                 shuttingDown.compareAndSet(true, false);
             }
         }
-    }
-
-    /**
-     * Synchronously replicate the unreplicated CRDT states to a data member
-     * in the cluster.
-     */
-    private void replicateCRDTs() {
-        final CRDTReplicationMigrationService replicationMigrationService
-                = nodeEngine.getService(CRDTReplicationMigrationService.SERVICE_NAME);
-        replicationMigrationService.syncReplicateDirtyCRDTs();
     }
 
     private boolean callGracefulShutdownAwareServices(final int maxWaitSeconds) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/InternalPartitionService.java
@@ -23,12 +23,12 @@ import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionStateManager;
 import com.hazelcast.internal.partition.operation.FetchPartitionStateOperation;
 import com.hazelcast.nio.Address;
+import com.hazelcast.spi.GracefulShutdownAwareService;
 import com.hazelcast.spi.partition.IPartitionService;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-public interface InternalPartitionService extends IPartitionService {
+public interface InternalPartitionService extends IPartitionService, GracefulShutdownAwareService {
 
     /**
      * Retry count for migration operations.
@@ -73,8 +73,6 @@ public interface InternalPartitionService extends IPartitionService {
     void memberAdded(MemberImpl newMember);
 
     void memberRemoved(MemberImpl deadMember);
-
-    boolean prepareToSafeShutdown(long timeout, TimeUnit seconds);
 
     InternalPartition[] getInternalPartitions();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -875,7 +875,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
     }
 
     @Override
-    public boolean prepareToSafeShutdown(long timeout, TimeUnit unit) {
+    public boolean onShutdown(long timeout, TimeUnit unit) {
         if (!node.getClusterService().isJoined()) {
             return true;
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/GracefulShutdownAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/GracefulShutdownAwareService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spi;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An interface that can be implemented by SPI services to participate in graceful shutdown process, such as moving
+ * their internal data to another node or releasing their allocated resources gracefully.
+ */
+public interface GracefulShutdownAwareService {
+
+    /**
+     * A hook method that's called during graceful shutdown to provide safety for data managed by this service.
+     * Shutdown process is blocked until this method returns or shutdown timeouts. If this method does not
+     * return in time, then it's considered as failed to gracefully shutdown.
+     *
+     * @param timeout timeout for graceful shutdown
+     * @param unit time unit
+     * @return true if graceful shutdown is successful, false otherwise
+     */
+    boolean onShutdown(long timeout, TimeUnit unit);
+
+}


### PR DESCRIPTION
`GracefulShutdownAwareService` can be implemented by SPI services to participate in graceful shutdown process, such as moving their internal data to another node or releasing their allocated resources gracefully. `GracefulShutdownAwareService`s are called concurrently during shutdown.

*This is extracted from Raft feature branch.*