### PR TITLE
Fix broken unit test for LatestUpdate MergePolicy

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MergePolicyTest.java
@@ -84,11 +84,11 @@ public class MergePolicyTest extends HazelcastTestSupport {
         IMap<Object, Object> map2 = h2.getMap(mapName);
         map1.put("key1", "value");
         // prevent updating at the same time
-        sleepAtLeastMillis(1);
+        sleepAtLeastMillis(1000);
         map2.put("key1", "LatestUpdatedValue");
         map2.put("key2", "value2");
         // prevent updating at the same time
-        sleepAtLeastMillis(1);
+        sleepAtLeastMillis(1000);
         map1.put("key2", "LatestUpdatedValue2");
 
         // allow merge process to continue


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/6976

LatestUpdated record fields have no millis resolution. So the sleep time should be longer, enough to meet the seconds resolution expectations.