### PR TITLE
ClientReauthOperation should be retryable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -408,7 +408,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
         AtomicLong lastCorrelationId = ConcurrencyUtil.getOrPutIfAbsent(lastAuthenticationCorrelationIds,
                 clientUuid,
                 LAST_AUTH_CORRELATION_ID_CONSTRUCTOR_FUNC);
-        return ConcurrencyUtil.setIfGreaterThan(lastCorrelationId, newCorrelationId);
+        return ConcurrencyUtil.setIfEqualOrGreaterThan(lastCorrelationId, newCorrelationId);
     }
 
     public String addOwnershipMapping(String clientUuid, String ownerUuid) {

--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
@@ -48,10 +48,10 @@ public final class ConcurrencyUtil {
         }
     }
 
-    public static boolean setIfGreaterThan(AtomicLong oldValue, long newValue) {
+    public static boolean setIfEqualOrGreaterThan(AtomicLong oldValue, long newValue) {
         while (true) {
             long local = oldValue.get();
-            if (newValue <= local) {
+            if (newValue < local) {
                 return false;
             }
             if (oldValue.compareAndSet(local, newValue)) {

--- a/hazelcast/src/test/java/com/hazelcast/util/ConcurrencyUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/ConcurrencyUtilTest.java
@@ -27,9 +27,12 @@ import org.junit.runner.RunWith;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -91,6 +94,13 @@ public class ConcurrencyUtilTest extends HazelcastTestSupport {
     public void testGetOrPutSynchronized_whenMutexFactoryIsNull_thenThrowException() {
         ContextMutexFactory factory = null;
         ConcurrencyUtil.getOrPutSynchronized(map, 5, factory, constructorFunction);
+    }
+
+    @Test
+    public void testSetIfEqualOrGreaterThan() {
+        assertTrue(ConcurrencyUtil.setIfEqualOrGreaterThan(new AtomicLong(1), 1));
+        assertTrue(ConcurrencyUtil.setIfEqualOrGreaterThan(new AtomicLong(1), 2));
+        assertFalse(ConcurrencyUtil.setIfEqualOrGreaterThan(new AtomicLong(2), 1));
     }
 
     @Test


### PR DESCRIPTION
ClientReauthOperation is used with `invokeOnStableClusterSerial`
This requires for the operation to be safely retyable.

Before ClientReauthOperation was always throwing exception because
it was expecting to the new correlation id is always greater.

We are allowing it to be equal or greater than to last set
correlation id to make the operation safely retryable.

fixes https://github.com/hazelcast/hazelcast/issues/13758

(cherry picked from commit 6e2e1dc8349ef50f95576a0c9b8c840082d548f0)