### PR TITLE
Registered partition-lost-listener when creating ExpirationManager

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionLostListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionLostListenerTest.java
@@ -76,8 +76,9 @@ public class ClientPartitionLostListenerTest {
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
         client.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
-        // Expected = 2 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        assertRegistrationsSizeEventually(instance, 2);
+        // Expected = 4 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // + 2 from map and cache ExpirationManagers
+        assertRegistrationsSizeEventually(instance, 4);
     }
 
     @Test
@@ -86,12 +87,14 @@ public class ClientPartitionLostListenerTest {
         final HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
         final String registrationId = client.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
-        // Expected = 2 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        assertRegistrationsSizeEventually(instance, 2);
+        // Expected = 4 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // + 2 from map and cache ExpirationManagers
+        assertRegistrationsSizeEventually(instance, 4);
 
         client.getPartitionService().removePartitionLostListener(registrationId);
-        // Expected = 1 -> see {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        assertRegistrationsSizeEventually(instance, 1);
+        // Expected = 3 -> see {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // + 2 from map and cache ExpirationManagers
+        assertRegistrationsSizeEventually(instance, 3);
     }
 
     @Test
@@ -103,8 +106,9 @@ public class ClientPartitionLostListenerTest {
         final EventCollectingPartitionLostListener listener = new EventCollectingPartitionLostListener();
 
         client.getPartitionService().addPartitionLostListener(listener);
-        // Expected = 2 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        assertRegistrationsSizeEventually(instance, 2);
+        // Expected = 4 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // + 2 from map and cache ExpirationManagers
+        assertRegistrationsSizeEventually(instance, 4);
 
         final InternalPartitionServiceImpl partitionService = getNode(instance).getNodeEngine().getService(SERVICE_NAME);
         final int partitionId = 5;
@@ -130,9 +134,9 @@ public class ClientPartitionLostListenerTest {
         final EventCollectingPartitionLostListener listener = new EventCollectingPartitionLostListener();
         client.getPartitionService().addPartitionLostListener(listener);
         // Expected = 2 -> 1 added & 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        // * instances
-        assertRegistrationsSizeEventually(instance1, 3);
-        assertRegistrationsSizeEventually(instance2, 3);
+        // + 2 from map and cache ExpirationManagers * instances
+        assertRegistrationsSizeEventually(instance1, 7);
+        assertRegistrationsSizeEventually(instance2, 7);
 
         final InternalPartitionServiceImpl partitionService = getNode(other).getNodeEngine().getService(SERVICE_NAME);
         final int partitionId = 5;

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -212,6 +212,7 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
     @Override
     public void shutdown(boolean terminate) {
         if (!terminate) {
+            expirationManager.onShutdown();
             cacheEventHandler.shutdown();
             reset(true);
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.eviction;
 import com.hazelcast.core.IBiFunction;
 import com.hazelcast.nio.Address;
 import com.hazelcast.partition.PartitionLostEvent;
-import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
@@ -45,7 +44,7 @@ import static java.lang.Math.min;
 
 @SuppressWarnings("checkstyle:magicnumber")
 @SuppressFBWarnings({"URF_UNREAD_FIELD"})
-public abstract class ClearExpiredRecordsTask<T, S> implements Runnable, PartitionLostListener {
+public abstract class ClearExpiredRecordsTask<T, S> implements Runnable {
 
     private static final int DIFFERENCE_BETWEEN_TWO_SUBSEQUENT_PARTITION_CLEANUP_MILLIS = 1000;
 
@@ -63,7 +62,6 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable, Partiti
     private final InternalOperationService operationService;
     private final AtomicBoolean singleRunPermit = new AtomicBoolean(false);
     private final AtomicInteger partitionLostCounter = new AtomicInteger();
-    private final AtomicBoolean partitionLostListenerRegistered = new AtomicBoolean(false);
 
     private volatile int lastSeenPartitionLostCount;
 
@@ -110,10 +108,6 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable, Partiti
         try {
             if (!singleRunPermit.compareAndSet(false, true)) {
                 return;
-            }
-
-            if (partitionLostListenerRegistered.compareAndSet(false, true)) {
-                partitionService.addPartitionLostListener(this);
             }
 
             runInternal();
@@ -186,7 +180,6 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable, Partiti
      * remove leftover backup entries. Otherwise leftover entries can remain on
      * backups forever.
      */
-    @Override
     public final void partitionLost(PartitionLostEvent event) {
         partitionLostCounter.incrementAndGet();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -446,6 +446,7 @@ class MapServiceContextImpl implements MapServiceContext {
         removeAllRecordStoresOfAllMaps(true, false);
         mapNearCacheManager.shutdown();
         mapContainers.clear();
+        expirationManager.onShutdown();
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/BasicClusterStateTest.java
@@ -359,10 +359,10 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
 
         changeClusterStateEventually(master, ClusterState.PASSIVE);
         master.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
-        // Expected = 2 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        // * instances
-        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 3);
-        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 3);
+        // Expected = 7 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // + 2 from map and cache ExpirationManagers * instances
+        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 7);
+        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 7);
     }
 
     @Test
@@ -372,16 +372,17 @@ public class BasicClusterStateTest extends HazelcastTestSupport {
         final HazelcastInstance other = factory.newHazelcastInstance();
 
         final String registrationId = master.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
-        // Expected = 3 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        // * instances
-        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 3);
-        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 3);
+        // Expected = 7 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // + 2 from map and cache ExpirationManagers * instances
+        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 7);
+        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 7);
 
         changeClusterStateEventually(master, ClusterState.PASSIVE);
         master.getPartitionService().removePartitionLostListener(registrationId);
-        // Expected = 2 -> see {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService} * instances
-        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 2);
-        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 2);
+        // Expected = 6 -> see {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // + 2 from map and cache ExpirationManagers* instances
+        assertRegistrationsSizeEventually(other, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 6);
+        assertRegistrationsSizeEventually(master, InternalPartitionService.SERVICE_NAME, PARTITION_LOST_EVENT_TOPIC, 6);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerRegistrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/PartitionLostListenerRegistrationTest.java
@@ -61,8 +61,9 @@ public class PartitionLostListenerRegistrationTest extends HazelcastTestSupport 
         final String id = instance.getPartitionService().addPartitionLostListener(mock(PartitionLostListener.class));
         assertNotNull(id);
 
-        // Expected = 2 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        assertRegistrationsSizeEventually(instance, 2);
+        // Expected = 4 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // + 2 from map and cache ExpirationManagers
+        assertRegistrationsSizeEventually(instance, 4);
     }
 
     @Test
@@ -71,8 +72,9 @@ public class PartitionLostListenerRegistrationTest extends HazelcastTestSupport 
         config.addListenerConfig(new ListenerConfig(mock(PartitionLostListener.class)));
 
         HazelcastInstance instance = createHazelcastInstance(config);
-        // Expected = 2 -> 1 from config + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        assertRegistrationsSizeEventually(instance, 2);
+        // Expected = 4 -> 1 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // + 2 from map and cache ExpirationManagers
+        assertRegistrationsSizeEventually(instance, 4);
     }
 
     @Test
@@ -86,12 +88,13 @@ public class PartitionLostListenerRegistrationTest extends HazelcastTestSupport 
         String id2 = partitionService.addPartitionLostListener(listener);
 
         assertNotEquals(id1, id2);
-        // Expected = 3 -> 2 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        assertRegistrationsSizeEventually(instance, 3);
+        // Expected = 5 -> 2 added + 1 from {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
+        // + 2 from map and cache ExpirationManagers
+        assertRegistrationsSizeEventually(instance, 5);
     }
 
     @Test
-    public void test_removeMigrationListener_whenRegisteredListenerRemovedSuccessfully() {
+    public void test_removePartitionLostListener_whenRegisteredListenerRemovedSuccessfully() {
         HazelcastInstance instance = createHazelcastInstance();
         PartitionService partitionService = instance.getPartitionService();
 
@@ -102,11 +105,12 @@ public class PartitionLostListenerRegistrationTest extends HazelcastTestSupport 
 
         assertTrue(result);
         // Expected = 1 -> see {@link com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService}
-        assertRegistrationsSizeEventually(instance, 1);
+        // + 2 from map and cache ExpirationManagers
+        assertRegistrationsSizeEventually(instance, 3);
     }
 
     @Test
-    public void test_removeMigrationListener_whenNonExistingRegistrationIdRemoved() {
+    public void test_removePartitionLostListener_whenNonExistingRegistrationIdRemoved() {
         HazelcastInstance instance = createHazelcastInstance();
         PartitionService partitionService = instance.getPartitionService();
 
@@ -115,7 +119,7 @@ public class PartitionLostListenerRegistrationTest extends HazelcastTestSupport 
     }
 
     @Test(expected = NullPointerException.class)
-    public void test_removeMigrationListener_whenNullRegistrationIdRemoved() {
+    public void test_removePartitionLostListener_whenNullRegistrationIdRemoved() {
         HazelcastInstance instance = createHazelcastInstance();
         PartitionService partitionService = instance.getPartitionService();
 


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/13520

Reasoning: Registering lost-listener inside run method of cleaning-task is too late. Because there may be a partition-lost between the period of `ExpirationManager` creation and cleaning-tasks' first run.