### PR TITLE
Fixes issue with registration of channels regarding metrics

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
@@ -129,6 +129,8 @@ public abstract class AbstractChannel implements Channel {
                 throw newEx;
             }
 
+            onConnect();
+
             if (logger.isFinestEnabled()) {
                 logger.finest("Successfully connected to: " + address + " using socket " + socketChannel.socket());
             }
@@ -139,6 +141,13 @@ public abstract class AbstractChannel implements Channel {
             IOUtil.closeResource(this);
             throw e;
         }
+    }
+
+    /**
+     * Template method that can be implemented when the {@link #connect(InetSocketAddress, int)}
+     * has completed.
+     */
+    protected void onConnect() {
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -206,7 +206,7 @@ public final class NioNetworking implements Networking {
 
     @Override
     public Channel register(SocketChannel socketChannel, boolean clientMode) throws IOException {
-        NioChannel channel = new NioChannel(socketChannel, clientMode, channelInitializer);
+        NioChannel channel = new NioChannel(socketChannel, clientMode, channelInitializer, metricsRegistry);
 
         socketChannel.configureBlocking(false);
 
@@ -216,10 +216,6 @@ public final class NioNetworking implements Networking {
         channels.add(channel);
 
         channel.init(inboundPipeline, outboundPipeline);
-
-        String metricsId = channel.localSocketAddress() + "->" + channel.remoteSocketAddress();
-        metricsRegistry.scanAndRegister(outboundPipeline, "tcp.connection[" + metricsId + "].out");
-        metricsRegistry.scanAndRegister(inboundPipeline, "tcp.connection[" + metricsId + "].in");
 
         ioBalancer.channelAdded(inboundPipeline, outboundPipeline);
 


### PR DESCRIPTION
The problem was that the channel wasn't connected yet, so
the local and remote address are not known yet.

The fix is to move the registration of the metrics
to the NioChannel.connect. So that the registration
takes place after the connection is established.

fixes https://github.com/hazelcast/hazelcast/issues/13768