### PR TITLE
Made entry removal and stats update atomic

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/NearCachedClientCacheProxy.java
@@ -560,7 +560,7 @@ public class NearCachedClientCacheProxy<K, V> extends ClientCacheProxy<K, V> {
 
     private void releaseRemainingReservedKeys(Map<Object, Long> reservedKeys) {
         for (Object key : reservedKeys.keySet()) {
-            nearCache.remove(key);
+            nearCache.invalidate(key);
         }
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/NearCacheStatsStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/nearcache/NearCacheStatsStressTest.java
@@ -127,7 +127,7 @@ public class NearCacheStatsStressTest extends HazelcastTestSupport {
         public void run() {
             while (!stop.get()) {
                 Object key = getInt(KEY_SPACE);
-                nearCache.remove(key);
+                nearCache.invalidate(key);
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCache.java
@@ -92,19 +92,12 @@ public interface NearCache<K, V> extends InitializingObject {
     void put(K key, Data keyData, V value);
 
     /**
-     * Removes the value associated with the given {@code key}.
-     *
-     * @param key the key of the value will be removed
-     */
-    boolean remove(K key);
-
-    /**
      * Removes the value associated with the given {@code key}
      * and increases the invalidation statistics.
      *
      * @param key the key of the value will be invalidated
      */
-    boolean invalidate(K key);
+    void invalidate(K key);
 
     /**
      * Removes all stored values.
@@ -115,6 +108,13 @@ public interface NearCache<K, V> extends InitializingObject {
      * Clears the record store and destroys it.
      */
     void destroy();
+
+    /**
+     * Gets the count of stored records.
+     *
+     * @return the count of stored records
+     */
+    int size();
 
     /**
      * Gets the {@link com.hazelcast.config.InMemoryFormat} of the storage for internal records.
@@ -151,13 +151,6 @@ public interface NearCache<K, V> extends InitializingObject {
      * @return the best candidate object to store, selected from the given {@code candidates}.
      */
     Object selectToSave(Object... candidates);
-
-    /**
-     * Gets the count of stored records.
-     *
-     * @return the count of stored records
-     */
-    int size();
 
     /**
      * Executes the Near Cache pre-loader on the given {@link DataStructureAdapter}.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/NearCacheRecordStore.java
@@ -40,14 +40,6 @@ public interface NearCacheRecordStore<K, V> extends InitializingObject {
     V get(K key);
 
     /**
-     * Gets the record associated with the given {@code key}.
-     *
-     * @param key the key from which to get the associated {@link NearCacheRecord}.
-     * @return the {@link NearCacheRecord} associated with the given {@code key}.
-     */
-    NearCacheRecord getRecord(K key);
-
-    /**
      * Puts (associates) a value with the given {@code key}.
      *
      * @param key     the key to which the given value will be associated.
@@ -57,20 +49,12 @@ public interface NearCacheRecordStore<K, V> extends InitializingObject {
     void put(K key, Data keyData, V value);
 
     /**
-     * Removes the value associated with the given {@code key}.
-     *
-     * @param key the key from which the value will be removed.
-     * @return {@code true} if the value was removed, otherwise {@code false}.
-     */
-    boolean remove(K key);
-
-    /**
      * Removes the value associated with the given {@code key}
      * and increases the invalidation statistics.
      *
      * @param key the key of the value will be invalidated
      */
-    boolean invalidate(K key);
+    void invalidate(K key);
 
     /**
      * Removes all stored values.
@@ -81,6 +65,21 @@ public interface NearCacheRecordStore<K, V> extends InitializingObject {
      * Clears the record store and destroys it.
      */
     void destroy();
+
+    /**
+     * Gets the number of stored records.
+     *
+     * @return the number of stored records.
+     */
+    int size();
+
+    /**
+     * Gets the record associated with the given {@code key}.
+     *
+     * @param key the key from which to get the associated {@link NearCacheRecord}.
+     * @return the {@link NearCacheRecord} associated with the given {@code key}.
+     */
+    NearCacheRecord getRecord(K key);
 
     /**
      * Get the {@link com.hazelcast.monitor.NearCacheStats} instance to monitor this record store.
@@ -96,13 +95,6 @@ public interface NearCacheRecordStore<K, V> extends InitializingObject {
      * @return the best candidate object to store, selected from the given {@code candidates}.
      */
     Object selectToSave(Object... candidates);
-
-    /**
-     * Gets the number of stored records.
-     *
-     * @return the number of stored records.
-     */
-    int size();
 
     /**
      * Performs expiration and evicts expired records.

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCache.java
@@ -36,10 +36,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.config.NearCacheConfig.DEFAULT_MEMORY_FORMAT;
 import static com.hazelcast.util.Preconditions.checkNotInstanceOf;
-import static com.hazelcast.util.Preconditions.checkNotNull;
 
 public class DefaultNearCache<K, V> implements NearCache<K, V> {
-
     protected final String name;
     protected final TaskScheduler scheduler;
     protected final ClassLoader classLoader;
@@ -115,7 +113,6 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
 
     @Override
     public V get(K key) {
-        checkNotNull(key, "key cannot be null on get!");
         checkKeyFormat(key);
 
         return nearCacheRecordStore.get(key);
@@ -123,7 +120,6 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
 
     @Override
     public void put(K key, Data keyData, V value) {
-        checkNotNull(key, "key cannot be null on put!");
         checkKeyFormat(key);
 
         nearCacheRecordStore.doEvictionIfRequired();
@@ -132,19 +128,10 @@ public class DefaultNearCache<K, V> implements NearCache<K, V> {
     }
 
     @Override
-    public boolean remove(K key) {
-        checkNotNull(key, "key cannot be null on remove!");
+    public void invalidate(K key) {
         checkKeyFormat(key);
 
-        return nearCacheRecordStore.remove(key);
-    }
-
-    @Override
-    public boolean invalidate(K key) {
-        checkNotNull(key, "key cannot be null on invalidate!");
-        checkKeyFormat(key);
-
-        return nearCacheRecordStore.invalidate(key);
+        nearCacheRecordStore.invalidate(key);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheRecordStoreTestSupport.java
@@ -56,7 +56,7 @@ abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTestSuppor
         assertEquals(DEFAULT_RECORD_COUNT, nearCacheRecordStore.size());
 
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            nearCacheRecordStore.remove(i);
+            nearCacheRecordStore.invalidate(i);
             assertNull(nearCacheRecordStore.get(i));
         }
 
@@ -130,11 +130,13 @@ abstract class NearCacheRecordStoreTestSupport extends CommonNearCacheTestSuppor
                 // NOP
         }
 
+        int sizeBefore = nearCacheRecordStore.size();
         for (int i = 0; i < DEFAULT_RECORD_COUNT; i++) {
-            if (nearCacheRecordStore.remove(i * 3)) {
-                expectedEntryCount--;
-            }
+            nearCacheRecordStore.invalidate(i * 3);
         }
+        int sizeAfter = nearCacheRecordStore.size();
+        int invalidatedSize = sizeBefore - sizeAfter;
+        expectedEntryCount -= invalidatedSize;
 
         assertEquals(expectedEntryCount, nearCacheStats.getOwnedEntryCount());
         switch (inMemoryFormat) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/NearCacheTestSupport.java
@@ -127,7 +127,7 @@ public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
         assertEquals(nearCache.size(), managedNearCacheRecordStore.latestSize);
 
         for (int i = 0; i < 2 * DEFAULT_RECORD_COUNT; i++) {
-            nearCache.remove(i);
+            nearCache.invalidate(i);
             assertEquals((Integer) i, managedNearCacheRecordStore.latestKeyOnRemove);
             assertEquals(i < DEFAULT_RECORD_COUNT, managedNearCacheRecordStore.latestResultOnRemove);
         }
@@ -302,19 +302,13 @@ public abstract class NearCacheTestSupport extends CommonNearCacheTestSupport {
         }
 
         @Override
-        public boolean remove(Integer key) {
+        public void invalidate(Integer key) {
             if (expectedKeyValueMappings == null) {
                 throw new IllegalStateException("Near Cache is already destroyed");
             }
             boolean result = expectedKeyValueMappings.remove(key) != null;
             latestKeyOnRemove = key;
             latestResultOnRemove = result;
-            return result;
-        }
-
-        @Override
-        public boolean invalidate(Integer key) {
-            return remove(key);
         }
 
         @Override


### PR DESCRIPTION
Reasoning: More than one method can attempt to change a stats counter
concurrently. For example, for owned entry counter, it is possible that
near-cache clear() method sets it to 0, then near-cache remove() decrements it.
In the cases like this, we can see a negative value in stats. To prevent this,
we are making entry-removal and stats-update atomic.

+ Deleted `remove` method of `NearCache` interface, we have `invalidate` and it is sufficient.


closes https://github.com/hazelcast/hazelcast/issues/13848

ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/2488