### PR TITLE
Update default hibernate to version 5

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -162,8 +162,8 @@
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-hibernate3</artifactId>
-            <version>3.8.1</version>
+            <artifactId>hazelcast-hibernate5</artifactId>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>

--- a/hazelcast-spring/pom.xml
+++ b/hazelcast-spring/pom.xml
@@ -139,10 +139,29 @@
 
     <profiles>
         <profile>
-            <id>hibernate-4</id>
+            <id>hibernate-5</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <dependencies>
+                <!--TEST DEPENDENCIES-->
+                <dependency>
+                    <groupId>com.hazelcast</groupId>
+                    <artifactId>hazelcast-hibernate5</artifactId>
+                    <version>1.2.3</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.hibernate</groupId>
+                    <artifactId>hibernate-core</artifactId>
+                    <version>5.0.9.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>hibernate-4</id>
             <dependencies>
                 <!--TEST DEPENDENCIES-->
                 <dependency>


### PR DESCRIPTION
Addressing #13250 by switching HZ hibernate bundled with `hazelcast-all` to `hazelcast-hibernate5` that uses `hibernate-core@5.0.9.Final`. For `hibernate-spring` I added a new `hibernate-5` profile similar to existing `hibernate-3` and `hibernate-4` which is the new `activeByDefault`.