### PR TITLE
Cancel pending invocations & wait-set entries when client disconnects

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientDisconnectTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientDisconnectTest.java
@@ -25,22 +25,32 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.IQueue;
+import com.hazelcast.core.Message;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationparker.impl.OperationParkerImpl;
+import com.hazelcast.spi.impl.operationservice.impl.Invocation;
+import com.hazelcast.spi.impl.operationservice.impl.InvocationRegistry;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.ReliableMessageListener;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -53,12 +63,11 @@ public class ClientDisconnectTest extends HazelcastTestSupport {
         hazelcastFactory.terminateAll();
     }
 
-
     @Test
     public void testClientOperationCancelled_whenDisconnected() throws Exception {
         Config config = new Config();
         config.setProperty(GroupProperty.CLIENT_ENDPOINT_REMOVE_DELAY_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE));
-        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance(config);
         final String queueName = "q";
 
         final HazelcastInstance clientInstance = hazelcastFactory.newHazelcastClient();
@@ -111,7 +120,7 @@ public class ClientDisconnectTest extends HazelcastTestSupport {
     public void testClientOperationCancelled_whenDisconnected_lock() throws Exception {
         Config config = new Config();
         config.setProperty(GroupProperty.CLIENT_ENDPOINT_REMOVE_DELAY_SECONDS.getName(), String.valueOf(Integer.MAX_VALUE));
-        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance();
+        HazelcastInstance hazelcastInstance = hazelcastFactory.newHazelcastInstance(config);
         final String name = "m";
 
         final IMap<Object, Object> map = hazelcastInstance.getMap(name);
@@ -162,4 +171,89 @@ public class ClientDisconnectTest extends HazelcastTestSupport {
         }, 3);
     }
 
+    @Test
+    public void testPendingInvocationAndWaitEntryCancelled_whenDisconnected_withLock() {
+        Config config = new Config();
+        HazelcastInstance server = hazelcastFactory.newHazelcastInstance(config);
+        final String name = randomName();
+        server.getLock(name).lock();
+
+        final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    client.getLock(name).lock();
+                } catch (Throwable ignored) {
+                }
+            }
+        });
+
+        sleepSeconds(3);
+
+        client.shutdown();
+
+        assertEmptyPendingInvocationAndWaitSet(server);
+    }
+
+    @Test
+    public void testPendingInvocationAndWaitEntryCancelled_whenDisconnected_withReliableTopic() {
+        Config config = new Config();
+        HazelcastInstance server = hazelcastFactory.newHazelcastInstance(config);
+
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+        // ReliableTopic listener registers a blocking invocation
+        client.getReliableTopic(randomName()).addMessageListener(new NopReliableMessageListener());
+
+        client.shutdown();
+
+        assertEmptyPendingInvocationAndWaitSet(server);
+    }
+
+    private void assertEmptyPendingInvocationAndWaitSet(HazelcastInstance server) {
+        NodeEngineImpl nodeEngine = getNodeEngineImpl(server);
+        OperationServiceImpl operationService = (OperationServiceImpl) nodeEngine.getOperationService();
+        final InvocationRegistry invocationRegistry = operationService.getInvocationRegistry();
+        final OperationParkerImpl operationParker = (OperationParkerImpl) nodeEngine.getOperationParker();
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertThat(invocationRegistry.entrySet(), Matchers.<Map.Entry<Long, Invocation>>empty());
+            }
+        }, 10);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(0, operationParker.getTotalParkedOperationCount());
+            }
+        }, 10);
+    }
+
+    private static class NopReliableMessageListener implements ReliableMessageListener<Object> {
+        @Override
+        public long retrieveInitialSequence() {
+            return 0;
+        }
+
+        @Override
+        public void storeSequence(long sequence) {
+        }
+
+        @Override
+        public boolean isLossTolerant() {
+            return false;
+        }
+
+        @Override
+        public boolean isTerminal(Throwable failure) {
+            return false;
+        }
+
+        @Override
+        public void onMessage(Message<Object> message) {
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/WaitSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/WaitSet.java
@@ -96,6 +96,8 @@ public class WaitSet implements LiveOperationsTracker, Iterable<WaitSetEntry> {
                 if (entry.isExpired()) {
                     // expired
                     entry.onExpire();
+                } else if (entry.isCancelled()) {
+                    entry.onCancel();
                 } else {
                     if (entry.shouldWait()) {
                         return;
@@ -179,6 +181,18 @@ public class WaitSet implements LiveOperationsTracker, Iterable<WaitSetEntry> {
             Operation op = entry.getOperation();
             if (callerUuid.equals(op.getCallerUuid())) {
                 entry.setValid(false);
+            }
+        }
+    }
+
+    public void cancelAll(String callerUuid, Throwable cause) {
+        for (WaitSetEntry entry : queue) {
+            if (!entry.isValid()) {
+                continue;
+            }
+            Operation op = entry.getOperation();
+            if (callerUuid.equals(op.getCallerUuid())) {
+                entry.cancel(cause);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/WaitSetEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationparker/impl/WaitSetEntry.java
@@ -142,10 +142,9 @@ class WaitSetEntry extends AbstractLocalOperation implements Delayed, PartitionA
 
         valid = false;
         if (expired) {
-            blockingOperation.onWaitExpire();
+            onExpire();
         } else {
-            OperationResponseHandler responseHandler = op.getOperationResponseHandler();
-            responseHandler.sendResponse(op, cancelResponse);
+            onCancel();
         }
     }
 
@@ -192,6 +191,11 @@ class WaitSetEntry extends AbstractLocalOperation implements Delayed, PartitionA
 
     public void onExpire() {
         blockingOperation.onWaitExpire();
+    }
+
+    public void onCancel() {
+        OperationResponseHandler responseHandler = op.getOperationResponseHandler();
+        responseHandler.sendResponse(op, cancelResponse);
     }
 
     public void cancel(Object error) {


### PR DESCRIPTION
When client wants to execute an operation, a member submits an invocation
on behalf of that client. And when response is received on member-side,
invocation is deregistered and response is forwarded to the client.

If that's a blocking operation, such as lock or reliable-topic message listener,
that operation is parked in a wait-set until it's notified by a notifier operation.
When client is disconnected, entry is wait-set is marked as invalid and removed
from the wait-set eventually.
But invocation on member-side is not notified
and does not receive any response, hence stays in the registry either until timeout
or forever depending on the invocation's target (local or remove)
and/or operation's type (backup-aware or not).

Instead, with this change, when a client is disconnected, wait-set entry will be cancelled
with an exception which then will be propagated to the submitting invocation as a response.
This way, pending invocation will be deregistered.

This is different from the member is removal case. Because members do not submit invocations
on behalf of other members, every member submits and keeps track of its own invocations.

Fixes #13388