### PR TITLE
Use weighted average in index stats tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
@@ -133,13 +133,21 @@ public class ClientIndexStatsTest extends LocalIndexStatsTest {
             assertNotNull(indexStats2);
 
             LocalIndexStatsImpl combinedIndexStats = new LocalIndexStatsImpl();
-            assertEquals(indexStats1.getHitCount(), indexStats2.getHitCount());
-            combinedIndexStats.setHitCount(indexStats1.getHitCount());
+            long hitCount1 = indexStats1.getHitCount();
+            long hitCount2 = indexStats2.getHitCount();
+            assertEquals(hitCount1, hitCount2);
+            combinedIndexStats.setHitCount(hitCount1);
 
             assertEquals(indexStats1.getQueryCount(), indexStats2.getQueryCount());
             combinedIndexStats.setQueryCount(indexStats1.getQueryCount());
-            combinedIndexStats.setAverageHitSelectivity(
-                    (indexStats1.getAverageHitSelectivity() + indexStats2.getAverageHitSelectivity()) / 2.0);
+            if (hitCount1 + hitCount2 == 0) {
+                combinedIndexStats.setAverageHitSelectivity(0.0);
+            } else {
+                // use weighted average for better precision
+                combinedIndexStats.setAverageHitSelectivity(
+                        (hitCount1 * indexStats1.getAverageHitSelectivity() + hitCount2 * indexStats2.getAverageHitSelectivity())
+                                / (hitCount1 + hitCount2));
+            }
             combinedIndexStats
                     .setAverageHitLatency((indexStats1.getAverageHitLatency() + indexStats2.getAverageHitLatency()) / 2);
 


### PR DESCRIPTION
If for some reason query result sizes are skewed in a favor of a certain
member, the usual averaging stats computation may suffer from a precision
loss. To fix that weighted averaging is used.

Fixes: https://github.com/hazelcast/hazelcast/issues/13657