### PR TITLE
Ignore VersionedInCurrentVersionTest on JDKs 6 and 7

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/VersionedInCurrentVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/VersionedInCurrentVersionTest.java
@@ -49,6 +49,8 @@ import java.util.Set;
 import static com.hazelcast.instance.BuildInfoProvider.getBuildInfo;
 import static com.hazelcast.internal.cluster.Versions.CURRENT_CLUSTER_VERSION;
 import static com.hazelcast.internal.cluster.Versions.PREVIOUS_CLUSTER_VERSION;
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatNoJDK6;
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatNoJDK7;
 import static com.hazelcast.test.ReflectionsHelper.REFLECTIONS;
 import static com.hazelcast.test.ReflectionsHelper.filterNonConcreteClasses;
 import static com.hazelcast.test.starter.HazelcastStarterUtils.rethrowGuardianException;
@@ -77,6 +79,9 @@ public class VersionedInCurrentVersionTest {
 
     @Before
     public void setup() throws Exception {
+        assumeThatNoJDK6();
+        assumeThatNoJDK7();
+
         Set<Class<? extends Versioned>> versionedClasses = REFLECTIONS.getSubTypesOf(Versioned.class);
         Set<Class<? extends DataSerializable>> dsClasses = REFLECTIONS.getSubTypesOf(DataSerializable.class);
         Set<Class<? extends Versioned>> versionedSincePreviousVersion = versionedClassesInPreviousVersion();

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1545,6 +1545,10 @@ public abstract class HazelcastTestSupport {
         assumeFalse("Java 6 used", JAVA_VERSION.startsWith("1.6."));
     }
 
+    public static void assumeThatNoJDK7() {
+        assumeFalse("Java 7 used", JAVA_VERSION.startsWith("1.7."));
+    }
+
     public static void assumeThatJDK8() {
         assumeTrue("Java 8 should be used", JAVA_VERSION.startsWith("1.8."));
     }


### PR DESCRIPTION
This test causes problems on older JDKs without TLSv1.2 support because of downloading of Maven artifacts. However, it's completely fine to test this functionality only on newer JDKs.