### PR TITLE
ClientConfig accepts user context

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
@@ -121,6 +122,8 @@ public class ClientConfig {
 
     private final Map<String, ClientFlakeIdGeneratorConfig> flakeIdGeneratorConfigMap =
             new ConcurrentHashMap<String, ClientFlakeIdGeneratorConfig>();
+
+    private ConcurrentMap<String, Object> userContext = new ConcurrentHashMap<String, Object>();
 
     /**
      * Sets the pattern matcher which is used to match item names to
@@ -958,5 +961,17 @@ public class ClientConfig {
         }
 
         return lookupByPattern(configPatternMatcher, queryCacheConfigsForMap, cacheName);
+    }
+
+    public ClientConfig setUserContext(ConcurrentMap<String, Object> userContext) {
+        if (userContext == null) {
+            throw new IllegalArgumentException("userContext can't be null");
+        }
+        this.userContext = userContext;
+        return this;
+    }
+
+    public ConcurrentMap<String, Object> getUserContext() {
+        return userContext;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -256,6 +256,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         invocationService = initInvocationService();
         listenerService = initListenerService();
         userContext = new ConcurrentHashMap<String, Object>();
+        userContext.putAll(config.getUserContext());
         diagnostics = initDiagnostics();
 
         hazelcastCacheManager = new ClientICacheManager(this);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/ClientConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/ClientConfigTest.java
@@ -31,6 +31,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import static org.junit.Assert.assertEquals;
 
@@ -71,5 +73,29 @@ public class ClientConfigTest {
         Map<Integer, com.hazelcast.nio.serialization.PortableFactory> factories = serializationConfig.getPortableFactories();
         assertEquals(1, factories.size());
         assertEquals(factories.get(PortableFactory.FACTORY_ID).create(Employee.CLASS_ID).getClassId(), Employee.CLASS_ID);
+    }
+
+    @Test
+    public void testUserContext_passContext() {
+        hazelcastFactory.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        ConcurrentMap<String, Object> context = new ConcurrentHashMap<String, Object>();
+        context.put("key1", "value1");
+        Object value2 = new Object();
+        context.put("key2", value2);
+
+        // check set setter returns ClientConfig instance
+        clientConfig = clientConfig.setUserContext(context);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        ConcurrentMap<String, Object> returnedContext = client.getUserContext();
+        assertEquals(context, returnedContext);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUserContext_throwExceptionWhenContextNull() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setUserContext(null);
     }
 }


### PR DESCRIPTION
Fixes #13398

With this the client config support for user context is on-par with server-side. 

We might think of adding a support for XML config, it makes sense especially for the Spring config. But that's out of the scope for this PR. 