### PR TITLE
Unified partition cleaning methods

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -314,10 +314,12 @@ public interface RecordStore<R extends Record> {
     /**
      * Clears internal partition data.
      *
-     * @param onShutdown true if {@code close} is called during MapService shutdown,
-     *                   false otherwise.
+     * @param onShutdown           true if {@code close} is called during
+     *                             MapService shutdown, false otherwise.
+     * @param onRecordStoreDestroy true if record-store will be destroyed,
+     *                             otherwise false.
      */
-    void clearPartition(boolean onShutdown, boolean onMapDestroy);
+    void clearPartition(boolean onShutdown, boolean onRecordStoreDestroy);
 
     /**
      * Resets the record store to it's initial state.


### PR DESCRIPTION
pre-work to fix  hazelcast/hazelcast-enterprise#859

Now we only have `clearPartitionsOf` instead of `clearMapsHavingLesserBackupCountThan` and `clearPartitionData`