### PR TITLE
[3.11] Fix remove WAN event cycle

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/BaseRemoveOperation.java
@@ -17,10 +17,15 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.MutatingOperation;
+
+import java.io.IOException;
 
 public abstract class BaseRemoveOperation extends LockAwareOperation
         implements BackupAwareOperation, MutatingOperation {
@@ -40,23 +45,6 @@ public abstract class BaseRemoveOperation extends LockAwareOperation
     }
 
     public BaseRemoveOperation() {
-    }
-
-    @Override
-    public void innerBeforeRun() throws Exception {
-        super.innerBeforeRun();
-        // RU_COMPAT_3_10
-        //
-        // we restore both the disableWanReplicationEvent and the ttl flags
-        // before the operation is getting executed
-        //
-        // this may happen if the operation was created by a 3.10.5+ member
-        // which carries over the disableWanReplicationEvent flag's value
-        // in the TTL field for wire format compatibility reasons
-        if ((ttl & BITMASK_TTL_DISABLE_WAN) == 0) {
-            disableWanReplicationEvent = true;
-            ttl ^= BITMASK_TTL_DISABLE_WAN;
-        }
     }
 
     @Override
@@ -96,5 +84,46 @@ public abstract class BaseRemoveOperation extends LockAwareOperation
     @Override
     public void onWaitExpire() {
         sendResponse(null);
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        // RU_COMPAT_3_10
+        if (disableWanReplicationEvent && out.getVersion().isEqualTo(Versions.V3_10)) {
+
+            // disableWanReplicationEvent flag is not serialized in 3.10, which may
+            // lead to publishing remove WAN events by error, if the operation
+            // executes on a remote node. This may lead to republishing remove
+            // events to clusters that have already processed it, possibly causing
+            // data loss, if the removed entry has been added back since then.
+            //
+            // Serializing the field would break the compatibility, hence
+            // we encode its value into the TTL field, which is serialized
+            // but not used for remove operations.
+            //
+            // Note that this serialization has the side effect that the
+            // value of TTL changes, but it is acceptable since the field
+            // is not in use.
+            // This value change is done during serialization to keep
+            // clusters already on 3.11+ unaffected from this compatibility trick.
+            this.ttl ^= BITMASK_TTL_DISABLE_WAN;
+        }
+
+        super.writeInternal(out);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+
+        // RU_COMPAT_3_10
+        if (in.getVersion().isEqualTo(Versions.V3_10)) {
+            // restore disableWanReplicationEvent flag
+            //
+            // this may happen if the operation was created by a 3.10.5+ member
+            // which carries over the disableWanReplicationEvent flag's value
+            // in the TTL field for wire format compatibility reasons
+            disableWanReplicationEvent |= (ttl & BITMASK_TTL_DISABLE_WAN) == 0;
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/RemoveBaseOperationWanFlagSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/RemoveBaseOperationWanFlagSerializationTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.operation;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.ObjectDataInputStream;
+import com.hazelcast.internal.serialization.impl.ObjectDataOutputStream;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.version.Version;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+import org.mockito.Mock;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteOrder;
+
+import static com.hazelcast.internal.cluster.Versions.V3_10;
+import static com.hazelcast.internal.cluster.Versions.V3_11;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class RemoveBaseOperationWanFlagSerializationTest {
+
+    static final String MAP_NAME = "map";
+
+    @Parameters(name = "clusterVersion: {0} byteOrder:{1} disableWanReplication:{2}")
+    public static Iterable<Object[]> parameters() {
+        return asList(new Object[][]{
+                {V3_10, ByteOrder.LITTLE_ENDIAN, true},
+                {V3_10, ByteOrder.LITTLE_ENDIAN, false},
+                {V3_10, ByteOrder.BIG_ENDIAN, true},
+                {V3_10, ByteOrder.BIG_ENDIAN, false},
+
+                {V3_11, ByteOrder.LITTLE_ENDIAN, true},
+                {V3_11, ByteOrder.LITTLE_ENDIAN, false},
+                {V3_11, ByteOrder.BIG_ENDIAN, true},
+                {V3_11, ByteOrder.BIG_ENDIAN, false},
+                });
+    }
+
+    @Parameter
+    public Version version;
+
+    @Parameter(1)
+    public ByteOrder byteOrder;
+
+    @Parameter(2)
+    public boolean disableWanReplication;
+
+    @Mock
+    Data keyMock;
+
+    @Mock
+    private InternalSerializationService serializationServiceMock;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        when(serializationServiceMock.getByteOrder()).thenReturn(byteOrder);
+    }
+
+    @Test
+    public void testRemoveOperation() throws IOException {
+        BaseRemoveOperation original = new RemoveOperation(MAP_NAME, keyMock, disableWanReplication);
+        BaseRemoveOperation deserialized = new RemoveOperation();
+
+        testSerialization(original, deserialized);
+    }
+
+    @Test
+    public void testDeleteOperation() throws IOException {
+        BaseRemoveOperation original = new DeleteOperation(MAP_NAME, keyMock, disableWanReplication);
+        BaseRemoveOperation deserialized = new DeleteOperation();
+
+        testSerialization(original, deserialized);
+    }
+
+    private void testSerialization(BaseRemoveOperation originalOp, BaseRemoveOperation deserializedOp) throws IOException {
+        serializeAndDeserialize(originalOp, deserializedOp);
+
+        assertEquals(originalOp.disableWanReplicationEvent, deserializedOp.disableWanReplicationEvent);
+    }
+
+    void serializeAndDeserialize(Operation originalOp, Operation deserializedOp) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectDataOutputStream out = new ObjectDataOutputStream(baos, serializationServiceMock);
+        out.setVersion(version);
+        originalOp.writeData(out);
+
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectDataInputStream in = new ObjectDataInputStream(bais, serializationServiceMock);
+        in.setVersion(version);
+
+        deserializedOp.readData(in);
+    }
+
+}


### PR DESCRIPTION
`3.11` OS part of the fix for the issue described in detail in hazelcast/hazelcast-enterprise/issues/2340

`3.10.x` OS part: https://github.com/hazelcast/hazelcast/pull/13623
`3.10.x` EE part: https://github.com/hazelcast/hazelcast-enterprise/pull/2342
`3.11` EE part: https://github.com/hazelcast/hazelcast-enterprise/pull/2344