### PR TITLE
Fixing xsd definition of client credentials

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.11.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.11.xsd
@@ -412,7 +412,7 @@
     </xs:complexType>
     <xs:complexType name="security">
         <xs:sequence>
-            <xs:element name="credentials" type="credentials" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="credentials" type="credentials" minOccurs="0" maxOccurs="1"/>
             <xs:element name="credentials-factory" type="security-object" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
     </xs:complexType>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -402,6 +402,25 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void testSecurityConfig_onlyFactory() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "  <security>\n"
+                + "        <credentials-factory class-name=\"com.hazelcast.examples.MyCredentialsFactory\">\n"
+                + "            <properties>\n"
+                + "                <property name=\"property\">value</property>\n"
+                + "            </properties>\n"
+                + "        </credentials-factory>\n"
+                + "    </security>"
+                + HAZELCAST_CLIENT_END_TAG;
+        ClientConfig config = buildConfig(xml);
+        ClientSecurityConfig securityConfig = config.getSecurityConfig();
+        CredentialsFactoryConfig credentialsFactoryConfig = securityConfig.getCredentialsFactoryConfig();
+        assertEquals("com.hazelcast.examples.MyCredentialsFactory", credentialsFactoryConfig.getClassName());
+        Properties properties = credentialsFactoryConfig.getProperties();
+        assertEquals("value", properties.getProperty("property"));
+    }
+
+    @Test
     public void testLeftovers() {
         assertEquals(40, fullClientConfig.getExecutorPoolSize());
         assertEquals("com.hazelcast.client.util.RandomLB", fullClientConfig.getLoadBalancer().getClass().getName());


### PR DESCRIPTION
In client security xml definitions, credentials tag is forced
to use(min-occur was 1).
It has to be skipped when credentials factory is defined.
This prd fixed related xsd.