### PR TITLE
Improve IPv6 bind address selection mechanism

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -25,9 +25,9 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.AddressUtil;
-import com.hazelcast.util.CollectionUtil;
 
 import java.io.IOException;
+import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -43,11 +43,21 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import static com.hazelcast.util.AddressUtil.fixScopeIdAndGetInetAddress;
+import static com.hazelcast.util.CollectionUtil.isEmpty;
+import static com.hazelcast.util.CollectionUtil.isNotEmpty;
 import static com.hazelcast.util.MapUtil.createLinkedHashMap;
 
 class DefaultAddressPicker extends AbstractAddressPicker {
 
+    /**
+     * See https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html
+     */
     static final String PREFER_IPV4_STACK = "java.net.preferIPv4Stack";
+
+    /**
+     * See https://docs.oracle.com/javase/8/docs/api/java/net/doc-files/net-properties.html
+     */
+    static final String PREFER_IPV6_ADDRESSES = "java.net.preferIPv6Addresses";
 
     private final HazelcastProperties hazelcastProperties;
     private final Config config;
@@ -55,10 +65,10 @@ class DefaultAddressPicker extends AbstractAddressPicker {
     private Address publicAddress;
     private Address bindAddress;
 
-    DefaultAddressPicker(Config config, HazelcastProperties hazelcastProperties, ILogger logger) {
+    DefaultAddressPicker(Config config, ILogger logger) {
         super(config.getNetworkConfig(), logger);
         this.config = config;
-        this.hazelcastProperties = hazelcastProperties;
+        this.hazelcastProperties = new HazelcastProperties(config);
     }
 
     @Override
@@ -125,9 +135,7 @@ class DefaultAddressPicker extends AbstractAddressPicker {
                 || interfaces.contains(new InterfaceDefinition("localhost"))) {
             return pickLoopbackAddress();
         }
-        if (preferIPv4Stack()) {
-            logger.info("Prefer IPv4 stack is true.");
-        }
+        logger.info("Prefer IPv4 stack is " + preferIPv4Stack() + ", prefer IPv6 addresses is " + preferIPv6Addresses());
         if (interfaces.size() > 0) {
             AddressDefinition addressDef = pickMatchingAddress(interfaces);
             if (addressDef != null) {
@@ -269,27 +277,54 @@ class DefaultAddressPicker extends AbstractAddressPicker {
     AddressDefinition pickMatchingAddress(Collection<InterfaceDefinition> interfaces) throws SocketException {
         Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
         boolean preferIPv4Stack = preferIPv4Stack();
-        boolean matchInterfaceDefinition = CollectionUtil.isNotEmpty(interfaces);
+        boolean preferIPv6Addresses = preferIPv6Addresses();
+        AddressDefinition matchingAddress = null;
+
+        // There are 3 possible value pairs for preferIPv4Stack & preferIPv6Addresses:
+        // - preferIPv4Stack=true, preferIPv6Addresses=false: Only an IPv4 address will be picked.
+        // - preferIPv4Stack=false, preferIPv6Addresses=false: Either an IPv4 or IPv6 address may be picked, no preference.
+        // - preferIPv4Stack=false, preferIPv6Addresses=true: Either an IPv4 or IPv6 address may be picked
+        // but IPv6 address will be preferred over IPv4.
+
         while (networkInterfaces.hasMoreElements()) {
             NetworkInterface ni = networkInterfaces.nextElement();
-            if (!matchInterfaceDefinition && skipInterface(ni)) {
+            if (isEmpty(interfaces) && skipInterface(ni)) {
                 continue;
             }
             Enumeration<InetAddress> e = ni.getInetAddresses();
             while (e.hasMoreElements()) {
                 InetAddress inetAddress = e.nextElement();
                 if (preferIPv4Stack && inetAddress instanceof Inet6Address) {
+                    // IPv4 stack is preferred, so only IPv4 address can be picked.
                     continue;
                 }
-                if (matchInterfaceDefinition) {
-                    AddressDefinition address = match(inetAddress, interfaces);
-                    if (address != null) {
-                        return address;
+
+                AddressDefinition address = getMatchingAddress(interfaces, inetAddress);
+                if (address == null) {
+                    continue;
+                }
+                matchingAddress = address;
+
+                if (preferIPv6Addresses) {
+                    // IPv6 address is preferred, return if address is IPv6.
+                    if (inetAddress instanceof Inet6Address) {
+                        return matchingAddress;
                     }
-                } else if (!inetAddress.isLoopbackAddress()) {
-                    return new AddressDefinition(inetAddress);
+                } else if (inetAddress instanceof Inet4Address) {
+                    // No IPv6 address preference, return if address is IPv4.
+                    return matchingAddress;
                 }
             }
+        }
+        // nothing matched to IP version preference, return what we have.
+        return matchingAddress;
+    }
+
+    private AddressDefinition getMatchingAddress(Collection<InterfaceDefinition> interfaces, InetAddress inetAddress) {
+        if (isNotEmpty(interfaces)) {
+            return match(inetAddress, interfaces);
+        } else if (!inetAddress.isLoopbackAddress()) {
+            return new AddressDefinition(inetAddress);
         }
         return null;
     }
@@ -319,6 +354,10 @@ class DefaultAddressPicker extends AbstractAddressPicker {
     private boolean preferIPv4Stack() {
         return Boolean.getBoolean(PREFER_IPV4_STACK)
                 || hazelcastProperties.getBoolean(GroupProperty.PREFER_IPv4_STACK);
+    }
+
+    private boolean preferIPv6Addresses() {
+        return !preferIPv4Stack() && Boolean.getBoolean(PREFER_IPV6_ADDRESSES);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -59,7 +59,7 @@ public class DefaultNodeContext implements NodeContext {
 
         final ILogger addressPickerLogger = node.getLogger(AddressPicker.class);
         if (!memberAddressProviderConfig.isEnabled()) {
-            return new DefaultAddressPicker(config, node.getProperties(), addressPickerLogger);
+            return new DefaultAddressPicker(config, addressPickerLogger);
         }
 
         MemberAddressProvider implementation = memberAddressProviderConfig.getImplementation();

--- a/hazelcast/src/test/java/com/hazelcast/instance/IpVersionPreferenceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/IpVersionPreferenceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.hazelcast.instance.DefaultAddressPicker.PREFER_IPV4_STACK;
+import static com.hazelcast.instance.DefaultAddressPicker.PREFER_IPV6_ADDRESSES;
+import static com.hazelcast.instance.DefaultAddressPickerTest.findIPv6NonLoopbackInterface;
+import static com.hazelcast.spi.properties.GroupProperty.PREFER_IPv4_STACK;
+import static com.hazelcast.test.OverridePropertyRule.clear;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeNotNull;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class IpVersionPreferenceTest {
+
+    @Rule
+    public final OverridePropertyRule ruleSysPropHazelcastLocalAddress = clear("hazelcast.local.localAddress");
+    @Rule
+    public final OverridePropertyRule ruleSysPropPreferIpv4Stack = clear(PREFER_IPV4_STACK);
+    @Rule
+    public final OverridePropertyRule ruleSysPropPreferIpv6Addresses = clear(PREFER_IPV6_ADDRESSES);
+    @Rule
+    public final OverridePropertyRule ruleSysPropPreferHzIpv4 = clear(PREFER_IPv4_STACK.getName());
+
+    @Parameter
+    public Boolean hazelcastIpv4;
+
+    @Parameter(value = 1)
+    public Boolean javaIpv4;
+
+    @Parameter(value = 2)
+    public Boolean javaIpv6;
+
+    private static final Boolean[] BOOL_VALUES = new Boolean[] {Boolean.TRUE, Boolean.FALSE, null};
+
+    @Parameters(name = "hazelcastIpv4:{0} javaIpv4:{1} javaIpv6:{2}")
+    public static Collection<Object[]> parameters() {
+        List<Object[]> params = new ArrayList<Object[]>();
+        for (Boolean i : BOOL_VALUES) {
+            for (Boolean j : BOOL_VALUES) {
+                for (Boolean k : BOOL_VALUES) {
+                    params.add(new Object[] {i, j, k});
+                }
+            }
+        }
+        return params;
+    }
+
+    @Test
+    public void testBindAddress() throws Exception {
+        ruleSysPropPreferHzIpv4.setOrClearProperty(hazelcastIpv4 == null ? null : String.valueOf(hazelcastIpv4));
+        ruleSysPropPreferIpv4Stack.setOrClearProperty(javaIpv4 == null ? null : String.valueOf(javaIpv4));
+        ruleSysPropPreferIpv6Addresses.setOrClearProperty(javaIpv6 == null ? null : String.valueOf(javaIpv6));
+
+        boolean expectedIPv6 = !getOrDefault(hazelcastIpv4, true)
+                        && !getOrDefault(javaIpv4, false)
+                        && getOrDefault(javaIpv6, false);
+
+        if (expectedIPv6) {
+            assumeNotNull(findIPv6NonLoopbackInterface());
+        }
+
+        DefaultAddressPicker addressPicker = new DefaultAddressPicker(new Config(), Logger.getLogger(AddressPicker.class));
+        try {
+            addressPicker.pickAddress();
+            Address bindAddress = addressPicker.getBindAddress();
+            assertEquals("Bind address: " + bindAddress, expectedIPv6, bindAddress.isIPv6());
+        } finally {
+            IOUtil.closeResource(addressPicker.getServerSocketChannel());
+        }
+    }
+
+    private boolean getOrDefault(Boolean value, boolean defaultValue) {
+        return value != null ? value : defaultValue;
+    }
+}


### PR DESCRIPTION
- When preferIPv4Stack is true, then an IPv4 address is going to be selected.
- When preferIPv4Stack is false & preferIPv6Addresses is true, then IPv6 addresses
will be preferred over IPv4 addresses. Either an IPv6 or an IPv4 address may be selected.
- When both preferIPv4Stack & preferIPv6Addresses are false, then either an IPv6 or an IPv4 address may be selected, there will be no preference.

Fixes #11820