### PR TITLE
[BACKPORT] Configurable map eviction batch size

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -63,6 +63,7 @@ import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.config.InMemoryFormat.OBJECT;
 import static com.hazelcast.map.impl.eviction.Evictor.NULL_EVICTOR;
 import static com.hazelcast.map.impl.mapstore.MapStoreContextFactory.createMapStoreContext;
+import static com.hazelcast.spi.properties.GroupProperty.MAP_EVICTION_BATCH_SIZE;
 import static java.lang.System.getProperty;
 
 /**
@@ -153,8 +154,10 @@ public class MapContainer {
         } else {
             MemoryInfoAccessor memoryInfoAccessor = getMemoryInfoAccessor();
             EvictionChecker evictionChecker = new EvictionChecker(memoryInfoAccessor, mapServiceContext);
-            IPartitionService partitionService = mapServiceContext.getNodeEngine().getPartitionService();
-            evictor = new EvictorImpl(mapEvictionPolicy, evictionChecker, partitionService);
+            NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+            IPartitionService partitionService = nodeEngine.getPartitionService();
+            int batchSize = nodeEngine.getProperties().getInteger(MAP_EVICTION_BATCH_SIZE);
+            evictor = new EvictorImpl(mapEvictionPolicy, evictionChecker, partitionService, batchSize);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -542,6 +542,20 @@ public final class GroupProperty {
     public static final HazelcastProperty MAP_EXPIRY_DELAY_SECONDS
             = new HazelcastProperty("hazelcast.map.expiry.delay.seconds", 10, SECONDS);
 
+    /**
+     * Maximum number of IMap entries Hazelcast will evict during a single eviction cycle.
+     * Eviction cycle is triggered by a map mutation. Typically it's OK to evict at most a single entry.
+     * However imagine the scenario where you are inserting values in a loop and in each iteration you double entry
+     * size. In this situation Hazelcast has to evict more than just a single entry - as all existing entries are
+     * smaller than the entry which is about to be added and removing any old entry cannot make sufficient room
+     * for the new entry.
+     *
+     * Default: 1
+     *
+     */
+    public static final HazelcastProperty MAP_EVICTION_BATCH_SIZE
+            = new HazelcastProperty("hazelcast.map.eviction.batch.size", 1);
+
     public static final HazelcastProperty LOGGING_TYPE
             = new HazelcastProperty("hazelcast.logging.type", "jdk");
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionMaxSizePolicyTest.java
@@ -368,7 +368,7 @@ public class EvictionMaxSizePolicyTest extends HazelcastTestSupport {
     private static final class TestEvictor extends EvictorImpl {
 
         TestEvictor(MapEvictionPolicy mapEvictionPolicy, EvictionChecker evictionChecker, IPartitionService partitionService) {
-            super(mapEvictionPolicy, evictionChecker, partitionService);
+            super(mapEvictionPolicy, evictionChecker, partitionService, 1);
         }
 
         @Override


### PR DESCRIPTION
By default Hazelcast map evicts just a single entry in each eviction
cycle. However this is insufficient when inserting entries with
increasingly larger payload size - as evicting a single entry cannot
make sufficient room for a new (larger) entry.

(cherry picked from commit 0c54f99196ef42e7053d8396592eb35a44fbf59a)
Backport of https://github.com/hazelcast/hazelcast/pull/13598