### PR TITLE
Fix memory leak of nioChannels

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
@@ -129,7 +129,7 @@ class ClusterConnector {
         this.ownerConnectionAddress = ownerConnectionAddress;
     }
 
-    Connection connectAsOwner(Address address) {
+    private Connection connectAsOwner(Address address) {
         Connection connection = null;
         try {
             logger.info("Trying to connect to " + address + " as owner member");

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.networking;
 
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.IOUtil;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -108,27 +109,35 @@ public abstract class AbstractChannel implements Channel {
 
     @Override
     public void connect(InetSocketAddress address, int timeoutMillis) throws IOException {
-        checkNotNull(address, "address");
-        checkNotNegative(timeoutMillis, "timeoutMillis can't be negative");
-
-        // since the connect method is blocking, we need to configure blocking.
-        socketChannel.configureBlocking(true);
-
         try {
-            if (timeoutMillis > 0) {
-                socketChannel.socket().connect(address, timeoutMillis);
-            } else {
-                socketChannel.connect(address);
-            }
-        } catch (SocketException ex) {
-            //we want to include the address in the exception.
-            SocketException newEx = new SocketException(ex.getMessage() + " to address " + address);
-            newEx.setStackTrace(ex.getStackTrace());
-            throw newEx;
-        }
+            checkNotNull(address, "address");
+            checkNotNegative(timeoutMillis, "timeoutMillis can't be negative");
 
-        if (logger.isFinestEnabled()) {
-            logger.finest("Successfully connected to: " + address + " using socket " + socketChannel.socket());
+            // since the connect method is blocking, we need to configure blocking.
+            socketChannel.configureBlocking(true);
+
+            try {
+                if (timeoutMillis > 0) {
+                    socketChannel.socket().connect(address, timeoutMillis);
+                } else {
+                    socketChannel.connect(address);
+                }
+            } catch (SocketException ex) {
+                //we want to include the address in the exception.
+                SocketException newEx = new SocketException(ex.getMessage() + " to address " + address);
+                newEx.setStackTrace(ex.getStackTrace());
+                throw newEx;
+            }
+
+            if (logger.isFinestEnabled()) {
+                logger.finest("Successfully connected to: " + address + " using socket " + socketChannel.socket());
+            }
+        } catch (RuntimeException e) {
+            IOUtil.closeResource(this);
+            throw e;
+        } catch (IOException e) {
+            IOUtil.closeResource(this);
+            throw e;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
@@ -198,6 +198,8 @@ public interface Channel extends Closeable {
      * <li>if there is a timeout.</li>
      * </ol>
      *
+     * In case of failure, channel is closed automatically and exception is thrown to user.
+     *
      * @param address       the address to connect to.
      * @param timeoutMillis the timeout in millis, or 0 if waiting indefinitely.
      * @throws IOException if connecting fails.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -119,6 +119,11 @@ public final class NioNetworking implements Networking {
         return outputThreads;
     }
 
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "used only for testing")
+    public Set<NioChannel> getChannels() {
+        return channels;
+    }
+
     public IOBalancer getIOBalancer() {
         return ioBalancer;
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioChannelMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioChannelMemoryLeakTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.networking.nio;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.tcp.TcpIpConnectionManager;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.spi.properties.GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS;
+import static com.hazelcast.spi.properties.GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS;
+import static junit.framework.TestCase.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class NioChannelMemoryLeakTest extends HazelcastTestSupport {
+
+
+    @After
+    public void cleanUp() {
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testNioChannelLeak() {
+        Config config = new Config();
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getTcpIpConfig().addMember("127.0.0.1:6000").setEnabled(true);
+        join.getMulticastConfig().setEnabled(false);
+
+        config.setProperty(MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "1");
+        config.setProperty(MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "1");
+        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        TcpIpConnectionManager connectionManager = (TcpIpConnectionManager) getConnectionManager(instance);
+        final NioNetworking networking = (NioNetworking) connectionManager.getNetworking();
+        sleepSeconds(2);
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(0, networking.getChannels().size());
+            }
+        });
+        instance.shutdown();
+    }
+
+}


### PR DESCRIPTION
When a channel is registered to `NioNetworking` the related connection
fails with exception, channel objects are not closed. This causes
memory leak. With this pr they will be closed to prevent the leak.

fixes https://github.com/hazelcast/hazelcast/issues/13701