### PR TITLE
Upgrade failsafe plugin version to work with Java 10+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <maven.spotbugs.plugin.version>3.1.3.1</maven.spotbugs.plugin.version>
         <maven.sonar.plugin.version>3.3.0.603</maven.sonar.plugin.version>
         <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
-        <maven.failsafe.plugin.version>2.20.1</maven.failsafe.plugin.version>
+        <maven.failsafe.plugin.version>2.22.0</maven.failsafe.plugin.version>
         <maven.cobertura.plugin.version>2.6</maven.cobertura.plugin.version>
 
         <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
This PR resolves NPE in failsafe plugin executed with Java 10 (https://issues.apache.org/jira/browse/SUREFIRE-1439) as can be seen in
https://hazelcast-l337.ci.cloudbees.com/view/Hazelcast/job/Hazelcast-3.x-ZuluJDK10/8/consoleFull

**Snippet from the problematic Jenkins/Maven log**
```
16:59:25 [INFO] --- maven-failsafe-plugin:2.20.1:integration-test (default) @ hazelcast ---
16:59:25 [JENKINS] Recording test results
16:59:28 [BFA] Scanning build for known causes...
16:59:31 [BFA] No failure causes found
16:59:31 [BFA] Done. 3s
16:59:32 [INFO] ------------------------------------------------------------------------
16:59:32 [INFO] Reactor Summary:
16:59:32 [INFO] 
16:59:32 [INFO] Hazelcast Root 3.11-SNAPSHOT ....................... SUCCESS [  6.114 s]
16:59:32 [INFO] hazelcast .......................................... FAILURE [  01:22 h]
16:59:32 [INFO] hazelcast-client ................................... SKIPPED
16:59:32 [INFO] hazelcast-spring ................................... SKIPPED
16:59:32 [INFO] hazelcast-build-utils .............................. SKIPPED
16:59:32 [INFO] hazelcast-all ...................................... SKIPPED
16:59:32 [INFO] modulepath-tests 3.11-SNAPSHOT ..................... SKIPPED
16:59:32 [INFO] ------------------------------------------------------------------------
16:59:32 [INFO] BUILD FAILURE
16:59:32 [INFO] ------------------------------------------------------------------------
16:59:32 [INFO] Total time: 01:22 h
16:59:32 [INFO] Finished at: 2018-08-07T16:59:32+03:00
16:59:32 [INFO] ------------------------------------------------------------------------
16:59:32 Waiting for Jenkins to finish collecting data
16:59:33 [ERROR] Failed to execute goal org.apache.maven.plugins:maven-failsafe-plugin:2.20.1:integration-test (default) on project hazelcast: Execution default of goal org.apache.maven.plugins:maven-failsafe-plugin:2.20.1:integration-test failed. NullPointerException -> [Help 1]
16:59:33 [ERROR] 
16:59:33 [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
16:59:33 [ERROR] Re-run Maven using the -X switch to enable full debug logging.
```