### PR TITLE
Removes stale caching of ringbuffer in AbstractRingBufferOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/AbstractRingBufferOperation.java
@@ -47,7 +47,6 @@ public abstract class AbstractRingBufferOperation extends Operation implements N
         PartitionAwareOperation, ServiceNamespaceAware {
 
     protected String name;
-    private RingbufferContainer ringbuffer;
 
     public AbstractRingBufferOperation() {
     }
@@ -75,9 +74,6 @@ public abstract class AbstractRingBufferOperation extends Operation implements N
      * @return the ringbuffer container
      */
     RingbufferContainer getRingBufferContainer() {
-        if (ringbuffer != null) {
-            return ringbuffer;
-        }
         final RingbufferService service = getService();
         final ObjectNamespace ns = RingbufferService.getRingbufferNamespace(name);
 
@@ -87,7 +83,6 @@ public abstract class AbstractRingBufferOperation extends Operation implements N
         }
 
         ringbuffer.cleanup();
-        this.ringbuffer = ringbuffer;
         return ringbuffer;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -598,6 +598,21 @@ public abstract class HazelcastTestSupport {
         }
     }
 
+    public static String generateKeyForPartition(HazelcastInstance instance, String prefix, int partitionId) {
+        Cluster cluster = instance.getCluster();
+        checkPartitionCountGreaterOrEqualMemberCount(instance);
+
+        Member localMember = cluster.getLocalMember();
+        PartitionService partitionService = instance.getPartitionService();
+        while (true) {
+            String id = prefix + randomString();
+            Partition partition = partitionService.getPartition(id);
+            if (partition.getPartitionId() == partitionId) {
+                return id;
+            }
+        }
+    }
+
     public String[] generateKeysBelongingToSamePartitionsOwnedBy(HazelcastInstance instance, int keyCount) {
         int partitionId = getPartitionId(instance);
         String[] keys = new String[keyCount];

--- a/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/SubscriptionMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/topic/impl/reliable/SubscriptionMigrationTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.topic.impl.reliable;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ITopic;
+import com.hazelcast.core.Message;
+import com.hazelcast.core.MessageListener;
+import com.hazelcast.core.MigrationEvent;
+import com.hazelcast.core.MigrationListener;
+import com.hazelcast.ringbuffer.impl.RingbufferService;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertTrue;
+
+@Category({QuickTest.class, ParallelTest.class})
+@RunWith(HazelcastParallelClassRunner.class)
+public class SubscriptionMigrationTest extends HazelcastTestSupport {
+
+    @Rule
+    public OverridePropertyRule overridePropertyRule = OverridePropertyRule.set("hazelcast.partition.count", "2");
+
+    // gh issue: https://github.com/hazelcast/hazelcast/issues/13602
+    @Test
+    public void testListenerReceivesMessagesAfterPartitionIsMigratedBack() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance instance1 = factory.newHazelcastInstance();
+
+        final String rtNameOnPartition0 = generateReliableTopicNameForPartition(instance1, 0);
+        final String rtNameOnPartition1 = generateReliableTopicNameForPartition(instance1, 1);
+
+        ITopic<String> topic0 = instance1.getReliableTopic(rtNameOnPartition0);
+        ITopic<String> topic1 = instance1.getReliableTopic(rtNameOnPartition1);
+
+        final CountingMigrationListener migrationListener = new CountingMigrationListener();
+        instance1.getPartitionService().addMigrationListener(migrationListener);
+
+        final PayloadMessageListener<String> listener0 = new PayloadMessageListener<String>();
+        final PayloadMessageListener<String> listener1 = new PayloadMessageListener<String>();
+
+        topic0.addMessageListener(listener0);
+        topic1.addMessageListener(listener1);
+
+        topic0.publish("itemA");
+        topic1.publish("item1");
+
+        HazelcastInstance instance2 = factory.newHazelcastInstance();
+
+        assertEqualsEventually(1, migrationListener.partitionMigrationCount);
+
+        instance2.shutdown();
+
+        assertEqualsEventually(2, migrationListener.partitionMigrationCount);
+
+        topic0.publish("itemB");
+        topic1.publish("item2");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertTrue(listener0.isReceived("itemA"));
+                assertTrue(listener0.isReceived("itemB"));
+                assertTrue(listener1.isReceived("item1"));
+                assertTrue(listener1.isReceived("item2"));
+            }
+        });
+    }
+
+    public class PayloadMessageListener<V> implements MessageListener<V> {
+
+        private Collection<V> receivedMessages = new HashSet<V>();
+
+        @Override
+        public void onMessage(Message<V> message) {
+            receivedMessages.add(message.getMessageObject());
+        }
+
+        boolean isReceived(V message) {
+            return receivedMessages.contains(message);
+        }
+    }
+
+    public class CountingMigrationListener implements MigrationListener {
+
+        AtomicInteger partitionMigrationCount = new AtomicInteger();
+
+        @Override
+        public void migrationStarted(MigrationEvent migrationEvent) {
+
+        }
+
+        @Override
+        public synchronized void migrationCompleted(MigrationEvent migrationEvent) {
+            partitionMigrationCount.incrementAndGet();
+        }
+
+        @Override
+        public void migrationFailed(MigrationEvent migrationEvent) {
+
+        }
+    }
+
+    private String generateReliableTopicNameForPartition(HazelcastInstance instance, int partitionId) {
+        return generateKeyForPartition(instance, RingbufferService.TOPIC_RB_PREFIX, partitionId);
+    }
+
+}


### PR DESCRIPTION
Note: If the description below is too confusing, there is an excellent explanation of the problem in the bug report itself.

AbstractRingBufferOperation caches the ringbuffer that it operates on. This may cause operations running on wrong ringbuffer container because RingBuffer.ReadMany operation is a long living operation and partition migrations may cause cached ringbuffer container to go stale. When the partition that the ringbuffer is located in migrates, reference to ringbuffer container becomes stale. However, it does not create an adverse effect because operation service detects that the required partition is not in the same instance that ReadMany is called from anymore. So the operation service does a remote operation. However, later the same partition may come back to the initial instance in the future due to further changes in network. This time ringbuffer operations are local and they use the stale ringbuffer container.

This PR removes unnecceassary caching that causes stale container.

Fixes https://github.com/hazelcast/hazelcast/issues/13602