### PR TITLE
fix bug in javadoc. Ttl returns millisecond

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
@@ -107,9 +107,9 @@ public interface EntryView<K, V> {
     long getVersion();
 
     /**
-     * Returns the last set time to live second.
+     * Returns the last set time to live in milliseconds.
      *
-     * @return the last set time to live second
+     * @return the last set time to live in milliseconds.
      */
     long getTtl();
 }


### PR DESCRIPTION
(cherry picked from commit ca68c8c370c73d123d0070ebe352517a7daa6ddd)