### PR TITLE
Fix symmetric-entryption <iteration-count/> XSD type. We have to allow bigger values than 255

### DIFF
--- a/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
@@ -2166,7 +2166,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="iteration-count" type="xs:unsignedByte" default="19">
+            <xs:element name="iteration-count" type="xs:int" default="19">
                 <xs:annotation>
                     <xs:documentation>
                         Iteration count to use when generating the secret key.

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -266,6 +266,28 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testSymmetricEncryptionConfig() {
+        String xml = HAZELCAST_START_TAG
+                + "    <network>\n"
+                + "      <symmetric-encryption enabled=\"true\">\n"
+                + "        <algorithm>AES</algorithm>\n"
+                + "        <salt>thesalt</salt>\n"
+                + "        <password>thepass</password>\n"
+                + "        <iteration-count>7531</iteration-count>\n"
+                + "      </symmetric-encryption>"
+                + "    </network>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        SymmetricEncryptionConfig symmetricEncryptionConfig = config.getNetworkConfig().getSymmetricEncryptionConfig();
+        assertTrue(symmetricEncryptionConfig.isEnabled());
+        assertEquals("AES", symmetricEncryptionConfig.getAlgorithm());
+        assertEquals("thesalt", symmetricEncryptionConfig.getSalt());
+        assertEquals("thepass", symmetricEncryptionConfig.getPassword());
+        assertEquals(7531, symmetricEncryptionConfig.getIterationCount());
+    }
+
+    @Test
     public void readPortCount() {
         // check when it is explicitly set
         Config config = buildConfig(HAZELCAST_START_TAG


### PR DESCRIPTION
This PR fixes XSD type for `iteration-count` element under symmetric encryption configuration.
The original value space (0-255) is too small and it's protection against brute force attacks is negligible.

The issue is only related to XML configuration. The property type is correct in programmatic configuration.