### PR TITLE
Introduce WAN publisher ID

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.11.xsd
@@ -2803,15 +2803,24 @@
                     <xs:attribute name="group-name" use="required">
                         <xs:annotation>
                             <xs:documentation>
-                                Sets the WAN publisher name used for identifying the publisher in
-                                a WanReplicationConfig.
-                                This name will also be used as an endpoint group name for authentication
+                                Sets the group name used as an endpoint group name for authentication
                                 on the target endpoint.
-                                The group name can also be defined in the publisher properties which
-                                takes precedence over this value. In such cases, this value will only
-                                be used as part of a WAN publisher identifier and the value defined in
-                                the properties will be used for authentication.
-                                This value must be unique for a single WAN replication scheme.
+                                If there is no separate publisher ID property defined, this group name
+                                will also be used as a WAN publisher ID. This ID is then used for
+                                identifying the publisher in a WanReplicationConfig.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="publisher-id">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Sets the publisher ID used for identifying the publisher in a
+                                WanReplicationConfig.
+                                If there is no publisher ID defined (it is empty), the group name will
+                                be used as a publisher ID.
                             </xs:documentation>
                         </xs:annotation>
                         <xs:simpleType>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -927,6 +927,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
 
         WanPublisherConfig publisherConfig = wcfg.getWanPublisherConfigs().get(0);
         assertEquals("tokyo", publisherConfig.getGroupName());
+        assertEquals("tokyoPublisherId", publisherConfig.getPublisherId());
         assertEquals("com.hazelcast.enterprise.wan.replication.WanBatchReplication", publisherConfig.getClassName());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, publisherConfig.getQueueFullBehavior());
         assertEquals(WanPublisherState.STOPPED, publisherConfig.getInitialPublisherState());
@@ -941,6 +942,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
 
         WanPublisherConfig customPublisher = wcfg.getWanPublisherConfigs().get(1);
         assertEquals("istanbul", customPublisher.getGroupName());
+        assertEquals("istanbulPublisherId", customPublisher.getPublisherId());
         assertEquals("com.hazelcast.wan.custom.CustomPublisher", customPublisher.getClassName());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, customPublisher.getQueueFullBehavior());
         Map<String, Comparable> customPublisherProps = customPublisher.getProperties();

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -58,7 +58,9 @@
                 <hz:property name="hazelcast.partition.count">277</hz:property>
             </hz:properties>
             <hz:wan-replication name="testWan">
-                <hz:wan-publisher group-name="tokyo" class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">
+                <hz:wan-publisher group-name="tokyo"
+                                  publisher-id="tokyoPublisherId"
+                                  class-name="com.hazelcast.enterprise.wan.replication.WanBatchReplication">
                     <hz:queue-full-behavior>THROW_EXCEPTION</hz:queue-full-behavior>
                     <hz:queue-capacity>1000</hz:queue-capacity>
                     <hz:initial-publisher-state>STOPPED</hz:initial-publisher-state>
@@ -73,7 +75,9 @@
                         <hz:property name="group.password">pass</hz:property>
                     </hz:properties>
                 </hz:wan-publisher>
-                <hz:wan-publisher group-name="istanbul" class-name="com.hazelcast.wan.custom.CustomPublisher">
+                <hz:wan-publisher group-name="istanbul"
+                                  publisher-id="istanbulPublisherId"
+                                  class-name="com.hazelcast.wan.custom.CustomPublisher">
                     <hz:queue-full-behavior>THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE</hz:queue-full-behavior>
                     <hz:aws enabled="false"
                             access-key="sample-access-key"

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -51,6 +51,7 @@ import static com.hazelcast.config.PermissionConfig.PermissionType.TRANSACTION;
 import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.Preconditions.isNotNull;
 import static com.hazelcast.util.StringUtil.isNullOrEmpty;
+import static com.hazelcast.util.StringUtil.isNullOrEmptyAfterTrim;
 import static java.util.Arrays.asList;
 
 /**
@@ -683,7 +684,9 @@ public class ConfigXmlGenerator {
     }
 
     private static void wanReplicationPublisherXmlGenerator(XmlGenerator gen, WanPublisherConfig p) {
-        gen.open("wan-publisher", "group-name", p.getGroupName())
+        String publisherId = !isNullOrEmptyAfterTrim(p.getPublisherId())
+                ? p.getPublisherId() : "";
+        gen.open("wan-publisher", "group-name", p.getGroupName(), "publisher-id", publisherId)
            .node("class-name", p.getClassName())
            .node("queue-full-behavior", p.getQueueFullBehavior())
            .node("initial-publisher-state", p.getInitialPublisherState())

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -112,7 +112,7 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
      * If there is no publisher ID defined (it is empty), the group name will
      * be used as a publisher ID.
      *
-     * @return the WAN publisher ID
+     * @return the WAN publisher ID or {@code null} if no publisher ID is set
      * @see #getGroupName()
      */
     public String getPublisherId() {

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.Preconditions.isNotNull;
+import static com.hazelcast.util.StringUtil.isNullOrEmptyAfterTrim;
 
 /**
  * Configuration object for a WAN publisher. A single publisher defines how
@@ -46,6 +47,7 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
     private static final WANQueueFullBehavior DEFAULT_QUEUE_FULL_BEHAVIOR = WANQueueFullBehavior.DISCARD_AFTER_MUTATION;
 
     private String groupName = "dev";
+    private String publisherId;
     private int queueCapacity = DEFAULT_QUEUE_CAPACITY;
     private WANQueueFullBehavior queueFullBehavior = DEFAULT_QUEUE_FULL_BEHAVIOR;
     private WanPublisherState initialPublisherState = WanPublisherState.REPLICATING;
@@ -75,42 +77,60 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
     }
 
     /**
-     * Returns the WAN publisher name used for identifying the publisher in
-     * a {@link WanReplicationConfig}.
-     * <p>
-     * This name will also be used as an endpoint group name for authentication
+     * Returns the group name used as an endpoint group name for authentication
      * on the target endpoint.
-     * <p>
-     * The group name can also be defined in the publisher properties which
-     * takes precedence over this value. In such cases, this value will only
-     * be used as part of a WAN publisher identifier and the value defined in
-     * the properties will be used for authentication.
-     * This value must be unique for a single WAN replication scheme.
+     * If there is no separate publisher ID property defined, this group name
+     * will also be used as a WAN publisher ID. This ID is then used for
+     * identifying the publisher in a {@link WanReplicationConfig}.
      *
-     * @return the WAN publisher name and endpoint group name
+     * @return the WAN endpoint group name
+     * @see #getPublisherId()
      */
     public String getGroupName() {
         return groupName;
     }
 
     /**
-     * Sets the WAN publisher name used for identifying the publisher in
-     * a {@link WanReplicationConfig}.
-     * <p>
-     * This name will also be used as an endpoint group name for authentication
+     * Sets the group name used as an endpoint group name for authentication
      * on the target endpoint.
-     * <p>
-     * The group name can also be defined in the publisher properties which
-     * takes precedence over this value. In such cases, this value will only
-     * be used as part of a WAN publisher identifier and the value defined in
-     * the properties will be used for authentication.
-     * This value must be unique for a single WAN replication scheme.
+     * If there is no separate publisher ID property defined, this group name
+     * will also be used as a WAN publisher ID. This ID is then used for
+     * identifying the publisher in a {@link WanReplicationConfig}.
      *
-     * @param groupName the WAN publisher name and publisher group name
+     * @param groupName the WAN endpoint group name
      * @return this config
+     * @see #getPublisherId()
      */
     public WanPublisherConfig setGroupName(String groupName) {
         this.groupName = groupName;
+        return this;
+    }
+
+    /**
+     * Returns the publisher ID used for identifying the publisher in a
+     * {@link WanReplicationConfig}.
+     * If there is no publisher ID defined (it is empty), the group name will
+     * be used as a publisher ID.
+     *
+     * @return the WAN publisher ID
+     * @see #getGroupName()
+     */
+    public String getPublisherId() {
+        return publisherId;
+    }
+
+    /**
+     * Sets the publisher ID used for identifying the publisher in a
+     * {@link WanReplicationConfig}.
+     * If there is no publisher ID defined (it is empty), the group name will
+     * be used as a publisher ID.
+     *
+     * @param publisherId the WAN publisher ID
+     * @return this config
+     * @see #getGroupName()
+     */
+    public WanPublisherConfig setPublisherId(String publisherId) {
+        this.publisherId = !isNullOrEmptyAfterTrim(publisherId) ? publisherId : null;
         return this;
     }
 
@@ -303,6 +323,7 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
     public String toString() {
         return "WanPublisherConfig{"
                 + "groupName='" + groupName + '\''
+                + ", publisherId='" + publisherId + '\''
                 + ", queueCapacity=" + queueCapacity
                 + ", queueFullBehavior=" + queueFullBehavior
                 + ", initialPublisherState=" + initialPublisherState
@@ -343,6 +364,7 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
         if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             out.writeByte(initialPublisherState.getId());
             out.writeObject(wanSyncConfig);
+            out.writeUTF(publisherId);
         }
     }
 
@@ -362,6 +384,7 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
         if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             initialPublisherState = WanPublisherState.getByType(in.readByte());
             wanSyncConfig = in.readObject();
+            publisherId = in.readUTF();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -639,6 +639,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
             if ("wan-publisher".equals(nodeName)) {
                 WanPublisherConfig publisherConfig = new WanPublisherConfig();
                 publisherConfig.setGroupName(getAttribute(nodeTarget, "group-name"));
+                publisherConfig.setPublisherId(getAttribute(nodeTarget, "publisher-id"));
                 for (Node targetChild : childElements(nodeTarget)) {
                     handleWanPublisherConfig(publisherConfig, targetChild);
                 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTO.java
@@ -18,9 +18,10 @@ package com.hazelcast.internal.management.dto;
 
 import com.hazelcast.config.WANQueueFullBehavior;
 import com.hazelcast.config.WanPublisherConfig;
-import com.hazelcast.internal.management.JsonSerializable;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.management.JsonSerializable;
 
 import java.util.Map;
 
@@ -39,7 +40,9 @@ public class WanPublisherConfigDTO implements JsonSerializable {
     public JsonObject toJson() {
         JsonObject object = new JsonObject();
         object.add("groupName", config.getGroupName());
-        object.add("publisherId", config.getPublisherId());
+        if (config.getPublisherId() != null) {
+            object.add("publisherId", config.getPublisherId());
+        }
         object.add("queueCapacity", config.getQueueCapacity());
         object.add("className", config.getClassName());
         object.add("queueFullBehavior", config.getQueueFullBehavior().getId());
@@ -55,7 +58,10 @@ public class WanPublisherConfigDTO implements JsonSerializable {
     public void fromJson(JsonObject json) {
         config = new WanPublisherConfig();
         config.setGroupName(json.get("groupName").asString());
-        config.setPublisherId(json.get("publisherId").asString());
+        JsonValue publisherId = json.get("publisherId");
+        if (publisherId != null && !publisherId.isNull()) {
+            config.setPublisherId(publisherId.asString());
+        }
         config.setQueueCapacity(json.get("queueCapacity").asInt());
         config.setClassName(json.get("className").asString());
         int queueFullBehavior = json.get("queueFullBehavior").asInt();

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTO.java
@@ -39,6 +39,7 @@ public class WanPublisherConfigDTO implements JsonSerializable {
     public JsonObject toJson() {
         JsonObject object = new JsonObject();
         object.add("groupName", config.getGroupName());
+        object.add("publisherId", config.getPublisherId());
         object.add("queueCapacity", config.getQueueCapacity());
         object.add("className", config.getClassName());
         object.add("queueFullBehavior", config.getQueueFullBehavior().getId());
@@ -54,6 +55,7 @@ public class WanPublisherConfigDTO implements JsonSerializable {
     public void fromJson(JsonObject json) {
         config = new WanPublisherConfig();
         config.setGroupName(json.get("groupName").asString());
+        config.setPublisherId(json.get("publisherId").asString());
         config.setQueueCapacity(json.get("queueCapacity").asInt());
         config.setClassName(json.get("className").asString());
         int queueFullBehavior = json.get("queueFullBehavior").asInt();

--- a/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.11.xsd
@@ -2468,15 +2468,21 @@
         <xs:attribute name="group-name" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    Sets the WAN publisher name used for identifying the publisher in
-                    a WanReplicationConfig.
-                    This name will also be used as an endpoint group name for authentication
+                    Sets the group name used as an endpoint group name for authentication
                     on the target endpoint.
-                    The group name can also be defined in the publisher properties which
-                    takes precedence over this value. In such cases, this value will only
-                    be used as part of a WAN publisher identifier and the value defined in
-                    the properties will be used for authentication.
-                    This value must be unique for a single WAN replication scheme.
+                    If there is no separate publisher ID property defined, this group name
+                    will also be used as a WAN publisher ID. This ID is then used for
+                    identifying the publisher in a WanReplicationConfig.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="publisher-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the publisher ID used for identifying the publisher in a
+                    WanReplicationConfig.
+                    If there is no publisher ID defined (it is empty), the group name will
+                    be used as a publisher ID.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -273,7 +273,7 @@
             </discovery-strategies>
     -->
     <wan-replication name="my-wan-cluster-batch">
-        <wan-publisher group-name="nyc">
+        <wan-publisher group-name="nyc" publisher-id="nycPublisherId">
             <class-name>com.hazelcast.enterprise.wan.replication.WanBatchReplication</class-name>
             <queue-capacity>15000</queue-capacity>
             <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>
@@ -288,7 +288,6 @@
                 <property name="response.timeout.millis">60000</property>
                 <property name="ack.type">ACK_ON_OPERATION_COMPLETE</property>
                 <property name="snapshot.enabled">false</property>
-                <property name="group.name">nyc-override</property>
                 <property name="group.password">nyc-pass</property>
             </properties>
             <!--<aws enabled="false">-->

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1049,6 +1049,7 @@ class ConfigCompatibilityChecker {
         boolean check(WanPublisherConfig c1, WanPublisherConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getGroupName(), c2.getGroupName())
+                    && nullSafeEqual(c1.getPublisherId(), c2.getPublisherId())
                     && nullSafeEqual(c1.getQueueCapacity(), c2.getQueueCapacity())
                     && nullSafeEqual(c1.getQueueFullBehavior(), c2.getQueueFullBehavior())
                     && nullSafeEqual(c1.getInitialPublisherState(), c2.getInitialPublisherState())

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1120,6 +1120,7 @@ public class ConfigXmlGeneratorTest {
                 .setWanConsumerConfig(new WanConsumerConfig().setClassName("dummyClass").setProperties(props));
         WanPublisherConfig publisherConfig = new WanPublisherConfig()
                 .setGroupName("dummyGroup")
+                .setPublisherId("dummyPublisherId")
                 .setClassName("dummyClass")
                 .setAwsConfig(getDummyAwsConfig())
                 .setInitialPublisherState(WanPublisherState.STOPPED)

--- a/hazelcast/src/test/java/com/hazelcast/config/WanPublisherConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/WanPublisherConfigTest.java
@@ -43,6 +43,7 @@ public class WanPublisherConfigTest {
         properties.put("key", "value");
 
         config.setGroupName("groupName");
+        config.setPublisherId("publisherId");
         config.setQueueCapacity(500);
         config.setQueueFullBehavior(WANQueueFullBehavior.THROW_EXCEPTION);
         config.setProperties(properties);
@@ -58,6 +59,7 @@ public class WanPublisherConfigTest {
 
     static void assertWanPublisherConfig(WanPublisherConfig expected, WanPublisherConfig actual) {
         assertEquals(expected.getGroupName(), actual.getGroupName());
+        assertEquals(expected.getPublisherId(), actual.getPublisherId());
         assertEquals(expected.getQueueCapacity(), actual.getQueueCapacity());
         assertEquals(expected.getQueueFullBehavior(), actual.getQueueFullBehavior());
         assertEquals(expected.getProperties(), actual.getProperties());

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1153,7 +1153,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         String configName  = "test";
         String xml = HAZELCAST_START_TAG
                 + "  <wan-replication name=\"" + configName + "\">\n"
-                + "        <wan-publisher group-name=\"nyc\">\n"
+                + "        <wan-publisher group-name=\"nyc\" publisher-id=\"publisherId\">\n"
                 + "            <class-name>PublisherClassName</class-name>\n"
                 + "            <queue-capacity>15000</queue-capacity>\n"
                 + "            <queue-full-behavior>DISCARD_AFTER_MUTATION</queue-full-behavior>\n"
@@ -1191,6 +1191,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         WanPublisherConfig publisherConfig = publishers.get(0);
         assertEquals("PublisherClassName", publisherConfig.getClassName());
         assertEquals("nyc", publisherConfig.getGroupName());
+        assertEquals("publisherId", publisherConfig.getPublisherId());
         assertEquals(15000, publisherConfig.getQueueCapacity());
         assertEquals(DISCARD_AFTER_MUTATION, publisherConfig.getQueueFullBehavior());
         assertEquals(WanPublisherState.STOPPED, publisherConfig.getInitialPublisherState());
@@ -1494,7 +1495,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     public void testWanConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <wan-replication name=\"my-wan-cluster\">\n"
-                + "      <wan-publisher group-name=\"istanbul\">\n"
+                + "      <wan-publisher group-name=\"istanbul\" publisher-id=\"istanbulPublisherId\">\n"
                 + "         <class-name>com.hazelcast.wan.custom.WanPublisher</class-name>\n"
                 + "         <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>\n"
                 + "         <queue-capacity>21</queue-capacity>\n"
@@ -1547,6 +1548,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(2, publisherConfigs.size());
         WanPublisherConfig publisherConfig1 = publisherConfigs.get(0);
         assertEquals("istanbul", publisherConfig1.getGroupName());
+        assertEquals("istanbulPublisherId", publisherConfig1.getPublisherId());
         assertEquals("com.hazelcast.wan.custom.WanPublisher", publisherConfig1.getClassName());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, publisherConfig1.getQueueFullBehavior());
         assertEquals(WanPublisherState.REPLICATING, publisherConfig1.getInitialPublisherState());
@@ -1561,6 +1563,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
 
         WanPublisherConfig publisherConfig2 = publisherConfigs.get(1);
         assertEquals("ankara", publisherConfig2.getGroupName());
+        assertNull(publisherConfig2.getPublisherId());
         assertEquals(WANQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, publisherConfig2.getQueueFullBehavior());
         assertEquals(WanPublisherState.STOPPED, publisherConfig2.getInitialPublisherState());
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTOTest.java
@@ -43,6 +43,7 @@ public class WanPublisherConfigDTOTest {
 
         WanPublisherConfig expected = new WanPublisherConfig()
                 .setGroupName("myGroupName")
+                .setPublisherId("myPublisherId")
                 .setQueueCapacity(23)
                 .setClassName("myClassName")
                 .setQueueFullBehavior(WANQueueFullBehavior.THROW_EXCEPTION)
@@ -56,6 +57,7 @@ public class WanPublisherConfigDTOTest {
 
         WanPublisherConfig actual = deserialized.getConfig();
         assertEquals(expected.getGroupName(), actual.getGroupName());
+        assertEquals(expected.getPublisherId(), actual.getPublisherId());
         assertEquals(expected.getQueueCapacity(), actual.getQueueCapacity());
         assertEquals(expected.getClassName(), actual.getClassName());
         assertEquals(expected.getQueueFullBehavior(), actual.getQueueFullBehavior());

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -58,7 +58,7 @@
         <property name="foo">bar</property>
     </properties>
     <wan-replication name="my-wan-cluster">
-        <wan-publisher group-name="tokyo">
+        <wan-publisher group-name="tokyo" publisher-id="tokyoPublisherId">
             <class-name>com.hazelcast.enterprise.wan.replication.WanBatchReplication</class-name>
             <queue-capacity>1000</queue-capacity>
             <queue-full-behavior>THROW_EXCEPTION</queue-full-behavior>


### PR DESCRIPTION
Introduces a WAN publisher ID which is used to refer to a specific WAN
publisher in a WAN replication scheme. If a WAN publisher ID is not
used, the group name is used as a publisher ID.
The WAN publisher ID may be useful when the target group names are not
unique for all of the WAN replication publishers in a single WAN
replication scheme.

Example - this is how we would currently configure two publishers with the same group name:
```xml
<wan-replication name="my-wan">
  <!-- Cross-region -->
  <wan-publisher group-name="someOtherUniqueID">
      <properties>
          <property name="group.name">london</property>
       </properties>
  </wan-publisher>
  <!-- local-region -->
  <wan-publisher group-name="london">
  </wan-publisher>
</wan-replication>
```
Now we remove the `group.name` property and allow this instead:
```xml
<wan-replication name="my-wan">
  <!-- Cross-region -->
  <wan-publisher group-name="london" publisher-id="someOtherUniqueID">
  </wan-publisher>
  <!-- local-region -->
  <wan-publisher group-name="london">
  </wan-publisher>
</wan-replication>
```

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2419
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2424