### PR TITLE
Fixes potential NullPointerException when invalidation metadata missing

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheInvalidationMetaDataFetcher.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/nearcache/invalidation/ClientCacheInvalidationMetaDataFetcher.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.cache.impl.nearcache.invalidation;
 
-
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CacheFetchNearCacheInvalidationMetadataCodec.ResponseParameters;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapInvalidationMetaDataFetcher.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/map/impl/nearcache/invalidation/ClientMapInvalidationMetaDataFetcher.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.map.impl.nearcache.invalidation;
 
-
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapFetchNearCacheInvalidationMetadataCodec.ResponseParameters;


### PR DESCRIPTION
When an exception occurs while fetching invalidation metadata,
there is no reason to proceed processing null metadata.
`IllegalStateException`s are now logged at finest level, covering
member-side `HazelcastInstanceNotActive` and client-side
`HazelcastClientOffline` and `HazelcastClientNotActive` exceptions.

Fixes #13700 