### PR TITLE
Sets cache record store expirable when a backup is put

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -1116,6 +1116,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     protected R doPutRecord(Data key, R record, String source, boolean updateJournal) {
+        markExpirable(record.getExpirationTime());
         R oldRecord = records.put(key, record);
         if (updateJournal) {
             if (oldRecord != null) {

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.cache.eviction;
 
 import com.hazelcast.cache.CacheTestSupport;
 import com.hazelcast.cache.HazelcastExpiryPolicy;
+import com.hazelcast.cache.ICache;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -40,8 +41,11 @@ import javax.cache.event.CacheEntryExpiredListener;
 import javax.cache.event.CacheEntryListener;
 import javax.cache.event.CacheEntryListenerException;
 import javax.cache.expiry.Duration;
+import javax.cache.expiry.EternalExpiryPolicy;
 import javax.cache.expiry.ExpiryPolicy;
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -103,11 +107,97 @@ public class CacheExpirationTest extends CacheTestSupport {
     }
 
     @Test
-    public void testSimpleExpiration() {
+    public void testSimpleExpiration_put() {
         SimpleExpiryListener listener = new SimpleExpiryListener();
-        CacheConfig cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(1, 1, 1), listener);
-        Cache cache = createCache(cacheConfig);
+        CacheConfig<String, String> cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(1, 1, 1), listener);
+        Cache<String, String> cache = createCache(cacheConfig);
         cache.put("key", "value");
+
+        assertEqualsEventually(1, listener.getExpirationCount());
+    }
+
+    @Test
+    public void testSimpleExpiration_putAsync() {
+        SimpleExpiryListener listener = new SimpleExpiryListener();
+        CacheConfig<String, String> cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(1, 1, 1), listener);
+        Cache<String, String> cache = createCache(cacheConfig);
+        ((ICache<String, String>) cache).putAsync("key", "value");
+
+        assertEqualsEventually(1, listener.getExpirationCount());
+    }
+
+    @Test
+    public void testSimpleExpiration_putAll() {
+        SimpleExpiryListener listener = new SimpleExpiryListener();
+        CacheConfig<String, String> cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(1, 1, 1), listener);
+        Cache<String, String> cache = createCache(cacheConfig);
+
+        Map<String, String> entries = new HashMap<String, String>();
+        entries.put("key1", "value1");
+        entries.put("key2", "value2");
+        cache.putAll(entries);
+
+        assertEqualsEventually(2, listener.getExpirationCount());
+    }
+
+    @Test
+    public void testSimpleExpiration_getAndPut() {
+        SimpleExpiryListener listener = new SimpleExpiryListener();
+        CacheConfig<String, String> cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(1, 1, 1), listener);
+        Cache<String, String> cache = createCache(cacheConfig);
+        cache.getAndPut("key", "value");
+
+        assertEqualsEventually(1, listener.getExpirationCount());
+    }
+
+    @Test
+    public void testSimpleExpiration_getAndPutAsync() {
+        SimpleExpiryListener listener = new SimpleExpiryListener();
+        CacheConfig<String, String> cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(1, 1, 1), listener);
+        Cache<String, String> cache = createCache(cacheConfig);
+        ((ICache<String, String>) cache).getAndPutAsync("key", "value");
+
+        assertEqualsEventually(1, listener.getExpirationCount());
+    }
+
+    @Test
+    public void testSimpleExpiration_getAndReplace() {
+        SimpleExpiryListener listener = new SimpleExpiryListener();
+        CacheConfig<String, String> cacheConfig = createCacheConfig(new EternalExpiryPolicy(), listener);
+        Cache<String, String> cache = createCache(cacheConfig);
+        cache.put("key", "value");
+        cache.unwrap(ICache.class).getAndReplace("key", "value", new HazelcastExpiryPolicy(1, 1, 1));
+
+        assertEqualsEventually(1, listener.getExpirationCount());
+    }
+
+    @Test
+    public void testSimpleExpiration_getAndReplaceAsync() {
+        SimpleExpiryListener listener = new SimpleExpiryListener();
+        CacheConfig<String, String> cacheConfig = createCacheConfig(new EternalExpiryPolicy(), listener);
+        Cache<String, String> cache = createCache(cacheConfig);
+        cache.put("key", "value");
+        cache.unwrap(ICache.class).getAndReplaceAsync("key", "value", new HazelcastExpiryPolicy(1, 1, 1));
+
+        assertEqualsEventually(1, listener.getExpirationCount());
+    }
+
+    @Test
+    public void testSimpleExpiration_putIfAbsent() {
+        SimpleExpiryListener listener = new SimpleExpiryListener();
+        CacheConfig<String, String> cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(1, 1, 1), listener);
+        Cache<String, String> cache = createCache(cacheConfig);
+        cache.putIfAbsent("key", "value");
+
+        assertEqualsEventually(1, listener.getExpirationCount());
+    }
+
+    @Test
+    public void testSimpleExpiration_putIfAbsentAsync() {
+        SimpleExpiryListener listener = new SimpleExpiryListener();
+        CacheConfig<String, String> cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(1, 1, 1), listener);
+        Cache<String, String> cache = createCache(cacheConfig);
+        ((ICache<String, String>) cache).putIfAbsentAsync("key", "value");
 
         assertEqualsEventually(1, listener.getExpirationCount());
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/CacheExpirationPromotionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/CacheExpirationPromotionTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.eviction;
+
+import com.hazelcast.cache.HazelcastCacheManager;
+import com.hazelcast.cache.ICache;
+import com.hazelcast.cache.impl.HazelcastServerCacheManager;
+import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
+import com.hazelcast.config.CacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.backup.BackupAccessor;
+import com.hazelcast.test.backup.TestBackupUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import javax.cache.expiry.CreatedExpiryPolicy;
+import javax.cache.expiry.Duration;
+import javax.cache.spi.CachingProvider;
+import java.util.concurrent.TimeUnit;
+
+import static com.hazelcast.cache.impl.eviction.CacheClearExpiredRecordsTask.PROP_TASK_PERIOD_SECONDS;
+import static com.hazelcast.test.OverridePropertyRule.set;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({ParallelTest.class, QuickTest.class})
+public class CacheExpirationPromotionTest extends HazelcastTestSupport {
+
+    @Rule
+    public final OverridePropertyRule overrideTaskSecondsRule = set(PROP_TASK_PERIOD_SECONDS, "1");
+
+    private String cacheName = "test";
+    private int nodeCount = 3;
+    private TestHazelcastInstanceFactory factory;
+    private HazelcastInstance[] instances;
+
+    protected CacheConfig getCacheConfig() {
+        CacheConfig cacheConfig = new CacheConfig();
+        cacheConfig.setName(cacheName);
+        cacheConfig.setBackupCount(1);
+        return cacheConfig;
+    }
+
+    @Before
+    public void setup() {
+        factory = createHazelcastInstanceFactory(nodeCount);
+        instances = new HazelcastInstance[nodeCount];
+        for (int i = 0; i < nodeCount; i++) {
+            instances[i] = factory.newHazelcastInstance(getConfig());
+        }
+    }
+
+    @Test
+    public void promoted_replica_should_send_eviction_to_other_backup() {
+        final CachingProvider provider = HazelcastServerCachingProvider.createCachingProvider(instances[0]);
+        provider.getCacheManager().createCache(cacheName, getCacheConfig());
+        HazelcastCacheManager cacheManager = (HazelcastServerCacheManager) provider.getCacheManager();
+
+        final String keyOwnedByLastInstance = generateKeyOwnedBy(instances[nodeCount - 1]);
+
+        ICache<String, String> cache = cacheManager.getCache(cacheName).unwrap(ICache.class);
+        cache.put(keyOwnedByLastInstance, "dummyVal", new CreatedExpiryPolicy(new Duration(TimeUnit.SECONDS, 5)));
+
+        final BackupAccessor<String, String> backupAccessor = TestBackupUtils.newCacheAccessor(instances, cacheName, 1);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertNotNull(backupAccessor.get(keyOwnedByLastInstance));
+            }
+        });
+
+        instances[nodeCount - 1].shutdown();
+
+        // the backup replica became the primary, now the backup is the other node.
+        // we check if the newly appointed replica sent expiration to backups
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(0, backupAccessor.size());
+            }
+        });
+    }
+}


### PR DESCRIPTION
When an expirable cache entry is created (or a cache entry is updated to be expirable), we mark the record store expirable. So a periodic task to remove expired entries is started. Backup put operations did not mark the record store as expirable so the periodic task did not automatically start. Normally this does not cause a memory leak because primary replica is responsible for sending expiration operations to backups. Sometimes a primary replica is lost and one of its backups is promoted. This new primary replica did not start expiration task unless a new expirable entry is created on it. In this scenario an expired record may live forever.

This PR gets cache backup put operations to mark the respective record store as expirable. Therefore all hazelcast instances run the periodic task once there is an expirable record (primary or backup does not matter).

Fixes #13520