### PR TITLE
Skip index option for sql queries.

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientSkipIndexIntegrationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientSkipIndexIntegrationTest.java
@@ -1,0 +1,27 @@
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.query.impl.predicates.SkipIndexAbstractIntegrationTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class ClientSkipIndexIntegrationTest extends SkipIndexAbstractIntegrationTest {
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    public HazelcastInstance getHazelcastInstance() {
+        HazelcastInstance server = hazelcastFactory.newHazelcastInstance();
+        return hazelcastFactory.newHazelcastClient();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/SqlPredicate.java
@@ -18,11 +18,12 @@ package com.hazelcast.query;
 
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.BinaryInterface;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
+import com.hazelcast.query.impl.SkipIndexPredicate;
 import com.hazelcast.query.impl.predicates.AndPredicate;
 import com.hazelcast.query.impl.predicates.CompoundPredicate;
 import com.hazelcast.query.impl.predicates.OrPredicate;
@@ -53,10 +54,64 @@ import static com.hazelcast.query.Predicates.regex;
  * This class contains methods related to conversion of sql query to predicate.
  */
 @BinaryInterface
+@SuppressWarnings("checkstyle:methodcount")
 public class SqlPredicate
         implements IndexAwarePredicate, VisitablePredicate, IdentifiedDataSerializable {
 
+    /**
+     * Disables the skip index syntax. The only reason why this property should be set to true is if
+     * someone is using % as first character in their fieldname and do not want it to be interpreted
+     * as 'skipIndex'.
+     */
+    private static final boolean SKIP_INDEX_ENABLED = !Boolean.getBoolean("hazelcast.query.disableSkipIndex");
+
     private static final long serialVersionUID = 1;
+
+    private interface ComparisonPredicateFactory {
+        Predicate create(String attribute, Comparable c);
+    }
+
+    private static final ComparisonPredicateFactory EQUAL_FACTORY = new ComparisonPredicateFactory() {
+        @Override
+        public Predicate create(String attribute, Comparable c) {
+            return equal(attribute, c);
+        }
+    };
+
+    private static final ComparisonPredicateFactory NOT_EQUAL_FACTORY = new ComparisonPredicateFactory() {
+        @Override
+        public Predicate create(String attribute, Comparable c) {
+            return notEqual(attribute, c);
+        }
+    };
+
+    private static final ComparisonPredicateFactory GREATER_THAN_FACTORY = new ComparisonPredicateFactory() {
+        @Override
+        public Predicate create(String attribute, Comparable c) {
+            return greaterThan(attribute, c);
+        }
+    };
+
+    private static final ComparisonPredicateFactory GREATER_EQUAL_FACTORY = new ComparisonPredicateFactory() {
+        @Override
+        public Predicate create(String attribute, Comparable c) {
+            return greaterEqual(attribute, c);
+        }
+    };
+
+    private static final ComparisonPredicateFactory LESS_EQUAL_FACTORY = new ComparisonPredicateFactory() {
+        @Override
+        public Predicate create(String attribute, Comparable c) {
+            return lessEqual(attribute, c);
+        }
+    };
+
+    private static final ComparisonPredicateFactory LESS_THAN_FACTORY = new ComparisonPredicateFactory() {
+        @Override
+        public Predicate create(String attribute, Comparable c) {
+            return lessThan(attribute, c);
+        }
+    };
 
     transient Predicate predicate;
     private String sql;
@@ -117,6 +172,7 @@ public class SqlPredicate
         return (phrase.length() > 2) ? phrase.replace("''", "'") : phrase;
     }
 
+
     private Predicate createPredicate(String sql) {
         String paramSql = sql;
         Map<String, String> mapPhrases = new HashMap<String, String>();
@@ -161,41 +217,17 @@ public class SqlPredicate
                 if (tokenObj instanceof String && parser.isOperand((String) tokenObj)) {
                     String token = (String) tokenObj;
                     if ("=".equals(token) || "==".equals(token)) {
-                        int position = (i - 2);
-                        validateOperandPosition(position);
-                        Object first = toValue(tokens.remove(position), mapPhrases);
-                        Object second = toValue(tokens.remove(position), mapPhrases);
-                        setOrAdd(tokens, position, equal((String) first, (Comparable) second));
+                        createComparison(mapPhrases, tokens, i, EQUAL_FACTORY);
                     } else if ("!=".equals(token) || "<>".equals(token)) {
-                        int position = (i - 2);
-                        validateOperandPosition(position);
-                        Object first = toValue(tokens.remove(position), mapPhrases);
-                        Object second = toValue(tokens.remove(position), mapPhrases);
-                        setOrAdd(tokens, position, notEqual((String) first, (Comparable) second));
+                        createComparison(mapPhrases, tokens, i, NOT_EQUAL_FACTORY);
                     } else if (">".equals(token)) {
-                        int position = (i - 2);
-                        validateOperandPosition(position);
-                        Object first = toValue(tokens.remove(position), mapPhrases);
-                        Object second = toValue(tokens.remove(position), mapPhrases);
-                        setOrAdd(tokens, position, greaterThan((String) first, (Comparable) second));
+                        createComparison(mapPhrases, tokens, i, GREATER_THAN_FACTORY);
                     } else if (">=".equals(token)) {
-                        int position = (i - 2);
-                        validateOperandPosition(position);
-                        Object first = toValue(tokens.remove(position), mapPhrases);
-                        Object second = toValue(tokens.remove(position), mapPhrases);
-                        setOrAdd(tokens, position, greaterEqual((String) first, (Comparable) second));
+                        createComparison(mapPhrases, tokens, i, GREATER_EQUAL_FACTORY);
                     } else if ("<=".equals(token)) {
-                        int position = (i - 2);
-                        validateOperandPosition(position);
-                        Object first = toValue(tokens.remove(position), mapPhrases);
-                        Object second = toValue(tokens.remove(position), mapPhrases);
-                        setOrAdd(tokens, position, lessEqual((String) first, (Comparable) second));
+                        createComparison(mapPhrases, tokens, i, LESS_EQUAL_FACTORY);
                     } else if ("<".equals(token)) {
-                        int position = (i - 2);
-                        validateOperandPosition(position);
-                        Object first = toValue(tokens.remove(position), mapPhrases);
-                        Object second = toValue(tokens.remove(position), mapPhrases);
-                        setOrAdd(tokens, position, lessThan((String) first, (Comparable) second));
+                        createComparison(mapPhrases, tokens, i, LESS_THAN_FACTORY);
                     } else if ("LIKE".equalsIgnoreCase(token)) {
                         int position = (i - 2);
                         validateOperandPosition(position);
@@ -217,9 +249,15 @@ public class SqlPredicate
                     } else if ("IN".equalsIgnoreCase(token)) {
                         int position = i - 2;
                         validateOperandPosition(position);
-                        Object exp = toValue(tokens.remove(position), mapPhrases);
+                        String exp = (String) toValue(tokens.remove(position), mapPhrases);
                         String[] values = toValue(((String) tokens.remove(position)).split(","), mapPhrases);
-                        setOrAdd(tokens, position, Predicates.in((String) exp, values));
+
+                        if (skipIndex(exp)) {
+                            exp = exp.substring(1);
+                            setOrAdd(tokens, position, new SkipIndexPredicate(Predicates.in(exp, values)));
+                        } else {
+                            setOrAdd(tokens, position, Predicates.in(exp, values));
+                        }
                     } else if ("NOT".equalsIgnoreCase(token)) {
                         int position = i - 1;
                         validateOperandPosition(position);
@@ -255,6 +293,27 @@ public class SqlPredicate
             }
         }
         return (Predicate) tokens.get(0);
+    }
+
+    private void createComparison(Map<String, String> mapPhrases,
+                                  List<Object> tokens,
+                                  int i,
+                                  ComparisonPredicateFactory factory) {
+        int position = (i - 2);
+        validateOperandPosition(position);
+        String first = (String) toValue(tokens.remove(position), mapPhrases);
+        Comparable second = (Comparable) toValue(tokens.remove(position), mapPhrases);
+
+        if (skipIndex(first)) {
+            first = first.substring(1);
+            setOrAdd(tokens, position, new SkipIndexPredicate(factory.create(first, second)));
+        } else {
+            setOrAdd(tokens, position, factory.create(first, second));
+        }
+    }
+
+    private boolean skipIndex(String first) {
+        return SKIP_INDEX_ENABLED && first.startsWith("%");
     }
 
     private void validateOperandPosition(int pos) {
@@ -308,7 +367,6 @@ public class SqlPredicate
     /**
      * Return a {@link CompoundPredicate}, possibly flattened if one or both arguments is an instance of
      * {@code CompoundPredicate}.
-     *
      */
     static <T extends CompoundPredicate> T flattenCompound(Predicate predicateLeft, Predicate predicateRight, Class<T> klass) {
         // The following could have been achieved with {@link com.hazelcast.query.impl.predicates.FlatteningVisitor},
@@ -322,7 +380,7 @@ public class SqlPredicate
             predicates = new Predicate[left.length + right.length];
             ArrayUtils.concat(left, right, predicates);
         } else {
-            predicates = new Predicate[] {predicateLeft, predicateRight};
+            predicates = new Predicate[]{predicateLeft, predicateRight};
         }
         try {
             CompoundPredicate compoundPredicate = klass.newInstance();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/SkipIndexPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/SkipIndexPredicate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+
+import com.hazelcast.query.Predicate;
+
+import java.util.Map;
+
+/**
+ * The {@link SkipIndexPredicate} is a predicate that prevents
+ * an index from being used on the wrapped predicate.
+ *
+ * It isn't exposed as user API; it will only be created when
+ * making use of index suppression option in the
+ * {@link com.hazelcast.query.SqlPredicate}
+ *
+ * SkipIndexPredicate also isn't send over the wire; so we don't
+ * need to worry about backward compatibility in future releases.
+ */
+public class SkipIndexPredicate implements Predicate {
+
+    private Predicate target;
+
+    public SkipIndexPredicate(Predicate target) {
+        this.target = target;
+    }
+
+    public Predicate getTarget() {
+        return target;
+    }
+
+    @Override
+    public boolean apply(Map.Entry mapEntry) {
+        return target.apply(mapEntry);
+    }
+
+    @Override
+    public String toString() {
+        return "SkipIndex(" + target + ')';
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableConventionsTest.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.SerializableByConvention;
+import com.hazelcast.query.impl.SkipIndexPredicate;
 import com.hazelcast.spi.AbstractLocalOperation;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.test.HazelcastParallelClassRunner;
@@ -75,6 +76,7 @@ public class DataSerializableConventionsTest {
         whiteList.add(Throwable.class);
         whiteList.add(Permission.class);
         whiteList.add(PermissionCollection.class);
+        whiteList.add(SkipIndexPredicate.class);
         SERIALIZABLE_WHITE_LIST = Collections.unmodifiableSet(whiteList);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/projection/Query2Benchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/Query2Benchmark.java
@@ -1,0 +1,110 @@
+package com.hazelcast.projection;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.query.impl.predicates.EqualPredicate;
+import com.hazelcast.spi.properties.GroupProperty;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(value = 1, warmups = 1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+public class Query2Benchmark {
+    IMap map;
+
+    @Setup
+    public void prepare() {
+        Config config = new Config();
+        MapConfig mapConfig = new MapConfig("map");
+        config.setProperty(GroupProperty.QUERY_PREDICATE_PARALLEL_EVALUATION.getName(),"true");
+        mapConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        mapConfig.addMapIndexConfig(new MapIndexConfig("f1", false));
+        mapConfig.addMapIndexConfig(new MapIndexConfig("f2", false));
+        mapConfig.addMapIndexConfig(new MapIndexConfig("f3", false));
+        mapConfig.addMapIndexConfig(new MapIndexConfig("f4", false));
+        config.addMapConfig(mapConfig);
+
+        HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
+        map = hz.getMap(mapConfig.getName());
+        for (int k = 0; k < 100000; k++) {
+            Pojo pojo = new Pojo(100, 100, 100, 100);
+            map.put(k, pojo);
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Benchmark
+    public void testAllIndices() {
+        map.keySet(new SqlPredicate("f1=100 and f2=100 and f3=100 and f4=100 and f5=0"));
+    }
+
+    @Benchmark
+    public void testSuppression() {
+        map.keySet(new SqlPredicate("%f1=100 and %f2=100 and %f3=100 and %f4=100 and f5=0"));
+    }
+
+    public static class Pojo implements DataSerializable {
+        private int f1;
+        private int f3;
+        private int f2;
+        private int f4;
+        private int f5;
+
+        public Pojo() {
+        }
+
+        public Pojo(int f1, int f2, int f3, int f4) {
+            this.f1 = f1;
+            this.f2 = f2;
+            this.f3 = f3;
+            this.f4 = f4;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeInt(f1);
+            out.writeInt(f2);
+            out.writeInt(f3);
+            out.writeInt(f4);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            f1 = in.readInt();
+            f2 = in.readInt();
+            f3 = in.readInt();
+            f4 = in.readInt();
+        }
+    }
+
+}
+

--- a/hazelcast/src/test/java/com/hazelcast/projection/QueryBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/QueryBenchmark.java
@@ -1,0 +1,92 @@
+package com.hazelcast.projection;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.SqlPredicate;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Fork(value = 1, warmups = 1)
+@Warmup(iterations = 2)
+@Measurement(iterations = 5)
+public class QueryBenchmark {
+    IMap map;
+
+    @Setup
+    public void prepare() {
+        Config config = new Config();
+        MapConfig mapConfig = new MapConfig("persons");
+        config.addMapConfig(mapConfig);
+        mapConfig.addMapIndexConfig(new MapIndexConfig("age", false));
+        mapConfig.addMapIndexConfig(new MapIndexConfig("iq", false));
+
+        HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
+        map = hz.getMap("persons");
+        for (int k = 0; k < 100000; k++) {
+            Person person = new Person(k, 100);
+            map.put(k, person);
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Benchmark
+    public void testAllIndices() {
+        map.keySet(new SqlPredicate("age=10 and iq=100"));
+    }
+
+    @Benchmark
+    public void testSuppression() {
+        map.keySet(new SqlPredicate("age=10 and %iq=100"));
+    }
+
+    public static class Person implements Serializable {
+        private int iq;
+        private int age;
+
+        public Person(int age, int iq) {
+            this.age = age;
+            this.iq = iq;
+        }
+
+        public int getIq() {
+            return iq;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        @Override
+        public String toString() {
+            return "Person{" +
+                    "age=" + age +
+                    ", iq=" + iq +
+                    '}';
+        }
+    }
+
+}
+

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SkipIndexAbstractIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SkipIndexAbstractIntegrationTest.java
@@ -1,0 +1,48 @@
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+import static org.junit.Assert.assertEquals;
+
+
+public abstract class SkipIndexAbstractIntegrationTest extends HazelcastTestSupport {
+
+    @Test
+    public void testIndexSuppressionDoesntChangeOutcome() {
+        HazelcastInstance hz = getHazelcastInstance();
+        IMap<Integer, Pojo> map = hz.getMap("foo");
+        map.addIndex("f", false);
+
+        for (int k = 0; k < 20; k++) {
+            map.put(k, new Pojo(k));
+        }
+
+        assertEquals(1, map.values(new SqlPredicate("%f=10")).size());
+        assertEquals(9, map.values(new SqlPredicate("%f>10")).size());
+        assertEquals(10, map.values(new SqlPredicate("%f>=10")).size());
+        assertEquals(19, map.values(new SqlPredicate("%f!=10")).size());
+        assertEquals(10, map.values(new SqlPredicate("%f<10")).size());
+        assertEquals(11, map.values(new SqlPredicate("%f<=10")).size());
+        assertEquals(5, map.values(new SqlPredicate("%f in (1,2,3,4,5)")).size());
+
+        hz.shutdown();
+    }
+
+    public abstract HazelcastInstance getHazelcastInstance();
+
+    public static class Pojo implements Serializable {
+
+        public int f;
+
+        public Pojo(int f) {
+            this.f = f;
+        }
+
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SkipIndexMultiMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SkipIndexMultiMemberTest.java
@@ -1,0 +1,33 @@
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class SkipIndexMultiMemberTest extends SkipIndexAbstractIntegrationTest {
+
+    private TestHazelcastInstanceFactory hzFactory;
+
+    @Before
+    public void before() {
+        hzFactory = createHazelcastInstanceFactory(2);
+    }
+
+    @After
+    public void after() {
+        hzFactory.shutdownAll();
+    }
+
+    @Override
+    public HazelcastInstance getHazelcastInstance() {
+        return hzFactory.newInstances()[0];
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SkipIndexSingleMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SkipIndexSingleMemberTest.java
@@ -1,0 +1,31 @@
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class SkipIndexSingleMemberTest extends SkipIndexAbstractIntegrationTest {
+    private TestHazelcastInstanceFactory hzFactory;
+
+    @Before
+    public void before() {
+        hzFactory = createHazelcastInstanceFactory(1);
+    }
+
+    @After
+    public void after() {
+        hzFactory.shutdownAll();
+    }
+
+    @Override
+    public HazelcastInstance getHazelcastInstance() {
+        return hzFactory.newInstances()[0];
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SqlPredicateSkipIndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/SqlPredicateSkipIndexTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.Predicate;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.query.impl.SkipIndexPredicate;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class SqlPredicateSkipIndexTest extends HazelcastTestSupport {
+
+    @Test
+    public void testInPredicate() {
+        SqlPredicate sqlPredicate = new SqlPredicate("%age in (1)");
+        Predicate p = sqlPredicate.getPredicate();
+
+        SkipIndexPredicate skipIndexPredicate = (SkipIndexPredicate) p;
+
+        InPredicate inPredicate = (InPredicate) skipIndexPredicate.getTarget();
+        assertEquals("age", inPredicate.attributeName, "age");
+        assertArrayEquals(new String[]{"1"}, inPredicate.values);
+    }
+
+    @Test
+    public void testEqualPredicate() {
+        SqlPredicate sqlPredicate = new SqlPredicate("%age=40");
+        Predicate p = sqlPredicate.getPredicate();
+
+        SkipIndexPredicate skipIndexPredicate = (SkipIndexPredicate) p;
+
+        EqualPredicate equalPredicate = (EqualPredicate) skipIndexPredicate.getTarget();
+        assertEquals("age", equalPredicate.attributeName, "age");
+        assertEquals("40", equalPredicate.value);
+    }
+
+    @Test
+    public void testNotEqualNotPredicate() {
+        notEqualPredicate("<>");
+        notEqualPredicate("!=");
+    }
+
+    public void notEqualPredicate(String operator) {
+        SqlPredicate sqlPredicate = new SqlPredicate("%age" + operator + "40");
+        Predicate p = sqlPredicate.getPredicate();
+
+        SkipIndexPredicate skipIndexPredicate = (SkipIndexPredicate) p;
+
+        NotEqualPredicate equalPredicate = (NotEqualPredicate) skipIndexPredicate.getTarget();
+        assertEquals("age", equalPredicate.attributeName, "age");
+        assertEquals("40", equalPredicate.value);
+    }
+
+    @Test
+    public void testGreaterLess() {
+        greaterLess(">");
+        greaterLess(">=");
+        greaterLess("<");
+        greaterLess("<=");
+    }
+
+    public void greaterLess(String operator) {
+        SqlPredicate sqlPredicate = new SqlPredicate("%age" + operator + "40");
+        Predicate p = sqlPredicate.getPredicate();
+
+        SkipIndexPredicate skipIndexPredicate = (SkipIndexPredicate) p;
+
+        GreaterLessPredicate equalPredicate = (GreaterLessPredicate) skipIndexPredicate.getTarget();
+        assertEquals("age", equalPredicate.attributeName, "age");
+        assertEquals("40", equalPredicate.value);
+    }
+}


### PR DESCRIPTION
Index can be skipped by adding % as prefix to the attribute.

E.g.

```
%age=20 and height=200
```

In this case the index on age is skipped.