### PR TITLE
[POC][DONT MERGE] add client disconnect to rest

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -238,6 +238,9 @@
     <suppress checks="IllegalType"
               files="com[\\/]hazelcast[\\/]internal[\\/]serialization[\\/]impl[\\/]LinkedListStreamSerializer"/>
 
+    <!-- Rest -->
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]internal[\\/]ascii[\\/]rest[\\/]HttpPostCommandProcessor"/>
+
     <!-- Spring -->
     <suppress checks="FileLength" files="com[\\/]hazelcast[\\/]spring[\\/]HazelcastConfigBeanDefinitionParser"/>
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -428,6 +428,29 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
         return partitionListenerService;
     }
 
+    public boolean disconnect(String clientUuid) {
+
+
+        Collection<Member> memberList = nodeEngine.getClusterService().getMembers();
+        OperationService operationService = nodeEngine.getOperationService();
+
+        String ownerMember = ownershipMappings.get(clientUuid);
+        if (ownerMember == null) {
+            logger.info("Client is not found to disconnect. client uuid " + clientUuid);
+            //there is no such client
+            return false;
+        }
+
+        logger.info("Disconnecting client manually. client uuid :" + clientUuid);
+
+        for (Member member : memberList) {
+            ClientDisconnectionOperation op = new ClientDisconnectionOperation(clientUuid, ownerMember);
+            operationService.createInvocationBuilder(SERVICE_NAME, op, member.getAddress()).invoke();
+        }
+
+        return true;
+    }
+
     private final class ConnectionListenerImpl implements ConnectionListener {
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -37,6 +37,7 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
     public static final String URI_SHUTDOWN_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/clusterShutdown";
     public static final String URI_SHUTDOWN_NODE_CLUSTER_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/memberShutdown";
     public static final String URI_CLUSTER_NODES_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/nodes";
+    public static final String URI_CLIENT_KICKOFF_URL = URI_CLUSTER_MANAGEMENT_BASE_URL + "/disconnectClient";
 
     // Hot restart
     public static final String URI_FORCESTART_CLUSTER_URL =  URI_CLUSTER_MANAGEMENT_BASE_URL + "/forceStart";

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -33,6 +33,7 @@ import com.hazelcast.security.SecurityService;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.StringUtil;
 import com.hazelcast.version.Version;
 import com.hazelcast.wan.WanReplicationService;
@@ -114,6 +115,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                 command.setResponse(HttpCommand.RES_400);
             }
         } catch (Exception e) {
+            EmptyStatement.ignore(e);
             command.setResponse(HttpCommand.RES_500);
         }
         textCommandService.sendResponse(command);
@@ -140,7 +142,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                 }
             }
         } catch (Throwable throwable) {
-            logger.warning("Error occurred while changing cluster state", throwable);
+            logger.warning("Error occurred while disconnecting client", throwable);
             res = exceptionResponse(throwable);
         }
         command.setResponse(HttpCommand.CONTENT_TYPE_JSON, stringToBytes(res));


### PR DESCRIPTION
This call disconnects client from cluster.
Any lock/semaphore/transaction related to client is released immediately.

Sample call:
curl --data "dev&dev-pass&7a987754-c432-418a-9f97-b940145bd484" http://127.0.0.1:5701/hazelcast/rest/management/cluster/disconnectClient

Fail response when client is not found with given uuid
{"status":"fail"}⏎                                                                                                                                                                                                                        sancar@sancar ~/p/hazelcast-enterprise> curl --data "dev&dev-pass&6e7a8b4b-32b4-4482-b741-fbc2cdc41372" http://127.0.0.1:5701/hazelcast/rest/management/cluster/disconnectClient

Success respinse
{"status":"success"}