### PR TITLE
Remove WAN consistency periodic check config

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
@@ -2427,22 +2427,6 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="consistency-check-period-millis" minOccurs="0" type="xs:long">
-                <xs:annotation>
-                    <xs:documentation>
-                        Period (in milliseconds) for checking consistency of data
-                        between source and target cluster.
-                        Any inconsistency will not be reconciled, it will be merely reported via
-                        the usual mechanisms (e.g. statistics, diagnostics). The user must
-                        initiate WAN sync to reconcile there differences.
-                        For the check procedure to work properly, the target cluster should
-                        support merkle trees and the data structures being synced should be
-                        configured with merkle trees enabled both on the source and target cluster.
-                        Default value is 0, which means the periodic check is disabled.
-                        The period must not be negative.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
         </xs:all>
     </xs:complexType>
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -997,7 +997,6 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         final WanSyncConfig wanSyncConfig = publisherConfig.getWanSyncConfig();
         assertNotNull(wanSyncConfig);
         assertEquals(ConsistencyCheckStrategy.MERKLE_TREES, wanSyncConfig.getConsistencyCheckStrategy());
-        assertEquals(12345, wanSyncConfig.getConsistencyCheckPeriodMillis());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -120,7 +120,6 @@
                 <hz:wan-publisher group-name="tokyo" class-name="PublisherClassName">
                     <hz:wan-sync>
                         <hz:consistency-check-strategy>MERKLE_TREES</hz:consistency-check-strategy>
-                        <hz:consistency-check-period-millis>12345</hz:consistency-check-period-millis>
                     </hz:wan-sync>
                 </hz:wan-publisher>
                 <hz:wan-consumer implementation="wanConsumer" persist-wan-replicated-data="false"/>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -698,7 +698,6 @@ public class ConfigXmlGenerator {
     private static void wanReplicationSyncGenerator(XmlGenerator gen, WanSyncConfig c) {
         gen.open("wan-sync")
            .node("consistency-check-strategy", c.getConsistencyCheckStrategy())
-           .node("consistency-check-period-millis", c.getConsistencyCheckPeriodMillis())
            .close();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/WanSyncConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanSyncConfig.java
@@ -19,7 +19,6 @@ package com.hazelcast.config;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.util.Preconditions;
 
 import java.io.IOException;
 
@@ -30,10 +29,8 @@ import java.io.IOException;
  * @since 3.11
  */
 public class WanSyncConfig implements IdentifiedDataSerializable {
-    private static final long DEFAULT_CONSISTENCY_CHECK_PERIOD_MILLIS = 0;
 
     private ConsistencyCheckStrategy consistencyCheckStrategy = ConsistencyCheckStrategy.NONE;
-    private long consistencyCheckPeriodMillis = DEFAULT_CONSISTENCY_CHECK_PERIOD_MILLIS;
 
     /**
      * Returns the strategy for checking consistency of data between source and
@@ -66,43 +63,6 @@ public class WanSyncConfig implements IdentifiedDataSerializable {
         return this;
     }
 
-    /**
-     * Returns the period (in milliseconds) for checking consistency of data
-     * between source and target cluster.
-     * Any inconsistency will not be reconciled, it will be merely reported via
-     * the usual mechanisms (e.g. statistics, diagnostics). The user must
-     * initiate WAN sync to reconcile there differences.
-     * For the check procedure to work properly, the target cluster should
-     * support merkle trees and the data structures being synced should be
-     * configured with merkle trees enabled both on the source and target cluster.
-     * Default value is {@code 0}, which means the periodic check is disabled.
-     * The period must not be negative.
-     */
-    public long getConsistencyCheckPeriodMillis() {
-        return consistencyCheckPeriodMillis;
-    }
-
-    /**
-     * Sets the period (in milliseconds) for checking consistency of data
-     * between source and target cluster.
-     * Any inconsistency will not be reconciled, it will be merely reported via
-     * the usual mechanisms (e.g. statistics, diagnostics). The user must
-     * initiate WAN sync to reconcile there differences.
-     * For the check procedure to work properly, the target cluster should
-     * support merkle trees and the data structures being synced should be
-     * configured with merkle trees enabled both on the source and target cluster.
-     * Default value is {@code 0}, which means the periodic check is disabled.
-     * The period must not be negative.
-     *
-     * @param consistencyCheckPeriodMillis the updated period (in milliseconds)
-     * @throws IllegalArgumentException if the provided period is negative
-     */
-    public void setConsistencyCheckPeriodMillis(long consistencyCheckPeriodMillis) {
-        Preconditions.checkNotNegative(consistencyCheckPeriodMillis,
-                "Provided consistencyCheckPeriodMillis must not be negative");
-        this.consistencyCheckPeriodMillis = consistencyCheckPeriodMillis;
-    }
-
     @Override
     public int getFactoryId() {
         return ConfigDataSerializerHook.F_ID;
@@ -116,20 +76,17 @@ public class WanSyncConfig implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeByte(consistencyCheckStrategy.getId());
-        out.writeLong(consistencyCheckPeriodMillis);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         consistencyCheckStrategy = ConsistencyCheckStrategy.getById(in.readByte());
-        consistencyCheckPeriodMillis = in.readLong();
     }
 
     @Override
     public String toString() {
         return "WanSyncConfig{"
                 + "consistencyCheckStrategy=" + consistencyCheckStrategy
-                + ", consistencyCheckPeriodMillis=" + consistencyCheckPeriodMillis
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -683,13 +683,10 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
     private void handleWanSync(WanSyncConfig wanSyncConfig, Node node) {
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
-            String value = getTextContent(child).trim();
             if ("consistency-check-strategy".equals(nodeName)) {
                 String strategy = getTextContent(child);
                 wanSyncConfig.setConsistencyCheckStrategy(
                         ConsistencyCheckStrategy.valueOf(upperCaseInternal(strategy)));
-            } else if ("consistency-check-period-millis".equalsIgnoreCase(nodeName)) {
-                wanSyncConfig.setConsistencyCheckPeriodMillis(getLongValue("consistency-check-period-millis", value));
             }
         }
     }

--- a/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
@@ -2488,22 +2488,6 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="consistency-check-period-millis" type="xs:int" minOccurs="0" default="-1">
-                <xs:annotation>
-                    <xs:documentation>
-                        Period (in milliseconds) for checking consistency of data
-                        between source and target cluster.
-                        Any inconsistency will not be reconciled, it will be merely reported via
-                        the usual mechanisms (e.g. statistics, diagnostics). The user must
-                        initiate WAN sync to reconcile there differences.
-                        For the check procedure to work properly, the target cluster should
-                        support merkle trees and the data structures being synced should be
-                        configured with merkle trees enabled both on the source and target cluster.
-                        Default value is 0, which means the periodic check is disabled.
-                        The period must not be negative.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
         </xs:all>
     </xs:complexType>
     <xs:complexType name="wan-consumer">

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -226,17 +226,6 @@
                 check procedure to work properly, the target cluster should support the
                 chosen strategy.
                 Default value is NONE, which means the check is disabled.
-            - <consistency-check-period-millis>:
-                Period (in milliseconds) for checking consistency of data
-                between source and target cluster.
-                Any inconsistency will not be reconciled, it will be merely reported via
-                the usual mechanisms (e.g. statistics, diagnostics). The user must
-                initiate WAN sync to reconcile there differences.
-                For the check procedure to work properly, the target cluster should
-                support merkle trees and the data structures being synced should be
-                configured with merkle trees enabled both on the source and target cluster.
-                Default value is 0, which means the periodic check is disabled.
-                The period must not be negative.
         * <aws>:
             Set its "enabled" attribute to true for discovery within Amazon EC2. It has the following sub-elements:
             - <access-key>:
@@ -291,7 +280,6 @@
             <initial-publisher-state>REPLICATING</initial-publisher-state>
             <wan-sync>
                 <consistency-check-strategy>NONE</consistency-check-strategy>
-                <consistency-check-period-millis>0</consistency-check-period-millis>
             </wan-sync>
             <properties>
                 <property name="endpoints">10.3.5.1:5701,10.3.5.2:5701</property>

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -898,8 +898,7 @@ class ConfigCompatibilityChecker {
         @Override
         boolean check(WanSyncConfig c1, WanSyncConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
-                    && nullSafeEqual(c1.getConsistencyCheckStrategy(), c2.getConsistencyCheckStrategy())
-                    && nullSafeEqual(c1.getConsistencyCheckPeriodMillis(), c2.getConsistencyCheckPeriodMillis());
+                    && nullSafeEqual(c1.getConsistencyCheckStrategy(), c2.getConsistencyCheckStrategy());
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1125,8 +1125,7 @@ public class ConfigXmlGeneratorTest {
                 .setInitialPublisherState(WanPublisherState.STOPPED)
                 .setDiscoveryConfig(getDummyDiscoveryConfig());
         publisherConfig.getWanSyncConfig()
-                       .setConsistencyCheckStrategy(ConsistencyCheckStrategy.MERKLE_TREES)
-                       .setConsistencyCheckPeriodMillis(12345);
+                       .setConsistencyCheckStrategy(ConsistencyCheckStrategy.MERKLE_TREES);
         WanConsumerConfig wanConsumerConfig = new WanConsumerConfig()
                 .setClassName("dummyClass")
                 .setProperties(props)

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1205,7 +1205,6 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "            <class-name>PublisherClassName</class-name>\n"
                 + "            <wan-sync>\n"
                 + "                <consistency-check-strategy>MERKLE_TREES</consistency-check-strategy>\n"
-                + "                <consistency-check-period-millis>12345</consistency-check-period-millis>\n"
                 + "            </wan-sync>\n"
                 + "        </wan-publisher>\n"
                 + "    </wan-replication>\n"
@@ -1222,8 +1221,6 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         WanPublisherConfig publisherConfig = publishers.get(0);
         assertEquals(ConsistencyCheckStrategy.MERKLE_TREES, publisherConfig.getWanSyncConfig()
                                                                            .getConsistencyCheckStrategy());
-        assertEquals(12345, publisherConfig.getWanSyncConfig()
-                                           .getConsistencyCheckPeriodMillis());
     }
 
     @Test

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -65,7 +65,6 @@
             <initial-publisher-state>REPLICATING</initial-publisher-state>
             <wan-sync>
                 <consistency-check-strategy>MERKLE_TREES</consistency-check-strategy>
-                <consistency-check-period-millis>10000</consistency-check-period-millis>
             </wan-sync>
             <properties>
                 <property name="batch.size">50</property>


### PR DESCRIPTION
Periodic consistency check with Merkle trees will not be implemented in 3.11, this change removes it.