### PR TITLE
Increase TTL and add assertion to clarify failure cause for racy test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
@@ -272,8 +272,8 @@ public class CacheExpirationTest extends CacheTestSupport {
 
         for (int i = 0; i < KEY_RANGE; i++) {
             cache.put(i, i);
-            assertTrue("Expected to remove entry " + i + " but entry was not present. Expired entry count: " +
-                    listener.getExpirationCount().get(), cache.remove(i));
+            assertTrue("Expected to remove entry " + i + " but entry was not present. Expired entry count: "
+                    + listener.getExpirationCount().get(), cache.remove(i));
         }
 
         sleepAtLeastSeconds(ttlSeconds);

--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
@@ -53,6 +53,7 @@ import static com.hazelcast.cache.impl.eviction.CacheClearExpiredRecordsTask.PRO
 import static com.hazelcast.test.OverridePropertyRule.set;
 import static com.hazelcast.test.backup.TestBackupUtils.assertBackupSizeEventually;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -263,15 +264,19 @@ public class CacheExpirationTest extends CacheTestSupport {
     @Test
     public void test_whenEntryIsRemovedBackupIsCleaned() {
         SimpleExpiryListener listener = new SimpleExpiryListener();
-        CacheConfig<Integer, Integer> cacheConfig = createCacheConfig(new HazelcastExpiryPolicy(FIVE_SECONDS, FIVE_SECONDS, FIVE_SECONDS), listener);
+        int ttlSeconds = 10;
+        Duration duration = new Duration(TimeUnit.SECONDS, ttlSeconds);
+        HazelcastExpiryPolicy expiryPolicy = new HazelcastExpiryPolicy(duration, duration, duration);
+        CacheConfig<Integer, Integer> cacheConfig = createCacheConfig(expiryPolicy, listener);
         Cache<Integer, Integer> cache = createCache(cacheConfig);
 
         for (int i = 0; i < KEY_RANGE; i++) {
             cache.put(i, i);
-            cache.remove(i);
+            assertTrue("Expected to remove entry " + i + " but entry was not present. Expired entry count: " +
+                    listener.getExpirationCount().get(), cache.remove(i));
         }
 
-        sleepAtLeastSeconds(5);
+        sleepAtLeastSeconds(ttlSeconds);
         assertEquals(0, listener.getExpirationCount().get());
         for (int i = 1; i < CLUSTER_SIZE; i++) {
             BackupAccessor backupAccessor = TestBackupUtils.newCacheAccessor(instances, cache.getName(), i);


### PR DESCRIPTION
The test adds entries and tries to remove them immediately afterwards
before TTL has expired. If there is a big pause between adding and
removing entries, they may expire before they are removed. We increase
the TTL and add an assertion message to clarify the cause.

If the problem persists, we may have to change the test or remove
altogether.

Fixes: https://github.com/hazelcast/hazelcast/issues/13619