### PR TITLE
Use exact avg selectivity calculation in index tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
@@ -23,12 +23,22 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.LocalIndexStatsTest;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.map.impl.PartitionContainer;
+import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.monitor.LocalIndexStats;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.impl.LocalIndexStatsImpl;
 import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+import com.hazelcast.monitor.impl.PerIndexStats;
 import com.hazelcast.query.PartitionPredicate;
 import com.hazelcast.query.Predicates;
+import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -38,8 +48,11 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
@@ -105,19 +118,21 @@ public class ClientIndexStatsTest extends LocalIndexStatsTest {
 
     @Override
     protected LocalMapStats stats() {
-        LocalMapStats stats1 = map1.getLocalMapStats();
-        LocalMapStats stats2 = map2.getLocalMapStats();
-        return combineStats(stats1, stats2);
+        return combineStats(map1, map2);
     }
 
     @Override
     protected LocalMapStats noStats() {
-        LocalMapStats stats1 = noStatsMap1.getLocalMapStats();
-        LocalMapStats stats2 = noStatsMap2.getLocalMapStats();
-        return combineStats(stats1, stats2);
+        return combineStats(noStatsMap1, noStatsMap2);
     }
 
-    private static LocalMapStats combineStats(LocalMapStats stats1, LocalMapStats stats2) {
+    private static LocalMapStats combineStats(IMap map1, IMap map2) {
+        LocalMapStats stats1 = map1.getLocalMapStats();
+        LocalMapStats stats2 = map2.getLocalMapStats();
+
+        List<Indexes> allIndexes = getAllIndexes(map1);
+        allIndexes.addAll(getAllIndexes(map2));
+
         LocalMapStatsImpl combinedStats = new LocalMapStatsImpl();
 
         assertEquals(stats1.getQueryCount(), stats2.getQueryCount());
@@ -138,10 +153,18 @@ public class ClientIndexStatsTest extends LocalIndexStatsTest {
 
             assertEquals(indexStats1.getQueryCount(), indexStats2.getQueryCount());
             combinedIndexStats.setQueryCount(indexStats1.getQueryCount());
-            combinedIndexStats.setAverageHitSelectivity(
-                    (indexStats1.getAverageHitSelectivity() + indexStats2.getAverageHitSelectivity()) / 2.0);
             combinedIndexStats
                     .setAverageHitLatency((indexStats1.getAverageHitLatency() + indexStats2.getAverageHitLatency()) / 2);
+
+            long totalHitCount = 0;
+            double totalNormalizedHitCardinality = 0.0;
+            for (Indexes indexes : allIndexes) {
+                PerIndexStats perIndexStats = indexes.getIndex(indexEntry.getKey()).getPerIndexStats();
+                totalHitCount += perIndexStats.getHitCount();
+                totalNormalizedHitCardinality += perIndexStats.getTotalNormalizedHitCardinality();
+            }
+            combinedIndexStats
+                    .setAverageHitSelectivity(totalHitCount == 0 ? 0.0 : 1.0 - totalNormalizedHitCardinality / totalHitCount);
 
             combinedIndexStats.setInsertCount(indexStats1.getInsertCount() + indexStats2.getInsertCount());
             combinedIndexStats.setTotalInsertLatency(indexStats1.getTotalInsertLatency() + indexStats2.getTotalInsertLatency());
@@ -159,6 +182,38 @@ public class ClientIndexStatsTest extends LocalIndexStatsTest {
         combinedStats.setIndexStats(combinedIndexStatsMap);
 
         return combinedStats;
+    }
+
+    private static List<Indexes> getAllIndexes(IMap map) {
+        MapProxyImpl mapProxy = (MapProxyImpl) map;
+        String mapName = mapProxy.getName();
+        NodeEngine nodeEngine = mapProxy.getNodeEngine();
+        IPartitionService partitionService = nodeEngine.getPartitionService();
+        MapService mapService = nodeEngine.getService(MapService.SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+
+        Indexes maybeGlobalIndexes = mapContainer.getIndexes();
+        if (maybeGlobalIndexes != null) {
+            return Collections.singletonList(maybeGlobalIndexes);
+        }
+
+        PartitionContainer[] partitionContainers = mapServiceContext.getPartitionContainers();
+        List<Indexes> allIndexes = new ArrayList<Indexes>();
+        for (PartitionContainer partitionContainer : partitionContainers) {
+            IPartition partition = partitionService.getPartition(partitionContainer.getPartitionId());
+            if (!partition.isLocal()) {
+                continue;
+            }
+
+            Indexes partitionIndexes = partitionContainer.getIndexes().get(mapName);
+            if (partitionIndexes == null) {
+                continue;
+            }
+            assert !partitionIndexes.isGlobal();
+            allIndexes.add(partitionIndexes);
+        }
+        return allIndexes;
     }
 
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
@@ -130,7 +130,8 @@ public class ClientIndexStatsTest extends LocalIndexStatsTest {
         LocalMapStats stats1 = map1.getLocalMapStats();
         LocalMapStats stats2 = map2.getLocalMapStats();
 
-        List<Indexes> allIndexes = getAllIndexes(map1);
+        List<Indexes> allIndexes = new ArrayList<Indexes>();
+        allIndexes.addAll(getAllIndexes(map1));
         allIndexes.addAll(getAllIndexes(map2));
 
         LocalMapStatsImpl combinedStats = new LocalMapStatsImpl();

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
@@ -521,7 +521,7 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testInsertUpdateRemoveAreNotEffectEachOther() {
+    public void testInsertUpdateRemoveAreNotAffectingEachOther() {
         map.addIndex("__key", false);
         assertEquals(0, keyStats().getInsertCount());
         assertEquals(0, keyStats().getUpdateCount());


### PR DESCRIPTION
If for some reason query result sizes are skewed in a favor of a certain
member, the simple averaging stats computation may suffer from a precision
loss. To fix that the exact calculation is used in tests now.

Fixes: https://github.com/hazelcast/hazelcast/issues/13657