### PR TITLE
Wait for safe state before destroying cache

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/stats/CacheStatsTest.java
@@ -621,6 +621,7 @@ public class CacheStatsTest extends CacheTestSupport {
         if (useBackups) {
             // Create the second instance to store data as backup.
             instance2 = getHazelcastInstance();
+            waitAllForSafeState(factory.getAllHazelcastInstances());
             CachingProvider cp = getCachingProvider(instance2);
             CacheManager cm = cp.getCacheManager();
             cache = createCache(cacheName);
@@ -670,6 +671,7 @@ public class CacheStatsTest extends CacheTestSupport {
             // so the second instance will be owner of some partitions
             // and the first instance will lose ownership of some instances.
             instance2 = getHazelcastInstance();
+            waitAllForSafeState(factory.getAllHazelcastInstances());
             CachingProvider cp = getCachingProvider(instance2);
             CacheManager cm = cp.getCacheManager();
             ICache<Integer, String> c = cm.getCache(cacheName).unwrap(ICache.class);


### PR DESCRIPTION
Cache destroy and migrations are inherently racy, as for all of the
structures. In the test, after a second instance is created, some
partitions are replicated to the new member. This member is already
in the process of destroying the cache. The migration can then
re-create the record store after the destroy mechanism already checks
if the migrating partition contains the record store to be removed.

Since all of the data structures suffer from this problem, it should be
addressed systematically. We then fix the test to wait for migrations to
complete before proceeding to destroy the cache.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/930