### PR TITLE
Fix wrong parameter while scheduling active migration finalization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -319,9 +319,7 @@ public class MigrationManager {
     void scheduleActiveMigrationFinalization(final MigrationInfo migrationInfo) {
         partitionServiceLock.lock();
         try {
-            // we use activeMigrationInfo because it contains migrated replica fragment namespaces
-            final MigrationInfo activeMigrationInfo = this.activeMigrationInfo;
-            if (activeMigrationInfo != null && migrationInfo.equals(activeMigrationInfo)) {
+            if (migrationInfo.equals(activeMigrationInfo)) {
                 if (activeMigrationInfo.startProcessing()) {
                     activeMigrationInfo.setStatus(migrationInfo.getStatus());
                     finalizeMigration(activeMigrationInfo);
@@ -331,9 +329,9 @@ public class MigrationManager {
                     nodeEngine.getExecutionService().schedule(new Runnable() {
                         @Override
                         public void run() {
-                            scheduleActiveMigrationFinalization(activeMigrationInfo);
+                            scheduleActiveMigrationFinalization(migrationInfo);
                         }
-                    }, 3, TimeUnit.SECONDS);
+                    }, 1, TimeUnit.SECONDS);
                 }
                 return;
             }


### PR DESCRIPTION
While scheduling finalization of a migration, `MigrationInfo` sent by master
should be used, not the local `MigrationInfo`. Because local `MigrationInfo`
will not have expected status, finalization will fail later.

Also reduced scheduling delay to 1 second from 3 seconds.

Fixes #13833