### PR TITLE
Fixing heartbeat resume condition

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/HeartbeatManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/HeartbeatManager.java
@@ -97,6 +97,12 @@ public class HeartbeatManager implements Runnable {
                 connection.onHeartbeatFailed();
                 fireHeartbeatStopped(connection);
             }
+        } else {
+            if (!connection.isHeartBeating()) {
+                logger.warning("Heartbeat is back to healthy for the connection: " + connection);
+                connection.onHeartbeatResumed();
+                fireHeartbeatResumed(connection);
+            }
         }
 
         if (now - connection.lastWriteTimeMillis() > heartbeatInterval) {
@@ -119,12 +125,6 @@ public class HeartbeatManager implements Runnable {
                     }
                 }
             });
-        } else {
-            if (!connection.isHeartBeating()) {
-                logger.warning("Heartbeat is back to healthy for the connection: " + connection);
-                connection.onHeartbeatResumed();
-                fireHeartbeatResumed(connection);
-            }
         }
     }
 


### PR DESCRIPTION
With the fix #13578, the condition of resuming heartbeat is became
broken.

It is fixed so that, heartbeat of a connection becomes healthy when
last read time is lower than heartbeat timeout.

(cherry picked from commit 23af8bf321470a3274aa8c131e5830d2ef0fa05a)