### PR TITLE
Skip server near cache for client txn request

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapContainsKeyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapContainsKeyMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.protocol.task.AbstractTransactionalMessageTask;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.tx.TransactionalMapProxy;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
@@ -40,7 +41,7 @@ public class TransactionalMapContainsKeyMessageTask
     protected Object innerCall() throws Exception {
         final TransactionContext context = endpoint.getTransactionContext(parameters.txnId);
         final TransactionalMap map = context.getMap(parameters.name);
-        return map.containsKey(parameters.key);
+        return ((TransactionalMapProxy) map).containsKey(parameters.key, true);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/transactionalmap/TransactionalMapGetMessageTask.java
@@ -22,6 +22,7 @@ import com.hazelcast.client.impl.protocol.task.AbstractTransactionalMessageTask;
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.tx.TransactionalMapProxy;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
@@ -40,7 +41,7 @@ public class TransactionalMapGetMessageTask
     protected Object innerCall() throws Exception {
         final TransactionContext context = endpoint.getTransactionContext(parameters.txnId);
         final TransactionalMap map = context.getMap(parameters.name);
-        Object response = map.get(parameters.key);
+        Object response = ((TransactionalMapProxy) map).get(parameters.key, true);
         return serializationService.toData(response);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -60,6 +60,10 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
     @Override
     public boolean containsKey(Object key) {
+        return containsKey(key, false);
+    }
+
+    public boolean containsKey(Object key, boolean skipNearCacheLookup) {
         checkTransactionState();
         checkNotNull(key, "key can't be null");
 
@@ -68,7 +72,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         if (valueWrapper != null) {
             return (valueWrapper.type != Type.REMOVED);
         }
-        return containsKeyInternal(keyData, key);
+        return containsKeyInternal(keyData, key, skipNearCacheLookup);
     }
 
     @Override
@@ -97,17 +101,20 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
 
     @Override
     public Object get(Object key) {
+        return get(key, false);
+    }
+
+    public Object get(Object key, boolean skipNearCacheLookup) {
         checkTransactionState();
         checkNotNull(key, "key can't be null");
 
         Object nearCacheKey = toNearCacheKeyWithStrategy(key);
         Data keyData = mapServiceContext.toData(nearCacheKey, partitionStrategy);
-
         TxnValueWrapper currentValue = txMap.get(keyData);
         if (currentValue != null) {
             return checkIfRemoved(currentValue);
         }
-        return toObjectIfNeeded(getInternal(nearCacheKey, keyData));
+        return toObjectIfNeeded(getInternal(nearCacheKey, keyData, skipNearCacheLookup));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxySupport.java
@@ -56,7 +56,6 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
 
     protected final Map<Data, VersionedValue> valueMap = new HashMap<Data, VersionedValue>();
 
-    protected final boolean nearCacheEnabled;
     protected final String name;
     protected final MapServiceContext mapServiceContext;
     protected final MapNearCacheManager mapNearCacheManager;
@@ -67,6 +66,7 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
     protected final InternalSerializationService ss;
 
     private final boolean serializeKeys;
+    private final boolean nearCacheEnabled;
     private final RecordComparator recordComparator;
 
     TransactionalMapProxySupport(String name, MapService mapService, NodeEngine nodeEngine, Transaction transaction) {
@@ -107,8 +107,8 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         }
     }
 
-    boolean containsKeyInternal(Data dataKey, Object objectKey) {
-        if (nearCacheEnabled) {
+    boolean containsKeyInternal(Data dataKey, Object objectKey, boolean skipNearCacheLookup) {
+        if (!skipNearCacheLookup && nearCacheEnabled) {
             Object nearCacheKey = serializeKeys ? dataKey : objectKey;
             Object cachedValue = getCachedValue(nearCacheKey, false);
             if (cachedValue != NOT_CACHED) {
@@ -127,8 +127,8 @@ public abstract class TransactionalMapProxySupport extends TransactionalDistribu
         }
     }
 
-    Object getInternal(Object nearCacheKey, Data keyData) {
-        if (nearCacheEnabled) {
+    Object getInternal(Object nearCacheKey, Data keyData, boolean skipNearCacheLookup) {
+        if (!skipNearCacheLookup && nearCacheEnabled) {
             Object value = getCachedValue(nearCacheKey, true);
             if (value != NOT_CACHED) {
                 return value;


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/13371

Removed near cache lookup when server-side txn map proxy is called by client message tasks. Reasoning is, all near cache accesses should come from application local so client requests have nothing to do with server near cache.