### PR TITLE
Fix lock timeout behaviour when key owner is gone

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientConditionProxy.java
@@ -86,7 +86,7 @@ public class ClientConditionProxy extends PartitionSpecificClientProxy implement
         final long timeoutInMillis = unit.toMillis(time);
         ClientMessage request = ConditionAwaitCodec
                 .encodeRequest(conditionId, threadId, timeoutInMillis, name, referenceIdGenerator.getNextReferenceId());
-        ClientMessage response = invokeOnPartition(request);
+        ClientMessage response = invokeOnPartition(request, Long.MAX_VALUE);
         return ConditionAwaitCodec.decodeResponse(response).response;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientLockProxy.java
@@ -113,14 +113,14 @@ public class ClientLockProxy extends PartitionSpecificClientProxy implements ILo
     public void lock() {
         ClientMessage request = LockLockCodec
                 .encodeRequest(name, -1, ThreadUtil.getThreadId(), referenceIdGenerator.getNextReferenceId());
-        invokeOnPartition(request);
+        invokeOnPartition(request, Long.MAX_VALUE);
     }
 
     @Override
     public void lockInterruptibly() throws InterruptedException {
         ClientMessage request = LockLockCodec
                 .encodeRequest(name, -1, ThreadUtil.getThreadId(), referenceIdGenerator.getNextReferenceId());
-        invokeOnPartitionInterruptibly(request);
+        invokeOnPartitionInterruptibly(request, Long.MAX_VALUE);
     }
 
     @Override
@@ -145,7 +145,8 @@ public class ClientLockProxy extends PartitionSpecificClientProxy implements ILo
         long threadId = ThreadUtil.getThreadId();
         ClientMessage request = LockTryLockCodec
                 .encodeRequest(name, threadId, leaseTimeInMillis, timeoutInMillis, referenceIdGenerator.getNextReferenceId());
-        LockTryLockCodec.ResponseParameters resultParameters = LockTryLockCodec.decodeResponse(invokeOnPartition(request));
+        ClientMessage clientMessage = invokeOnPartition(request, Long.MAX_VALUE);
+        LockTryLockCodec.ResponseParameters resultParameters = LockTryLockCodec.decodeResponse(clientMessage);
         return resultParameters.response;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -624,7 +624,19 @@ public class ClientMapProxy<K, V> extends ClientProxy
         Data keyData = toData(key);
         ClientMessage request = MapLockCodec.encodeRequest(name, keyData, getThreadId(), getTimeInMillis(leaseTime, timeUnit),
                 lockReferenceIdGenerator.getNextReferenceId());
-        invoke(request, keyData);
+        invoke(request, keyData, Long.MAX_VALUE);
+    }
+
+    private <T> T invoke(ClientMessage clientMessage, Object key, long invocationTimeoutSeconds) {
+        final int partitionId = getContext().getPartitionService().getPartitionId(key);
+        try {
+            ClientInvocation clientInvocation = new ClientInvocation(getClient(), clientMessage, getName(), partitionId);
+            clientInvocation.setInvocationTimeoutMillis(invocationTimeoutSeconds);
+            final Future future = clientInvocation.invoke();
+            return (T) future.get();
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
     }
 
     @Override
@@ -661,7 +673,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
         ClientMessage request = MapTryLockCodec.encodeRequest(name, keyData, getThreadId(), leaseTimeMillis, timeoutMillis,
                 lockReferenceIdGenerator.getNextReferenceId());
 
-        ClientMessage response = invoke(request, keyData);
+        ClientMessage response = invoke(request, keyData, Long.MAX_VALUE);
         MapTryLockCodec.ResponseParameters resultParameters = MapTryLockCodec.decodeResponse(response);
         return resultParameters.response;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -75,6 +75,7 @@ public class ClientInvocation implements Runnable {
     private volatile ClientConnection sendConnection;
     private EventHandler handler;
     private volatile long invokeCount;
+    private volatile long invocationTimeoutMillis;
 
     protected ClientInvocation(HazelcastClientInstanceImpl client,
                                ClientMessage clientMessage,
@@ -97,6 +98,7 @@ public class ClientInvocation implements Runnable {
         this.callIdSequence = invocationService.getCallIdSequence();
         this.clientInvocationFuture = new ClientInvocationFuture(this, executionService,
                 clientMessage, logger, callIdSequence);
+        this.invocationTimeoutMillis = invocationService.getInvocationTimeoutMillis();
     }
 
     /**
@@ -195,6 +197,10 @@ public class ClientInvocation implements Runnable {
         }
     }
 
+    public void setInvocationTimeoutMillis(long invocationTimeoutMillis) {
+        this.invocationTimeoutMillis = invocationTimeoutMillis;
+    }
+
     public void notify(ClientMessage clientMessage) {
         if (clientMessage == null) {
             throw new IllegalArgumentException("response can't be null");
@@ -225,7 +231,7 @@ public class ClientInvocation implements Runnable {
         }
 
         long timePassed = System.currentTimeMillis() - startTimeMillis;
-        if (timePassed > invocationService.getInvocationTimeoutMillis()) {
+        if (timePassed > invocationTimeoutMillis) {
             if (logger.isFinestEnabled()) {
                 logger.finest("Exception will not be retried because invocation timed out", exception);
             }

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -345,7 +345,7 @@ public class LockAdvancedTest extends HazelcastTestSupport {
         assertTrue(lock1.tryLock());
         lock1.unlock();
         lock1.unlock();
-        assertOpenEventually(latch, 10);
+        assertOpenEventually(latch);
     }
 
     @Test(timeout = 100000)


### PR DESCRIPTION
When a client waiting on lock to get it, if the member that it
is waiting on shuts down/terminated , client retries it on new
owner of the lock.

If a client waits for longer than client.invocation.timeout.seconds,
when exception came from server, it is wrapped inside
OperationTimeoutException and thrown to user.
This pr changes this behaviour so that waiting lock operations
(map.lock/trylock lock.lock/trylock condition.await) operations will
not throw OperationTimeoutException but retry the operation.

fixes https://github.com/hazelcast/hazelcast/issues/13551