### PR TITLE
Fixes retention issue on IOBalancer.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerThread.java
@@ -18,8 +18,12 @@ package com.hazelcast.internal.networking.nio.iobalancer;
 
 import com.hazelcast.logging.ILogger;
 
+import java.util.concurrent.BlockingQueue;
+
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
+import static java.lang.System.currentTimeMillis;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 class IOBalancerThread extends Thread {
@@ -27,14 +31,20 @@ class IOBalancerThread extends Thread {
 
     private final IOBalancer ioBalancer;
     private final ILogger log;
-    private final int balancerIntervalSeconds;
+    private final long balancerIntervalMs;
+    private final BlockingQueue<Runnable> workQueue;
     private volatile boolean shutdown;
 
-    IOBalancerThread(IOBalancer ioBalancer, int balancerIntervalSeconds, String hzName, ILogger log) {
+    IOBalancerThread(IOBalancer ioBalancer,
+                     int balancerIntervalSeconds,
+                     String hzName,
+                     ILogger log,
+                     BlockingQueue<Runnable> workQueue) {
         super(createThreadName(hzName, THREAD_NAME_PREFIX));
         this.ioBalancer = ioBalancer;
         this.log = log;
-        this.balancerIntervalSeconds = balancerIntervalSeconds;
+        this.balancerIntervalMs = SECONDS.toMillis(balancerIntervalSeconds);
+        this.workQueue = workQueue;
     }
 
     void shutdown() {
@@ -48,10 +58,21 @@ class IOBalancerThread extends Thread {
     public void run() {
         try {
             log.finest("Starting IOBalancer thread");
+            long nextRebalanceMs = currentTimeMillis() + balancerIntervalMs;
             while (!shutdown) {
-                ioBalancer.checkInboundPipelines();
-                ioBalancer.checkOutboundPipelines();
-                SECONDS.sleep(balancerIntervalSeconds);
+                for (; ; ) {
+                    long maxPollDurationMs = nextRebalanceMs - currentTimeMillis();
+                    Runnable task = maxPollDurationMs <= 0 ? workQueue.poll() : workQueue.poll(maxPollDurationMs, MILLISECONDS);
+                    if (task == null) {
+                        // we are finished with taking task from the queue, lets
+                        // do a bit of rebalancing.
+                        break;
+                    }
+                    task.run();
+                }
+
+                ioBalancer.rebalance();
+                nextRebalanceMs = currentTimeMillis() + balancerIntervalMs;
             }
         } catch (InterruptedException e) {
             log.finest("IOBalancer thread stopped");

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
@@ -22,11 +22,8 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.util.ItemCounter;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.LinkedBlockingQueue;
 
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
@@ -39,8 +36,6 @@ import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
  * {@link #removePipeline(MigratablePipeline)}
  */
 class LoadTracker {
-    final Queue<Runnable> tasks = new LinkedBlockingQueue<Runnable>();
-
     private final ILogger logger;
 
     //all known IO ioThreads. we assume no. of ioThreads is constant during a lifespan of a member
@@ -80,21 +75,11 @@ class LoadTracker {
      * @return recalculated imbalance
      */
     LoadImbalance updateImbalance() {
-        handleAddedOrRemovedConnections();
         clearWorkingImbalance();
         updateNewWorkingImbalance();
         updateNewFinalImbalance();
         printDebugTable();
         return imbalance;
-    }
-
-    private void handleAddedOrRemovedConnections() {
-        Iterator<Runnable> iterator = tasks.iterator();
-        while (iterator.hasNext()) {
-            Runnable task = iterator.next();
-            task.run();
-            iterator.remove();
-        }
     }
 
     // just for testing
@@ -136,13 +121,6 @@ class LoadTracker {
         }
     }
 
-    void notifyPipelineAdded(MigratablePipeline pipeline) {
-        tasks.offer(new AddPipelineTask(pipeline));
-    }
-
-    void notifyPipelineRemoved(MigratablePipeline pipeline) {
-        tasks.offer(new RemovePipelineTask(pipeline));
-    }
 
     private void updateNewWorkingImbalance() {
         for (MigratablePipeline pipeline : pipelines) {
@@ -180,7 +158,7 @@ class LoadTracker {
         pipelines.add(pipeline);
     }
 
-    private void removePipeline(MigratablePipeline pipeline) {
+    public void removePipeline(MigratablePipeline pipeline) {
         pipelines.remove(pipeline);
         pipelineLoadCount.remove(pipeline);
         lastLoadCounter.remove(pipeline);
@@ -255,39 +233,5 @@ class LoadTracker {
         sb.append(LINE_SEPARATOR);
     }
 
-    class RemovePipelineTask implements Runnable {
 
-        private final MigratablePipeline pipeline;
-
-        RemovePipelineTask(MigratablePipeline pipeline) {
-            this.pipeline = pipeline;
-        }
-
-        @Override
-        public void run() {
-            if (logger.isFinestEnabled()) {
-                logger.finest("Removing pipeline: " + pipeline);
-            }
-
-            removePipeline(pipeline);
-        }
-    }
-
-    class AddPipelineTask implements Runnable {
-
-        private final MigratablePipeline pipeline;
-
-        AddPipelineTask(MigratablePipeline pipeline) {
-            this.pipeline = pipeline;
-        }
-
-        @Override
-        public void run() {
-            if (logger.isFinestEnabled()) {
-                logger.finest("Adding pipeline: " + pipeline);
-            }
-
-            addPipeline(pipeline);
-        }
-    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancerTest.java
@@ -45,8 +45,7 @@ public class IOBalancerTest {
 
         ioBalancer.channelAdded(inboundPipeline, outboundPipeline);
 
-        assertTrue(ioBalancer.getInLoadTracker().tasks.isEmpty());
-        assertTrue(ioBalancer.getOutLoadTracker().tasks.isEmpty());
+        assertTrue(ioBalancer.getWorkQueue().isEmpty());
     }
 
     // https://github.com/hazelcast/hazelcast/issues/11501
@@ -58,7 +57,6 @@ public class IOBalancerTest {
 
         ioBalancer.channelRemoved(inboundPipeline, outboundPipelines);
 
-        assertTrue(ioBalancer.getInLoadTracker().tasks.isEmpty());
-        assertTrue(ioBalancer.getOutLoadTracker().tasks.isEmpty());
+        assertTrue(ioBalancer.getWorkQueue().isEmpty());
     }
 }


### PR DESCRIPTION
If connections get created very rapidly, tasks in the IOBalancer
can accumulate and this can lead to retention of the NioChannel
and its resources.

This PR fixes that by processing tasks immediately in the IOBalancer
when they arrive instead of waiting up to 20s.