### PR TITLE
Dont keep the endpoint reference to clean client resources

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -460,13 +460,15 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
             }
 
             String localMemberUuid = node.getThisUuid();
-            String ownerUuid = ownershipMappings.get(endpoint.getUuid());
+            final String clientUuid = endpoint.getUuid();
+            String ownerUuid = ownershipMappings.get(clientUuid);
             if (localMemberUuid.equals(ownerUuid)) {
+                final long authenticationCorrelationId = endpoint.getAuthenticationCorrelationId();
                 try {
                     nodeEngine.getExecutionService().schedule(new Runnable() {
                         @Override
                         public void run() {
-                            callDisconnectionOperation(endpoint);
+                            callDisconnectionOperation(clientUuid, authenticationCorrelationId);
                         }
                     }, endpointRemoveDelaySeconds, TimeUnit.SECONDS);
                 } catch (RejectedExecutionException e) {
@@ -477,11 +479,10 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
             }
         }
 
-        private void callDisconnectionOperation(ClientEndpointImpl endpoint) {
+        private void callDisconnectionOperation(String clientUuid, long authenticationCorrelationId) {
             Collection<Member> memberList = nodeEngine.getClusterService().getMembers();
             OperationService operationService = nodeEngine.getOperationService();
             String memberUuid = getLocalMember().getUuid();
-            String clientUuid = endpoint.getUuid();
 
             String ownerMember = ownershipMappings.get(clientUuid);
             if (!memberUuid.equals(ownerMember)) {
@@ -489,7 +490,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
                 return;
             }
 
-            if (lastAuthenticationCorrelationIds.get(clientUuid).get() > endpoint.getAuthenticationCorrelationId()) {
+            if (lastAuthenticationCorrelationIds.get(clientUuid).get() > authenticationCorrelationId) {
                 //a new authentication already made for that client. This check is needed to detect
                 // "a disconnected client is reconnected back to same node"
                 return;


### PR DESCRIPTION
We are scheduling a task to clean client resources after some
time(60 seconds). Eventough endpoint is removed, we were keeping
a reference to it via this task. This was causing unncessary leak
for 60 seconds since the endpoint keeps reference to heavy objects
like `connection`.

With this pr, we are passing only necessary fields objects of
client endpoint to task to avoid keeping reference to the client
endpoint itself.

(cherry picked from commit e3632c642065d7729c61b322ba8eb6329106a7bb)