### PR TITLE
Fix timing issue in ClientMapTest.testSet

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -416,11 +416,10 @@ public class ClientMapTest extends HazelcastTestSupport {
         assertEquals("value2", map.get("key1"));
 
         map.set("key1", "value3", 1, TimeUnit.SECONDS);
-        assertEquals("value3", map.get("key1"));
 
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertNull(map.get("key1"));
             }
         });


### PR DESCRIPTION
There's no guarantee that `map.get(key)` will return non-null value
when it's called immediately after `map.set(...)` with TTL.

```
map.set(key, "value3", 1, TimeUnit.SECONDS);
// --- key may expire between these lines ---
assertEquals("value3", map.get(key));
```

Fixes #13905