### PR TITLE
Allow for overrideable hard-remove behavior in cache record store

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheRecordStore.java
@@ -363,7 +363,7 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
     }
 
     @Override
-    public void sampleAndHardRemoveEntries(int entryCountToRemove) {
+    public void sampleAndForceRemoveEntries(int entryCountToRemove) {
         assertRunningOnPartitionThread();
 
         Queue<Data> keysToRemove = new LinkedList<Data>();
@@ -374,13 +374,13 @@ public abstract class AbstractCacheRecordStore<R extends CacheRecord, CRM extend
 
         Data dataKey;
         while ((dataKey = keysToRemove.poll()) != null) {
-            removeRecord(dataKey);
-            addToDeferredDisposeQueue(dataKey);
+            forceRemoveRecord(dataKey);
         }
     }
 
-    protected void addToDeferredDisposeQueue(Object object) {
-        // NOP intentionally
+    protected void forceRemoveRecord(Data key) {
+        // overridden in other context
+        removeRecord(key);
     }
 
     protected Data toData(Object obj) {

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/ICacheRecordStore.java
@@ -498,7 +498,7 @@ public interface ICacheRecordStore {
      */
     boolean evictIfRequired();
 
-    void sampleAndHardRemoveEntries(int count);
+    void sampleAndForceRemoveEntries(int count);
 
     /**
      * Determines whether wan replication is enabled or not for this record store.

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheExpireBatchBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheExpireBatchBackupOperation.java
@@ -65,7 +65,7 @@ public class CacheExpireBatchBackupOperation extends CacheOperation {
     private void equalizeEntryCountWithPrimary() {
         int diff = recordStore.size() - primaryEntryCount;
         if (diff > 0) {
-            recordStore.sampleAndHardRemoveEntries(diff);
+            recordStore.sampleAndForceRemoveEntries(diff);
 
             assert recordStore.size() == primaryEntryCount : String.format("Failed"
                             + " to remove %d entries while attempting to match"


### PR DESCRIPTION
Preparation for fix for native memory stats when force-removing entries
to make backup partition entry count equal to primary