### PR TITLE
Do not use -SNAPSHOT version of Hazelcast in a test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MergePolicyProviderConstructorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/test/MergePolicyProviderConstructorTest.java
@@ -47,7 +47,7 @@ public class MergePolicyProviderConstructorTest extends HazelcastTestSupport {
     @Before
     public void setUp() {
         Config config = new Config();
-        hz = HazelcastStarter.newHazelcastInstance("3.11-SNAPSHOT", config, false);
+        hz = HazelcastStarter.newHazelcastInstance("3.10", config, false);
     }
 
     @After
@@ -57,6 +57,8 @@ public class MergePolicyProviderConstructorTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor() throws Exception {
+        //this is testing the Hazelcast Started can create an instances of merge policies
+
         NodeEngine nodeEngine = getNodeEngineImpl(hz);
         CacheService service = nodeEngine.getService(CacheService.SERVICE_NAME);
         CacheMergePolicyProvider mergePolicyProvider = service.getMergePolicyProvider();


### PR DESCRIPTION
The test is testing the compatibility framework. It check whether the
framework can create various merge policies and whether it fails fast when
the policy does not exist. There is no reason why it should use the -SNAPSHOT
version of Hazelcast. It just makes the build non-repeatable.