### PR TITLE
Configurable map eviction batch size

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -69,6 +69,7 @@ import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.map.impl.eviction.Evictor.NULL_EVICTOR;
 import static com.hazelcast.map.impl.mapstore.MapStoreContextFactory.createMapStoreContext;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_EVICTION_BATCH_SIZE;
 import static java.lang.System.getProperty;
 
 /**
@@ -172,8 +173,10 @@ public class MapContainer {
         } else {
             MemoryInfoAccessor memoryInfoAccessor = getMemoryInfoAccessor();
             EvictionChecker evictionChecker = new EvictionChecker(memoryInfoAccessor, mapServiceContext);
-            IPartitionService partitionService = mapServiceContext.getNodeEngine().getPartitionService();
-            evictor = new EvictorImpl(mapEvictionPolicy, evictionChecker, partitionService);
+            NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+            IPartitionService partitionService = nodeEngine.getPartitionService();
+            int batchSize = nodeEngine.getProperties().getInteger(MAP_EVICTION_BATCH_SIZE);
+            evictor = new EvictorImpl(mapEvictionPolicy, evictionChecker, partitionService, batchSize);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -542,6 +542,20 @@ public final class GroupProperty {
     public static final HazelcastProperty MAP_EXPIRY_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.map.expiry.delay.seconds", 10, SECONDS);
 
+    /**
+     * Maximum number of IMap entries Hazelcast will evict during a single eviction cycle.
+     * Eviction cycle is triggered by a map mutation. Typically it's OK to evict at most a single entry.
+     * However imagine the scenario where you are inserting values in a loop and in each iteration you double entry
+     * size. In this situation Hazelcast has to evict more than just a single entry - as all existing entries are
+     * smaller than the entry which is about to be added and removing any old entry cannot make sufficient room
+     * for the new entry.
+     *
+     * Default: 1
+     *
+     */
+    public static final HazelcastProperty MAP_EVICTION_BATCH_SIZE
+            = new HazelcastProperty("hazelcast.map.eviction.batch.size", 1);
+
     public static final HazelcastProperty LOGGING_TYPE
             = new HazelcastProperty("hazelcast.logging.type", "jdk");
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
@@ -368,7 +368,7 @@ public class EvictionMaxSizePolicyTest extends HazelcastTestSupport {
     private static final class TestEvictor extends EvictorImpl {
 
         TestEvictor(MapEvictionPolicy mapEvictionPolicy, EvictionChecker evictionChecker, IPartitionService partitionService) {
-            super(mapEvictionPolicy, evictionChecker, partitionService);
+            super(mapEvictionPolicy, evictionChecker, partitionService, 1);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -29,6 +29,7 @@ import com.hazelcast.core.EntryView;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -62,6 +63,7 @@ import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.PER_NODE;
 import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.PER_PARTITION;
 import static com.hazelcast.map.EvictionMaxSizePolicyTest.setMockRuntimeMemoryInfoAccessor;
 import static com.hazelcast.map.impl.eviction.MapClearExpiredRecordsTask.PROP_TASK_PERIOD_SECONDS;
+import static java.lang.Math.max;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -788,6 +790,32 @@ public class EvictionTest extends HazelcastTestSupport {
         }
 
         assertBackupsSweptOnAllNodes(mapName, maxSize, instances);
+    }
+
+    @Test
+    public void testEviction_increasingEntrySize() {
+        int maxSizeMB = 50;
+        String mapName = randomMapName();
+
+        Config config = newConfig(mapName, maxSizeMB, MaxSizeConfig.MaxSizePolicy.USED_HEAP_SIZE);
+        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "1");
+        config.setProperty(GroupProperty.MAP_EVICTION_BATCH_SIZE.getName(), "2");
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        IMap<Integer, byte[]> map = instance.getMap(mapName);
+
+        int perIterationIncrementBytes = 2048;
+        long maxObservedHeapCost = 0;
+        for (int i = 0; i < 1000; i++) {
+            int payloadSizeBytes = i * perIterationIncrementBytes;
+            map.put(i, new byte[payloadSizeBytes]);
+            maxObservedHeapCost = max(maxObservedHeapCost, map.getLocalMapStats().getHeapCost());
+        }
+
+        double toleranceFactor = 1.1d;
+        long maxAllowedHeapCost = (long) (MemoryUnit.MEGABYTES.toBytes(maxSizeMB) * toleranceFactor);
+        long minAllowedHeapCost = (long) (MemoryUnit.MEGABYTES.toBytes(maxSizeMB) / toleranceFactor);
+        assertBetween("Maximum cost", maxObservedHeapCost, minAllowedHeapCost, maxAllowedHeapCost);
     }
 
     private void assertBackupsSweptOnAllNodes(String mapName, int maxSize, HazelcastInstance[] instances) {


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/13529

By default Hazelcast map evicts just a single entry in each eviction
cycle. However this is insufficient when inserting entries with
increasingly larger payload size - as evicting a single entry cannot
make sufficient room for a new (larger) entry.