### PR TITLE
[BACKPORT] Account for partitioned indexes when iterating

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -82,7 +82,7 @@ public class QueryRunner {
      */
     public ResultSegment runPartitionScanQueryOnPartitionChunk(Query query, int partitionId, int tableIndex, int fetchSize) {
         final MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
-        final Predicate predicate = queryOptimizer.optimize(query.getPredicate(), mapContainer.getIndexes());
+        final Predicate predicate = queryOptimizer.optimize(query.getPredicate(), mapContainer.getIndexes(partitionId));
         final QueryableEntriesSegment entries = partitionScanExecutor
                 .execute(query.getMapName(), predicate, partitionId, tableIndex, fetchSize);
 


### PR DESCRIPTION
Before that change only global indexes were used while iterating
partition entries. Depending on the execution paths that was manifested
as exceptions.

(cherry-picked from bf8f9858136a75b8ca24f6134a534ccb4b88218a)

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2265