### PR TITLE
[Java 9] Open some packages for reflection in Java runtime

### DIFF
--- a/modulepath-tests/pom.xml
+++ b/modulepath-tests/pom.xml
@@ -56,6 +56,33 @@
                 <version>2.22.0</version>
                 <configuration combine.self="override">
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <!--
+                    Allow access to Operating system metrics:
+                        open jdk.management/com.sun.management.internal
+
+                    Avoid warnings caused by reflection in
+                    SelectorOptimizer:
+                        open java.base/sun.nio.ch
+                    FilteringClassLoader:
+                        open java.base/java.lang
+                    TimedMemberStateFactoryHelper:
+                        open java.management/sun.management
+
+                    Powermock issue workaround (https://github.com/powermock/powermock/issues/905):
+                        export java.xml/jdk.xml.internal
+                     -->
+                    <argLine>
+                        ${vmHeapSettings}
+                        --add-opens jdk.management/com.sun.management.internal=com.hazelcast.core
+                        --add-opens java.base/sun.nio.ch=com.hazelcast.core
+                        --add-opens java.base/java.lang=com.hazelcast.core
+                        --add-opens java.management/sun.management=com.hazelcast.core
+                        --add-exports java.xml/jdk.xml.internal=com.hazelcast.core
+                        --illegal-access=warn
+                        -Dhazelcast.phone.home.enabled=false
+                        -Dlog4j.skipJansi=true
+                        ${extraVmArgs}
+                    </argLine>
                 </configuration>
             </plugin>
 

--- a/modulepath-tests/pom.xml
+++ b/modulepath-tests/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.0</version>
                 <configuration combine.self="override">
                     <release>9</release>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1023,13 +1023,28 @@
                             <useFile>false</useFile>
                             <trimStackTrace>false</trimStackTrace>
                             <!--
-                            The jdk.xml.internal package export is added to workaround Powermock issue https://github.com/powermock/powermock/issues/905 in tests.
-                            The package opening from jdk.management module is added to allow reflection access to OS level metrics in OperatingSystemMetricSet class.
+                            Allow access to Operating system metrics:
+                                open jdk.management/com.sun.management.internal
+
+                            Avoid warnings caused by reflection in
+                            SelectorOptimizer:
+                                open java.base/sun.nio.ch
+                            FilteringClassLoader:
+                                open java.base/java.lang
+                            TimedMemberStateFactoryHelper:
+                                open java.management/sun.management
+
+                            Powermock issue workaround (https://github.com/powermock/powermock/issues/905):
+                                export java.xml/jdk.xml.internal
                              -->
                             <argLine>
                                 ${vmHeapSettings}
-                                --add-exports java.xml/jdk.xml.internal=ALL-UNNAMED
                                 --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+                                --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+                                --add-opens java.base/java.lang=ALL-UNNAMED
+                                --add-opens java.management/sun.management=ALL-UNNAMED
+                                --add-exports java.xml/jdk.xml.internal=ALL-UNNAMED
+                                --illegal-access=warn
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false


### PR DESCRIPTION
This PR opens some Java runtime packages for reflection in Java 9 and newer.
It prevents the Illegal reflective access warnings caused by Hazelcast.

Similar changes are done in EE: hazelcast/hazelcast-enterprise#2313