### PR TITLE
[FORWARD PORT] Refactored client query cache server-response handling code paths.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.querycache.subscriber;
 
+import com.hazelcast.config.EvictionConfig;
 import com.hazelcast.config.MapIndexConfig;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.IMap;
@@ -46,7 +47,6 @@ import static com.hazelcast.query.impl.IndexCopyBehavior.COPY_ON_READ;
  * @param <V> the value type for this {@link InternalQueryCache}
  */
 abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K, V> {
-
     protected final boolean includeValue;
     protected final String mapName;
     protected final String cacheId;
@@ -102,6 +102,14 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
 
     protected Predicate getPredicate() {
         return queryCacheConfig.getPredicateConfig().getImplementation();
+    }
+
+    @Override
+    public boolean reachedMaxCapacity() {
+        EvictionConfig evictionConfig = queryCacheConfig.getEvictionConfig();
+        EvictionConfig.MaxSizePolicy maximumSizePolicy = evictionConfig.getMaximumSizePolicy();
+        return maximumSizePolicy == EvictionConfig.MaxSizePolicy.ENTRY_COUNT
+                && size() == evictionConfig.getSize();
     }
 
     private EvictionListener getEvictionListener() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractQueryCacheEndToEndConstructor.java
@@ -47,7 +47,6 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
     protected final SubscriberContext subscriberContext;
     protected final ILogger logger = Logger.getLogger(getClass());
 
-    protected boolean includeValue;
     protected InternalQueryCache queryCache;
 
     private Predicate predicate;
@@ -147,8 +146,6 @@ public abstract class AbstractQueryCacheEndToEndConstructor implements QueryCach
             return null;
         }
 
-        // init some required parameters
-        this.includeValue = queryCacheConfig.isIncludeValue();
         this.predicate = queryCacheConfig.getPredicateConfig().getImplementation();
 
         return queryCacheConfig;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -49,7 +49,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,6 +56,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.map.impl.querycache.subscriber.AbstractQueryCacheEndToEndConstructor.OPERATION_WAIT_TIMEOUT_MINUTES;
+import static com.hazelcast.map.impl.querycache.subscriber.EventPublisherHelper.publishEntryEvent;
 import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.Preconditions.checkNoNullInside;
@@ -80,35 +80,44 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
     }
 
     @Override
-    public void setInternal(K key, V value, boolean callDelegate, EntryEventType eventType) {
+    public void set(K key, V value, EntryEventType eventType) {
+        setInternal(key, value, eventType, true);
+    }
+
+    @Override
+    public void prepopulate(K key, V value) {
+        setInternal(key, value, EntryEventType.ADDED, false);
+    }
+
+    /**
+     * @param doEvictionCheck when doing pre-population of query cache, set
+     *                        this to false since we quit population if we reach max capacity {@link
+     *                        #reachedMaxCapacity()}, eviction is not needed.
+     */
+    private void setInternal(K key, V value, EntryEventType eventType, boolean doEvictionCheck) {
         Data keyData = toData(key);
         Data valueData = toData(value);
 
-        if (callDelegate) {
-            getDelegate().set(keyData, valueData);
-        }
-        QueryCacheRecord oldRecord = recordStore.add(keyData, valueData);
+        QueryCacheRecord oldRecord = doEvictionCheck
+                ? recordStore.add(keyData, valueData) : recordStore.addWithoutEvictionCheck(keyData, valueData);
 
         if (eventType != null) {
-            EventPublisherHelper.publishEntryEvent(context, mapName, cacheId, keyData, valueData, oldRecord, eventType);
+            publishEntryEvent(context, mapName, cacheId, keyData, valueData, oldRecord, eventType);
         }
     }
 
     @Override
-    public void deleteInternal(Object key, boolean callDelegate, EntryEventType eventType) {
+    public void delete(Object key, EntryEventType eventType) {
         checkNotNull(key, "key cannot be null");
 
         Data keyData = toData(key);
 
-        if (callDelegate) {
-            getDelegate().delete(keyData);
-        }
         QueryCacheRecord oldRecord = recordStore.remove(keyData);
         if (oldRecord == null) {
             return;
         }
         if (eventType != null) {
-            EventPublisherHelper.publishEntryEvent(context, mapName, cacheId, keyData, null, oldRecord, eventType);
+            publishEntryEvent(context, mapName, cacheId, keyData, null, oldRecord, eventType);
         }
     }
 
@@ -494,9 +503,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
         int removedEntryCount = 0;
 
         Set<Data> keys = recordStore.keySet();
-        Iterator<Data> iterator = keys.iterator();
-        while (iterator.hasNext()) {
-            Data keyData = iterator.next();
+        for (Data keyData : keys) {
             if (context.getPartitionId(keyData) == partitionId) {
                 if (recordStore.remove(keyData) != null) {
                     removedEntryCount++;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRecordStore.java
@@ -83,6 +83,11 @@ class DefaultQueryCacheRecordStore implements QueryCacheRecordStore {
     public QueryCacheRecord add(Data keyData, Data valueData) {
         evictionOperator.evictIfRequired();
 
+        return addWithoutEvictionCheck(keyData, valueData);
+    }
+
+    @Override
+    public QueryCacheRecord addWithoutEvictionCheck(Data keyData, Data valueData) {
         QueryCacheRecord newRecord = recordFactory.createRecord(valueData);
         QueryCacheRecord oldRecord = cache.put(keyData, newRecord);
         saveIndex(keyData, newRecord, oldRecord);
@@ -151,15 +156,10 @@ class DefaultQueryCacheRecordStore implements QueryCacheRecordStore {
 
     @Override
     public int clear() {
-        int removeCount = 0;
-        Set<Data> dataKeys = keySet();
-        for (Data dataKey : dataKeys) {
-            QueryCacheRecord oldRecord = remove(dataKey);
-            if (oldRecord != null) {
-                removeCount++;
-            }
-        }
-        return removeCount;
+        int removedEntryCount = cache.size();
+        cache.clear();
+        indexes.clearAll();
+        return removedEntryCount;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
@@ -30,9 +30,15 @@ import com.hazelcast.query.impl.Indexes;
  */
 public interface InternalQueryCache<K, V> extends QueryCache<K, V> {
 
-    void setInternal(K key, V value, boolean callDelegate, EntryEventType eventType);
+    void set(K key, V value, EntryEventType eventType);
 
-    void deleteInternal(Object key, boolean callDelegate, EntryEventType eventType);
+    /**
+     * Used during initial population of query cache. Initially fetched data
+     * from cluster will be written to query cache by the help of this method.
+     */
+    void prepopulate(K key, V value);
+
+    void delete(Object key, EntryEventType eventType);
 
     /**
      * Scans all entries in this {@link QueryCache} to remove matching ones
@@ -54,4 +60,13 @@ public interface InternalQueryCache<K, V> extends QueryCache<K, V> {
      * @return internally used ID for this query cache
      */
     String getCacheId();
+
+    /**
+     * Used to quit pre-population when max size is reached.
+     *
+     * @return {@code true} if this query cache is at its max capacity,
+     * otherwise return {@code false}
+     * @see com.hazelcast.config.QueryCacheConfig#populate
+     */
+    boolean reachedMaxCapacity();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCache.java
@@ -29,6 +29,7 @@ import java.util.Set;
 /**
  * Object for neutral {@code InternalQueryCache} implementation.
  */
+@SuppressWarnings("checkstyle:methodcount")
 public final class NullQueryCache implements InternalQueryCache {
 
     /**
@@ -40,11 +41,16 @@ public final class NullQueryCache implements InternalQueryCache {
     }
 
     @Override
-    public void setInternal(Object key, Object value, boolean callDelegate, EntryEventType eventType) {
+    public void set(Object key, Object value, EntryEventType eventType) {
     }
 
     @Override
-    public void deleteInternal(Object key, boolean callDelegate, EntryEventType eventType) {
+    public void prepopulate(Object key, Object value) {
+
+    }
+
+    @Override
+    public void delete(Object key, EntryEventType eventType) {
     }
 
     @Override
@@ -74,6 +80,11 @@ public final class NullQueryCache implements InternalQueryCache {
     @Override
     public String getCacheId() {
         return null;
+    }
+
+    @Override
+    public boolean reachedMaxCapacity() {
+        return false;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheRecordStore.java
@@ -29,6 +29,8 @@ public interface QueryCacheRecordStore {
 
     QueryCacheRecord add(Data keyData, Data valueData);
 
+    QueryCacheRecord addWithoutEvictionCheck(Data keyData, Data valueData);
+
     QueryCacheRecord get(Data keyData);
 
     QueryCacheRecord remove(Data keyData);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
@@ -86,11 +86,11 @@ class SubscriberAccumulatorHandler implements AccumulatorHandler<QueryCacheEvent
             case UPDATED:
             case MERGED:
             case LOADED:
-                queryCache.setInternal(keyData, valueData, false, entryEventType);
+                queryCache.set(keyData, valueData, entryEventType);
                 break;
             case REMOVED:
             case EVICTED:
-                queryCache.deleteInternal(keyData, false, entryEventType);
+                queryCache.delete(keyData, entryEventType);
                 break;
             case CLEAR_ALL:
                 handleMapWideEvent(eventData, entryEventType, clearAllRemovedCountHolders);


### PR DESCRIPTION
- Introduced reachedMaxCapacity method to quit pre-population if query
  cache is at its evictable max capacity.
- Removed loop that iterates over all entries while clearing query cache.
  Instead directly called clear method of backing data structure.
- Renamed methods

forward port of https://github.com/hazelcast/hazelcast/pull/13575