### PR TITLE
[BACKPORT]Added storage destroy to release HD resources.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -316,7 +316,7 @@ class MapServiceContextImpl implements MapServiceContext {
                 RecordStore recordStore = iter.next();
                 final MapContainer mapContainer = recordStore.getMapContainer();
                 if (backupCount > mapContainer.getTotalBackupCount()) {
-                    recordStore.clearPartition(false, false);
+                    recordStore.clearPartition(false, true);
                     iter.remove();
                 }
             }
@@ -328,7 +328,7 @@ class MapServiceContextImpl implements MapServiceContext {
         final PartitionContainer container = partitionContainers[partitionId];
         if (container != null) {
             for (RecordStore mapPartition : container.getMaps().values()) {
-                mapPartition.clearPartition(false, false);
+                mapPartition.clearPartition(false, true);
             }
             container.getMaps().clear();
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapSplitBrainHandlerService.java
@@ -58,14 +58,14 @@ class MapSplitBrainHandlerService extends AbstractSplitBrainHandlerService<Recor
     protected void onStoreCollection(RecordStore recordStore) {
         assertRunningOnPartitionThread();
 
-        ((DefaultRecordStore) recordStore).clearIndexedData();
+        ((DefaultRecordStore) recordStore).clearOtherDataThanStorage(true);
     }
 
     @Override
     protected void destroyStore(RecordStore store) {
         assertRunningOnPartitionThread();
 
-        store.destroyInternals();
+        ((DefaultRecordStore) store).destroyStorageAfterClear(false);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/Storage.java
@@ -69,6 +69,9 @@ public interface Storage<K, R> {
 
     boolean isEmpty();
 
+    /**
+     * @param isDuringShutdown only used by hot-restart.
+     */
     void clear(boolean isDuringShutdown);
 
     void destroy(boolean isDuringShutdown);


### PR DESCRIPTION
To release key+value pairs storage#clear should be called,
storage#destroy only releases internal resources of backing
data structure

closes https://github.com/hazelcast/hazelcast-enterprise/issues/859