### PR TITLE
WanRESTTest should not execute in parallel

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
@@ -45,7 +44,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class, ParallelTest.class})
+@Category({QuickTest.class})
 public class WanRESTTest extends HazelcastTestSupport {
     private WanReplicationService wanServiceMock;
     private HTTPCommunicator communicator;

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @RunWith(HazelcastSerialClassRunner.class)
-@Category({QuickTest.class})
+@Category(QuickTest.class)
 public class WanRESTTest extends HazelcastTestSupport {
     private WanReplicationService wanServiceMock;
     private HTTPCommunicator communicator;


### PR DESCRIPTION
Since it uses real network, members could try and form clusters. Since
the network config is different, members will fail to start since they
cannot join each other.

Examples of failure:
https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-pr-builder/17241/testReport/junit/com.hazelcast.wan/WanRESTTest/resumeFail/
https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-pr-builder/17251/testReport/junit/com.hazelcast.wan/WanRESTTest/consistencyCheckFail/
https://hazelcast-l337.ci.cloudbees.com/job/Hazelcast-pr-builder/17261/testReport/junit/com.hazelcast.wan/WanRESTTest/consistencyCheckFail/

```
13:47:11,367 ERROR |resumeFail| - [cluster] hz.39b773bc-07fd-4d6f-a544-06be54728455.generic-operation.thread-0 - [127.0.0.1]:5702 [dev] [3.11-SNAPSHOT] Node could not join cluster. A Configuration mismatch was detected: Incompatible joiners! expected: multicast, found: tcp-ip Node is going to shutdown now!
13:47:11,367 ERROR |resumeFail| - [cluster] hz.39b773bc-07fd-4d6f-a544-06be54728455.generic-operation.thread-1 - [127.0.0.1]:5702 [dev] [3.11-SNAPSHOT] Node could not join cluster. A Configuration mismatch was detected: Incompatible joiners! expected: multicast, found: tcp-ip Node is going to shutdown now!
```