### PR TITLE
Fixes blocking RingBuffer ReadManyOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -79,11 +79,15 @@ public class ReadManyOperation<O> extends AbstractRingBufferOperation
             return false;
         }
 
-        if (ringbuffer.shouldWait(sequence)) {
+        if (sequence > ringbuffer.tailSequence() + 1
+                || (sequence < ringbuffer.headSequence() && !ringbuffer.getStore().isEnabled())) {
+            //no need to wait, let the operation continue and fail in beforeRun
+            return false;
+        }
+        if (sequence == ringbuffer.tailSequence() + 1) {
             // the sequence is not readable
             return true;
         }
-
         sequence = ringbuffer.readMany(sequence, resultSet);
         return !resultSet.isMinSizeReached();
     }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadManyOperation.java
@@ -79,8 +79,7 @@ public class ReadManyOperation<O> extends AbstractRingBufferOperation
             return false;
         }
 
-        if (sequence > ringbuffer.tailSequence() + 1
-                || (sequence < ringbuffer.headSequence() && !ringbuffer.getStore().isEnabled())) {
+        if (ringbuffer.isTooLargeSequence(sequence) || ringbuffer.isStaleSequence(sequence)) {
             //no need to wait, let the operation continue and fail in beforeRun
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/ringbuffer/impl/operations/ReadOneOperation.java
@@ -50,7 +50,12 @@ public class ReadOneOperation extends AbstractRingBufferOperation implements Blo
     @Override
     public boolean shouldWait() {
         RingbufferContainer ringbuffer = getRingBufferContainer();
-        return ringbuffer.shouldWait(sequence);
+        if (ringbuffer.isTooLargeSequence(sequence) || ringbuffer.isStaleSequence(sequence)) {
+            //no need to wait, let the operation continue and fail in beforeRun
+            return false;
+        }
+        // the sequence is not readable
+        return sequence == ringbuffer.tailSequence() + 1;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/EventJournalCacheDataStructureAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/impl/journal/EventJournalCacheDataStructureAdapter.java
@@ -68,6 +68,11 @@ public class EventJournalCacheDataStructureAdapter<K, V>
     }
 
     @Override
+    public void putAll(Map<K, V> map) {
+        cache.putAll(map);
+    }
+
+    @Override
     public void load(K key) {
         throw new UnsupportedOperationException();
     }

--- a/hazelcast/src/test/java/com/hazelcast/journal/EventJournalDataStructureAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/journal/EventJournalDataStructureAdapter.java
@@ -32,6 +32,8 @@ public interface EventJournalDataStructureAdapter<K, V, EJ_TYPE> extends EventJo
 
     V put(K key, V value, long ttl, TimeUnit timeunit);
 
+    void putAll(Map<K, V> map);
+
     void load(K key);
 
     void loadAll(Set<K> keys);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/journal/EventJournalMapDataStructureAdapter.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/journal/EventJournalMapDataStructureAdapter.java
@@ -27,6 +27,7 @@ import com.hazelcast.projection.Projection;
 import com.hazelcast.ringbuffer.ReadResultSet;
 import com.hazelcast.spi.ObjectNamespace;
 
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -58,6 +59,11 @@ public class EventJournalMapDataStructureAdapter<K, V>
     @Override
     public V put(K key, V value, long ttl, TimeUnit timeunit) {
         return map.put(key, value, ttl, timeunit);
+    }
+
+    @Override
+    public void putAll(Map<K, V> map) {
+        this.map.putAll(map);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAbstractTest.java
@@ -29,9 +29,12 @@ import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.util.RootCauseMatcher;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -64,6 +67,9 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
     private Config config;
     private HazelcastInstance local;
     private String name;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setup() {
@@ -722,10 +728,11 @@ public abstract class RingbufferAbstractTest extends HazelcastTestSupport {
     }
 
 
-    @Test(expected = ExecutionException.class)
+    @Test
     public void readManyAsync_whenHitsStale_shouldNotBeBlocked() throws Exception {
         ICompletableFuture<ReadResultSet<String>> f = ringbuffer.readManyAsync(0, 1, 10, null);
         ringbuffer.addAllAsync(asList("0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"), OVERWRITE);
+        expectedException.expect(new RootCauseMatcher(StaleSequenceException.class));
         f.get();
     }
 


### PR DESCRIPTION
ReadManyOperation(async) blocks when there is no item in the ringbuffer. Then the thread is parked. When an add operation adds new items, it attempts to unblock waiting read operations. Before unparking the op, the system calls the op's shouldWait method again. shouldWait throws because now sequence is stale (AddAll operation added too many items and overwritten the first one). Since it throws during unparking, the exception is not sent to the requesting party. It is logged and dropped instead. This PR catches StaleSequnceException within shouldWait and lets the operation unblock. The unblocked operation, then returns exception to the calling party.

Fixes https://github.com/hazelcast/hazelcast/issues/13705