### PR TITLE
Sent queued expired keys on commit migration step

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/AbstractCacheService.java
@@ -288,6 +288,8 @@ public abstract class AbstractCacheService implements ICacheService, PreJoinAwar
 
     @Override
     public void commitMigration(PartitionMigrationEvent event) {
+        expirationManager.onCommitMigration(event);
+
         if (event.getMigrationEndpoint() == MigrationEndpoint.SOURCE) {
             clearCachesHavingLesserBackupCountThan(event.getPartitionId(), event.getNewReplicaIndex());
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/eviction/CacheClearExpiredRecordsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/eviction/CacheClearExpiredRecordsTask.java
@@ -108,21 +108,17 @@ public class CacheClearExpiredRecordsTask
     }
 
     @Override
-    public void sendResponse(Operation op, Object response) {
-        CachePartitionSegment container = containers[op.getPartitionId()];
-        Iterator<ICacheRecordStore> iterator = container.recordStoreIterator();
-        while (iterator.hasNext()) {
-            tryToSendBackupExpiryOp(iterator.next(), false);
-        }
-    }
-
-    @Override
     public void tryToSendBackupExpiryOp(ICacheRecordStore store, boolean checkIfReachedBatch) {
         InvalidationQueue<ExpiredKey> expiredKeys = store.getExpiredKeysQueue();
         int totalBackupCount = store.getConfig().getTotalBackupCount();
         int partitionId = store.getPartitionId();
 
         toBackupSender.trySendExpiryOp(store, expiredKeys, totalBackupCount, partitionId, checkIfReachedBatch);
+    }
+
+    @Override
+    public Iterator<ICacheRecordStore> storeIterator(CachePartitionSegment container) {
+        return container.recordStoreIterator();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -29,7 +29,6 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.ServiceNamespace;
-import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -67,7 +66,7 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
     }
 
     public final void prepare(CachePartitionSegment segment, Collection<ServiceNamespace> namespaces,
-            int replicaIndex) {
+                              int replicaIndex) {
 
         for (ServiceNamespace namespace : namespaces) {
             ObjectNamespace ns = (ObjectNamespace) namespace;
@@ -144,7 +143,6 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
         }
         int count = data.size();
         out.writeInt(count);
-        long now = Clock.currentTimeMillis();
         for (Map.Entry<String, Map<Data, CacheRecord>> entry : data.entrySet()) {
             Map<Data, CacheRecord> cacheMap = entry.getValue();
             int subCount = cacheMap.size();
@@ -154,9 +152,6 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
                 final Data key = e.getKey();
                 final CacheRecord record = e.getValue();
 
-                if (record.isExpiredAt(now)) {
-                    continue;
-                }
                 out.writeData(key);
                 out.writeObject(record);
             }

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/CacheExpirationBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/CacheExpirationBouncingMemberTest.java
@@ -52,6 +52,8 @@ import static junit.framework.TestCase.assertTrue;
 @Category(SlowTest.class)
 public class CacheExpirationBouncingMemberTest extends HazelcastTestSupport {
 
+    private static final long FIVE_MINUNTES = 5 * 60 * 1000;
+
     private String cacheName = "test";
     private int backupCount = 3;
     private int keySpace = 1000;
@@ -71,7 +73,7 @@ public class CacheExpirationBouncingMemberTest extends HazelcastTestSupport {
         return cacheConfig;
     }
 
-    @Test
+    @Test(timeout = FIVE_MINUNTES)
     public void backups_should_be_empty_after_expiration() {
         Runnable[] methods = new Runnable[2];
         HazelcastInstance testDriver = bounceMemberRule.getNextTestDriver();


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/13520

__Issues:__
1. On primary replica, expired keys are kept in a queue in order to send backups. If 
   primary replica migrates to a new owner, these queued keys were staying on   
   previous primary replica owner node and were not sent to backup replicas. 
2. When migrating primary, `CacheReplicationOperation` was checking for expired keys 
   and was not transferring them to new primary replica owner node. But during this 
   expiry check, it was not adding those expired keys to expired-key-queues so as a 
   result of this, backup replicas were staying unaware of these keys.

__Fixes:__
For issue#1: Sent already queued expired keys on commit migration step to backup replicas.
For issue#2: Removed expiration check from `CacheReplicationOperation` (aligned 
             behavior with `MapReplicationOperation` that it doesn't check if keys 
             are expired)

This is the main fixer line: https://github.com/hazelcast/hazelcast/compare/master...ahmetmircik:fix/3.11/CacheExpirationBouncingMemberTest3?expand=1#diff-b601ae5b93a58646c38d7fc36bfe3e04R142

Other changes are tiny refactorings.