### PR TITLE
Hint when missing AWS module

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -21,6 +21,7 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.cluster.Joiner;
 import com.hazelcast.cluster.impl.TcpIpJoiner;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.ListenerConfig;
@@ -108,6 +109,7 @@ import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_ENABLED;
 import static com.hazelcast.spi.properties.GroupProperty.SHUTDOWNHOOK_POLICY;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
+import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 import static com.hazelcast.util.StringUtil.isNullOrEmpty;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
 import static java.lang.Thread.currentThread;
@@ -777,18 +779,33 @@ public class Node {
                 logger.info("Creating TcpIpJoiner");
                 return new TcpIpJoiner(this);
             } else if (join.getAwsConfig().isEnabled()) {
-                Class clazz;
-                try {
-                    logger.info("Creating AWSJoiner");
-                    clazz = Class.forName("com.hazelcast.cluster.impl.TcpIpJoinerOverAWS");
-                    Constructor constructor = clazz.getConstructor(Node.class);
-                    return (Joiner) constructor.newInstance(this);
-                } catch (Exception e) {
-                    throw rethrow(e);
-                }
+                logger.info("Creating AWSJoiner");
+                return createAwsJoiner();
             }
         }
         return null;
+    }
+
+    private Joiner createAwsJoiner() {
+        try {
+            Class clazz = Class.forName("com.hazelcast.cluster.impl.TcpIpJoinerOverAWS");
+            Constructor constructor = clazz.getConstructor(Node.class);
+            return (Joiner) constructor.newInstance(this);
+        } catch (ClassNotFoundException e) {
+            StringBuilder message = new StringBuilder("Your Hazelcast network configuration has AWS discovery ")
+                    .append("enabled, but there is no Hazelcast AWS module on a classpath. ")
+                    .append(LINE_SEPARATOR)
+                    .append("Hint: If you are using Maven then add this dependency into your pom.xml:")
+                    .append(LINE_SEPARATOR)
+                    .append("<dependency>").append(LINE_SEPARATOR)
+                    .append("    <groupId>com.hazelcast</groupId>").append(LINE_SEPARATOR)
+                    .append("    <artifactId>hazelcast-aws</artifactId>").append(LINE_SEPARATOR)
+                    .append("    <version>${hazelcast-aws.version}</version>").append(LINE_SEPARATOR)
+                    .append("</dependency>").append(LINE_SEPARATOR);
+            throw new ConfigurationException(message.toString(), e);
+        } catch (Exception e) {
+            throw rethrow(e);
+        }
     }
 
     public String getThisUuid() {

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -792,17 +792,16 @@ public class Node {
             Constructor constructor = clazz.getConstructor(Node.class);
             return (Joiner) constructor.newInstance(this);
         } catch (ClassNotFoundException e) {
-            StringBuilder message = new StringBuilder("Your Hazelcast network configuration has AWS discovery ")
-                    .append("enabled, but there is no Hazelcast AWS module on a classpath. ")
-                    .append(LINE_SEPARATOR)
-                    .append("Hint: If you are using Maven then add this dependency into your pom.xml:")
-                    .append(LINE_SEPARATOR)
-                    .append("<dependency>").append(LINE_SEPARATOR)
-                    .append("    <groupId>com.hazelcast</groupId>").append(LINE_SEPARATOR)
-                    .append("    <artifactId>hazelcast-aws</artifactId>").append(LINE_SEPARATOR)
-                    .append("    <version>${hazelcast-aws.version}</version>").append(LINE_SEPARATOR)
-                    .append("</dependency>").append(LINE_SEPARATOR);
-            throw new ConfigurationException(message.toString(), e);
+            String message = "Your Hazelcast network configuration has AWS discovery "
+                     + "enabled, but there is no Hazelcast AWS module on a classpath. " + LINE_SEPARATOR
+                     + "Hint: If you are using Maven then add this dependency into your pom.xml:" + LINE_SEPARATOR
+                     + "<dependency>" + LINE_SEPARATOR
+                     + "    <groupId>com.hazelcast</groupId>" + LINE_SEPARATOR
+                     + "    <artifactId>hazelcast-aws</artifactId>" + LINE_SEPARATOR
+                     + "    <version>insert hazelcast-aws version</version>" + LINE_SEPARATOR
+                     + "</dependency>" + LINE_SEPARATOR
+                     + " See https://github.com/hazelcast/hazelcast-aws for additional details";
+            throw new ConfigurationException(message, e);
         } catch (Exception e) {
             throw rethrow(e);
         }


### PR DESCRIPTION
This gives users a better guidance when the AWS module is missing.
There is also a small behaviour change: The original code would throw
`HazelcastException`. The new code throws `ConfigurationException` - this
is a subclass of `HazelcastException` so it should not cause compatibility
issues.

For a comparison, here is the original stacktrace:
```
com.hazelcast.core.HazelcastException: java.lang.ClassNotFoundException: com.hazelcast.cluster.impl.TcpIpJoinerOverAWS

	at com.hazelcast.util.ExceptionUtil$1.create(ExceptionUtil.java:40)
	at com.hazelcast.util.ExceptionUtil.peel(ExceptionUtil.java:124)
	at com.hazelcast.util.ExceptionUtil.peel(ExceptionUtil.java:69)
	at com.hazelcast.util.ExceptionUtil.rethrow(ExceptionUtil.java:129)
	at com.hazelcast.instance.Node.createJoiner(Node.java:787)
	at com.hazelcast.instance.DefaultNodeContext.createJoiner(DefaultNodeContext.java:133)
	at com.hazelcast.instance.Node.<init>(Node.java:229)
	at com.hazelcast.instance.HazelcastInstanceImpl.createNode(HazelcastInstanceImpl.java:156)
	at com.hazelcast.instance.HazelcastInstanceImpl.<init>(HazelcastInstanceImpl.java:126)
	at com.hazelcast.instance.HazelcastInstanceFactory.constructHazelcastInstance(HazelcastInstanceFactory.java:196)
	at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:175)
	at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:125)
	at com.hazelcast.core.Hazelcast.newHazelcastInstance(Hazelcast.java:57)
	at awstest.AwsTest.foo(AwsTest.java:16)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.ClassNotFoundException: com.hazelcast.cluster.impl.TcpIpJoinerOverAWS
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at com.hazelcast.instance.Node.createJoiner(Node.java:783)
	... 31 more
```

and here is a new one:
```
com.hazelcast.config.ConfigurationException: Your Hazelcast network configuration has AWS discovery enabled, but there is no Hazelcast AWS module on a classpath.
Hint: If you are using Maven then add this dependency into your pom.xml:
<dependency>
    <groupId>com.hazelcast</groupId>
    <artifactId>hazelcast-aws</artifactId>
    <version>${hazelcast-aws.version}</version>
</dependency>

	at com.hazelcast.instance.Node.createJoiner(Node.java:800)
	at com.hazelcast.instance.DefaultNodeContext.createJoiner(DefaultNodeContext.java:133)
	at com.hazelcast.instance.Node.<init>(Node.java:232)
	at com.hazelcast.instance.HazelcastInstanceImpl.createNode(HazelcastInstanceImpl.java:156)
	at com.hazelcast.instance.HazelcastInstanceImpl.<init>(HazelcastInstanceImpl.java:126)
	at com.hazelcast.instance.HazelcastInstanceFactory.constructHazelcastInstance(HazelcastInstanceFactory.java:196)
	at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:175)
	at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:125)
	at com.hazelcast.core.Hazelcast.newHazelcastInstance(Hazelcast.java:57)
	at awstest.AwsTest.foo(AwsTest.java:17)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.ClassNotFoundException: com.hazelcast.cluster.impl.TcpIpJoinerOverAWS
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at com.hazelcast.instance.Node.createJoiner(Node.java:786)
	... 31 more
```