### PR TITLE
Made backup expiry tasks aware from partition lost events.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -122,7 +122,8 @@ import static java.lang.Thread.currentThread;
  * The ProxyManager handles client proxy instantiation and retrieval at start and runtime by registering
  * corresponding service manager names and their {@link com.hazelcast.client.spi.ClientProxyFactory}s.
  */
-@SuppressWarnings({"checkstyle:classfanoutcomplexity", "checkstyle:classdataabstractioncoupling"})
+@SuppressWarnings({"checkstyle:classfanoutcomplexity",
+        "checkstyle:classdataabstractioncoupling", "checkstyle:methodcount"})
 public final class ProxyManager {
 
     private static final long DISTRIBUTED_OBJECT_SYNC_PERIOD_MILLIS = 10000;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -1529,7 +1529,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     @Override
-    public InvalidationQueue<ExpiredKey> getExpiredKeys() {
+    public InvalidationQueue<ExpiredKey> getExpiredKeysQueue() {
         return this.expiredKeys;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -552,5 +552,5 @@ public interface ICacheRecordStore {
      */
     void evictExpiredEntries(int percentage);
 
-    InvalidationQueue<ExpiredKey> getExpiredKeys();
+    InvalidationQueue<ExpiredKey> getExpiredKeysQueue();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ToBackupSender.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ToBackupSender.java
@@ -103,8 +103,8 @@ public final class ToBackupSender<RS> {
         invokeBackupExpiryOperation(expiredKeys, backupReplicaCount, partitionId, recordStore);
     }
 
-    private void invokeBackupExpiryOperation(Collection<ExpiredKey> expiredKeys, int backupReplicaCount,
-                                             int partitionId, RS recordStore) {
+    public void invokeBackupExpiryOperation(Collection<ExpiredKey> expiredKeys, int backupReplicaCount,
+                                            int partitionId, RS recordStore) {
         for (int replicaIndex = 1; replicaIndex < backupReplicaCount + 1; replicaIndex++) {
             if (backupOpFilter.apply(partitionId, replicaIndex)) {
                 Operation operation = backupOpSupplier.apply(recordStore, expiredKeys);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/EvictBatchBackupOperation.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedList;
 
-import static com.hazelcast.util.CollectionUtil.isNotEmpty;
 import static com.hazelcast.util.TimeUtil.zeroOutMs;
 
 /**
@@ -50,7 +49,6 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
     public EvictBatchBackupOperation(String name, Collection<ExpiredKey> expiredKeys, int primaryEntryCount) {
         super(name);
 
-        assert isNotEmpty(expiredKeys);
         assert name != null;
 
         this.name = name;
@@ -112,7 +110,7 @@ public class EvictBatchBackupOperation extends MapOperation implements BackupOpe
         return super.onInvocationException(throwable);
     }
 
-    protected boolean canEvictRecord(Record existingRecord, ExpiredKey expiredKey) {
+    private boolean canEvictRecord(Record existingRecord, ExpiredKey expiredKey) {
         if (existingRecord == null) {
             return false;
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -311,7 +311,7 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
     }
 
     @Override
-    public InvalidationQueue<ExpiredKey> getExpiredKeys() {
+    public InvalidationQueue<ExpiredKey> getExpiredKeysQueue() {
         return expiredKeys;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStore.java
@@ -358,7 +358,7 @@ public interface RecordStore<R extends Record> {
 
     MapDataStore<Data, Object> getMapDataStore();
 
-    InvalidationQueue<ExpiredKey> getExpiredKeys();
+    InvalidationQueue<ExpiredKey> getExpiredKeysQueue();
 
     /**
      * Returns the partition id this RecordStore belongs to.

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/BackupExpirationBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/BackupExpirationBouncingMemberTest.java
@@ -94,7 +94,9 @@ public class BackupExpirationBouncingMemberTest extends HazelcastTestSupport {
                         String msg = "Failed on node: %s, current cluster state is: %s, "
                                 + "ownedEntryCount: %d, backupEntryCount: %d";
 
-                        String formattedMsg = String.format(msg, node, clusterState.toString(),
+                        String formattedMsg = String.format(msg,
+                                node,
+                                clusterState.toString(),
                                 localMapStats.getOwnedEntryCount(),
                                 localMapStats.getBackupEntryCount());
 

--- a/hazelcast/src/test/java/com/hazelcast/map/BackupExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BackupExpirationTest.java
@@ -36,6 +36,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -149,6 +150,7 @@ public class BackupExpirationTest extends HazelcastTestSupport {
     // This EP mimics TTL expiration process by creating a record
     // which expires after 100 millis. TTL expired key should not be added to the expiration queue
     // after `recordStore.get`.
+    @SuppressFBWarnings("SE_NO_SERIALVERSIONID")
     public static final class BackupExpirationQueueLengthFinder
             extends AbstractEntryProcessor implements HazelcastInstanceAware {
 
@@ -167,7 +169,7 @@ public class BackupExpirationTest extends HazelcastTestSupport {
             sleepSeconds(1);
             recordStore.get(dataKey, false, null);
 
-            InvalidationQueue expiredKeys = recordStore.getExpiredKeys();
+            InvalidationQueue expiredKeys = recordStore.getExpiredKeysQueue();
             return expiredKeys.size();
         }
 


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/13520

After an ungraceful shutdown, backups can have expired entries.
And these entries can remain forever on them. Reason for this is,
the lost invalidations on a primary partition. During ungraceful
shutdown, these invalidations can be lost before sending them to
backups.

To fix this, after detecting a partition lost, we send expiry operations
to remove leftover backup entries. Otherwise leftover entries can remain
on backups forever.