### PR TITLE
Unified partition cleaning methods - 2

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -85,22 +85,22 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
     void initPartitionsContainers();
 
     /**
-     * Clears all partitions which the supplied predicate matches.
+     * Removes all record stores inside the supplied partition ID matching with
+     * the supplied predicate.
      *
-     * @param predicate   predicate to select partitions to be cleared
-     * @param partitionId partition ID
+     * @param predicate            to find partitions to be removed
+     * @param partitionId          partition ID
+     * @param onShutdown           {@code true} if this method is called during map service shutdown,
+     *                             otherwise set {@code false}
+     * @param onRecordStoreDestroy {@code true} if this method is called during to destroy record store,
+     *                             otherwise set {@code false}
+     * @see MapManagedService#reset()
+     * @see MapManagedService#shutdown(boolean)
      */
-    void clearPartitionsOf(Predicate<RecordStore> predicate, int partitionId);
+    void removeRecordStoresFromPartitionMatchingWith(Predicate<RecordStore> predicate, int partitionId,
+                                                     boolean onShutdown, boolean onRecordStoreDestroy);
 
     MapService getService();
-
-    /**
-     * Clears all partition based data allocated by MapService.
-     *
-     * @param onShutdown {@code true} if {@code clearPartitions} is called during MapService shutdown,
-     *                   {@code false} otherwise
-     */
-    void clearPartitions(boolean onShutdown, boolean onRecordStoreDestroy);
 
     void destroyMapStores();
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -58,7 +58,7 @@ class MapSplitBrainHandlerService extends AbstractSplitBrainHandlerService<Recor
     protected void onStoreCollection(RecordStore recordStore) {
         assertRunningOnPartitionThread();
 
-        ((DefaultRecordStore) recordStore).clearIndexedData();
+        ((DefaultRecordStore) recordStore).clearIndexedData(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/PartitionContainer.java
@@ -208,15 +208,6 @@ public class PartitionContainer {
         }
     }
 
-    public void clear(boolean onShutdown, boolean onRecordStoreDestroy) {
-        for (RecordStore recordStore : maps.values()) {
-            recordStore.clearPartition(onShutdown, onRecordStoreDestroy);
-            mapService.getMapServiceContext().getEventJournal().destroy(
-                    recordStore.getMapContainer().getObjectNamespace(), partitionId);
-        }
-        maps.clear();
-    }
-
     public boolean hasRunningCleanup() {
         return hasRunningCleanup;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.EntryView;
+import com.hazelcast.core.IMap;
 import com.hazelcast.internal.eviction.ExpiredKey;
 import com.hazelcast.internal.nearcache.impl.invalidation.InvalidationQueue;
 import com.hazelcast.map.impl.MapContainer;
@@ -317,29 +318,9 @@ public interface RecordStore<R extends Record> {
      */
     long softFlush();
 
-    /**
-     * Clears internal partition data.
-     *
-     * @param onShutdown           true if {@code close} is called during
-     *                             MapService shutdown, false otherwise.
-     * @param onRecordStoreDestroy true if record-store will be destroyed,
-     *                             otherwise false.
-     */
-    void clearPartition(boolean onShutdown, boolean onRecordStoreDestroy);
-
-    /**
-     * Resets the record store to it's initial state.
-     * Used in replication operations.
-     *
-     * @see #putRecord(Data, Record)
-     */
-    void reset();
-
     boolean forceUnlock(Data dataKey);
 
     long getOwnedEntryCost();
-
-    int clear();
 
     boolean isEmpty();
 
@@ -419,14 +400,6 @@ public interface RecordStore<R extends Record> {
      * This can be used to release unused resources.
      */
     void disposeDeferredBlocks();
-
-    void destroy();
-
-    /**
-     * Like {@link #destroy()} but does not touch state on other services
-     * like lock service or event journal service.
-     */
-    void destroyInternals();
 
     /**
      * Initialize the recordStore after creation
@@ -519,4 +492,48 @@ public interface RecordStore<R extends Record> {
      * for this map.
      */
     boolean hasQueryCache();
+
+    /**
+     * Called by {@link IMap#destroy()} or {@link
+     * com.hazelcast.map.impl.MapMigrationAwareService}
+     *
+     * Clears internal partition data.
+     *
+     * @param onShutdown           true if {@code close} is called during
+     *                             MapService shutdown, false otherwise.
+     * @param onRecordStoreDestroy true if record-store will be destroyed,
+     *                             otherwise false.
+     */
+    void clearPartition(boolean onShutdown, boolean onRecordStoreDestroy);
+
+    /**
+     * Called by {@link IMap#clear()}.
+     *
+     * Clears data in this record store.
+     *
+     * @return number of cleared entries.
+     */
+    int clear();
+
+    /**
+     * Resets the record store to it's initial state.
+     *
+     * Used in replication operations.
+     *
+     * @see #putRecord(Data, Record)
+     */
+    void reset();
+
+    /**
+     * Called by {@link IMap#destroy()}.
+     *
+     * Destroys data in this record store.
+     */
+    void destroy();
+
+    /**
+     * Like {@link #destroy()} but does not touch state on other services
+     * like lock service or event journal service.
+     */
+    void destroyInternals();
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -48,7 +48,6 @@ public class Indexes {
     private final IndexCopyBehavior indexCopyBehavior;
     private final QueryContextProvider queryContextProvider;
     private final InternalSerializationService serializationService;
-
     private final ConcurrentMap<String, InternalIndex> mapIndexes = new ConcurrentHashMap<String, InternalIndex>(3);
     private final AtomicReference<InternalIndex[]> indexes = new AtomicReference<InternalIndex[]>(EMPTY_INDEX);
 


### PR DESCRIPTION
follow-up of PR: https://github.com/hazelcast/hazelcast/pull/13593

pre-work for the issue: https://github.com/hazelcast/hazelcast-enterprise/issues/859

This PR contains below refactoring :

- Removed unneeded `PartitionContainer#clear` and introduced `removeAllRecordStoresOfAllMaps` to use instead of it. This new method makes use of `removeRecordStoresFromPartitionMatchingWith` which is doing same things with the removed method `PartitionContainer#clear`
    
- Renamed `clearPartitionsOf` to `removeRecordStoresFromPartitionMatchingWith`
