### PR TITLE
Speed up closing Hazelcast connections in tests.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -119,10 +119,12 @@ public final class NioChannel extends AbstractChannel {
             inboundPipeline.requestClose();
             outboundPipeline.requestClose();
 
-            try {
-                Thread.sleep(DELAY_MS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+            if (DELAY_MS > 0) {
+                try {
+                    Thread.sleep(DELAY_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
 
             try {

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -137,6 +137,8 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
         System.setProperty("hazelcast.wait.seconds.before.join", "1");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
         System.setProperty("java.net.preferIPv4Stack", "true");
+        // speed up closing connections in com.hazelcast.internal.networking.nio.NioChannel.doClose()
+        System.setProperty("hazelcast.channel.close.delayMs", "0");
     }
 
     // When running a compatibility test, all com.hazelcast.* classes are transformed so that none are


### PR DESCRIPTION
This PR disables connection close delay for tests. The delay causes nightly build aborts as the builds take more than 8hr. They have run ~5hr before merging the IO pipelines PRs.
E.g. https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-3.x-nightly/183/

The IO pipeline stuff introduced a delay in connection closing to allow proper shutdown in handlers (namely the TLS handlers). https://github.com/hazelcast/hazelcast/pull/12295/files#diff-58926a8de148a712a88c68ca16d6604eR123
