### PR TITLE
Server should not close clients when client only listens

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/HeartbeatManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/HeartbeatManager.java
@@ -99,7 +99,7 @@ public class HeartbeatManager implements Runnable {
             }
         }
 
-        if (now - connection.lastReadTimeMillis() > heartbeatInterval) {
+        if (now - connection.lastWriteTimeMillis() > heartbeatInterval) {
             ClientMessage request = ClientPingCodec.encodeRequest();
             final ClientInvocation clientInvocation = new ClientInvocation(client, request, null, connection);
             clientInvocation.setBypassHeartbeatCheck(true);


### PR DESCRIPTION
Client was not sending Ping to server when last read time is
up-to-date. When server constantly pushes events to client,
client does not send any ping to server. And consequently,
server closes client because it does not send any ping.

Client logic has changed so that it send pings if there is no
outgoing packages recently, rarther than looking at incoming
packages.

fixes https://github.com/hazelcast/hazelcast/issues/13576

(cherry picked from commit 9bb70fa34594b21caaf03808d82f0999c1421c91)