### PR TITLE
Allow null maxIdle when merging map entries in a 3.11 cluster

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/merge/MapMergingEntryImpl.java
@@ -210,9 +210,15 @@ public class MapMergingEntryImpl
         out.writeLong(lastUpdateTime);
         out.writeLong(version);
         out.writeLong(ttl);
-        //RU_COMPAT_3_10
+        // RU_COMPAT_3_10
+        // WAN events received from source cluster also carry null maxIdle
+        // even when cluster version is 3.11
         if (out.getVersion().isGreaterOrEqual(V3_11)) {
-            out.writeLong(maxIdle);
+            boolean hasMaxIdle = maxIdle != null;
+            out.writeBoolean(hasMaxIdle);
+            if (hasMaxIdle) {
+                out.writeLong(maxIdle);
+            }
         }
     }
 
@@ -230,8 +236,13 @@ public class MapMergingEntryImpl
         version = in.readLong();
         ttl = in.readLong();
         //RU_COMPAT_3_10
+        // WAN events received from source cluster also carry null maxIdle
+        // even when cluster version is 3.11
         if (in.getVersion().isGreaterOrEqual(V3_11)) {
-            maxIdle = in.readLong();
+            boolean hasMaxIdle = in.readBoolean();
+            if (hasMaxIdle) {
+                maxIdle = in.readLong();
+            }
         }
     }
 


### PR DESCRIPTION
WAN events do not carry the maxIdle value. The WAN event processing uses
map merge functionality and expects it to handle the scenario when
maxIdle is null. The fix allows for this case.

NOTE: 
Tests are in EE and they are currently `@Ignore`d until this fix is merged. 

NOTE 2:
Also, having such WAN specifics in map merge classes is not very good. I've been considering adding a `WanMapMergingEntryImpl` which would allow the `MapMergingEntryImpl` to continue evolving without any fear of breaking WAN compatibility. This can allow us better evolvability in the future but we still need the changes in `MapMergingEntryImpl`. The reason is as follows:
- the `WanMapMergingEntryImpl` would be constructed when we are processing WAN events but only if the cluster version is 3.11 or higher (see [here](https://github.com/hazelcast/hazelcast-enterprise/blob/master/hazelcast-enterprise/src/main/java/com/hazelcast/map/impl/EnterpriseMapReplicationSupportingService.java#L215)). For instance,
```
MapMergeTypes mergingEntry = nodeEngine.getClusterService().getClusterVersion().isGreaterOrEqual(Versions.V3_11)
                    ? createWanMergingEntry(nodeEngine.getSerializationService(), event.getEntryView()) 
                    : createMergingEntry(nodeEngine.getSerializationService(), event.getEntryView());
``` 
- let's say the cluster version is 3.10 and we are in the middle of RU. We then proceed to create the current `MapMergingEntryImpl`. After this, the cluster version can change to 3.11 before we actually serialize the entry. We again hit the same issue then - the old `MapMergingEntryImpl` will be constructed with a `maxIdle == null` and we get a NPE on serialization.
Bottom line - we can add a WAN specific merging entry and it might help us in the future. But we still need this check for now. I appreciate any input on the subject.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2414