### PR TITLE
Do not expose internal API in ObjectDataOutput

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.BufferObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.collection.ArrayUtils;
 
 import java.io.IOException;
@@ -444,7 +445,7 @@ class ByteArrayObjectDataOutput extends VersionedObjectDataOutput implements Buf
     }
 
     @Override
-    public InternalSerializationService getSerializationService() {
+    public SerializationService getSerializationService() {
         return service;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/EmptyObjectDataOutput.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.internal.serialization.impl;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -145,7 +145,7 @@ final class EmptyObjectDataOutput extends VersionedObjectDataOutput implements O
     }
 
     @Override
-    public InternalSerializationService getSerializationService() {
+    public SerializationService getSerializationService() {
         return null;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ObjectDataOutputStream.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.Bits;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.Closeable;
 import java.io.DataOutputStream;
@@ -283,7 +284,7 @@ public class ObjectDataOutputStream extends VersionedObjectDataOutput implements
     }
 
     @Override
-    public InternalSerializationService getSerializationService() {
+    public SerializationService getSerializationService() {
         return serializationService;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ObjectDataOutput.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.nio;
 
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.serialization.SerializationService;
 
 import java.io.DataOutput;
 import java.io.IOException;
@@ -113,5 +113,5 @@ public interface ObjectDataOutput extends DataOutput, VersionAware {
     /**
      * @return serialization service for this object
      */
-    InternalSerializationService getSerializationService();
+    SerializationService getSerializationService();
 }


### PR DESCRIPTION
Use `SerializationService` instead of `InternalSerializationService`
in `ObjectDataOutput` interface

Fixes #13505 