### PR TITLE
[BACKPORT] Fix MigrationInvocationsSafetyTest failure

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
@@ -276,6 +276,11 @@ public class MigrationInvocationsSafetyTest extends PartitionCorrectnessTestSupp
             final AtomicReference<MigrationInfo> committedMigrationInfoRef = new AtomicReference<MigrationInfo>();
 
             @Override
+            public void onMigrationStart(MigrationParticipant participant, MigrationInfo migrationInfo) {
+                assertClusterStateEventually(ClusterState.ACTIVE, destination);
+            }
+
+            @Override
             public void onMigrationCommit(MigrationParticipant participant, MigrationInfo migrationInfo) {
                 if (participant == MigrationParticipant.DESTINATION && committedMigrationInfoRef.compareAndSet(null, migrationInfo)) {
                     dropOperationsBetween(destination, master, SpiDataSerializerHook.F_ID, singletonList(NORMAL_RESPONSE));


### PR DESCRIPTION
In migrationCommit_shouldBeRetried_whenTargetNotResponds test, the master node should wait until the destination node commits the cluster state change. Otherwise, migrations could fail due to the cluster state of the destination node, leading to duplicate "before migration" events on migration sources.

Backport of #13677

Fixes #13582