### PR TITLE
getTask connection to MC uses HTTP POST method

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -25,6 +25,8 @@ import com.hazelcast.core.MembershipEvent;
 import com.hazelcast.core.MembershipListener;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.internal.ascii.rest.HttpCommand;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.management.operation.UpdateManagementCenterUrlOperation;
 import com.hazelcast.internal.management.request.AsyncConsoleRequest;
 import com.hazelcast.internal.management.request.ChangeClusterStateRequest;
@@ -46,8 +48,6 @@ import com.hazelcast.internal.management.request.RunGcRequest;
 import com.hazelcast.internal.management.request.ShutdownClusterRequest;
 import com.hazelcast.internal.management.request.ThreadDumpRequest;
 import com.hazelcast.internal.management.request.TriggerPartialStartRequest;
-import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Address;
@@ -583,11 +583,12 @@ public class ManagementCenterService {
             if (logger.isFinestEnabled()) {
                 logger.finest("Opening getTask connection:" + url);
             }
-            URLConnection connection = connectionFactory != null
-                                        ? connectionFactory.openConnection(url)
-                                        : url.openConnection();
+            HttpURLConnection connection = (HttpURLConnection) (connectionFactory != null
+                    ? connectionFactory.openConnection(url)
+                    : url.openConnection());
 
             connection.setRequestProperty("Connection", "keep-alive");
+            connection.setRequestMethod("POST");
             return connection;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/MancenterServlet.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/MancenterServlet.java
@@ -16,13 +16,11 @@
 
 package com.hazelcast.internal.management;
 
-import javax.servlet.ServletException;
+import com.hazelcast.internal.json.JsonObject;
+
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import com.hazelcast.internal.json.JsonObject;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 
@@ -32,32 +30,34 @@ public class MancenterServlet extends HttpServlet {
     private volatile String clusterName = "";
 
     @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         if (req.getPathInfo().contains("memberStateCheck")) {
             if (memberState != null) {
                 resp.getWriter().write(memberState.toJson().toString());
             } else {
                 resp.getWriter().write("");
             }
-        } else if (req.getPathInfo().contains("getTask.do")) {
-            clusterName = req.getParameter("cluster");
-            resp.getWriter().write("{}");
         } else if (req.getPathInfo().contains("getClusterName")) {
             resp.getWriter().write(clusterName);
         }
     }
 
     @Override
-    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        BufferedReader br = req.getReader();
-        StringBuilder sb = new StringBuilder();
-        String str;
-        while ((str = br.readLine()) != null) {
-            sb.append(str);
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        if (req.getPathInfo().contains("getTask.do")) {
+            clusterName = req.getParameter("cluster");
+            resp.getWriter().write("{}");
+        } else if (req.getPathInfo().contains("collector.do")) {
+            BufferedReader br = req.getReader();
+            StringBuilder sb = new StringBuilder();
+            String str;
+            while ((str = br.readLine()) != null) {
+                sb.append(str);
+            }
+            final String json = sb.toString();
+            final JsonObject object = JsonObject.readFrom(json);
+            process(object);
         }
-        final String json = sb.toString();
-        final JsonObject object = JsonObject.readFrom(json);
-        process(object);
     }
 
     public void process(JsonObject json) {


### PR DESCRIPTION
HTTP GET method was used previously. Since this operation changes
state on MC, it needs to allow HTTP POST methods only. In MC 3.11,
endpoint is changed to support both GET & POST to keep compatibility
with HZ 3.10.x. With MC 3.12, only POST will be supported for this
endpoint.