### PR TITLE
allow duplicates on clientConnectionManager.addConnectionListener

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -82,9 +82,9 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeoutException;
@@ -130,7 +130,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager, Con
             = new ConcurrentHashMap<Address, ClientConnection>();
     private final ConcurrentMap<Address, AuthenticationFuture> connectionsInProgress =
             new ConcurrentHashMap<Address, AuthenticationFuture>();
-    private final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<ConnectionListener>();
+    private final Collection<ConnectionListener> connectionListeners = new CopyOnWriteArrayList<ConnectionListener>();
     private final boolean allowInvokeWhenDisconnected;
     private final Credentials credentials;
     private final NioEventLoopGroup eventLoopGroup;


### PR DESCRIPTION
ClientConnectionManagerImpl is changed to allow duplicate registry
of connection listeners to make it compatible with
ConnectionListenable.addConnectionListener contract.

fixes https://github.com/hazelcast/hazelcast/issues/12784

(cherry picked from commit efb71bd80d25a4cf00df2cc282c186e3d178443d)