### PR TITLE
Fix NPE when jcache not in classpath

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -490,7 +490,9 @@ public final class ProxyManager {
 
     private void createCachesOnCluster() {
         ClientCacheProxyFactory proxyFactory = (ClientCacheProxyFactory) getClientProxyFactory(ICacheService.SERVICE_NAME);
-        proxyFactory.recreateCachesOnCluster();
+        if (proxyFactory != null) {
+            proxyFactory.recreateCachesOnCluster();
+        }
     }
 
     private final class DistributedObjectEventHandler extends ClientAddDistributedObjectListenerCodec.AbstractEventHandler


### PR DESCRIPTION
fixing a bug recently introduced in #13810

fixes #13851

(cherry picked from commit 0ae63554413e19520e136b5a35fec3c05d801866)