### PR TITLE
OperationThreadSampleDiagnostics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -47,6 +47,7 @@ import com.hazelcast.internal.diagnostics.MemberHeartbeatPlugin;
 import com.hazelcast.internal.diagnostics.MetricsPlugin;
 import com.hazelcast.internal.diagnostics.NetworkingImbalancePlugin;
 import com.hazelcast.internal.diagnostics.OperationHeartbeatPlugin;
+import com.hazelcast.internal.diagnostics.OperationThreadSamplerPlugin;
 import com.hazelcast.internal.diagnostics.OverloadedConnectionsPlugin;
 import com.hazelcast.internal.diagnostics.PendingInvocationsPlugin;
 import com.hazelcast.internal.diagnostics.SlowOperationPlugin;
@@ -448,6 +449,7 @@ public class DefaultNodeExtension implements NodeExtension {
         diagnostics.register(new MemberHeartbeatPlugin(nodeEngine));
         diagnostics.register(new NetworkingImbalancePlugin(nodeEngine));
         diagnostics.register(new OperationHeartbeatPlugin(nodeEngine));
+        diagnostics.register(new OperationThreadSamplerPlugin(nodeEngine));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationThreadSamplerPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationThreadSamplerPlugin.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.diagnostics;
+
+import com.hazelcast.spi.NamedOperation;
+import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.operationexecutor.OperationExecutor;
+import com.hazelcast.spi.impl.operationexecutor.OperationRunner;
+import com.hazelcast.spi.impl.operationservice.InternalOperationService;
+import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
+import com.hazelcast.spi.properties.HazelcastProperty;
+import com.hazelcast.util.ItemCounter;
+
+import java.util.concurrent.locks.LockSupport;
+
+import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * The OperationThreadSamplerPlugin is a {@link DiagnosticsPlugin} that samples the
+ * operations threads and checks with operations/tasks are running. We have
+ * the slow operation detector; which is very useful for very slow operations.
+ * But it isn't useful for high volumes of not too slow operations.
+ *
+ * With the operation sampler we have a lot better understanding which operations
+ * are actually running.
+ */
+public class OperationThreadSamplerPlugin extends DiagnosticsPlugin {
+
+    /**
+     * The sample period in seconds.
+     *
+     * This is the frequency it will dump content to file. It isn't the frequency
+     * that the operations are being sampled.
+     *
+     * <p>
+     * If set to 0, the plugin is disabled.
+     */
+    public static final HazelcastProperty PERIOD_SECONDS
+            = new HazelcastProperty(PREFIX + ".operationthreadsamples.period.seconds", 0, SECONDS);
+
+    /**
+     * The period in milliseconds between taking samples.
+     *
+     * The lower the period, the higher the overhead, but also the higher the
+     * precision.
+     */
+    public static final HazelcastProperty SAMPLER_PERIOD_MILLIS
+            = new HazelcastProperty(PREFIX + ".operationthreadsamples.sampler.period.millis", 100, MILLISECONDS);
+
+    /**
+     * If the name the data-structure the operation operates on should be included.
+     *
+     * WARNING: This feature should not be used in production because it can lead to
+     * quite a lot of litter and it can lead to uncontrolled memory growth because the
+     * samples of old data-structures will not be removed.
+     *
+     * Also each time the samples are taken, quite a lot of litter can be generated. So
+     * probably you do not want to have a too low SAMPLER_PERIOD_MILLIS because the lower
+     * it gets, the more litter is created.
+     */
+    public static final HazelcastProperty INCLUDE_NAME
+            = new HazelcastProperty(PREFIX + ".operationthreadsamples.includeName", false);
+    public static final float HUNDRED = 100f;
+
+
+    private final long periodMillis;
+    private final long samplerPeriodMillis;
+    private final ItemCounter<String> partitionSpecificSamples = new ItemCounter<String>();
+    private final ItemCounter<String> genericSamples = new ItemCounter<String>();
+    private final OperationExecutor executor;
+    private final NodeEngineImpl nodeEngine;
+    private final boolean includeName;
+
+    public OperationThreadSamplerPlugin(NodeEngineImpl nodeEngine) {
+        super(nodeEngine.getLogger(OperationThreadSamplerPlugin.class));
+        this.nodeEngine = nodeEngine;
+        InternalOperationService operationService = nodeEngine.getOperationService();
+        this.executor = ((OperationServiceImpl) operationService).getOperationExecutor();
+        HazelcastProperties props = nodeEngine.getProperties();
+        this.periodMillis = props.getMillis(PERIOD_SECONDS);
+        this.samplerPeriodMillis = props.getMillis(SAMPLER_PERIOD_MILLIS);
+        this.includeName = props.getBoolean(INCLUDE_NAME);
+    }
+
+    @Override
+    public long getPeriodMillis() {
+        return periodMillis;
+    }
+
+    @Override
+    public void onStart() {
+        logger.info("Plugin:active: period-millis:" + periodMillis + " sampler-period-millis:" + samplerPeriodMillis);
+
+        new SampleThread().start();
+    }
+
+    @Override
+    public void run(DiagnosticsLogWriter writer) {
+        writer.startSection("OperationThreadSamples");
+        write(writer, "Partition", partitionSpecificSamples);
+        write(writer, "Generic", genericSamples);
+        writer.endSection();
+    }
+
+    private void write(DiagnosticsLogWriter writer, String text, ItemCounter<String> samples) {
+        writer.startSection(text);
+        long total = samples.total();
+        for (String name : samples.descendingKeys()) {
+            long s = samples.get(name);
+            writer.writeKeyValueEntry(name, s + " " + (HUNDRED * s / total) + "%");
+        }
+        writer.endSection();
+    }
+
+    private class SampleThread extends Thread {
+
+        @Override
+        public void run() {
+            long nextRunMillis = System.currentTimeMillis();
+
+            while (nodeEngine.isActive()) {
+                LockSupport.parkUntil(nextRunMillis);
+                nextRunMillis = samplerPeriodMillis;
+                sample(executor.getPartitionOperationRunners(), partitionSpecificSamples);
+                sample(executor.getGenericOperationRunners(), genericSamples);
+            }
+        }
+
+        private void sample(OperationRunner[] runners, ItemCounter<String> samples) {
+            for (OperationRunner runner : runners) {
+                Object task = runner.currentTask();
+                if (task != null) {
+                    samples.inc(toKey(task));
+                }
+            }
+        }
+
+        private String toKey(Object task) {
+            String name;
+            if (includeName) {
+                if (task instanceof NamedOperation) {
+                    name = task.getClass().getName() + "#" + ((NamedOperation) task).getName();
+                } else {
+                    name = task.getClass().getName();
+                }
+            } else {
+                name = task.getClass().getName();
+            }
+            return name;
+        }
+    }
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ItemCounter.java
@@ -33,6 +33,18 @@ import static java.util.Collections.sort;
 public final class ItemCounter<T> {
 
     private final Map<T, MutableLong> map = new HashMap<T, MutableLong>();
+    private long total;
+
+    /**
+     * Returns the total counts.
+     *
+     * Complexity is O(1).
+     *
+     * @return total count.
+     */
+    public long total() {
+        return total;
+    }
 
     /**
      * Returns an iterator over all keys.
@@ -89,9 +101,21 @@ public final class ItemCounter<T> {
         if (entry == null) {
             entry = MutableLong.valueOf(value);
             map.put(item, entry);
+            total += value;
         } else {
+            total -= entry.value;
+            total += value;
             entry.value = value;
         }
+    }
+
+    /**
+     * Increases the count by on for the given item.
+     *
+     * @param item
+     */
+    public void inc(T item) {
+        add(item, 1);
     }
 
     /**
@@ -108,6 +132,7 @@ public final class ItemCounter<T> {
         } else {
             entry.value += delta;
         }
+        total += delta;
     }
 
     /**
@@ -120,6 +145,7 @@ public final class ItemCounter<T> {
         for (MutableLong entry : map.values()) {
             entry.value = 0;
         }
+        total = 0;
     }
 
     /**
@@ -127,6 +153,7 @@ public final class ItemCounter<T> {
      */
     public void clear() {
         map.clear();
+        total = 0;
     }
 
     /**
@@ -142,16 +169,19 @@ public final class ItemCounter<T> {
         if (entry == null) {
             entry = MutableLong.valueOf(value);
             map.put(item, entry);
+            total += value;
             return 0;
         }
 
         long oldValue = entry.value;
+        total = total - oldValue + value;
         entry.value = value;
         return oldValue;
     }
 
     public void remove(T item) {
-        map.remove(item);
+        MutableLong entry = map.remove(item);
+        total -= entry == null ? 0 : entry.value;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/util/ItemCounterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ItemCounterTest.java
@@ -83,10 +83,13 @@ public class ItemCounterTest extends HazelcastTestSupport {
         Object object = new Object();
 
         counter.set(object, Long.MIN_VALUE);
+
+        long oldTotal = counter.total();
         counter.set(object, value);
         long count = counter.get(object);
 
         assertEquals(value, count);
+        assertEquals(Long.MAX_VALUE, counter.total());
     }
 
     @Test
@@ -98,6 +101,7 @@ public class ItemCounterTest extends HazelcastTestSupport {
         long count = counter.get(object);
 
         assertEquals(delta, count);
+        assertEquals(1, counter.total());
     }
 
     @Test
@@ -111,6 +115,7 @@ public class ItemCounterTest extends HazelcastTestSupport {
         long count = counter.get(object);
 
         assertEquals(delta + initialValue, count);
+        assertEquals(2, counter.total());
     }
 
     @Test
@@ -129,6 +134,7 @@ public class ItemCounterTest extends HazelcastTestSupport {
 
         assertEquals(0, count1);
         assertEquals(0, count2);
+        assertEquals(0, counter.total());
     }
 
     @Test
@@ -141,13 +147,14 @@ public class ItemCounterTest extends HazelcastTestSupport {
 
         count = counter.get(object);
         assertEquals(newValue, count);
+        assertEquals(newValue, counter.total());
     }
 
     @Test
     public void testGetAndSet_overridePreviousValue() {
         Object object = new Object();
-        long initialValue = Long.MIN_VALUE;
-        long newValue = Long.MAX_VALUE;
+        long initialValue = 10;
+        long newValue = 20;
 
         counter.set(object, initialValue);
 
@@ -156,6 +163,7 @@ public class ItemCounterTest extends HazelcastTestSupport {
 
         count = counter.get(object);
         assertEquals(newValue, count);
+        assertEquals(count, counter.total());
     }
 
     @Test


### PR DESCRIPTION
It samples the operation-runners in the same way the
slow operation detector works.

This plugin is disabled by default, so forms no risk.

Example output:

```
28-08-2018 07:40:07 1535442007330 OperationThreadSamples[
                          Partition[
                                  com.hazelcast.map.impl.operation.HDPutOperation=16150734 85.56849%
                                  com.hazelcast.spi.impl.operationservice.impl.operations.Backup=1146500 6.0742917%
                                  com.hazelcast.map.impl.operation.HDGetOperation=494884 2.6219537%
                                  com.hazelcast.nio.Packet=361629 1.915953%
                                  com.hazelcast.client.impl.protocol.task.map.MapPutMessageTask=321317 1.7023753%
                                  com.hazelcast.client.impl.protocol.task.map.MapGetMessageTask=222022 1.1762987%
                                  com.hazelcast.map.impl.operation.AddIndexOperation=174180 0.9228261%
                                  com.hazelcast.internal.partition.operation.PartitionBackupReplicaAntiEntropyOperation=2269 0.012021429%
                                  com.hazelcast.map.impl.operation.HDMapSizeOperation=1096 0.005806737%]
                          Generic[
                                  com.hazelcast.client.impl.ClientEngineImpl$PriorityPartitionSpecificRunnable=2308 35.738617%
                                  com.hazelcast.nio.Packet=1767 27.361412%
                                  com.hazelcast.map.impl.query.HDQueryOperation=994 15.391762%
                                  com.hazelcast.internal.cluster.impl.operations.JoinRequestOp=821 12.712914%
                                  com.hazelcast.spi.impl.operationservice.impl.operations.PartitionIteratingOperation=278 4.3047385%
                                  com.hazelcast.internal.cluster.impl.operations.HeartbeatOp=93 1.4400743%
                                  com.hazelcast.internal.cluster.impl.operations.OnJoinOp=89 1.3781357%
                                  com.hazelcast.internal.cluster.impl.operations.WhoisMasterOp=75 1.1613503%
                                  com.hazelcast.client.impl.operations.ClientReAuthOperation=33 0.51099414%]]
```

The current output only shows the absolute number of samples; so it can be a bit of a pain if you care for a small time window. But it can still be calculated by making a delta by hand.

