### PR TITLE
Transactional put/set operation should replicate result of interceptPut

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -72,12 +72,17 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
 
     @Override
     public Operation getBackupOperation() {
-        final Record record = recordStore.getRecord(dataKey);
-        final RecordInfo replicationInfo = buildRecordInfo(record);
+        Record record = recordStore.getRecord(dataKey);
+        RecordInfo replicationInfo = buildRecordInfo(record);
         if (isPostProcessing(recordStore)) {
             dataValue = mapServiceContext.toData(record.getValue());
         }
-        return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, putTransient);
+        return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, shouldUnlockKeyOnBackup(),
+                putTransient, !canThisOpGenerateWANEvent());
+    }
+
+    protected boolean shouldUnlockKeyOnBackup() {
+        return false;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LegacyMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LegacyMergeOperation.java
@@ -20,8 +20,6 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.map.impl.record.RecordInfo;
-import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -90,9 +88,7 @@ public class LegacyMergeOperation extends BasePutOperation {
         if (dataValue == null) {
             return new RemoveBackupOperation(name, dataKey, false, disableWanReplicationEvent);
         } else {
-            final Record record = recordStore.getRecord(dataKey);
-            final RecordInfo replicationInfo = Records.buildRecordInfo(record);
-            return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, false, false, disableWanReplicationEvent);
+           return super.getBackupOperation();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -20,15 +20,11 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.BasePutOperation;
-import com.hazelcast.map.impl.operation.PutBackupOperation;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.map.impl.record.RecordInfo;
-import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventService;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.transaction.TransactionException;
@@ -108,10 +104,9 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
         return true;
     }
 
-    public Operation getBackupOperation() {
-        final Record record = recordStore.getRecord(dataKey);
-        final RecordInfo replicationInfo = record != null ? Records.buildRecordInfo(record) : null;
-        return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, true, false);
+    @Override
+    protected boolean shouldUnlockKeyOnBackup() {
+        return true;
     }
 
     public void onWaitExpire() {


### PR DESCRIPTION
`TxnSetOperation` was not taking changes made by `MapInterceptor` into account
while sending backups.

Fixes #12705