### PR TITLE
Add hazelcast-kubernetes to hazelcast-all

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -105,6 +105,7 @@
                                             org.apache.commons.logging;resolution:=optional,
                                             javax.script.*;resolution:=optional,
                                             org.jclouds.*;resolution:=optional,
+                                            javax.naming.*;resolution:=optional
                                         </Import-Package>
                                     </overrideInstructions>
                                 </transformer>

--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -167,6 +167,11 @@
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-kubernetes</artifactId>
+            <version>1.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-spring</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
Follow up of: https://github.com/hazelcast/hazelcast/pull/13686
The blocker (hazelcast/hazelcast-kubernetes#97) has been resolved, so I think we're ready to put `hazelcast-kubernetes` into `hazelcast-all`.