### PR TITLE
Include Merkle tree footprint in Map stats

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -226,7 +226,7 @@ class MapServiceContextImpl implements MapServiceContext {
         return new RingbufferMapEventJournalImpl(getNodeEngine(), this);
     }
 
-    private LocalMapStatsProvider createLocalMapStatsProvider() {
+    protected LocalMapStatsProvider createLocalMapStatsProvider() {
         return new LocalMapStatsProvider(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalMapStats.java
@@ -198,13 +198,20 @@ public interface LocalMapStats extends LocalInstanceStats {
     long total();
 
     /**
-     * Cost of map & Near Cache & backup in bytes
+     * Cost of map & Near Cache & backup & Merkle trees in bytes
      * <p>
      * When {@link com.hazelcast.config.InMemoryFormat#OBJECT} is used, the heapcost is zero.
      *
      * @return heap cost
      */
     long getHeapCost();
+
+    /**
+     * Returns the heap cost of the Merkle trees
+     *
+     * @return the heap cost of the Merkle trees
+     */
+    long getMerkleTreesCost();
 
     /**
      * Returns statistics related to the Near Cache.

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -113,10 +113,15 @@ public class LocalMapStatsImpl implements LocalMapStats {
     @Probe
     private volatile long backupEntryMemoryCost;
     /**
-     * Holds total heap cost of map & Near Cache & backups.
+     * Holds total heap cost of map & Near Cache & backups & Merkle trees.
      */
     @Probe
     private volatile long heapCost;
+    /**
+     * Holds the total memory footprint of the Merkle trees
+     */
+    @Probe
+    private volatile long merkleTreesCost;
     @Probe
     private volatile long lockedEntryCount;
     @Probe
@@ -304,6 +309,15 @@ public class LocalMapStatsImpl implements LocalMapStats {
     }
 
     @Override
+    public long getMerkleTreesCost() {
+        return merkleTreesCost;
+    }
+
+    public void setMerkleTreesCost(long merkleTreeCost) {
+        this.merkleTreesCost = merkleTreeCost;
+    }
+
+    @Override
     public NearCacheStats getNearCacheStats() {
         return nearCacheStats;
     }
@@ -444,6 +458,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
         root.add("maxRemoveLatency", NANOSECONDS.toMillis(maxRemoveLatency));
 
         root.add("heapCost", heapCost);
+        root.add("merkleTreesCost", merkleTreesCost);
         if (nearCacheStats != null) {
             root.add("nearCacheStats", nearCacheStats.toJson());
         }
@@ -490,6 +505,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
         lockedEntryCount = getLong(json, "lockedEntryCount", -1L);
         dirtyEntryCount = getLong(json, "dirtyEntryCount", -1L);
         heapCost = getLong(json, "heapCost", -1L);
+        merkleTreesCost = getLong(json, "merkleTreesCost", -1L);
         JsonValue jsonNearCacheStats = json.get("nearCacheStats");
         if (jsonNearCacheStats != null) {
             nearCacheStats = new NearCacheStatsImpl();
@@ -538,6 +554,7 @@ public class LocalMapStatsImpl implements LocalMapStats {
                 + ", lockedEntryCount=" + lockedEntryCount
                 + ", dirtyEntryCount=" + dirtyEntryCount
                 + ", heapCost=" + heapCost
+                + ", merkleTreesCost=" + merkleTreesCost
                 + ", nearCacheStats=" + (nearCacheStats != null ? nearCacheStats : "")
                 + ", queryCount=" + queryCount
                 + ", indexedQueryCount=" + indexedQueryCount

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -290,7 +290,7 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
         NUMBER_OF_EVENTS.incrementAndGet(this);
     }
 
-    @Probe
+    @Override
     public long getHeapCost() {
         return 0;
     }
@@ -299,7 +299,6 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
     public void setHeapCost(long heapCost) {
     }
 
-    @Probe
     @Override
     public long getMerkleTreesCost() {
         return 0;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImpl.java
@@ -301,6 +301,16 @@ public class LocalReplicatedMapStatsImpl implements LocalReplicatedMapStats {
 
     @Probe
     @Override
+    public long getMerkleTreesCost() {
+        return 0;
+    }
+
+    // TODO: unused
+    public void setMerkleTreesCost(long merkleTreesCost) {
+    }
+
+    @Probe
+    @Override
     public long getReplicationEventCount() {
         return 0;
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/OAHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/OAHashSet.java
@@ -312,7 +312,7 @@ public class OAHashSet<E> extends AbstractSet<E> {
      * @return the current memory consumption
      */
     @SuppressWarnings("checkstyle:trailingcomment")
-    public int footprint() {
+    public long footprint() {
         return
                 INT_SIZE_IN_BYTES * hashes.length // size of hashes array
                 + REFERENCE_COST_IN_BYTES * table.length // size of table array

--- a/hazelcast/src/main/java/com/hazelcast/wan/merkletree/MerkleTree.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/merkletree/MerkleTree.java
@@ -91,7 +91,7 @@ public interface MerkleTree extends MerkleTreeView {
      *
      * @return the memory footprint of the Merkle Tree in bytes
      */
-    int footprint();
+    long footprint();
 
     /**
      * Clears the Merkle tree

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalReplicatedMapStatsImplTest.java
@@ -65,6 +65,7 @@ public class LocalReplicatedMapStatsImplTest {
         localReplicatedMapStats.incrementReceivedEvents();
 
         localReplicatedMapStats.setHeapCost(7461762);
+        localReplicatedMapStats.setMerkleTreesCost(6548888);
     }
 
     @Test
@@ -95,6 +96,7 @@ public class LocalReplicatedMapStatsImplTest {
         assertEquals(2, localReplicatedMapStats.getEventOperationCount());
 
         assertEquals(0, localReplicatedMapStats.getHeapCost());
+        assertEquals(0, localReplicatedMapStats.getMerkleTreesCost());
         assertNotNull(localReplicatedMapStats.toString());
     }
 
@@ -130,6 +132,7 @@ public class LocalReplicatedMapStatsImplTest {
         assertEquals(2, deserialized.getEventOperationCount());
 
         assertEquals(0, deserialized.getHeapCost());
+        assertEquals(0, deserialized.getMerkleTreesCost());
         assertNotNull(deserialized.toString());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/collection/OAHashSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/collection/OAHashSetTest.java
@@ -472,11 +472,11 @@ public class OAHashSetTest {
     @Test
     public void testFootprintReflectsCapacityIncrease() {
         final OAHashSet<Integer> set = new OAHashSet<Integer>(8);
-        final int originalFootprint = set.footprint();
+        final long originalFootprint = set.footprint();
 
         populateSet(set, 10);
 
-        final int footprintAfterCapacityIncrease = set.footprint();
+        final long footprintAfterCapacityIncrease = set.footprint();
         assertTrue(footprintAfterCapacityIncrease > originalFootprint);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/wan/merkletree/ArrayMerkleTreeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/merkletree/ArrayMerkleTreeTest.java
@@ -63,6 +63,19 @@ public class ArrayMerkleTreeTest {
     }
 
     @Test
+    public void testFootprintChanges() {
+        MerkleTree merkleTree = new ArrayMerkleTree(3, 10);
+
+        long footprintBeforeAdd = merkleTree.footprint();
+        for (int i = 0; i < 100; i++) {
+            merkleTree.updateAdd(i, i);
+        }
+        long footprintAfterAdd = merkleTree.footprint();
+
+        assertTrue(footprintAfterAdd > footprintBeforeAdd);
+    }
+
+    @Test
     public void testUpdateAdd() {
         MerkleTree merkleTree = new ArrayMerkleTree(3);
 


### PR DESCRIPTION
- Include Merkle tree memory footprint in Maps' heapCost
- Add Merkle tree memory footprint as a new probe
- Guarantee visibility of the up-to-date Merkle footprint for the metrics collector

EE part: https://github.com/hazelcast/hazelcast-enterprise/pull/2305