### PR TITLE
Removed unneeded iterations and object creations during client messag…

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMessageUnpackingSet.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMessageUnpackingSet.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.proxy;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.core.IFunction;
+
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+/**
+ * Unpacks client message and places it into a backing list. List is fine
+ * to back this set since we know that elements extracted from clint
+ * message will be unique.
+ *
+ * @param <E> type of elements in this set
+ */
+@SuppressWarnings("checkstyle:anoninnerlength")
+final class ClientMessageUnpackingSet<E> extends AbstractSet<E> {
+    final int numOfElementsInResponse;
+    final ClientMessage response;
+    final IFunction<ClientMessage, E> function;
+
+    List<E> backingList;
+
+    private ClientMessageUnpackingSet(int numOfElementsInMessage,
+                                      ClientMessage clientMessage,
+                                      IFunction<ClientMessage, E> function) {
+        this.numOfElementsInResponse = numOfElementsInMessage;
+        this.response = clientMessage;
+        this.function = function;
+    }
+
+    static <T> Set<T> toClientMessageUnpackingSet(ClientMessage response, IFunction<ClientMessage, T> function) {
+        assert response != null;
+        assert function != null;
+
+        int numOfElementsInResponse = response.getInt();
+
+        if (numOfElementsInResponse == 0) {
+            return Collections.emptySet();
+        }
+
+        return new ClientMessageUnpackingSet<T>(numOfElementsInResponse, response, function);
+    }
+
+    @Override
+    public int size() {
+        return numOfElementsInResponse;
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return new Iterator<E>() {
+            int visited;
+
+            @Override
+            public boolean hasNext() {
+                return visited != numOfElementsInResponse;
+            }
+
+            @Override
+            public E next() {
+                if (visited >= numOfElementsInResponse) {
+                    throw new NoSuchElementException();
+                }
+
+                if (backingList != null && visited < backingList.size()) {
+                    return backingList.get(visited++);
+                }
+
+                if (backingList == null) {
+                    backingList = new ArrayList<E>(numOfElementsInResponse);
+                }
+
+                E element = function.apply(response);
+                backingList.add(element);
+
+                visited++;
+                return element;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}


### PR DESCRIPTION
…e convertion to user object

fix candidate for: https://github.com/hazelcast/hazelcast/issues/13590

I did some quick simulator runs(1 client-1 server) seems we may have some gains compared to master. These are the results. 

* Tests only doing size check of returning sets from `keySet` and `entrySet` methods.  

__keySet__:

 | keyCount 	| master 	| fix 	| increase 	|
|----------	|-----------------	|-----------------	|----------	|
| 100 	| 38,906.68 ops/s 	| 45,077.51 ops/s 	| 18% 	|
| 1_000 	| 16,703.54 ops/s 	| 24,531.73 ops/s 	| 50% 	|
| 100_000 	| 40.18 ops/s 	| 200.85 ops/s 	| 400% 	|

__entrySet__:

| entryCount 	| master 	| fix 	| increase 	|
|------------	|-----------------	|-----------------	|-------------	|
| 100 	| 39,953.71 ops/s 	| 42,463.02 ops/s 	| nearly-same 	|
| 1_000 	| 15,911.12 ops/s 	| 20,403.84 ops/s 	| 33% 	|
| 100_000 	| 23.13 ops/s 	| 155.39 ops/s 	| 500% 	|