### PR TITLE
Fixes test that does not respect ByteOrder overrides

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DefaultSerializationServiceBuilderTest.java
@@ -36,25 +36,27 @@ import static org.junit.Assert.assertEquals;
 @Category({QuickTest.class, ParallelTest.class})
 public class DefaultSerializationServiceBuilderTest {
 
+    private final String BYTE_ORDER_OVERRRIDE_PROPERTY = "hazelcast.serialization.byteOrder";
+
     @Test
     public void test_byteOrderIsOverridden_whenLittleEndian() {
-        System.setProperty("hazelcast.serialization.byteOrder", "LITTLE_ENDIAN");
+        System.setProperty(BYTE_ORDER_OVERRRIDE_PROPERTY, "LITTLE_ENDIAN");
         try {
             InternalSerializationService serializationService = getSerializationServiceBuilder().build();
             assertEquals(ByteOrder.LITTLE_ENDIAN, serializationService.getByteOrder());
         } finally {
-            System.clearProperty("hazelcast.serialization.byteOrder");
+            System.clearProperty(BYTE_ORDER_OVERRRIDE_PROPERTY);
         }
     }
 
     @Test
     public void test_byteOrderIsOverridden_whenBigEndian() {
-        System.setProperty("hazelcast.serialization.byteOrder", "BIG_ENDIAN");
+        System.setProperty(BYTE_ORDER_OVERRRIDE_PROPERTY, "BIG_ENDIAN");
         try {
             InternalSerializationService serializationService = getSerializationServiceBuilder().build();
             assertEquals(ByteOrder.BIG_ENDIAN, serializationService.getByteOrder());
         } finally {
-            System.clearProperty("hazelcast.serialization.byteOrder");
+            System.clearProperty(BYTE_ORDER_OVERRRIDE_PROPERTY);
         }
     }
 
@@ -92,9 +94,17 @@ public class DefaultSerializationServiceBuilderTest {
 
     @Test
     public void test_nullByteOrder() {
-        InternalSerializationService serializationService = getSerializationServiceBuilder()
-                .setByteOrder(null).build();
-        assertEquals(DEFAULT_BYTE_ORDER, serializationService.getByteOrder());
+        String override = System.getProperty(BYTE_ORDER_OVERRRIDE_PROPERTY);
+        System.clearProperty(BYTE_ORDER_OVERRRIDE_PROPERTY);
+        try {
+            InternalSerializationService serializationService = getSerializationServiceBuilder()
+                    .setByteOrder(null).build();
+            assertEquals(DEFAULT_BYTE_ORDER, serializationService.getByteOrder());
+        } finally {
+            if (override != null) {
+                System.setProperty(BYTE_ORDER_OVERRRIDE_PROPERTY, override);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
This test assumed the byte order was always BIG_ENDIAN when not set in programmatic configuration. However, it is possible to override the default setting using system properties.

This test ensures the default ByteOrder is BIG_ENDIAN unless overridden by the user. I am not sure if this test is worth having it at all, yet here is a fix.

fixes https://github.com/hazelcast/hazelcast/issues/13548