### PR TITLE
Re-introduce setAccessible call to OperatingSystemMetricSet

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
@@ -117,6 +117,7 @@ public final class OperatingSystemMetricSet {
     private static Method getMethod(Object source, String methodName, String name) {
         try {
             Method method = source.getClass().getMethod(methodName);
+            method.setAccessible(true);
             return method;
         } catch (Exception e) {
             if (LOGGER.isFinestEnabled()) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/TestMetricsReader.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/TestMetricsReader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.DoubleProbeFunction;
+import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.ProbeFunction;
+
+/**
+ * Metrics reader for {@link LongProbeFunction} and {@link DoubleProbeFunction} metrics.
+ */
+public class TestMetricsReader {
+
+    protected final MetricsRegistryImpl metricsRegistry;
+    protected final String name;
+
+    public TestMetricsReader(MetricsRegistryImpl metricsRegistry, String name) {
+        this.metricsRegistry = metricsRegistry;
+        this.name = name;
+    }
+
+    public Number read() throws Exception {
+        ProbeInstance probeInstance = metricsRegistry.getProbeInstance(name);
+        ProbeFunction function = probeInstance.function;
+        Object source = probeInstance.source;
+
+        if (function instanceof LongProbeFunction) {
+            LongProbeFunction longFunction = (LongProbeFunction) function;
+            return longFunction.get(source);
+        } else if (function instanceof DoubleProbeFunction) {
+            DoubleProbeFunction doubleFunction = (DoubleProbeFunction) function;
+            return doubleFunction.get(source);
+        } else {
+            throw new IllegalStateException("Unexpected probe function type " + function.getClass().getName());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.metrics.metricsets;
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.LongGauge;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
+import com.hazelcast.internal.metrics.impl.TestMetricsReader;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -38,6 +39,7 @@ import static com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet
 import static com.hazelcast.logging.Logger.getLogger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -91,6 +93,13 @@ public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
     private void assertContainsSensor(String parameter) {
         boolean contains = metricsRegistry.getNames().contains(parameter);
         assertTrue("sensor: " + parameter + " is not found", contains);
+        TestMetricsReader reader = new TestMetricsReader(metricsRegistry, parameter);
+        try {
+            Number value = reader.read();
+            assertNotNull(value);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to get a metric " + parameter, e);
+        }
     }
 
     private void assumeOperatingSystemMXBeanType(String expected) {

--- a/pom.xml
+++ b/pom.xml
@@ -1024,10 +1024,12 @@
                             <trimStackTrace>false</trimStackTrace>
                             <!--
                             The jdk.xml.internal package export is added to workaround Powermock issue https://github.com/powermock/powermock/issues/905 in tests.
+                            The package opening from jdk.management module is added to allow reflection access to OS level metrics in OperatingSystemMetricSet class.
                              -->
                             <argLine>
                                 ${vmHeapSettings}
                                 --add-exports java.xml/jdk.xml.internal=ALL-UNNAMED
+                                --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false


### PR DESCRIPTION
Fixes #13564.
Fixes #13565.

Re-introduce the `setAccessible` call to `OperatingSystemMetricSet` and improve tests to read probe values during testing.
Fix the Java 9+ behavior by opening the `jdk.management` module for reflection in `pom.xml`.

Once we are not bind by Java 6 compiler requirement, we should use reflection as a fallback only and work with management interfaces where possible. It would resolve the Java 9+ problems in a clean way.