### PR TITLE
[BACKPORT 3.10.x] Fixes package lookup in Bytebuddy on IBM JDK

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/HazelcastProxyFactory.java
@@ -404,7 +404,7 @@ public class HazelcastProxyFactory {
         public static final AllAsPublicConstructorStrategy INSTANCE = new AllAsPublicConstructorStrategy();
 
         @Override
-        public MethodRegistry inject(MethodRegistry methodRegistry) {
+        public MethodRegistry inject(TypeDescription instrumentedType, MethodRegistry methodRegistry) {
             return methodRegistry.append(new LatentMatcher.Resolved<MethodDescription>(isConstructor()),
                     new MethodRegistry.Handler.ForImplementation(SuperMethodCall.INSTANCE),
                     MethodAttributeAppender.NoOp.INSTANCE,

--- a/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ServiceLoaderTest.java
@@ -96,10 +96,10 @@ public class ServiceLoaderTest extends HazelcastTestSupport {
 
     @Test
     public void testHookDeduplication() {
-        ClassLoader parentClassloader = PortableHook.class.getClassLoader();
-
         Class<?> hook = newClassImplementingInterface("com.hazelcast.internal.serialization.SomeHook",
-                PortableHook.class, parentClassloader);
+                PortableHook.class, PortableHook.class.getClassLoader());
+
+        ClassLoader parentClassloader = hook.getClassLoader();
 
         //child classloader delegating everything to its parent
         URLClassLoader childClassloader = new URLClassLoader(new URL[]{}, parentClassloader);

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.6</powermock.version>
         <jmh.version>1.16</jmh.version>
-        <bytebuddy.version>1.6.12</bytebuddy.version>
+        <bytebuddy.version>1.8.17</bytebuddy.version>
         <commons-lang3.version>3.4</commons-lang3.version>
         <felix.utils.version>1.10.0</felix.utils.version>
         <findbugs.annotations.version>3.0.0</findbugs.annotations.version>


### PR DESCRIPTION
Backport of #13541.
Fixes #13534.
The package lookup in Byte Buddy doesn't work correctly on IBM Java 8 (raphw/byte-buddy#510).