### PR TITLE
Fix avg selectivity calculation in index stats tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/IndexStatsChangingNumberOfMembersTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/IndexStatsChangingNumberOfMembersTest.java
@@ -406,8 +406,11 @@ public class IndexStatsChangingNumberOfMembersTest extends HazelcastTestSupport 
         }
         double averageHitSelectivity = totalHitCount == 0 ? 0.0 : 1.0 - totalNormalizedHitCardinality / totalHitCount;
 
-        return totalHitCount + initialHits == 0 ? 0.0 :
-                (averageHitSelectivity * totalHitCount + initialTotalSelectivityCount) / (totalHitCount + initialHits);
+        if (totalHitCount + initialHits == 0) {
+            return 0.0;
+        } else {
+            return (averageHitSelectivity * totalHitCount + initialTotalSelectivityCount) / (totalHitCount + initialHits);
+        }
     }
 
     private static List<Indexes> getAllIndexes(IMap map) {


### PR DESCRIPTION
EE part: https://github.com/hazelcast/hazelcast-enterprise/pull/2467

1. Exact avg selectivity calculation is now used to raise the precession.

2. Number of entries is increased to raise the accuracy.

3. Floating point assert tolerance relaxed where it was too high.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2383