### PR TITLE
Remove AWS IPv4 enforcement

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -17,9 +17,7 @@
 package com.hazelcast.instance;
 
 import com.hazelcast.cluster.impl.TcpIpJoiner;
-import com.hazelcast.config.AwsConfig;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.core.HazelcastException;
@@ -385,13 +383,8 @@ class DefaultAddressPicker implements AddressPicker {
     }
 
     private boolean preferIPv4Stack() {
-        boolean preferIPv4Stack = Boolean.getBoolean(PREFER_IPV4_STACK)
+        return Boolean.getBoolean(PREFER_IPV4_STACK)
                 || hazelcastProperties.getBoolean(GroupProperty.PREFER_IPv4_STACK);
-        // AWS does not support IPv6
-        JoinConfig join = config.getNetworkConfig().getJoin();
-        AwsConfig awsConfig = join.getAwsConfig();
-        boolean awsEnabled = awsConfig != null && awsConfig.isEnabled();
-        return preferIPv4Stack || awsEnabled;
     }
 
     @Override


### PR DESCRIPTION
AWS supports IPv6 since the end of 2016.

Fixes #11821