### PR TITLE
Create PNCounter statistics on replication and remove on migration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/crdt/pncounter/PNCounterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/crdt/pncounter/PNCounterService.java
@@ -124,7 +124,9 @@ public class PNCounterService implements
         return counters.containsKey(name);
     }
 
-    /** Returns the PN counter statistics for the counter with the given {@code name} */
+    /**
+     * Returns the PN counter statistics for the counter with the given {@code name}
+     */
     public LocalPNCounterStatsImpl getLocalPNCounterStats(String name) {
         return getOrPutSynchronized(statsMap, name, statsMap, statsConstructorFunction);
     }
@@ -190,7 +192,10 @@ public class PNCounterService implements
 
     @Override
     public void merge(String name, PNCounterImpl value) {
-        getCounter(name).merge(value);
+        PNCounterImpl counter = getCounter(name);
+        counter.merge(value);
+        long counterValue = counter.get(null).getValue();
+        getLocalPNCounterStats(name).setValue(counterValue);
     }
 
     @Override
@@ -226,6 +231,7 @@ public class PNCounterService implements
             }
             if (counter.markMigrated(vectorClock)) {
                 counters.remove(counterName);
+                statsMap.remove(counterName);
             } else {
                 allCleared = false;
             }

--- a/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/PNCounterStatisticsSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/crdt/pncounter/PNCounterStatisticsSplitBrainTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.crdt.pncounter;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.monitor.LocalPNCounterStats;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.SplitBrainTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests PNCounter statistics are replicated and migrated together with
+ * PNCounter state.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PNCounterStatisticsSplitBrainTest extends SplitBrainTestSupport {
+
+    private String counterName = randomMapName("counter-");
+    private MergeLifecycleListener mergeLifecycleListener;
+
+    @Override
+    protected Config config() {
+        Config config = super.config();
+        config.getPNCounterConfig(counterName).setReplicaCount(2);
+        return config;
+    }
+
+    @Override
+    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
+        waitAllForSafeState(instances);
+
+        getCounter(instances[0]).addAndGet(100);
+
+        assertContainsCounterStatsEventually(true, instances[0], instances[1]);
+        assertContainsCounterStatsEventually(false, instances[2]);
+    }
+
+    @Override
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
+        mergeLifecycleListener = new MergeLifecycleListener(secondBrain.length);
+        for (HazelcastInstance instance : secondBrain) {
+            instance.getLifecycleService().addLifecycleListener(mergeLifecycleListener);
+        }
+
+        getCounter(secondBrain[0]).addAndGet(100);
+
+        assertContainsCounterStatsEventually(true, firstBrain[0], firstBrain[1]);
+        assertContainsCounterStatsEventually(true, secondBrain[0]);
+    }
+
+    @Override
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
+        // wait until merge completes
+        mergeLifecycleListener.await();
+
+        assertContainsCounterStatsEventually(true, instances[0], instances[1]);
+        assertContainsCounterStatsEventually(false, instances[2]);
+    }
+
+    private PNCounter getCounter(HazelcastInstance instance) {
+        final PNCounter pnCounter = instance.getPNCounter(counterName);
+        ((PNCounterProxy) pnCounter).setOperationTryCount(1);
+        pnCounter.reset();
+        return pnCounter;
+    }
+
+    private void assertContainsCounterStatsEventually(final boolean contains, final HazelcastInstance... instances) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                for (HazelcastInstance instance : instances) {
+                    PNCounterService service = getNodeEngineImpl(instance).getService(PNCounterService.SERVICE_NAME);
+                    Map<String, LocalPNCounterStats> stats = service.getStats();
+
+                    assertEquals(contains, stats.containsKey(counterName));
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
PNCounter statistics were previously created only when the counter was
being mutated. The counter state may also be created because of
replication and the counter state may be removed because of migration.
PNCounter statistics should follow this lifecycle.

Fixes: https://github.com/hazelcast/hazelcast/issues/13793