### PR TITLE
Refactored expiration cleaners for map and cache

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -149,7 +149,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
         for (int i = 0; i < partitionCount; i++) {
             segments[i] = newPartitionSegment(i);
         }
-        this.clearExpiredRecordsTask = new CacheClearExpiredRecordsTask(nodeEngine, this.segments);
+        this.clearExpiredRecordsTask = new CacheClearExpiredRecordsTask(this.segments, nodeEngine);
         this.expirationManager = new ExpirationManager(this.clearExpiredRecordsTask, nodeEngine);
         this.cacheEventHandler = new CacheEventHandler(nodeEngine);
         this.splitBrainHandlerService = new CacheSplitBrainHandlerService(nodeEngine, segments);
@@ -165,9 +165,9 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
     }
 
     public Object getMergePolicy(String name) {
-            CacheConfig cacheConfig = configs.get(name);
-            String mergePolicyName = cacheConfig.getMergePolicy();
-            return mergePolicyProvider.getMergePolicy(mergePolicyName);
+        CacheConfig cacheConfig = configs.get(name);
+        String mergePolicyName = cacheConfig.getMergePolicy();
+        return mergePolicyProvider.getMergePolicy(mergePolicyName);
     }
 
     public ConcurrentMap<String, CacheConfig> getConfigs() {
@@ -783,7 +783,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
 
     public <K, V> ICompletableFuture createCacheConfigOnAllMembersAsync(PreJoinCacheConfig<K, V> cacheConfig) {
         return InvocationUtil.invokeOnStableClusterSerial(getNodeEngine(),
-                    new AddCacheConfigOperationSupplier(cacheConfig),
-                    MAX_ADD_CACHE_CONFIG_RETRIES);
+                new AddCacheConfigOperationSupplier(cacheConfig),
+                MAX_ADD_CACHE_CONFIG_RETRIES);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheExpireBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheExpireBatchBackupOperation.java
@@ -33,8 +33,8 @@ import java.util.LinkedList;
  */
 public class CacheExpireBatchBackupOperation extends CacheOperation {
 
-    private Collection<ExpiredKey> expiredKeys;
     private int primaryEntryCount;
+    private Collection<ExpiredKey> expiredKeys;
 
     public CacheExpireBatchBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ToBackupSender.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ToBackupSender.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.eviction;
+
+import com.hazelcast.core.IBiFunction;
+import com.hazelcast.internal.nearcache.impl.invalidation.InvalidationQueue;
+import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.util.CollectionUtil;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Queue;
+
+/**
+ * Helper class to create and send backup expiration operations.
+ *
+ * @param <RS> type of record store
+ */
+public final class ToBackupSender<RS> {
+
+    private static final int MAX_EXPIRED_KEY_COUNT_IN_BATCH = 100;
+
+    private final String serviceName;
+    private final OperationService operationService;
+    private final IBiFunction<Integer, Integer, Boolean> backupOpFilter;
+    private final IBiFunction<RS, Collection<ExpiredKey>, Operation> backupOpSupplier;
+
+    private ToBackupSender(String serviceName,
+                           IBiFunction<RS, Collection<ExpiredKey>, Operation> backupOpSupplier,
+                           IBiFunction<Integer, Integer, Boolean> backupOpFilter,
+                           NodeEngine nodeEngine) {
+        this.serviceName = serviceName;
+        this.backupOpFilter = backupOpFilter;
+        this.backupOpSupplier = backupOpSupplier;
+        this.operationService = nodeEngine.getOperationService();
+    }
+
+    static <S> ToBackupSender<S> newToBackupSender(String serviceName,
+                                                   IBiFunction<S, Collection<ExpiredKey>, Operation> operationSupplier,
+                                                   IBiFunction<Integer, Integer, Boolean> backupOpFilter,
+                                                   NodeEngine nodeEngine) {
+        return new ToBackupSender<S>(serviceName, operationSupplier, backupOpFilter, nodeEngine);
+    }
+
+    private static Collection<ExpiredKey> tryTakeExpiredKeys(InvalidationQueue<ExpiredKey> invalidationQueue,
+                                                             boolean checkIfReachedBatch) {
+        int size = invalidationQueue.size();
+        if (size == 0 || checkIfReachedBatch && size < MAX_EXPIRED_KEY_COUNT_IN_BATCH) {
+            return null;
+        }
+
+        if (!invalidationQueue.tryAcquire()) {
+            return null;
+        }
+
+        Collection<ExpiredKey> expiredKeys;
+        try {
+            expiredKeys = pollExpiredKeys(invalidationQueue);
+        } finally {
+            invalidationQueue.release();
+        }
+
+        return expiredKeys;
+    }
+
+    private static Collection<ExpiredKey> pollExpiredKeys(Queue<ExpiredKey> expiredKeys) {
+        Collection<ExpiredKey> polledKeys = new ArrayList<ExpiredKey>(expiredKeys.size());
+
+        do {
+            ExpiredKey expiredKey = expiredKeys.poll();
+            if (expiredKey == null) {
+                break;
+            }
+            polledKeys.add(expiredKey);
+        } while (true);
+
+        return polledKeys;
+    }
+
+    public void trySendExpiryOp(RS recordStore, InvalidationQueue invalidationQueue,
+                                int backupReplicaCount, int partitionId, boolean checkIfReachedBatch) {
+        Collection<ExpiredKey> expiredKeys = tryTakeExpiredKeys(invalidationQueue, checkIfReachedBatch);
+        if (CollectionUtil.isEmpty(expiredKeys)) {
+            return;
+        }
+        // send expired keys to all backups
+        invokeBackupExpiryOperation(expiredKeys, backupReplicaCount, partitionId, recordStore);
+    }
+
+    private void invokeBackupExpiryOperation(Collection<ExpiredKey> expiredKeys, int backupReplicaCount,
+                                             int partitionId, RS recordStore) {
+        for (int replicaIndex = 1; replicaIndex < backupReplicaCount + 1; replicaIndex++) {
+            if (backupOpFilter.apply(partitionId, replicaIndex)) {
+                Operation operation = backupOpSupplier.apply(recordStore, expiredKeys);
+                operationService.createInvocationBuilder(serviceName, operation, partitionId)
+                        .setReplicaIndex(replicaIndex).invoke();
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -168,7 +168,7 @@ class MapServiceContextImpl implements MapServiceContext {
         this.mapConstructor = createMapConstructor();
         this.queryCacheContext = new NodeQueryCacheContext(this);
         this.partitionContainers = createPartitionContainers();
-        this.clearExpiredRecordsTask = new MapClearExpiredRecordsTask(nodeEngine, partitionContainers);
+        this.clearExpiredRecordsTask = new MapClearExpiredRecordsTask(partitionContainers, nodeEngine);
         this.expirationManager = new ExpirationManager(clearExpiredRecordsTask, nodeEngine);
         this.mapNearCacheManager = createMapNearCacheManager();
         this.localMapStatsProvider = createLocalMapStatsProvider();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/eviction/EvictorImpl.java
@@ -98,7 +98,7 @@ public class EvictorImpl implements Evictor {
         recordStore.evict(key, backup);
 
         if (!backup) {
-            recordStore.doPostEvictionOperations(record, backup);
+            recordStore.doPostEvictionOperations(record);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
@@ -40,9 +40,9 @@ import static com.hazelcast.util.TimeUtil.zeroOutMs;
  */
 public class EvictBatchBackupOperation extends MapOperation implements BackupOperation {
 
+    private int primaryEntryCount;
     private String name;
     private Collection<ExpiredKey> expiredKeys;
-    private int primaryEntryCount;
 
     public EvictBatchBackupOperation() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -18,31 +18,24 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.core.EntryView;
-import com.hazelcast.internal.eviction.ExpirationManager;
 import com.hazelcast.internal.eviction.ExpiredKey;
 import com.hazelcast.internal.nearcache.impl.invalidation.InvalidationQueue;
 import com.hazelcast.map.impl.MapContainer;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.event.MapEventPublisher;
 import com.hazelcast.map.impl.eviction.Evictor;
-import com.hazelcast.map.impl.operation.EvictBatchBackupOperation;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.Operation;
-import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.NoSuchElementException;
-import java.util.Queue;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.core.EntryEventType.EVICTED;
@@ -54,8 +47,6 @@ import static com.hazelcast.map.impl.ExpirationTimeSetter.getLifeStartTime;
 import static com.hazelcast.map.impl.ExpirationTimeSetter.setExpirationTime;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.eviction.Evictor.NULL_EVICTOR;
-import static com.hazelcast.map.impl.eviction.MapClearExpiredRecordsTask.MAX_EXPIRED_KEY_COUNT_IN_BATCH;
-
 
 /**
  * Contains eviction specific functionality.
@@ -66,7 +57,6 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
     protected final EventService eventService;
     protected final MapEventPublisher mapEventPublisher;
     protected final Address thisAddress;
-    protected final ExpirationManager expirationManager;
     protected final InvalidationQueue<ExpiredKey> expiredKeys = new InvalidationQueue<ExpiredKey>();
     /**
      * Iterates over a pre-set entry count/percentage in one round.
@@ -83,7 +73,6 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         eventService = nodeEngine.getEventService();
         mapEventPublisher = mapServiceContext.getMapEventPublisher();
         thisAddress = nodeEngine.getThisAddress();
-        expirationManager = mapServiceContext.getExpirationManager();
     }
 
     /**
@@ -228,7 +217,7 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         }
         evict(key, backup);
         if (!backup) {
-            doPostEvictionOperations(record, backup);
+            doPostEvictionOperations(record);
         }
         return null;
     }
@@ -288,7 +277,7 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
     }
 
     @Override
-    public void doPostEvictionOperations(Record record, boolean backup) {
+    public void doPostEvictionOperations(Record record) {
         // Fire EVICTED event also in case of expiration because historically eviction-listener
         // listens all kind of eviction and expiration events and by firing EVICTED event we are preserving
         // this behavior.
@@ -302,8 +291,8 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         }
 
         long now = getNow();
-        boolean idleExpired = isIdleExpired(record, now, backup);
-        boolean ttlExpired = isTTLExpired(record, now, backup);
+        boolean idleExpired = isIdleExpired(record, now, false);
+        boolean ttlExpired = isTTLExpired(record, now, false);
         boolean expired = idleExpired || ttlExpired;
 
         if (expired && hasEventRegistration) {
@@ -335,62 +324,7 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
             expiredKeys.offer(new ExpiredKey(toHeapData(record.getKey()), record.getCreationTime()));
         }
 
-        sendExpiredKeysToBackups(true);
-    }
-
-    public void sendExpiredKeysToBackups(boolean checkIfReachedBatch) {
-        InvalidationQueue<ExpiredKey> invalidationQueue = getExpiredKeys();
-
-        int size = invalidationQueue.size();
-        if (size == 0 || checkIfReachedBatch && size < MAX_EXPIRED_KEY_COUNT_IN_BATCH) {
-            return;
-        }
-
-        if (!invalidationQueue.tryAcquire()) {
-            return;
-        }
-
-        Collection<ExpiredKey> expiredKeys;
-        try {
-            expiredKeys = pollExpiredKeys(invalidationQueue);
-        } finally {
-            invalidationQueue.release();
-        }
-
-        if (expiredKeys.size() == 0) {
-            return;
-        }
-
-        // send expired keys to all backups
-        OperationService operationService = mapServiceContext.getNodeEngine().getOperationService();
-        int backupReplicaCount = getMapContainer().getTotalBackupCount();
-        for (int replicaIndex = 1; replicaIndex < backupReplicaCount + 1; replicaIndex++) {
-            if (hasReplicaAddress(getPartitionId(), replicaIndex)) {
-                Operation operation = new EvictBatchBackupOperation(getName(), expiredKeys, size());
-                operationService.createInvocationBuilder(MapService.SERVICE_NAME, operation, getPartitionId())
-                        .setReplicaIndex(replicaIndex).invoke();
-            }
-        }
-    }
-
-    protected boolean hasReplicaAddress(int partitionId, int replicaIndex) {
-        return mapServiceContext.getNodeEngine()
-                .getPartitionService().getPartition(partitionId).getReplicaAddress(replicaIndex) != null;
-    }
-
-
-    private static Collection<ExpiredKey> pollExpiredKeys(Queue<ExpiredKey> expiredKeys) {
-        Collection<ExpiredKey> polledKeys = new ArrayList<ExpiredKey>(expiredKeys.size());
-
-        do {
-            ExpiredKey expiredKey = expiredKeys.poll();
-            if (expiredKey == null) {
-                break;
-            }
-            polledKeys.add(expiredKey);
-        } while (true);
-
-        return polledKeys;
+        mapServiceContext.getExpirationManager().getTask().tryToSendBackupExpiryOp(this, true);
     }
 
     protected void accessRecord(Record record, long now) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -353,9 +353,8 @@ public interface RecordStore<R extends Record> {
      * Does post eviction operations like sending events
      *
      * @param record record to process
-     * @param backup <code>true</code> if a backup partition, otherwise <code>false</code>.
      */
-    void doPostEvictionOperations(Record record, boolean backup);
+    void doPostEvictionOperations(Record record);
 
     MapDataStore<Data, Object> getMapDataStore();
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/BackupExpirationBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/BackupExpirationBouncingMemberTest.java
@@ -20,14 +20,12 @@ import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.map.impl.MapService;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.bounce.BounceMemberRule;
-import com.hazelcast.util.StringUtil;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -92,21 +90,13 @@ public class BackupExpirationBouncingMemberTest extends HazelcastTestSupport {
                         ClusterState clusterState = node.getCluster().getClusterState();
                         IMap map = node.getMap(mapName);
 
-                        MapService mapService = getNodeEngineImpl(node).getService(MapService.SERVICE_NAME);
-                        long lastStartMillis = getLastStartMillis(mapService.getMapServiceContext().getExpirationManager());
-                        long lastEndMillis = getLastEndMillis(mapService.getMapServiceContext().getExpirationManager());
-
                         LocalMapStats localMapStats = map.getLocalMapStats();
                         String msg = "Failed on node: %s, current cluster state is: %s, "
-                                + "ownedEntryCount: %d, backupEntryCount: %d, "
-                                + "expiredRecordsCleanerTask=[now: %s, lastStart: %s, lastEnd: %s]";
+                                + "ownedEntryCount: %d, backupEntryCount: %d";
 
                         String formattedMsg = String.format(msg, node, clusterState.toString(),
                                 localMapStats.getOwnedEntryCount(),
-                                localMapStats.getBackupEntryCount(),
-                                StringUtil.timeToStringFriendly(System.currentTimeMillis()),
-                                StringUtil.timeToStringFriendly(lastStartMillis),
-                                StringUtil.timeToStringFriendly(lastEndMillis));
+                                localMapStats.getBackupEntryCount());
 
                         assertEquals(formattedMsg, 0, getTotalEntryCount(localMapStats));
                     }
@@ -145,13 +135,5 @@ public class BackupExpirationBouncingMemberTest extends HazelcastTestSupport {
                 hz.getMap(mapName).set(i, i);
             }
         }
-    }
-
-    private long getLastStartMillis(ExpirationManager expirationManager) {
-        return expirationManager.task.lastStartMillis;
-    }
-
-    private long getLastEndMillis(ExpirationManager expirationManager) {
-        return expirationManager.task.lastEndMillis;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/CacheExpirationManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/CacheExpirationManagerTest.java
@@ -188,7 +188,7 @@ public class CacheExpirationManagerTest extends AbstractExpirationManagerTest {
 
     @Override
     protected ExpirationManager newExpirationManager(HazelcastInstance node) {
-        return new ExpirationManager(new CacheClearExpiredRecordsTask(getNodeEngineImpl(node), getPartitionSegments(node)), getNodeEngineImpl(node));
+        return new ExpirationManager(new CacheClearExpiredRecordsTask(getPartitionSegments(node), getNodeEngineImpl(node)), getNodeEngineImpl(node));
     }
 
     @Override


### PR DESCRIPTION
needed cleanup before fix of https://github.com/hazelcast/hazelcast/issues/13520

- Introduced `ToBackupSender` to unify backup expiry operations sending functionality.
- Combined `MapClearExpiredRecordsTask` and `CacheClearExpiredRecordsTask` under `ClearExpiredRecordsTask` as much as possible.
