### PR TITLE
Fixes backup eviction when running on mixed cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
@@ -16,9 +16,9 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.eviction.ExpiredKey;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.internal.eviction.ExpiredKey;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.spi.BackupOperation;
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
 
+import static com.hazelcast.util.MapUtil.zeroOutMillis;
 import static com.hazelcast.util.CollectionUtil.isNotEmpty;
 
 /**
@@ -93,7 +94,8 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
         // we send it to backups a new record is added with same key, when we send queued item
         // to backups, backups should not remove it. Comparing creation times to be sure that
         // we are deleting correct record.
-        return existingRecord.getCreationTime() == expiredKey.getCreationTime();
+        // since 3.11, creationTime is maintained at second accuracy
+        return existingRecord.getCreationTime() == zeroOutMillis(expiredKey.getCreationTime());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.record;
 
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.util.MapUtil;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static com.hazelcast.nio.Bits.INT_SIZE_IN_BYTES;
@@ -35,7 +36,7 @@ public abstract class AbstractRecord<V> implements Record<V> {
      * Base time to be used for storing time values as diffs (int) rather than full blown epoch based vals (long)
      * This allows for a space in seconds, of roughly 68 years.
      */
-    public static final long EPOCH_TIME = zeroOutMillis(System.currentTimeMillis());
+    public static final long EPOCH_TIME = MapUtil.zeroOutMillis(System.currentTimeMillis());
 
     private static final int NUMBER_OF_LONGS = 2;
     private static final int NUMBER_OF_INTS = 5;
@@ -268,7 +269,4 @@ public abstract class AbstractRecord<V> implements Record<V> {
         return diff;
     }
 
-    private static long zeroOutMillis(long value) {
-        return SECONDS.toMillis(MILLISECONDS.toSeconds(value));
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/MapUtil.java
@@ -25,6 +25,9 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 /**
  * Utility class for Maps
  */
@@ -101,4 +104,7 @@ public final class MapUtil {
         return map == null || map.isEmpty();
     }
 
+    public static long zeroOutMillis(long value) {
+        return SECONDS.toMillis(MILLISECONDS.toSeconds(value));
+    }
 }


### PR DESCRIPTION
Creation time of expired keys received from 3.10 members has millisecond
accuracy and does not pass the creation time equality condition, as it
is stored with seconds accuracy on 3.11 member.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2330