### PR TITLE
Mark cluster state operations as UrgentSystemOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/CommitClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/CommitClusterStateOp.java
@@ -27,6 +27,7 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.transaction.TransactionException;
@@ -35,7 +36,8 @@ import java.io.IOException;
 
 import static java.lang.String.format;
 
-public class CommitClusterStateOp extends Operation implements AllowedDuringPassiveState, IdentifiedDataSerializable {
+public class CommitClusterStateOp extends Operation implements AllowedDuringPassiveState, UrgentSystemOperation,
+        IdentifiedDataSerializable {
 
     private ClusterStateChange stateChange;
     private Address initiator;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
@@ -28,13 +28,15 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 import com.hazelcast.transaction.TransactionException;
 
 import java.io.IOException;
 
-public class LockClusterStateOp  extends Operation implements AllowedDuringPassiveState, IdentifiedDataSerializable {
+public class LockClusterStateOp  extends Operation implements AllowedDuringPassiveState, UrgentSystemOperation,
+        IdentifiedDataSerializable {
 
     private ClusterStateChange stateChange;
     private Address initiator;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/RollbackClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/RollbackClusterStateOp.java
@@ -26,12 +26,14 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.UrgentSystemOperation;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
 
 import java.io.IOException;
 
-public class RollbackClusterStateOp extends Operation implements AllowedDuringPassiveState, IdentifiedDataSerializable {
+public class RollbackClusterStateOp extends Operation implements AllowedDuringPassiveState, UrgentSystemOperation,
+        IdentifiedDataSerializable {
 
     private Address initiator;
     private String txnId;


### PR DESCRIPTION
Otherwise, they may get rejected by backpressure. This is not desired
especially while shutting down the cluster.

Fixes #13730