### PR TITLE
Fixes LazySamplingEntryIterableIterator

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
@@ -206,7 +206,7 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
         private final int firstSegmentIndex;
         private int currentSegmentIndex;
         private int currentBucketIndex;
-        private HashEntry<K, V> currentEntry;
+        private HashEntry<K, V> mostRecentlyReturnedEntry;
         private int returnedEntryCount;
         private boolean reachedToEnd;
         private E currentSample;
@@ -247,28 +247,26 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
                     }
                     do {
                         // If current entry is not initialized yet, initialize it
-                        if (currentEntry == null) {
-                            currentEntry = table[currentBucketIndex];
+                        if (mostRecentlyReturnedEntry == null) {
+                            mostRecentlyReturnedEntry = table[currentBucketIndex];
+                        } else {
+                            mostRecentlyReturnedEntry = mostRecentlyReturnedEntry.next;
                         }
-                        while (currentEntry != null) {
-                            V value = currentEntry.value();
-                            K key = currentEntry.key();
-                            // Advance to next entry
-                            currentEntry = currentEntry.next;
+
+                        while (mostRecentlyReturnedEntry != null) {
+                            V value = mostRecentlyReturnedEntry.value();
+                            K key = mostRecentlyReturnedEntry.key();
+
                             if (isValidForSampling(value)) {
                                 currentSample = createSamplingEntry(key, value);
                                 // If we reached end of entries, advance current bucket index
-                                if (currentEntry == null) {
-                                    currentBucketIndex = ++currentBucketIndex < table.length ? currentBucketIndex : 0;
-                                }
                                 returnedEntryCount++;
                                 return;
                             }
+                            mostRecentlyReturnedEntry = mostRecentlyReturnedEntry.next;
                         }
                         // Advance current bucket index
                         currentBucketIndex = ++currentBucketIndex < table.length ? currentBucketIndex : 0;
-                        // Clear current entry index to initialize at next bucket
-                        currentEntry = null;
                     } while (currentBucketIndex != firstBucketIndex);
                 }
                 // Advance current segment index
@@ -276,7 +274,7 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
                 // Clear current bucket index to initialize at next segment
                 currentBucketIndex = -1;
                 // Clear current entry index to initialize at next segment
-                currentEntry = null;
+                mostRecentlyReturnedEntry = null;
             } while (currentSegmentIndex != firstSegmentIndex);
 
             reachedToEnd = true;


### PR DESCRIPTION
This iterator starts iterating from a random segment and a random bucket in that segment. When the only item is located in the starting point, the iterator fails to progress after returning the first element. It keeps resetting `currentEntry` to the first and only element in the bucket at each iteration. That is because `currentEntry` has 3 different meanings depending on the state of the iteration:
1. We havent checked any item in the current bucket (currentEntry is null)
2. We exhausted all the items in the current bucket (currentEntry is null)
3. There is something to return from this bucket ( currentEntry is not null)

We cannot determine if we are at state 1 or 2. The code assumes that we are at state 1 when in doubt.

Now, currentEntry always points to the latest returned entry in the current bucket, so it can mean only 2 things
1. We havent checked any item in the current bucket ( currentEntry is null )
2. We returned an item from this bucket ( currentEntry is not null)

fixes https://github.com/hazelcast/hazelcast/issues/13927

The issue is reliable reproducable when you set `LazySamplingEntryIterableIterator#randomNumber` to 11.