### PR TITLE
Increases wait time in cache expiration backup test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
@@ -263,7 +263,7 @@ public class CacheExpirationTest extends CacheTestSupport {
     @Test
     public void test_whenEntryIsRemovedBackupIsCleaned() {
         SimpleExpiryListener listener = new SimpleExpiryListener();
-        CacheConfig<Integer, Integer> cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(1000, 1000, 1000), listener);
+        CacheConfig<Integer, Integer> cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(FIVE_SECONDS, FIVE_SECONDS, FIVE_SECONDS), listener);
         Cache<Integer, Integer> cache = createCache(cacheConfig);
 
         for (int i = 0; i < KEY_RANGE; i++) {
@@ -271,7 +271,7 @@ public class CacheExpirationTest extends CacheTestSupport {
             cache.remove(i);
         }
 
-        sleepAtLeastSeconds(1);
+        sleepAtLeastSeconds(5);
         assertEquals(0, listener.getExpirationCount().get());
         for (int i = 1; i < CLUSTER_SIZE; i++) {
             BackupAccessor backupAccessor = TestBackupUtils.newCacheAccessor(instances, cache.getName(), i);


### PR DESCRIPTION
The test does put-remove and ensures that backups also remove the entries. It ensures that remove operation is responsible for removals but not the expirations by waiting allowing expiration amount of time to pass. When the test experiences hiccups, one second wait may still cause expirations. So this pr increases the expiration time to 5 seconds to allow for hiccups.

Fixes https://github.com/hazelcast/hazelcast/issues/13619