### PR TITLE
Add WAN specific map and cache entry view to keep compatibility

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -283,7 +283,6 @@
     <suppress checks="NPathComplexity|CyclomaticComplexity"
               files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]querycache[\\/]event[\\/]DefaultQueryCacheEventData"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]query[\\/]MapQueryEngineImpl"/>
-    <suppress checks="NPathComplexity|CyclomaticComplexity" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]SimpleEntryView"/>
 
     <!-- PhoneHome -->
     <suppress checks="NPathComplexity" files="com[\\/]hazelcast[\\/]util[\\/]PhoneHome"/>

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/merge/entry/DefaultCacheEntryView.java
@@ -104,6 +104,7 @@ public class DefaultCacheEntryView
         out.writeLong(accessHit);
         out.writeData(key);
         out.writeData(value);
+        // RU_COMPAT_3_10
         if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             out.writeData(expiryPolicy);
         }
@@ -117,6 +118,10 @@ public class DefaultCacheEntryView
         accessHit = in.readLong();
         key = in.readData();
         value = in.readData();
+        // RU_COMPAT_3_10
+        // DO NOT REMOVE UNTIL WAN PROTOCOL HAS BEEN IMPLEMENTED
+        // THE SOURCE CLUSTER SERIALIZES THE com.hazelcast.map.impl.wan.WanMapEntryView
+        // THE TARGET CLUSTER SHOULD DESERIALIZE THIS CLASS
         if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             expiryPolicy = in.readData();
         }

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryView.java
@@ -118,5 +118,5 @@ public interface EntryView<K, V> {
      *
      * @return the last set max idle time in milliseconds.
      */
-    long getMaxIdle();
+    Long getMaxIdle();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
@@ -44,7 +44,7 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
     private long lastUpdateTime;
     private long version;
     private long ttl;
-    private long maxIdle;
+    private Long maxIdle;
 
     private SerializationService serializationService;
     private MapMergePolicy mergePolicy;
@@ -190,11 +190,11 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
     }
 
     @Override
-    public long getMaxIdle() {
+    public Long getMaxIdle() {
         return maxIdle;
     }
 
-    public LazyEntryView<K, V> setMaxIdle(long maxIdle) {
+    public LazyEntryView<K, V> setMaxIdle(Long maxIdle) {
         this.maxIdle = maxIdle;
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/NullEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/NullEntryView.java
@@ -88,7 +88,7 @@ class NullEntryView<K, V> implements EntryView<K, V> {
     }
 
     @Override
-    public long getMaxIdle() {
-        return 0;
+    public Long getMaxIdle() {
+        return 0L;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/SimpleEntryView.java
@@ -214,7 +214,7 @@ public class SimpleEntryView<K, V>
     }
 
     @Override
-    public long getMaxIdle() {
+    public Long getMaxIdle() {
         return maxIdle;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/LazyEntryViewFromRecord.java
@@ -107,7 +107,7 @@ public class LazyEntryViewFromRecord<R extends Record> extends SampleableConcurr
     }
 
     @Override
-    public long getMaxIdle() {
+    public Long getMaxIdle() {
         return record.getMaxIdle();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
@@ -35,7 +35,7 @@ public class MapReplicationUpdate implements ReplicationEventObject, IdentifiedD
     /** The policy how to merge the entry on the receiving cluster */
     private Object mergePolicy;
     /** The updated entry */
-    private EntryView<Data, Data> entryView;
+    private WanMapEntryView<Data, Data> entryView;
 
     public MapReplicationUpdate() {
     }
@@ -45,7 +45,11 @@ public class MapReplicationUpdate implements ReplicationEventObject, IdentifiedD
                                 EntryView<Data, Data> entryView) {
         this.mergePolicy = mergePolicy;
         this.mapName = mapName;
-        this.entryView = entryView;
+        if (entryView instanceof WanMapEntryView) {
+            this.entryView = (WanMapEntryView<Data, Data>) entryView;
+        } else {
+            this.entryView = new WanMapEntryView<Data, Data>(entryView);
+        }
     }
 
     public String getMapName() {
@@ -64,11 +68,11 @@ public class MapReplicationUpdate implements ReplicationEventObject, IdentifiedD
         this.mergePolicy = mergePolicy;
     }
 
-    public EntryView<Data, Data> getEntryView() {
+    public WanMapEntryView<Data, Data> getEntryView() {
         return entryView;
     }
 
-    public void setEntryView(EntryView<Data, Data> entryView) {
+    public void setEntryView(WanMapEntryView<Data, Data> entryView) {
         this.entryView = entryView;
     }
 
@@ -83,7 +87,13 @@ public class MapReplicationUpdate implements ReplicationEventObject, IdentifiedD
     public void readData(ObjectDataInput in) throws IOException {
         mapName = in.readUTF();
         mergePolicy = in.readObject();
-        entryView = in.readObject();
+        EntryView<Data, Data> entryView = in.readObject();
+
+        if (entryView instanceof WanMapEntryView) {
+            this.entryView = (WanMapEntryView<Data, Data>) entryView;
+        } else {
+            this.entryView = new WanMapEntryView<Data, Data>(entryView);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapEntryView.java
@@ -118,27 +118,13 @@ public class WanMapEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
     }
 
     @Override
-    public long getMaxIdle() {
-        return 0;
-    }
-
-    /**
-     * Needed for client protocol compatibility.
-     */
-    @SuppressWarnings("unused")
-    public long getEvictionCriteriaNumber() {
-        return 0;
-    }
-
-    /**
-     * Needed for client protocol compatibility.
-     */
-    @SuppressWarnings("unused")
-    public void setEvictionCriteriaNumber(long evictionCriteriaNumber) {
+    public Long getMaxIdle() {
+        return null;
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
+        // the serialized format must match the serialized format for a 3.8 SimpleEntryView
         IOUtil.writeObject(out, key);
         IOUtil.writeObject(out, value);
         out.writeLong(cost);
@@ -149,7 +135,6 @@ public class WanMapEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         out.writeLong(lastStoredTime);
         out.writeLong(lastUpdateTime);
         out.writeLong(version);
-        // writes the deprecated evictionCriteriaNumber to the data output (client protocol compatibility)
         out.writeLong(0);
         out.writeLong(ttl);
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedMapEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/ReplicatedMapEntryView.java
@@ -131,7 +131,7 @@ public class ReplicatedMapEntryView<K, V>
     }
 
     @Override
-    public long getMaxIdle() {
+    public Long getMaxIdle() {
         return maxIdle;
     }
 


### PR DESCRIPTION
WAN may send entry view implementations to older clusters (3.8+) and we
expect the entry to be deserialized successfully. This creates the
problem that each time we change the existing entry views, WAN
compatibility may be broken.
We then introduce WAN specific entry views. These may change only
when the WAN protocol is introduced. WAN events must carry only
these entry views so that all clusters starting with 3.8 can deserialize
them.

Fixes:
https://github.com/hazelcast/hazelcast-enterprise/issues/2231
https://github.com/hazelcast/hazelcast-enterprise/issues/2243
https://github.com/hazelcast/hazelcast-enterprise/issues/2331

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2291