### PR TITLE
Fixing distributed object sync scheduling

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ProxyManager.java
@@ -237,8 +237,8 @@ public final class ProxyManager {
         AbstractClientInvocationService invocationService = (AbstractClientInvocationService) client.getInvocationService();
         invocationTimeoutMillis = invocationService.getInvocationTimeoutMillis();
         invocationRetryPauseMillis = invocationService.getInvocationRetryPauseMillis();
-        client.getClientExecutionService().schedule(new SyncDistributedObjectsTask(),
-                DISTRIBUTED_OBJECT_SYNC_PERIOD_MILLIS, TimeUnit.MILLISECONDS);
+        client.getClientExecutionService().scheduleWithRepetition(new SyncDistributedObjectsTask(),
+                DISTRIBUTED_OBJECT_SYNC_PERIOD_MILLIS, DISTRIBUTED_OBJECT_SYNC_PERIOD_MILLIS, TimeUnit.MILLISECONDS);
     }
 
     private void readProxyDescriptors() {


### PR DESCRIPTION
it was meant to be scheduled periodically but made a delayed
scheduling by mistake.

This was also causing build times to increase since client waits
for delayed executions in shutdown.

(cherry picked from commit 0f71f4bd63d432e64557edf7c1fcc81cfd80c6e8)