### PR TITLE
Fixes inconsistent config in EntryProcessorBouncingNodesTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
@@ -28,108 +28,88 @@ import com.hazelcast.query.EntryObject;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.PredicateBuilder;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.After;
+import com.hazelcast.test.bounce.BounceMemberRule;
+import com.hazelcast.test.bounce.BounceTestConfiguration;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.Assert.assertEquals;
 
 /**
  * Creates a map that is used to test data consistency while nodes are joining and leaving the cluster.
- *
+ * <p>
  * The basic idea is pretty simple. We'll add a number to a list for each key in the IMap. This allows us to verify whether
  * the numbers are added in the correct order and also whether there's any data loss as nodes leave or join the cluster.
  */
-@RunWith(HazelcastSerialClassRunner.class)
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastSerialParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class EntryProcessorBouncingNodesTest extends HazelcastTestSupport {
 
-    private static final int ENTRIES = 10;
-    private static final int ITERATIONS = 50;
+    private static final int ENTRIES = 50;
+    private static final int ITERATIONS = 100;
     private static final String MAP_NAME = "entryProcessorBouncingNodesTestMap";
 
-    private TestHazelcastInstanceFactory instanceFactory;
+    @Parameters(name = "withPredicate={0}, withIndex={1}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {false, false}, {true, false}, {true, true}
+        });
+    }
+
+    @Parameter
+    public boolean withPredicate;
+
+    @Parameter
+    public boolean withIndex;
+
+    @Rule
+    public BounceMemberRule bounceMemberRule = BounceMemberRule
+            .with(getConfig())
+            .clusterSize(3)
+            .driverCount(1)
+            .driverType(BounceTestConfiguration.DriverType.ALWAYS_UP_MEMBER)
+            .build();
 
     @Before
     public void setUp() {
-        instanceFactory = new TestHazelcastInstanceFactory(500);
-    }
-
-    @After
-    public void tearDown() {
-        instanceFactory.shutdownAll();
-    }
-
-    /**
-     * Tests {@link com.hazelcast.map.impl.operation.EntryOperation}.
-     */
-    @Test
-    public void testEntryProcessorWhileTwoNodesAreBouncing_withoutPredicate() {
-        testEntryProcessorWhileTwoNodesAreBouncing(false, false);
-    }
-
-    /**
-     * Tests {@link com.hazelcast.map.impl.operation.MultipleEntryWithPredicateOperation}.
-     */
-    @Test
-    public void testEntryProcessorWhileTwoNodesAreBouncing_withPredicateNoIndex() {
-        testEntryProcessorWhileTwoNodesAreBouncing(true, false);
-    }
-
-    @Test
-    public void testEntryProcessorWhileTwoNodesAreBouncing_withPredicateWithIndex() {
-        testEntryProcessorWhileTwoNodesAreBouncing(true, true);
-    }
-
-    private void testEntryProcessorWhileTwoNodesAreBouncing(boolean withPredicate, boolean withIndex) {
-        CountDownLatch startLatch = new CountDownLatch(1);
-        AtomicBoolean isRunning = new AtomicBoolean(true);
-
-        // start up three instances
-        HazelcastInstance instance = newInstance(withIndex);
-        HazelcastInstance instance2 = newInstance(withIndex);
-        HazelcastInstance instance3 = newInstance(withIndex);
-
-        assertClusterSize(3, instance, instance3);
-        assertClusterSizeEventually(3, instance2);
-
-        final IMap<Integer, ListHolder> map = instance.getMap(MAP_NAME);
-        final ListHolder expected = new ListHolder();
-
+        HazelcastInstance instance = bounceMemberRule.getSteadyMember();
+        IMap<Integer, ListHolder> map = instance.getMap(MAP_NAME);
         // initialize the list synchronously to ensure the map is correctly initialized
         InitMapProcessor initProcessor = new InitMapProcessor();
         for (int i = 0; i < ENTRIES; ++i) {
             map.executeOnKey(i, initProcessor);
         }
         assertEquals(ENTRIES, map.size());
+    }
 
-        // spin up the thread that stops/starts the instance2 and instance3, always keeping one instance running
-        Runnable runnable = new TwoNodesRestartingRunnable(startLatch, isRunning, withIndex, instance2, instance3);
-        Thread bounceThread = new Thread(runnable);
-        bounceThread.start();
-
+    @Test
+    public void testEntryProcessorWhileTwoNodesAreBouncing() {
         // now, with nodes joining and leaving the cluster concurrently, start adding numbers to the lists
+        final ListHolder expected = new ListHolder();
         int iteration = 0;
+
+        HazelcastInstance steadyMember = bounceMemberRule.getSteadyMember();
+        final IMap<Integer, ListHolder> map = steadyMember.getMap(MAP_NAME);
         while (iteration < ITERATIONS) {
-            if (iteration == 30) {
-                // let the bounce threads start bouncing
-                startLatch.countDown();
-            }
             IncrementProcessor processor = new IncrementProcessor(iteration);
             expected.add(iteration);
             for (int i = 0; i < ENTRIES; ++i) {
@@ -141,15 +121,8 @@ public class EntryProcessorBouncingNodesTest extends HazelcastTestSupport {
                     map.executeOnKey(i, processor);
                 }
             }
-            // give processing time to catch up
             ++iteration;
         }
-
-        // signal the bounce threads that we're done
-        isRunning.set(false);
-
-        // wait for the instance bounces to complete
-        assertJoinable(bounceThread);
 
         for (int i = 0; i < ENTRIES; i++) {
             final int index = i;
@@ -167,51 +140,15 @@ public class EntryProcessorBouncingNodesTest extends HazelcastTestSupport {
         }
     }
 
-    private HazelcastInstance newInstance(boolean withIndex) {
-        Config config = getConfig();
-
+    @Override
+    protected Config getConfig() {
+        Config config = super.getConfig();
         MapConfig mapConfig = config.getMapConfig(MAP_NAME);
         mapConfig.setBackupCount(2);
         if (withIndex) {
             mapConfig.addMapIndexConfig(new MapIndexConfig("__key", true));
         }
-
-        return instanceFactory.newHazelcastInstance(config);
-    }
-
-    private class TwoNodesRestartingRunnable implements Runnable {
-
-        private final CountDownLatch start;
-        private final AtomicBoolean isRunning;
-        private final boolean withIndex;
-
-        private HazelcastInstance instance1;
-        private HazelcastInstance instance2;
-
-        private TwoNodesRestartingRunnable(CountDownLatch startLatch, AtomicBoolean isRunning, boolean withIndex,
-                                           HazelcastInstance h1, HazelcastInstance h2) {
-            this.start = startLatch;
-            this.isRunning = isRunning;
-            this.withIndex = withIndex;
-            this.instance1 = h1;
-            this.instance2 = h2;
-        }
-
-        @Override
-        public void run() {
-            try {
-                start.await();
-                while (isRunning.get()) {
-                    instance1.shutdown();
-                    instance2.shutdown();
-                    sleepMillis(10);
-                    instance1 = newInstance(withIndex);
-                    instance2 = newInstance(withIndex);
-                }
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-        }
+        return config;
     }
 
     private static class InitMapProcessor extends AbstractEntryProcessor<Integer, ListHolder> {


### PR DESCRIPTION
Bouncing nodes are started with indexes on in withPredicateNoIndex test. Inconsistent config in cluster causes entry processors to believe there are indexes whereas there aren't any. So some entries cannot be found even though they are present in the record stores.

EntryProcessorBouncingNodesTest is also refactored. The test scenario is exactly the same but assertions are simpler.

This PR also refactors the test to use BounceMemberRule(simpler/less cod, same scenario).

The first commit only fixes the test failure. Second commit refactors the test.

Fixes https://github.com/hazelcast/hazelcast/issues/13832