### PR TITLE
Remove 3.9 RU code

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cardinality/impl/CardinalityEstimatorService.java
@@ -20,7 +20,6 @@ import com.hazelcast.cardinality.impl.hyperloglog.HyperLogLog;
 import com.hazelcast.cardinality.impl.operations.MergeOperation;
 import com.hazelcast.cardinality.impl.operations.ReplicationOperation;
 import com.hazelcast.config.CardinalityEstimatorConfig;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
@@ -180,10 +179,6 @@ public class CardinalityEstimatorService
 
     @Override
     public String getQuorumName(String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory, quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddMapConfigMessageTask.java
@@ -33,12 +33,9 @@ import com.hazelcast.instance.Node;
 import com.hazelcast.map.eviction.MapEvictionPolicy;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.version.Version;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.hazelcast.internal.cluster.Versions.V3_10;
 
 public class AddMapConfigMessageTask
         extends AbstractAddConfigMessageTask<DynamicConfigAddMapConfigCodec.RequestParameters> {
@@ -84,13 +81,11 @@ public class AddMapConfigMessageTask
         config.setMaxIdleSeconds(parameters.maxIdleSeconds);
         config.setMaxSizeConfig(new MaxSizeConfig(parameters.maxSizeConfigSize,
                 MaxSizeConfig.MaxSizePolicy.valueOf(parameters.maxSizeConfigMaxSizePolicy)));
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
-        if (clusterVersion.isGreaterOrEqual(V3_10) && parameters.mergeBatchSizeExist) {
+        if (parameters.mergeBatchSizeExist) {
             MergePolicyConfig mergePolicyConfig = mergePolicyConfig(true, parameters.mergePolicy,
                     parameters.mergeBatchSize);
             config.setMergePolicyConfig(mergePolicyConfig);
         } else {
-            // RU_COMPAT_3_9
             config.setMergePolicy(parameters.mergePolicy);
         }
         if (parameters.nearCacheConfig != null) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReplicatedMapConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/dynamicconfig/AddReplicatedMapConfigMessageTask.java
@@ -26,11 +26,8 @@ import com.hazelcast.config.ReplicatedMapConfig;
 import com.hazelcast.instance.Node;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.version.Version;
 
 import java.util.ArrayList;
-
-import static com.hazelcast.internal.cluster.Versions.V3_10;
 
 public class AddReplicatedMapConfigMessageTask
         extends AbstractAddConfigMessageTask<DynamicConfigAddReplicatedMapConfigCodec.RequestParameters> {
@@ -54,13 +51,11 @@ public class AddReplicatedMapConfigMessageTask
         ReplicatedMapConfig config = new ReplicatedMapConfig(parameters.name);
         config.setAsyncFillup(parameters.asyncFillup);
         config.setInMemoryFormat(InMemoryFormat.valueOf(parameters.inMemoryFormat));
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
-        if (clusterVersion.isGreaterOrEqual(V3_10) && parameters.mergeBatchSizeExist) {
+        if (parameters.mergeBatchSizeExist) {
             MergePolicyConfig mergePolicyConfig = mergePolicyConfig(true, parameters.mergePolicy,
                     parameters.mergeBatchSize);
             config.setMergePolicyConfig(mergePolicyConfig);
         } else {
-            // RU_COMPAT_3_9
             config.setMergePolicy(parameters.mergePolicy);
         }
         config.setStatisticsEnabled(parameters.statisticsEnabled);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/ListService.java
@@ -22,7 +22,6 @@ import com.hazelcast.collection.impl.list.operations.ListReplicationOperation;
 import com.hazelcast.collection.impl.txnlist.TransactionalListProxy;
 import com.hazelcast.config.ListConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionReplicationEvent;
@@ -108,10 +107,6 @@ public class ListService extends CollectionService {
 
     @Override
     public String getQuorumName(String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory,
                 quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetService.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/SetService.java
@@ -22,7 +22,6 @@ import com.hazelcast.collection.impl.set.operations.SetReplicationOperation;
 import com.hazelcast.collection.impl.txnset.TransactionalSetProxy;
 import com.hazelcast.config.SetConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.PartitionReplicationEvent;
@@ -108,10 +107,6 @@ public class SetService extends CollectionService {
 
     @Override
     public String getQuorumName(final String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory,
                 quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomiclong/AtomicLongService.java
@@ -19,7 +19,6 @@ package com.hazelcast.concurrent.atomiclong;
 import com.hazelcast.concurrent.atomiclong.operations.AtomicLongReplicationOperation;
 import com.hazelcast.concurrent.atomiclong.operations.MergeOperation;
 import com.hazelcast.config.AtomicLongConfig;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
@@ -180,10 +179,6 @@ public class AtomicLongService
 
     @Override
     public String getQuorumName(String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory,
                 quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/atomicreference/AtomicReferenceService.java
@@ -19,7 +19,6 @@ package com.hazelcast.concurrent.atomicreference;
 import com.hazelcast.concurrent.atomicreference.operations.AtomicReferenceReplicationOperation;
 import com.hazelcast.concurrent.atomicreference.operations.MergeOperation;
 import com.hazelcast.config.AtomicReferenceConfig;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.ManagedService;
@@ -183,10 +182,6 @@ public class AtomicReferenceService
 
     @Override
     public String getQuorumName(String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory,
                 quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/CountDownLatchService.java
@@ -18,7 +18,6 @@ package com.hazelcast.concurrent.countdownlatch;
 
 import com.hazelcast.concurrent.countdownlatch.operations.CountDownLatchReplicationOperation;
 import com.hazelcast.config.CountDownLatchConfig;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
@@ -209,10 +208,6 @@ public class CountDownLatchService implements ManagedService, RemoteService, Mig
 
     @Override
     public String getQuorumName(String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory,
                 quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/semaphore/SemaphoreService.java
@@ -19,7 +19,6 @@ package com.hazelcast.concurrent.semaphore;
 import com.hazelcast.concurrent.semaphore.operations.SemaphoreDetachMemberOperation;
 import com.hazelcast.concurrent.semaphore.operations.SemaphoreReplicationOperation;
 import com.hazelcast.config.SemaphoreConfig;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.spi.ClientAwareService;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MemberAttributeServiceEvent;
@@ -213,10 +212,6 @@ public class SemaphoreService implements ManagedService, MigrationAwareService, 
 
     @Override
     public String getQuorumName(final String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory, quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -252,11 +251,8 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, V
         out.writeUTF(name);
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeUTF(quorumName);
-            out.writeObject(mergePolicyConfig);
-        }
+        out.writeUTF(quorumName);
+        out.writeObject(mergePolicyConfig);
     }
 
     @Override
@@ -264,11 +260,8 @@ public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, V
         name = in.readUTF();
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            quorumName = in.readUTF();
-            mergePolicyConfig = in.readObject();
-        }
+        quorumName = in.readUTF();
+        mergePolicyConfig = in.readObject();
     }
 
     @SuppressWarnings("checkstyle:npathcomplexity")

--- a/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -286,11 +285,8 @@ public abstract class CollectionConfig<T extends CollectionConfig>
         out.writeInt(asyncBackupCount);
         out.writeInt(maxSize);
         out.writeBoolean(statisticsEnabled);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeUTF(quorumName);
-            out.writeObject(mergePolicyConfig);
-        }
+        out.writeUTF(quorumName);
+        out.writeObject(mergePolicyConfig);
     }
 
     @Override
@@ -301,11 +297,8 @@ public abstract class CollectionConfig<T extends CollectionConfig>
         asyncBackupCount = in.readInt();
         maxSize = in.readInt();
         statisticsEnabled = in.readBoolean();
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            quorumName = in.readUTF();
-            mergePolicyConfig = in.readObject();
-        }
+        quorumName = in.readUTF();
+        mergePolicyConfig = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
@@ -17,7 +17,6 @@
 package com.hazelcast.config;
 
 import com.hazelcast.durableexecutor.DurableExecutorService;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -218,10 +217,7 @@ public class DurableExecutorConfig implements IdentifiedDataSerializable, Versio
         out.writeInt(poolSize);
         out.writeInt(durability);
         out.writeInt(capacity);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeUTF(quorumName);
-        }
+        out.writeUTF(quorumName);
     }
 
     @Override
@@ -230,10 +226,7 @@ public class DurableExecutorConfig implements IdentifiedDataSerializable, Versio
         poolSize = in.readInt();
         durability = in.readInt();
         capacity = in.readInt();
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            quorumName = in.readUTF();
-        }
+        quorumName = in.readUTF();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -214,10 +213,7 @@ public class ExecutorConfig implements IdentifiedDataSerializable, Versioned {
         out.writeInt(poolSize);
         out.writeInt(queueCapacity);
         out.writeBoolean(statisticsEnabled);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeUTF(quorumName);
-        }
+        out.writeUTF(quorumName);
     }
 
     @Override
@@ -226,10 +222,7 @@ public class ExecutorConfig implements IdentifiedDataSerializable, Versioned {
         poolSize = in.readInt();
         queueCapacity = in.readInt();
         statisticsEnabled = in.readBoolean();
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            quorumName = in.readUTF();
-        }
+        quorumName = in.readUTF();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.map.eviction.LFUEvictionPolicy;
 import com.hazelcast.map.eviction.LRUEvictionPolicy;
 import com.hazelcast.map.eviction.MapEvictionPolicy;
@@ -1067,12 +1066,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         out.writeObject(nearCacheConfig);
         out.writeBoolean(readBackupData);
         out.writeUTF(cacheDeserializedValues.name());
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeObject(mergePolicyConfig);
-        } else {
-            out.writeUTF(mergePolicyConfig.getPolicy());
-        }
+        out.writeObject(mergePolicyConfig);
         out.writeUTF(inMemoryFormat.name());
         out.writeObject(wanReplicationRef);
         writeNullableList(entryListenerConfigs, out);
@@ -1100,12 +1094,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         nearCacheConfig = in.readObject();
         readBackupData = in.readBoolean();
         cacheDeserializedValues = CacheDeserializedValues.valueOf(in.readUTF());
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            mergePolicyConfig = in.readObject();
-        } else {
-            mergePolicyConfig.setPolicy(in.readUTF());
-        }
+        mergePolicyConfig = in.readObject();
         inMemoryFormat = InMemoryFormat.valueOf(in.readUTF());
         wanReplicationRef = in.readObject();
         entryListenerConfigs = readNullableList(in);

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -374,11 +373,8 @@ public class MultiMapConfig implements SplitBrainMergeTypeProvider, IdentifiedDa
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
         out.writeBoolean(statisticsEnabled);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeUTF(quorumName);
-            out.writeObject(mergePolicyConfig);
-        }
+        out.writeUTF(quorumName);
+        out.writeObject(mergePolicyConfig);
     }
 
     @Override
@@ -398,11 +394,8 @@ public class MultiMapConfig implements SplitBrainMergeTypeProvider, IdentifiedDa
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
         statisticsEnabled = in.readBoolean();
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            quorumName = in.readUTF();
-            mergePolicyConfig = in.readObject();
-        }
+        quorumName = in.readUTF();
+        mergePolicyConfig = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -379,10 +378,7 @@ public class QueueConfig implements SplitBrainMergeTypeProvider, IdentifiedDataS
         out.writeObject(queueStoreConfig);
         out.writeBoolean(statisticsEnabled);
         out.writeUTF(quorumName);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeObject(mergePolicyConfig);
-        }
+        out.writeObject(mergePolicyConfig);
     }
 
     @Override
@@ -396,10 +392,7 @@ public class QueueConfig implements SplitBrainMergeTypeProvider, IdentifiedDataS
         queueStoreConfig = in.readObject();
         statisticsEnabled = in.readBoolean();
         quorumName = in.readUTF();
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            mergePolicyConfig = in.readObject();
-        }
+        mergePolicyConfig = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -414,16 +413,9 @@ public class ReplicatedMapConfig implements SplitBrainMergeTypeProvider, Identif
         out.writeUTF(inMemoryFormat.name());
         out.writeBoolean(asyncFillup);
         out.writeBoolean(statisticsEnabled);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isLessThan(Versions.V3_10)) {
-            out.writeUTF(mergePolicyConfig.getPolicy());
-        }
         writeNullableList(listenerConfigs, out);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeUTF(quorumName);
-            out.writeObject(mergePolicyConfig);
-        }
+        out.writeUTF(quorumName);
+        out.writeObject(mergePolicyConfig);
     }
 
     @Override
@@ -432,16 +424,9 @@ public class ReplicatedMapConfig implements SplitBrainMergeTypeProvider, Identif
         inMemoryFormat = InMemoryFormat.valueOf(in.readUTF());
         asyncFillup = in.readBoolean();
         statisticsEnabled = in.readBoolean();
-        // RU_COMPAT_3_9
-        if (in.getVersion().isUnknownOrLessThan(Versions.V3_10)) {
-            mergePolicyConfig.setPolicy(in.readUTF());
-        }
         listenerConfigs = readNullableList(in);
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            quorumName = in.readUTF();
-            mergePolicyConfig = in.readObject();
-        }
+        quorumName = in.readUTF();
+        mergePolicyConfig = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -391,11 +390,8 @@ public class RingbufferConfig implements SplitBrainMergeTypeProvider, Identified
         out.writeInt(timeToLiveSeconds);
         out.writeUTF(inMemoryFormat.name());
         out.writeObject(ringbufferStoreConfig);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeUTF(quorumName);
-            out.writeObject(mergePolicyConfig);
-        }
+        out.writeUTF(quorumName);
+        out.writeObject(mergePolicyConfig);
     }
 
     @Override
@@ -407,11 +403,8 @@ public class RingbufferConfig implements SplitBrainMergeTypeProvider, Identified
         timeToLiveSeconds = in.readInt();
         inMemoryFormat = InMemoryFormat.valueOf(in.readUTF());
         ringbufferStoreConfig = in.readObject();
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            quorumName = in.readUTF();
-            mergePolicyConfig = in.readObject();
-        }
+        quorumName = in.readUTF();
+        mergePolicyConfig = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -197,19 +196,19 @@ public class ScheduledExecutorConfig implements SplitBrainMergeTypeProvider, Ide
 
 
     /**
-    * Gets the {@link MergePolicyConfig} for the scheduler.
-    *
-    * @return the {@link MergePolicyConfig} for the scheduler
-    */
+     * Gets the {@link MergePolicyConfig} for the scheduler.
+     *
+     * @return the {@link MergePolicyConfig} for the scheduler
+     */
     public MergePolicyConfig getMergePolicyConfig() {
         return mergePolicyConfig;
     }
 
     /**
-    * Sets the {@link MergePolicyConfig} for the scheduler.
-    *
-    * @return this executor config instance
-    */
+     * Sets the {@link MergePolicyConfig} for the scheduler.
+     *
+     * @return this executor config instance
+     */
     public ScheduledExecutorConfig setMergePolicyConfig(MergePolicyConfig mergePolicyConfig) {
         this.mergePolicyConfig = checkNotNull(mergePolicyConfig, "mergePolicyConfig cannot be null");
         return this;
@@ -255,11 +254,8 @@ public class ScheduledExecutorConfig implements SplitBrainMergeTypeProvider, Ide
         out.writeInt(durability);
         out.writeInt(capacity);
         out.writeInt(poolSize);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeUTF(quorumName);
-            out.writeObject(mergePolicyConfig);
-        }
+        out.writeUTF(quorumName);
+        out.writeObject(mergePolicyConfig);
     }
 
     @Override
@@ -268,11 +264,8 @@ public class ScheduledExecutorConfig implements SplitBrainMergeTypeProvider, Ide
         durability = in.readInt();
         capacity = in.readInt();
         poolSize = in.readInt();
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            quorumName = in.readUTF();
-            mergePolicyConfig = in.readObject();
-        }
+        quorumName = in.readUTF();
+        mergePolicyConfig = in.readObject();
     }
 
     @SuppressWarnings({"checkstyle:npathcomplexity"})

--- a/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
@@ -227,10 +226,7 @@ public class SemaphoreConfig implements IdentifiedDataSerializable, Versioned {
         out.writeInt(initialPermits);
         out.writeInt(backupCount);
         out.writeInt(asyncBackupCount);
-        // RU_COMPAT_3_9
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            out.writeUTF(quorumName);
-        }
+        out.writeUTF(quorumName);
     }
 
     @Override
@@ -239,10 +235,7 @@ public class SemaphoreConfig implements IdentifiedDataSerializable, Versioned {
         initialPermits = in.readInt();
         backupCount = in.readInt();
         asyncBackupCount = in.readInt();
-        // RU_COMPAT_3_9
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_10)) {
-            quorumName = in.readUTF();
-        }
+        quorumName = in.readUTF();
     }
 
     @SuppressWarnings("checkstyle:npathcomplexity")

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DistributedDurableExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DistributedDurableExecutorService.java
@@ -18,7 +18,6 @@ package com.hazelcast.durableexecutor.impl;
 
 import com.hazelcast.config.DurableExecutorConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.spi.ManagedService;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.NodeEngine;
@@ -155,10 +154,6 @@ public class DistributedDurableExecutorService implements ManagedService, Remote
 
     @Override
     public String getQuorumName(final String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory,
                 quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -17,7 +17,6 @@
 package com.hazelcast.executor.impl;
 
 import com.hazelcast.config.ExecutorConfig;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.monitor.impl.LocalExecutorStatsImpl;
@@ -230,10 +229,6 @@ public class DistributedExecutorService implements ManagedService, RemoteService
 
     @Override
     public String getQuorumName(final String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         if (name == null) {
             // see CancellationOperation#getName()
             return null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -838,7 +838,7 @@ public class MembershipManager {
                         // we don't suspect from 'address' and we need to learn its response
                         done = false;
 
-                        // RU_COMPAT_39
+                        // RU_COMPAT_3_9
                         if (clusterService.getClusterVersion().isGreaterThan(Versions.V3_9)) {
                             // Mastership claim is idempotent.
                             // We will retry our claim to member until it explicitly rejects or accepts our claim.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
@@ -30,7 +30,7 @@ import java.util.Collection;
  * A {@code JoinMessage} issued by the master node of a subcluster to the master of another subcluster
  * while searching for other clusters for split brain recovery.
  */
-// RU_COMPAT_39: Do not remove Versioned interface!
+// RU_COMPAT_3_9: Do not remove Versioned interface!
 // Version info is needed on 3.9 members while deserializing the operation.
 public class SplitBrainJoinMessage extends JoinMessage implements Versioned {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
@@ -27,7 +27,7 @@ import com.hazelcast.nio.serialization.impl.Versioned;
 import java.io.IOException;
 
 /** A heartbeat sent from one cluster member to another. The sent timestamp is the cluster clock time of the sending member */
-// RU_COMPAT_39: Do not remove Versioned interface!
+// RU_COMPAT_3_9: Do not remove Versioned interface!
 // Version info is needed on 3.9 members while deserializing the operation.
 public final class HeartbeatOp extends AbstractClusterOperation implements Versioned {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterConfirmationOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterConfirmationOp.java
@@ -29,7 +29,7 @@ import java.io.IOException;
  */
 @Deprecated
 // Master confirmation logic is not needed in 3.10. This operation is still here to remain compatible with 3.9.
-// RU_COMPAT_39: Do not remove Versioned interface!
+// RU_COMPAT_3_9: Do not remove Versioned interface!
 // Version info is needed on 3.9 members while deserializing the operation.
 public class MasterConfirmationOp extends AbstractClusterOperation implements Versioned {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
@@ -37,7 +37,7 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 
-// RU_COMPAT_39: Do not remove Versioned interface!
+// RU_COMPAT_3_9: Do not remove Versioned interface!
 // Version info is needed on 3.9 members while deserializing the operation.
 public class MembersUpdateOp extends AbstractClusterOperation implements Versioned {
     /** The master cluster clock time. */

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/MergePolicyValidator.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/MergePolicyValidator.java
@@ -30,7 +30,6 @@ import com.hazelcast.spi.merge.MergingValue;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
 import com.hazelcast.spi.merge.SplitBrainMergeTypeProvider;
-import com.hazelcast.version.Version;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -62,16 +61,14 @@ public final class MergePolicyValidator {
      * the supplied {@code mergePolicy}, {@code false} otherwise
      */
     public static boolean checkMergePolicySupportsInMemoryFormat(String name, Object mergePolicy, InMemoryFormat inMemoryFormat,
-                                                                 Version clusterVersion, boolean failFast, ILogger logger) {
+                                                                 boolean failFast, ILogger logger) {
         if (inMemoryFormat != NATIVE) {
             return true;
         }
-        // RU_COMPAT_3_9 (in 3.11 just check instanceof SplitBrainMergePolicy)
-        if (mergePolicy instanceof SplitBrainMergePolicy && clusterVersion.isGreaterOrEqual(V3_10)) {
+        if (mergePolicy instanceof SplitBrainMergePolicy) {
             return true;
         }
-        // RU_COMPAT_3_9 (in 3.11 just check failFast)
-        if (failFast && clusterVersion.isGreaterOrEqual(V3_10)) {
+        if (failFast) {
             throw new InvalidConfigurationException(createSplitRecoveryWarningMsg(name, mergePolicy.getClass().getName()));
         }
         logger.warning(createSplitRecoveryWarningMsg(name, mergePolicy.getClass().getName()));

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -293,7 +293,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
                                 @Override
                                 public void onResponse(Object response) {
                                     resetMasterTriggeredFlag();
-                                    // RU_COMPAT_310
+                                    // RU_COMPAT_3_10
                                     if (response instanceof PartitionRuntimeState) {
                                         PartitionRuntimeState partitionState = (PartitionRuntimeState) response;
                                         partitionState.setEndpoint(masterAddress);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -1344,7 +1344,7 @@ public class MigrationManager {
                 logger.warning("Destination " + destination + " is not a member anymore");
                 return false;
             }
-            // RU_COMPAT_39
+            // RU_COMPAT_3_9
             boolean idempotentRetry = node.getClusterService().getClusterVersion().isGreaterThan(Versions.V3_9);
             try {
                 if (logger.isFinestEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
@@ -37,7 +37,7 @@ import java.util.Map;
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.PARTITION_BACKUP_REPLICA_ANTI_ENTROPY;
 
 // should not be an urgent operation. required to be in order with backup operations on target node
-// RU_COMPAT_39: Do not remove Versioned interface! Version info is needed on 3.9 members while deserializing the operation.
+// RU_COMPAT_3_9: Do not remove Versioned interface! Version info is needed on 3.9 members while deserializing the operation.
 public final class PartitionBackupReplicaAntiEntropyOperation
         extends AbstractPartitionOperation
         implements PartitionAwareOperation, AllowedDuringPassiveState, Versioned {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
@@ -54,7 +54,7 @@ import java.util.Collections;
  * </ul>
  * An empty response can be sent if the current replica version is 0.
  */
-// RU_COMPAT_39: Do not remove Versioned interface!
+// RU_COMPAT_3_9: Do not remove Versioned interface!
 // Version info is needed on 3.9 members while deserializing the operation.
 public final class PartitionReplicaSyncRequest extends AbstractPartitionOperation
         implements PartitionAwareOperation, MigrationCycleOperation, Versioned {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
@@ -58,7 +58,7 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createError
  * <li>if the node is not a replica anymore it will clear the replica versions for the partition</li>
  * </ul>
  */
-// RU_COMPAT_39: Do not remove Versioned interface!
+// RU_COMPAT_3_9: Do not remove Versioned interface!
 // Version info is needed on 3.9 members while deserializing the operation.
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public class PartitionReplicaSyncResponse extends AbstractPartitionOperation

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRetryResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRetryResponse.java
@@ -38,7 +38,7 @@ import java.util.Collections;
  * The response to a {@link PartitionReplicaSyncRequest} that the replica should retry. This will reset the current ongoing
  * synchronization request state and retry the request if this node is still a replica of this partition.
  */
-// RU_COMPAT_39: Do not remove Versioned interface!
+// RU_COMPAT_3_9: Do not remove Versioned interface!
 // Version info is needed on 3.9 members while deserializing the operation.
 public class PartitionReplicaSyncRetryResponse
         extends AbstractPartitionOperation

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapIndexSynchronizer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapIndexSynchronizer.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-// RU_COMPAT_V3_9
+// RU_COMPAT_3_9
 
 /**
  * This class is responsible for tracking cluster version changes and synchronizes indexes if needed.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapService.java
@@ -95,7 +95,7 @@ public class MapService implements ManagedService, FragmentedMigrationAwareServi
     protected ClientAwareService clientAwareService;
     protected MapQuorumAwareService quorumAwareService;
     protected MapServiceContext mapServiceContext;
-    // RU_COMPAT_V3_9
+    // RU_COMPAT_3_9
     protected MapIndexSynchronizer mapIndexSynchronizer;
 
     public MapService() {
@@ -253,7 +253,7 @@ public class MapService implements ManagedService, FragmentedMigrationAwareServi
     }
 
     @Override
-    // RU_COMPAT_V3_9
+    // RU_COMPAT_3_9
     // We wont need to sync the indexes in 3.10+ clusters.
     public void onClusterVersionChange(Version newVersion) {
         mapIndexSynchronizer.onClusterVersionChange(newVersion);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -248,7 +248,7 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        // RU_COMPAT_39
+        // RU_COMPAT_3_9
         Version inputversion = in.getVersion();
         // read index info when object input comes from 3.9 EE (version UNKNOWN)
         // or 3.10 EE on cluster version 3.9 (inputVersion < 3.10)

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/MultiMapService.java
@@ -23,7 +23,6 @@ import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.map.impl.event.EventData;
 import com.hazelcast.monitor.LocalMultiMapStats;
 import com.hazelcast.monitor.impl.LocalMultiMapStatsImpl;
@@ -483,10 +482,6 @@ public class MultiMapService implements ManagedService, RemoteService, Fragmente
 
     @Override
     public String getQuorumName(String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory,
                 quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -27,7 +27,6 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberSelector;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.serialization.impl.HeapData;
@@ -148,7 +147,7 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
             partitionContainers[i] = new PartitionContainer(this, i);
         }
         antiEntropyFuture = nodeEngine.getExecutionService().getGlobalTaskScheduler()
-                .scheduleWithRepetition(antiEntropyTask, 0, SYNC_INTERVAL_SECONDS, TimeUnit.SECONDS);
+                                      .scheduleWithRepetition(antiEntropyTask, 0, SYNC_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
     @Override
@@ -372,10 +371,6 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
 
     @Override
     public String getQuorumName(String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory, quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;
     }
@@ -426,8 +421,8 @@ public class ReplicatedMapService implements ManagedService, RemoteService, Even
                             .setPartitionId(i)
                             .setValidateTarget(false);
                     operationService.createInvocationBuilder(SERVICE_NAME, operation, address)
-                            .setTryCount(INVOCATION_TRY_COUNT)
-                            .invoke();
+                                    .setTryCount(INVOCATION_TRY_COUNT)
+                                    .invoke();
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/RingbufferService.java
@@ -19,7 +19,6 @@ package com.hazelcast.ringbuffer.impl;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.core.DistributedObject;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.quorum.QuorumService;
@@ -320,10 +319,6 @@ public class RingbufferService implements ManagedService, RemoteService, Fragmen
 
     @Override
     public String getQuorumName(final String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory,
                 quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/DistributedScheduledExecutorService.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.partition.PartitionLostEvent;
 import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.scheduledexecutor.impl.operations.MergeOperation;
@@ -303,10 +302,6 @@ public class DistributedScheduledExecutorService
 
     @Override
     public String getQuorumName(final String name) {
-        // RU_COMPAT_3_9
-        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_10)) {
-            return null;
-        }
         Object quorumName = getOrPutSynchronized(quorumConfigCache, name, quorumConfigCacheMutexFactory, quorumConfigConstructor);
         return quorumName == NULL_OBJECT ? null : (String) quorumName;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/AbstractRegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/AbstractRegistrationOperation.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 
 import static java.lang.String.format;
 
-// RU_COMPAT_39: Do not remove Versioned interface!
+// RU_COMPAT_3_9: Do not remove Versioned interface!
 // Version info is needed on 3.9 members while deserializing the operation.
 abstract class AbstractRegistrationOperation extends Operation
         implements AllowedDuringPassiveState, IdentifiedDataSerializable, Versioned {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractContainerMerger.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/AbstractContainerMerger.java
@@ -19,7 +19,6 @@ package com.hazelcast.spi.impl.merge;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.cluster.ClusterService;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
@@ -78,12 +77,6 @@ public abstract class AbstractContainerMerger<C, V, T extends MergingValue<V>> i
 
     @Override
     public final void run() {
-        // we cannot merge into a 3.9 cluster, since not all members may understand the new merge operation
-        // RU_COMPAT_3_9
-        if (clusterService.getClusterVersion().isLessThan(Versions.V3_10)) {
-            logger.info("Cluster needs to run version " + Versions.V3_10 + " to merge " + getLabel() + " instances");
-            return;
-        }
         int valueCount = collector.getMergingValueCount();
         if (valueCount == 0) {
             return;


### PR DESCRIPTION
- remove RU code for extending split brain protection (quorum)
- remove RU code for merge policies for additional data structures

Also aligned some `RU_COMPAT` comments with the more common format.