### PR TITLE
Introduced system property to provide backward

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryLoadedListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryLoadedListenerTest.java
@@ -300,7 +300,7 @@ public class ClientEntryLoadedListenerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void add_listener_notified_after_loadAll() {
+    public void add_listener_not_notified_after_loadAll() {
         final AtomicInteger addEventCount = new AtomicInteger();
 
         IMap<Integer, Integer> map = client.getMap("add_listener_notified_after_loadAll");
@@ -311,12 +311,12 @@ public class ClientEntryLoadedListenerTest extends HazelcastTestSupport {
 
         map.loadAll(true);
 
-        assertTrueEventually(new AssertTask() {
+        assertTrueAllTheTime(new AssertTask() {
             @Override
             public void run() {
-                assertEquals(5, addEventCount.get());
+                assertEquals(0, addEventCount.get());
             }
-        });
+        }, 5);
     }
 
     static class LoadAndAddListener implements EntryLoadedListener<Integer, Integer>,

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -301,7 +301,7 @@ public class Indexes {
          *                                   used for queryable entries, otherwise set {@code false}
          * @return this builder instance
          */
-        public Builder usesCacheQueryableEntries(boolean usesCachedQueryableEntries) {
+        public Builder usesCachedQueryableEntries(boolean usesCachedQueryableEntries) {
             this.usesCachedQueryableEntries = usesCachedQueryableEntries;
             return this;
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -401,6 +401,7 @@ public final class GroupProperty {
 
     /**
      * The interval at which master confirmations are sent from non-master nodes to the master node
+     *
      * @deprecated since 3.10
      */
     @Deprecated
@@ -408,6 +409,7 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.master.confirmation.interval.seconds", 30, SECONDS);
     /**
      * The timeout which defines when a cluster member is removed because it has not sent any master confirmations.
+     *
      * @deprecated since 3.10
      */
     @Deprecated
@@ -534,27 +536,42 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.map.replica.scheduled.task.delay.seconds", 10, SECONDS);
 
     /**
-     * You can use MAP_EXPIRY_DELAY_SECONDS to deal with some possible edge cases, such as using EntryProcessor.
-     * Without this delay, you may see that an EntryProcessor running on the owner partition found a key, but
-     * EntryBackupProcessor did not find it on backup, and as a result when backup promotes to owner
-     * you will end up with an unprocessed key.
+     * You can use MAP_EXPIRY_DELAY_SECONDS to deal with some possible
+     * edge cases, such as using EntryProcessor. Without this delay, you
+     * may see that an EntryProcessor running on the owner partition
+     * found a key, but EntryBackupProcessor did not find it on backup,
+     * and as a result when backup promotes to owner you will end up
+     * with an unprocessed key.
      */
     public static final HazelcastProperty MAP_EXPIRY_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.map.expiry.delay.seconds", 10, SECONDS);
 
     /**
-     * Maximum number of IMap entries Hazelcast will evict during a single eviction cycle.
-     * Eviction cycle is triggered by a map mutation. Typically it's OK to evict at most a single entry.
-     * However imagine the scenario where you are inserting values in a loop and in each iteration you double entry
-     * size. In this situation Hazelcast has to evict more than just a single entry - as all existing entries are
-     * smaller than the entry which is about to be added and removing any old entry cannot make sufficient room
-     * for the new entry.
+     * Maximum number of IMap entries Hazelcast will evict during a
+     * single eviction cycle. Eviction cycle is triggered by a map
+     * mutation. Typically it's OK to evict at most a single entry.
+     * However imagine the scenario where you are inserting values in a
+     * loop and in each iteration you double entry size. In this
+     * situation Hazelcast has to evict more than just a single entry -
+     * as all existing entries are smaller than the entry which is about
+     * to be added and removing any old entry cannot make sufficient
+     * room for the new entry.
      *
      * Default: 1
-     *
      */
     public static final HazelcastProperty MAP_EVICTION_BATCH_SIZE
             = new HazelcastProperty("hazelcast.map.eviction.batch.size", 1);
+
+    /**
+     * This property is a switch between old and new event publishing
+     * behavior of map#loadAll. When it is true, map#loadAll publishes
+     * entry ADDED events, when false, map#loadAll publishes entry
+     * LOADED events. By default LOADED events will be published.
+     *
+     * @since 3.11
+     */
+    public static final HazelcastProperty MAP_LOAD_ALL_PUBLISHES_ADD_EVENT
+            = new HazelcastProperty("hazelcast.map.loadAll.publishes.add.event", false);
 
     public static final HazelcastProperty LOGGING_TYPE
             = new HazelcastProperty("hazelcast.logging.type", "jdk");
@@ -985,20 +1002,20 @@ public final class GroupProperty {
     /**
      * By default, search for data structures config is performed within static configuration first:
      * <ul>
-     *     <li>Exact match in static config</li>
-     *     <li>Wildcard match in static config</li>
-     *     <li>Exact match in dynamic config</li>
-     *     <li>Wildcard match in dynamic config</li>
-     *     <li>Fallback to default</li>
+     * <li>Exact match in static config</li>
+     * <li>Wildcard match in static config</li>
+     * <li>Exact match in dynamic config</li>
+     * <li>Wildcard match in dynamic config</li>
+     * <li>Fallback to default</li>
      * </ul>
      * But sometimes it makes sense to perform search within dynamic configs first. If this property is set to
      * <code>true</code>, search algorithm changes to:
      * <ul>
-     *     <li>Exact match in dynamic config</li>
-     *     <li>Wildcard match in dynamic config</li>
-     *     <li>Exact match in static config</li>
-     *     <li>Wildcard match in static config</li>
-     *     <li>Fallback to default</li>
+     * <li>Exact match in dynamic config</li>
+     * <li>Wildcard match in dynamic config</li>
+     * <li>Exact match in static config</li>
+     * <li>Wildcard match in static config</li>
+     * <li>Fallback to default</li>
      * </ul>
      */
     public static final HazelcastProperty SEARCH_DYNAMIC_CONFIG_FIRST

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerCompatibleModeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerCompatibleModeTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapStoreConfig;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.MapListener;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.spi.properties.GroupProperty.MAP_LOAD_ALL_PUBLISHES_ADD_EVENT;
+import static org.junit.Assert.assertEquals;
+
+@SuppressWarnings("deprecation")
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class EntryLoadedListenerCompatibleModeTest extends HazelcastTestSupport {
+
+    private static final TestHazelcastInstanceFactory FACTORY = new TestHazelcastInstanceFactory();
+
+    private static HazelcastInstance node;
+
+    @BeforeClass
+    public static void setUp() {
+        Config config = new Config();
+
+        config.setProperty(MAP_LOAD_ALL_PUBLISHES_ADD_EVENT.getName(), "true");
+        MapStoreConfig mapStoreConfig = new MapStoreConfig();
+        mapStoreConfig.setEnabled(true);
+        mapStoreConfig.setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER);
+        mapStoreConfig.setClassName(EntryLoadedListenerTest.TestMapLoader.class.getName());
+        config.getMapConfig("default").setMapStoreConfig(mapStoreConfig);
+
+        FACTORY.newHazelcastInstance(config);
+        FACTORY.newHazelcastInstance(config);
+        node = FACTORY.newHazelcastInstance(config);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        FACTORY.shutdownAll();
+    }
+
+    @Test
+    public void add_listener_notified_after_loadAll_when_backward_compatibility_mode_on() {
+        final AtomicInteger addEventCount = new AtomicInteger();
+        IMap<Integer, Integer> map = node.getMap("add_listener_notified_after_loadAll");
+        map.clear();
+
+        MapListener listener = new AddListener(addEventCount);
+        map.addEntryListener(listener, true);
+
+        map.loadAll(true);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(5, addEventCount.get());
+            }
+        }, 10);
+    }
+
+    static class AddListener implements EntryAddedListener<Integer, Integer> {
+
+        private final AtomicInteger addEventCount;
+
+        public AddListener(AtomicInteger addEventCount) {
+            this.addEventCount = addEventCount;
+        }
+
+        @Override
+        public void entryAdded(EntryEvent<Integer, Integer> event) {
+            addEventCount.incrementAndGet();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerTest.java
@@ -64,6 +64,7 @@ public class EntryLoadedListenerTest extends HazelcastTestSupport {
     @BeforeClass
     public static void setUp() {
         Config config = new Config();
+
         MapStoreConfig mapStoreConfig = new MapStoreConfig();
         mapStoreConfig.setEnabled(true);
         mapStoreConfig.setInitialLoadMode(MapStoreConfig.InitialLoadMode.EAGER);
@@ -289,7 +290,7 @@ public class EntryLoadedListenerTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void add_listener_notified_after_loadAll() {
+    public void add_listener_not_notified_after_loadAll() {
         final AtomicInteger addEventCount = new AtomicInteger();
 
         IMap<Integer, Integer> map = node.getMap("add_listener_notified_after_loadAll");
@@ -300,12 +301,12 @@ public class EntryLoadedListenerTest extends HazelcastTestSupport {
 
         map.loadAll(true);
 
-        assertTrueEventually(new AssertTask() {
+        assertTrueAllTheTime(new AssertTask() {
             @Override
             public void run() {
-                assertEquals(5, addEventCount.get());
+                assertEquals(0, addEventCount.get());
             }
-        });
+        }, 5);
     }
 
     static class LoadAndAddListener implements EntryLoadedListener<Integer, Integer>,

--- a/hazelcast/src/test/java/com/hazelcast/map/InterceptorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/InterceptorTest.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.hazelcast.spi.properties.GroupProperty.MAP_LOAD_ALL_PUBLISHES_ADD_EVENT;
 import static com.hazelcast.util.StringUtil.LOCALE_INTERNAL;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -206,6 +207,7 @@ public class InterceptorTest extends HazelcastTestSupport {
     public void testPutEvent_withInterceptor_withLoadAll() {
         String name = randomString();
         Config config = getConfig();
+        config.setProperty(MAP_LOAD_ALL_PUBLISHES_ADD_EVENT.getName(), "true");
         MapStoreConfig mapStoreConfig = new MapStoreConfig()
                 .setEnabled(true)
                 .setImplementation(new DummyLoader());

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/LoadAllTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/LoadAllTest.java
@@ -161,12 +161,12 @@ public class LoadAllTest extends AbstractMapStoreTest {
         populateMap(map, itemCount);
         evictRange(map, 0, 700);
 
-        final CountDownLatch addEventCounter = new CountDownLatch(700);
-        addListener(map, addEventCounter);
+        final CountDownLatch loadEventCounter = new CountDownLatch(700);
+        addLoadedListener(map, loadEventCounter);
 
         map.loadAll(false);
 
-        assertOpenEventually(addEventCounter);
+        assertOpenEventually(loadEventCounter);
         assertEquals(itemCount, map.size());
     }
 
@@ -177,17 +177,14 @@ public class LoadAllTest extends AbstractMapStoreTest {
         final Config config = createNewConfig(mapName);
         final HazelcastInstance node = createHazelcastInstance(config);
         final IMap<Integer, Integer> map = node.getMap(mapName);
-        final CountDownLatch eventCounter = new CountDownLatch(itemCount);
         final CountDownLatch loadedCounter = new CountDownLatch(itemCount);
         populateMap(map, itemCount);
         map.evictAll();
 
-        addListener(map, eventCounter);
         addLoadedListener(map, loadedCounter);
 
         map.loadAll(true);
 
-        assertOpenEventually(eventCounter);
         assertOpenEventually(loadedCounter);
         assertEquals(itemCount, map.size());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/MapStoreTest.java
@@ -36,7 +36,7 @@ import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapStoreWrapper;
 import com.hazelcast.map.impl.mapstore.writebehind.MapStoreWithCounter;
 import com.hazelcast.map.impl.proxy.MapProxyImpl;
-import com.hazelcast.map.listener.EntryAddedListener;
+import com.hazelcast.map.listener.EntryLoadedListener;
 import com.hazelcast.map.listener.EntryUpdatedListener;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.SampleTestObjects.Employee;
@@ -765,9 +765,9 @@ public class MapStoreTest extends AbstractMapStoreTest {
         IMap map = node.getMap(mapName);
 
         final CountDownLatch latch = new CountDownLatch(numberOfEntriesToLoad);
-        map.addEntryListener(new EntryAddedListener<Object, Object>() {
+        map.addEntryListener(new EntryLoadedListener<Object, Object>() {
             @Override
-            public void entryAdded(EntryEvent<Object, Object> event) {
+            public void entryLoaded(EntryEvent<Object, Object> event) {
                 latch.countDown();
             }
         }, true);


### PR DESCRIPTION
compatible event firing behavior for map#loadAll.

When compatibility mode is on loadAll will fire ADD events,
when off, it will fire LOADED event. By default LOADED events
will be fired.