### PR TITLE
Fix query runner empty/failure results inconsistency

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/Result.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/Result.java
@@ -31,7 +31,8 @@ import java.util.Map;
 public interface Result<T extends Result> extends IdentifiedDataSerializable {
 
     /**
-     * @return partition IDs of this result.
+     * Returns partition IDs associated with this result or {@code null} if this
+     * result is an empty/failure result.
      */
     Collection<Integer> getPartitionIds();
 


### PR DESCRIPTION
Before this fix an empty/failure result was indicated inconsistently by
either returning null result or returning non-null result with null
partition IDs. This change fixes this inconsistency in a favor of the
later method.