### PR TITLE
Changes required to remove backup expired entries on native backed cache/map

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -81,6 +81,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 
 import static com.hazelcast.cache.impl.CacheEventContextUtil.createBaseEventContext;
@@ -365,9 +366,15 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     public void sampleAndHardRemoveEntries(int entryCountToRemove) {
         assertRunningOnPartitionThread();
 
+        Queue<Data> keysToRemove = new LinkedList<Data>();
         Iterable<EvictionCandidate<Data, R>> entries = records.sample(entryCountToRemove);
         for (EvictionCandidate<Data, R> entry : entries) {
-            removeRecord(entry.getAccessor());
+            keysToRemove.add(entry.getAccessor());
+        }
+
+        Data dataKey;
+        while ((dataKey = keysToRemove.poll()) != null) {
+            removeRecord(dataKey);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheRecordStore.java
@@ -162,4 +162,9 @@ public class CacheRecordStore
             return serializationService.toData(obj);
         }
     }
+
+    @Override
+    public void disposeDeferredBlocks() {
+        // NOP
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -553,4 +553,6 @@ public interface ICacheRecordStore {
     void evictExpiredEntries(int percentage);
 
     InvalidationQueue<ExpiredKey> getExpiredKeysQueue();
+
+    void disposeDeferredBlocks();
 }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheExpireBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheExpireBatchBackupOperation.java
@@ -67,9 +67,20 @@ public class CacheExpireBatchBackupOperation extends CacheOperation {
         if (diff > 0) {
             recordStore.sampleAndHardRemoveEntries(diff);
 
-            assert recordStore.size() == primaryEntryCount : String.format("Failed to remove %d entries while attempting "
-                    + "to match primary entry count %d, recordStore size is now %d",
+            assert recordStore.size() == primaryEntryCount : String.format("Failed"
+                            + " to remove %d entries while attempting to match"
+                            + " primary entry count %d,"
+                            + " recordStore size is now %d",
                     diff, primaryEntryCount, recordStore.size());
+        }
+    }
+
+    @Override
+    public void afterRun() throws Exception {
+        try {
+            super.afterRun();
+        } finally {
+            recordStore.disposeDeferredBlocks();
         }
     }
 
@@ -86,9 +97,6 @@ public class CacheExpireBatchBackupOperation extends CacheOperation {
     }
 
     protected void evictIfSame(ExpiredKey key) {
-        if (recordStore == null) {
-            return;
-        }
         CacheRecord record = recordStore.getRecord(key.getKey());
         if (record != null && record.getCreationTime() == key.getCreationTime()) {
             recordStore.removeRecord(key.getKey());

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/MapExpirationStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/MapExpirationStressTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.eviction;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.NightlyTest;
+import com.hazelcast.test.backup.BackupAccessor;
+import com.hazelcast.test.backup.TestBackupUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.map.impl.eviction.MapClearExpiredRecordsTask.PROP_TASK_PERIOD_SECONDS;
+import static com.hazelcast.test.OverridePropertyRule.set;
+import static com.hazelcast.test.backup.TestBackupUtils.assertBackupSizeEventually;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(NightlyTest.class)
+public class MapExpirationStressTest extends HazelcastTestSupport {
+
+    @Rule
+    public final OverridePropertyRule overrideTaskSecondsRule = set(PROP_TASK_PERIOD_SECONDS, "2");
+
+    protected final String mapName = "test";
+
+    private static final int CLUSTER_SIZE = 5;
+    private static final int KEY_RANGE = 100000;
+
+    private HazelcastInstance[] instances = new HazelcastInstance[CLUSTER_SIZE];
+    private TestHazelcastInstanceFactory factory;
+
+    private Random random = new Random();
+    private final AtomicBoolean done = new AtomicBoolean();
+    private final int DURATION_SECONDS = 20;
+
+    @Before
+    public void setup() {
+        Config config = getConfig();
+        config.addMapConfig(getMapConfig());
+        factory = createHazelcastInstanceFactory(CLUSTER_SIZE);
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            instances[i] = factory.newHazelcastInstance(config);
+        }
+    }
+
+    protected MapConfig getMapConfig() {
+        MapConfig mapConfig = new MapConfig();
+        mapConfig.setName(mapName);
+        mapConfig.setMaxIdleSeconds(2);
+        mapConfig.setBackupCount(CLUSTER_SIZE - 1);
+        return mapConfig;
+    }
+
+    @Test
+    public void test() throws InterruptedException {
+        List<Thread> list = new ArrayList<Thread>();
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            list.add(new Thread(new TestRunner(instances[i].getMap(mapName), done)));
+        }
+
+        for (Thread thread : list) {
+            thread.start();
+        }
+
+        sleepAtLeastSeconds(DURATION_SECONDS);
+
+        done.set(true);
+        for (Thread thread : list) {
+            thread.join();
+        }
+
+        assertRecords(instances);
+    }
+
+    protected void assertRecords(final HazelcastInstance[] instances) {
+        for (int i = 1; i < instances.length; i++) {
+            BackupAccessor backupAccessor = TestBackupUtils.newCacheAccessor(instances, mapName, i);
+            assertBackupSizeEventually(0, backupAccessor);
+        }
+        for (int i = 0; i < instances.length; i++) {
+            final int index = i;
+            assertEqualsEventually(new Callable<Integer>() {
+                @Override
+                public Integer call() {
+                    return instances[index].getMap(mapName).size();
+                }
+            }, 0);
+        }
+        instances[0].getMap(mapName).destroy();
+    }
+
+    protected void doOp(IMap map) {
+        int op = random.nextInt(3);
+        int key = random.nextInt(KEY_RANGE);
+        int val = random.nextInt(KEY_RANGE);
+        switch (op) {
+            case 0:
+                map.put(key, val);
+                break;
+            case 1:
+                map.remove(key);
+                break;
+            case 2:
+                map.get(key);
+                break;
+            default:
+                map.get(key);
+                break;
+        }
+    }
+
+    class TestRunner implements Runnable {
+        private IMap map;
+        private AtomicBoolean done;
+
+        TestRunner(IMap map, AtomicBoolean done) {
+            this.map = map;
+            this.done = done;
+        }
+
+        @Override
+        public void run() {
+            while (!done.get()) {
+                doOp(map);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Removed keys after collection in cache and map backup cleaner operations.
  Because removals during iteration can cause missed entries on hd maps.
- Added expiration stress test for imap
- Added disposeDeferredBlocks method for icache record store

ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/2494

outcome of the investigations for the issue: https://github.com/hazelcast/hazelcast-enterprise/issues/2479