### PR TITLE
Transactional put/set operation should replicate result of interceptPut

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BasePutOperation.java
@@ -95,12 +95,17 @@ public abstract class BasePutOperation extends LockAwareOperation implements Bac
 
     @Override
     public Operation getBackupOperation() {
-        final Record record = recordStore.getRecord(dataKey);
-        final RecordInfo replicationInfo = buildRecordInfo(record);
+        Record record = recordStore.getRecord(dataKey);
+        RecordInfo replicationInfo = buildRecordInfo(record);
         if (isPostProcessing(recordStore)) {
             dataValue = mapServiceContext.toData(record.getValue());
         }
-        return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, putTransient);
+        return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, shouldUnlockKeyOnBackup(),
+                putTransient, !canThisOpGenerateWANEvent());
+    }
+
+    protected boolean shouldUnlockKeyOnBackup() {
+        return false;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LegacyMergeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/LegacyMergeOperation.java
@@ -20,8 +20,6 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.map.impl.record.RecordInfo;
-import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.map.merge.MapMergePolicy;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -96,9 +94,7 @@ public class LegacyMergeOperation extends BasePutOperation {
         if (dataValue == null) {
             return new RemoveBackupOperation(name, dataKey, false, disableWanReplicationEvent);
         } else {
-            final Record record = recordStore.getRecord(dataKey);
-            final RecordInfo replicationInfo = Records.buildRecordInfo(record);
-            return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, false, false, disableWanReplicationEvent);
+           return super.getBackupOperation();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TxnSetOperation.java
@@ -20,15 +20,11 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.BasePutOperation;
-import com.hazelcast.map.impl.operation.PutBackupOperation;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.map.impl.record.RecordInfo;
-import com.hazelcast.map.impl.record.Records;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventService;
-import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.WaitNotifyKey;
 import com.hazelcast.spi.impl.MutatingOperation;
 import com.hazelcast.transaction.TransactionException;
@@ -112,10 +108,9 @@ public class TxnSetOperation extends BasePutOperation implements MapTxnOperation
         return true;
     }
 
-    public Operation getBackupOperation() {
-        final Record record = recordStore.getRecord(dataKey);
-        final RecordInfo replicationInfo = record != null ? Records.buildRecordInfo(record) : null;
-        return new PutBackupOperation(name, dataKey, dataValue, replicationInfo, true, false);
+    @Override
+    protected boolean shouldUnlockKeyOnBackup() {
+        return true;
     }
 
     public void onWaitExpire() {

--- a/hazelcast/src/test/java/com/hazelcast/map/InterceptorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/InterceptorTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapLoader;
+import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -29,12 +30,14 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionalTask;
+import com.hazelcast.transaction.TransactionalTaskContext;
 import com.hazelcast.util.StringUtil;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -106,7 +109,7 @@ public class InterceptorTest extends HazelcastTestSupport {
         for (int i = 0; i < 100; i++) {
             map.put(i, i);
         }
-        map.addInterceptor(new NegativeInterceptor());
+        map.addInterceptor(new NegativeGetInterceptor());
         for (int i = 0; i < 100; i++) {
             assertEquals(i * -1, map.get(i));
         }
@@ -215,6 +218,63 @@ public class InterceptorTest extends HazelcastTestSupport {
         }, 15);
     }
 
+    @Test
+    public void testInterceptPut_replicatedToBackups() {
+        String name = randomString();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        Config config = getConfig();
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+
+        IMap<Object, Object> map = hz2.getMap(name);
+        map.addInterceptor(new NegativePutInterceptor());
+
+        int count = 1000;
+        for (int i = 1; i <= count; i++) {
+            map.set(i, i);
+        }
+        waitAllForSafeState(hz1, hz2);
+
+        hz1.getLifecycleService().terminate();
+
+        for (int i = 1; i <= count; i++) {
+            assertEquals(-i, map.get(i));
+        }
+    }
+
+    @Test
+    public void testInterceptPut_replicatedToBackups_usingTransactions() {
+        final String name = randomString();
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+        Config config = getConfig();
+        HazelcastInstance hz1 = factory.newHazelcastInstance(config);
+        HazelcastInstance hz2 = factory.newHazelcastInstance(config);
+
+        IMap<Object, Object> map = hz2.getMap(name);
+        map.addInterceptor(new NegativePutInterceptor());
+
+        final int count = 1000;
+        hz2.executeTransaction(new TransactionalTask<Object>() {
+            @Override
+            public Object execute(TransactionalTaskContext context) throws TransactionException {
+                TransactionalMap<Object, Object> txMap = context.getMap(name);
+                for (int i = 1; i <= count; i++) {
+                    txMap.set(i, i);
+                }
+                return null;
+            }
+        });
+        waitAllForSafeState(hz1, hz2);
+
+        hz1.getLifecycleService().terminate();
+
+        for (int i = 1; i <= count; i++) {
+            assertEquals(-i, map.get(i));
+        }
+    }
+
     static class DummyLoader implements MapLoader<Integer, String> {
         @Override
         public String load(Integer key) {
@@ -263,46 +323,11 @@ public class InterceptorTest extends HazelcastTestSupport {
         }
     }
 
-    public static class SimpleInterceptor implements MapInterceptor, Serializable {
+    static class MapInterceptorAdaptor implements MapInterceptor {
 
         @Override
         public Object interceptGet(Object value) {
-            if (value == null) {
-                return null;
-            }
-            return value + ":";
-        }
-
-        @Override
-        public void afterGet(Object value) {
-        }
-
-        @Override
-        public Object interceptPut(Object oldValue, Object newValue) {
-            return newValue.toString().toUpperCase(StringUtil.LOCALE_INTERNAL);
-        }
-
-        @Override
-        public void afterPut(Object value) {
-        }
-
-        @Override
-        public Object interceptRemove(Object removedValue) {
-            if (removedValue.equals("ISTANBUL")) {
-                throw new RuntimeException("you can not remove this");
-            }
-            return removedValue;
-        }
-
-        @Override
-        public void afterRemove(Object value) {
-        }
-    }
-
-    static class NegativeInterceptor implements MapInterceptor, Serializable {
-        @Override
-        public Object interceptGet(Object value) {
-            return ((Integer) value) * -1;
+            return value;
         }
 
         @Override
@@ -325,6 +350,45 @@ public class InterceptorTest extends HazelcastTestSupport {
 
         @Override
         public void afterRemove(Object value) {
+        }
+    }
+
+    public static class SimpleInterceptor extends MapInterceptorAdaptor {
+        @Override
+        public Object interceptGet(Object value) {
+            if (value == null) {
+                return null;
+            }
+            return value + ":";
+        }
+
+        @Override
+        public Object interceptPut(Object oldValue, Object newValue) {
+            return newValue.toString().toUpperCase(StringUtil.LOCALE_INTERNAL);
+        }
+
+        @Override
+        public Object interceptRemove(Object removedValue) {
+            if (removedValue.equals("ISTANBUL")) {
+                throw new RuntimeException("you can not remove this");
+            }
+            return removedValue;
+        }
+    }
+
+    static class NegativeGetInterceptor extends MapInterceptorAdaptor {
+
+        @Override
+        public Object interceptGet(Object value) {
+            return ((Integer) value) * -1;
+        }
+    }
+
+    static class NegativePutInterceptor extends MapInterceptorAdaptor {
+
+        @Override
+        public Object interceptPut(Object oldValue, Object newValue) {
+            return ((Integer) newValue) * -1;
         }
     }
 }


### PR DESCRIPTION
`TxnSetOperation` was not taking changes made by `MapInterceptor` into account
while sending backups.

Fixes #12705

Backport of https://github.com/hazelcast/hazelcast/pull/13499