### PR TITLE
Throw ClientNotActiveException instead of generic HazelcastException

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.connection.nio;
 
 import com.hazelcast.client.AuthenticationException;
 import com.hazelcast.client.ClientExtension;
+import com.hazelcast.client.HazelcastClientNotActiveException;
 import com.hazelcast.client.HazelcastClientOfflineException;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.connection.AddressProvider;
@@ -322,6 +323,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     private void checkAllowed(Address target, boolean asOwner, boolean acquiresResources) throws IOException {
+        if (!alive) {
+            throw new HazelcastClientNotActiveException("ConnectionManager is not active!");
+        }
         if (asOwner) {
             connectionStrategy.beforeConnectToCluster(target);
             //opening an owner connection is always allowed
@@ -375,9 +379,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     private AuthenticationFuture triggerConnect(Address target, boolean asOwner) {
         if (!asOwner) {
             connectionStrategy.beforeOpenConnection(target);
-        }
-        if (!alive) {
-            throw new HazelcastException("ConnectionManager is not active!");
         }
 
         AuthenticationFuture future = new AuthenticationFuture();
@@ -459,9 +460,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     protected ClientConnection createSocketConnection(final Address remoteAddress) throws IOException {
-        if (!alive) {
-            throw new HazelcastException("ConnectionManager is not active!");
-        }
         SocketChannel socketChannel = null;
         try {
             socketChannel = SocketChannel.open();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientReconnectTest.java
@@ -152,7 +152,7 @@ public class ClientReconnectTest extends HazelcastTestSupport {
     }
 
     @Test(expected = HazelcastClientNotActiveException.class)
-    public void testExceptionAfterClientShutdown() throws Exception {
+    public void testExceptionAfterClientShutdown() {
         hazelcastFactory.newHazelcastInstance();
         ClientConfig clientConfig = new ClientConfig();
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
@@ -163,6 +163,18 @@ public class ClientReconnectTest extends HazelcastTestSupport {
         //to force weak references to be cleaned and get not active exception from serialization service
         System.gc();
         test.get("key");
+    }
+
+    @Test(expected = HazelcastClientNotActiveException.class)
+    public void testExceptionAfterClientShutdown_fromClientConnectionManager() {
+        hazelcastFactory.newHazelcastInstance();
+        ClientConfig clientConfig = new ClientConfig();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        IMap<Object, Object> test = client.getMap("test");
+        test.put("key", "value");
+        client.shutdown();
+        test.size();
     }
 
     @Test


### PR DESCRIPTION
alive check in ClientConnectionManager is moved to a more centralized
method and type of the exception is fixed.