### PR TITLE
Improve jitter tolerance by retrying test when JitterRule is enabled

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTest.java
@@ -41,6 +41,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.jitter.RetryableUponHiccups;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -671,10 +672,12 @@ public class ExecutorServiceTest extends ExecutorServiceTestSupport {
     /* ############ cancellation ############ */
 
     @Test
+    @RetryableUponHiccups
     public void testCancellationAwareTask() throws Exception {
         SleepingTask task = new SleepingTask(5);
         ExecutorService executor = createSingleNodeExecutorService("testCancellationAwareTask");
         Future future = executor.submit(task);
+
         try {
             future.get(2, TimeUnit.SECONDS);
             fail("Should throw TimeoutException!");

--- a/hazelcast/src/test/java/com/hazelcast/test/jitter/RetryableUponHiccups.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/jitter/RetryableUponHiccups.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test.jitter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks a test as retryable
+ *
+ * When a test fails while Jitter monitor is enabled and hiccups are detected, it will retried based on the options passed in
+ * this annotation. On failures that hiccups where not detected, or where not severe enough to cross the {@link #thresholdMs()}
+ * option, there will be no retry attempts.
+ */
+@Retention(RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RetryableUponHiccups {
+    /**
+     * @return The max allowed accumulated pauses during this test before it avails of a retry
+     */
+    int thresholdMs() default 1000;
+
+    /**
+     * @return The number of retries before the test is marked as failed.
+     */
+    int retries() default 3;
+
+    /**
+     * @return The cool down period between retries, to maximize chances for a more stable environment during the next cycle
+     */
+    int coolDownPeriodMs() default 5000;
+}


### PR DESCRIPTION
Poor man's attempt to minimize test failures due to Jitter on build environment. 
When `@JitterRule` is enabled, and a test fails, if hiccups are detected, we can retry the test given that its marked as `@RetryableUponHiccups`

The new annotation provides options to control retry attempts, cool-down periods between attempts and a hiccup threshold before a test avails of a retry.

Tested by melting my dev environment
`stress -c 2000 --timeout 90s ` on one of the hiccup sensitive tests