### PR TITLE
Remove/fix broken index stats selectivity tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
@@ -43,6 +43,7 @@ import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -114,6 +115,13 @@ public class ClientIndexStatsTest extends LocalIndexStatsTest {
         assertEquals(0, map2.getLocalMapStats().getIndexedQueryCount());
         assertEquals(0, map1.getLocalMapStats().getIndexStats().get("this").getQueryCount());
         assertEquals(0, map2.getLocalMapStats().getIndexStats().get("this").getQueryCount());
+    }
+
+    @Test
+    @Ignore
+    @Override
+    public void testAverageQuerySelectivityCalculation_WhenSomePartitionsAreEmpty() {
+        // do nothing
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
@@ -773,7 +773,7 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
             public void query(Predicate predicate) {
                 map.project(Projections.singleAttribute("this"), predicate);
             }
-        },};
+        }, };
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalIndexStatsTest.java
@@ -265,13 +265,13 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
 
     @Test
     public void testAverageQuerySelectivityCalculation_ChangingNumberOfIndex() {
-        double expected1 = 1.0 - 0.01;
+        double expected1 = 1.0 - 0.001;
         double expected2 = 1.0 - 0.1;
         double expected3 = 1.0 - 0.4;
 
         map.addIndex("__key", false);
         map.addIndex("this", true);
-        for (int i = 0; i < 100; ++i) {
+        for (int i = 0; i < 1000; ++i) {
             map.put(i, i);
         }
         assertEquals(0.0, keyStats().getAverageHitSelectivity(), 0.0);
@@ -284,24 +284,24 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
             assertEquals(expected1, valueStats().getAverageHitSelectivity(), 0.015);
         }
 
-        for (int i = 100; i < 200; ++i) {
+        for (int i = 1000; i < 2000; ++i) {
             map.put(i, i);
         }
 
         for (int i = 1; i <= QUERIES; ++i) {
-            map.entrySet(Predicates.greaterEqual("__key", 180));
-            map.entrySet(Predicates.greaterEqual("this", 180));
+            map.entrySet(Predicates.greaterEqual("__key", 1800));
+            map.entrySet(Predicates.greaterEqual("this", 1800));
             assertEquals((expected1 * QUERIES + expected2 * i) / (QUERIES + i), keyStats().getAverageHitSelectivity(), 0.015);
             assertEquals((expected1 * QUERIES + expected2 * i) / (QUERIES + i), valueStats().getAverageHitSelectivity(), 0.015);
         }
 
-        for (int i = 150; i < 200; ++i) {
+        for (int i = 1500; i < 2000; ++i) {
             map.remove(i);
         }
 
         for (int i = 1; i <= QUERIES; ++i) {
-            map.entrySet(Predicates.greaterEqual("__key", 90));
-            map.entrySet(Predicates.greaterEqual("this", 90));
+            map.entrySet(Predicates.greaterEqual("__key", 900));
+            map.entrySet(Predicates.greaterEqual("this", 900));
             assertEquals(((expected1 + expected2) * QUERIES + expected3 * i) / (2 * QUERIES + i),
                     keyStats().getAverageHitSelectivity(), 0.015);
             assertEquals(((expected1 + expected2) * QUERIES + expected3 * i) / (2 * QUERIES + i),
@@ -773,7 +773,7 @@ public class LocalIndexStatsTest extends HazelcastTestSupport {
             public void query(Predicate predicate) {
                 map.project(Projections.singleAttribute("this"), predicate);
             }
-        }, };
+        },};
     }
 
 }


### PR DESCRIPTION
Consider the following setup: a map with 10 entries, like 1 -> 1, 2 -> 2,
..., which is hosted by 2 members and the partition count is much higher
than 10. We are really unlucky and the first member is hosting only a
single map entry, say 1 -> 1; all other entries are hosted by the second
member.

Now, if we query for the 1 -> 1 entry using indexes, on the first member
the selectivity will be 0.0 (we are selecting "all" entries) while on
the second member it will be 1.0 (we are selecting nothing), but the
expected selectivity is 0.9.

No matter what we do, we can't recover the expected selectivity without
going into much details about partitions and entries distribution among
cluster members for each query in question.

Fixes: https://github.com/hazelcast/hazelcast/issues/13657