### PR TITLE
Expose WAN consistency check and publisher status change via REST

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -50,6 +50,11 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
     public static final String URI_WAN_SYNC_ALL_MAPS = URI_MANCENTER_BASE_URL + "/wan/sync/allmaps";
     public static final String URI_MANCENTER_WAN_CLEAR_QUEUES = URI_MANCENTER_BASE_URL + "/wan/clearWanQueues";
     public static final String URI_ADD_WAN_CONFIG = URI_MANCENTER_BASE_URL + "/wan/addWanConfig";
+    public static final String URI_WAN_PAUSE_PUBLISHER = URI_MANCENTER_BASE_URL + "/wan/pausePublisher";
+    public static final String URI_WAN_STOP_PUBLISHER = URI_MANCENTER_BASE_URL + "/wan/stopPublisher";
+    public static final String URI_WAN_RESUME_PUBLISHER = URI_MANCENTER_BASE_URL + "/wan/resumePublisher";
+    public static final String URI_WAN_CONSISTENCY_CHECK_MAP = URI_MANCENTER_BASE_URL + "/wan/consistencyCheck/map";
+
     public static final String LEGACY_URI_WAN_SYNC_MAP = "/hazelcast/rest/wan/sync/map";
     public static final String LEGACY_URI_WAN_SYNC_ALL_MAPS = "/hazelcast/rest/wan/sync/allmaps";
     public static final String LEGACY_URI_MANCENTER_WAN_CLEAR_QUEUES = "/hazelcast/rest/mancenter/clearWanQueues";

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -229,14 +229,34 @@ public class HTTPCommunicator {
         return doPost(url, groupName, groupPassword).response;
     }
 
-    public String syncMapOverWAN(String wanRepName, String targetGroupName, String mapName) throws IOException {
+    public String syncMapOverWAN(String wanRepName, String publisherId, String mapName) throws IOException {
         String url = address + "mancenter/wan/sync/map";
-        return doPost(url, wanRepName, targetGroupName, mapName).response;
+        return doPost(url, wanRepName, publisherId, mapName).response;
     }
 
-    public String syncMapsOverWAN(String wanRepName, String targetGroupName) throws IOException {
+    public String syncMapsOverWAN(String wanRepName, String publisherId) throws IOException {
         String url = address + "mancenter/wan/sync/allmaps";
-        return doPost(url, wanRepName, targetGroupName).response;
+        return doPost(url, wanRepName, publisherId).response;
+    }
+
+    public String wanMapConsistencyCheck(String wanRepName, String publisherId, String mapName) throws IOException {
+        String url = address + "mancenter/wan/consistencyCheck/map";
+        return doPost(url, wanRepName, publisherId, mapName).response;
+    }
+
+    public String wanPausePublisher(String wanRepName, String publisherId) throws IOException {
+        String url = address + "mancenter/wan/pausePublisher";
+        return doPost(url, wanRepName, publisherId).response;
+    }
+
+    public String wanStopPublisher(String wanRepName, String publisherId) throws IOException {
+        String url = address + "mancenter/wan/stopPublisher";
+        return doPost(url, wanRepName, publisherId).response;
+    }
+
+    public String wanResumePublisher(String wanRepName, String publisherId) throws IOException {
+        String url = address + "mancenter/wan/resumePublisher";
+        return doPost(url, wanRepName, publisherId).response;
     }
 
     public String wanClearQueues(String wanRepName, String targetGroupName) throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wan;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.DefaultNodeContext;
+import com.hazelcast.instance.DefaultNodeExtension;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeExtension;
+import com.hazelcast.internal.ascii.HTTPCommunicator;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class WanRESTTest extends HazelcastTestSupport {
+    private WanReplicationService wanServiceMock;
+    private HTTPCommunicator communicator;
+
+    @Before
+    public void initInstance() {
+        wanServiceMock = mock(WanReplicationService.class);
+        HazelcastInstance instance = HazelcastInstanceFactory.newHazelcastInstance(getConfig(), randomName(),
+                new WanServiceMockingNodeContext(wanServiceMock));
+        communicator = new HTTPCommunicator(instance);
+    }
+
+    @Test
+    public void pauseSuccess() throws Exception {
+        assertSuccess(communicator.wanPausePublisher("atob", "B"));
+        verify(wanServiceMock, times(1)).pause("atob", "B");
+    }
+
+    @Test
+    public void stopSuccess() throws Exception {
+        assertSuccess(communicator.wanStopPublisher("atob", "B"));
+        verify(wanServiceMock, times(1)).stop("atob", "B");
+    }
+
+    @Test
+    public void resumeSuccess() throws Exception {
+        assertSuccess(communicator.wanResumePublisher("atob", "B"));
+        verify(wanServiceMock, times(1)).resume("atob", "B");
+    }
+
+    @Test
+    public void consistencyCheckSuccess() throws Exception {
+        assertSuccess(communicator.wanMapConsistencyCheck("atob", "B", "mapName"));
+        verify(wanServiceMock, times(1)).consistencyCheck("atob", "B", "mapName");
+    }
+
+    @Test
+    public void pauseFail() throws Exception {
+        doThrow(new RuntimeException("Error occurred"))
+                .when(wanServiceMock)
+                .pause("atob", "B");
+        assertFail(communicator.wanPausePublisher("atob", "B"));
+        verify(wanServiceMock, times(1)).pause("atob", "B");
+    }
+
+    @Test
+    public void stopFail() throws Exception {
+        doThrow(new RuntimeException("Error occurred"))
+                .when(wanServiceMock)
+                .stop("atob", "B");
+        assertFail(communicator.wanStopPublisher("atob", "B"));
+        verify(wanServiceMock, times(1)).stop("atob", "B");
+    }
+
+    @Test
+    public void resumeFail() throws Exception {
+        doThrow(new RuntimeException("Error occurred"))
+                .when(wanServiceMock)
+                .resume("atob", "B");
+        assertFail(communicator.wanResumePublisher("atob", "B"));
+        verify(wanServiceMock, times(1)).resume("atob", "B");
+    }
+
+    @Test
+    public void consistencyCheckFail() throws Exception {
+        doThrow(new RuntimeException("Error occurred"))
+                .when(wanServiceMock)
+                .consistencyCheck("atob", "B", "mapName");
+        assertFail(communicator.wanMapConsistencyCheck("atob", "B", "mapName"));
+        verify(wanServiceMock, times(1)).consistencyCheck("atob", "B", "mapName");
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = smallInstanceConfig()
+                .setProperty(GroupProperty.REST_ENABLED.getName(), "true");
+        JoinConfig joinConfig = config.getNetworkConfig().getJoin();
+        joinConfig.getMulticastConfig()
+                  .setEnabled(false);
+        joinConfig.getTcpIpConfig()
+                  .setEnabled(true)
+                  .addMember("127.0.0.1");
+        return config;
+    }
+
+    @After
+    public void cleanup() {
+        HazelcastInstanceFactory.shutdownAll();
+    }
+
+    private void assertFail(String jsonResult) {
+        JsonObject result = Json.parse(jsonResult).asObject();
+        assertEquals("fail", result.getString("status", null));
+    }
+
+    private void assertSuccess(String jsonResult) {
+        JsonObject result = Json.parse(jsonResult).asObject();
+        assertEquals("success", result.getString("status", null));
+    }
+
+    private static class WanServiceMockingNodeContext extends DefaultNodeContext {
+        private final WanReplicationService wanReplicationService;
+
+        WanServiceMockingNodeContext(WanReplicationService wanReplicationService) {
+            super();
+            this.wanReplicationService = wanReplicationService;
+        }
+
+        @Override
+        public NodeExtension createNodeExtension(Node node) {
+            return new WanServiceMockingNodeExtension(node, wanReplicationService);
+        }
+    }
+
+    private static class WanServiceMockingNodeExtension extends DefaultNodeExtension {
+        private final WanReplicationService wanReplicationService;
+
+        WanServiceMockingNodeExtension(Node node, WanReplicationService wanReplicationService) {
+            super(node);
+            this.wanReplicationService = wanReplicationService;
+        }
+
+        @Override
+        public <T> T createService(Class<T> clazz) {
+            return clazz.isAssignableFrom(WanReplicationService.class)
+                    ? (T) wanReplicationService : super.createService(clazz);
+        }
+    }
+}


### PR DESCRIPTION
Exposes the API to change WAN publisher status and to initiate the WAN
map consistency check via REST.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2418