### PR TITLE
Write LOADED to event journal on map load

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheEventJournalBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCacheEventJournalBasicTest.java
@@ -58,7 +58,9 @@ public class ClientCacheEventJournalBasicTest extends CacheEventJournalBasicTest
 
     @After
     public final void terminate() {
-        factory.terminateAll();
+        if (factory != null) {
+            factory.terminateAll();
+        }
         HazelcastClientManager.shutdownAll();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -63,7 +63,7 @@ import com.hazelcast.map.impl.record.ObjectRecordComparator;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.impl.record.RecordComparator;
 import com.hazelcast.map.impl.recordstore.DefaultRecordStore;
-import com.hazelcast.map.impl.recordstore.EventJournalUpdaterRecordStoreMutationObserver;
+import com.hazelcast.map.impl.recordstore.EventJournalWriterRecordStoreMutationObserver;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.impl.recordstore.RecordStoreMutationObserver;
 import com.hazelcast.map.listener.MapPartitionLostListener;
@@ -873,7 +873,7 @@ class MapServiceContextImpl implements MapServiceContext {
 
     private void addEventJournalUpdaterObserver(Collection<RecordStoreMutationObserver<Record>> observers, String mapName, int
             partitionId) {
-        RecordStoreMutationObserver<Record> observer = new EventJournalUpdaterRecordStoreMutationObserver(getEventJournal(),
+        RecordStoreMutationObserver<Record> observer = new EventJournalWriterRecordStoreMutationObserver(getEventJournal(),
                 getMapContainer(mapName), partitionId);
         observers.add(observer);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournal.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/MapEventJournal.java
@@ -106,6 +106,20 @@ public interface MapEventJournal extends EventJournal<InternalEventJournalMapEve
     void writeEvictEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId, Data key, Object value);
 
     /**
+     * Writes an {@link com.hazelcast.core.EntryEventType#LOADED} to the event journal.
+     * If there is no event journal configured for this map, the method will do nothing.
+     * If an event is added to the event journal, all parked operations waiting for
+     * new events on that journal will be unparked.
+     *
+     * @param journalConfig the event journal config for the map in which the event occurred
+     * @param namespace     the map namespace
+     * @param partitionId   the entry key partition
+     * @param key           the entry key
+     * @param value         the entry value
+     */
+    void writeLoadEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId, Data key, Object value);
+
+    /**
      * Returns {@code true} if the object has a configured and enabled event journal.
      *
      * @param namespace the object namespace

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/journal/RingbufferMapEventJournalImpl.java
@@ -38,6 +38,7 @@ import com.hazelcast.spi.impl.operationparker.OperationParker;
 
 import static com.hazelcast.core.EntryEventType.ADDED;
 import static com.hazelcast.core.EntryEventType.EVICTED;
+import static com.hazelcast.core.EntryEventType.LOADED;
 import static com.hazelcast.core.EntryEventType.REMOVED;
 import static com.hazelcast.core.EntryEventType.UPDATED;
 
@@ -81,6 +82,12 @@ public class RingbufferMapEventJournalImpl implements MapEventJournal {
     public void writeEvictEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId,
                                 Data key, Object value) {
         addToEventRingbuffer(journalConfig, namespace, partitionId, EVICTED, key, value, null);
+    }
+
+    @Override
+    public void writeLoadEvent(EventJournalConfig journalConfig, ObjectNamespace namespace, int partitionId, Data key,
+                               Object value) {
+        addToEventRingbuffer(journalConfig, namespace, partitionId, LOADED, key, null, value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeRecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeRecordStoreMutationObserver.java
@@ -74,6 +74,13 @@ class CompositeRecordStoreMutationObserver<R extends Record> implements RecordSt
     }
 
     @Override
+    public void onLoadRecord(Data key, R record) {
+        for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
+            mutationObserver.onLoadRecord(key, record);
+        }
+    }
+
+    @Override
     public void onDestroy(boolean internal) {
         for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
             mutationObserver.onDestroy(internal);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -329,7 +329,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         if (value != null) {
             record = createRecord(value, DEFAULT_TTL, DEFAULT_MAX_IDLE, getNow());
             storage.put(key, record);
-            mutationObserver.onPutRecord(key, record);
+            mutationObserver.onLoadRecord(key, record);
             if (!backup) {
                 saveIndex(record, null);
                 mapEventPublisher.publishEvent(callerAddress, name, EntryEventType.LOADED,
@@ -917,7 +917,11 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
             value = mapServiceContext.interceptPut(name, null, value);
             record = createRecord(value, ttl, maxIdle, now);
             storage.put(key, record);
-            mutationObserver.onPutRecord(key, record);
+            if (canPublishLoadEvent()) {
+                mutationObserver.onLoadRecord(key, record);
+            } else {
+                mutationObserver.onPutRecord(key, record);
+            }
         } else {
             oldValue = record.getValue();
             value = mapServiceContext.interceptPut(name, oldValue, value);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterRecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterRecordStoreMutationObserver.java
@@ -23,14 +23,14 @@ import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
 
-public class EventJournalUpdaterRecordStoreMutationObserver implements RecordStoreMutationObserver {
+public class EventJournalWriterRecordStoreMutationObserver implements RecordStoreMutationObserver {
     private final MapEventJournal eventJournal;
     private final int partitionId;
     private final EventJournalConfig eventJournalConfig;
     private final ObjectNamespace objectNamespace;
 
-    public EventJournalUpdaterRecordStoreMutationObserver(MapEventJournal eventJournal, MapContainer mapContainer,
-                                                          int partitionId) {
+    public EventJournalWriterRecordStoreMutationObserver(MapEventJournal eventJournal, MapContainer mapContainer,
+                                                         int partitionId) {
         this.eventJournal = eventJournal;
         this.partitionId = partitionId;
         this.eventJournalConfig = mapContainer.getEventJournalConfig();
@@ -66,6 +66,11 @@ public class EventJournalUpdaterRecordStoreMutationObserver implements RecordSto
     @Override
     public void onEvictRecord(Data key, Record record) {
         eventJournal.writeEvictEvent(eventJournalConfig, objectNamespace, partitionId, record.getKey(), record.getValue());
+    }
+
+    @Override
+    public void onLoadRecord(Data key, Record record) {
+        eventJournal.writeLoadEvent(eventJournalConfig, objectNamespace, partitionId, record.getKey(), record.getValue());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreMutationObserver.java
@@ -74,6 +74,14 @@ public interface RecordStoreMutationObserver<R extends Record> {
     void onEvictRecord(Data key, R record);
 
     /**
+     * Called when a record is loaded into the observed {@link RecordStore}
+     *
+     * @param key      The key of the record
+     * @param record   The record
+     */
+    void onLoadRecord(Data key, R record);
+
+    /**
      * Called when the observed {@link RecordStore} is being destroyed.
      * The observer should release all resources. The implementations of
      * this method should be idempotent.

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/CacheEventJournalBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/CacheEventJournalBasicTest.java
@@ -95,6 +95,24 @@ public class CacheEventJournalBasicTest<K, V> extends AbstractEventJournalBasicT
         // not tested
     }
 
+    @Override
+    @Ignore
+    public void receiveLoadedEventsWhenLoad() {
+        // not tested
+    }
+
+    @Override
+    @Ignore
+    public void receiveLoadedEventsWhenLoadAll() {
+        // not tested
+    }
+
+    @Override
+    @Ignore
+    public void receiveAddedEventsWhenLoadAll() {
+        // not tested
+    }
+
     protected CacheManager createCacheManager() {
         CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(getRandomInstance());
         return cachingProvider.getCacheManager();

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/EventJournalCacheDataStructureAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/EventJournalCacheDataStructureAdapter.java
@@ -68,6 +68,16 @@ public class EventJournalCacheDataStructureAdapter<K, V>
     }
 
     @Override
+    public void load(K key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void loadAll(Set<K> keys) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public ObjectNamespace getNamespace() {
         return CacheService.getObjectNamespace(cache.getPrefixedName());
     }

--- a/hazelcast/src/test/java/com/hazelcast/journal/EventJournalDataStructureAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/journal/EventJournalDataStructureAdapter.java
@@ -32,6 +32,10 @@ public interface EventJournalDataStructureAdapter<K, V, EJ_TYPE> extends EventJo
 
     V put(K key, V value, long ttl, TimeUnit timeunit);
 
+    void load(K key);
+
+    void loadAll(Set<K> keys);
+
     ObjectNamespace getNamespace();
 
     Set<Map.Entry<K, V>> entrySet();

--- a/hazelcast/src/test/java/com/hazelcast/journal/EventJournalEventAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/journal/EventJournalEventAdapter.java
@@ -52,6 +52,6 @@ public interface EventJournalEventAdapter<K, V, EJ_TYPE> extends Serializable {
      * events may have separate enums for event types.
      */
     enum EventType {
-        ADDED, REMOVED, UPDATED, EVICTED;
+        ADDED, REMOVED, UPDATED, EVICTED, LOADED;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/EventJournalMapDataStructureAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/EventJournalMapDataStructureAdapter.java
@@ -61,6 +61,16 @@ public class EventJournalMapDataStructureAdapter<K, V>
     }
 
     @Override
+    public void load(K key) {
+        map.get(key);
+    }
+
+    @Override
+    public void loadAll(Set<K> keys) {
+        map.loadAll(keys, true);
+    }
+
+    @Override
     public ObjectNamespace getNamespace() {
         return MapService.getObjectNamespace(map.getName());
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/EventJournalMapEventAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/EventJournalMapEventAdapter.java
@@ -46,6 +46,8 @@ public class EventJournalMapEventAdapter<K, V> implements EventJournalEventAdapt
                 return EventType.UPDATED;
             case EVICTED:
                 return EventType.EVICTED;
+            case LOADED:
+                return EventType.LOADED;
             default:
                 throw new IllegalArgumentException("Unknown event journal event type " + e.getType());
         }


### PR DESCRIPTION
- Extend `MapEventJournal` with `writeLoadEvent`
- Extend `RecordStoreMutationObserver` with `onLoadRecord`
- Call `mutationObserver.onLoadRecord()` from `DefaultRecordStore.loadRecordOrNull()`
- Call either `onLoadRecord()` or `onPutRecord()` from `DefaultRecordStore.putFromLoadInternal()` based on `DefaultRecordStore.canPublishLoadEvent()`
- Update event journal tests

Implements #13667 

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/2376