### PR TITLE
[IBM JDK] #13534 fix package lookup in Byte Buddy

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
@@ -436,7 +436,7 @@ public class HazelcastProxyFactory {
         public static final AllAsPublicConstructorStrategy INSTANCE = new AllAsPublicConstructorStrategy();
 
         @Override
-        public MethodRegistry inject(MethodRegistry methodRegistry) {
+        public MethodRegistry inject(TypeDescription instrumentedType, MethodRegistry methodRegistry) {
             return methodRegistry.append(new LatentMatcher.Resolved<MethodDescription>(isConstructor()),
                     new MethodRegistry.Handler.ForImplementation(SuperMethodCall.INSTANCE),
                     MethodAttributeAppender.NoOp.INSTANCE,

--- a/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
@@ -96,10 +96,10 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
 
     @Test
     public void testHookDeduplication() {
-        ClassLoader parentClassloader = PortableHook.class.getClassLoader();
-
         Class<?> hook = newClassImplementingInterface("com.hazelcast.internal.serialization.SomeHook",
-                PortableHook.class, parentClassloader);
+                PortableHook.class, PortableHook.class.getClassLoader());
+
+        ClassLoader parentClassloader = hook.getClassLoader();
 
         //child classloader delegating everything to its parent
         URLClassLoader childClassloader = new URLClassLoader(new URL[]{}, parentClassloader);

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.19.0</mockito.version>
         <powermock.version>2.0.0-beta.5</powermock.version>
-        <bytebuddy.version>1.6.12</bytebuddy.version>
+        <bytebuddy.version>1.8.17</bytebuddy.version>
         <reflections.version>0.9.10</reflections.version>
         <jmh.version>1.16</jmh.version>
         <commons-lang3.version>3.4</commons-lang3.version>


### PR DESCRIPTION
Fixes #13534.
The package lookup in Byte Buddy doesn't work correctly on IBM Java 8 (raphw/byte-buddy#510).