### PR TITLE
[Backport, Java 9] Fix OperatingSystemMetricSet

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSet.java
@@ -19,10 +19,13 @@ package com.hazelcast.internal.metrics.metricsets;
 import com.hazelcast.internal.metrics.DoubleProbeFunction;
 import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
+import java.util.logging.Level;
 
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -32,6 +35,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 public final class OperatingSystemMetricSet {
 
+    private static final ILogger LOGGER = Logger.getLogger(OperatingSystemMetricSet.class);
     private static final long PERCENTAGE_MULTIPLIER = 100;
     private static final Object[] EMPTY_ARGS = new Object[0];
 
@@ -56,7 +60,11 @@ public final class OperatingSystemMetricSet {
         registerMethod(metricsRegistry, mxBean, "getTotalSwapSpaceSize", "os.totalSwapSpaceSize");
         registerMethod(metricsRegistry, mxBean, "getMaxFileDescriptorCount", "os.maxFileDescriptorCount");
         registerMethod(metricsRegistry, mxBean, "getOpenFileDescriptorCount", "os.openFileDescriptorCount");
+
+        // value will be between 0.0 and 1.0
         registerMethod(metricsRegistry, mxBean, "getProcessCpuLoad", "os.processCpuLoad", PERCENTAGE_MULTIPLIER);
+
+        // value will between 0.0 and 1.0
         registerMethod(metricsRegistry, mxBean, "getSystemCpuLoad", "os.systemCpuLoad", PERCENTAGE_MULTIPLIER);
 
         metricsRegistry.register(mxBean, "os.systemLoadAverage", MANDATORY,
@@ -75,7 +83,7 @@ public final class OperatingSystemMetricSet {
 
     private static void registerMethod(MetricsRegistry metricsRegistry, Object osBean, String methodName, String name,
                                        final long multiplier) {
-        final Method method = getMethod(osBean, methodName);
+        final Method method = getMethod(osBean, methodName, name);
 
         if (method == null) {
             return;
@@ -103,14 +111,19 @@ public final class OperatingSystemMetricSet {
      *
      * @param source     the source object.
      * @param methodName the name of the method to retrieve.
+     * @param name the probe name
      * @return the method
      */
-    private static Method getMethod(Object source, String methodName) {
+    private static Method getMethod(Object source, String methodName, String name) {
         try {
-            Method method = source.getClass().getDeclaredMethod(methodName);
+            Method method = source.getClass().getMethod(methodName);
             method.setAccessible(true);
             return method;
         } catch (Exception e) {
+            if (LOGGER.isFinestEnabled()) {
+                LOGGER.log(Level.FINEST,
+                        "Unable to register OperatingSystemMXBean method " + methodName + " used for probe " + name, e);
+            }
             return null;
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/TestMetricsReader.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/impl/TestMetricsReader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.metrics.impl;
+
+import com.hazelcast.internal.metrics.DoubleProbeFunction;
+import com.hazelcast.internal.metrics.LongProbeFunction;
+import com.hazelcast.internal.metrics.ProbeFunction;
+
+/**
+ * Metrics reader for {@link LongProbeFunction} and {@link DoubleProbeFunction} metrics.
+ */
+public class TestMetricsReader {
+
+    protected final MetricsRegistryImpl metricsRegistry;
+    protected final String name;
+
+    public TestMetricsReader(MetricsRegistryImpl metricsRegistry, String name) {
+        this.metricsRegistry = metricsRegistry;
+        this.name = name;
+    }
+
+    public Number read() throws Exception {
+        ProbeInstance probeInstance = metricsRegistry.getProbeInstance(name);
+        ProbeFunction function = probeInstance.function;
+        Object source = probeInstance.source;
+
+        if (function instanceof LongProbeFunction) {
+            LongProbeFunction longFunction = (LongProbeFunction) function;
+            return longFunction.get(source);
+        } else if (function instanceof DoubleProbeFunction) {
+            DoubleProbeFunction doubleFunction = (DoubleProbeFunction) function;
+            return doubleFunction.get(source);
+        } else {
+            throw new IllegalStateException("Unexpected probe function type " + function.getClass().getName());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/metrics/metricsets/OperatingSystemMetricSetTest.java
@@ -19,10 +19,13 @@ package com.hazelcast.internal.metrics.metricsets;
 import com.hazelcast.internal.metrics.DoubleGauge;
 import com.hazelcast.internal.metrics.LongGauge;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
+import com.hazelcast.internal.metrics.impl.TestMetricsReader;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -36,6 +39,7 @@ import static com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet
 import static com.hazelcast.logging.Logger.getLogger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -62,8 +66,16 @@ public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testComSunManagementUnixOperatingSystem() {
-        assumeOperatingSystemMXBean("com.sun.management.UnixOperatingSystem");
+    public void testComSunManagementUnixOperatingSystemMXBean() {
+        assumeOperatingSystemMXBeanType("com.sun.management.UnixOperatingSystemMXBean");
+        assertContainsSensor("os.maxFileDescriptorCount");
+        assertContainsSensor("os.openFileDescriptorCount");
+
+    }
+
+    @Test
+    public void testComSunManagementOperatingSystemMXBean() {
+        assumeOperatingSystemMXBeanType("com.sun.management.OperatingSystemMXBean");
 
         assertContainsSensor("os.committedVirtualMemorySize");
         assertContainsSensor("os.freePhysicalMemorySize");
@@ -71,8 +83,6 @@ public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
         assertContainsSensor("os.processCpuTime");
         assertContainsSensor("os.totalPhysicalMemorySize");
         assertContainsSensor("os.totalSwapSpaceSize");
-        assertContainsSensor("os.maxFileDescriptorCount");
-        assertContainsSensor("os.openFileDescriptorCount");
 
         assumeThatNoJDK6();
         // only available in JDK 7+
@@ -80,35 +90,26 @@ public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
         assertContainsSensor("os.systemCpuLoad");
     }
 
-    @Test
-    public void testSunManagementOperatingSystemImpl() {
-        assumeOperatingSystemMXBean("sun.management.OperatingSystemImpl");
-
-        assertContainsSensor("os.committedVirtualMemorySize");
-        assertContainsSensor("os.freePhysicalMemorySize");
-        assertContainsSensor("os.freeSwapSpaceSize");
-        assertContainsSensor("os.processCpuTime");
-        assertContainsSensor("os.totalPhysicalMemorySize");
-        assertContainsSensor("os.totalSwapSpaceSize");
-        assertContainsSensor("os.processCpuLoad");
-        assertContainsSensor("os.systemCpuLoad");
-
-        assumeThatNoWindowsOS();
-        // not implemented on Windows
-        assertContainsSensor("os.maxFileDescriptorCount");
-        assertContainsSensor("os.openFileDescriptorCount");
-    }
-
     private void assertContainsSensor(String parameter) {
         boolean contains = metricsRegistry.getNames().contains(parameter);
         assertTrue("sensor: " + parameter + " is not found", contains);
+        TestMetricsReader reader = new TestMetricsReader(metricsRegistry, parameter);
+        try {
+            Number value = reader.read();
+            assertNotNull(value);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to get a metric " + parameter, e);
+        }
     }
 
-    private void assumeOperatingSystemMXBean(String expected) {
+    private void assumeOperatingSystemMXBeanType(String expected) {
         OperatingSystemMXBean bean = ManagementFactory.getOperatingSystemMXBean();
-        String foundClass = bean.getClass().getName();
-
-        assumeTrue(foundClass + " is not usable", expected.equals(foundClass));
+        try {
+            Class<?> expectedInterface = Class.forName(expected);
+            assumeTrue(expectedInterface.isAssignableFrom(bean.getClass()));
+        } catch (ClassNotFoundException e) {
+            throw new AssumptionViolatedException("MXBean interface " + expected + " was not found");
+        }
     }
 
     @Test
@@ -142,13 +143,13 @@ public class OperatingSystemMetricSetTest extends HazelcastTestSupport {
         assertFalse(parameterExist);
     }
 
-    public class FakeOperatingSystemBean {
+    public static class FakeOperatingSystemBean {
 
-        double doubleMethod() {
+        public double doubleMethod() {
             return 10;
         }
 
-        long longMethod() {
+        public long longMethod() {
             return 10;
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -982,7 +982,7 @@
         <profile>
             <id>jdk-9</id>
             <activation>
-                <jdk>1.9</jdk>
+                <jdk>[9,)</jdk>
             </activation>
             <build>
                 <plugins>
@@ -994,8 +994,14 @@
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <useFile>false</useFile>
                             <trimStackTrace>false</trimStackTrace>
+                            <!--
+                            The jdk.xml.internal package export is added to workaround Powermock issue https://github.com/powermock/powermock/issues/905 in tests.
+                            The package opening from jdk.management module is added to allow reflection access to OS level metrics in OperatingSystemMetricSet class.
+                             -->
                             <argLine>
                                 ${vmHeapSettings}
+                                --add-exports java.xml/jdk.xml.internal=ALL-UNNAMED
+                                --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
@@ -1009,6 +1015,11 @@
                                 <exclude>**/jsr/**.java</exclude>
                                 <exclude>**/**IT.java</exclude>
                                 <exclude>**/mapreduce/**.java</exclude>
+                                <!--
+                                  An outdated PaxRunner used by the OSGi test prevents executing on Java 9+.
+                                  TODO: remove this exclude once we have a proper fix in the test class.
+                                -->
+                                <exclude>**/HazelcastOSGiIntegrationTest.java</exclude>
                             </excludes>
                             <groups>com.hazelcast.test.annotation.QuickTest</groups>
                             <excludedGroups>


### PR DESCRIPTION
Backport fix and improve test coverage of OS metrics.

Upstream:
* #13549
* #13567

To proper work of the metrics on Java 9 (and newer) the following Java argument has to be provided:
```
--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
```