### PR TITLE
[BACKPORT] Fix ManagementCenterServiceIntegrationTest.testTimedMemberStateNotNull

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.management;
 
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.ParseException;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.monitor.TimedMemberState;
@@ -54,9 +55,12 @@ public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport
     private static final String clusterName = "Session Integration (AWS discovery)";
     private int portNum;
     private Server jettyServer;
+    private CloseableHttpClient client;
 
     @Before
     public void setUp() throws Exception {
+        client = HttpClientBuilder.create().disableRedirectHandling().build();
+
         portNum = availablePort();
         jettyServer = new Server(portNum);
         ServletHandler handler = new ServletHandler();
@@ -71,6 +75,7 @@ public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport
     public void tearDown() throws Exception {
         Hazelcast.shutdownAll();
         jettyServer.stop();
+        client.close();
     }
 
     @Test
@@ -78,7 +83,6 @@ public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                CloseableHttpClient client = HttpClientBuilder.create().disableRedirectHandling().build();
                 HttpUriRequest request = new HttpGet("http://localhost:" + portNum + "/mancen/memberStateCheck");
                 HttpResponse response = client.execute(request);
                 HttpEntity entity = response.getEntity();
@@ -86,7 +90,12 @@ public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport
                 assertNotNull(responseString);
                 assertNotEquals("", responseString);
 
-                JsonObject object = Json.parse(responseString).asObject();
+                JsonObject object;
+                try {
+                    object = Json.parse(responseString).asObject();
+                } catch (ParseException e) {
+                    throw new AssertionError("Failed to parse JSON: " + responseString);
+                }
                 TimedMemberState memberState = new TimedMemberState();
                 memberState.fromJson(object);
                 assertEquals(clusterName, memberState.getClusterName());
@@ -99,7 +108,6 @@ public class ManagementCenterServiceIntegrationTest extends HazelcastTestSupport
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                CloseableHttpClient client = HttpClientBuilder.create().disableRedirectHandling().build();
                 HttpUriRequest request = new HttpGet("http://localhost:" + portNum + "/mancen/getClusterName");
                 HttpResponse response = client.execute(request);
                 HttpEntity entity = response.getEntity();


### PR DESCRIPTION
Wrap ParseException with AssertionError to keep trying in case an
incorrectly formatted JSON string is received from the server. Also
close the HTTP client to prevent any possible resource leakage.

Fixes #8900

Backport of #13231

(cherry picked from commit a988ed8eaeda9393c65fa1d060a1f12f6a613fb3)