### PR TITLE
Extend timeout for TTL query test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
@@ -104,10 +104,10 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
 
     @Test
     @SuppressWarnings("deprecation")
-    public void testQueryWithTTL() throws Exception {
+    public void testQueryWithTTL() {
         Config config = getConfig();
         String mapName = "default";
-        config.getMapConfig(mapName).setTimeToLiveSeconds(5);
+        config.getMapConfig(mapName).setTimeToLiveSeconds(10);
 
         HazelcastInstance instance = createHazelcastInstance(config);
 
@@ -140,7 +140,9 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
 
         // check the query result before eviction
         Collection values = map.values(new SqlPredicate("active"));
-        assertEquals(activeEmployees, values.size());
+        assertEquals(String.format("Expected %s results but got %s. Number of evicted entries: %s.",
+                activeEmployees, values.size(), allEmployees - latch.getCount()),
+                activeEmployees, values.size());
 
         // wait until eviction is completed
         assertOpenEventually(latch);


### PR DESCRIPTION
As with most TTL tests, they are sensitive to a slow environment. We increase the TTL to allow for larger hiccups and add an assertion message to clarify the cause. 
If the test continues to fail, we might remove the assertion for "live" entries altogether as testing querying is already part of other tests.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2438