### PR TITLE
Add Merkle tree Management Center endpoint

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -48,6 +48,7 @@ import com.hazelcast.internal.management.request.RunGcRequest;
 import com.hazelcast.internal.management.request.ShutdownClusterRequest;
 import com.hazelcast.internal.management.request.ThreadDumpRequest;
 import com.hazelcast.internal.management.request.TriggerPartialStartRequest;
+import com.hazelcast.internal.management.request.WanCheckConsistencyRequest;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.Address;
@@ -446,25 +447,39 @@ public class ManagementCenterService {
             register(new ThreadDumpRequest());
             register(new ExecuteScriptRequest());
             register(new ConsoleCommandRequest());
-            register(new MapConfigRequest());
-            register(new ChangeWanStateRequest());
-            register(new MemberConfigRequest());
-            register(new ClusterPropsRequest());
             register(new RunGcRequest());
-            register(new GetMemberSystemPropertiesRequest());
             register(new GetMapEntryRequest());
             if (JCacheDetector.isJCacheAvailable(instance.node.getNodeEngine().getConfigClassLoader(), logger)) {
                 register(new GetCacheEntryRequest());
             } else {
                 logger.finest("javax.cache api is not detected on classpath.Skip registering GetCacheEntryRequest...");
             }
+            register(new TriggerPartialStartRequest());
+
+            registerConfigRequests();
+            registerClusterManagementRequests();
+            registerWanRequests();
+        }
+
+        private void registerConfigRequests() {
+            register(new GetMemberSystemPropertiesRequest());
+            register(new MapConfigRequest());
+            register(new MemberConfigRequest());
+        }
+
+        private void registerClusterManagementRequests() {
+            register(new ClusterPropsRequest());
             register(new GetClusterStateRequest());
             register(new ChangeClusterStateRequest());
             register(new ShutdownClusterRequest());
-            register(new ForceStartNodeRequest());
-            register(new TriggerPartialStartRequest());
-            register(new ClearWanQueuesRequest());
             register(new PromoteMemberRequest());
+            register(new ForceStartNodeRequest());
+        }
+
+        private void registerWanRequests() {
+            register(new ChangeWanStateRequest());
+            register(new ClearWanQueuesRequest());
+            register(new WanCheckConsistencyRequest());
         }
 
         public void register(ConsoleRequest consoleRequest) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/WanCheckConsistencyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/WanCheckConsistencyOperation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.operation;
+
+import com.hazelcast.spi.AbstractLocalOperation;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.wan.WanReplicationService;
+
+/**
+ * Checking consistency of the given map for the given wan replication
+ * schema and publisher
+ */
+public class WanCheckConsistencyOperation extends AbstractLocalOperation {
+    private String schemeName;
+    private String publisherName;
+    private String mapName;
+
+    public WanCheckConsistencyOperation(String schemeName, String publisherName, String mapName) {
+        this.schemeName = schemeName;
+        this.publisherName = publisherName;
+        this.mapName = mapName;
+    }
+
+    @Override
+    public void run() throws Exception {
+        NodeEngine nodeEngine = getNodeEngine();
+        WanReplicationService wanReplicationService = nodeEngine.getWanReplicationService();
+        wanReplicationService.consistencyCheck(schemeName, publisherName, mapName);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ConsoleRequestConstants.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ConsoleRequestConstants.java
@@ -45,6 +45,7 @@ public final class ConsoleRequestConstants {
     public static final int REQUEST_TYPE_CLEAR_WAN_QUEUES = 40;
     public static final int REQUEST_TYPE_CACHE_ENTRY = 41;
     public static final int REQUEST_TYPE_PROMOTE_MEMBER = 42;
+    public static final int REQUEST_TYPE_WAN_CHECK_CONSISTENCY = 43;
 
     private ConsoleRequestConstants() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/WanCheckConsistencyRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/WanCheckConsistencyRequest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.request;
+
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.management.ManagementCenterService;
+import com.hazelcast.internal.management.operation.WanCheckConsistencyOperation;
+
+import static com.hazelcast.internal.management.ManagementCenterService.resolveFuture;
+import static com.hazelcast.util.JsonUtil.getString;
+
+public class WanCheckConsistencyRequest implements ConsoleRequest {
+
+    /**
+     * Result message when {@link WanCheckConsistencyRequest} is invoked successfully
+     */
+    public static final String SUCCESS = "success";
+
+    private String schemeName;
+    private String publisherName;
+    private String mapName;
+
+    public WanCheckConsistencyRequest() {
+    }
+
+    public WanCheckConsistencyRequest(String schemeName, String publisherName, String mapName) {
+        this.schemeName = schemeName;
+        this.publisherName = publisherName;
+        this.mapName = mapName;
+    }
+
+    @Override
+    public int getType() {
+        return ConsoleRequestConstants.REQUEST_TYPE_WAN_CHECK_CONSISTENCY;
+    }
+
+    @Override
+    public void writeResponse(ManagementCenterService mcs, JsonObject out) throws Exception {
+        WanCheckConsistencyOperation operation = new WanCheckConsistencyOperation(schemeName, publisherName, mapName);
+        Object operationResult = resolveFuture(mcs.callOnThis(operation));
+        JsonObject result = new JsonObject();
+        if (operationResult == null) {
+            result.add("result", SUCCESS);
+        } else {
+            result.add("result", operationResult.toString());
+        }
+        out.add("result", result);
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        schemeName = getString(json, "schemeName");
+        publisherName = getString(json, "publisherName");
+        mapName = getString(json, "mapName");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/LocalWanPublisherStats.java
@@ -20,6 +20,7 @@ package com.hazelcast.monitor;
 import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.internal.management.JsonSerializable;
 import com.hazelcast.wan.impl.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;
+import com.hazelcast.wan.merkletree.ConsistencyCheckResult;
 
 import java.util.Map;
 
@@ -74,4 +75,9 @@ public interface LocalWanPublisherStats extends JsonSerializable {
      * Returns the counter for the successfully transfered cache WAN events.
      */
     Map<String, DistributedObjectWanEventCounters> getSentCacheEventCounter();
+
+    /**
+     * Returns the last results of the consistency checks, mapped by map name.
+     */
+    Map<String, ConsistencyCheckResult> getLastConsistencyCheckResults();
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanPublisherStatsImpl.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.config.WanPublisherState;
 import com.hazelcast.monitor.LocalWanPublisherStats;
 import com.hazelcast.wan.impl.DistributedServiceWanEventCounters.DistributedObjectWanEventCounters;
+import com.hazelcast.wan.merkletree.ConsistencyCheckResult;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -45,6 +46,7 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
     private volatile long totalPublishedEventCount;
     private volatile Map<String, DistributedObjectWanEventCounters> sentMapEventCounter;
     private volatile Map<String, DistributedObjectWanEventCounters> sentCacheEventCounter;
+    private volatile Map<String, ConsistencyCheckResult> lastConsistencyCheckResults;
 
     @Override
     public boolean isConnected() {
@@ -99,6 +101,16 @@ public class LocalWanPublisherStatsImpl implements LocalWanPublisherStats {
 
     public void setSentCacheEventCounter(Map<String, DistributedObjectWanEventCounters> sentCacheEventCounter) {
         this.sentCacheEventCounter = sentCacheEventCounter;
+    }
+
+    public void setLastConsistencyCheckResults(
+            Map<String, ConsistencyCheckResult> lastMerkleTreeRootComparisonResults) {
+        this.lastConsistencyCheckResults = lastMerkleTreeRootComparisonResults;
+    }
+
+    @Override
+    public Map<String, ConsistencyCheckResult> getLastConsistencyCheckResults() {
+        return lastConsistencyCheckResults;
     }
 
     public void incrementPublishedEventCount(long latency) {

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -108,6 +108,21 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
      */
     void syncAllMaps(String wanReplicationName, String targetGroupName);
 
+
+    /**
+     * Initiate WAN consistency check for a specific map.
+     * NOTE: not supported on OS, only on EE
+     *
+     * @param wanReplicationName the name of the wan replication config
+     * @param targetGroupName    the group name on the target cluster
+     * @param mapName            the map name
+     * @throws UnsupportedOperationException if the operation is not supported (not EE)
+     * @throws InvalidConfigurationException if there is no WAN replication config for {@code wanReplicationName}
+     * @throws SyncFailedException           if there is a anti-entropy request in progress
+     */
+    void consistencyCheck(String wanReplicationName, String targetGroupName, String mapName);
+
+
     /**
      * Clears WAN replication queues of the given wanReplicationName for the given target.
      *

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -137,6 +137,11 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
+    public void consistencyCheck(String wanReplicationName, String targetGroupName, String mapName) {
+        throw new UnsupportedOperationException("Consistency check is not supported.");
+    }
+
+    @Override
     public void clearQueues(String wanReplicationName, String targetGroupName) {
         throw new UnsupportedOperationException("Clearing WAN replication queues is not supported.");
     }

--- a/hazelcast/src/main/java/com/hazelcast/wan/merkletree/ConsistencyCheckResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/merkletree/ConsistencyCheckResult.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wan.merkletree;
+
+/**
+ * Result of the last WAN consistency check result
+ */
+public class ConsistencyCheckResult {
+    private final int lastCheckedCount;
+    private final int lastDiffCount;
+
+    public ConsistencyCheckResult() {
+        lastCheckedCount = 0;
+        lastDiffCount = 0;
+    }
+
+    /**
+     * Constructs the result of the merkle tree root comparison
+     *
+     * @param lastCheckedCount the number of last checked objects
+     * @param lastDiffCount    the number of different objects
+     */
+    public ConsistencyCheckResult(int lastCheckedCount,
+                                  int lastDiffCount) {
+        this.lastCheckedCount = lastCheckedCount;
+        this.lastDiffCount = lastDiffCount;
+    }
+
+    public int getLastCheckedCount() {
+        return lastCheckedCount;
+    }
+
+    public int getLastDiffCount() {
+        return lastDiffCount;
+    }
+
+    public boolean isRunning() {
+        return lastCheckedCount == -1 && lastDiffCount == -1;
+    }
+
+    public float getDiffPercentage() {
+        return lastCheckedCount != 0
+                ? (float) lastDiffCount / lastCheckedCount
+                : 0;
+    }
+
+    public boolean isDone() {
+        return lastCheckedCount > 0 && lastDiffCount > 0;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/WanCheckConsistencyRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/WanCheckConsistencyRequestTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.management.request.ChangeWanStateRequest;
+import com.hazelcast.internal.management.request.WanCheckConsistencyRequest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.util.JsonUtil.getString;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class WanCheckConsistencyRequestTest extends HazelcastTestSupport {
+    private ManagementCenterService managementCenterService;
+
+    @Before
+    public void setUp() {
+        HazelcastInstance hz = createHazelcastInstance();
+        Node node = getNode(hz);
+        managementCenterService = node.getManagementCenterService();
+    }
+
+    @Test
+    public void testCheckConsistency() throws Exception {
+        WanCheckConsistencyRequest request = new WanCheckConsistencyRequest("schema", "publisher", "mapName");
+        performTest(request);
+    }
+
+    private void performTest(WanCheckConsistencyRequest request) throws Exception {
+        JsonObject jsonObject = new JsonObject();
+        request.writeResponse(managementCenterService, jsonObject);
+
+        JsonObject result = (JsonObject) jsonObject.get("result");
+        assertNotEquals(ChangeWanStateRequest.SUCCESS, getString(result, "result"));
+    }
+}


### PR DESCRIPTION
The actual implementation of the consistency check will be done in EE.
This is only the endpoint that the MC can invoke.

The consistency check can be triggered by `WanCheckConsistencyRequest`.
The result of the check will be written eventually into the `LocalWanPublisherStats#lastConsistencyCheckResults`, which is populated periodically in the `TimedMemberState`.

EE counterpart: hazelcast/hazelcast-enterprise/pull/2315