### PR TITLE
Fixed backup evictor operations that are sent upon expiration on primary

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -20,14 +20,14 @@ import com.hazelcast.cache.CacheEntryView;
 import com.hazelcast.cache.CacheMergePolicy;
 import com.hazelcast.cache.impl.record.CacheRecord;
 import com.hazelcast.config.CacheConfig;
+import com.hazelcast.internal.eviction.ExpiredKey;
 import com.hazelcast.internal.nearcache.impl.invalidation.InvalidationQueue;
 import com.hazelcast.map.impl.MapEntries;
-import com.hazelcast.wan.impl.CallerProvenance;
-import com.hazelcast.internal.eviction.ExpiredKey;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.CacheMergeTypes;
+import com.hazelcast.wan.impl.CallerProvenance;
 
 import javax.cache.expiry.ExpiryPolicy;
 import javax.cache.processor.EntryProcessor;
@@ -180,7 +180,6 @@ public interface ICacheRecordStore {
     boolean remove(Data key, String caller, String origin, int completionId, CallerProvenance provenance);
 
     boolean remove(Data key, String caller, String origin, int completionId);
-
 
 
     /**
@@ -499,7 +498,7 @@ public interface ICacheRecordStore {
      */
     boolean evictIfRequired();
 
-    boolean evictOneEntry();
+    void sampleAndHardRemoveEntries(int count);
 
     /**
      * Determines whether wan replication is enabled or not for this record store.
@@ -518,8 +517,8 @@ public interface ICacheRecordStore {
     /**
      * Merges the given {@link CacheMergeTypes} via the given {@link SplitBrainMergePolicy}.
      *
-     * @param mergingEntry the {@link CacheMergeTypes} instance to merge
-     * @param mergePolicy  the {@link SplitBrainMergePolicy} instance to apply
+     * @param mergingEntry     the {@link CacheMergeTypes} instance to merge
+     * @param mergePolicy      the {@link SplitBrainMergePolicy} instance to apply
      * @param callerProvenance
      * @return the used {@link CacheRecord} if merge is applied, otherwise {@code null}
      */
@@ -529,12 +528,12 @@ public interface ICacheRecordStore {
     /**
      * Merges the given {@link CacheEntryView} via the given {@link CacheMergePolicy}.
      *
-     * @param cacheEntryView the {@link CacheEntryView} instance to merge
-     * @param mergePolicy    the {@link CacheMergePolicy} instance to apply
-     * @param caller         the UUID of the caller
-     * @param origin         source of the call
-     * @param completionId   User generated id which shall be received as a field of the cache event upon completion of
-     *                       the request in the cluster.
+     * @param cacheEntryView   the {@link CacheEntryView} instance to merge
+     * @param mergePolicy      the {@link CacheMergePolicy} instance to apply
+     * @param caller           the UUID of the caller
+     * @param origin           source of the call
+     * @param completionId     User generated id which shall be received as a field of the cache event upon completion of
+     *                         the request in the cluster.
      * @param callerProvenance
      * @return the used {@link CacheRecord} if merge is applied, otherwise {@code null}
      */

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheExpireBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheExpireBatchBackupOperation.java
@@ -34,28 +34,41 @@ import java.util.LinkedList;
 public class CacheExpireBatchBackupOperation extends CacheOperation {
 
     private Collection<ExpiredKey> expiredKeys;
-    private int ownerPartitionEntryCount;
+    private int primaryEntryCount;
 
     public CacheExpireBatchBackupOperation() {
     }
 
-    public CacheExpireBatchBackupOperation(String name, Collection<ExpiredKey> expiredKeys, int ownerPartitionEntryCount) {
+    public CacheExpireBatchBackupOperation(String name, Collection<ExpiredKey> expiredKeys, int primaryEntryCount) {
         super(name, true);
         this.expiredKeys = expiredKeys;
-        this.ownerPartitionEntryCount = ownerPartitionEntryCount;
+        this.primaryEntryCount = primaryEntryCount;
     }
 
     @Override
     public void run() {
+        if (recordStore == null) {
+            return;
+        }
+
         for (ExpiredKey expiredKey : expiredKeys) {
             evictIfSame(expiredKey);
         }
 
-        int diff = recordStore.size() - ownerPartitionEntryCount;
-        for (int i = 0; i < diff; i++) {
-            recordStore.evictOneEntry();
+        equalizeEntryCountWithPrimary();
+    }
+
+    /**
+     * Equalizes backup entry count with primary in order to have identical
+     * memory occupancy.
+     */
+    private void equalizeEntryCountWithPrimary() {
+        int diff = recordStore.size() - primaryEntryCount;
+        if (diff > 0) {
+            recordStore.sampleAndHardRemoveEntries(diff);
         }
-        assert recordStore.size() == ownerPartitionEntryCount;
+
+        assert recordStore.size() == primaryEntryCount;
     }
 
     @Override
@@ -93,7 +106,7 @@ public class CacheExpireBatchBackupOperation extends CacheOperation {
             out.writeData(expiredKey.getKey());
             out.writeLong(expiredKey.getCreationTime());
         }
-        out.writeInt(ownerPartitionEntryCount);
+        out.writeInt(primaryEntryCount);
     }
 
     @Override
@@ -104,6 +117,6 @@ public class CacheExpireBatchBackupOperation extends CacheOperation {
         for (int i = 0; i < size; i++) {
             expiredKeys.add(new ExpiredKey(in.readData(), in.readLong()));
         }
-        ownerPartitionEntryCount = in.readInt();
+        primaryEntryCount = in.readInt();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
@@ -18,9 +18,12 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.internal.eviction.ExpiredKey;
 import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.eviction.Evictor;
 import com.hazelcast.map.impl.record.Record;
+import com.hazelcast.map.impl.recordstore.LazyEntryViewFromRecord;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.exception.WrongTargetException;
@@ -39,12 +42,12 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
 
     private String name;
     private Collection<ExpiredKey> expiredKeys;
-    private int ownerPartitionEntryCount;
+    private int primaryEntryCount;
 
     public EvictBatchBackupOperation() {
     }
 
-    public EvictBatchBackupOperation(String name, Collection<ExpiredKey> expiredKeys, int ownerPartitionEntryCount) {
+    public EvictBatchBackupOperation(String name, Collection<ExpiredKey> expiredKeys, int primaryEntryCount) {
         super(name);
 
         assert isNotEmpty(expiredKeys);
@@ -52,11 +55,16 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
 
         this.name = name;
         this.expiredKeys = expiredKeys;
-        this.ownerPartitionEntryCount = ownerPartitionEntryCount;
+        this.primaryEntryCount = primaryEntryCount;
+        this.createRecordStoreOnDemand = false;
     }
 
     @Override
     public void run() {
+        if (recordStore == null) {
+            return;
+        }
+
         for (ExpiredKey expiredKey : expiredKeys) {
             Record existingRecord = recordStore.getRecord(expiredKey.getKey());
             if (canEvictRecord(existingRecord, expiredKey)) {
@@ -64,10 +72,31 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
             }
         }
 
-        // equalize backup entry count to owner entry count to have identical memory occupancy
-        int diff = recordStore.size() - ownerPartitionEntryCount;
-        for (int i = 0; i < diff; i++) {
-            mapContainer.getEvictor().evict(recordStore, null);
+        equalizeEntryCountWithPrimary();
+    }
+
+    /**
+     * Equalizes backup entry count with primary in order to have identical
+     * memory occupancy.
+     *
+     * If eviction configured for this map, equalize entry count by using
+     * evictor, otherwise, sample entries and evict them from this backup
+     * replica.
+     */
+    private void equalizeEntryCountWithPrimary() {
+        int diff = recordStore.size() - primaryEntryCount;
+
+        Evictor evictor = mapContainer.getEvictor();
+        if (evictor != Evictor.NULL_EVICTOR) {
+            for (int i = 0; i < diff; i++) {
+                evictor.evict(recordStore, null);
+            }
+        } else {
+            Iterable<LazyEntryViewFromRecord> sample = recordStore.getStorage().getRandomSamples(diff);
+            for (LazyEntryViewFromRecord entryViewFromRecord : sample) {
+                Data dataKey = entryViewFromRecord.getRecord().getKey();
+                recordStore.evict(dataKey, true);
+            }
         }
     }
 
@@ -113,7 +142,7 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
             out.writeData(expiredKey.getKey());
             out.writeLong(expiredKey.getCreationTime());
         }
-        out.writeInt(ownerPartitionEntryCount);
+        out.writeInt(primaryEntryCount);
     }
 
     @Override
@@ -126,6 +155,6 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
         for (int i = 0; i < size; i++) {
             expiredKeys.add(new ExpiredKey(in.readData(), in.readLong()));
         }
-        ownerPartitionEntryCount = in.readInt();
+        primaryEntryCount = in.readInt();
     }
 }


### PR DESCRIPTION
- Used evictor if map has eviction configured otherwise hard remove is done
- Hard remove is fixed cache backup evictor

related to https://github.com/hazelcast/hazelcast/issues/13520