### PR TITLE
Fix possible NullPointerException in AbstractCacheRecordStore#canSend…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -36,6 +36,7 @@ import com.hazelcast.config.WanConsumerConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.core.ManagedContext;
+import com.hazelcast.core.Member;
 import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.diagnostics.StoreLatencyPlugin;
 import com.hazelcast.internal.eviction.EvictionChecker;
@@ -538,7 +539,11 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
         // newer members still benefit from periodic removal of expired entries.
         //
         // RU_COMPAT_3_10
-        return nodeEngine.getClusterService().getMember(replicaAddress).getVersion().asVersion().isGreaterOrEqual(Versions.V3_11);
+        Member member = nodeEngine.getClusterService().getMember(replicaAddress);
+        if (member == null) {
+             return false;
+        }
+        return member.getVersion().asVersion().isGreaterOrEqual(Versions.V3_11);
     }
 
     public R accessRecord(Data key, R record, ExpiryPolicy expiryPolicy, long now) {


### PR DESCRIPTION
…BackupExpiration

A cache entry is removed at `get` time if it is found to be expired. The member sends backups expiration events to evict the backup entries for it too. If the backup member leaves the cluster between the detection and creation of eviction operation, AbstractCacheRecordStore#canSendBackupExpiration may find related member object to be null. This causes NullPointerException and the expiration event is not sent. Moreover HiDensityNativeMemoryCacheRecordStore's onProcessExpiredEntry method is not called. This leads to corresponding entry to be removed from the record store but its memory is not deallocated. This leads to memory leak.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/869