### PR TITLE
Check memberlist version while locking cluster state

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.operations.LockClusterStateOp;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.util.LockGuard;
@@ -192,8 +193,8 @@ public class ClusterStateManager {
      * @param leaseTime
      * @param partitionStateVersion
      */
-    public void lockClusterState(ClusterStateChange stateChange, Address initiator, String txnId,
-                                 long leaseTime, int partitionStateVersion) {
+    public void lockClusterState(ClusterStateChange stateChange, Address initiator, String txnId, long leaseTime,
+            int memberListVersion, int partitionStateVersion) {
         Preconditions.checkNotNull(stateChange);
         clusterServiceLock.lock();
         try {
@@ -210,6 +211,7 @@ public class ClusterStateManager {
                 validateClusterVersionChange((Version) stateChange.getNewState());
             }
 
+            checkMemberListVersion(memberListVersion);
             checkMigrationsAndPartitionStateVersion(stateChange, partitionStateVersion);
 
             lockOrExtendClusterState(initiator, txnId, leaseTime);
@@ -224,6 +226,19 @@ public class ClusterStateManager {
             }
         } finally {
             clusterServiceLock.unlock();
+        }
+    }
+
+    private void checkMemberListVersion(int memberListVersion) {
+        // RU_COMPAT_V3_10
+        if (clusterVersion.isGreaterOrEqual(Versions.V3_11)) {
+            int thisMemberListVersion = node.getClusterService().getMemberListVersion();
+            if (memberListVersion != thisMemberListVersion) {
+                throw new IllegalStateException(
+                        "Can not lock cluster state! Member list versions are not matching!"
+                                + " Expected version: " + memberListVersion
+                                + ", Current version: " + thisMemberListVersion);
+            }
         }
     }
 
@@ -344,12 +359,12 @@ public class ClusterStateManager {
     }
 
     void changeClusterState(ClusterStateChange newState, MemberMap memberMap, int partitionStateVersion,
-                            boolean isTransient) {
+            boolean isTransient) {
         changeClusterState(newState, memberMap, DEFAULT_TX_OPTIONS, partitionStateVersion, isTransient);
     }
 
-    void changeClusterState(ClusterStateChange newState, MemberMap memberMap,
-            TransactionOptions options, int partitionStateVersion, boolean isTransient) {
+    void changeClusterState(ClusterStateChange newState, MemberMap memberMap, TransactionOptions options,
+            int partitionStateVersion, boolean isTransient) {
         checkParameters(newState, options);
         if (isCurrentStateEqualToRequestedOne(newState)) {
             return;
@@ -364,12 +379,14 @@ public class ClusterStateManager {
         try {
             String txnId = tx.getTxnId();
             Collection<MemberImpl> members = memberMap.getMembers();
+            int memberListVersion = memberMap.getVersion();
 
-            addTransactionRecords(newState, tx, members, partitionStateVersion, isTransient);
+            addTransactionRecords(newState, tx, members, memberListVersion, partitionStateVersion, isTransient);
 
-            lockClusterStateOnAllMembers(newState, nodeEngine, options.getTimeoutMillis(), txnId, members, partitionStateVersion);
+            lockClusterStateOnAllMembers(newState, nodeEngine, options.getTimeoutMillis(), txnId, members,
+                    memberListVersion, partitionStateVersion);
 
-            checkMemberListChange(memberMap.getVersion());
+            checkMemberListChange(memberListVersion);
 
             tx.prepare();
 
@@ -406,13 +423,14 @@ public class ClusterStateManager {
     }
 
     private void lockClusterStateOnAllMembers(ClusterStateChange stateChange, NodeEngineImpl nodeEngine, long leaseTime,
-                                              String txnId, Collection<MemberImpl> members, int partitionStateVersion) {
+            String txnId, Collection<MemberImpl> members, int memberListVersion, int partitionStateVersion) {
 
         Collection<Future> futures = new ArrayList<Future>(members.size());
 
         final Address thisAddress = node.getThisAddress();
         for (Member member : members) {
-            Operation op = new LockClusterStateOp(stateChange, thisAddress, txnId, leaseTime, partitionStateVersion);
+            Operation op = new LockClusterStateOp(stateChange, thisAddress, txnId, leaseTime, memberListVersion,
+                    partitionStateVersion);
             Future future = nodeEngine.getOperationService().invokeOnTarget(SERVICE_NAME, op, member.getAddress());
             futures.add(future);
         }
@@ -422,12 +440,12 @@ public class ClusterStateManager {
         exceptionHandler.rethrowIfFailed();
     }
 
-    private void addTransactionRecords(ClusterStateChange stateChange, Transaction tx,
-                                       Collection<MemberImpl> members, int partitionStateVersion, boolean isTransient) {
+    private void addTransactionRecords(ClusterStateChange stateChange, Transaction tx, Collection<MemberImpl> members,
+            int memberListVersion, int partitionStateVersion, boolean isTransient) {
         long leaseTime = Math.min(tx.getTimeoutMillis(), LOCK_LEASE_EXTENSION_MILLIS);
         for (Member member : members) {
             tx.add(new ClusterStateTransactionLogRecord(stateChange, node.getThisAddress(),
-                    member.getAddress(), tx.getTxnId(), leaseTime, partitionStateVersion, isTransient));
+                    member.getAddress(), tx.getTxnId(), leaseTime, memberListVersion, partitionStateVersion, isTransient));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -17,12 +17,14 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.cluster.ClusterState;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.operations.CommitClusterStateOp;
 import com.hazelcast.internal.cluster.impl.operations.LockClusterStateOp;
 import com.hazelcast.internal.cluster.impl.operations.RollbackClusterStateOp;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.transaction.impl.TargetAwareTransactionLogRecord;
 import com.hazelcast.util.Preconditions;
@@ -35,13 +37,14 @@ import java.io.IOException;
  * @see ClusterState
  * @see com.hazelcast.core.Cluster#changeClusterState(ClusterState, com.hazelcast.transaction.TransactionOptions)
  */
-public class ClusterStateTransactionLogRecord implements TargetAwareTransactionLogRecord {
+public class ClusterStateTransactionLogRecord implements TargetAwareTransactionLogRecord, Versioned {
 
     ClusterStateChange stateChange;
     Address initiator;
     Address target;
     String txnId;
     long leaseTime;
+    int memberListVersion;
     int partitionStateVersion;
     boolean isTransient;
 
@@ -49,7 +52,8 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
     }
 
     public ClusterStateTransactionLogRecord(ClusterStateChange stateChange, Address initiator, Address target,
-            String txnId, long leaseTime, int partitionStateVersion, boolean isTransient) {
+            String txnId, long leaseTime, int memberListVersion, int partitionStateVersion, boolean isTransient) {
+        this.memberListVersion = memberListVersion;
         Preconditions.checkNotNull(stateChange);
         Preconditions.checkNotNull(initiator);
         Preconditions.checkNotNull(target);
@@ -72,7 +76,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
 
     @Override
     public Operation newPrepareOperation() {
-        return new LockClusterStateOp(stateChange, initiator, txnId, leaseTime, partitionStateVersion);
+        return new LockClusterStateOp(stateChange, initiator, txnId, leaseTime, memberListVersion, partitionStateVersion);
     }
 
     @Override
@@ -99,6 +103,10 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         out.writeLong(leaseTime);
         out.writeInt(partitionStateVersion);
         out.writeBoolean(isTransient);
+        // RU_COMPAT_V3_10
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
+            out.writeInt(memberListVersion);
+        }
     }
 
     @Override
@@ -110,6 +118,10 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         leaseTime = in.readLong();
         partitionStateVersion = in.readInt();
         isTransient = in.readBoolean();
+        // RU_COMPAT_V3_10
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
+            memberListVersion = in.readInt();
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/AdvancedClusterStateTest.java
@@ -175,10 +175,13 @@ public class AdvancedClusterStateTest extends HazelcastTestSupport {
 
     private void lockClusterState(HazelcastInstance hz) {
         final Node node = getNode(hz);
+        ClusterServiceImpl clusterService = node.getClusterService();
+        int memberListVersion = clusterService.getMemberListVersion();
         int partitionStateVersion = node.getPartitionService().getPartitionStateVersion();
         long timeoutInMillis = TimeUnit.SECONDS.toMillis(60);
-        ClusterStateManager clusterStateManager = node.clusterService.getClusterStateManager();
-        clusterStateManager.lockClusterState(ClusterStateChange.from(ClusterState.FROZEN), node.getThisAddress(), "fakeTxn", timeoutInMillis, partitionStateVersion);
+        ClusterStateManager clusterStateManager = clusterService.getClusterStateManager();
+        clusterStateManager.lockClusterState(ClusterStateChange.from(ClusterState.FROZEN), node.getThisAddress(), "fakeTxn",
+                timeoutInMillis, memberListVersion, partitionStateVersion);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializationTest.java
@@ -65,7 +65,8 @@ public class ClusterDataSerializationTest {
     @Test
     public void testSerializationOf_clusterStateChangeTxnLogRecord_whenVersionChange() throws UnknownHostException {
         ClusterStateTransactionLogRecord txnLogRecord = new ClusterStateTransactionLogRecord(VERSION_CLUSTER_STATE_CHANGE,
-                new Address("127.0.0.1", 5071), new Address("127.0.0.1", 5702), UUID.randomUUID().toString(), 120, 130, false);
+                new Address("127.0.0.1", 5071), new Address("127.0.0.1", 5702), UUID.randomUUID().toString(), 120,
+                111, 130, false);
 
         Data serialized = SERIALIZATION_SERVICE.toData(txnLogRecord);
 
@@ -76,13 +77,15 @@ public class ClusterDataSerializationTest {
         assertEquals(txnLogRecord.txnId, deserialized.txnId);
         assertEquals(txnLogRecord.leaseTime, deserialized.leaseTime);
         assertEquals(txnLogRecord.isTransient, deserialized.isTransient);
+        assertEquals(txnLogRecord.memberListVersion, deserialized.memberListVersion);
         assertEquals(txnLogRecord.partitionStateVersion, deserialized.partitionStateVersion);
     }
 
     @Test
     public void testSerializationOf_clusterStateChangeTxnLogRecord_whenStateChange() throws UnknownHostException {
         ClusterStateTransactionLogRecord txnLogRecord = new ClusterStateTransactionLogRecord(CLUSTER_STATE_CHANGE,
-                new Address("127.0.0.1", 5071), new Address("127.0.0.1", 5702), UUID.randomUUID().toString(), 120, 130, false);
+                new Address("127.0.0.1", 5071), new Address("127.0.0.1", 5702), UUID.randomUUID().toString(), 120,
+                111, 130, false);
 
         Data serialized = SERIALIZATION_SERVICE.toData(txnLogRecord);
 
@@ -93,6 +96,7 @@ public class ClusterDataSerializationTest {
         assertEquals(txnLogRecord.txnId, deserialized.txnId);
         assertEquals(txnLogRecord.leaseTime, deserialized.leaseTime);
         assertEquals(txnLogRecord.isTransient, deserialized.isTransient);
+        assertEquals(txnLogRecord.memberListVersion, deserialized.memberListVersion);
         assertEquals(txnLogRecord.partitionStateVersion, deserialized.partitionStateVersion);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterStateManagerTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeExtension;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.util.LockGuard;
 import com.hazelcast.logging.ILogger;
@@ -63,6 +64,8 @@ public class ClusterStateManagerTest {
     private static final String ANOTHER_TXN = "another-txn";
     private static final MemberVersion CURRENT_NODE_VERSION = MemberVersion.of(BuildInfoProvider.getBuildInfo().getVersion());
     private static final Version CURRENT_CLUSTER_VERSION = Version.of(BuildInfoProvider.getBuildInfo().getVersion());
+    private static final int MEMBERLIST_VERSION = 1;
+    private static final int PARTITION_VERSION = 1;
 
     private final Node node = mock(Node.class);
     private final InternalPartitionService partitionService = mock(InternalPartitionService.class);
@@ -86,6 +89,10 @@ public class ClusterStateManagerTest {
 
         when(clusterService.getMembershipManager()).thenReturn(membershipManager);
         when(clusterService.getClusterJoinManager()).thenReturn(mock(ClusterJoinManager.class));
+
+        when(clusterService.getMemberListVersion()).thenReturn(MEMBERLIST_VERSION);
+        when(membershipManager.getMemberListVersion()).thenReturn(MEMBERLIST_VERSION);
+        when(partitionService.getPartitionStateVersion()).thenReturn(PARTITION_VERSION);
 
         clusterStateManager = new ClusterStateManager(node, lock);
     }
@@ -128,30 +135,30 @@ public class ClusterStateManagerTest {
     @Test(expected = NullPointerException.class)
     public void test_lockClusterState_nullState() throws Exception {
         Address initiator = newAddress();
-        clusterStateManager.lockClusterState(null, initiator, TXN, 1000, 0);
+        clusterStateManager.lockClusterState(null, initiator, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
     }
 
     @Test(expected = NullPointerException.class)
     public void test_lockClusterState_nullInitiator() throws Exception {
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), null, TXN, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), null, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
     }
 
     @Test(expected = NullPointerException.class)
     public void test_lockClusterState_nullTransactionId() throws Exception {
         Address initiator = newAddress();
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, null, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, null, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void test_lockClusterState_nonPositiveLeaseTime() throws Exception {
         Address initiator = newAddress();
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, -1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, -1000, MEMBERLIST_VERSION, PARTITION_VERSION);
     }
 
     @Test
     public void test_lockClusterState_success() throws Exception {
         Address initiator = newAddress();
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
 
         assertLockedBy(initiator);
     }
@@ -160,9 +167,9 @@ public class ClusterStateManagerTest {
     public void test_lockClusterState_fail() throws Exception {
         Address initiator = newAddress();
         final ClusterStateChange newState = ClusterStateChange.from(FROZEN);
-        clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
+        clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
 
-        clusterStateManager.lockClusterState(newState, initiator, ANOTHER_TXN, 1000, 0);
+        clusterStateManager.lockClusterState(newState, initiator, ANOTHER_TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -170,7 +177,7 @@ public class ClusterStateManagerTest {
         when(partitionService.hasOnGoingMigrationLocal()).thenReturn(true);
 
         Address initiator = newAddress();
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -180,7 +187,7 @@ public class ClusterStateManagerTest {
 
         Address initiator = newAddress();
         final ClusterStateChange newState = ClusterStateChange.from(ACTIVE);
-        clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
+        clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
 
         assertLockedBy(initiator);
     }
@@ -192,7 +199,7 @@ public class ClusterStateManagerTest {
 
         Address initiator = newAddress();
         final ClusterStateChange newState = ClusterStateChange.from(PASSIVE);
-        clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, 0);
+        clusterStateManager.lockClusterState(newState, initiator, TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
 
         assertLockedBy(initiator);
     }
@@ -209,25 +216,31 @@ public class ClusterStateManagerTest {
 
     @Test
     public void test_unlockClusterState_fail_whenLockedByElse() throws Exception {
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
         assertFalse(clusterStateManager.rollbackClusterState(ANOTHER_TXN));
     }
 
     @Test(expected = IllegalStateException.class)
     public void test_lockClusterState_fail_withDifferentPartitionStateVersions() throws Exception {
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1000, 1);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION + 1);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void test_lockClusterState_fail_withDifferentMemberListVersions() throws Exception {
+        clusterStateManager.clusterVersion = Versions.CURRENT_CLUSTER_VERSION;
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1000, MEMBERLIST_VERSION - 1, PARTITION_VERSION);
     }
 
     @Test
     public void test_unlockClusterState_success() throws Exception {
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1000, MEMBERLIST_VERSION, PARTITION_VERSION);
         assertTrue(clusterStateManager.rollbackClusterState(TXN));
     }
 
     @Test
     public void test_lockClusterState_getLockExpiryTime() throws Exception {
         final Address initiator = newAddress();
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, TimeUnit.DAYS.toMillis(1), 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, TimeUnit.DAYS.toMillis(1), MEMBERLIST_VERSION, PARTITION_VERSION);
 
         final LockGuard stateLock = clusterStateManager.getStateLock();
         assertTrue(Clock.currentTimeMillis() + TimeUnit.HOURS.toMillis(12) < stateLock.getLockExpiryTime());
@@ -236,8 +249,8 @@ public class ClusterStateManagerTest {
     @Test
     public void test_lockClusterState_extendLease() throws Exception {
         final Address initiator = newAddress();
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 10000, 0);
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, TimeUnit.DAYS.toMillis(1), 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 10000, MEMBERLIST_VERSION, PARTITION_VERSION);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, TimeUnit.DAYS.toMillis(1), MEMBERLIST_VERSION, PARTITION_VERSION);
 
         final LockGuard stateLock = clusterStateManager.getStateLock();
         assertTrue(Clock.currentTimeMillis() + TimeUnit.HOURS.toMillis(12) < stateLock.getLockExpiryTime());
@@ -253,7 +266,7 @@ public class ClusterStateManagerTest {
 
     @Test
     public void test_lockClusterState_expiry() throws Exception {
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), newAddress(), TXN, 1, MEMBERLIST_VERSION, PARTITION_VERSION);
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
@@ -287,7 +300,7 @@ public class ClusterStateManagerTest {
     @Test(expected = TransactionException.class)
     public void test_changeLocalClusterState_fail_whenLockedByElse() throws Exception {
         final Address initiator = newAddress();
-        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 10000, 0);
+        clusterStateManager.lockClusterState(ClusterStateChange.from(FROZEN), initiator, TXN, 10000, MEMBERLIST_VERSION, PARTITION_VERSION);
         clusterStateManager.commitClusterState(ClusterStateChange.from(FROZEN), initiator, ANOTHER_TXN);
     }
 
@@ -295,7 +308,7 @@ public class ClusterStateManagerTest {
     public void test_changeLocalClusterState_success() throws Exception {
         final ClusterStateChange newState = ClusterStateChange.from(FROZEN);
         final Address initiator = newAddress();
-        clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, 0);
+        clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, MEMBERLIST_VERSION, PARTITION_VERSION);
         clusterStateManager.commitClusterState(newState, initiator, TXN);
 
         assertEquals(newState.getNewState(), clusterStateManager.getState());
@@ -307,7 +320,7 @@ public class ClusterStateManagerTest {
     public void changeLocalClusterState_shouldChangeNodeStateToShuttingDown_whenStateBecomes_PASSIVE() throws Exception {
         final ClusterStateChange newState = ClusterStateChange.from(PASSIVE);
         final Address initiator = newAddress();
-        clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, 0);
+        clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, MEMBERLIST_VERSION, PARTITION_VERSION);
         clusterStateManager.commitClusterState(newState, initiator, TXN);
 
         assertEquals(newState.getNewState(), clusterStateManager.getState());
@@ -319,7 +332,7 @@ public class ClusterStateManagerTest {
         final ClusterStateChange newState = ClusterStateChange.from(ACTIVE);
         final Address initiator = newAddress();
         clusterStateManager.initialClusterState(FROZEN, CURRENT_CLUSTER_VERSION);
-        clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, 0);
+        clusterStateManager.lockClusterState(newState, initiator, TXN, 10000, MEMBERLIST_VERSION, PARTITION_VERSION);
         clusterStateManager.commitClusterState(newState, initiator, TXN);
 
         assertEquals(newState.getNewState(), clusterStateManager.getState());


### PR DESCRIPTION
While changing cluster state/version, initiator checks for membership changes
during transaction. But member list of initiator and remote members' are not compared.
If initiator has a stale member list, then newly joined members will not receive state
change request and transaction will be partially complete.

To prevent that, initiator will send its local member list version with state change
request and target members will compare it with their local versions.

Fixes #13787