### PR TITLE
[Java 9+] Log a warning if Modular Java is used to run Hazelcast without proper access to internal Java API

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -22,6 +22,8 @@ import com.hazelcast.core.DuplicateInstanceNameException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.internal.jmx.ManagementService;
+import com.hazelcast.internal.util.ModularJavaUtils;
+import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.util.ExceptionUtil;
@@ -57,6 +59,10 @@ public final class HazelcastInstanceFactory {
 
     private static final AtomicInteger FACTORY_ID_GEN = new AtomicInteger();
     private static final ConcurrentMap<String, InstanceFuture> INSTANCE_MAP = new ConcurrentHashMap<String, InstanceFuture>(5);
+
+    static {
+        ModularJavaUtils.checkJavaInternalAccess(Logger.getLogger(HazelcastInstanceFactory.class));
+    }
 
     private HazelcastInstanceFactory() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
@@ -25,7 +25,10 @@ public enum JavaVersion {
     JAVA_1_6,
     JAVA_1_7,
     JAVA_1_8,
-    JAVA_1_9;
+    JAVA_9,
+    JAVA_10,
+    JAVA_11,
+    JAVA_12;
 
     private static final JavaVersion CURRENT_VERSION = detectCurrentVersion();
 
@@ -50,21 +53,27 @@ public enum JavaVersion {
             // this should not happen but it's better to stay on the safe side
             return UNKNOWN;
         }
+        JavaVersion result = UNKNOWN;
         if (version.startsWith("1.")) {
             String withoutMajor = version.substring(2, version.length());
             if (withoutMajor.startsWith("6")) {
-                return JAVA_1_6;
+                result = JAVA_1_6;
             } else if (withoutMajor.startsWith("7")) {
-                return JAVA_1_7;
+                result = JAVA_1_7;
             } else if (withoutMajor.startsWith("8")) {
-                return JAVA_1_8;
+                result = JAVA_1_8;
             }
-            return UNKNOWN;
         } else if (version.startsWith("9")) {
             // from version 9 the string does not start with "1."
-            return JAVA_1_9;
+            result = JAVA_9;
+        } else if (version.startsWith("10")) {
+            result = JAVA_10;
+        } else if (version.startsWith("11")) {
+            result = JAVA_11;
+        } else if (version.startsWith("12")) {
+            result = JAVA_12;
         }
-        return UNKNOWN;
+        return result;
     }
 
     static boolean isAtLeast(JavaVersion currentVersion, JavaVersion minVersion) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ModularJavaUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ModularJavaUtils.java
@@ -87,7 +87,7 @@ public final class ModularJavaUtils {
                     + " but without proper access to required Java packages."
                     + " Use additional Java arguments to provide Hazelcast access to Java internal API."
                     + " The internal API access is used to get the best performance results. Arguments to be used:\n"
-                    + createOpenPackageJavaArguments(hazelcastModule, requirements));
+                    + " --add-modules java.se"  + createOpenPackageJavaArguments(hazelcastModule, requirements));
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ModularJavaUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ModularJavaUtils.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import static com.hazelcast.internal.util.ModularJavaUtils.PackageAccessRequirement.createRequirement;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+/**
+ * Helper class for simplify work with Java module system (Java 9+) in older Java versions.
+ */
+public final class ModularJavaUtils {
+
+    private static final ILogger LOGGER = Logger.getLogger(ModularJavaUtils.class);
+
+    private ModularJavaUtils() {
+    }
+
+    public static String getHazelcastModuleName() {
+        if (!JavaVersion.isAtLeast(JavaVersion.JAVA_9)) {
+            return null;
+        }
+        try {
+            Method methodGetModule = Class.class.getMethod("getModule");
+            Class<?> classModule = Class.forName("java.lang.Module");
+            Method methodGetName = classModule.getMethod("getName");
+            Object moduleHazelcast = methodGetModule.invoke(Hazelcast.class);
+            return (String) methodGetName.invoke(moduleHazelcast);
+        } catch (Exception e) {
+            LOGGER.finest("Getting Hazelcast module name failed", e);
+            return null;
+        }
+    }
+
+    /**
+     * Prints warning to given {@link ILogger} if Hazelcast is not provided a sufficient access to Java internal packages on
+     * Java 9 and newer.
+     */
+    public static void checkJavaInternalAccess(ILogger logger) {
+        if (logger == null || !JavaVersion.isAtLeast(JavaVersion.JAVA_9)) {
+            // older Java versions are fine with the reflection
+            return;
+        }
+
+        Map<String, PackageAccessRequirement[]> requirements = new TreeMap<String, PackageAccessRequirement[]>();
+        requirements.put("java.base",
+                new PackageAccessRequirement[] {
+                        createRequirement(false, "jdk.internal.ref"),
+                        createRequirement(true, "java.lang"),
+                        createRequirement(true, "java.nio"),
+                        createRequirement(true, "sun.nio.ch")
+                        });
+        requirements.put("jdk.management",
+                new PackageAccessRequirement[] { createRequirement(true, "com.sun.management.internal") });
+        requirements.put("java.management", new PackageAccessRequirement[] { createRequirement(true, "sun.management") });
+        checkPackageRequirements(logger, requirements);
+    }
+
+    protected static void checkPackageRequirements(ILogger logger, Map<String, PackageAccessRequirement[]> requirements) {
+        if (!hasHazelcastPackageAccess(requirements)) {
+            String hazelcastModule = getHazelcastModuleName();
+            if (hazelcastModule == null) {
+                hazelcastModule = "ALL-UNNAMED";
+            }
+            logger.warning("Hazelcast is starting in a Java modular environment (Java 9 and newer)"
+                    + " but without proper access to required Java packages."
+                    + " Use additional Java arguments to provide Hazelcast access to Java internal API."
+                    + " The internal API access is used to get the best performance results. Arguments to be used:\n"
+                    + createOpenPackageJavaArguments(hazelcastModule, requirements));
+        }
+    }
+
+    private static boolean hasHazelcastPackageAccess(Map<String, PackageAccessRequirement[]> requirements) {
+        try {
+            Class<?> classModuleLayer = Class.forName("java.lang.ModuleLayer");
+            Class<?> classModule = Class.forName("java.lang.Module");
+            Method methodGetModule = Class.class.getMethod("getModule");
+            Method methodBoot = classModuleLayer.getMethod("boot");
+            Method methodModules = classModuleLayer.getMethod("modules");
+
+            Method methodGetName = classModule.getMethod("getName");
+            Method methodIsOpen = classModule.getMethod("isOpen", String.class, classModule);
+            Method methodIsExported = classModule.getMethod("isExported", String.class, classModule);
+
+            Object moduleHazelcast = methodGetModule.invoke(Hazelcast.class);
+            Object moduleLayerBoot = methodBoot.invoke(null);
+            Set<?> moduleSet = (Set<?>) methodModules.invoke(moduleLayerBoot);
+            for (Object m : moduleSet) {
+                PackageAccessRequirement[] reqArray = requirements.get(methodGetName.invoke(m));
+                if (reqArray == null) {
+                    continue;
+                }
+                for (PackageAccessRequirement req : reqArray) {
+                    Method methodToCheck = req.isForReflection() ? methodIsOpen : methodIsExported;
+                    boolean hasAccess = (Boolean) methodToCheck.invoke(m, req.getPackageName(), moduleHazelcast);
+                    if (!hasAccess) {
+                        return false;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.finest("Checking Hazelcast package access", e);
+            return false;
+        }
+        return true;
+    }
+
+    private static String createOpenPackageJavaArguments(String hzModuleName,
+            Map<String, PackageAccessRequirement[]> requirements) {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, PackageAccessRequirement[]> moduleEntry : requirements.entrySet()) {
+            for (PackageAccessRequirement requirement : moduleEntry.getValue()) {
+                sb.append((requirement.forReflection ? " --add-opens " : " --add-exports ") + moduleEntry.getKey() + "/"
+                        + requirement.packageName + "=" + hzModuleName);
+            }
+        }
+        return sb.toString();
+    }
+
+    public static final class PackageAccessRequirement {
+        private final String packageName;
+        private final boolean forReflection;
+
+        private PackageAccessRequirement(boolean forReflection, String packageName) {
+            this.packageName = packageName;
+            this.forReflection = forReflection;
+        }
+
+        public static PackageAccessRequirement createRequirement(boolean forReflection, String packageName) {
+            return new PackageAccessRequirement(forReflection, packageName);
+        }
+
+        public String getPackageName() {
+            return packageName;
+        }
+
+        public boolean isForReflection() {
+            return forReflection;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
@@ -16,22 +16,26 @@
 
 package com.hazelcast.internal.util;
 
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.ParallelTest;
-import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
+import static com.hazelcast.internal.util.JavaVersion.JAVA_10;
+import static com.hazelcast.internal.util.JavaVersion.JAVA_11;
+import static com.hazelcast.internal.util.JavaVersion.JAVA_12;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_1_6;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_1_7;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_1_8;
-import static com.hazelcast.internal.util.JavaVersion.JAVA_1_9;
+import static com.hazelcast.internal.util.JavaVersion.JAVA_9;
 import static com.hazelcast.internal.util.JavaVersion.UNKNOWN;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -43,8 +47,13 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertEquals(JAVA_1_6, JavaVersion.parseVersion("1.6"));
         assertEquals(JAVA_1_7, JavaVersion.parseVersion("1.7"));
         assertEquals(JAVA_1_8, JavaVersion.parseVersion("1.8"));
-        assertEquals(JAVA_1_9, JavaVersion.parseVersion("9-ea"));
-        assertEquals(JAVA_1_9, JavaVersion.parseVersion("9"));
+        assertEquals(JAVA_9, JavaVersion.parseVersion("9-ea"));
+        assertEquals(JAVA_9, JavaVersion.parseVersion("9"));
+        assertEquals(JAVA_10, JavaVersion.parseVersion("10.0.0.2"));
+        assertEquals(JAVA_11, JavaVersion.parseVersion("11-ea"));
+        assertEquals(JAVA_11, JavaVersion.parseVersion("11"));
+        assertEquals(JAVA_12, JavaVersion.parseVersion("12-ea"));
+        assertEquals(JAVA_12, JavaVersion.parseVersion("12"));
     }
 
     @Test
@@ -53,7 +62,10 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
         assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_7));
         assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_8));
-        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_9));
+        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_9));
+        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_10));
+        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_11));
+        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_12));
     }
 
     @Test
@@ -62,7 +74,10 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertTrue(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_6));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_7));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_8));
-        assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_9));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_9));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_10));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_11));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_12));
     }
 
     @Test
@@ -71,7 +86,9 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertTrue(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_6));
         assertTrue(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_7));
         assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_8));
-        assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_9));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_9));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_10));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_11));
     }
 
     @Test
@@ -80,15 +97,38 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertTrue(JavaVersion.isAtLeast(JAVA_1_8, JAVA_1_6));
         assertTrue(JavaVersion.isAtLeast(JAVA_1_8, JAVA_1_7));
         assertTrue(JavaVersion.isAtLeast(JAVA_1_8, JAVA_1_8));
-        assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_1_9));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_9));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_10));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_11));
     }
 
     @Test
     public void testIsAtLeast_1_9() {
-        assertTrue(JavaVersion.isAtLeast(JAVA_1_9, UNKNOWN));
-        assertTrue(JavaVersion.isAtLeast(JAVA_1_9, JAVA_1_6));
-        assertTrue(JavaVersion.isAtLeast(JAVA_1_9, JAVA_1_7));
-        assertTrue(JavaVersion.isAtLeast(JAVA_1_9, JAVA_1_8));
-        assertTrue(JavaVersion.isAtLeast(JAVA_1_9, JAVA_1_9));
+        assertTrue(JavaVersion.isAtLeast(JAVA_9, UNKNOWN));
+        assertTrue(JavaVersion.isAtLeast(JAVA_9, JAVA_1_6));
+        assertTrue(JavaVersion.isAtLeast(JAVA_9, JAVA_1_7));
+        assertTrue(JavaVersion.isAtLeast(JAVA_9, JAVA_1_8));
+        assertTrue(JavaVersion.isAtLeast(JAVA_9, JAVA_9));
+        assertFalse(JavaVersion.isAtLeast(JAVA_9, JAVA_10));
+        assertFalse(JavaVersion.isAtLeast(JAVA_9, JAVA_11));
+    }
+
+    @Test
+    public void testIsAtLeastSequence() {
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_6, UNKNOWN));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_6));
+        assertTrue(JavaVersion.isAtLeast(JAVA_1_8, JAVA_1_7));
+        assertTrue(JavaVersion.isAtLeast(JAVA_9, JAVA_1_8));
+        assertTrue(JavaVersion.isAtLeast(JAVA_10, JAVA_9));
+        assertTrue(JavaVersion.isAtLeast(JAVA_11, JAVA_10));
+        assertTrue(JavaVersion.isAtLeast(JAVA_12, JAVA_11));
+
+        assertFalse(JavaVersion.isAtLeast(UNKNOWN, JAVA_1_6));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_6, JAVA_1_7));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_7, JAVA_1_8));
+        assertFalse(JavaVersion.isAtLeast(JAVA_1_8, JAVA_9));
+        assertFalse(JavaVersion.isAtLeast(JAVA_9, JAVA_10));
+        assertFalse(JavaVersion.isAtLeast(JAVA_10, JAVA_11));
+        assertFalse(JavaVersion.isAtLeast(JAVA_11, JAVA_12));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ModularJavaUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ModularJavaUtilsTest.java
@@ -31,8 +31,6 @@ import static org.mockito.Mockito.verify;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.script.ScriptEngine;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -61,7 +59,7 @@ public class ModularJavaUtilsTest {
     }
 
     /**
-     * Tests that {@link ModularJavaUtils#checkPackageRequirements(ILogger, ScriptEngine, Map)} logs a warning with the missing
+     * Tests that {@link ModularJavaUtils#checkPackageRequirements(ILogger, Map)} logs a warning with the missing
      * Java argument if a Java internal package access not provided to Hazelcast and the test is running on Java 9 or newer.
      */
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ModularJavaUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ModularJavaUtilsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import static com.hazelcast.internal.util.ModularJavaUtils.checkJavaInternalAccess;
+import static com.hazelcast.internal.util.ModularJavaUtils.checkPackageRequirements;
+import static com.hazelcast.internal.util.ModularJavaUtils.PackageAccessRequirement.createRequirement;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.script.ScriptEngine;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.hazelcast.internal.util.ModularJavaUtils.PackageAccessRequirement;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Tests that {@link ModularJavaUtils} correctly logs warnings about missing package access on Java 9+.
+ */
+@Category({ QuickTest.class, ParallelTest.class })
+public class ModularJavaUtilsTest {
+
+    /**
+     * Tests that the testsuite is running without missing-package-access warnings. I.e. the access to Java internal packages is
+     * provided.
+     */
+    @Test
+    public void testNoMissingPackageAccessInTestsuite() {
+        ILogger logger = mock(ILogger.class);
+
+        checkJavaInternalAccess(logger);
+
+        verify(logger, never()).warning(anyString());
+    }
+
+    /**
+     * Tests that {@link ModularJavaUtils#checkPackageRequirements(ILogger, ScriptEngine, Map)} logs a warning with the missing
+     * Java argument if a Java internal package access not provided to Hazelcast and the test is running on Java 9 or newer.
+     */
+    @Test
+    public void testMissingAccess() {
+        assumeTrue(JavaVersion.isAtLeast(JavaVersion.JAVA_9));
+
+        ILogger logger = mock(ILogger.class);
+
+        Map<String, PackageAccessRequirement[]> requirements = new HashMap<String, PackageAccessRequirement[]>();
+        requirements.put("java.base", new PackageAccessRequirement[] { createRequirement(true, "jdk.internal.misc") });
+        checkPackageRequirements(logger, requirements);
+
+        verify(logger, times(1)).warning(contains("--add-opens java.base/jdk.internal.misc=ALL-UNNAMED"));
+    }
+
+    @Test
+    public void testHazelcastModuleName() {
+        assertNull("Hazelcast module name should be null as the testsuite runs hazelcast on the classpath",
+                ModularJavaUtils.getHazelcastModuleName());
+    }
+
+    @Test
+    public void testNoExceptionWhenNullLogger() {
+        checkJavaInternalAccess(null);
+    }
+
+}

--- a/modulepath-tests/src/test/java/com/hazelcast/test/modulepath/SmokeModulePathTest.java
+++ b/modulepath-tests/src/test/java/com/hazelcast/test/modulepath/SmokeModulePathTest.java
@@ -37,6 +37,7 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.internal.util.ModularJavaUtils;
 
 /**
  * Basic test which checks if correct Hazelcast modules are on the modulepath. It also checks that Hazelcast members and clients
@@ -71,6 +72,14 @@ public class SmokeModulePathTest {
         Set<String> hazelcastModuleNames = ModuleLayer.boot().modules().stream().map(Module::getName)
                 .filter(s -> s.contains("hazelcast")).collect(Collectors.toSet());
         assertThat(hazelcastModuleNames, hasItems("com.hazelcast.core", "com.hazelcast.client", "com.hazelcast.tests"));
+    }
+
+    /**
+     * Verify the name of Hazelcast module returned by {@link ModularJavaUtils#getHazelcastModuleName()}.
+     */
+    @Test
+    public void testHazelcastModuleName() {
+        assertEquals("com.hazelcast.core", ModularJavaUtils.getHazelcastModuleName());
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -1038,6 +1038,7 @@
                              -->
                             <argLine>
                                 ${vmHeapSettings}
+                                --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
                                 --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
                                 --add-opens java.base/sun.nio.ch=ALL-UNNAMED
                                 --add-opens java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
Related to issue: #13151 

This PR adds a warning when Hazelcast doesn't have proper access rights to internal Java packages on newer Java versions (9+):

```
$ java -version
openjdk version "9.0.1.3"
OpenJDK Runtime Environment (Zulu build 9.0.1.3+11)
OpenJDK 64-Bit Server VM (Zulu build 9.0.1.3+11, mixed mode)

$ java -jar hazelcast-3.11-SNAPSHOT.jar 
Sep 20, 2018 2:33:03 PM com.hazelcast.instance.HazelcastInstanceFactory
WARNING: Hazelcast is starting in a Java modular environment (Java 9 and newer) but without proper access to required Java packages. Use additional Java arguments to provide Hazelcast access to Java internal API. The internal API access is used to get the best performance results. Arguments to be used:
 --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED
Sep 20, 2018 2:33:03 PM com.hazelcast.config.XmlConfigLocator
INFO: Loading 'hazelcast-default.xml' from classpath.
Sep 20, 2018 2:33:04 PM com.hazelcast.instance.AddressPicker
INFO: [LOCAL] [dev] [3.11-SNAPSHOT] Prefer IPv4 stack is true.
...

$ java --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED -jar hazelcast/target/hazelcast-3.11-SNAPSHOT.jar
Sep 20, 2018 2:35:21 PM com.hazelcast.config.XmlConfigLocator
INFO: Loading 'hazelcast-default.xml' from classpath.
Sep 20, 2018 2:35:22 PM com.hazelcast.instance.AddressPicker
INFO: [LOCAL] [dev] [3.11-SNAPSHOT] Prefer IPv4 stack is true.
...
```
