### PR TITLE
Fix possible NPE in TcpIpConnectionChannelErrorHandler

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
@@ -94,7 +94,10 @@ public abstract class AbstractChannel implements Channel {
     @Override
     public SocketAddress remoteSocketAddress() {
         if (remoteAddress == null) {
-            REMOTE_ADDRESS.compareAndSet(this, null, socket().getRemoteSocketAddress());
+            Socket socket = socket();
+            if (socket != null) {
+                REMOTE_ADDRESS.compareAndSet(this, null, socket.getRemoteSocketAddress());
+            }
         }
         return remoteAddress;
     }
@@ -102,7 +105,10 @@ public abstract class AbstractChannel implements Channel {
     @Override
     public SocketAddress localSocketAddress() {
         if (localAddress == null) {
-            LOCAL_ADDRESS.compareAndSet(this, null, socket().getLocalSocketAddress());
+            Socket socket = socket();
+            if (socket != null) {
+                LOCAL_ADDRESS.compareAndSet(this, null, socket().getLocalSocketAddress());
+            }
         }
         return localAddress;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -23,6 +23,7 @@ import com.hazelcast.internal.networking.OutboundFrame;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
 import java.util.Date;
 
@@ -145,20 +146,20 @@ public final class NioChannel extends AbstractChannel {
     //  this toString implementation is very useful for debugging. Please don't remove it.
     @Override
     public String toString() {
-        try {
-            InetSocketAddress local = (InetSocketAddress) localSocketAddress();
-            InetSocketAddress remote = (InetSocketAddress) remoteSocketAddress();
-            String s = isClientMode() ? local.getPort() + "=>" + remote.getPort() : local.getPort() + "->" + remote.getPort();
+        String local = getPort(localSocketAddress());
+        String remote = getPort(remoteSocketAddress());
+        String s = local + (isClientMode() ? "=>" : "->") + remote;
 
-            // this is added for debugging so that 'client' and 'server' have a different indentation and are easy to recognize.
-            if (!isClientMode()) {
-                s = "                                                                                " + s;
-            }
+        // this is added for debugging so that 'client' and 'server' have a different indentation and are easy to recognize.
+//        if (!isClientMode()) {
+//            s = "                                                                                " + s;
+//        }
 
-            Date date = new Date();
-            return date.getHours() + ":" + date.getMinutes() + ":" + date.getSeconds() + " " + s;
-        } catch (NullPointerException e) {
-            return "Better protection needed";
-        }
+        Date date = new Date();
+        return date.getHours() + ":" + date.getMinutes() + ":" + date.getSeconds() + " " + s;
+    }
+
+    private String getPort(SocketAddress socketAddress) {
+        return socketAddress == null ? "*missing*" : Integer.toString(((InetSocketAddress) socketAddress).getPort());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipeline.java
@@ -311,10 +311,14 @@ public abstract class NioPipeline implements MigratablePipeline, Runnable {
         @Override
         public void run0() {
             try {
+                boolean hasHandlers = false;
                 for (ChannelHandler handler : handlers()) {
+                    hasHandlers = true;
                     handler.requestClose();
                 }
-                NioPipeline.this.run();
+                if (hasHandlers) {
+                    NioPipeline.this.run();
+                }
             } catch (Exception e) {
                 logger.finest("Error while closing outbound", e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionChannelErrorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnectionChannelErrorHandler.java
@@ -43,10 +43,13 @@ public class TcpIpConnectionChannelErrorHandler implements ChannelErrorHandler {
             logger.severe(error);
         } else {
             TcpIpConnection connection = (TcpIpConnection) channel.attributeMap().get(TcpIpConnection.class);
-            if (error instanceof EOFException) {
-                connection.close("Connection closed by the other side", error);
+            if (connection != null) {
+                String closeReason = (error instanceof EOFException)
+                        ? "Connection closed by the other side"
+                        : "Exception in " + connection + ", thread=" + Thread.currentThread().getName();
+                connection.close(closeReason, error);
             } else {
-                connection.close("Exception in " + connection + ", thread=" + Thread.currentThread().getName(), error);
+                logger.warning("Channel error occured", error);
             }
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.jmx.ManagementService;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -117,7 +118,8 @@ public class TestAwareInstanceFactory {
     protected void shutdownInstances(List<HazelcastInstance> listToRemove) {
         if (listToRemove != null) {
             for (HazelcastInstance hz : listToRemove) {
-                hz.shutdown();
+                ManagementService.shutdown(hz.getName());
+                hz.getLifecycleService().terminate();
             }
         }
     }


### PR DESCRIPTION
This PR prevents several NPEs in IO pipeline code.

I started to investigate the code when I saw following trace entry in a test log:
```
15:22:00,930 TRACE - [NioInboundPipeline] hz._hzInstance_1_dev.IO.thread-in-0 - [127.0.0.1]:5701 [dev] [3.11-SNAPSHOT] Error while closing outbound
java.lang.NullPointerException
        at com.hazelcast.core@3.11-SNAPSHOT/com.hazelcast.nio.tcp.TcpIpConnectionChannelErrorHandler.onError(TcpIpConnectionChannelErrorHandler.java:49) ~[hazelcast-3.11-SNAPSHOT.jar:?]
        at com.hazelcast.core@3.11-SNAPSHOT/com.hazelcast.internal.networking.nio.NioPipeline.onError(NioPipeline.java:265) ~[hazelcast-3.11-SNAPSHOT.jar:?]
        at com.hazelcast.core@3.11-SNAPSHOT/com.hazelcast.internal.networking.nio.NioPipeline.run(NioPipeline.java:221) ~[hazelcast-3.11-SNAPSHOT.jar:?]
        at com.hazelcast.core@3.11-SNAPSHOT/com.hazelcast.internal.networking.nio.NioPipeline$RequestCloseTask.run0(NioPipeline.java:309) [hazelcast-3.11-SNAPSHOT.jar:?]
        at com.hazelcast.core@3.11-SNAPSHOT/com.hazelcast.internal.networking.nio.NioPipelineTask.run(NioPipelineTask.java:47) [hazelcast-3.11-SNAPSHOT.jar:?]
        at com.hazelcast.core@3.11-SNAPSHOT/com.hazelcast.internal.networking.nio.NioThread.processTaskQueue(NioThread.java:340) [hazelcast-3.11-SNAPSHOT.jar:?]
        at com.hazelcast.core@3.11-SNAPSHOT/com.hazelcast.internal.networking.nio.NioThread.selectLoop(NioThread.java:275) [hazelcast-3.11-SNAPSHOT.jar:?]
        at com.hazelcast.core@3.11-SNAPSHOT/com.hazelcast.internal.networking.nio.NioThread.run(NioThread.java:234) [hazelcast-3.11-SNAPSHOT.jar:?]
```