### PR TITLE
Cleared storage before destroy to release all HD resources.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -209,10 +209,10 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
     private void removeRecordStoresHavingLesserBackupCountThan(int partitionId, int thresholdReplicaIndex) {
         if (thresholdReplicaIndex < 0) {
             mapServiceContext.removeRecordStoresFromPartitionMatchingWith(allRecordStores(), partitionId,
-                    false, false);
+                    false, true);
         } else {
             mapServiceContext.removeRecordStoresFromPartitionMatchingWith(lesserBackupMapsThen(thresholdReplicaIndex),
-                    partitionId, false, false);
+                    partitionId, false, true);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -58,14 +58,14 @@ class MapSplitBrainHandlerService extends AbstractSplitBrainHandlerService<Recor
     protected void onStoreCollection(RecordStore recordStore) {
         assertRunningOnPartitionThread();
 
-        ((DefaultRecordStore) recordStore).clearIndexedData(false);
+        ((DefaultRecordStore) recordStore).clearOtherDataThanStorage(true);
     }
 
     @Override
     protected void destroyStore(RecordStore store) {
         assertRunningOnPartitionThread();
 
-        store.destroyInternals();
+        ((DefaultRecordStore) store).destroyStorageAfterClear(false, true);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -144,9 +144,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
      * @param backup             <code>true</code> if backup, false otherwise.
      */
     private void flush(Collection<Record> recordsToBeFlushed, boolean backup) {
-        Iterator<Record> iterator = recordsToBeFlushed.iterator();
-        while (iterator.hasNext()) {
-            Record record = iterator.next();
+        for (Record record : recordsToBeFlushed) {
             mapDataStore.flush(record.getKey(), record.getValue(), backup);
         }
     }
@@ -840,6 +838,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         saveIndex(record, oldValue);
         return oldValue;
     }
+
     @Override
     public boolean replace(Data key, Object expect, Object update) {
         checkIfLoaded();
@@ -1201,28 +1200,64 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     @Override
     public void destroy() {
         clearPartition(false, true);
-        storage.destroy(false);
-        mutationObserver.onDestroy(false);
     }
 
     @Override
-    public void destroyInternals() {
-        clearMapStore();
-        clearStorage(false);
-        storage.destroy(false);
-        mutationObserver.onDestroy(true);
-    }
-
-    @Override
-    public void clearPartition(boolean onShutdown, boolean onRecordStoreDestroy) {
-        clearOtherResourcesThanStorage(onRecordStoreDestroy);
-        clearStorage(onShutdown || onRecordStoreDestroy);
-    }
-
-    public void clearOtherResourcesThanStorage(boolean onRecordStoreDestroy) {
-        clearMapStore();
+    public void clearPartition(boolean onShutdown, boolean onStorageDestroy) {
         clearLockStore();
-        clearIndexedData(onRecordStoreDestroy);
+        clearOtherDataThanStorage(onStorageDestroy);
+
+        if (onShutdown) {
+            if (hasPooledMemoryAllocator()) {
+                destroyStorageImmediate(true, true);
+            } else {
+                destroyStorageAfterClear(true, true);
+            }
+        } else {
+            if (onStorageDestroy) {
+                destroyStorageAfterClear(false, false);
+            } else {
+                clearStorage(false);
+            }
+        }
+    }
+
+    private boolean hasPooledMemoryAllocator() {
+        NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
+        NativeMemoryConfig nativeMemoryConfig = nodeEngine.getConfig().getNativeMemoryConfig();
+        return nativeMemoryConfig != null && nativeMemoryConfig.getAllocatorType() == POOLED;
+    }
+
+    /**
+     * Only cleans the data other than storage-data that is held on this record
+     * store. Other services data like lock-service-data is not cleared here.
+     */
+    public void clearOtherDataThanStorage(boolean onStorageDestroy) {
+        clearMapStore();
+        clearIndexedData(onStorageDestroy);
+    }
+
+    private void destroyStorageImmediate(boolean isDuringShutdown, boolean internal) {
+        storage.destroy(isDuringShutdown);
+        mutationObserver.onDestroy(internal);
+    }
+
+    /**
+     * Calls also {@link #clearStorage(boolean)} to release allocated HD memory
+     * of key+value pairs because {@link #destroyStorageImmediate(boolean, boolean)}
+     * only releases internal resources of backing data structure.
+     *
+     * @param isDuringShutdown {@link Storage#clear(boolean)}
+     * @param internal         see {@link RecordStoreMutationObserver#onDestroy(boolean)}}
+     */
+    public void destroyStorageAfterClear(boolean isDuringShutdown, boolean internal) {
+        clearStorage(isDuringShutdown);
+        destroyStorageImmediate(isDuringShutdown, internal);
+    }
+
+    private void clearStorage(boolean isDuringShutdown) {
+        storage.clear(isDuringShutdown);
+        mutationObserver.onClear();
     }
 
     private void clearLockStore() {
@@ -1234,23 +1269,6 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }
     }
 
-    public void clearStorage(boolean onShutdown) {
-        if (onShutdown) {
-            NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
-            NativeMemoryConfig nativeMemoryConfig = nodeEngine.getConfig().getNativeMemoryConfig();
-            boolean shouldClear = (nativeMemoryConfig != null && nativeMemoryConfig.getAllocatorType() != POOLED);
-            if (shouldClear) {
-                storage.clear(true);
-                mutationObserver.onClear();
-            }
-            storage.destroy(true);
-            mutationObserver.onDestroy(true);
-        } else {
-            storage.clear(false);
-            mutationObserver.onClear();
-        }
-    }
-
     private void clearMapStore() {
         mapDataStore.reset();
     }
@@ -1258,9 +1276,9 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     /**
      * Only indexed data will be removed, index info will stay.
      */
-    public void clearIndexedData(boolean onRecordStoreDestroy) {
+    private void clearIndexedData(boolean onStorageDestroy) {
         clearGlobalIndexes();
-        clearPartitionedIndexes(onRecordStoreDestroy);
+        clearPartitionedIndexes(onStorageDestroy);
     }
 
     private void clearGlobalIndexes() {
@@ -1274,13 +1292,13 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         }
     }
 
-    private void clearPartitionedIndexes(boolean onRecordStoreDestroy) {
+    private void clearPartitionedIndexes(boolean onStorageDestroy) {
         Indexes indexes = mapContainer.getIndexes(partitionId);
         if (indexes.isGlobal()) {
             return;
         }
 
-        if (onRecordStoreDestroy) {
+        if (onStorageDestroy) {
             indexes.destroyIndexes();
         } else {
             indexes.clearAll();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -530,10 +530,4 @@ public interface RecordStore<R extends Record> {
      * Destroys data in this record store.
      */
     void destroy();
-
-    /**
-     * Like {@link #destroy()} but does not touch state on other services
-     * like lock service or event journal service.
-     */
-    void destroyInternals();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
@@ -69,6 +69,9 @@ public interface Storage<K, R> {
 
     boolean isEmpty();
 
+    /**
+     * @param isDuringShutdown only used by hot-restart.
+     */
     void clear(boolean isDuringShutdown);
 
     void destroy(boolean isDuringShutdown);


### PR DESCRIPTION
To release key+value pairs storage#clear should be called,
storage#destroy only releases internal resources of backing
data structure.

__About PR:__ 
All resource releasing functionality collected inside `clearPartition` method.

fixes https://github.com/hazelcast/hazelcast-enterprise/issues/859

ee counterpart https://github.com/hazelcast/hazelcast-enterprise/pull/2363