### PR TITLE
Follow-up on writing LOADED events to the event journal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -948,6 +948,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
     }
 
     private boolean canPublishLoadEvent() {
+        // RU_COMPAT_3_10
         NodeEngine nodeEngine = mapServiceContext.getNodeEngine();
         ClusterService clusterService = nodeEngine.getClusterService();
         boolean version311OrLater = clusterService.getClusterVersion().isGreaterOrEqual(Versions.V3_11);


### PR DESCRIPTION
- `RU_COMPAT_3_10` added to `DefaultRecordStore#canPublishLoadEvent`
- Extracted common parts of the `loadAll` tests in `AbstractEventJournalBasicTest`

Induced by comments in #13674