### PR TITLE
[3.10.z] FIx wrong dependencies in hazelcast-all.pom

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -80,11 +80,18 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.hazelcast:*:*</include>
+                                    <include>com.eclipsesource.minimal-json:*:*</include>
                                 </includes>
                                 <excludes>
                                     <exclude>com.hazelcast:hazelcast-all:*</exclude>
                                 </excludes>
                             </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.eclipsesource.json</pattern>
+                                    <shadedPattern>com.hazelcast.com.eclipsesource.json</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <transformers>
                                 <transformer
                                         implementation="com.hazelcast.buildutils.HazelcastManifestTransformer">


### PR DESCRIPTION
Fixes #13883 in the maintenance branch.
The master (3.11) branch don't have this issue as the sources from minimal-json library are now part of the hazelcast sourcebase.

This PR duplicates the `minimal-json` relocation configuration in hazelcast-all POM file. It workarounds Maven dependencies resolution in multimodule projects.