### PR TITLE
Add WAN publisher group name property

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
@@ -2801,6 +2801,19 @@
                     </xs:sequence>
                     <xs:attributeGroup ref="class-or-bean-name"/>
                     <xs:attribute name="group-name" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Sets the WAN publisher name used for identifying the publisher in
+                                a WanReplicationConfig.
+                                This name will also be used as an endpoint group name for authentication
+                                on the target endpoint.
+                                The group name can also be defined in the publisher properties which
+                                takes precedence over this value. In such cases, this value will only
+                                be used as part of a WAN publisher identifier and the value defined in
+                                the properties will be used for authentication.
+                                This value must be unique for a single WAN replication scheme.
+                            </xs:documentation>
+                        </xs:annotation>
                         <xs:simpleType>
                             <xs:restriction base="xs:string"/>
                         </xs:simpleType>

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -75,22 +75,38 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
     }
 
     /**
-     * Returns the group name of this publisher. The group name is used for
-     * identifying the publisher in a {@link WanReplicationConfig} and for
-     * authentication on the target endpoint.
+     * Returns the WAN publisher name used for identifying the publisher in
+     * a {@link WanReplicationConfig}.
+     * <p>
+     * This name will also be used as an endpoint group name for authentication
+     * on the target endpoint.
+     * <p>
+     * The group name can also be defined in the publisher properties which
+     * takes precedence over this value. In such cases, this value will only
+     * be used as part of a WAN publisher identifier and the value defined in
+     * the properties will be used for authentication.
+     * This value must be unique for a single WAN replication scheme.
      *
-     * @return the publisher group name
+     * @return the WAN publisher name and endpoint group name
      */
     public String getGroupName() {
         return groupName;
     }
 
     /**
-     * Set the group name of this publisher. The group name is used for
-     * identifying the publisher in a {@link WanReplicationConfig} and for
-     * authentication on the target endpoint.
+     * Sets the WAN publisher name used for identifying the publisher in
+     * a {@link WanReplicationConfig}.
+     * <p>
+     * This name will also be used as an endpoint group name for authentication
+     * on the target endpoint.
+     * <p>
+     * The group name can also be defined in the publisher properties which
+     * takes precedence over this value. In such cases, this value will only
+     * be used as part of a WAN publisher identifier and the value defined in
+     * the properties will be used for authentication.
+     * This value must be unique for a single WAN replication scheme.
      *
-     * @param groupName the publisher group name
+     * @param groupName the WAN publisher name and publisher group name
      * @return this config
      */
     public WanPublisherConfig setGroupName(String groupName) {

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalWanStatsImpl.java
@@ -25,8 +25,16 @@ import com.hazelcast.util.Clock;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Local WAN replication statistics for a single WAN replication scheme.
+ * A single WAN replication scheme can contain multiple WAN replication
+ * publishers, identified by name.
+ */
 public class LocalWanStatsImpl implements LocalWanStats {
-
+    /**
+     * Local WAN replication statistics for a single scheme, grouped by WAN
+     * publisher name.
+     */
     private volatile Map<String, LocalWanPublisherStats> localPublisherStatsMap = new HashMap<String, LocalWanPublisherStats>();
     private volatile long creationTime;
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
@@ -2468,7 +2468,15 @@
         <xs:attribute name="group-name" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    The group name of target WAN cluster
+                    Sets the WAN publisher name used for identifying the publisher in
+                    a WanReplicationConfig.
+                    This name will also be used as an endpoint group name for authentication
+                    on the target endpoint.
+                    The group name can also be defined in the publisher properties which
+                    takes precedence over this value. In such cases, this value will only
+                    be used as part of a WAN publisher identifier and the value defined in
+                    the properties will be used for authentication.
+                    This value must be unique for a single WAN replication scheme.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -288,6 +288,7 @@
                 <property name="response.timeout.millis">60000</property>
                 <property name="ack.type">ACK_ON_OPERATION_COMPLETE</property>
                 <property name="snapshot.enabled">false</property>
+                <property name="group.name">nyc-override</property>
                 <property name="group.password">nyc-pass</property>
             </properties>
             <!--<aws enabled="false">-->


### PR DESCRIPTION
Until now, the "group-name" attribute was used both as an identifier for
a specific publisher in a WAN replication scheme and as a group name
for authentication. This does not allow replicating to two distinct
clusters with the same group name as the latter one will be overwritten.

We add the ability to configure the group name for authentication in the
publisher group properties. The "group-name" attribute still must be
unique but now it can be used only for identification of a single
publisher in a WAN replication scheme.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2393
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2401