### PR TITLE
Fix OS metrics on IBM Java 8 and Java 9+

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
@@ -19,10 +19,13 @@ package com.hazelcast.internal.metrics.metricsets;
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
+import java.util.logging.Level;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -32,6 +35,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 public final class OperatingSystemMetricSet {
 
+    private static final ILogger LOGGER = Logger.getLogger(OperatingSystemMetricSet.class);
     private static final long PERCENTAGE_MULTIPLIER = 100;
     private static final Object[] EMPTY_ARGS = new Object[0];
 
@@ -79,7 +83,7 @@ public final class OperatingSystemMetricSet {
 
     private static void registerMethod(MetricsRegistry metricsRegistry, Object osBean, String methodName, String name,
                                        final long multiplier) {
-        final Method method = getMethod(osBean, methodName);
+        final Method method = getMethod(osBean, methodName, name);
 
         if (method == null) {
             return;
@@ -107,14 +111,18 @@ public final class OperatingSystemMetricSet {
      *
      * @param source     the source object.
      * @param methodName the name of the method to retrieve.
+     * @param name the probe name
      * @return the method
      */
-    private static Method getMethod(Object source, String methodName) {
+    private static Method getMethod(Object source, String methodName, String name) {
         try {
-            Method method = source.getClass().getDeclaredMethod(methodName);
-            method.setAccessible(true);
+            Method method = source.getClass().getMethod(methodName);
             return method;
         } catch (Exception e) {
+            if (LOGGER.isFinestEnabled()) {
+                LOGGER.log(Level.FINEST,
+                        "Unable to register OperatingSystemMXBean method " + methodName + " used for probe " + name, e);
+            }
             return null;
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 
         <maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>
         <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
-        <maven.spotbugs.plugin.version>3.1.3.1</maven.spotbugs.plugin.version>
+        <maven.spotbugs.plugin.version>3.1.6</maven.spotbugs.plugin.version>
         <maven.sonar.plugin.version>3.3.0.603</maven.sonar.plugin.version>
         <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
         <maven.failsafe.plugin.version>2.22.0</maven.failsafe.plugin.version>


### PR DESCRIPTION
Fixes #13463.

This commit fixes OS metrics on Java 9+ and IBM Java 8  by removing unneeded `setAccessible` call. The MXBean methods (if they are present) are all public  and covered by interfaces `com.sun.management.OperatingSystemMXBean` and its child interface `com.sun.management.UnixOperatingSystemMXBean` (in Java 9 part of [jdk.management](https://docs.oracle.com/javase/9/docs/api/jdk.management-summary.html) module).