### PR TITLE
[DO NOT MERGE] Throw HazelcastInstanceNotActive when serialization service is disposed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.PartitioningStrategy;
 import com.hazelcast.instance.OutOfMemoryErrorDispatcher;
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -59,6 +60,9 @@ public final class SerializationUtil {
         }
         if (e instanceof HazelcastSerializationException) {
             throw (HazelcastSerializationException) e;
+        }
+        if (e instanceof HazelcastInstanceNotActiveException) {
+            throw (HazelcastInstanceNotActiveException) e;
         }
         throw new HazelcastSerializationException(e);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/DataSerializableSerializationTest.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
@@ -46,6 +48,18 @@ public class DataSerializableSerializationTest extends HazelcastTestSupport {
 
     private SerializationService ss = new DefaultSerializationServiceBuilder().setVersion(InternalSerializationService.VERSION_1)
                                                                               .build();
+
+    @Test(expected = HazelcastInstanceNotActiveException.class)
+    public void givenSerializationDisposed_whenAttemptToDeserializeIDS_thenThrowInstanceNotActive() {
+        InternalSerializationService serializationService = new DefaultSerializationServiceBuilder()
+                .addDataSerializableFactory(1, new IDSPersonFactory())
+                .build();
+        Data data = serializationService.toData(new IDSPerson("James Bond"));
+
+        serializationService.dispose();
+
+        serializationService.toObject(data);
+    }
 
     @Test
     public void serializeAndDeserialize_DataSerializable() {

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.nio.serialization;
 
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.PortableContext;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
@@ -42,6 +43,18 @@ public class PortableTest {
 
     static final int PORTABLE_FACTORY_ID = TestSerializationConstants.PORTABLE_FACTORY_ID;
     static final int IDENTIFIED_FACTORY_ID = TestSerializationConstants.DATA_SERIALIZABLE_FACTORY_ID;
+
+    @Test(expected = HazelcastInstanceNotActiveException.class)
+    public void givenSerializationDisposed_whenAttemptToDeserializePortable_thenThrowInstanceNotActive() {
+        InternalSerializationService serializationService = new DefaultSerializationServiceBuilder()
+                .addPortableFactory(PORTABLE_FACTORY_ID, new TestPortableFactory())
+                .build();
+        Data data = serializationService.toData(new TestObject2());
+
+        serializationService.dispose();
+
+        serializationService.toObject(data);
+    }
 
     @Test
     public void testBasics() {


### PR DESCRIPTION
Fixes #13724

Original problem:
When serialization service is disposed then DataSerializableSerializer
and PortableSerializer clear their internal factories. Hence if there
is another thread asking to deserialize Data then a factory won't be found
and it will throw SerializationException. This Exception is misleading
as in it indicates there is something wrong with Serialization config
while in the fact it's just HazelcastInstance shutting down.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2413