### PR TITLE
move checkSSLAllowed to client implemantation

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -193,16 +193,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         this.outboundPortCount = outboundPorts.size();
         this.heartbeat = new HeartbeatManager(this, client);
         this.authenticationTimeout = heartbeat.getHeartbeatTimeout();
-        checkSslAllowed();
-    }
-
-    private void checkSslAllowed() {
-        SSLConfig sslConfig = client.getClientConfig().getNetworkConfig().getSSLConfig();
-        if (sslConfig != null && sslConfig.isEnabled()) {
-            if (!BuildInfoProvider.getBuildInfo().isEnterprise()) {
-                throw new IllegalStateException("SSL/TLS requires Hazelcast Enterprise Edition");
-            }
-        }
     }
 
     private Collection<Integer> getOutboundPorts(ClientNetworkConfig networkConfig) {


### PR DESCRIPTION
This pr moves SSL check to the hazelcast client implementation. Other possible enterprise feature checks can be done in the added method too.