### PR TITLE
Fix AbstractDistributedObject nodeEngine field usage

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/AbstractDistributedObject.java
@@ -174,52 +174,52 @@ public abstract class AbstractDistributedObject<S extends RemoteService> impleme
     }
 
     protected boolean isClusterVersionLessThan(Version version) {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
         return clusterVersion.isLessThan(version);
     }
 
     protected boolean isClusterVersionUnknownOrLessThan(Version version) {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
         return clusterVersion.isUnknownOrLessThan(version);
     }
 
     protected boolean isClusterVersionLessOrEqual(Version version) {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
         return clusterVersion.isLessOrEqual(version);
     }
 
     protected boolean isClusterVersionUnknownOrLessOrEqual(Version version) {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
         return clusterVersion.isUnknownOrLessOrEqual(version);
     }
 
     protected boolean isClusterVersionGreaterThan(Version version) {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
         return clusterVersion.isGreaterThan(version);
     }
 
     protected boolean isClusterVersionUnknownOrGreaterThan(Version version) {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
         return clusterVersion.isUnknownOrGreaterThan(version);
     }
 
     protected boolean isClusterVersionGreaterOrEqual(Version version) {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
         return clusterVersion.isGreaterOrEqual(version);
     }
 
     protected boolean isClusterVersionUnknownOrGreaterOrEqual(Version version) {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
         return clusterVersion.isUnknownOrGreaterOrEqual(version);
     }
 
     protected boolean isClusterVersionEqualTo(Version version) {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
         return clusterVersion.isEqualTo(version);
     }
 
     protected boolean isClusterVersionUnknown() {
-        Version clusterVersion = nodeEngine.getClusterService().getClusterVersion();
+        Version clusterVersion = getNodeEngine().getClusterService().getClusterVersion();
         return clusterVersion.isUnknown();
     }
 }


### PR DESCRIPTION
Methods in AbstractDistributedObject should not access `nodeEngine` field
directly, but call `getNodeEngine()` method to retrieve it. `nodeEngine` field
is set to `null` when HazelcastInstance is terminated. `getNodeEngine()` method
takes care of that and throws `HazelcastInstanceNotActiveException`.

Fixes #13728