### PR TITLE
Whitelist "process reaper thread" in the Thread Leak Tests

### DIFF
--- a/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLeakTestUtils.java
@@ -40,9 +40,13 @@ public final class ThreadLeakTestUtils {
      * List of whitelisted classes of threads, which are allowed to be not joinable.
      * We should not add classes of Hazelcast production code here, just test related classes.
      */
-    private static final List<Class> THREAD_CLASS_WHITELIST = asList(new Class[]{
+    private static final List<Class<?>> THREAD_CLASS_WHITELIST = asList(new Class<?>[]{
             JitterThread.class,
     });
+    private static final List<String> THREAD_NAME_WHITELIST = asList(
+            "process reaper",
+            "surefire-forkedjvm-ping-30s"
+    );
 
     private static final ILogger LOGGER = Logger.getLogger(ThreadLeakTestUtils.class);
 
@@ -100,7 +104,9 @@ public final class ThreadLeakTestUtils {
         Iterator<Thread> iterator = threads.iterator();
         while (iterator.hasNext()) {
             Thread thread = iterator.next();
-            if (THREAD_CLASS_WHITELIST.contains(thread.getClass())) {
+            Class<? extends Thread> threadClass = thread.getClass();
+            String threadName = thread.getName();
+            if (THREAD_CLASS_WHITELIST.contains(threadClass) || THREAD_NAME_WHITELIST.contains(threadName)) {
                 iterator.remove();
             }
         }


### PR DESCRIPTION
Fixes #13568
JDK creates the "reaper thread" whenever is starts an external process.
In this case surefure starts some kind of a ping process as I can
see this in treaddump:
```
"surefire-forkedjvm-ping-30s"
	java.lang.Thread.State: RUNNABLE, cpu=1290000000 nsecs, usr=960000000 nsecs, blocked=147 msecs, waited=2228583 msecs
		at java.io.FileInputStream.readBytes(Native Method)
		at java.io.FileInputStream.read(FileInputStream.java:239)
		at java.io.BufferedInputStream.read1(BufferedInputStream.java:273)
		at java.io.BufferedInputStream.read(BufferedInputStream.java:334)
		at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:282)
		at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:324)
		at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:176)
		at java.io.InputStreamReader.read(InputStreamReader.java:184)
		at java.io.Reader.read(Reader.java:100)
		at java.util.Scanner.readInput(Scanner.java:797)
		at java.util.Scanner.findWithinHorizon(Scanner.java:1676)
		at java.util.Scanner.hasNextLine(Scanner.java:1493)
		at org.apache.maven.surefire.booter.PpidChecker$ProcessInfoConsumer.execute(PpidChecker.java:301)
		at org.apache.maven.surefire.booter.PpidChecker.unix(PpidChecker.java:160)
		at org.apache.maven.surefire.booter.PpidChecker.isProcessAlive(PpidChecker.java:115)
		at org.apache.maven.surefire.booter.ForkedBooter$2.run(ForkedBooter.java:213)
		at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:471)
		at java.util.concurrent.FutureTask$Sync.innerRunAndReset(FutureTask.java:351)
		at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:178)
		at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:165)
		at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:267)
		at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1153)
		at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:622)
		at java.lang.Thread.run(Thread.java:704)
```

This appears to be a periodic task scheduled by the surefire runner.
Adding both reaper thread and the sureping ping to a leak test whitelist.

Backport will follow. 