### PR TITLE
[DON'T MERGE] Merkle trees to accept custom leaf data sets

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractRecordStore.java
@@ -147,7 +147,7 @@ abstract class AbstractRecordStore implements RecordStore<Record> {
             record.onAccess(now);
         }
         record.onUpdate(now);
-        mutationObserver.onUpdateRecord(key, record, value);
+        mutationObserver.onUpdateRecord(record, value);
         storage.updateRecordValue(key, record, value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeRecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/CompositeRecordStoreMutationObserver.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.nio.serialization.Data;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -39,44 +38,44 @@ class CompositeRecordStoreMutationObserver<R extends Record> implements RecordSt
     }
 
     @Override
-    public void onPutRecord(Data key, R record) {
+    public void onPutRecord(R record) {
         for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
-            mutationObserver.onPutRecord(key, record);
+            mutationObserver.onPutRecord(record);
         }
     }
 
     @Override
-    public void onReplicationPutRecord(Data key, R record) {
+    public void onReplicationPutRecord(R record) {
         for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
-            mutationObserver.onReplicationPutRecord(key, record);
+            mutationObserver.onReplicationPutRecord(record);
         }
     }
 
     @Override
-    public void onUpdateRecord(Data key, R record, Object newValue) {
+    public void onUpdateRecord(R record, Object newValue) {
         for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
-            mutationObserver.onUpdateRecord(key, record, newValue);
+            mutationObserver.onUpdateRecord(record, newValue);
         }
     }
 
     @Override
-    public void onRemoveRecord(Data key, R record) {
+    public void onRemoveRecord(R record) {
         for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
-            mutationObserver.onRemoveRecord(key, record);
+            mutationObserver.onRemoveRecord(record);
         }
     }
 
     @Override
-    public void onEvictRecord(Data key, R record) {
+    public void onEvictRecord(R record) {
         for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
-            mutationObserver.onEvictRecord(key, record);
+            mutationObserver.onEvictRecord(record);
         }
     }
 
     @Override
-    public void onLoadRecord(Data key, R record) {
+    public void onLoadRecord(R record) {
         for (RecordStoreMutationObserver<R> mutationObserver : mutationObservers) {
-            mutationObserver.onLoadRecord(key, record);
+            mutationObserver.onLoadRecord(record);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterRecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/EventJournalWriterRecordStoreMutationObserver.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.journal.MapEventJournal;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.ObjectNamespace;
 
 public class EventJournalWriterRecordStoreMutationObserver implements RecordStoreMutationObserver {
@@ -43,33 +42,33 @@ public class EventJournalWriterRecordStoreMutationObserver implements RecordStor
     }
 
     @Override
-    public void onPutRecord(Data key, Record record) {
+    public void onPutRecord(Record record) {
         eventJournal.writeAddEvent(eventJournalConfig, objectNamespace, partitionId, record.getKey(), record.getValue());
     }
 
     @Override
-    public void onReplicationPutRecord(Data key, Record record) {
+    public void onReplicationPutRecord(Record record) {
         // NOP
     }
 
     @Override
-    public void onUpdateRecord(Data key, Record record, Object newValue) {
+    public void onUpdateRecord(Record record, Object newValue) {
         eventJournal.writeUpdateEvent(eventJournalConfig, objectNamespace, partitionId,
                 record.getKey(), record.getValue(), newValue);
     }
 
     @Override
-    public void onRemoveRecord(Data key, Record record) {
+    public void onRemoveRecord(Record record) {
         eventJournal.writeRemoveEvent(eventJournalConfig, objectNamespace, partitionId, record.getKey(), record.getValue());
     }
 
     @Override
-    public void onEvictRecord(Data key, Record record) {
+    public void onEvictRecord(Record record) {
         eventJournal.writeEvictEvent(eventJournalConfig, objectNamespace, partitionId, record.getKey(), record.getValue());
     }
 
     @Override
-    public void onLoadRecord(Data key, Record record) {
+    public void onLoadRecord(Record record) {
         eventJournal.writeLoadEvent(eventJournalConfig, objectNamespace, partitionId, record.getKey(), record.getValue());
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/RecordStoreMutationObserver.java
@@ -18,7 +18,6 @@ package com.hazelcast.map.impl.recordstore;
 
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.record.Record;
-import com.hazelcast.nio.serialization.Data;
 
 /**
  * Interface for observing {@link RecordStore} mutations
@@ -34,52 +33,46 @@ public interface RecordStoreMutationObserver<R extends Record> {
     /**
      * Called when a new record is added to the {@link RecordStore}
      *
-     * @param key    The key of the record
      * @param record The record
      */
-    void onPutRecord(Data key, R record);
+    void onPutRecord(R record);
 
     /**
      * Called when a new record is added to the {@link RecordStore} due
      * to replication
      *
-     * @param key    The key of the record
      * @param record The record
      */
-    void onReplicationPutRecord(Data key, R record);
+    void onReplicationPutRecord(R record);
 
     /**
      * Called when a new record is updated in the observed {@link RecordStore}
      *
-     * @param key      The key of the record
      * @param record   The record
      * @param newValue The new value of the record
      */
-    void onUpdateRecord(Data key, R record, Object newValue);
+    void onUpdateRecord(R record, Object newValue);
 
     /**
      * Called when a record is removed from the observed {@link RecordStore}
      *
-     * @param key    The key of the record
      * @param record The record
      */
-    void onRemoveRecord(Data key, R record);
+    void onRemoveRecord(R record);
 
     /**
      * Called when a record is evicted from the observed {@link RecordStore}
      *
-     * @param key    The key of the record
      * @param record The record
      */
-    void onEvictRecord(Data key, R record);
+    void onEvictRecord(R record);
 
     /**
      * Called when a record is loaded into the observed {@link RecordStore}
      *
-     * @param key      The key of the record
      * @param record   The record
      */
-    void onLoadRecord(Data key, R record);
+    void onLoadRecord(R record);
 
     /**
      * Called when the observed {@link RecordStore} is being destroyed.

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/HashAcceptorSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/HashAcceptorSet.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.util.collection;
+
+import java.util.Set;
+
+/**
+ * Interface extending {@link Set} to accept hash on certain methods. This
+ * can be act as an optimisation by avoiding the call to the expensive
+ * {@link Object#hashCode()} methods if the hashCode is already known on
+ * the caller side;
+ *
+ * @param <E> the type of elements maintained by this set
+ */
+public interface HashAcceptorSet<E> extends Set<E> {
+    /**
+     * Adds the specified element to this set if it is not already present.
+     * <p>
+     * This variant of {@link #add(Object)} acts as an optimisation to
+     * enable avoiding {@link #hashCode()} calls if the hash is already
+     * known on the caller side.
+     *
+     * @param elementToAdd element to be added to this set
+     * @param hash         the hash of the element to be added
+     * @return <tt>true</tt> if this set did not already contain the specified
+     * element
+     * @see #add(Object)
+     */
+    boolean add(E elementToAdd, int hash);
+
+    /**
+     * Returns <tt>true</tt> if this set contains the specified element
+     * with the hash provided in parameter.
+     * <p>
+     * This variant of {@link #contains(Object)} acts as an optimisation to
+     * enable avoiding {@link #hashCode()} calls if the hash is already
+     * known on the caller side.
+     *
+     * @param objectToCheck element whose presence in this set is to be tested
+     * @param hash          the hash of the element to be tested
+     * @return <tt>true</tt> if this set contains the specified element
+     * @see #contains(Object)
+     */
+    boolean contains(Object objectToCheck, int hash);
+
+    /**
+     * Removes the specified element from this set if it is present with
+     * the hash provided in parameter.
+     * <p>
+     * This variant of {@link #remove(Object)} acts as an optimisation to
+     * enable avoiding {@link #hashCode()} calls if the hash is already
+     * known on the caller side.
+     *
+     * @param objectToRemove object to be removed from this set, if present
+     * @param hash           the hash of the element to be removed
+     * @return <tt>true</tt> if this set contained the specified element
+     * @see #remove(Object)
+     */
+    boolean remove(Object objectToRemove, int hash);
+
+    /**
+     * Returns the current memory consumption (in bytes)
+     *
+     * @return the current memory consumption
+     */
+    long footprint();
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/OAHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/OAHashSet.java
@@ -52,8 +52,10 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * elements are removed.
  *
  * @param <E> The type of the elements stored in the set
+ *
+ * @see HashAcceptorSet
  */
-public class OAHashSet<E> extends AbstractSet<E> {
+public class OAHashSet<E> extends AbstractSet<E> implements HashAcceptorSet<E> {
     private static final int DEFAULT_INITIAL_CAPACITY = 16;
     private static final float DEFAULT_LOAD_FACTOR = 0.6F;
 
@@ -126,19 +128,7 @@ public class OAHashSet<E> extends AbstractSet<E> {
         return add(element, element.hashCode());
     }
 
-    /**
-     * Adds the specified element to this set if it is not already present.
-     * <p>
-     * This variant of {@link #add(Object)} acts as an optimisation to
-     * enable avoiding {@link #hashCode()} calls if the hash is already
-     * known on the caller side.
-     *
-     * @param elementToAdd element to be added to this set
-     * @param hash         the hash of the element to be added
-     * @return <tt>true</tt> if this set did not already contain the specified
-     * element
-     * @see #add(Object)
-     */
+    @Override
     public boolean add(E elementToAdd, int hash) {
         checkNotNull(elementToAdd);
 
@@ -170,19 +160,7 @@ public class OAHashSet<E> extends AbstractSet<E> {
         return contains(objectToCheck, objectToCheck.hashCode());
     }
 
-    /**
-     * Returns <tt>true</tt> if this set contains the specified element
-     * with the hash provided in parameter.
-     * <p>
-     * This variant of {@link #contains(Object)} acts as an optimisation to
-     * enable avoiding {@link #hashCode()} calls if the hash is already
-     * known on the caller side.
-     *
-     * @param objectToCheck element whose presence in this set is to be tested
-     * @param hash          the hash of the element to be tested
-     * @return <tt>true</tt> if this set contains the specified element
-     * @see #contains(Object)
-     */
+    @Override
     public boolean contains(Object objectToCheck, int hash) {
         checkNotNull(objectToCheck);
 
@@ -204,19 +182,7 @@ public class OAHashSet<E> extends AbstractSet<E> {
         return remove(objectToRemove, objectToRemove.hashCode());
     }
 
-    /**
-     * Removes the specified element from this set if it is present with
-     * the hash provided in parameter.
-     * <p>
-     * This variant of {@link #remove(Object)} acts as an optimisation to
-     * enable avoiding {@link #hashCode()} calls if the hash is already
-     * known on the caller side.
-     *
-     * @param objectToRemove object to be removed from this set, if present
-     * @param hash           the hash of the element to be removed
-     * @return <tt>true</tt> if this set contained the specified element
-     * @see #remove(Object)
-     */
+    @Override
     public boolean remove(Object objectToRemove, int hash) {
         checkNotNull(objectToRemove);
 
@@ -239,7 +205,7 @@ public class OAHashSet<E> extends AbstractSet<E> {
     public boolean removeAll(Collection<?> elementsToRemove) {
         boolean setChanged = false;
         for (Object objectToRemove : elementsToRemove) {
-            setChanged |= remove(objectToRemove.hashCode());
+            setChanged |= remove(objectToRemove);
         }
 
         return setChanged;
@@ -313,15 +279,11 @@ public class OAHashSet<E> extends AbstractSet<E> {
         return capacity;
     }
 
-    /**
-     * Returns the current memory consumption (in bytes)
-     *
-     * @return the current memory consumption
-     */
     @SuppressWarnings("checkstyle:trailingcomment")
+    @Override
     public long footprint() {
         return
-                INT_SIZE_IN_BYTES * hashes.length // size of hashes array
+                ((long) INT_SIZE_IN_BYTES) * hashes.length // size of hashes array
                 + REFERENCE_COST_IN_BYTES * table.length // size of table array
                 + REFERENCE_COST_IN_BYTES // reference to hashes array
                 + REFERENCE_COST_IN_BYTES // reference to table array

--- a/hazelcast/src/main/java/com/hazelcast/wan/merkletree/LeafOAHashSetFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/merkletree/LeafOAHashSetFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wan.merkletree;
+
+import com.hazelcast.util.collection.HashAcceptorSet;
+import com.hazelcast.util.collection.OAHashSet;
+
+/**
+ * {@link LeafSetFactory} implementation that creates {@link OAHashSet}
+ */
+public class LeafOAHashSetFactory<T> implements LeafSetFactory<T> {
+    @Override
+    public HashAcceptorSet<T> createLeafSet(int initialSize) {
+        return new OAHashSet<T>(initialSize);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/wan/merkletree/LeafSetFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/merkletree/LeafSetFactory.java
@@ -1,0 +1,18 @@
+package com.hazelcast.wan.merkletree;
+
+import com.hazelcast.util.collection.HashAcceptorSet;
+
+/**
+ * Interface used by {@link ArrayMerkleTree} for creating the sets act as
+ * its data blocks.
+ */
+public interface LeafSetFactory<T> {
+
+    /**
+     * Creates a set
+     *
+     * @param initialSize The initial size of the set to create
+     * @return The created set
+     */
+    HashAcceptorSet<T> createLeafSet(int initialSize);
+}

--- a/hazelcast/src/test/java/com/hazelcast/wan/merkletree/ArrayMerkleTreeBenchmark.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/merkletree/ArrayMerkleTreeBenchmark.java
@@ -124,7 +124,8 @@ public class ArrayMerkleTreeBenchmark {
     }
 
     private ArrayMerkleTree createMerkleTree(CreateInstanceBenchmarkContext context) {
-        ArrayMerkleTree merkleTree = new ArrayMerkleTree(context.depth);
+        LeafOAHashSetFactory factory = new LeafOAHashSetFactory();
+        ArrayMerkleTree merkleTree = new ArrayMerkleTree(context.depth, factory);
         context.merkleTrees.add(merkleTree);
         return merkleTree;
     }
@@ -145,7 +146,8 @@ public class ArrayMerkleTreeBenchmark {
 
         @Setup(Level.Trial)
         public void setUp() {
-            merkleTree = new ArrayMerkleTree(depth);
+            LeafOAHashSetFactory factory = new LeafOAHashSetFactory();
+            merkleTree = new ArrayMerkleTree(depth, factory);
         }
 
         @TearDown(Level.Trial)
@@ -193,5 +195,4 @@ public class ArrayMerkleTreeBenchmark {
 
         new Runner(opt).run();
     }
-
 }

--- a/hazelcast/src/test/java/com/hazelcast/wan/merkletree/ArrayMerkleTreeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/merkletree/ArrayMerkleTreeTest.java
@@ -39,25 +39,25 @@ public class ArrayMerkleTreeTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testDepthBelowMinDepthThrows() {
-        new ArrayMerkleTree(1);
+        createMerkleTree(1);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testDepthAboveMaxDepthThrows() {
-        new ArrayMerkleTree(28);
+        createMerkleTree(28);
     }
 
     @Test
     public void testDepth() {
-        MerkleTree merkleTree = new ArrayMerkleTree(3);
+        MerkleTree merkleTree = createMerkleTree(3);
 
         assertEquals(3, merkleTree.depth());
     }
 
     @Test
     public void testFootprint() {
-        MerkleTree merkleTree1 = new ArrayMerkleTree(3);
-        MerkleTree merkleTree2 = new ArrayMerkleTree(3);
+        MerkleTree merkleTree1 = createMerkleTree(3);
+        MerkleTree merkleTree2 = createMerkleTree(3);
 
         for (int i = 0; i < 10; i++) {
             merkleTree1.updateAdd(i, i);
@@ -72,7 +72,7 @@ public class ArrayMerkleTreeTest {
 
     @Test
     public void testFootprintChanges() {
-        MerkleTree merkleTree = new ArrayMerkleTree(3);
+        MerkleTree merkleTree = createMerkleTree(3);
 
         long footprintBeforeAdd = merkleTree.footprint();
         for (int i = 0; i < 100; i++) {
@@ -85,7 +85,7 @@ public class ArrayMerkleTreeTest {
 
     @Test
     public void testUpdateAdd() {
-        MerkleTree merkleTree = new ArrayMerkleTree(3);
+        MerkleTree merkleTree = createMerkleTree(3);
 
         merkleTree.updateAdd(1, 1);
         merkleTree.updateAdd(2, 2);
@@ -103,7 +103,7 @@ public class ArrayMerkleTreeTest {
 
     @Test
     public void testUpdateAddUpdateBranch() {
-        MerkleTree merkleTree = new ArrayMerkleTree(3);
+        MerkleTree merkleTree = createMerkleTree(3);
 
         merkleTree.updateAdd(-3, 4);
         merkleTree.updateAdd(-2, 2);
@@ -138,7 +138,7 @@ public class ArrayMerkleTreeTest {
 
     @Test
     public void testUpdateReplaceUpdateBranch() {
-        MerkleTree merkleTree = new ArrayMerkleTree(3);
+        MerkleTree merkleTree = createMerkleTree(3);
 
         merkleTree.updateAdd(-3, 4);
         merkleTree.updateAdd(-2, 2);
@@ -175,7 +175,7 @@ public class ArrayMerkleTreeTest {
 
     @Test
     public void testUpdateRemoveUpdateBranch() {
-        MerkleTree merkleTree = new ArrayMerkleTree(3);
+        MerkleTree merkleTree = createMerkleTree(3);
 
         merkleTree.updateAdd(-3, 4);
         merkleTree.updateAdd(-2, 2);
@@ -211,7 +211,7 @@ public class ArrayMerkleTreeTest {
 
     @Test
     public void testUpdateReplace() {
-        MerkleTree merkleTree = new ArrayMerkleTree(3);
+        MerkleTree merkleTree = createMerkleTree(3);
 
         merkleTree.updateAdd(1, 1);
         merkleTree.updateAdd(2, 2);
@@ -230,7 +230,7 @@ public class ArrayMerkleTreeTest {
 
     @Test
     public void testUpdateRemove() {
-        MerkleTree merkleTree = new ArrayMerkleTree(3);
+        MerkleTree merkleTree = createMerkleTree(3);
 
         merkleTree.updateAdd(1, 1);
         merkleTree.updateAdd(2, 2);
@@ -248,7 +248,7 @@ public class ArrayMerkleTreeTest {
 
     @Test
     public void forEachKeyOfLeaf() {
-        MerkleTree merkleTree = new ArrayMerkleTree(3);
+        MerkleTree merkleTree = createMerkleTree(3);
 
         merkleTree.updateAdd(0x80000000, 1); // leaf 3
         merkleTree.updateAdd(0xC0000000, 2); // leaf 4
@@ -271,8 +271,8 @@ public class ArrayMerkleTreeTest {
 
     @Test
     public void testTreeDepthsDontImpactNodeHashes() {
-        MerkleTree merkleTreeShallow = new ArrayMerkleTree(2);
-        MerkleTree merkleTreeDeep = new ArrayMerkleTree(4);
+        MerkleTree merkleTreeShallow = createMerkleTree(2);
+        MerkleTree merkleTreeDeep = createMerkleTree(4);
 
         merkleTreeShallow.updateAdd(0x80000000, 1); // leaf 1
         merkleTreeShallow.updateAdd(0xA0000000, 2); // leaf 1
@@ -307,7 +307,7 @@ public class ArrayMerkleTreeTest {
 
     @Test
     public void testClear() {
-        MerkleTree merkleTree = new ArrayMerkleTree(4);
+        MerkleTree merkleTree = createMerkleTree(4);
 
         merkleTree.updateAdd(0x80000000, 1); // leaf 7
         merkleTree.updateAdd(0xA0000000, 2); // leaf 8
@@ -345,6 +345,10 @@ public class ArrayMerkleTreeTest {
         merkleTree.forEachKeyOfNode(nodeOrder, consumerNode);
         assertEquals(expectedKeys.length, consumerNode.keys.size());
         assertTrue(consumerNode.keys.containsAll(asList(expectedKeys)));
+    }
+
+    private ArrayMerkleTree createMerkleTree(int depth) {
+        return new ArrayMerkleTree(depth, new LeafOAHashSetFactory());
     }
 
     private static class KeyCatcherConsumer implements Consumer<Object> {

--- a/hazelcast/src/test/java/com/hazelcast/wan/merkletree/MerkleTreeUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/merkletree/MerkleTreeUtilTest.java
@@ -433,7 +433,7 @@ public class MerkleTreeUtilTest {
 
     @Test
     public void testSerialization() throws IOException {
-        MerkleTree merkleTree = new ArrayMerkleTree(4);
+        MerkleTree merkleTree = new ArrayMerkleTree(4, new LeafOAHashSetFactory());
         merkleTree.updateAdd(0x80000000, 1); // leaf 7
         merkleTree.updateAdd(0xA0000000, 2); // leaf 8
         merkleTree.updateAdd(0xC0000000, 3); // leaf 9


### PR DESCRIPTION
Instead of using fix OAHashSet data type, Merkle trees now can use custom implementation for its data sets. This is done by:

- `ArrayMerkleTree` to use factory for creating the data sets
- Extract `OAHashSet`'s specific methods to `HashAcceptorSet` interface

This change also removes no longer needed `key` parameter from the `RecordStoreMutationObserver` methods.