### PR TITLE
Fix TcpIpConnectionManager_MemoryLeakTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_MemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnectionManager_MemoryLeakTest.java
@@ -54,6 +54,8 @@ public class TcpIpConnectionManager_MemoryLeakTest extends HazelcastTestSupport 
         HazelcastInstance hz2 = Hazelcast.newHazelcastInstance();
         hz2.shutdown();
 
+        assertClusterSizeEventually(1, hz1);
+
         assertTrueAllTheTime(new AssertTask() {
             @Override
             public void run() throws Exception {


### PR DESCRIPTION
Wait for member to observe membership change before assertion.

Fixes: https://github.com/hazelcast/hazelcast/issues/13958