### PR TITLE
Add XSDs for 3.12 development cycle

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.12.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.12.xsd
@@ -1,0 +1,844 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.hazelcast.com/schema/client-config"
+           targetNamespace="http://www.hazelcast.com/schema/client-config"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:element name="hazelcast-client">
+        <xs:complexType>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:element ref="import" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="config-replacers" type="config-replacers" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="group" type="cluster-group" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="license-key" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="network" type="network" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="executor-pool-size" type="executor-pool-size" minOccurs="0" maxOccurs="1"
+                            default="100"/>
+                <xs:element name="security" type="security" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="listeners" type="listeners" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="serialization" type="serialization" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="native-memory" type="native-memory" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="proxy-factories" type="proxy-factories" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="load-balancer" type="load-balancer" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="near-cache" type="near-cache-client" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="query-caches" type="query-caches" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="connection-strategy" type="connection-strategy" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="instance-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="user-code-deployment" type="user-code-deployment" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="flake-id-generator" type="flake-id-generator" minOccurs="0"
+                            maxOccurs="unbounded"/>
+                <xs:element name="reliable-topic" type="reliable-topic" minOccurs="0"
+                            maxOccurs="unbounded"/>
+            </xs:choice>
+            <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="import">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:restriction base="xs:anyType">
+                    <xs:attribute name="resource" type="xs:string" use="required"/>
+                </xs:restriction>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:complexType name="config-replacers">
+        <xs:sequence>
+            <xs:element name="replacer" type="replacer" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="fail-if-value-missing" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Controls if missing replacement value should lead to stop the boot process.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:boolean"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="replacer">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="class-name" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="aliased-discovery-strategy">
+        <xs:sequence>
+            <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether the the discovery stategy is enabled or not. Value can be true or false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connection-timeout-seconds" type="xs:int" use="optional" default="5">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum amount of time Hazelcast is going to try to connect to a well known member
+                    before giving up. Please check if the specific discovery strategy supports this property.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <!--NETWORK-->
+    <xs:complexType name="network">
+        <xs:all>
+            <xs:element ref="cluster-members" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="smart-routing" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="redo-operation" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="connection-timeout" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="connection-attempt-period" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="connection-attempt-limit" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="socket-options" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="ssl" type="ssl" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="aws" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1" />
+            <xs:element name="gcp" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1" />
+            <xs:element name="azure" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1" />
+            <xs:element name="kubernetes" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1" />
+            <xs:element name="eureka" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1" />
+            <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="outbound-ports" type="outbound-ports" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="icmp-ping" type="icmp-ping" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="hazelcast-cloud" type="hazelcast-cloud" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="discovery-strategies">
+        <xs:sequence>
+            <xs:element name="node-filter" type="discovery-node-filter" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategy" type="discovery-strategy" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="icmp-ping">
+        <xs:all>
+            <xs:element name="timeout-milliseconds" type="xs:long" minOccurs="0" maxOccurs="1" default="1000"/>
+            <xs:element name="interval-milliseconds" type="xs:long" minOccurs="0" maxOccurs="1" default="1000"/>
+            <xs:element name="ttl" type="xs:int" minOccurs="0" maxOccurs="1" default="255"/>
+            <xs:element name="max-attempts" type="xs:int" minOccurs="0" maxOccurs="1" default="2"/>
+            <xs:element name="echo-fail-fast-on-startup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="hazelcast-cloud">
+        <xs:all>
+            <xs:element name="discovery-token" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="discovery-node-filter">
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="discovery-strategy">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:element name="cluster-members">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="address" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="smart-routing" default="false">
+        <xs:annotation>
+            <xs:documentation>
+                If true, client will route the key based operations to owner of the key at
+                the best effort.
+                Note that it uses a cached version of
+                com.hazelcast.core.PartitionService#getPartitions() and doesn't
+                guarantee that the operation will always be executed on the
+                owner. The cached table is updated every
+                second.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+            <xs:restriction base="xs:boolean"/>
+        </xs:simpleType>
+    </xs:element>
+    <xs:element name="redo-operation" default="false">
+        <xs:annotation>
+            <xs:documentation>
+                If true, client will redo the operations that were executing on the server
+                and client lost
+                the connection. This can be because of network, or simply
+                because the member died.
+                However it is not
+                clear
+                whether the application is performed or not. For
+                idempotent operations this is harmless, but for
+                non
+                idempotent ones retrying
+                can cause to undesirable effects. Note that the redo can perform on any
+                member.
+                If false, the operation will throw a RuntimeException that is wrapping a
+                java.io.IOException.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+            <xs:restriction base="xs:boolean"/>
+        </xs:simpleType>
+    </xs:element>
+    <xs:element name="connection-timeout" default="60000">
+        <xs:simpleType>
+            <xs:restriction base="xs:int">
+                <xs:minInclusive value="1"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:element>
+    <xs:element name="connection-attempt-period" default="3000">
+        <xs:simpleType>
+            <xs:restriction base="xs:int">
+                <xs:minInclusive value="1"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:element>
+    <xs:element name="connection-attempt-limit" default="2">
+        <xs:simpleType>
+            <xs:restriction base="xs:int">
+                <xs:minInclusive value="0"/>
+            </xs:restriction>
+        </xs:simpleType>
+    </xs:element>
+    <xs:element name="socket-options">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="tcp-no-delay" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
+                <xs:element name="keep-alive" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
+                <xs:element name="reuse-address" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
+                <xs:element name="linger-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="3"/>
+                <xs:element name="timeout" type="xs:int" minOccurs="0" maxOccurs="1" default="-1"/>
+                <xs:element name="buffer-size" minOccurs="0" maxOccurs="1" default="128">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:unsignedInt">
+                            <xs:minInclusive value="1"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:element>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+    <!--NETWORK END-->
+    <xs:simpleType name="executor-pool-size">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="proxy-factories">
+        <xs:sequence>
+            <xs:element name="proxy-factory" type="proxy-factory" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="proxy-factory">
+        <xs:attribute name="service">
+            <xs:simpleType>
+                <xs:restriction base="non-space-string"/>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="class-name">
+            <xs:simpleType>
+                <xs:restriction base="non-space-string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="load-balancer">
+        <xs:attribute name="type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="random"/>
+                    <xs:enumeration value="round-robin"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="near-cache-client">
+        <xs:complexContent>
+            <xs:extension base="near-cache">
+                <xs:attribute name="name" use="required">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <!--query-caches start-->
+    <xs:complexType name="query-caches">
+        <xs:sequence>
+            <xs:element name="query-cache" type="query-cache" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="query-cache">
+        <xs:all>
+            <xs:element name="include-value" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
+            <xs:element name="predicate" type="predicate" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="entry-listeners" type="entry-listeners" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY"/>
+            <xs:element name="populate" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
+            <xs:element name="coalesce" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="delay-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
+            <xs:element name="batch-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="1"/>
+            <xs:element name="buffer-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="16"/>
+            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="indexes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="index" type="index" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="mapName" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="predicate">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="type" use="required">
+                    <xs:simpleType>
+                        <xs:restriction base="non-space-string">
+                            <xs:enumeration value="class-name"/>
+                            <xs:enumeration value="sql"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="index">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="ordered" type="xs:boolean" use="optional" default="false"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="item-listener">
+        <xs:simpleContent>
+            <xs:extension base="listener-base">
+                <xs:attribute name="include-value" type="xs:boolean" use="optional" default="true"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="entry-listeners">
+        <xs:sequence>
+            <xs:element name="entry-listener" type="entry-listener" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="entry-listener">
+        <xs:simpleContent>
+            <xs:extension base="item-listener">
+                <xs:attribute name="local" type="xs:boolean" use="optional" default="false"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <!--query-caches end-->
+
+    <xs:complexType name="connection-strategy">
+        <xs:all>
+            <xs:element name="connection-retry" type="connection-retry" minOccurs="0"
+                        maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="async-start" type="xs:boolean" default="false" use="optional"/>
+        <xs:attribute name="reconnect-mode" type="reconnect-mode" default="ON" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="connection-retry">
+        <xs:all>
+            <xs:element name="initial-backoff-millis" type="xs:int" minOccurs="0" maxOccurs="1" default="1000"/>
+            <xs:element name="max-backoff-millis" type="xs:int" minOccurs="0" maxOccurs="1" default="30000"/>
+            <xs:element name="multiplier" type="xs:double" minOccurs="0" maxOccurs="1" default="2"/>
+            <xs:element name="fail-on-max-backoff" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="jitter" type="xs:double" minOccurs="0" maxOccurs="1" default="0.2"/>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="false" use="optional"/>
+    </xs:complexType>
+
+    <xs:simpleType name="reconnect-mode">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="OFF"/>
+            <xs:enumeration value="ON"/>
+            <xs:enumeration value="ASYNC"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="cluster-group">
+        <xs:all>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" default="dev"/>
+            <xs:element name="password" type="xs:string" minOccurs="0" maxOccurs="1" default="dev-pass"/>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="listeners">
+        <xs:sequence>
+            <xs:element name="listener" type="listener-base" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="listener-base">
+        <xs:annotation>
+            <xs:documentation>One of membership-listener, instance-listener or migration-listener
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="non-space-string"/>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="security">
+        <xs:sequence>
+            <xs:element name="credentials" type="credentials" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="credentials-factory" type="security-object" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="credentials">
+        <xs:annotation>
+            <xs:documentation>Credentials className
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="non-space-string"/>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="security-object">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="class-name" type="non-space-string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="near-cache">
+        <xs:all>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY"/>
+            <xs:element name="serialize-keys" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="invalidate-on-change" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
+            <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
+            <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0"/>
+            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Deprecated since 3.8, please use &lt;eviction/&gt;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="eviction-policy" type="eviction-policy" minOccurs="0" maxOccurs="1" default="LRU">
+                <xs:annotation>
+                    <xs:documentation>
+                        Deprecated since 3.8, please use &lt;eviction/&gt;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cache-local-entries" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        Deprecated since 3.8, has no effect on a client since there is no local part of the distributed
+                        data
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="local-update-policy" type="xs:string" default="INVALIDATE" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="preloader" type="preloader" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:simpleType name="eviction-policy">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="LRU"/>
+            <xs:enumeration value="LFU"/>
+            <xs:enumeration value="RANDOM"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="max-size-policy">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ENTRY_COUNT"/>
+            <xs:enumeration value="USED_NATIVE_MEMORY_SIZE"/>
+            <xs:enumeration value="USED_NATIVE_MEMORY_PERCENTAGE"/>
+            <xs:enumeration value="FREE_NATIVE_MEMORY_SIZE"/>
+            <xs:enumeration value="FREE_NATIVE_MEMORY_PERCENTAGE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="eviction">
+        <xs:attribute name="size" type="xs:nonNegativeInteger" default="10000" use="optional"/>
+        <xs:attribute name="max-size-policy" type="max-size-policy" default="ENTRY_COUNT" use="optional"/>
+        <xs:attribute name="eviction-policy" type="eviction-policy" default="LRU" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="preloader">
+        <xs:attribute name="enabled" type="xs:boolean" default="false" use="optional"/>
+        <xs:attribute name="directory" type="xs:string" use="optional"/>
+        <xs:attribute name="store-initial-delay-seconds" type="xs:positiveInteger" default="600" use="optional"/>
+        <xs:attribute name="store-interval-seconds" type="xs:positiveInteger" default="600" use="optional"/>
+    </xs:complexType>
+
+    <xs:simpleType name="in-memory-format">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="BINARY"/>
+            <xs:enumeration value="OBJECT"/>
+            <xs:enumeration value="NATIVE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="non-space-string">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\S.*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="serialization">
+        <xs:all>
+            <xs:element name="portable-version" type="xs:unsignedInt" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="use-native-byte-order" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="byte-order" minOccurs="0" maxOccurs="1" default="BIG_ENDIAN">
+                <xs:simpleType>
+                    <xs:restriction base="non-space-string">
+                        <xs:enumeration value="BIG_ENDIAN"/>
+                        <xs:enumeration value="LITTLE_ENDIAN"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="enable-compression" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="enable-shared-object" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="allow-unsafe" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="data-serializable-factories" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="data-serializable-factory" type="serialization-factory" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="portable-factories" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="portable-factory" type="serialization-factory" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="serializers" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:choice minOccurs="1" maxOccurs="unbounded">
+                        <xs:element name="global-serializer" type="global-serializer" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Global serializer class to be registered if no other serializer is applicable.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="serializer" type="serializer" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="check-class-def-errors" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
+            <xs:element name="java-serialization-filter" type="java-serialization-filter" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Basic protection against untrusted deserialization based on class/package blacklisting and
+                        whitelisting.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="serialization-factory">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="factory-id" use="required" type="xs:unsignedInt"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="serializer">
+        <xs:attribute name="class-name" type="xs:string" use="required"/>
+        <xs:attribute name="type-class" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="global-serializer">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="override-java-serialization" type="xs:boolean" default="false" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Java Serializable and Externalizable is prior to global serializer by default. If set true
+                            the Java serialization step assumed to be handled by the global serializer.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="java-serialization-filter">
+        <xs:all>
+            <xs:element name="blacklist" type="filter-list" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Blacklisted classes and packages, which are not allowed to be deserialized.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="whitelist" type="filter-list" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Whitelisted classes and packages, which are allowed to be deserialized. If the list is empty
+                        (no class or package name provided) then all classes are allowed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="defaults-disabled" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Disables including default list entries (hardcoded in Hazelcast source code).
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:boolean"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="filter-list">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="class" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name of a class to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="package" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name of a package to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="prefix" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Class name prefix to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="socket-interceptor">
+        <xs:all>
+            <xs:element name="class-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" default="false" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="native-memory">
+        <xs:all>
+            <xs:element name="size" type="memory-size" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="min-block-size" type="xs:positiveInteger" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="page-size" type="xs:positiveInteger" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="metadata-space-percentage" minOccurs="0" maxOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:decimal">
+                        <xs:totalDigits value="3"/>
+                        <xs:fractionDigits value="1"/>
+                        <xs:minInclusive value="5"/>
+                        <xs:maxInclusive value="95"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="allocator-type" default="POOLED" type="memory-allocator-type"/>
+        <xs:attribute name="enabled" default="false" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="memory-size">
+        <xs:attribute name="value" type="xs:int" default="128"/>
+        <xs:attribute name="unit" type="memory-unit" default="MEGABYTES"/>
+    </xs:complexType>
+
+    <xs:simpleType name="memory-unit">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="BYTES"/>
+            <xs:enumeration value="KILOBYTES"/>
+            <xs:enumeration value="MEGABYTES"/>
+            <xs:enumeration value="GIGABYTES"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="memory-allocator-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="STANDARD"/>
+            <xs:enumeration value="POOLED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="property">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required" type="non-space-string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="properties">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="property"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="ssl">
+        <xs:all>
+            <xs:element name="factory-class-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" default="false" type="xs:boolean"/>
+    </xs:complexType>
+    <xs:complexType name="user-code-deployment">
+        <xs:all>
+            <xs:element name="jarPaths" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="jarPath" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="classNames" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="className" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable User Code Deployment on this client, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="outbound-ports">
+        <xs:sequence>
+            <xs:element name="ports" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="flake-id-generator">
+        <xs:all>
+            <xs:element name="prefetch-count" minOccurs="0" default="100">
+                <xs:annotation>
+                    <xs:documentation>
+                        How many IDs are pre-fetched on the background when one call to newId() is made.
+                        Value must be in the range 1..100,000, default is 100.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:int">
+                        <xs:minInclusive value="1"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="prefetch-validity-millis" type="xs:long" minOccurs="0" default="600000">
+                <xs:annotation>
+                    <xs:documentation>
+                        For how long the pre-fetched IDs can be used. If this time elapses, new IDs will be fetched.
+                        Time unit is milliseconds.
+                        If value is &lt;= 0, validity is unlimited. Default value is 600,000 (10 minutes).
+                        The IDs contain timestamp component, which ensures rough global ordering of IDs. If an ID
+                        is assigned to an event that occurred much later, it will be much out of order.
+                        If you don't need ordering, set this value to 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the ID generator.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="reliable-topic">
+        <xs:all>
+            <xs:element name="topic-overload-policy" minOccurs="0" default="BLOCK">
+                <xs:annotation>
+                    <xs:documentation>
+                        Policy to deal with an overloaded topic; so topic where there is no place to store new messages.
+                        Options are
+                        DISCARD_OLDEST: Using this policy, a message that has not expired can be overwritten.
+                        No matter the retention period set, the overwrite will just overwrite the item.
+                        DISCARD_NEWEST : The message that was to be published, is discarded.
+                        BLOCK : The caller will wait till there space in the ringbuffer.
+                        ERROR : The publish call immediately fails.(Default Value)
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="DISCARD_OLDEST"/>
+                        <xs:enumeration value="DISCARD_NEWEST"/>
+                        <xs:enumeration value="BLOCK"/>
+                        <xs:enumeration value="ERROR"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="read-batch-size" type="xs:int" minOccurs="0" default="10">
+                <xs:annotation>
+                    <xs:documentation>
+                        The maximum number of items to read in a batch.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the Reliable Topic.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/hazelcast-spring/src/main/resources/META-INF/spring.schemas
+++ b/hazelcast-spring/src/main/resources/META-INF/spring.schemas
@@ -18,4 +18,5 @@ http\://www.hazelcast.com/schema/spring/hazelcast-spring-3.8.xsd=hazelcast-sprin
 http\://www.hazelcast.com/schema/spring/hazelcast-spring-3.9.xsd=hazelcast-spring-3.9.xsd
 http\://www.hazelcast.com/schema/spring/hazelcast-spring-3.10.xsd=hazelcast-spring-3.10.xsd
 http\://www.hazelcast.com/schema/spring/hazelcast-spring-3.11.xsd=hazelcast-spring-3.11.xsd
-http\://www.hazelcast.com/schema/spring/hazelcast-spring.xsd=hazelcast-spring-3.11.xsd
+http\://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd=hazelcast-spring-3.12.xsd
+http\://www.hazelcast.com/schema/spring/hazelcast-spring.xsd=hazelcast-spring-3.12.xsd

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -1,0 +1,4173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.hazelcast.com/schema/spring"
+           xmlns:tool="http://www.springframework.org/schema/tool"
+           targetNamespace="http://www.hazelcast.com/schema/spring"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:import namespace="http://www.springframework.org/schema/tool"
+               schemaLocation="http://www.springframework.org/schema/tool/spring-tool.xsd"/>
+    <xs:element name="config">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="hazelcast-bean">
+                    <xs:sequence>
+                        <xs:element name="spring-aware" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="instance-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="group" type="group" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="license-key" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="management-center" type="management-center" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="wan-replication" type="wan-replication" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="network" type="network" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="partition-group" type="partition-group" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="executor-service" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="pool-size" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The number of executor threads per Member for the Executor.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="queue-capacity" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Executor's task queue capacity. 0 means Integer.MAX_VALUE.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="statistics-enabled" type="parameterized-boolean"
+                                              use="optional" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Enable/disable statistics
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="durable-executor-service" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="pool-size" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The number of executor threads per Member for the Executor.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="durability" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The durability of the executor
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="capacity" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Executor's task capacity (per partition)
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="scheduled-executor-service" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:all>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                </xs:all>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="pool-size" use="optional" type="xs:string" default="16">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The number of executor threads per member for the executor.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="durability" use="optional" type="xs:string" default="1">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The durability of the scheduled executor.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="capacity" use="optional" type="xs:string" default="100">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The maximum number of tasks that a scheduler can have at any given point
+                                            in time per partition.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="cardinality-estimator" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:all>
+                                    <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Number of synchronous backups. For example, if 1 is set as the backup-count,
+                                                then the cardinality estimation will be copied to one other JVM for
+                                                fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1"
+                                                default="0">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Number of asynchronous backups. For example, if 1 is set as the
+                                                async-backup-count,
+                                                then cardinality estimation will be copied to one other JVM (asynchronously) for
+                                                fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                </xs:all>
+                                <xs:attribute name="name" type="xs:string" use="optional" default="default">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Name of the cardinality estimator.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="queue" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="item-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="item-listener" type="item-listener" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="queue-store" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                                            </xs:sequence>
+                                            <xs:attribute name="enabled" use="required" type="xs:string"/>
+                                            <xs:attribute name="class-name" use="optional" type="xs:string"/>
+                                            <xs:attribute name="factory-class-name" use="optional" type="xs:string"/>
+                                            <xs:attribute name="store-implementation" use="optional" type="xs:string"/>
+                                            <xs:attribute name="factory-implementation" use="optional" type="xs:string"/>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="max-size" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Value of maximum size of items in the Queue.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Count of synchronous backups. Remember that, Queue is a non-partitioned
+                                            data structure, i.e. all entries of a Set resides in one partition. When
+                                            this parameter is '1', it means there will be a backup of that Set in
+                                            another node in the cluster. When it is '2', 2 nodes will have the backup.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="async-backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Count of asynchronous backups.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="statistics-enabled" type="parameterized-boolean"
+                                              use="optional" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Enable/disable statistics.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="empty-queue-ttl" use="optional" default="-1">
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:int">
+                                            <xs:minInclusive value="-1"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="lock" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="ringbuffer" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="ringbuffer-store" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Includes the ring buffer store factory class name. The store format is the same as
+                                                the in-memory-format for the ringbuffer.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="properties" type="properties" minOccurs="0"
+                                                            maxOccurs="1"/>
+                                            </xs:sequence>
+                                            <xs:attribute name="enabled" use="required" type="parameterized-boolean"/>
+                                            <xs:attributeGroup ref="class-or-bean-name">
+                                                <xs:annotation>
+                                                    <xs:documentation>
+                                                        Name of the class or bean implementing MapLoader and/or MapStore.
+                                                    </xs:documentation>
+                                                </xs:annotation>
+                                            </xs:attributeGroup>
+                                            <xs:attribute name="factory-class-name" use="optional" type="xs:string"/>
+                                            <xs:attribute name="factory-implementation" use="optional"
+                                                          type="xs:string"/>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="capacity" use="optional" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of items in the ringbuffer. If no time-to-live-seconds is set, the size will
+                                            always
+                                            be equal to capacity after the head completed the first loop around the ring. This is
+                                            because no items are getting retired. The default value is 10000.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count" default="1">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of synchronous backups. For example, if 1 is set as the backup-count,
+                                            then the items in the ringbuffer are copied to one other JVM for fail-safety.
+                                            `backup-count` + `async-backup-count` cannot be bigger than maximum
+                                            backup count which is `6`. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="async-backup-count" use="optional" type="parameterized-backup-count"
+                                              default="0">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of asynchronous backups. For example, if 1 is set as the backup-count,
+                                            then the items in the ringbuffer are copied to one other JVM for fail-safety.
+                                            `backup-count` + `async-backup-count` cannot be bigger than maximum
+                                            backup count which is `6`. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="time-to-live-seconds" use="optional" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Maximum number of seconds for each entry to stay in the ringbuffer. Entries that are
+                                            older than &lt;time-to-live-seconds&gt; and are not updated for &lt;time-to-live-seconds&gt;
+                                            are automatically evicted from the map.
+                                            Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="in-memory-format" use="optional" type="in-memory-format" default="BINARY">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Data type used to store entries.
+                                            Possible values:
+                                            BINARY (default): keys and values are stored as binary data.
+                                            OBJECT: values are stored in their object forms.
+                                            NATIVE: keys and values are stored in native memory. Only available on Hazelcast
+                                            Enterprise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="atomic-long" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="atomic-reference" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="count-down-latch" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="semaphore" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="initial-permits" use="optional" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The thread count to which the concurrent access is limited. For example, if you set
+                                            it to "3", concurrent access to the object is limited to 3 threads.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count" default="1">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of synchronous backups. For example, if 1 is set as the backup-count,
+                                            then the items in the ringbuffer are copied to one other JVM for fail-safety.
+                                            `backup-count` + `async-backup-count` cannot be bigger than maximum
+                                            backup count which is `6`. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="async-backup-count" use="optional" type="parameterized-backup-count"
+                                              default="0">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of asynchronous backups. For example, if 1 is set as the backup-count,
+                                            then the items in the ringbuffer are copied to one other JVM for fail-safety.
+                                            `backup-count` + `async-backup-count` cannot be bigger than maximum
+                                            backup count which is `6`. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="reliable-topic" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="message-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="message-listener" type="listener" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="statistics-enabled" type="parameterized-boolean" use="optional"
+                                              default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Enable/disable statistics.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="read-batch-size" use="optional" type="xs:int" default="10">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The maximum number of items to read in a batch.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="topic-overload-policy" use="optional" type="topic-overload-policy">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Policy to handle an overloaded topic. Available values are `DISCARD_OLDEST`,
+                                            `DISCARD_NEWEST`,
+                                            `BLOCK` and `ERROR`. The default value is `BLOCK.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="map" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="map-store" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="properties" type="properties" minOccurs="0"
+                                                            maxOccurs="1"/>
+                                            </xs:sequence>
+                                            <xs:attribute name="enabled" use="required" type="xs:string"/>
+                                            <xs:attributeGroup ref="class-or-bean-name">
+                                                <xs:annotation>
+                                                    <xs:documentation>
+                                                        Name of the class or bean implementing MapLoader and/or MapStore.
+                                                    </xs:documentation>
+                                                </xs:annotation>
+                                            </xs:attributeGroup>
+                                            <xs:attribute name="factory-class-name" use="optional" type="xs:string"/>
+                                            <xs:attribute name="factory-implementation" use="optional"
+                                                          type="xs:string"/>
+                                            <xs:attribute name="write-delay-seconds" use="required" type="xs:string">
+                                                <xs:annotation>
+                                                    <xs:documentation>
+                                                        Number of seconds to delay to call the MapStore.store(key,
+                                                        value).
+                                                        If the value is zero then it is write-through so
+                                                        MapStore.store(key, value) will be called as soon as the
+                                                        entry is updated. Otherwise it is write-behind so updates will
+                                                        be stored after write-delay-seconds value by calling
+                                                        Hazelcast.storeAll(map). Default value is 0.
+                                                    </xs:documentation>
+                                                </xs:annotation>
+                                            </xs:attribute>
+                                            <xs:attribute name="write-batch-size" use="optional" type="xs:string">
+                                                <xs:annotation>
+                                                    <xs:documentation>
+                                                        Used to create batch chunks when writing map store. In default
+                                                        mode all entries will be tried to persist in one go. To create
+                                                        batch chunks, minimum meaningful value for write-batch-size is
+                                                        2.
+                                                        For values smaller than 2, it works as in default mode.
+                                                    </xs:documentation>
+                                                </xs:annotation>
+                                            </xs:attribute>
+                                            <xs:attribute name="write-coalescing" use="optional" type="parameterized-boolean"
+                                                          default="true">
+                                                <xs:annotation>
+                                                    <xs:documentation>
+                                                        Setting write-coalescing is meaningful if you are using
+                                                        write-behind map-store. Otherwise it has no effect.
+                                                        When write-coalescing is true, only the latest
+                                                        store operation on a key in the write-delay-seconds
+                                                        time-window will be reflected to the map-store.
+                                                    </xs:documentation>
+                                                </xs:annotation>
+                                            </xs:attribute>
+                                            <xs:attribute name="initial-mode">
+                                                <xs:simpleType>
+                                                    <xs:restriction base="non-space-string">
+                                                        <xs:enumeration value="LAZY"/>
+                                                        <xs:enumeration value="EAGER"/>
+                                                    </xs:restriction>
+                                                </xs:simpleType>
+                                            </xs:attribute>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="near-cache" type="near-cache" minOccurs="0" maxOccurs="1"/>
+                                    <xs:element name="query-caches" type="query-caches" minOccurs="0" maxOccurs="1"/>
+                                    <xs:element name="wan-replication-ref" type="wan-replication-ref" minOccurs="0">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Hazelcast can replicate some or all of the cluster data. For example,
+                                                you can have 5 different maps but you want only one of these maps
+                                                replicating across clusters. To achieve this you mark the maps
+                                                to be replicated by adding this element.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="indexes" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                This configuration lets you index the attributes and also order them.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="index" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:attribute name="attribute" type="xs:string" use="required"/>
+                                                        <xs:attribute name="ordered" type="xs:string" use="optional"
+                                                                      default="false"/>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="attributes" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                This configuration lets you define extractors for custom attributes.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="attribute" minOccurs="0" maxOccurs="unbounded">
+                                                    <xs:complexType>
+                                                        <xs:attribute name="name" type="xs:string" use="required"/>
+                                                        <xs:attribute name="extractor" type="xs:string" use="required"/>
+                                                    </xs:complexType>
+                                                </xs:element>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="entry-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                This configuration lets you add listeners (listener classes) for the
+                                                map entries.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="entry-listener" type="entry-listener" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                    <xs:element name="partition-lost-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>List of partition lost listeners</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="partition-lost-listener" type="listener"
+                                                            minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1"/>
+                                    <xs:element name="map-eviction-policy" type="map-eviction-policy" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Internal eviction algorithm finds most appropriate entry
+                                                to evict from this map by using this policy.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="partition-strategy" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="in-memory-format" use="optional" type="xs:string" default="BINARY">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Data type used to store entries.
+                                            Possible values:
+                                            BINARY (default): keys and values are stored as binary data.
+                                            OBJECT: values are stored in their object forms.
+                                            NATIVE: keys and values are stored in native memory. Only available on Hazelcast
+                                            Enterprise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="statistics-enabled" use="optional" type="parameterized-boolean"
+                                              default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            You can retrieve some statistics like owned entry count, backup entry count,
+                                            last update time, locked entry count by setting this parameter's value
+                                            as "true". The method for retrieving the statistics is `getLocalMapStats()`.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="optimize-queries" use="optional" type="parameterized-boolean">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            This parameter is deprecated as of Hazelcast 3.6
+                                            Use cache-deserialized-values attribute instead.
+
+                                            When both optimize-query and cache-deserialized-values are used at the same time
+                                            Hazelcast will do its best to detect possible conflicts. Conflict detection
+                                            is done on best-effort basis and you should not rely on it.
+
+                                            This parameter is used to increase the speed of query processes in the map.
+                                            It only works when `in-memory-format` is set as `BINARY` and performs
+                                            a pre-caching on the entries queried.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="cache-deserialized-values" use="optional"
+                                              type="parameterized-cache-deserialized">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Control caching of de-serialized values. Caching makes query evaluation faster, but it
+                                            cost memory.
+                                            Possible Values:
+                                            NEVER: Never cache de-serialized object
+                                            INDEX-ONLY: Cache values only when they are inserted into an index.
+                                            ALWAYS: Always cache de-serialized values.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of sync backups. If 1 is set as the backup-count for example, then
+                                            all
+                                            entries of the map will be copied to another JVM for fail-safety. Valid
+                                            numbers are 0 (no backup), 1, 2 ... 6.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="async-backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of async backups. If 1 is set as the backup-count for example, then
+                                            all
+                                            entries of the map will be copied to another JVM for fail-safety. Valid
+                                            numbers are 0 (no backup), 1, 2 ... 6.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="time-to-live-seconds" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Maximum number of seconds for each entry to stay in the map. Entries that
+                                            are older than `time-to-live-seconds` and not updated for
+                                            `time-to-live-seconds` will get automatically evicted from the map. Any
+                                            integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="max-size" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Maximum size. Any integer between 0 and Integer.MAX_VALUE. 0 means
+                                            Integer.MAX_VALUE. Default is 0.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <!--max-size-policy attribute wasn't converted to enumeration to support case-insensitivity-->
+                                <xs:attribute name="max-size-policy" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Valid values are:
+                                            PER_NODE: Maximum number of map entries in each Hazelcast instance.
+                                            This is the default policy.
+                                            PER_PARTITION: Maximum number of map entries within each partition. Storage size
+                                            depends on the partition count in a Hazelcast instance.
+                                            This attribute should not be used often.
+                                            Avoid using this attribute with a small cluster: if the cluster is small it will
+                                            be hosting more partitions, and therefore map entries, than that of a larger
+                                            cluster. Thus, for a small cluster, eviction of the entries will decrease
+                                            performance (the number of entries is large).
+                                            USED_HEAP_SIZE: Maximum used heap size in megabytes per map for each Hazelcast
+                                            instance.
+                                            USED_HEAP_PERCENTAGE: Maximum used heap size percentage per map for each Hazelcast
+                                            instance.
+                                            If, for example, JVM is configured to have 1000 MB and this value is 10, then the map
+                                            entries will be evicted when used heap size exceeds 100 MB.
+                                            FREE_HEAP_SIZE: Minimum free heap size in megabytes for each JVM.
+                                            FREE_HEAP_PERCENTAGE: Minimum free heap size percentage for each JVM.
+                                            For example, if JVM is configured to have 1000 MB and this value is 10,
+                                            then the map entries will be evicted when free heap size is below 100 MB.
+                                            USED_NATIVE_MEMORY_SIZE: Maximum used native memory size in megabytes per map
+                                            for each Hazelcast instance.
+                                            USED_NATIVE_MEMORY_PERCENTAGE: Maximum used native memory size percentage per map
+                                            for each Hazelcast instance.
+                                            FREE_NATIVE_MEMORY_SIZE: Minimum free native memory size in megabytes
+                                            for each Hazelcast instance.
+                                            FREE_NATIVE_MEMORY_PERCENTAGE: Minimum free native memory size percentage
+                                            for each Hazelcast instance.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="max-idle-seconds" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Maximum number of seconds for each entry to stay idle in the map. Entries
+                                            that are idle(not touched) for more than max-idle-seconds will get
+                                            automatically evicted from the map. Entry is touched if get, put or
+                                            containsKey is called. Any integer between 0 and Integer.MAX_VALUE. 0 means
+                                            infinite. Default is 0.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="eviction-percentage" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            This parameter is deprecated as of version 3.7 due to the eviction mechanism change.
+                                            (New eviction mechanism uses a probabilistic algorithm based on sampling. Please see
+                                            documentation for further details.)
+
+                                            When max. size is reached, specified percentage of the map will be evicted.
+                                            Any integer between 0 and 100. If 25 is set for example, 25% of the
+                                            entries will get evicted.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="min-eviction-check-millis" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            This parameter is deprecated as of version 3.7 due to the eviction mechanism change.
+                                            (New eviction mechanism uses a probabilistic algorithm based on sampling. Please see
+                                            documentation for further details.)
+
+                                            Minimum time in milliseconds which should pass before checking if a
+                                            partition of this map is evictable or not. Default value is 100 millis.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="eviction-policy" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Valid values are: NONE (no eviction), LRU (Least Recently Used), LFU
+                                            (Least Frequently Used). NONE is the default.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="read-backup-data" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            This boolean parameter enables reading local backup entries when set as
+                                            `true`.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="cache" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                When maximum size is reached, cache is evicted based on the eviction policy.
+
+                                                size:
+                                                maximum size can be any integer between 0 and Integer.MAX_VALUE.
+
+                                                Default value is 0.
+
+                                                max-size-policy:
+                                                max-size-policy has these valid values:
+                                                ENTRY_COUNT (Maximum number of cache entries in the cache),
+                                                USED_NATIVE_MEMORY_SIZE (Maximum used native memory size in megabytes per cache
+                                                for each Hazelcast instance),
+                                                USED_NATIVE_MEMORY_PERCENTAGE (Maximum used native memory size percentage per
+                                                cache
+                                                for each Hazelcast instance),
+                                                FREE_NATIVE_MEMORY_SIZE (Minimum free native memory size in megabytes for each
+                                                Hazelcast instance),
+                                                FREE_NATIVE_MEMORY_PERCENTAGE (Minimum free native memory size percentage for each
+                                                Hazelcast instance).
+
+                                                Default value is "ENTRY_COUNT".
+
+                                                eviction-policy:
+                                                Eviction policy has these valid values:
+                                                LRU (Least Recently Used),
+                                                LFU (Least Frequently Used).
+
+                                                Default value is "LRU".
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="cache-entry-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>List of cache entry listeners</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="cache-entry-listener" type="cache-entry-listener"
+                                                            minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="partition-lost-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>List of partition lost listeners</xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="partition-lost-listener" type="listener"
+                                                            minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="expiry-policy-factory" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Defines the expiry policy factory class name or
+                                                defines the expiry policy factory from predefined ones with duration
+                                                configuration.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="timed-expiry-policy-factory"
+                                                            type="timed-expiry-policy-factory"
+                                                            minOccurs="0" maxOccurs="1"/>
+                                            </xs:sequence>
+                                            <xs:attribute name="class-name"/>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="wan-replication-ref" type="wan-replication-ref" minOccurs="0">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Hazelcast can replicate some or all of the cluster data. For example,
+                                                you can have 5 different caches but you want only one of these caches
+                                                replicating across clusters. To achieve this you mark the caches
+                                                to be replicated by adding this element.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                While recovering from split-brain (network partitioning), cache entries in the
+                                                small cluster
+                                                merge into the bigger cluster based on the policy set here.
+                                                When an entry merges into the cluster, an entry with the same key might already
+                                                exist in the cluster.
+                                                The values of these entries might be different for that same key. Which value
+                                                should be set for the
+                                                key? The conflict is resolved by the policy set here.
+                                                <p>
+                                                    <br/>There are built-in merge policies, such as:
+                                                    <br/>`com.hazelcast.cache.merge.PassThroughCacheMergePolicy` or
+                                                    `PASS_THROUGH`:
+                                                    The entry will be added directly even though there is an existing entry for
+                                                    the key.
+                                                    <br/>`com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy` or
+                                                    `PUT_IF_ABSENT`:
+                                                    The entry will be added if there is no existing entry for the key.
+                                                    <br/>`com.hazelcast.cache.merge.HigherHitsCacheMergePolicy` or `HIGHER_HITS`:
+                                                    The entry with the higher number of hits wins.
+                                                    <br/>`com.hazelcast.cache.merge.LatestAccessCacheMergePolicy` or
+                                                    `LATEST_ACCESS`:
+                                                    The entry which has been accessed more recently wins.
+                                                    <br/>Default policy is 'com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy'
+                                                </p>
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" type="xs:string" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation>Name of the cache.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="key-type" type="non-space-string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>the type of keys provided as full class name
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="value-type" type="non-space-string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>the type of values provided as full class name
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="statistics-enabled" type="parameterized-boolean" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Defines whether statistics gathering is enabled on a cache.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="management-enabled" type="parameterized-boolean" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Defines whether management is enabled on a cache.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="read-through" type="parameterized-boolean" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Set if read-through caching should be used.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="disable-per-entry-invalidation-events" type="parameterized-boolean"
+                                              use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Disables invalidation events for per entry but full-flush invalidation events are
+                                            still enabled.
+                                            Full-flush invalidation event means that invalidation events for all entries on clear.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="write-through" type="parameterized-boolean" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Set if write-through caching should be used.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="in-memory-format" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Data type that will be used for storing records. Possible values:
+                                            BINARY (default): keys and values will be stored as binary data
+                                            OBJECT : values will be stored in their object forms
+                                            NATIVE : keys and values will be stored in native memory.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="cache-loader-factory" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Defines the cache loader factory class name.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="cache-loader" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Defines the cache loader class name.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="cache-writer-factory" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Defines the cache writer factory class name.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="cache-writer" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Defines the cache writer class name.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="expiry-policy-factory" type="xs:string" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Defines the expiry policy factory class name.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of synchronous backups. For example, if `1` is set as the `backup-count`,
+                                            then all entries of the cache are copied to one other instance as synchronous for
+                                            fail-safety.
+                                            `backup-count` + `async-backup-count` cannot be bigger than maximum backup count which
+                                            is `6`.
+                                            Valid numbers are 0 (no backup), 1, 2 ... 6.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="async-backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of asynchronous backups. For example, if `1` is set as the
+                                            `async-backup-count`,
+                                            then all entries of the cache are copied to one other instance as asynchronous for
+                                            fail-safety.
+                                            `backup-count` + `async-backup-count` cannot be bigger than maximum backup count which
+                                            is `6`.
+                                            Valid numbers are 0 (no backup), 1, 2 ... 6.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="hot-restart-enabled" use="optional" type="parameterized-boolean">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            This boolean parameter enables hot-restart feature when set as true.
+                                            Only available on Hazelcast Enterprise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="event-journal" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Configuration for an event journal. The event journal keeps events related
+                                        to a specific partition and data structure. For instance, it could keep
+                                        map add, update, remove, merge events along with the key, old value, new value and so on.
+                                        This configuration is not tied to a specific data structure and can be reused.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:attribute name="map-name" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the map to which this config applies.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="cache-name" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the cache to which this config applies.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="enabled" type="parameterized-boolean" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            True if the event journal is enabled, false otherwise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="capacity" use="optional" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of items in the event journal. If no time-to-live-seconds
+                                            is set, the size will always be equal to capacity after the event
+                                            journal has been filled. This is because no items are getting retired.
+                                            The default value is 10000.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="time-to-live-seconds" use="optional" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Maximum number of seconds for each entry to stay in the event journal.
+                                            Entries that are older than &lt;time-to-live-seconds&gt; are evicted from the journal.
+                                            Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="merkle-tree" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Configuration for a merkle tree.
+                                        The merkle tree is a data structure used for efficient comparison of the
+                                        difference in the contents of large data structures. The precision of
+                                        such a comparison mechanism is defined by the depth of the merkle tree.
+                                        A larger depth means that a data synchronization mechanism will be able
+                                        to pinpoint a smaller subset of the data structure contents in which a
+                                        change occurred. This causes the synchronization mechanism to be more
+                                        efficient. On the other hand, a larger tree depth means the merkle tree
+                                        will consume more memory.
+                                        A smaller depth means the data synchronization mechanism will have to
+                                        transfer larger chunks of the data structure in which a possible change
+                                        happened. On the other hand, a shallower tree consumes less memory.
+                                        The depth must be between 2 and 27 (exclusive).
+                                        As the comparison mechanism is iterative, a larger depth will also prolong
+                                        the duration of the comparison mechanism. Care must be taken to not have
+                                        large tree depths if the latency of the comparison operation is high.
+                                        The default depth is 10.
+                                        This configuration is not tied to a specific data structure and can be
+                                        reused.
+                                        See https://en.wikipedia.org/wiki/Merkle_tree.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:attribute name="map-name" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The name of the map to which this config applies.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="enabled" type="parameterized-boolean" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            True if the merkle tree is enabled, false otherwise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="depth" type="parameterized-unsigned-int">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The depth of the merkle tree.
+                                            A larger depth means that a data synchronization mechanism will be able
+                                            to pinpoint a smaller subset of the data structure contents in which a
+                                            change occurred. This causes the synchronization mechanism to be more
+                                            efficient. On the other hand, a larger tree depth means the merkle tree
+                                            will consume more memory.
+                                            A smaller depth means the data synchronization mechanism will have to
+                                            transfer larger chunks of the data structure in which a possible change
+                                            happened. On the other hand, a shallower tree consumes less memory.
+                                            The depth must be between 2 and 27 (exclusive). The default depth is 10.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="multimap" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="entry-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="entry-listener" type="entry-listener" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" type="xs:string" use="optional" default="default"/>
+                                <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of sync backups. If 1 is set as the backup-count for example, then
+                                            all
+                                            entries of the map will be copied to another JVM for fail-safety. Valid
+                                            numbers are 0 (no backup), 1, 2 ... 6.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="async-backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of async backups. If 1 is set as the backup-count for example, then
+                                            all
+                                            entries of the map will be copied to another JVM for fail-safety. Valid
+                                            numbers are 0 (no backup), 1, 2 ... 6.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="value-collection-type" type="xs:string" use="optional" default="SET">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Type of value collection. It can be Set or List.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="statistics-enabled" use="optional" type="parameterized-boolean"
+                                              default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            You can retrieve some statistics like owned entry count, backup entry count,
+                                            last update time, locked entry count by setting this parameter's value
+                                            as "true". The method for retrieving the statistics is `getLocalMultiMapStats()`.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="binary" use="optional" type="parameterized-boolean" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            By default, BINARY in-memory format is used, meaning that the object is stored
+                                            in a serialized form. You can set it to false, then, the OBJECT in-memory format
+                                            is used, which is useful when the OBJECT in-memory format has a smaller memory
+                                            footprint than BINARY.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="list" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="item-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="item-listener" type="item-listener" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="max-size" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Maximum size. Any integer between 0 and Integer.MAX_VALUE. 0 means
+                                            Integer.MAX_VALUE. Default is 0.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Count of synchronous backups. Remember that, List is a non-partitioned data
+                                            structure, i.e. all entries of a List resides in one partition. When this
+                                            parameter is '1', it means there will be a backup of that List in another
+                                            node in the cluster. When it is '2', 2 nodes will have the backup.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="async-backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Count of asynchronous backups.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="statistics-enabled" type="parameterized-boolean"
+                                              use="optional" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Enable/disable statistics
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="set" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="item-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="item-listener" type="item-listener" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="max-size" use="optional" type="xs:string">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Maximum size. Any integer between 0 and Integer.MAX_VALUE. 0 means
+                                            Integer.MAX_VALUE. Default is 0.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Count of synchronous backups. Remember that, Set is a non-partitioned data
+                                            structure, i.e. all entries of a List resides in one partition. When this
+                                            parameter is '1', it means there will be a backup of that List in another
+                                            node in the cluster. When it is '2', 2 nodes will have the backup.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="async-backup-count" use="optional" type="parameterized-backup-count">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Count of asynchronous backups.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="statistics-enabled" type="parameterized-boolean"
+                                              use="optional" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Enable/disable statistics
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="topic" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="statistics-enabled" type="parameterized-boolean" minOccurs="0" maxOccurs="1"
+                                                default="true">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                If set as `true`, you can retrieve statistics for the topic using the
+                                                method `getLocalTopicStats()`.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="global-ordering-enabled" type="parameterized-boolean" minOccurs="0"
+                                                maxOccurs="1"
+                                                default="false">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                By default, it is false, meaning there is no global order
+                                                guarantee by default.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="message-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="message-listener" type="listener" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="multi-threading-enabled" type="parameterized-boolean" minOccurs="0"
+                                                maxOccurs="1"
+                                                default="false">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Default is `false`, meaning only one dedicated thread will handle topic messages.
+                                                When multi-threading enabled (true) all threads from event thread pool can be used
+                                                for message handling.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="name" type="xs:string" use="optional" default="default"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="jobtracker" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    The JobTracker configuration is used to setup behavior of the Hazelcast MapReduce
+                                    framework. Every JobTracker is capable of running multiple map reduce jobs at once
+                                    and so once configuration is meant as a shared resource for all jobs created by
+                                    the same JobTracker. The configuration gives full control over the expected load
+                                    behavior and thread counts to be used.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:attribute name="name" use="required" type="xs:string"/>
+                                <xs:attribute name="max-thread-size" use="optional" type="xs:nonNegativeInteger"
+                                              default="0">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The max-thread-size setting configures the maximum thread pool size of the
+                                            JobTracker.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="queue-size" use="optional" type="xs:nonNegativeInteger"
+                                              default="0">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The queue-size defines the maximum number of tasks are able to wait to be
+                                            processed. A value of 0 means number of partitions * 2.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="retry-count" use="optional" type="xs:nonNegativeInteger"
+                                              default="0">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            retry-count is currently not used but reserved for later use where the
+                                            framework will automatically try to restart / retry operations from an
+                                            available savepoint.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="chunk-size" use="optional" type="xs:nonNegativeInteger"
+                                              default="1000">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The chunk-size defined the number of emitted values before a chunk is sent
+                                            to the reducers. If your emitted values are big or you want to better
+                                            balance your work you might want to change this to a lower or higher value.
+                                            A value of 0 means immediate transmission but remember that low values
+                                            mean higher traffic costs. A very high value might cause an OutOfMemoryError
+                                            to occur if emitted values not fit into heap memory before being send to
+                                            reducers. To prevent this you might want to use a combiner to pre-reduce
+                                            values on mapping nodes.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="communicate-stats" use="optional" type="parameterized-boolean" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The communicate-stats setting defines if statistics (for example about
+                                            processed entries) are transmitted to the job emitter. This might be used
+                                            to show any kind of progress to an user inside of an UI system but produces
+                                            additional traffic. If not needed you might want to deactivate this.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="topology-changed-strategy" use="optional"
+                                              type="topology-changed-strategy" default="CANCEL_RUNNING_OPERATION">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The topology-changed-strategy defines how the map reduce framework will
+                                            react on topology changes while executing a job. Currently only
+                                            CANCEL_RUNNING_OPERATION is fully supported which throws an exception to the
+                                            job emitter (throws com.hazelcast.mapreduce.TopologyChangedException).
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="replicatedmap" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    A replicated map is a implementation
+                                    of the map
+                                    interface which is not
+                                    partitioned but fully replicates all data to all members.
+                                    Due to the nature of weak consistency there is a chance of reading staled data
+                                    and no
+                                    guarantee is given to retrieve the same value on multiple get calls.
+                                    ReplicatedMap was added in Hazelcast 3.2.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="entry-listeners" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType>
+                                            <xs:sequence>
+                                                <xs:element name="entry-listener" type="entry-listener" minOccurs="0"
+                                                            maxOccurs="unbounded"/>
+                                            </xs:sequence>
+                                        </xs:complexType>
+                                    </xs:element>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+                                </xs:sequence>
+                                <xs:attribute name="name" type="xs:string" use="optional" default="default"/>
+                                <xs:attribute name="in-memory-format" type="in-memory-format" use="optional"
+                                              default="OBJECT"/>
+                                <xs:attribute name="concurrency-level" type="concurrency-level" use="optional"
+                                              default="32">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Number of parallel mutexes to minimize contention on keys. The default value
+                                            is 32 which
+                                            is a good number for lots of applications. If higher contention is seen on
+                                            writes to values
+                                            inside of the replicated map this value can be adjusted to the needs.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="replication-delay-millis" type="parameterized-unsigned-int" use="optional"
+                                              default="100">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Defines a number of milliseconds after a put is executed before the value is
+                                            replicated
+                                            to other nodes. In this time multiple puts can be operated and are cached up
+                                            to be send
+                                            at once.
+                                            Default value is 100ms before a replication is operated, if set to 0 no
+                                            delay is used and
+                                            all values are replicated one by one.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="async-fillup" type="parameterized-boolean" use="optional" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            This value defines it the replicated map is available for reads before the
+                                            initial
+                                            replication is completed. Default is true. If set to false no Exception will
+                                            be
+                                            thrown when replicated map is not yet ready but call will block until
+                                            finished.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="statistics-enabled" type="parameterized-boolean" use="optional"
+                                              default="true"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="listeners" type="listeners" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="serialization" type="serialization" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="native-memory" type="native-memory" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="security" type="security" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="member-attributes" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="attribute" type="attribute" maxOccurs="unbounded">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Specify the name, type and value of your attribute here.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                            <xs:unique name="uniqueAttributeConstraint">
+                                <xs:selector xpath="./*"/>
+                                <xs:field xpath="@name"/>
+                            </xs:unique>
+                        </xs:element>
+                        <xs:element name="services" type="services" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="quorum" type="quorum" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="lite-member" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                                <xs:attribute name="enabled" type="parameterized-boolean">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            True to set the node as a lite member, false otherwise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="hot-restart-persistence" type="hot-restart-persistence" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="flake-id-generator" type="flake-id-generator" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="crdt-replication" type="crdt-replication" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="pn-counter" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:all>
+                                    <xs:element name="replica-count" type="crdt-replica-count" minOccurs="0" maxOccurs="1" default="2147483647">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Number of replicas on which the CRDT state will be kept. The updates are replicated
+                                                asynchronously between replicas.
+                                                The number must be greater than 1 and up to 2147483647 (Integer.MAX_VALUE).
+                                                The default value is 2147483647 (Integer.MAX_VALUE).
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                    <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                                        <xs:annotation>
+                                            <xs:documentation>
+                                                Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                                                You should set the quorum-ref's value as the quorum's name.
+                                                IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                                                It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                                                The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                                                specified one.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                    </xs:element>
+                                </xs:all>
+                                <xs:attribute name="name" type="xs:string" use="optional" default="default">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Name of the PN counter.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="statistics-enabled" type="parameterized-boolean"
+                                              use="optional" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            Enable/disable statistics for this PN counter.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="data-serializable-factories">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="data-serializable-factory" type="serialization-factory" minOccurs="0"
+                            maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Custom classes implementing com.hazelcast.nio.serialization.DataSerializableFactory to be registered.
+                            These can be used to speed up serialization/deserialization of objects.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="portable-factories">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="portable-factory" type="serialization-factory" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>
+                            PortableFactory class to be registered.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="serializers">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="global-serializer" type="global-serializer" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Global serializer class to be registered if no other serializer is applicable.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="serializer" type="serializer" minOccurs="0" maxOccurs="unbounded">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Defines the class name of the serializer implementation.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="java-serialization-filter">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="blacklist" type="filter-list" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Blacklist used for deserialization class filtering.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="whitelist" type="filter-list" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Blacklist used for deserialization class filtering.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+            <xs:attribute name="defaults-disabled" use="optional" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        Disables including default list entries (hardcoded in Hazelcast source code).
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:boolean"/>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="filter-list">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="class" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name of a class to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="package" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name of a package to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="prefix" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Class name prefix to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="serialization-factory">
+        <xs:attributeGroup ref="class-or-bean-name"/>
+        <xs:attribute name="factory-id" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="global-serializer">
+        <xs:attributeGroup ref="class-or-bean-name"/>
+        <xs:attribute name="override-java-serialization" type="parameterized-boolean" default="false" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="serializer">
+        <xs:attributeGroup ref="class-or-bean-name"/>
+        <xs:attribute name="type-class" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:element name="hazelcast">
+        <xs:annotation>
+            <xs:documentation>
+                Configure the hazelcast instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.HazelcastInstance"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="hazelcast-bean">
+                    <xs:sequence>
+                        <xs:element ref="config" minOccurs="0" maxOccurs="1"/>
+                    </xs:sequence>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="client">
+        <xs:annotation>
+            <xs:documentation>
+                Configure the hazelcast client
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.HazelcastInstance"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="hazelcast-bean">
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:element name="spring-aware" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="group" type="group" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="network" type="network-client" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="security" type="client-security" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="listeners" type="listeners" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="serialization" type="serialization" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="proxy-factories" type="proxy-factories" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="load-balancer" type="load-balancer" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="near-cache" type="near-cache-client" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="query-caches" type="query-caches-client" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="connection-strategy" type="connection-strategy" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="user-code-deployment" type="user-code-deployment-client" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="flake-id-generator" type="client-flake-id-generator" minOccurs="0" maxOccurs="unbounded"/>
+                        <xs:element name="reliable-topic" type="client-reliable-topic" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:choice>
+                    <xs:attribute name="executor-pool-size" type="xs:int" use="optional"/>
+                    <xs:attribute name="credentials-ref" type="xs:string" use="optional"/>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="map" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast IMap instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IMap"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:element name="cache-manager">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a JCache cache manager from specified Hazelcast instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="javax.cache.CacheManager"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="hazelcast-bean">
+                    <xs:sequence>
+                        <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                    </xs:sequence>
+                    <xs:attribute name="instance-ref" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[The name of the HazelcastInstance that this bean depends on.]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                <![CDATA[The name of this bean in Hazelcast context (HazelcastInstance.getMap(name)).]]>
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="uri" type="xs:string" use="optional"/>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="multiMap" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast MultiMap instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.MultiMap"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="replicatedMap" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast ReplicatedMap instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ReplicatedMap"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="queue" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast IQueue instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IQueue"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="ringbuffer" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast Ringbuffer instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.ringbuffer.Ringbuffer"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="topic" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast ITopic instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ITopic"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="reliableTopic" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast ITopic instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ITopic"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="set" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast ISet instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ISet"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="list" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast IList instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IList"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="executorService" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast IExecutorService instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IExecutorService"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="durableExecutorService" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast IExecutorService instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.durableexecutor.DurableExecutorService"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="scheduledExecutorService" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast IScheduledExecutorService instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.scheduledexecutor.IScheduledExecutorService"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="idGenerator" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast IdGenerator instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IdGenerator"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="flakeIdGenerator" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast FlakeIdGenerator instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.flakeidgen.FlakeIdGenerator"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="cardinalityEstimator" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast CardinalityEstimator instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.cardinality.CardinalityEstimator"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="atomicLong" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast IAtomicLong instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IAtomicLong"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="atomicReference" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast IAtomicReference instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.IAtomicReference"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="countDownLatch" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast ICountDownLatch instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ICountDownLatch"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="semaphore" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast ISemaphore instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ISemaphore"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="lock" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast ILock instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.ILock"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="PNCounter" type="hazelcast-type">
+        <xs:annotation>
+            <xs:documentation>
+                Retrieve a Hazelcast PNCounter instance
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.crdt.pncounter.PNCounter"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:element name="hibernate-region-factory" type="hibernate-cache"/>
+
+    <!-- internal elements -->
+    <xs:complexType name="hazelcast-bean">
+        <xs:attribute name="id" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The unique identifier for a bean.
+                    A bean ID may not be used more than once within the same <beans> element.]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="lazy-init" type="xs:string" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[Indicates whether or not this bean is to be lazily initialized.
+                    If false, it will be instantiated on startup by bean factories that perform
+                    eager initialization of singletons.]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="scope" type="xs:string" use="optional" default="singleton">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The scope of this bean: typically "singleton", or "prototype".]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="depends-on" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[The names of the beans that this bean depends on being initialized.]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="hazelcast-type">
+        <xs:complexContent>
+            <xs:extension base="hazelcast-bean">
+                <xs:sequence/>
+                <xs:attribute name="instance-ref" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[The name of the HazelcastInstance that this bean depends on.]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[The name of this bean in Hazelcast context (HazelcastInstance.getMap(name)).]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="network">
+        <xs:sequence>
+            <xs:element name="outbound-ports" type="outbound-ports" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="join" type="join" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="interfaces" type="interfaces" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="ssl" type="ssl" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="symmetric-encryption" type="symmetric-encryption" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Encryption algorithm such as DES/ECB/PKCS5Padding, PBEWithMD5AndDES, AES/CBC/PKCS5Padding,
+                        Blowfish, DESede.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="reuse-address" type="parameterized-boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="member-address-provider" type="member-address-provider" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        This configuration is not intended to provide addresses of other cluster members with
+                        which the hazelcast instance will form a cluster. This is an SPI for advanced use in
+                        cases where the DefaultAddressPicker does not pick suitable addresses to bind to
+                        and publish to other cluster members. For instance, this could allow easier
+                        deployment in some cases when running on Docker, AWS or other cloud environments.
+                        That said, if you are just starting with Hazelcast, you will probably want to
+                        set the member addresses by using the tcp-ip or multicast configuration
+                        or adding a discovery strategy.
+                        Member address provider allows to plug in own strategy to customize:
+                        1. What address Hazelcast will bind to
+                        2. What address Hazelcast will advertise to other members on which they can bind to
+
+                        In most environments you don't need to customize this and the default strategy will work just
+                        fine. However in some cloud environments the default strategy does not make the right choice and
+                        the member address provider delegates the process of address picking to external code.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="failure-detector" type="failure-detector" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="public-address" type="xs:string" use="optional"/>
+        <xs:attribute name="port" type="xs:string" use="required"/>
+        <xs:attribute name="port-auto-increment" type="xs:string" use="optional" default="true"/>
+        <xs:attribute name="port-count" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="tcp-ip">
+        <xs:sequence>
+            <xs:element name="required-member" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:choice>
+                <xs:element name="members" type="members" default="127.0.0.1"/>
+                <xs:sequence>
+                    <xs:element name="member" type="member" default="127.0.0.1" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:sequence>
+                    <xs:element name="interface" type="interface" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:string" use="optional" default="false"/>
+        <xs:attribute name="connection-timeout-seconds" type="xs:string" use="optional" default="5"/>
+    </xs:complexType>
+
+    <xs:complexType name="multicast">
+        <xs:sequence>
+            <xs:element name="trusted-interfaces" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Includes IP addresses of trusted members. When a node wants to join to the cluster,
+                        its join request will be rejected if it is not a trusted member. You can give an IP
+                        addresses range using the wildcard (*) on the last digit of the IP address
+                        (e.g. 192.168.1.* or 192.168.1.100-110).
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="interface" type="interface" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:string" use="optional" default="true"/>
+        <xs:attribute name="multicast-group" type="xs:string" use="optional" default="224.2.2.3"/>
+        <xs:attribute name="multicast-port" type="xs:string" use="optional" default="54327"/>
+        <xs:attribute name="multicast-timeout-seconds" type="xs:string" use="optional" default="2"/>
+        <xs:attribute name="multicast-time-to-live" type="xs:string" use="optional" default="32"/>
+        <xs:attribute name="loopback-mode-enabled" type="parameterized-boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="aliased-discovery-strategy">
+        <xs:sequence/>
+        <xs:anyAttribute processContents="skip" />
+    </xs:complexType>
+
+    <xs:complexType name="discovery-strategies">
+        <xs:sequence>
+            <xs:element name="node-filter" type="discovery-node-filter" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategy" type="discovery-strategy" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="discovery-service-provider" type="discovery-service-provider" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="discovery-service-provider">
+        <xs:attributeGroup ref="class-or-bean-name"/>
+    </xs:complexType>
+    <xs:complexType name="discovery-node-filter">
+        <xs:attributeGroup ref="class-or-bean-name"/>
+    </xs:complexType>
+    <xs:complexType name="discovery-strategy">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="class-or-bean-name"/>
+        <xs:attribute name="discovery-strategy-factory" type="non-space-string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="wan-sync">
+        <xs:all>
+            <xs:element name="consistency-check-strategy" type="consistency-check-strategy" minOccurs="0" default="NONE">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the strategy for checking consistency of data between source and
+                        target cluster. Any inconsistency will not be reconciled, it will be
+                        merely reported via the usual mechanisms (e.g. statistics, diagnostics).
+                        The user must initiate WAN sync to reconcile there differences. For the
+                        check procedure to work properly, the target cluster should support the
+                        chosen strategy.
+                        Default value is NONE, which means the check is disabled.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="merge-policy">
+        <xs:annotation>
+            <xs:documentation>
+                While recovering from split-brain (network partitioning), data structure entries in the small cluster
+                merge into the bigger cluster based on the policy set here. When an entry merges into the cluster,
+                an entry with the same key (or value) might already exist in the cluster.
+                The merge policy resolves these conflicts with different out-of-the-box or custom strategies.
+                The out-of-the-box merge polices can be references by their simple class name.
+                For custom merge policies you have to provide a fully qualified class name.
+                <p>
+                    The out-of-the-box policies are:
+                    <br/>DiscardMergePolicy: the entry from the smaller cluster will be discarded.
+                    <br/>HigherHitsMergePolicy: the entry with the higher number of hits wins.
+                    <br/>LatestAccessMergePolicy: the entry with the latest access wins.
+                    <br/>LatestUpdateMergePolicy: the entry with the latest update wins.
+                    <br/>PassThroughMergePolicy: the entry from the smaller cluster wins.
+                    <br/>PutIfAbsentMergePolicy: the entry from the smaller cluster wins if it doesn't exist in the cluster.
+                    <br/>The default policy is: PutIfAbsentMergePolicy
+                </p>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="batch-size" default="100" type="xs:positiveInteger" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="merge-policies">
+        <xs:sequence>
+            <xs:element name="map-merge-policy" type="map-merge-policy" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="map-merge-policy">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attributeGroup ref="class-or-bean-name"/>
+    </xs:complexType>
+
+    <xs:complexType name="map-eviction-policy">
+        <xs:attributeGroup ref="class-or-bean-name"/>
+    </xs:complexType>
+
+    <xs:complexType name="outbound-ports">
+        <xs:sequence>
+            <xs:element name="ports" minOccurs="0" maxOccurs="unbounded">
+                <xs:simpleType>
+                    <xs:restriction base="xs:string"/>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="join">
+        <xs:sequence>
+            <xs:element name="multicast" type="multicast" minOccurs="0"/>
+            <xs:element name="tcp-ip" type="tcp-ip" minOccurs="0"/>
+            <xs:element name="aws" type="aliased-discovery-strategy" minOccurs="0"/>
+            <xs:element name="gcp" type="aliased-discovery-strategy" minOccurs="0"/>
+            <xs:element name="azure" type="aliased-discovery-strategy" minOccurs="0"/>
+            <xs:element name="kubernetes" type="aliased-discovery-strategy" minOccurs="0"/>
+            <xs:element name="eureka" type="aliased-discovery-strategy" minOccurs="0"/>
+            <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="interfaces">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="interface" type="interface" default="127.0.0.1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:string" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:simpleType name="interface">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="cache-deserialized">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="NEVER"/>
+            <xs:enumeration value="ALWAYS"/>
+            <xs:enumeration value="INDEX-ONLY"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="parameterized-cache-deserialized">
+        <xs:union memberTypes="cache-deserialized parameterizedValueType"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="member">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="members">
+        <xs:restriction base="xs:string"/>
+    </xs:simpleType>
+
+    <xs:complexType name="group">
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="password" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:simpleType name="propertyNameEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="hazelcast.merge.first.run.delay.seconds"/>
+            <xs:enumeration value="hazelcast.merge.next.run.delay.seconds"/>
+            <xs:enumeration value="hazelcast.redo.wait.millis"/>
+            <xs:enumeration value="hazelcast.socket.bind.any"/>
+            <xs:enumeration value="hazelcast.serializer.gzip.enabled"/>
+            <xs:enumeration value="hazelcast.serializer.shared"/>
+            <xs:enumeration value="hazelcast.shutdownhook.enabled"/>
+            <xs:enumeration value="hazelcast.wait.seconds.before.join"/>
+            <xs:enumeration value="hazelcast.max.no.heartbeat.seconds"/>
+            <xs:enumeration value="hazelcast.initial.wait.seconds"/>
+            <xs:enumeration value="hazelcast.restart.on.max.idle"/>
+            <xs:enumeration value="hazelcast.partition.count"/>
+            <xs:enumeration value="hazelcast.map.remove.delay.seconds"/>
+            <xs:enumeration value="hazelcast.map.cleanup.delay.seconds"/>
+            <xs:enumeration value="hazelcast.executor.query.thread.count"/>
+            <xs:enumeration value="hazelcast.executor.event.thread.count"/>
+            <xs:enumeration value="hazelcast.executor.migration.thread.count"/>
+            <xs:enumeration value="hazelcast.executor.client.thread.count"/>
+            <xs:enumeration value="hazelcast.executor.store.thread.count"/>
+            <xs:enumeration value="hazelcast.log.state"/>
+            <xs:enumeration value="hazelcast.jmx"/>
+            <xs:enumeration value="hazelcast.jmx.detailed"/>
+            <xs:enumeration value="hazelcast.mancenter.enabled"/>
+            <xs:enumeration value="hazelcast.memcache.enabled"/>
+            <xs:enumeration value="hazelcast.rest.enabled"/>
+            <xs:enumeration value="hazelcast.map.load.chunk.size"/>
+            <xs:enumeration value="hazelcast.in.thread.priority"/>
+            <xs:enumeration value="hazelcast.out.thread.priority"/>
+            <xs:enumeration value="hazelcast.service.thread.priority"/>
+            <xs:enumeration value="hazelcast.socket.receive.buffer.size"/>
+            <xs:enumeration value="hazelcast.socket.send.buffer.size"/>
+            <xs:enumeration value="hazelcast.socket.keep.alive"/>
+            <xs:enumeration value="hazelcast.socket.no.delay"/>
+            <xs:enumeration value="hazelcast.heartbeat.interval.seconds"/>
+            <xs:enumeration value="hazelcast.icmp.enabled"/>
+            <xs:enumeration value="hazelcast.initial.min.cluster.size"/>
+            <xs:enumeration value="hazelcast.mc.atomiclong.excludes"/>
+            <xs:enumeration value="hazelcast.mc.countdownlatch.excludes"/>
+            <xs:enumeration value="hazelcast.mc.map.excludes"/>
+            <xs:enumeration value="hazelcast.mc.queue.excludes"/>
+            <xs:enumeration value="hazelcast.mc.semaphore.excludes"/>
+            <xs:enumeration value="hazelcast.mc.topic.excludes"/>
+            <xs:enumeration value="hazelcast.phone.home.enabled"/>
+            <xs:enumeration value="hazelcast.map.max.backup.count"/>
+            <xs:enumeration value="hazelcast.max.wait.seconds.before.join"/>
+            <xs:enumeration value="hazelcast.logging.type"/>
+            <xs:enumeration value="hazelcast.compatibility.3.6.client"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="propertyNameString">
+        <xs:restriction base="non-space-string"/>
+    </xs:simpleType>
+    <xs:simpleType name="propertyName">
+        <xs:union memberTypes="propertyNameEnum propertyNameString"/>
+    </xs:simpleType>
+    <xs:complexType name="property">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required" type="propertyName"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="properties">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="property"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="attributeName">
+        <xs:restriction base="non-space-string"/>
+    </xs:simpleType>
+    <xs:simpleType name="attributeTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="boolean"/>
+            <xs:enumeration value="byte"/>
+            <xs:enumeration value="double"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="int"/>
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="short"/>
+            <xs:enumeration value="string"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="attribute">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required" type="attributeName"/>
+                <!--xs:attribute name="name" use="required" type="xs:ID"/-->
+                <xs:attribute name="type" use="optional" default="string" type="attributeTypeEnum"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="attributes">
+        <xs:sequence>
+            <xs:element name="attribute" type="attribute" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="mutual-auth">
+        <xs:all>
+            <xs:element name="factory-class-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" default="false" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="ssl">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" default="false" type="xs:string"/>
+        <xs:attribute name="factory-class-name" type="xs:string" use="optional"/>
+        <xs:attribute name="factory-implementation" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="socket-interceptor">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" default="false" type="xs:string"/>
+        <xs:attributeGroup ref="class-or-bean-name"/>
+    </xs:complexType>
+
+    <xs:complexType name="symmetric-encryption">
+        <xs:sequence/>
+        <xs:attribute name="enabled" type="xs:string" use="optional" default="false"/>
+        <xs:attribute name="algorithm" use="optional" type="xs:string"/>
+        <xs:attribute name="salt" use="optional" type="xs:string"/>
+        <xs:attribute name="password" use="optional" type="xs:string"/>
+        <xs:attribute name="iteration-count" use="optional" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="member-address-provider">
+        <xs:all>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attributeGroup ref="class-or-bean-name">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the class implementing the com.hazelcast.spi.MemberAddressProvider interface.
+                    If both the implementation and the class name are provided, the implementation is used
+                    and the class name is ignored.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attributeGroup>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether the member address provider SPI is enabled or not. Values can be true or false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="icmp">
+        <xs:annotation>
+            <xs:documentation>
+                ICMP can be used in addition to the other detectors. It operates at layer 3 detects network
+                and hardware issues more quickly
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="timeout-milliseconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000">
+                <xs:annotation>
+                    <xs:documentation>Timeout in Milliseconds before declaring a failed ping</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ttl" type="xs:integer" minOccurs="0" maxOccurs="1" default="255">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of times the IP Datagram (ping) can be forwarded, in most cases
+                        all Hazelcast cluster members would be within one network switch/router therefore
+                        default of 0 is usually sufficient
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="parallel-mode" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>Run ICMP detection in parallel with the Heartbeat failure detector</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="fail-fast-on-startup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        Cluster Member will fail to start if it is unable to action an ICMP ping command when ICMP is enabled.
+                        Failure is usually due to OS level restrictions.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-attempts" type="xs:integer" minOccurs="0" maxOccurs="1" default="2">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of consecutive failed attempts before declaring a member suspect
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="interval-milliseconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000">
+                <xs:annotation>
+                    <xs:documentation>Time in milliseconds between each ICMP ping</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" default="false">
+            <xs:annotation>
+                <xs:documentation>Enables ICMP Pings to detect and suspect dead members</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="failure-detector">
+        <xs:all>
+            <xs:element name="icmp" type="icmp" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="hibernate-cache">
+        <xs:complexContent>
+            <xs:extension base="hazelcast-bean">
+                <xs:attribute name="instance-ref" type="xs:string" use="required"/>
+                <!-- valid values are DISTRIBUTED and LOCAL -->
+                <xs:attribute name="mode" type="xs:string" use="optional" default="DISTRIBUTED"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:simpleType name="non-space-string">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\S.*"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="wan-replication">
+        <xs:sequence>
+            <xs:element name="wan-publisher" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="queue-full-behavior" type="wan-queue-full-behavior" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="queue-capacity" type="parameterized-positive-integer" default="10000" minOccurs="0"
+                                    maxOccurs="1"/>
+                        <xs:element name="initial-publisher-state" type="initial-publisher-state" minOccurs="0" maxOccurs="1"
+                                    default="REPLICATING">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Defines the initial state in which a WAN publisher is started.
+                                    - REPLICATING (default):
+                                    State where both enqueuing new events is allowed, enqueued events are replicated to the target cluster
+                                    and WAN sync is enabled.
+                                    - PAUSED:
+                                    State where new events are enqueued but they are not dequeued. Some events which have been dequeued before
+                                    the state was switched may still be replicated to the target cluster but further events will not be
+                                    replicated. WAN sync is enabled.
+                                    - STOPPED:
+                                    State where neither new events are enqueued nor dequeued. As with the PAUSED state, some events might
+                                    still be replicated after the publisher has switched to this state. WAN sync is enabled.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="aws" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="gcp" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="azure" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="kubernetes" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="eureka" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="wan-sync" type="wan-sync" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Configuration for the WAN sync mechanism.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="class-or-bean-name"/>
+                    <xs:attribute name="group-name" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Sets the group name used as an endpoint group name for authentication
+                                on the target endpoint.
+                                If there is no separate publisher ID property defined, this group name
+                                will also be used as a WAN publisher ID. This ID is then used for
+                                identifying the publisher in a WanReplicationConfig.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="publisher-id">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Sets the publisher ID used for identifying the publisher in a
+                                WanReplicationConfig.
+                                If there is no publisher ID defined (it is empty), the group name will
+                                be used as a publisher ID.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="wan-consumer" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Config for processing WAN events received from a target cluster.
+                        You can configure certain behaviour when processing incoming WAN events
+                        or even configure your own implementation for a WAN consumer. A custom
+                        WAN consumer allows you to define custom processing logic and is usually
+                        used in combination with a custom WAN publisher.
+                        A custom consumer is optional and you may simply omit defining it which
+                        will cause the default processing logic to be used.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="properties" type="properties" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Properties for the custom WAN consumer. These properties are
+                                    accessible when initalizing the WAN consumer.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="class-or-bean-name">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Defines a custom WAN consumer (WanReplicationConsumer).
+                                If you don't define a class name or implementation, the default processing
+                                logic for incoming WAN events will be used.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attributeGroup>
+                    <xs:attribute name="persist-wan-replicated-data" type="parameterized-boolean" default="false">
+                        <xs:annotation>
+                            <xs:documentation>
+                                When true, an incoming event over WAN replication can be persisted to a
+                                database for example, otherwise it will not be persisted. Default value
+                                is false.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="partition-group">
+        <xs:sequence>
+            <xs:element name="member-group" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="interface" type="interface" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="parameterized-boolean" use="required"/>
+        <xs:attribute name="group-type" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="management-center" mixed="true">
+        <xs:sequence minOccurs="0">
+            <xs:element name="url" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="mutual-auth" type="mutual-auth" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:string" default="false" use="optional"/>
+        <xs:attribute name="url" type="xs:string" use="optional"/>
+        <xs:attribute name="update-interval" type="xs:string" default="3" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="cache-entry-listener">
+        <xs:attribute name="cache-entry-listener-factory" type="non-space-string" use="optional"/>
+        <xs:attribute name="cache-entry-event-filter-factory" type="non-space-string" use="optional"/>
+        <xs:attribute name="old-value-required" type="parameterized-boolean" use="optional" default="false"/>
+        <xs:attribute name="synchronous" type="parameterized-boolean" use="optional" default="false"/>
+    </xs:complexType>
+    <xs:complexType name="listener">
+        <xs:attributeGroup ref="class-or-bean-name"/>
+    </xs:complexType>
+    <xs:complexType name="item-listener">
+        <xs:complexContent>
+            <xs:extension base="listener">
+                <xs:attribute name="include-value" type="xs:string" use="optional" default="true"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="entry-listener">
+        <xs:complexContent>
+            <xs:extension base="item-listener">
+                <xs:attribute name="local" type="xs:string" use="optional" default="false"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="security">
+        <xs:sequence>
+            <xs:element name="member-credentials-factory" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="class-or-bean-name"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="member-login-modules" type="login-modules" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="client-login-modules" type="login-modules" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="client-permission-policy" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="class-or-bean-name"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="client-permissions" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="all-permissions" type="base-permission" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="map-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="queue-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="multimap-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="topic-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="list-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="set-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="lock-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="atomic-long-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="countdown-latch-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="semaphore-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="id-generator-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="executor-service-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="durable-executor-service-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="cardinality-estimator-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="scheduled-executor-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="pn-counter-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="transaction-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="cache-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                        <xs:element name="config-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="security-interceptors" type="interceptors" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="client-block-unmapped-actions" type="xs:boolean" default="true" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Block or allow actions, submitted as tasks in an Executor from clients and have no permission mappings.
+
+                        true: Blocks all actions that have no permission mapping
+                        false: Allows all actions that have no permission mapping
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:string" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="interceptors">
+        <xs:sequence>
+            <xs:element name="interceptor" type="interceptor" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="interceptor">
+        <xs:attributeGroup ref="class-or-bean-name"/>
+    </xs:complexType>
+
+    <xs:complexType name="login-modules">
+        <xs:sequence>
+            <xs:element name="login-module" type="login-module" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="login-module">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="class-or-bean-name"/>
+        <xs:attribute name="usage" use="optional" default="required">
+            <xs:simpleType>
+                <xs:union>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="REQUIRED"/>
+                            <xs:enumeration value="OPTIONAL"/>
+                            <xs:enumeration value="REQUISITE"/>
+                            <xs:enumeration value="SUFFICIENT"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                    <xs:simpleType>
+                        <xs:restriction base="non-space-string"/>
+                    </xs:simpleType>
+                </xs:union>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="base-permission">
+        <xs:sequence>
+            <xs:element name="endpoints" type="endpoints" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="principal" type="xs:string" use="optional" default="*">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the principal. Wildcards(*) can be used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="instance-permission">
+        <xs:complexContent>
+            <xs:extension base="base-permission">
+                <xs:sequence>
+                    <xs:element name="actions" type="actions" minOccurs="1" maxOccurs="1"/>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Name of the permission. Wildcards(*) can be used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="endpoints">
+        <xs:sequence>
+            <xs:element name="endpoint" minOccurs="1" maxOccurs="unbounded" default="127.0.0.1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Endpoint address of principal. Wildcards(*) can be used.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string"/>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="actions">
+        <xs:sequence>
+            <xs:element name="action" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Permission actions that are permitted on Hazelcast instance objects.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:union>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="all"/>
+                                <xs:enumeration value="create"/>
+                                <xs:enumeration value="destroy"/>
+                                <xs:enumeration value="modify"/>
+                                <xs:enumeration value="read"/>
+                                <xs:enumeration value="remove"/>
+                                <xs:enumeration value="lock"/>
+                                <xs:enumeration value="listen"/>
+                                <xs:enumeration value="release"/>
+                                <xs:enumeration value="acquire"/>
+                                <xs:enumeration value="put"/>
+                                <xs:enumeration value="add"/>
+                                <xs:enumeration value="index"/>
+                                <xs:enumeration value="intercept"/>
+                                <xs:enumeration value="publish"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                        <xs:simpleType>
+                            <xs:restriction base="non-space-string"/>
+                        </xs:simpleType>
+                    </xs:union>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="serialization">
+        <xs:sequence>
+            <xs:element ref="data-serializable-factories" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="portable-factories" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="serializers" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="java-serialization-filter" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="use-native-byte-order" use="optional" type="xs:string" default="false"/>
+        <xs:attribute name="byte-order" use="optional" default="BIG_ENDIAN">
+            <xs:simpleType>
+                <xs:restriction base="non-space-string">
+                    <xs:enumeration value="BIG_ENDIAN"/>
+                    <xs:enumeration value="LITTLE_ENDIAN"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="portable-version" use="optional" type="xs:string"/>
+        <xs:attribute name="check-class-def-errors" use="optional" type="xs:string" default="true"/>
+        <xs:attribute name="enable-compression" use="optional" type="xs:string" default="false"/>
+        <xs:attribute name="enable-shared-object" use="optional" type="xs:string" default="true"/>
+        <xs:attribute name="allow-unsafe" use="optional" type="xs:string" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="network-client">
+        <xs:sequence>
+            <xs:element name="member" type="member" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="socket-options" type="socket-options" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="ssl" type="ssl" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="aws" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="gcp" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="azure" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="kubernetes" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="eureka" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="outbound-ports" type="outbound-ports" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="icmp-ping" type="icmp-ping-client" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="hazelcast-cloud" type="hazelcast-cloud-client" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="smart-routing" use="optional" type="parameterized-boolean" default="true"/>
+        <xs:attribute name="redo-operation" use="optional" type="parameterized-boolean" default="false"/>
+        <xs:attribute name="connection-timeout" use="optional" type="parameterized-positive-integer" default="5000"/>
+        <xs:attribute name="connection-attempt-period" use="optional" type="parameterized-positive-integer" default="3000"/>
+        <xs:attribute name="connection-attempt-limit" use="optional" type="parameterized-non-negative-integer" default="2"/>
+    </xs:complexType>
+
+    <xs:complexType name="socket-options">
+        <xs:attribute name="tcp-no-delay" type="parameterized-boolean" use="optional" default="false"/>
+        <xs:attribute name="keep-alive" type="parameterized-boolean" use="optional" default="true"/>
+        <xs:attribute name="reuse-address" type="parameterized-boolean" use="optional" default="true"/>
+        <xs:attribute name="linger-seconds" type="parameterized-unsigned-int" use="optional" default="3"/>
+        <xs:attribute name="buffer-size" use="optional" default="32">
+            <xs:simpleType>
+                <xs:restriction base="xs:unsignedInt">
+                    <xs:minInclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="icmp-ping-client">
+        <xs:all>
+            <xs:element name="timeout-milliseconds" type="xs:long" minOccurs="0" maxOccurs="1" default="1000"/>
+            <xs:element name="interval-milliseconds" type="xs:long" minOccurs="0" maxOccurs="1" default="1000"/>
+            <xs:element name="ttl" type="xs:int" minOccurs="0" maxOccurs="1" default="255"/>
+            <xs:element name="max-attempts" type="xs:int" minOccurs="0" maxOccurs="1" default="2"/>
+            <xs:element name="echo-fail-fast-on-startup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="hazelcast-cloud-client">
+        <xs:all>
+            <xs:element name="discovery-token" type="xs:string" minOccurs="1" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="services">
+        <xs:sequence>
+            <xs:element name="service" type="service" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="enable-defaults" type="parameterized-boolean" default="true"/>
+    </xs:complexType>
+    <xs:complexType name="service">
+        <xs:sequence>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="class-name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Deprecated element, subject to remove. Please use class-name/implementation attributes instead
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="configuration" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                    <xs:attribute name="parser" type="xs:string" use="required"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attributeGroup ref="class-or-bean-name"/>
+        <xs:attribute name="enabled" type="parameterized-boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:simpleType name="parameterizedValueType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[$#]\{([^=^:]+)\}"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="parameterized-boolean">
+        <xs:union memberTypes="xs:boolean parameterizedValueType"/>
+    </xs:simpleType>
+    <xs:simpleType name="parameterized-unsigned-int">
+        <xs:union memberTypes="xs:unsignedInt parameterizedValueType"/>
+    </xs:simpleType>
+    <xs:simpleType name="parameterized-unsigned-long">
+        <xs:union memberTypes="xs:unsignedLong parameterizedValueType"/>
+    </xs:simpleType>
+    <xs:simpleType name="parameterized-double">
+        <xs:union memberTypes="xs:double parameterizedValueType"/>
+    </xs:simpleType>
+    <xs:simpleType name="parameterized-positive-integer">
+        <xs:union memberTypes="xs:positiveInteger parameterizedValueType"/>
+    </xs:simpleType>
+    <xs:simpleType name="parameterized-backup-count">
+        <xs:union memberTypes="backup-count parameterizedValueType"/>
+    </xs:simpleType>
+    <xs:simpleType name="backup-count">
+        <xs:restriction base="xs:byte">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="6"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="crdt-replica-count">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="2147483647"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="parameterized-non-negative-integer">
+        <xs:union memberTypes="xs:nonNegativeInteger parameterizedValueType"/>
+    </xs:simpleType>
+
+    <xs:complexType name="listeners">
+        <xs:sequence>
+            <xs:element name="listener" type="listener" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="client-security">
+        <xs:sequence>
+            <xs:element name="credentials" type="credentials" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="credentials-factory" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="class-or-bean-name"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="credentials">
+        <xs:annotation>
+            <xs:documentation>Credentials className
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="non-space-string"/>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="proxy-factories">
+        <xs:sequence>
+            <xs:element name="proxy-factory" type="proxy-factory" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="proxy-factory">
+        <xs:attribute name="service">
+            <xs:simpleType>
+                <xs:restriction base="non-space-string"/>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="class-name">
+            <xs:simpleType>
+                <xs:restriction base="non-space-string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="load-balancer">
+        <xs:attribute name="type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="random"/>
+                    <xs:enumeration value="round-robin"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="near-cache-client">
+        <xs:complexContent>
+            <xs:extension base="near-cache">
+                <xs:attribute name="name" use="required">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string"/>
+                    </xs:simpleType>
+                </xs:attribute>
+                <xs:attribute name="local-update-policy" type="local-update-policy-enum" use="optional" default="INVALIDATE"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="near-cache">
+        <xs:sequence>
+            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="preloader" type="preloader" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="in-memory-format" type="in-memory-format" use="optional" default="BINARY"/>
+        <xs:attribute name="serialize-keys" use="optional" type="parameterized-boolean" default="false"/>
+        <xs:attribute name="invalidate-on-change" use="optional" type="parameterized-boolean" default="true"/>
+        <xs:attribute name="time-to-live-seconds" use="optional" type="xs:string" default="0"/>
+        <xs:attribute name="max-idle-seconds" use="optional" type="xs:string" default="0"/>
+        <xs:attribute name="eviction-policy" use="optional" type="eviction-policy" default="LRU"/>
+        <xs:attribute name="max-size" use="optional" type="xs:string" default="0"/>
+        <xs:attribute name="cache-local-entries" use="optional" type="xs:string" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="query-caches">
+        <xs:sequence>
+            <xs:element name="query-cache" type="query-cache" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="query-cache">
+        <xs:all>
+            <xs:element name="include-value" type="parameterized-boolean" minOccurs="0" maxOccurs="1" default="true"/>
+            <xs:element name="predicate" type="predicate" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="entry-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        This configuration lets you add listeners (listener classes) for the
+                        map entries.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="entry-listener" type="entry-listener" minOccurs="0"
+                                    maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY"/>
+            <xs:element name="populate" type="parameterized-boolean" minOccurs="0" maxOccurs="1" default="true"/>
+            <xs:element name="coalesce" type="parameterized-boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="delay-seconds" type="parameterized-unsigned-int" minOccurs="0" maxOccurs="1" default="0"/>
+            <xs:element name="batch-size" type="parameterized-unsigned-int" minOccurs="0" maxOccurs="1" default="1"/>
+            <xs:element name="buffer-size" type="parameterized-unsigned-int" minOccurs="0" maxOccurs="1" default="16"/>
+            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="indexes" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        This configuration lets you index the attributes and also order them.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="index" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="attribute" type="xs:string" use="required"/>
+                                <xs:attribute name="ordered" type="xs:string" use="optional"
+                                              default="false"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="query-caches-client">
+        <xs:sequence>
+            <xs:element name="query-cache" type="query-cache-client" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="query-cache-client">
+        <xs:all>
+            <xs:element name="include-value" type="parameterized-boolean" minOccurs="0" maxOccurs="1" default="true"/>
+            <xs:element name="predicate" type="predicate" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="entry-listeners" type="entry-listeners" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY"/>
+            <xs:element name="populate" type="parameterized-boolean" minOccurs="0" maxOccurs="1" default="true"/>
+            <xs:element name="coalesce" type="parameterized-boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="delay-seconds" type="parameterized-unsigned-int" minOccurs="0" maxOccurs="1" default="0"/>
+            <xs:element name="batch-size" type="parameterized-unsigned-int" minOccurs="0" maxOccurs="1" default="1"/>
+            <xs:element name="buffer-size" type="parameterized-unsigned-int" minOccurs="0" maxOccurs="1" default="16"/>
+            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="indexes" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        This configuration lets you index the attributes and also order them.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="index" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="attribute" type="xs:string" use="required"/>
+                                <xs:attribute name="ordered" type="xs:string" use="optional"
+                                              default="false"/>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="mapName" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="user-code-deployment-client">
+        <xs:all>
+            <xs:element name="jarPaths" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="jarPath" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="classNames" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="className" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable User Code Deployment on this client, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="flake-id-generator">
+        <xs:attribute name="name" type="xs:string" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the Flake ID Generator.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="prefetchCount" default="100" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets how many IDs are pre-fetched on the background when one call to
+                    FlakeIdGenerator.newId() is made. Value must be in the range 1..100,000, default
+                    is 100.
+
+                    This setting pertains only to newId() calls made on the member that configured it.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="prefetchValidityMillis" type="xs:long" default="600000" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets for how long the pre-fetched IDs can be used. If this time elapses, a new batch of IDs
+                    will be fetched. Time unit is milliseconds, default is 600,000 (10 minutes).
+
+                    The IDs contain timestamp component, which ensures rough global ordering of IDs. If an
+                    ID is assigned to an object that was created much later, it will be much out of order. If you
+                    don't care about ordering, set this value to 0.
+
+                    This setting pertains only to newId() calls made on the member that configured it.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="idOffset" type="xs:long" default="0" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the offset that will be added to the returned IDs. Default value is 0. Setting might be
+                    useful when migrating from IdGenerator, default value works for all green-field projects.
+
+                    For example: Largest ID returned from IdGenerator is 150. FlakeIdGenerator now returns
+                    100. If you configure idOffset of 50 and stop using the IdGenerator, the next ID from
+                    FlakeIdGenerator will be 151 or larger and no duplicate IDs will be generated. In real-life,
+                    the IDs are much larger. You also need to add a reserve to the offset because the IDs
+                    from FlakeIdGenerator are only roughly ordered. Recommended reserve is 2^38, that is
+                    274877906944.
+
+                    Negative values are allowed to increase the lifespan of the generator, however keep in
+                    mind that the generated IDs might also be negative.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="nodeIdOffset" type="xs:long" default="0" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the offset that will be added to the node ID assigned to cluster member for this generator.
+                    Might be useful in A/B deployment scenarios where you have cluster A which you want to upgrade.
+                    You create cluster B and for some time both will generate IDs and you want to have them unique.
+                    In this case, configure node ID offset for generators on cluster B.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="statistics-enabled" type="parameterized-boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Enable/disable statistics.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="client-flake-id-generator">
+        <xs:attribute name="name" type="xs:string" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the Flake ID Generator.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="prefetchCount" default="100" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets how many IDs are pre-fetched on the background when one call to
+                    FlakeIdGenerator.newId() is made. Value must be in the range 1..100,000, default
+                    is 100.
+
+                    This setting pertains only to newId() calls made on the member that configured it.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="1" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="prefetchValidityMillis" type="xs:long" default="600000" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets for how long the pre-fetched IDs can be used. If this time elapses, a new batch of IDs
+                    will be fetched. Time unit is milliseconds, default is 600,000 (10 minutes).
+
+                    The IDs contain timestamp component, which ensures rough global ordering of IDs. If an
+                    ID is assigned to an object that was created much later, it will be much out of order. If you
+                    don't care about ordering, set this value to 0.
+
+                    This setting pertains only to newId() calls made on the member that configured it.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="client-reliable-topic">
+        <xs:all>
+            <xs:element name="topic-overload-policy" minOccurs="0" default="BLOCK">
+                <xs:annotation>
+                    <xs:documentation>
+                        Policy to deal with an overloaded topic; so topic where there is no place to store new messages.
+                        Options are
+                        DISCARD_OLDEST: Using this policy, a message that has not expired can be overwritten.
+                        No matter the retention period set, the overwrite will just overwrite the item.
+                        DISCARD_NEWEST : The message that was to be published, is discarded.
+                        BLOCK : The caller will wait till there space in the ringbuffer.
+                        ERROR : The publish call immediately fails.(Default Value)
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="DISCARD_OLDEST"/>
+                        <xs:enumeration value="DISCARD_NEWEST"/>
+                        <xs:enumeration value="BLOCK"/>
+                        <xs:enumeration value="ERROR"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="read-batch-size" type="xs:int" minOccurs="0" default="10">
+                <xs:annotation>
+                    <xs:documentation>
+                        The maximum number of items to read in a batch.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the Reliable Topic.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="predicate">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="type" use="required">
+                    <xs:simpleType>
+                        <xs:restriction base="non-space-string">
+                            <xs:enumeration value="class-name"/>
+                            <xs:enumeration value="sql"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="index">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="ordered" type="parameterized-boolean" use="optional" default="false"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="entry-listeners">
+        <xs:sequence>
+            <xs:element name="entry-listener" type="entry-listener" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="listener-base">
+        <xs:annotation>
+            <xs:documentation>One of membership-listener, instance-listener or migration-listener
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="non-space-string"/>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:simpleType name="eviction-policy-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="LRU"/>
+            <xs:enumeration value="LFU"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="eviction-policy">
+        <xs:union memberTypes="eviction-policy-enum non-space-string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="in-memory-format-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="BINARY"/>
+            <xs:enumeration value="OBJECT"/>
+            <xs:enumeration value="NATIVE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="in-memory-format">
+        <xs:union memberTypes="in-memory-format-enum non-space-string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="local-update-policy-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="INVALIDATE"/>
+            <xs:enumeration value="CACHE_ON_UPDATE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="topic-overload-policy-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="DISCARD_OLDEST"/>
+            <xs:enumeration value="DISCARD_NEWEST"/>
+            <xs:enumeration value="BLOCK"/>
+            <xs:enumeration value="ERROR"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="topic-overload-policy">
+        <xs:union memberTypes="topic-overload-policy-enum non-space-string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="time-unit">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="NANOSECONDS"/>
+            <xs:enumeration value="MICROSECONDS"/>
+            <xs:enumeration value="MILLISECONDS"/>
+            <xs:enumeration value="SECONDS"/>
+            <xs:enumeration value="MINUTES"/>
+            <xs:enumeration value="HOURS"/>
+            <xs:enumeration value="DAYS"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="expiry-policy-type">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="CREATED"/>
+            <xs:enumeration value="ACCESSED"/>
+            <xs:enumeration value="ETERNAL"/>
+            <xs:enumeration value="MODIFIED"/>
+            <xs:enumeration value="TOUCHED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="timed-expiry-policy-factory">
+        <xs:attribute name="expiry-policy-type" type="expiry-policy-type" use="required"/>
+        <xs:attribute name="duration-amount" type="xs:unsignedLong" use="optional"/>
+        <xs:attribute name="time-unit" type="time-unit" use="optional"/>
+    </xs:complexType>
+
+    <xs:simpleType name="concurrency-level">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="topology-changed-strategy">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CANCEL_RUNNING_OPERATION"/>
+            <xs:enumeration value="DISCARD_AND_RESTART"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="max-size-policy">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ENTRY_COUNT"/>
+            <xs:enumeration value="USED_NATIVE_MEMORY_SIZE"/>
+            <xs:enumeration value="USED_NATIVE_MEMORY_PERCENTAGE"/>
+            <xs:enumeration value="FREE_NATIVE_MEMORY_SIZE"/>
+            <xs:enumeration value="FREE_NATIVE_MEMORY_PERCENTAGE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="eviction">
+        <xs:attribute name="size" type="xs:nonNegativeInteger" default="10000" use="optional"/>
+        <xs:attribute name="max-size-policy" type="max-size-policy" default="ENTRY_COUNT" use="optional"/>
+        <xs:attribute name="eviction-policy" type="eviction-policy" default="LRU" use="optional"/>
+        <xs:attribute name="comparator-class-name" type="xs:string" use="optional"/>
+        <xs:attribute name="comparator-bean" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="preloader">
+        <xs:attribute name="enabled" type="parameterized-boolean" default="false"/>
+        <xs:attribute name="directory" type="xs:string" default="" use="optional"/>
+        <xs:attribute name="store-initial-delay-seconds" type="xs:positiveInteger" default="600" use="optional"/>
+        <xs:attribute name="store-interval-seconds" type="xs:positiveInteger" default="600" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="wan-replication-ref">
+        <xs:all>
+            <xs:element name="filters" type="wan-replication-ref-filters" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the list of class names implementing the CacheWanEventFilter or
+                        MapWanEventFilter for filtering outbound WAN replication events.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the wan-replication configuration. IMap or ICache instance uses this wan-replication config.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="merge-policy" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Resolve conflicts that occurred when target cluster already has the replicated
+                    entry key.
+
+                    4 merge policy implementations for IMap and 2 merge policy implementations for
+                    ICache are provided out-of-the-box.
+
+                    IMap has the following merge policies:
+                    com.hazelcast.map.merge.PutIfAbsentMapMergePolicy: Incoming entry merges from the
+                    source map to the target map if it does not exist in the target map.
+                    com.hazelcast.map.merge.HigherHitsMapMergePolicy: Incoming entry merges from the
+                    source map to the target map if the source entry has more hits than the target one.
+                    com.hazelcast.map.merge.PassThroughMergePolicy: Incoming entry merges from the
+                    source map to the target map unless the incoming entry is not null.
+                    com.hazelcast.map.merge.LatestUpdateMapMergePolicy: Incoming entry merges from the
+                    source map to the target map if the source entry has been updated more recently
+                    than the target entry. Please note that this merge policy can only be used when the
+                    clusters' clocks are in sync.
+
+                    ICache has the following merge policies:
+                    com.hazelcast.cache.merge.HigherHitsCacheMergePolicy: Incoming entry merges from
+                    the source cache to the target cache if the source entry has more hits than the
+                    target one.
+                    com.hazelcast.cache.merge.PassThroughCacheMergePolicy: Incoming entry merges from
+                    the source cache to the target cache unless the incoming entry is not null.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="republishing-enabled" type="parameterized-boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    When enabled, an incoming event to a member is forwarded to the target cluster of that member.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="native-memory">
+        <xs:all>
+            <xs:element name="size" type="memory-size" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="min-block-size" use="optional" type="xs:positiveInteger"/>
+        <xs:attribute name="page-size" use="optional" type="xs:positiveInteger"/>
+        <xs:attribute name="metadata-space-percentage" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:decimal">
+                    <xs:totalDigits value="3"/>
+                    <xs:fractionDigits value="1"/>
+                    <xs:minInclusive value="5"/>
+                    <xs:maxInclusive value="95"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="allocator-type" default="POOLED" type="memory-allocator-type"/>
+        <xs:attribute name="enabled" default="true" type="parameterized-boolean"/>
+    </xs:complexType>
+    <xs:complexType name="memory-size">
+        <xs:attribute name="value" type="parameterized-non-negative-integer" default="128"/>
+        <xs:attribute name="unit" type="memory-unit" default="MEGABYTES"/>
+    </xs:complexType>
+    <xs:simpleType name="memory-unit">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="BYTES"/>
+            <xs:enumeration value="KILOBYTES"/>
+            <xs:enumeration value="MEGABYTES"/>
+            <xs:enumeration value="GIGABYTES"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="memory-allocator-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="STANDARD"/>
+            <xs:enumeration value="POOLED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="quorum">
+        <xs:all>
+            <xs:element name="quorum-size" type="quorum-size" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-type" type="quorum-type" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-function-class-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-listeners" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="quorum-listener" type="quorum-listener" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element ref="choice-of-quorum-function" minOccurs="0" maxOccurs="1" />
+        </xs:all>
+        <xs:attribute name="enabled" type="parameterized-boolean" use="required"/>
+        <xs:attribute name="name" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:element name="choice-of-quorum-function" abstract="true"/>
+
+    <xs:element name="probabilistic-quorum" substitutionGroup="choice-of-quorum-function">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation>
+                    A probabilistic quorum function based on Phi Accrual failure detector. See
+                    com.hazelcast.internal.cluster.fd.PhiAccrualClusterFailureDetector for implementation
+                    details. Configuration:<br/>
+                    - <code>acceptable-heartbeat-pause</code>: duration in milliseconds corresponding to number
+                    of potentially lost/delayed heartbeats that will be accepted before considering it to be an anomaly.
+                    This margin is important to be able to survive sudden, occasional, pauses in heartbeat arrivals,
+                    due to for example garbage collection or network drops.<br/>
+                    - <code>threshold</code>: threshold for suspicion level. A low threshold is prone to generate
+                    many wrong suspicions but ensures a quick detection in the event of a real crash. Conversely, a high
+                    threshold generates fewer mistakes but needs more time to detect actual crashes.<br/>
+                    - <code>max-sample-size</code>: number of samples to use for calculation of mean and standard
+                    deviation of inter-arrival times.<br/>
+                    - <code>first-heartbeat-estimate</code>: bootstrap the stats with heartbeats that corresponds to
+                    this duration in milliseconds, with a rather high standard deviation (since environment is unknown
+                    in the beginning)<br/>
+                    - <code>min-std-deviation</code>: minimum standard deviation (in milliseconds) to use for the normal
+                    distribution used when calculating phi. Too low standard deviation might result in too much
+                    sensitivity for sudden, but normal, deviations in heartbeat inter arrival times.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:attribute name="acceptable-heartbeat-pause-millis" type="parameterized-unsigned-int" use="optional"
+                          default="60000"/>
+            <xs:attribute name="suspicion-threshold" type="parameterized-double" use="optional" default="10" />
+            <xs:attribute name="max-sample-size" type="parameterized-unsigned-int" use="optional" default="200"/>
+            <xs:attribute name="min-std-deviation-millis" type="parameterized-unsigned-long" use="optional" default="100" />
+            <xs:attribute name="heartbeat-interval-millis" type="parameterized-unsigned-long" use="optional" default="5000"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="recently-active-quorum" substitutionGroup="choice-of-quorum-function">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation>
+                    A quorum function that keeps track of the last heartbeat timestamp per each member. For a member
+                    to be considered live (for the purpose of determining presence of quorum), a heartbeat must have
+                    been received at most <code>heartbeat-tolerance</code> milliseconds before current time.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:attribute name="heartbeat-tolerance-millis" type="parameterized-unsigned-int" default="5000"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="quorum-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="READ"/>
+            <xs:enumeration value="WRITE"/>
+            <xs:enumeration value="READ_WRITE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="quorum-size">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="2"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="quorum-listener">
+        <xs:complexContent>
+            <xs:extension base="listener">
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="wan-replication-ref-filters">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="filter-impl" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="wan-ack-type-format-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ACK_ON_RECEIPT"/>
+            <xs:enumeration value="ACK_ON_OPERATION_COMPLETE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="wan-queue-full-behavior-format-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="DISCARD_AFTER_MUTATION"/>
+            <xs:enumeration value="THROW_EXCEPTION"/>
+            <xs:enumeration value="THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="initial-publisher-state-format-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="REPLICATING"/>
+            <xs:enumeration value="PAUSED"/>
+            <xs:enumeration value="STOPPED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="consistency-check-strategy-format-enum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="MERKLE_TREES"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="wan-ack-type">
+        <xs:union memberTypes="wan-ack-type-format-enum non-space-string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="wan-queue-full-behavior">
+        <xs:union memberTypes="wan-queue-full-behavior-format-enum non-space-string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="initial-publisher-state">
+        <xs:union memberTypes="initial-publisher-state-format-enum non-space-string"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="consistency-check-strategy">
+        <xs:union memberTypes="consistency-check-strategy-format-enum non-space-string"/>
+    </xs:simpleType>
+
+    <xs:complexType name="crdt-replication">
+        <xs:attribute name="replication-period-millis" type="parameterized-unsigned-int">
+            <xs:annotation>
+                <xs:documentation>
+                    The period between two replications of CRDT states in milliseconds.
+                    A lower value will increase the speed at which changes are disseminated
+                    to other cluster members at the expense of burst-like behaviour - less
+                    updates will be batched together in one replication message and one
+                    update to a CRDT may cause a sudden burst of replication messages in a
+                    short time interval.
+                    The value must be a positive non-null integer.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="max-concurrent-replication-targets" type="parameterized-unsigned-int">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum number of target members that we replicate the CRDT states
+                    to in one period. A higher count will lead to states being disseminated
+                    more rapidly at the expense of burst-like behaviour - one update to a
+                    CRDT will lead to a sudden burst in the number of replication messages
+                    in a short time interval.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="hot-restart-persistence">
+        <xs:sequence>
+            <xs:element name="base-dir" type="xs:string" minOccurs="0" maxOccurs="1" default="hot-restart">
+                <xs:annotation>
+                    <xs:documentation>
+                        Base directory for all hot-restart data. Can be an absolute or relative path to the node startup
+                        directory.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="backup-dir" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Base directory for hot backups. Each new backup will be created in a separate directory inside this one.
+                        Can be an absolute or relative path to the node startup directory.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="parameterized-boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable hot-restart, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="validation-timeout-seconds" type="parameterized-unsigned-int">
+            <xs:annotation>
+                <xs:documentation>
+                    Validation timeout for hot-restart process, includes validating
+                    cluster members expected to join and partition table on all cluster.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="data-load-timeout-seconds" type="parameterized-unsigned-int">
+            <xs:annotation>
+                <xs:documentation>
+                    Data load timeout for hot-restart process,
+                    all members in the cluster should complete restoring their local data
+                    before this timeout.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="cluster-data-recovery-policy" default="FULL_RECOVERY_ONLY">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies the policy that will be respected during hot restart cluster start. Valid values are :
+                    FULL_RECOVERY_ONLY : Starts the cluster only when all expected nodes are present and correct.
+                    Otherwise, it fails.
+                    PARTIAL_RECOVERY_MOST_RECENT : Starts the cluster with the members which have most up-to-date
+                    partition table and successfully restored their data. All other members will leave the cluster and
+                    force-start themselves. If no member restores its data successfully, cluster start fails.
+                    PARTIAL_RECOVERY_MOST_COMPLETE : Starts the cluster with the largest group of members which have the
+                    same partition table version and successfully restored their data. All other members will leave the
+                    cluster and force-start themselves. If no member restores its data successfully, cluster start fails.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="non-space-string">
+                    <xs:enumeration value="FULL_RECOVERY_ONLY"/>
+                    <xs:enumeration value="PARTIAL_RECOVERY_MOST_RECENT"/>
+                    <xs:enumeration value="PARTIAL_RECOVERY_MOST_COMPLETE"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="hot-restart">
+        <xs:attribute name="fsync" type="parameterized-boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    True if disk write should be followed by an fsync() system call,
+                    false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="enabled" type="parameterized-boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    True if hot-restart is enabled, false otherwise
+                    Only available on Hazelcast Enterprise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="connection-strategy">
+        <xs:choice>
+            <xs:element name="connection-retry" type="connection-retry" minOccurs="0"
+                        maxOccurs="1"/>
+        </xs:choice>
+        <xs:attribute name="async-start" type="xs:boolean" default="false" use="optional"/>
+        <xs:attribute name="reconnect-mode" type="reconnect-mode" default="ON" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="connection-retry">
+        <xs:all>
+            <xs:element name="initial-backoff-millis" type="xs:int" minOccurs="0" maxOccurs="1" default="1000"/>
+            <xs:element name="max-backoff-millis" type="xs:int" minOccurs="0" maxOccurs="1" default="30000"/>
+            <xs:element name="multiplier" type="xs:double" minOccurs="0" maxOccurs="1" default="2"/>
+            <xs:element name="fail-on-max-backoff" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false"/>
+            <xs:element name="jitter" type="xs:double" minOccurs="0" maxOccurs="1" default="0.2"/>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="false" use="optional"/>
+    </xs:complexType>
+
+    <xs:simpleType name="reconnect-mode">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="OFF"/>
+            <xs:enumeration value="ON"/>
+            <xs:enumeration value="ASYNC"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:attributeGroup name="class-or-bean-name">
+        <xs:attribute name="class-name" type="non-space-string" use="optional"/>
+        <xs:attribute name="implementation" type="non-space-string" use="optional"/>
+    </xs:attributeGroup>
+</xs:schema>

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/Versions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/Versions.java
@@ -40,8 +40,13 @@ public final class Versions {
      */
     public static final Version V3_11 = Version.of(3, 11);
 
-    public static final Version PREVIOUS_CLUSTER_VERSION = V3_10;
-    public static final Version CURRENT_CLUSTER_VERSION = V3_11;
+    /**
+     * Represents cluster version 3.12
+     */
+    public static final Version V3_12 = Version.of(3, 12);
+
+    public static final Version PREVIOUS_CLUSTER_VERSION = V3_11;
+    public static final Version CURRENT_CLUSTER_VERSION = V3_12;
 
     private Versions() {
     }

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -1,0 +1,4048 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.hazelcast.com/schema/config"
+           targetNamespace="http://www.hazelcast.com/schema/config"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:element name="hazelcast">
+        <xs:complexType>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:element ref="import"/>
+                <xs:element name="config-replacers" type="config-replacers" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="group" type="cluster-group" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="license-key" type="xs:string" minOccurs="0" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            To use Hazelcast Enterprise, you need to set the license key here or programmatically.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="instance-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="management-center" type="management-center" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="wan-replication" type="wan-replication" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="network" type="network" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="partition-group" type="partition-group" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="executor-service" type="executor-service" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="durable-executor-service" type="durable-executor-service" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="scheduled-executor-service" type="scheduled-executor-service" minOccurs="0"
+                            maxOccurs="unbounded"/>
+                <xs:element name="event-journal" type="event-journal" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="merkle-tree" type="merkle-tree" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="queue" type="queue" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="map" type="map" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="multimap" type="multimap" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="replicatedmap" type="replicatedmap" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="cache" type="cache" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="list" type="list" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="set" type="set" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="topic" type="topic" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="reliable-topic" type="reliable-topic" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="jobtracker" type="jobtracker" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="semaphore" type="semaphore" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="lock" type="lock" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="ringbuffer" type="ringbuffer" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="atomic-long" type="atomic-long" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="atomic-reference" type="atomic-reference" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="count-down-latch" type="count-down-latch" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="listeners" type="listeners" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="serialization" type="serialization" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="native-memory" type="native-memory" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="services" type="services" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="security" type="security" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="member-attributes" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="quorum" type="quorum" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="lite-member" type="lite-member" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="hot-restart-persistence" type="hot-restart-persistence" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="user-code-deployment" type="user-code-deployment" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="cardinality-estimator" type="cardinality-estimator" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="flake-id-generator" type="flake-id-generator" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="crdt-replication" type="crdt-replication" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="pn-counter" type="pn-counter" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:choice>
+            <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="import">
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:restriction base="xs:anyType">
+                    <xs:attribute name="resource" type="xs:string" use="required"/>
+                </xs:restriction>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="config-replacers">
+        <xs:sequence>
+            <xs:element name="replacer" type="replacer" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="fail-if-value-missing" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Controls if missing replacement value should lead to stop the boot process.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:boolean"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="replacer">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="class-name" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="map">
+        <xs:all>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data type used to store entries.
+                        Possible values:
+                        BINARY (default): keys and values are stored as binary data.
+                        OBJECT: values are stored in their object forms.
+                        NATIVE: keys and values are stored in native memory. Only available on Hazelcast Enterprise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the map, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="optimize-queries" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        This parameter is deprecated as of Hazelcast 3.6
+                        Use cache-deserialized-values attribute instead.
+
+                        When both optimize-query and cache-deserialized-values are used at the same time
+                        Hazelcast will do its best to detect possible conflicts. Conflict detection
+                        is done on best-effort basis and you should not rely on it.
+
+                        If true, increases the speed of query processes in the map. It only works when in-memory-format
+                        is set as BINARY and performs a pre-caching on the entries queried. Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cache-deserialized-values" type="cache-deserialized-values" minOccurs="0" maxOccurs="1"
+                        default="INDEX-ONLY">
+                <xs:annotation>
+                    <xs:documentation>
+                        Control caching of de-serialized values. Caching makes query evaluation faster, but it cost memory.
+                        Possible Values:
+                        NEVER: Never cache de-serialized object
+                        INDEX-ONLY: Cache values only when they are inserted into an index.
+                        ALWAYS: Always cache de-serialized values.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of synchronous backups. For example, if 1 is set as the backup-count,
+                        then all entries of the map will be copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of asynchronous backups. For example, if 1 is set as the backup-count,
+                        then all entries of the map will be copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of seconds for each entry to stay in the map. Entries that are
+                        older than &lt;time-to-live-seconds&gt; and are not updated for &lt;time-to-live-seconds&gt;
+                        are automatically evicted from the map.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of seconds for each entry to stay idle in the map. Entries that are
+                        idle(not touched) for more than &lt;max-idle-seconds&gt; are
+                        automatically evicted from the map. The entry is touched if get, put or containsKey is called.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="eviction-policy" type="eviction-policy" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Valid values are:
+                        NONE (no eviction).
+                        LRU (Least Recently Used).
+                        LFU (Least Frequently Used).
+                        RANDOM (evict random entry).
+                        NONE is the default.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="map-eviction-policy-class-name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Internal eviction algorithm finds most appropriate entry
+                        to evict from this map by using this policy.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-size" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum size of the map.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
+                        For max-size to work, set the eviction-policy property to a value other than NONE.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:simpleContent>
+                        <xs:extension base="xs:integer">
+                            <!--policy attribute didn't converted into enumeration to support case-insensitivity-->
+                            <xs:attribute name="policy" use="optional" default="PER_NODE">
+                                <xs:annotation>
+                                    <xs:documentation>
+                                        Valid values are:
+                                        PER_NODE: Maximum number of map entries in each Hazelcast instance.
+                                        This is the default policy.
+                                        PER_PARTITION: Maximum number of map entries within each partition. Storage size
+                                        depends on the partition count in a Hazelcast instance.
+                                        This attribute should not be used often.
+                                        Avoid using this attribute with a small cluster: if the cluster is small it will
+                                        be hosting more partitions, and therefore map entries, than that of a larger
+                                        cluster. Thus, for a small cluster, eviction of the entries will decrease
+                                        performance (the number of entries is large).
+                                        USED_HEAP_SIZE: Maximum used heap size in megabytes per map for each Hazelcast instance.
+                                        USED_HEAP_PERCENTAGE: Maximum used heap size percentage per map for each Hazelcast
+                                        instance.
+                                        If, for example, JVM is configured to have 1000 MB and this value is 10, then the map
+                                        entries will be evicted when used heap size exceeds 100 MB.
+                                        FREE_HEAP_SIZE: Minimum free heap size in megabytes for each JVM.
+                                        FREE_HEAP_PERCENTAGE: Minimum free heap size percentage for each JVM.
+                                        For example, if JVM is configured to have 1000 MB and this value is 10,
+                                        then the map entries will be evicted when free heap size is below 100 MB.
+                                        USED_NATIVE_MEMORY_SIZE: Maximum used native memory size in megabytes per map
+                                        for each Hazelcast instance.
+                                        USED_NATIVE_MEMORY_PERCENTAGE: Maximum used native memory size percentage per map
+                                        for each Hazelcast instance.
+                                        FREE_NATIVE_MEMORY_SIZE: Minimum free native memory size in megabytes
+                                        for each Hazelcast instance.
+                                        FREE_NATIVE_MEMORY_PERCENTAGE: Minimum free native memory size percentage
+                                        for each Hazelcast instance.
+                                    </xs:documentation>
+                                </xs:annotation>
+                            </xs:attribute>
+                        </xs:extension>
+                    </xs:simpleContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="eviction-percentage" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        This parameter is deprecated as of version 3.7 due to the eviction mechanism change.
+                        (New eviction mechanism uses a probabilistic algorithm based on sampling. Please see documentation for
+                        further details.)
+
+                        When the map reaches maximum size, this specified percentage of the map will be evicted. Set to any
+                        integer between 0 and 100.
+                        For example, if 25 is set, 25% of the entries are evicted.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:byte">
+                        <xs:minInclusive value="0"/>
+                        <xs:maxInclusive value="100"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="min-eviction-check-millis" type="xs:unsignedLong" minOccurs="0" maxOccurs="1"
+                        default="100">
+                <xs:annotation>
+                    <xs:documentation>
+                        This parameter is deprecated as of version 3.7 due to the eviction mechanism change.
+                        (New eviction mechanism uses a probabilistic algorithm based on sampling. Please see documentation for
+                        further details.)
+
+                        Minimum time in milliseconds which should pass before checking
+                        if a partition of this map is evictable or not.
+                        Default value is 100 millis.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="read-backup-data" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if reading local backup entries is enabled, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="map-store" type="map-store" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="near-cache" type="near-cache" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="wan-replication-ref" type="wan-replication-ref" minOccurs="0"/>
+            <xs:element name="indexes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="index" type="index" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="attributes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="attribute" type="map-attribute" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="entry-listeners" type="entry-listeners" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="partition-lost-listeners" type="partition-lost-listeners" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="partition-strategy" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="query-caches" type="query-caches" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the map.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="cache-entry-listeners">
+        <xs:sequence>
+            <xs:element name="cache-entry-listener" type="cache-entry-listener" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="cache-entry-listener">
+        <xs:all>
+            <xs:element name="cache-entry-listener-factory" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cache-entry-event-filter-factory" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="old-value-required" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    If true, previously assigned values for the affected keys will be sent to this
+                    cache-entry-listener implementation. Setting this attribute to true
+                    creates additional traffic. Default value is false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="synchronous" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    If true, this cache-entry-listener implementation will be called
+                    in a synchronous manner. Default value is false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="cache">
+        <xs:all>
+            <xs:element name="key-type" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The fully qualified class name of the cache key type.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="value-type" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The fully qualified class name of the cache value type.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if statistics gathering is enabled on the cache, false (default) otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="management-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if management is enabled on the cache, false (default) otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="read-through" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if read-through caching is used, false (default) otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="write-through" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if write-through caching is used, false (default) otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cache-loader-factory" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cache loader factory class name.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cache-loader" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cache loader class name.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cache-writer-factory" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cache writer factory class name.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cache-writer" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required" type="xs:string">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The cache writer class name.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="expiry-policy-factory" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:all>
+                        <xs:annotation>
+                            <xs:documentation>
+                                Defines the expiry policy factory class name or
+                                defines the expiry policy factory from predefined ones with duration configuration.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:element name="timed-expiry-policy-factory"
+                                    type="timed-expiry-policy-factory" minOccurs="0" maxOccurs="1"/>
+                    </xs:all>
+                    <xs:attribute name="class-name"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="cache-entry-listeners" type="cache-entry-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        List of cache entry listeners.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data type used to store entries.
+                        Possible values:
+                        BINARY (default): keys and values are stored as binary data.
+                        OBJECT: values are stored in their object forms.
+                        NATIVE: keys and values are stored in native memory. Only available on Hazelcast Enterprise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of synchronous backups. For example, if `1` is set as the `backup-count`,
+                        then all entries of the cache are copied to one other instance as synchronous for fail-safety.
+                        `backup-count` + `async-backup-count` cannot be bigger than maximum backup count which is `6`.
+                        Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of asynchronous backups. For example, if `1` is set as the `async-backup-count`,
+                        then all entries of the cache are copied to one other instance as asynchronous for fail-safety.
+                        `backup-count` + `async-backup-count` cannot be bigger than maximum backup count which is `6`.
+                        Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        When maximum size is reached, cache is evicted based on the eviction policy.
+
+                        size:
+                        maximum size can be any integer between 0 and Integer.MAX_VALUE.
+
+                        Default value is 0.
+
+                        max-size-policy:
+                        max-size-policy has these valid values:
+                        ENTRY_COUNT (Maximum number of cache entries in the cache),
+                        USED_NATIVE_MEMORY_SIZE (Maximum used native memory size in megabytes per cache for each Hazelcast
+                        instance),
+                        USED_NATIVE_MEMORY_PERCENTAGE (Maximum used native memory size percentage per cache for each Hazelcast
+                        instance),
+                        FREE_NATIVE_MEMORY_SIZE (Maximum free native memory size in megabytes for each Hazelcast instance),
+                        FREE_NATIVE_MEMORY_PERCENTAGE (Maximum free native memory size percentage for each Hazelcast instance).
+
+                        Default value is "ENTRY_COUNT".
+
+                        eviction-policy:
+                        Eviction policy has these valid values:
+                        LRU (Least Recently Used),
+                        LFU (Least Frequently Used).
+
+                        Default value is "LRU".
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="wan-replication-ref" type="wan-replication-ref" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Wan replication configuration for cache.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="partition-lost-listeners" type="partition-lost-listeners" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="merge-policy" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        While recovering from split-brain (network partitioning), cache entries in the small cluster
+                        merge into the bigger cluster based on the policy set here.
+                        When an entry merges into the cluster, an entry with the same key might already exist in the cluster.
+                        The values of these entries might be different for that same key. Which value should be set for the
+                        key? The conflict is resolved by the policy set here.
+                        <p>
+                            <br/>There are built-in merge policies, such as:
+                            <br/>`com.hazelcast.cache.merge.PassThroughCacheMergePolicy` or `PASS_THROUGH`:
+                            The entry will be added directly even though there is an existing entry for the key.
+                            <br/>`com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy` or `PUT_IF_ABSENT`:
+                            The entry will be added if there is no existing entry for the key.
+                            <br/>`com.hazelcast.cache.merge.HigherHitsCacheMergePolicy` or `HIGHER_HITS`:
+                            The entry with the higher number of hits wins.
+                            <br/>`com.hazelcast.cache.merge.LatestAccessCacheMergePolicy` or `LATEST_ACCESS`:
+                            The entry which has been accessed more recently wins.
+                            <br/>Default policy is 'com.hazelcast.cache.merge.PutIfAbsentCacheMergePolicy'
+                        </p>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hot-restart" type="hot-restart" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="disable-per-entry-invalidation-events" type="xs:boolean" minOccurs="0" maxOccurs="1"
+                        default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        Disables invalidation events for per entry but full-flush invalidation events are still enabled.
+                        Full-flush invalidation event means that invalidation events for all entries on clear.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the cache.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="queue">
+        <xs:all>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the queue, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of items in the queue.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of synchronous backups. For example, if 1 is set as the backup-count,
+                        then all entries of the queue are copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of asynchronous backups. For example, if 1 is set as the backup-count,
+                        then all entries of the queue are copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="empty-queue-ttl" type="empty-queue-ttl" minOccurs="0" maxOccurs="1" default="-1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Used to purge unused or empty queues. If you define a value (time in seconds) for this element,
+                        then your queue will be destroyed if it stays empty or unused for that time.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="item-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Lets you add listeners (listener classes) for the queue items. You can also set the attribute
+                        include-value to true if you want the item event to contain the item values, and you can set
+                        local to true if you want to listen to the items on the local node.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="item-listener" type="item-listener" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element ref="queue-store" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Includes the queue store factory class name and the following properties.
+
+                        Binary: By default, Hazelcast stores the queue items in serialized form in memory.
+                        Before it inserts the queue items into datastore, it deserializes them. But if you
+                        will not reach the queue store from an external application, you might prefer that the
+                        items be inserted in binary form. You can get rid of the de-serialization step; this
+                        would be a performance optimization. The binary feature is disabled by default.
+
+                        Memory Limit: This is the number of items after which Hazelcast will store items only to
+                        datastore. For example, if the memory limit is 1000, then the 1001st item will be put
+                        only to datastore. This feature is useful when you want to avoid out-of-memory conditions.
+                        The default number for memory-limit is 1000. If you want to always use memory, you can set
+                        it to Integer.MAX_VALUE.
+
+                        Bulk Load: When the queue is initialized, items are loaded from QueueStore in bulks. Bulk
+                        load is the size of these bulks. By default, bulk-load is 250.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the queue.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="list">
+        <xs:all>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the list, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum size of the list.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of synchronous backups. For example, if 1 is set as the backup-count,
+                        then all entries of the list are copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of asynchronous backups. For example, if 1 is set as the backup-count,
+                        then all entries of the list will be copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="item-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Lets you add listeners (listener classes) for the list items. You can also set the attribute
+                        include-value to true if you want the item event to contain the item values, and you can set
+                        local to true if you want to listen to the items on the local node.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="item-listener" type="item-listener" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the list.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="set">
+        <xs:all>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the set, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum size of the set.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of synchronous backups. For example, if 1 is set as the backup-count,
+                        then all entries of the set are copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of asynchronous backups. For example, if 1 is set as the backup-count,
+                        then all entries of the set will be copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="item-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Lets you add listeners (listener classes) for the set items. You can also set the attribute
+                        include-value to true if you want the item event to contain the item values, and you can set
+                        local to true if you want to listen to the items on the local node.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="item-listener" type="item-listener" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the set.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="multimap">
+        <xs:annotation>
+            <xs:documentation>
+                Hazelcast MultiMap is a specialized map where you can store multiple values under a single key.
+                Just like any other distributed data structure implementation in Hazelcast, MultiMap is distributed
+                and thread-safe. Hazelcast MultiMap is not an implementation of java.util.Map due to the difference
+                in method signatures. It supports most features of Hazelcast Map except for indexing, predicates and
+                MapLoader/MapStore.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of synchronous backups. For example, if 1 is set as the backup-count,
+                        then all entries of the multimap are copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of asynchronous backups. For example, if 1 is set as the backup-count,
+                        then all entries of the multimap are copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the multimap, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="binary" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        By default, BINARY in-memory format is used, meaning that the object is stored
+                        in a serialized form. You can set it to false, then, the OBJECT in-memory format
+                        is used, which is useful when the OBJECT in-memory format has a smaller memory
+                        footprint than BINARY.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="value-collection-type" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Type of the value collection : SET or LIST.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="non-space-string">
+                        <xs:enumeration value="SET"/>
+                        <xs:enumeration value="LIST"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="entry-listeners" type="entry-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Lets you add listeners (listener classes) for the multimap entries. You can also set the attribute
+                        include-value to true if you want the item event to contain the entry values, and you can set
+                        local to true if you want to listen to the entries on the local node.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the multimap.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="replicatedmap">
+        <xs:annotation>
+            <xs:documentation>
+                A ReplicatedMap is a map-like data structure with weak consistency
+                and values locally stored on every node of the cluster.
+                Whenever a value is written asynchronously, the new value will be internally
+                distributed to all existing cluster members, and eventually every node will have
+                the new value.
+                When a new node joins the cluster, the new node initially will request existing
+                values from older nodes and replicate them locally.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="OBJECT">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data type used to store entries.
+                        Possible values:
+                        BINARY: keys and values are stored as binary data.
+                        OBJECT (default): values are stored in their object forms.
+                        NATIVE: keys and values are stored in native memory. Only available on Hazelcast Enterprise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="concurrency-level" type="concurrency-level" minOccurs="0" maxOccurs="1" default="32">
+                <xs:annotation>
+                    <xs:documentation>
+                        Deprecated since version 3.6, concurrency-level is ignored.
+                        Number of parallel mutexes to minimize contention on keys. The default value is 32 which
+                        is a good number for lots of applications. If higher contention is seen on writes to values
+                        inside of the replicated map this value can be adjusted to the needs.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="replication-delay-millis" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="100">
+                <xs:annotation>
+                    <xs:documentation>
+                        Deprecated since version 3.6, replication-delay-millis is ignored.
+                        Defines the number of milliseconds after a put is executed before the value is replicated
+                        to other nodes. During this time, multiple puts can be operated and cached up to be sent
+                        out all at once after the delay.
+                        Default value is 100ms before a replication is operated. If set to 0, no delay is used and
+                        all values are replicated one by one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-fillup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if the replicated map is available for reads before the initial
+                        replication is completed, false otherwise. Default is true. If false, no Exception will be
+                        thrown when the replicated map is not yet ready, but call is blocked until
+                        the initial replication is completed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the replicated map, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="entry-listeners" type="entry-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Lets you add listeners (listener classes) for the replicated map entries. You can also set the attribute
+                        include-value to true if you want the item event to contain the entry values, and you can set
+                        local to true if you want to listen to the entries on the local node.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the replicated map.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="topic">
+        <xs:all>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the topic, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="global-ordering-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1"
+                        default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        Default is `false`, meaning there is no global order guarantee.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="message-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Lets you add listeners (listener classes) for the topic messages.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="message-listener" type="listener-base" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="multi-threading-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        Default is `false`, meaning only one dedicated thread will handle topic messages.
+                        When multi-threading enabled (true) all threads from event thread pool can be used for message handling.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the topic.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="reliable-topic">
+        <xs:all>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the reliable topic, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="message-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Lets you add listeners (listener classes) for the topic messages.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="message-listener" type="listener-base" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="read-batch-size" type="xs:int" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The maximum number of items to read in a batch.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="topic-overload-policy" type="topic-overload-policy" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Policy to handle an overloaded topic. Available values are `DISCARD_OLDEST`, `DISCARD_NEWEST`,
+                        `BLOCK` and `ERROR`. The default value is `BLOCK.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the reliable topic.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="jobtracker">
+        <xs:annotation>
+            <xs:documentation>
+                The JobTracker configuration is used to setup behavior of the Hazelcast MapReduce framework.
+                Every JobTracker is capable of running multiple map reduce jobs at once and so once configuration
+                is meant as a shared resource for all jobs created by the same JobTracker.
+                The configuration gives full control over the expected load behavior and thread counts to be used.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="max-thread-size" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The maximum thread pool size of the JobTracker.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="queue-size" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The maximum size of the queue; the maximum number of tasks that can wait to be processed. A
+                        value of 0 means number of partitions * 2.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="retry-count" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        retry-count is currently not used but reserved for later use where the framework will
+                        automatically try to restart / retry operations from an available savepoint.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="chunk-size" type="xs:nonNegativeInteger" minOccurs="0" maxOccurs="1" default="1000">
+                <xs:annotation>
+                    <xs:documentation>
+                        The number of emitted values before a chunk is sent to the reducers.
+                        If your emitted values are big, you might want to change this to a lower value. If you want
+                        to better balance your work, you might want to change this to a higher value.
+                        A value of 0 means immediate transmission, but remember that low values mean higher traffic
+                        costs.
+                        A very high value might cause an OutOfMemoryError to occur if emitted values do not fit into
+                        heap memory before being sent to reducers. To prevent this, you might want to use a combiner
+                        to pre-reduce values on mapping nodes.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="communicate-stats" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True if statistics (for example, about processed entries)
+                        are transmitted to the job emitter, false otherwise. This might be used to show any kind of progress to
+                        users inside of UI systems, but this produces additional traffic. If statistics are not needed, you might
+                        want to deactivate this.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="topology-changed-strategy" type="topology-changed-strategy" minOccurs="0" maxOccurs="1"
+                        default="CANCEL_RUNNING_OPERATION">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines how the map reduce framework will react on topology
+                        changes while executing a job.
+                        Currently only CANCEL_RUNNING_OPERATION is fully supported; it throws an exception to
+                        the job emitter (throws com.hazelcast.mapreduce.TopologyChangedException).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the JobTracker. Required.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="semaphore">
+        <xs:all>
+            <xs:element name="initial-permits" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The thread count to which the concurrent access is limited. For example, if you set
+                        it to "3", concurrent access to the object is limited to 3 threads.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of synchronous backups. For example, if 1 is set as the backup-count,
+                        then all permits of the semaphore are copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of asynchronous backups. For example, if 1 is set as the backup-count,
+                        then all permits of the semaphore are copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the semaphore. Required.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="lock">
+        <xs:all>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the lock.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="ringbuffer-store">
+        <xs:all>
+            <xs:element ref="factory-or-class-name" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" default="true" type="xs:boolean"/>
+    </xs:complexType>
+    <xs:complexType name="ringbuffer">
+        <xs:all>
+            <xs:element name="capacity" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of items in the ringbuffer. If no time-to-live-seconds is set, the size will always
+                        be equal to capacity after the head completed the first loop around the ring. This is
+                        because no items are getting retired. The default value is 10000.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of seconds for each entry to stay in the ringbuffer. Entries that are
+                        older than &lt;time-to-live-seconds&gt; and are not updated for &lt;time-to-live-seconds&gt;
+                        are automatically evicted from the map.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of synchronous backups. For example, if 1 is set as the backup-count,
+                        then the items in the ringbuffer are copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of asynchronous backups. For example, if 1 is set as the backup-count,
+                        then the items in the ringbuffer are copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data type used to store entries.
+                        Possible values:
+                        BINARY (default): keys and values are stored as binary data.
+                        OBJECT: values are stored in their object forms.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ringbuffer-store" type="ringbuffer-store" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Includes the ring buffer store factory class name. The store format is the same as the
+                        in-memory-format for the ringbuffer.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the ringbuffer. Required.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="atomic-long">
+        <xs:all>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the IAtomicLong. Required.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="atomic-reference">
+        <xs:all>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the IAtomicReference. Required.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="count-down-latch">
+        <xs:all>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the CountDownLatch. Required.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="merge-policy">
+        <xs:annotation>
+            <xs:documentation>
+                While recovering from split-brain (network partitioning), data structure entries in the small cluster
+                merge into the bigger cluster based on the policy set here. When an entry merges into the cluster,
+                an entry with the same key (or value) might already exist in the cluster.
+                The merge policy resolves these conflicts with different out-of-the-box or custom strategies.
+                The out-of-the-box merge polices can be references by their simple class name.
+                For custom merge policies you have to provide a fully qualified class name.
+                <p>
+                    The out-of-the-box policies are:
+                    <br/>DiscardMergePolicy: the entry from the smaller cluster will be discarded.
+                    <br/>HigherHitsMergePolicy: the entry with the higher number of hits wins.
+                    <br/>LatestAccessMergePolicy: the entry with the latest access wins.
+                    <br/>LatestUpdateMergePolicy: the entry with the latest update wins.
+                    <br/>PassThroughMergePolicy: the entry from the smaller cluster wins.
+                    <br/>PutIfAbsentMergePolicy: the entry from the smaller cluster wins if it doesn't exist in the cluster.
+                    <br/>The default policy is: PutIfAbsentMergePolicy
+                </p>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="batch-size" default="100" type="xs:positiveInteger" use="optional"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="network">
+        <xs:all>
+            <xs:element name="public-address" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Overrides the public address of a node. By default, a node selects its socket address
+                        as its public address. But behind a network address translation (NAT), two endpoints (nodes)
+                        may not be able to see/access each other. If both nodes set their public addresses to their
+                        defined addresses on NAT, then they can communicate with each other. In this case, their
+                        public addresses are not an address of a local network interface but a virtual address defined by NAT.
+                        This is optional to set and useful when you have a private cloud.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="port" type="port" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The ports which Hazelcast will use to communicate between cluster members. Its default value is 5701.
+                        It has the following attributes.
+                        port-count: The default value is 100, meaning that Hazelcast will try to bind 100 ports.
+                        If you set the value of port as 5701, as members join the cluster, Hazelcast tries to find
+                        ports between 5701 and 5801. You can change the port count in cases like having large
+                        instances on a single machine or you are willing to have only a few ports assigned.
+                        auto-increment: Default value is true. If port is set to 5701, Hazelcast will try to find free
+                        ports between 5701 and 5801. Normally, you will not need to change this value, but it comes
+                        in handy when needed. You may also want to choose to use only one port. In that case, you can
+                        disable the auto-increment feature of port by setting its value as false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="reuse-address" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        When you shutdown a cluster member, the server socket port will be in the TIME_WAIT
+                        state for the next couple of minutes. If you start the member right after shutting it down,
+                        you may not be able to bind it to the same port because it is in the TIME_WAIT state. If you
+                        set reuse-address to true, the TIME_WAIT state is ignored and you can bind the member to the
+                        same port again. Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="outbound-ports" type="outbound-ports" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        By default, Hazelcast lets the system pick up an ephemeral port during socket bind operation.
+                        But security policies/firewalls may require to restrict outbound ports to be used by
+                        Hazelcast-enabled applications. To fulfill this requirement, you can configure Hazelcast to use
+                        only defined outbound ports.
+                        outbound-ports has the ports attribute to allow you to define outbound ports.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="join" type="join" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="interfaces" type="interfaces" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="ssl" type="ssl" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="socket-interceptor" type="socket-interceptor" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="symmetric-encryption" type="symmetric-encryption" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        encryption algorithm such as
+                        DES/ECB/PKCS5Padding,
+                        PBEWithMD5AndDES,
+                        AES/CBC/PKCS5Padding,
+                        Blowfish,
+                        DESede
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="member-address-provider" type="member-address-provider" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        IMPORTANT
+                        This configuration is not intended to provide addresses of other cluster members with
+                        which the hazelcast instance will form a cluster. This is an SPI for advanced use in
+                        cases where the DefaultAddressPicker does not pick suitable addresses to bind to
+                        and publish to other cluster members. For instance, this could allow easier
+                        deployment in some cases when running on Docker, AWS or other cloud environments.
+                        That said, if you are just starting with Hazelcast, you will probably want to
+                        set the member addresses by using the tcp-ip or multicast configuration
+                        or adding a discovery strategy.
+                        Member address provider allows to plug in own strategy to customize:
+                        1. What address Hazelcast will bind to
+                        2. What address Hazelcast will advertise to other members on which they can bind to
+
+                        In most environments you don't need to customize this and the default strategy will work just
+                        fine. However in some cloud environments the default strategy does not make the right choice and
+                        the member address provider delegates the process of address picking to external code.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="failure-detector" type="failure-detector" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="tcp-ip">
+        <xs:choice maxOccurs="unbounded">
+            <xs:element name="required-member" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        IP address of the required member. Cluster will form only if the member with this IP
+                        address is found.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:sequence>
+                <xs:element name="member" type="xs:string" minOccurs="0" maxOccurs="unbounded" default="127.0.0.1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            IP address(es) of one or more well known members. Once members are connected to these
+                            well known ones, all member addresses will be communicated with each other.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:sequence>
+            <xs:element name="interface" type="xs:string" minOccurs="0" maxOccurs="1"
+                        default="127.0.0.1"/>
+            <xs:element name="members" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Comma separated IP addresses of one or more well known members.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="member-list" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="member" type="xs:string" minOccurs="0" maxOccurs="unbounded"
+                                    default="127.0.0.1"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether the TCP/IP discovery is enabled or not. Default value is false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connection-timeout-seconds" type="xs:int" use="optional" default="5">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum amount of time Hazelcast is going to try to connect to a well known member
+                    before giving up. Setting it to a too low value could mean that a member is not able
+                    to connect to a cluster. Setting it to a too high value means that member startup could
+                    slow down because of longer timeouts (e.g. when a well known member is not up). Increasing
+                    this value is recommended if you have many IPs listed and the members cannot properly
+                    build up the cluster. Its default value is 5.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="port">
+        <xs:simpleContent>
+            <xs:extension base="xs:unsignedShort">
+                <xs:attribute name="auto-increment" type="xs:boolean" use="optional" default="true"/>
+                <xs:attribute name="port-count" type="xs:unsignedInt" use="optional" default="100"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="member-address-provider">
+        <xs:all>
+            <xs:element name="class-name" type="non-space-string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the class implementing the com.hazelcast.spi.MemberAddressProvider interface
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether the member address provider SPI is enabled or not. Values can be true or false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="outbound-ports">
+        <xs:sequence>
+            <xs:element name="ports" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="multicast">
+        <xs:all>
+            <xs:element name="multicast-group" type="xs:string" minOccurs="0" maxOccurs="1" default="224.2.2.3">
+                <xs:annotation>
+                    <xs:documentation>
+                        The multicast group IP address. Specify it when you want to create clusters within the
+                        same network. Values can be between 224.0.0.0 and 239.255.255.255. Default value is 224.2.2.3.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="multicast-port" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="54327">
+                <xs:annotation>
+                    <xs:documentation>
+                        The multicast socket port through which the Hazelcast member listens and sends discovery messages.
+                        Default value is 54327.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="multicast-timeout-seconds" type="xs:int" minOccurs="0" maxOccurs="1" default="2">
+                <xs:annotation>
+                    <xs:documentation>
+                        Only when the nodes are starting up, this timeout (in seconds) specifies the period during
+                        which a node waits for a multicast response from another node. For example, if you set it
+                        to 60 seconds, each node will wait for 60 seconds until a leader node is selected.
+                        Its default value is 2 seconds.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="multicast-time-to-live" type="xs:int" minOccurs="0" maxOccurs="1" default="32">
+                <xs:annotation>
+                    <xs:documentation>
+                        Time-to-live value for multicast packets sent out to control the scope of multicasts.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="trusted-interfaces" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Includes IP addresses of trusted members. When a node wants to join to the cluster,
+                        its join request will be rejected if it is not a trusted member. You can give an IP
+                        addresses range using the wildcard (*) on the last digit of the IP address
+                        (e.g. 192.168.1.* or 192.168.1.100-110).
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="interface" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether the multicast discovery is enabled or not. Values can be true or false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="loopbackModeEnabled" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+    <xs:complexType name="aliased-discovery-strategy">
+        <xs:sequence>
+            <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether the EC2 discovery is enabled or not. Value can be true or false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="connection-timeout-seconds" type="xs:int" use="optional" default="5">
+            <xs:annotation>
+                <xs:documentation>
+                    The maximum amount of time Hazelcast is going to try to connect to a well known member
+                    before giving up. Please check if the specific discovery strategy supports this property.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="join">
+        <xs:annotation>
+            <xs:documentation>
+                The `join` configuration element is used to enable the Hazelcast instances to form a cluster,
+                i.e. to join the members. Three ways can be used to join the members: discovery by TCP/IP, by
+                multicast, and by discovery on AWS (EC2 auto-discovery).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="multicast" type="multicast" minOccurs="0"/>
+            <xs:element name="tcp-ip" type="tcp-ip" minOccurs="0"/>
+            <xs:element name="aws" type="aliased-discovery-strategy" minOccurs="0"/>
+            <xs:element name="gcp" type="aliased-discovery-strategy" minOccurs="0"/>
+            <xs:element name="azure" type="aliased-discovery-strategy" minOccurs="0"/>
+            <xs:element name="kubernetes" type="aliased-discovery-strategy" minOccurs="0"/>
+            <xs:element name="eureka" type="aliased-discovery-strategy" minOccurs="0"/>
+            <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="discovery-strategies">
+        <xs:sequence>
+            <xs:element name="node-filter" type="discovery-node-filter" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategy" type="discovery-strategy" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="discovery-node-filter">
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="discovery-strategy">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="interfaces">
+        <xs:annotation>
+            <xs:documentation>
+                You can specify which network interfaces that Hazelcast should use. Servers mostly have more
+                than one network interface, so you may want to list the valid IPs. Range characters
+                ('\*' and '-') can be used for simplicity. For instance, 10.3.10.\* refers to IPs between
+                10.3.10.0 and 10.3.10.255. Interface 10.3.10.4-18 refers to IPs between 10.3.10.4 and
+                10.3.10.18 (4 and 18 included). If network interface configuration is enabled (it is disabled
+                by default) and if Hazelcast cannot find an matching interface, then it will print a message
+                on the console and will not start on that node.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="interface" type="xs:string" default="127.0.0.1" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable these interfaces, false to disable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="executor-service">
+        <xs:all>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the executor task, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="pool-size" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="8">
+                <xs:annotation>
+                    <xs:documentation>
+                        The number of executor threads per member for the executor.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="queue-capacity" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Queue capacity of the executor task. 0 means Integer.MAX_VALUE.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the executor task.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="durable-executor-service">
+        <xs:all>
+            <xs:element name="pool-size" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="16">
+                <xs:annotation>
+                    <xs:documentation>
+                        The number of executor threads per member for the executor.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="durability" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The durability of the executor
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="capacity" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="100">
+                <xs:annotation>
+                    <xs:documentation>
+                        Capacity of the executor task per partition.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the durable executor.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="scheduled-executor-service">
+        <xs:all>
+            <xs:element name="pool-size" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="16">
+                <xs:annotation>
+                    <xs:documentation>
+                        The number of executor threads per member for the executor.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="durability" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The durability of the scheduled executor.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="capacity" type="xs:unsignedShort" minOccurs="0" maxOccurs="1" default="100">
+                <xs:annotation>
+                    <xs:documentation>
+                        The maximum number of tasks that a scheduler can have at any given point
+                        in time per partition.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the scheduled executor.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="cardinality-estimator">
+        <xs:all>
+            <xs:element name="backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of synchronous backups. For example, if 1 is set as the backup-count,
+                        then the cardinality estimation will be copied to one other JVM for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="async-backup-count" type="backup-count" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of asynchronous backups. For example, if 1 is set as the async-backup-count,
+                        then cardinality estimation will be copied to one other JVM (asynchronously) for
+                        fail-safety. Valid numbers are 0 (no backup), 1, 2 ... 6.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="merge-policy" type="merge-policy" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        While recovering from split-brain (network partitioning), CardinalityEstimator in the small cluster
+                        merge into the bigger cluster based on the policy set here. When an estimator merges into the cluster,
+                        an estimator with the same name might already exist in the cluster.
+                        The merge policy resolves these conflicts with different out-of-the-box strategies.
+                        The out-of-the-box merge polices can be references by their simple class name.
+                        <p>
+                            The out-of-the-box policies are:
+                            <br/>DiscardMergePolicy: the estimator from the smaller cluster will be discarded.
+                            <br/>HyperLogLogMergePolicy: the estimator will merge with the existing one, using the algorithmic merge for HyperLogLog.
+                            <br/>PassThroughMergePolicy: the estimator from the smaller cluster wins.
+                            <br/>PutIfAbsentMergePolicy: the estimator from the smaller cluster wins if it doesn't exist in the cluster.
+                            <br/>The default policy is: HyperLogLogMergePolicy
+                        </p>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the cardinality estimator.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="backup-count">
+        <xs:restriction base="xs:byte">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="6"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="empty-queue-ttl">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="-1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="concurrency-level">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="crdt-replica-count">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="1"/>
+            <xs:maxInclusive value="2147483647"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="symmetric-encryption">
+        <xs:annotation>
+            <xs:documentation>
+                Enterprise only. Hazelcast allows you to encrypt the entire socket level communication among
+                all Hazelcast members. Encryption is based on Java Cryptography Architecture. In symmetric
+                encryption, each node uses the same key, so the key is shared.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="algorithm" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        Encryption algorithm such as DES/ECB/PKCS5Padding, PBEWithMD5AndDES, Blowfish,
+                        or DESede.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="salt" type="xs:string" default="thesalt">
+                <xs:annotation>
+                    <xs:documentation>
+                        Salt value to use when generating the secret key.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="password" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>
+                        Pass phrase to use when generating the secret key.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="iteration-count" type="xs:int" default="19">
+                <xs:annotation>
+                    <xs:documentation>
+                        Iteration count to use when generating the secret key.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable symmetric encryption, false to disable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="failure-detector">
+        <xs:all>
+            <xs:element name="icmp" type="icmp"/>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="icmp">
+        <xs:annotation>
+            <xs:documentation>
+                ICMP can be used in addition to the other detectors. It operates at layer 3 detects network
+                and hardware issues more quickly
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="timeout-milliseconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000">
+                <xs:annotation>
+                    <xs:documentation>Timeout in Milliseconds before declaring a failed ping</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ttl" type="xs:integer" minOccurs="0" maxOccurs="1" default="255">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of times the IP Datagram (ping) can be forwarded, in most cases
+                        all Hazelcast cluster members would be within one network switch/router therefore
+                        default of 0 is usually sufficient
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="parallel-mode" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>Run ICMP detection in parallel with the Heartbeat failure detector</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="fail-fast-on-startup" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        Cluster Member will fail to start if it is unable to action an ICMP ping command when ICMP is enabled.
+                        Failure is usually due to OS level restrictions.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-attempts" type="xs:integer" minOccurs="0" maxOccurs="1" default="2">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of consecutive failed attempts before declaring a member suspect
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="interval-milliseconds" type="xs:integer" minOccurs="0" maxOccurs="1" default="1000">
+                <xs:annotation>
+                    <xs:documentation>Time in milliseconds between each ICMP ping</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" default="false">
+            <xs:annotation>
+                <xs:documentation>Enables ICMP Pings to detect and suspect dead members</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="map-store">
+        <xs:all>
+            <xs:element ref="factory-or-class-name" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the class implementing MapLoader and/or MapStore.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="write-delay-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The number of seconds to delay the store writes. Default value is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="write-batch-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The number of operations to be included in each batch processing round. Default value is 1.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="write-coalescing" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        Setting this is meaningful if you are using write behind in MapStore. When write-coalescing is true,
+                        only the latest store operation on a key in the write-delay-seconds time-window will be
+                        reflected to MapStore. Default value is true.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" default="true" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable this map-store, false to disable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="initial-mode">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the initial load mode.
+                    LAZY: default load mode, where load is asynchronous.
+                    EAGER: load is blocked till all partitions are loaded.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="non-space-string">
+                    <xs:enumeration value="LAZY"/>
+                    <xs:enumeration value="EAGER"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="query-caches">
+        <xs:sequence>
+            <xs:element name="query-cache" type="query-cache" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="query-cache">
+        <xs:all>
+            <xs:element name="include-value" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True to enable value caching, false to disable.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="predicate" type="predicate" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The predicate to filter events which will be applied to the QueryCache.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="entry-listeners" type="entry-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Lets you add listeners (listener classes) for the query cache entries.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data type used to store entries.
+                        Possible values:
+                        BINARY (default): keys and values are stored as binary data.
+                        OBJECT: values are stored in their object forms.
+                        NATIVE: keys and values are stored in native memory. Only available on Hazelcast Enterprise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="populate" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True to enable initial population of the query cache, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="coalesce" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True to enable coalescing of the query cache, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="delay-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The minimum number of seconds that an event waits in the node buffer.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="batch-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The batch size used to determine the number of events sent
+                        in a batch to the query cache.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="buffer-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="16">
+                <xs:annotation>
+                    <xs:documentation>
+                        The maximum number of events which can be stored in a partition buffer.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="indexes" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="index" type="index" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="predicate">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="type" use="required">
+                    <xs:simpleType>
+                        <xs:restriction base="non-space-string">
+                            <xs:enumeration value="class-name"/>
+                            <xs:enumeration value="sql"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:element name="factory-or-class-name" abstract="true"/>
+    <xs:element name="class-name" substitutionGroup="factory-or-class-name"/>
+    <xs:element name="factory-class-name" substitutionGroup="factory-or-class-name"/>
+    <xs:element name="queue-store">
+        <xs:complexType>
+            <xs:all>
+                <xs:element ref="factory-or-class-name" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+            </xs:all>
+            <xs:attribute name="enabled" default="true" type="xs:boolean"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:complexType name="wan-replication">
+        <xs:sequence>
+            <xs:element name="wan-publisher" type="wan-publisher" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="wan-consumer" type="wan-consumer" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name for your WAN replication configuration.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="wan-publisher" mixed="true">
+        <xs:all>
+            <xs:element name="class-name" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Fully qualified class name of WAN Replication implementation implementing WanReplicationEndpoint.
+                        Hazelcast Enterprise comes with com.hazelcast.enterprise.wan.replication.WanBatchReplication:
+                        Waits until a batch size is reached or a delay time is passed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="queue-capacity" type="xs:integer" default="10000" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="queue-full-behavior" type="wan-queue-full-behavior" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="initial-publisher-state" type="initial-publisher-state" minOccurs="0" maxOccurs="1"
+                        default="REPLICATING">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines the initial state in which a WAN publisher is started.
+                        - REPLICATING (default):
+                        State where both enqueuing new events is allowed, enqueued events are replicated to the target cluster
+                        and WAN sync is enabled.
+                        - PAUSED:
+                        State where new events are enqueued but they are not dequeued. Some events which have been dequeued before
+                        the state was switched may still be replicated to the target cluster but further events will not be
+                        replicated. WAN sync is enabled.
+                        - STOPPED:
+                        State where neither new events are enqueued nor dequeued. As with the PAUSED state, some events might
+                        still be replicated after the publisher has switched to this state. WAN sync is enabled.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="aws" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="gcp" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="azure" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="kubernetes" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="eureka" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="wan-sync" type="wan-sync" minOccurs="0"/>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="group-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the group name used as an endpoint group name for authentication
+                    on the target endpoint.
+                    If there is no separate publisher ID property defined, this group name
+                    will also be used as a WAN publisher ID. This ID is then used for
+                    identifying the publisher in a WanReplicationConfig.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="publisher-id" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the publisher ID used for identifying the publisher in a
+                    WanReplicationConfig.
+                    If there is no publisher ID defined (it is empty), the group name will
+                    be used as a publisher ID.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="wan-sync">
+        <xs:all>
+            <xs:element name="consistency-check-strategy" type="consistency-check-strategy" minOccurs="0" default="NONE">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the strategy for checking consistency of data between source and
+                        target cluster. Any inconsistency will not be reconciled, it will be
+                        merely reported via the usual mechanisms (e.g. statistics, diagnostics).
+                        The user must initiate WAN sync to reconcile there differences. For the
+                        check procedure to work properly, the target cluster should support the
+                        chosen strategy.
+                        Default value is NONE, which means the check is disabled.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="wan-consumer">
+        <xs:annotation>
+            <xs:documentation>
+                Config for processing WAN events received from a target cluster.
+                You can configure certain behaviour when processing incoming WAN events
+                or even configure your own implementation for a WAN consumer. A custom
+                WAN consumer allows you to define custom processing logic and is usually
+                used in combination with a custom WAN publisher.
+                A custom consumer is optional and you may simply omit defining it which
+                will cause the default processing logic to be used.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="class-name" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the fully qualified class name of the class implementing
+                        a custom WAN consumer (WanReplicationConsumer).
+                        If you don't define a class name, the default processing logic for
+                        incoming WAN events will be used.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="properties" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Properties for the custom WAN consumer. These properties are
+                        accessible when initalizing the WAN consumer.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="persist-wan-replicated-data" type="xs:boolean" minOccurs="0" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        When true, an incoming event over WAN replication can be persisted to a
+                        database for example, otherwise it will not be persisted. Default value
+                        is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="ssl">
+        <xs:all>
+            <xs:element name="factory-class-name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the com.hazelcast.nio.ssl.SSLContextFactory implementation class.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" default="false" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable this ssl configuration, false to disable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="mutual-auth">
+        <xs:all>
+            <xs:element name="factory-class-name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the com.hazelcast.nio.ssl.SSLContextFactory implementation class.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" default="false" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable this mutual-auth configuration, false to disable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="item-listener">
+        <xs:simpleContent>
+            <xs:extension base="listener-base">
+                <xs:attribute name="include-value" type="xs:boolean" use="optional" default="true"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="entry-listeners">
+        <xs:sequence>
+            <xs:element name="entry-listener" type="entry-listener" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="entry-listener">
+        <xs:simpleContent>
+            <xs:extension base="item-listener">
+                <xs:attribute name="local" type="xs:boolean" use="optional" default="false"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="partition-lost-listeners">
+        <xs:sequence>
+            <xs:element name="partition-lost-listener" type="partition-lost-listener" minOccurs="0"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="partition-lost-listener">
+        <xs:simpleContent>
+            <xs:extension base="listener-base"/>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="index">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="ordered" type="xs:boolean" use="optional" default="false"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="map-attribute">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="extractor" type="xs:string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="partition-group">
+        <xs:sequence>
+            <xs:element name="member-group" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="interface" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" default="false"/>
+        <xs:attribute name="group-type">
+            <xs:annotation>
+                <xs:documentation>
+                    When you enable partition grouping, Hazelcast presents three choices for you to configure
+                    partition groups.
+                    HOST_AWARE: You can group nodes automatically using the IP addresses of nodes, so nodes
+                    sharing the same network interface will be grouped together. All members on the same host
+                    (IP address or domain name) will be a single partition group.
+                    CUSTOM: You can do custom grouping using Hazelcast's interface matching configuration.
+                    This way, you can add different and multiple interfaces to a group.
+                    PER_MEMBER: You can give every member its own group. Each member is a group of its own
+                    and primary and backup partitions are distributed randomly (not on the same physical member).
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="non-space-string">
+                    <xs:enumeration value="HOST_AWARE"/>
+                    <xs:enumeration value="CUSTOM"/>
+                    <xs:enumeration value="PER_MEMBER"/>
+                    <xs:enumeration value="ZONE_AWARE"/>
+                    <xs:enumeration value="SPI"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="management-center" mixed="true">
+        <xs:sequence minOccurs="0">
+            <xs:element name="url" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Management Center endpoint/URL.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="mutual-auth" type="mutual-auth" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="enabled" type="xs:boolean" default="false" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable management center, false to disable.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="update-interval" type="xs:integer" default="3" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The time frequency (in seconds) for which Management Center will take
+                    information from the Hazelcast cluster.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="services">
+        <xs:sequence>
+            <xs:element name="service" type="service" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="enable-defaults" type="xs:boolean" default="true"/>
+    </xs:complexType>
+    <xs:complexType name="service">
+        <xs:all>
+            <xs:element name="name" type="xs:string" minOccurs="1" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name of the service to be registered.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="class-name" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name of the class that you develop for your service.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The custom properties that you can add to your service. You enable/disable
+                        these properties and set their values using this element.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="configuration" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        You can include configuration items which you develop using the Config object
+                        in your code.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                    <xs:attribute name="parser" type="xs:string" use="required"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="true"/>
+    </xs:complexType>
+    <xs:complexType name="security">
+        <xs:all>
+            <xs:element name="member-credentials-factory" type="security-object" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="member-login-modules" type="login-modules" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="client-login-modules" type="login-modules" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="client-permission-policy" type="security-object" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="client-permissions" type="permissions" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="security-interceptors" type="interceptors" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="client-block-unmapped-actions" type="xs:boolean" default="true" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Block or allow actions, submitted as tasks in an Executor from clients and have no permission mappings.
+
+                        true: Blocks all actions that have no permission mapping
+                        false: Allows all actions that have no permission mapping
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="false"/>
+    </xs:complexType>
+    <xs:complexType name="interceptors">
+        <xs:sequence>
+            <xs:element name="interceptor" type="interceptor" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="interceptor">
+        <xs:attribute name="class-name" type="non-space-string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="login-modules">
+        <xs:sequence>
+            <xs:element name="login-module" type="login-module" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="login-module">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="class-name" type="non-space-string" use="required"/>
+        <xs:attribute name="usage" use="optional" default="REQUIRED">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="REQUIRED"/>
+                    <xs:enumeration value="OPTIONAL"/>
+                    <xs:enumeration value="REQUISITE"/>
+                    <xs:enumeration value="SUFFICIENT"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="security-object">
+        <xs:sequence>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="class-name" type="non-space-string" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="permissions">
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="all-permissions" type="base-permission" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="map-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="queue-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="multimap-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="topic-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="list-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="set-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="lock-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="atomic-long-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="countdown-latch-permission" type="instance-permission" minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element name="semaphore-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="id-generator-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="executor-service-permission" type="instance-permission" minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element name="durable-executor-service-permission" type="instance-permission" minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element name="cardinality-estimator-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="scheduled-executor-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="pn-counter-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="transaction-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="cache-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="config-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="base-permission">
+        <xs:sequence>
+            <xs:element name="endpoints" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="endpoint" minOccurs="1" maxOccurs="unbounded" default="127.0.0.1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Endpoint address of the principal. Wildcards(*) can be used.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:restriction base="xs:string"/>
+                            </xs:simpleType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="principal" type="xs:string" use="optional" default="*">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the principal. Wildcards(*) can be used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="instance-permission">
+        <xs:complexContent>
+            <xs:extension base="base-permission">
+                <xs:sequence>
+                    <xs:element name="actions" type="actions" minOccurs="1" maxOccurs="1"/>
+                </xs:sequence>
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Name of the permission. Wildcards(*) can be used.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="actions">
+        <xs:sequence>
+            <xs:element name="action" minOccurs="1" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Permission actions that are permitted on Hazelcast instance objects.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:enumeration value="all"/>
+                        <xs:enumeration value="create"/>
+                        <xs:enumeration value="destroy"/>
+                        <xs:enumeration value="modify"/>
+                        <xs:enumeration value="read"/>
+                        <xs:enumeration value="remove"/>
+                        <xs:enumeration value="lock"/>
+                        <xs:enumeration value="listen"/>
+                        <xs:enumeration value="release"/>
+                        <xs:enumeration value="acquire"/>
+                        <xs:enumeration value="put"/>
+                        <xs:enumeration value="add"/>
+                        <xs:enumeration value="index"/>
+                        <xs:enumeration value="intercept"/>
+                        <xs:enumeration value="publish"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="cluster-group">
+        <xs:all>
+            <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" default="dev">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name of the group to be created.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="password" type="xs:string" minOccurs="0" maxOccurs="1" default="dev-pass">
+                <xs:annotation>
+                    <xs:documentation>
+                        Password of the group to be created.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="listeners">
+        <xs:sequence>
+            <xs:element name="listener" type="listener-base" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="listener-base">
+        <xs:annotation>
+            <xs:documentation>
+                One of the following: membership-listener, instance-listener, migration-listener or
+                partition-lost-listener.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="non-space-string"/>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="near-cache">
+        <xs:all>
+            <xs:element name="in-memory-format" type="in-memory-format" minOccurs="0" maxOccurs="1" default="BINARY">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data type used to store entries.
+                        Possible values:
+                        BINARY (default): keys and values are stored as binary data.
+                        OBJECT: values are stored in their object forms.
+                        NATIVE: keys and values are stored in native memory. Only available on Hazelcast Enterprise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="serialize-keys" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines if the Near Cache keys should be serialized or not.
+                        Keys should be serialized if they are mutable and need to be cloned via serialization.
+                        NOTE: It's not supported to disable key serialization with in-memory-format NATIVE.
+                        This setting will have no effect in that case.
+                        Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="invalidate-on-change" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True to evict the cached entries if the entries are changed (updated or removed).
+                        Default value is true.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of seconds for each entry to stay in the Near Cache. Entries that are
+                        older than time-to-live-seconds will get automatically evicted from the Near Cache.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-idle-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of seconds each entry can stay in the Near Cache as untouched (not-read).
+                        Entries that are not read (touched) more than max-idle-seconds value will get removed
+                        from the Near Cache.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="eviction" type="eviction" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="eviction-policy" type="eviction-policy" minOccurs="0" maxOccurs="1" default="LRU">
+                <xs:annotation>
+                    <xs:documentation>
+                        Valid values are:
+                        NONE (no extra eviction, time-to-live-seconds may still apply),
+                        LRU (Least Recently Used),
+                        LFU (Least Frequently Used).
+                        LRU is the default.
+                        Regardless of the eviction policy used, time-to-live-seconds will still apply.
+
+                        Deprecated since 3.8, please use &lt;eviction/&gt;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-size" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum size of the Near Cache. When max size is reached,
+                        cache is evicted based on the policy defined.
+                        Any integer between 0 and Integer.MAX_VALUE.
+                        0 means Integer.MAX_VALUE. Default is 0.
+
+                        Deprecated since 3.8, please use &lt;eviction/&gt;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cache-local-entries" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True to cache local entries, which belong to the member itself.
+                        This is useful when in-memory-format for Near Cache is different than the map's one.
+                        Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="optional" type="xs:string" default="default"/>
+    </xs:complexType>
+
+    <xs:simpleType name="in-memory-format">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="BINARY"/>
+            <xs:enumeration value="OBJECT"/>
+            <xs:enumeration value="NATIVE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="cache-deserialized-values">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="NEVER"/>
+            <xs:enumeration value="ALWAYS"/>
+            <xs:enumeration value="INDEX-ONLY"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="time-unit">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="NANOSECONDS"/>
+            <xs:enumeration value="MICROSECONDS"/>
+            <xs:enumeration value="MILLISECONDS"/>
+            <xs:enumeration value="SECONDS"/>
+            <xs:enumeration value="MINUTES"/>
+            <xs:enumeration value="HOURS"/>
+            <xs:enumeration value="DAYS"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="expiry-policy-type">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="CREATED"/>
+            <xs:enumeration value="ACCESSED"/>
+            <xs:enumeration value="ETERNAL"/>
+            <xs:enumeration value="MODIFIED"/>
+            <xs:enumeration value="TOUCHED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="timed-expiry-policy-factory">
+        <xs:attribute name="expiry-policy-type" type="expiry-policy-type" use="required"/>
+        <xs:attribute name="duration-amount" type="xs:unsignedLong" use="optional"/>
+        <xs:attribute name="time-unit" type="time-unit" use="optional"/>
+    </xs:complexType>
+
+    <xs:simpleType name="non-space-string">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\S.*"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="serialization">
+        <xs:all>
+            <xs:element name="portable-version" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The version of the portable serialization. Portable version is used to differentiate two
+                        same classes that have changes on it like adding/removing field or changing a type of a field.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="use-native-byte-order" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True to use native byte order of the underlying platform, false otherwise. Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="byte-order" minOccurs="0" maxOccurs="1" default="BIG_ENDIAN">
+                <xs:annotation>
+                    <xs:documentation>
+                        Defines the byte order that the serialization will use.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="non-space-string">
+                        <xs:enumeration value="BIG_ENDIAN"/>
+                        <xs:enumeration value="LITTLE_ENDIAN"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="enable-compression" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True to enable compression if default Java serialization is used, false otherwise.
+                        Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="enable-shared-object" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True to enable shared object if default Java serialization is used, false otherwise.
+                        Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="allow-unsafe" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        True to allow the usage of unsafe, false otherwise.
+                        Default value is false.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="data-serializable-factories" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="data-serializable-factory" type="serialization-factory" minOccurs="0"
+                                    maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Custom classes implementing com.hazelcast.nio.serialization.DataSerializableFactory to be
+                                    registered. These can be used to speed up serialization/deserialization of objects.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="portable-factories" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="portable-factory" type="serialization-factory" minOccurs="0"
+                                    maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    PortableFactory class to be registered.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="serializers" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:choice minOccurs="1" maxOccurs="unbounded">
+                        <xs:element name="global-serializer" type="global-serializer" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Global serializer class to be registered if no other serializer is applicable.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="serializer" type="serializer" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Defines the class name and the type class of the serializer implementation.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="check-class-def-errors" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        If true (default), serialization system will check class definitions error at start and throw a
+                        Serialization Exception with error definition.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="java-serialization-filter" type="java-serialization-filter" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Basic protection against untrusted deserialization based on class/package blacklisting and whitelisting.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="serialization-factory">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="factory-id" use="required" type="xs:unsignedInt"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="serializer">
+        <xs:attribute name="class-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the class that will be serialized.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="type-class" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The type of the class that will be serialized.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="global-serializer">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="override-java-serialization" type="xs:boolean" default="false" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Java Serializable and Externalizable is prior to global serializer by default. If set true
+                            the Java serialization step assumed to be handled by the global serializer.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="java-serialization-filter">
+        <xs:all>
+            <xs:element name="blacklist" type="filter-list" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Blacklisted classes and packages, which are not allowed to be deserialized.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="whitelist" type="filter-list" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Whitelisted classes and packages, which are allowed to be deserialized. If the list is empty
+                        (no class or package name provided) then all classes are allowed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="defaults-disabled" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    Disables including default list entries (hardcoded in Hazelcast source code).
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:boolean"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="filter-list">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="class" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name of a class to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="package" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Name of a package to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="prefix" type="xs:string" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Class name prefix to be included in the list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="socket-interceptor">
+        <xs:all>
+            <xs:element name="class-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="enabled" default="false" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="native-memory">
+        <xs:all>
+            <xs:element name="size" type="memory-size" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="min-block-size" type="xs:positiveInteger" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="page-size" type="xs:positiveInteger" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="metadata-space-percentage" minOccurs="0" maxOccurs="1">
+                <xs:simpleType>
+                    <xs:restriction base="xs:decimal">
+                        <xs:totalDigits value="3"/>
+                        <xs:fractionDigits value="1"/>
+                        <xs:minInclusive value="5"/>
+                        <xs:maxInclusive value="95"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="allocator-type" default="POOLED" type="memory-allocator-type"/>
+        <xs:attribute name="enabled" default="false" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="memory-size">
+        <xs:attribute name="value" type="xs:int" default="128"/>
+        <xs:attribute name="unit" type="memory-unit" default="MEGABYTES"/>
+    </xs:complexType>
+
+    <xs:simpleType name="memory-unit">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="BYTES"/>
+            <xs:enumeration value="KILOBYTES"/>
+            <xs:enumeration value="MEGABYTES"/>
+            <xs:enumeration value="GIGABYTES"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="topic-overload-policy">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="DISCARD_OLDEST"/>
+            <xs:enumeration value="DISCARD_NEWEST"/>
+            <xs:enumeration value="BLOCK"/>
+            <xs:enumeration value="ERROR"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="memory-allocator-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="STANDARD"/>
+            <xs:enumeration value="POOLED"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="property">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required" type="non-space-string"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="properties">
+        <xs:annotation>
+            <xs:documentation>
+                A full list of available properties can be found at
+                http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#system-properties
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="property"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:element name="member-attributes">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="attribute" type="attribute" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+        <xs:unique name="uniqueAttributeConstraint">
+            <xs:selector xpath="./*"/>
+            <xs:field xpath="@name"/>
+        </xs:unique>
+    </xs:element>
+    <xs:simpleType name="attributeName">
+        <xs:restriction base="non-space-string"/>
+    </xs:simpleType>
+    <xs:simpleType name="attributeTypeEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="boolean"/>
+            <xs:enumeration value="byte"/>
+            <xs:enumeration value="double"/>
+            <xs:enumeration value="float"/>
+            <xs:enumeration value="int"/>
+            <xs:enumeration value="long"/>
+            <xs:enumeration value="short"/>
+            <xs:enumeration value="string"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:complexType name="attribute">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" use="required" type="attributeName"/>
+                <!--xs:attribute name="name" use="required" type="xs:ID"/-->
+                <xs:attribute name="type" use="optional" default="string" type="attributeTypeEnum"/>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+    <xs:complexType name="attributes">
+        <xs:sequence>
+            <xs:element name="attribute" type="attribute" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="topology-changed-strategy">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CANCEL_RUNNING_OPERATION"/>
+            <xs:enumeration value="DISCARD_AND_RESTART"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="eviction-policy">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="LRU"/>
+            <xs:enumeration value="LFU"/>
+            <xs:enumeration value="RANDOM"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="max-size-policy">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="ENTRY_COUNT"/>
+            <xs:enumeration value="USED_NATIVE_MEMORY_SIZE"/>
+            <xs:enumeration value="USED_NATIVE_MEMORY_PERCENTAGE"/>
+            <xs:enumeration value="FREE_NATIVE_MEMORY_SIZE"/>
+            <xs:enumeration value="FREE_NATIVE_MEMORY_PERCENTAGE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="eviction">
+        <xs:attribute name="size" type="xs:nonNegativeInteger" default="10000" use="optional"/>
+        <xs:attribute name="max-size-policy" type="max-size-policy" default="ENTRY_COUNT" use="optional"/>
+        <xs:attribute name="eviction-policy" type="eviction-policy" default="LRU" use="optional"/>
+        <xs:attribute name="comparator-class-name" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="wan-replication-ref">
+        <xs:all>
+            <xs:element name="merge-policy" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Resolve conflicts that occurred when target cluster already has the replicated
+                        entry key.
+
+                        4 merge policy implementations for IMap and 2 merge policy implementations for
+                        ICache are provided out-of-the-box.
+
+                        IMap has the following merge policies:
+                        com.hazelcast.map.merge.PutIfAbsentMapMergePolicy: Incoming entry merges from the
+                        source map to the target map if it does not exist in the target map.
+                        com.hazelcast.map.merge.HigherHitsMapMergePolicy: Incoming entry merges from the
+                        source map to the target map if the source entry has more hits than the target one.
+                        com.hazelcast.map.merge.PassThroughMergePolicy: Incoming entry merges from the
+                        source map to the target map unless the incoming entry is not null.
+                        com.hazelcast.map.merge.LatestUpdateMapMergePolicy: Incoming entry merges from the
+                        source map to the target map if the source entry has been updated more recently
+                        than the target entry. Please note that this merge policy can only be used when the
+                        clusters' clocks are in sync.
+
+                        ICache has the following merge policies:
+                        com.hazelcast.cache.merge.HigherHitsCacheMergePolicy: Incoming entry merges from
+                        the source cache to the target cache if the source entry has more hits than the
+                        target one.
+                        com.hazelcast.cache.merge.PassThroughCacheMergePolicy: Incoming entry merges from
+                        the source cache to the target cache unless the incoming entry is not null.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="filters" type="wan-replication-ref-filters" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the list of class names implementing the CacheWanEventFilter or
+                        MapWanEventFilter for filtering outbound WAN replication events.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="republishing-enabled" type="xs:boolean" minOccurs="0" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        When enabled, an incoming event to a member is forwarded to the target cluster of that member.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the wan-replication configuration. IMap or ICache instance uses this wan-replication config.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="quorum">
+        <xs:all>
+            <xs:element name="quorum-size" type="quorum-size" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The minimum number of members required in a cluster for the cluster to remain in an
+                        operational state. If the number of members is below the defined minimum at any time,
+                        the operations are rejected and the rejected operations throw a QuorumException to
+                        their callers.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-type" type="quorum-type" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-function-class-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="quorum-listeners" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        You can register quorum listeners to be notified about quorum results. Quorum listeners
+                        are local to the member that they are registered, so they receive only events occurred on
+                        that local member.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="quorum-listener" type="quorum-listener" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element ref="choice-of-quorum-function" minOccurs="0" maxOccurs="1" />
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+        <xs:attribute name="name" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:element name="choice-of-quorum-function" abstract="true"/>
+
+    <xs:element name="member-count-quorum" substitutionGroup="choice-of-quorum-function">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation>
+                    Determines quorum based on the number of currently live cluster members.
+                    The minimum number of members required in a cluster for the cluster to remain in an
+                    operational state is configured separately in <code>&lt;quorum-size&gt;</code> element.
+                    If the number of members is below the defined minimum at any time,
+                    the operations are rejected and the rejected operations throw a QuorumException to
+                    their callers.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="probabilistic-quorum" substitutionGroup="choice-of-quorum-function">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation>
+                    A probabilistic quorum function based on Phi Accrual failure detector. See
+                    com.hazelcast.internal.cluster.fd.PhiAccrualClusterFailureDetector for implementation
+                    details. Configuration:<br/>
+                    - <code>acceptable-heartbeat-pause-millis</code>: duration in milliseconds corresponding to number
+                    of potentially lost/delayed heartbeats that will be accepted before considering it to be an anomaly.
+                    This margin is important to be able to survive sudden, occasional, pauses in heartbeat arrivals,
+                    due to for example garbage collection or network drops.<br/>
+                    - <code>suspicion-threshold</code>: threshold for suspicion level. A low threshold is prone to generate
+                    many wrong suspicions but ensures a quick detection in the event of a real crash. Conversely, a high
+                    threshold generates fewer mistakes but needs more time to detect actual crashes.<br/>
+                    - <code>max-sample-size</code>: number of samples to use for calculation of mean and standard
+                    deviation of inter-arrival times.<br/>
+                    - <code>heartbeat-interval-millis</code>: bootstrap the stats with heartbeats that corresponds to
+                    this duration in milliseconds, with a rather high standard deviation (since environment is unknown
+                    in the beginning)<br/>
+                    - <code>min-std-deviation-millis</code>: minimum standard deviation (in milliseconds) to use for the normal
+                    distribution used when calculating phi. Too low standard deviation might result in too much
+                    sensitivity for sudden, but normal, deviations in heartbeat inter arrival times.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:attribute name="acceptable-heartbeat-pause-millis" type="xs:unsignedLong" use="optional" default="60000"/>
+            <xs:attribute name="suspicion-threshold" type="xs:double" use="optional" default="10" />
+            <xs:attribute name="max-sample-size" type="xs:unsignedInt" use="optional" default="200"/>
+            <xs:attribute name="min-std-deviation-millis" type="xs:unsignedLong" use="optional" default="100" />
+            <xs:attribute name="heartbeat-interval-millis" type="xs:unsignedLong" use="optional" default="5000"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="recently-active-quorum" substitutionGroup="choice-of-quorum-function">
+        <xs:complexType>
+            <xs:annotation>
+                <xs:documentation>
+                    A quorum function that keeps track of the last heartbeat timestamp per each member. For a member
+                    to be considered live (for the purpose of determining presence of quorum), a heartbeat must have
+                    been received at most <code>heartbeat-tolerance</code> milliseconds before current time.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:attribute name="heartbeat-tolerance-millis" type="xs:unsignedInt" default="5000"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:simpleType name="quorum-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="READ"/>
+            <xs:enumeration value="WRITE"/>
+            <xs:enumeration value="READ_WRITE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="quorum-size">
+        <xs:restriction base="xs:int">
+            <xs:minInclusive value="0"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="quorum-listener">
+        <xs:simpleContent>
+            <xs:extension base="listener-base">
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
+    <xs:complexType name="lite-member">
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    True to set the node as a lite member, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="user-code-deployment">
+        <xs:all>
+            <xs:element name="class-cache-mode" default="ETERNAL">
+                <xs:annotation>
+                    <xs:documentation>
+                        Controls caching of user classes loaded from remote members.
+
+                        OFF: Never caches loaded classes. This is suitable for loading runnables, callables,
+                        entry processors, etc.
+                        ETERNAL: Cache indefinitely. This is suitable when you load long-living objects,
+                        such as domain objects stored in a map.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="non-space-string">
+                        <xs:enumeration value="OFF"/>
+                        <xs:enumeration value="ETERNAL"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="provider-mode" default="LOCAL_AND_CACHED_CLASSES">
+                <xs:annotation>
+                    <xs:documentation>
+                        Controls how to react on receiving a classloading request from a remote member
+
+                        OFF: Never serve classes to other members. This member will never server classes to remote
+                        members.
+                        LOCAL_CLASSES_ONLY: Serve classes from local classpath only. Classes loaded from other members
+                        will be used locally, but they won't be served to other members.
+                        LOCAL_AND_CACHED_CLASSES: Server classes loaded from both local classpath and from other members.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="non-space-string">
+                        <xs:enumeration value="OFF"/>
+                        <xs:enumeration value="LOCAL_CLASSES_ONLY"/>
+                        <xs:enumeration value="LOCAL_AND_CACHED_CLASSES"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+            <xs:element name="blacklist-prefixes" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Filter to constraint members to be used for classloading request when a class
+                        is not available locally.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="whitelist-prefixes" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Command separated list of prefixes of classes which will be loaded remotely.
+
+                        Use this to enable loading of explicitly selected user classes only and
+                        disable remote loading for all other classes. This gives you a fine-grained control
+                        over classloading.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="provider-filter" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Filter to constraint members to be used for classloading request when a class
+                        is not available locally.
+
+                        Filter format: HAS_ATTRIBUTE:foo this will send classloading requests
+                        only to members which has a member attribute foo set. Value is ignored,
+                        it can be any type. A present of the attribute is sufficient.
+
+                        This facility allows to have a control on classloading. You can e.g. start Hazelcast lite
+                        members dedicated for class-serving.
+
+                        Setting the filter to null will allow to load classes from all members.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable User Code Deployment on this member, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="hot-restart-persistence">
+        <xs:all>
+            <xs:element name="base-dir" type="xs:string" minOccurs="0" maxOccurs="1" default="hot-restart">
+                <xs:annotation>
+                    <xs:documentation>
+                        Base directory for all hot-restart data. Can be an absolute or relative path to the node startup
+                        directory.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="backup-dir" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Base directory for hot backups. Each new backup will be created in a separate directory inside this one.
+                        Can be an absolute or relative path to the node startup directory.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="parallelism" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Level of parallelism in Hot Restart Persistence. There will be this many IO threads,
+                        each writing in parallel to its own files. During the Hot Restart procedure, this many
+                        IO threads will be reading the files and this many Rebuilder threads will be rebuilding
+                        the HR metadata.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="validation-timeout-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Validation timeout for the Hot Restart procedure. Includes the time to validate
+                        cluster members expected to join and partition table of the whole cluster.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="data-load-timeout-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Data load timeout for Hot Restart procedure. All members in the cluster should
+                        complete restoring their local data before this timeout.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cluster-data-recovery-policy" type="xs:string" minOccurs="0" maxOccurs="1"
+                        default="FULL_RECOVERY_ONLY">
+                <xs:annotation>
+                    <xs:documentation>
+                        Specifies the policy that will be respected during hot restart cluster start. Valid values are :
+                        FULL_RECOVERY_ONLY : Starts the cluster only when all expected nodes are present and correct.
+                        Otherwise, it fails.
+                        PARTIAL_RECOVERY_MOST_RECENT : Starts the cluster with the members which have most up-to-date
+                        partition table and successfully restored their data. All other members will leave the cluster and
+                        force-start themselves. If no member restores its data successfully, cluster start fails.
+                        PARTIAL_RECOVERY_MOST_COMPLETE : Starts the cluster with the largest group of members which have the
+                        same partition table version and successfully restored their data. All other members will leave the
+                        cluster and force-start themselves. If no member restores its data successfully, cluster start fails.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    True to enable Hot Restart Persistence, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="crdt-replication">
+        <xs:all>
+            <xs:element name="replication-period-millis" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The period between two replications of CRDT states in milliseconds.
+                        A lower value will increase the speed at which changes are disseminated
+                        to other cluster members at the expense of burst-like behaviour - less
+                        updates will be batched together in one replication message and one
+                        update to a CRDT may cause a sudden burst of replication messages in a
+                        short time interval.
+                        The value must be a positive non-null integer.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="max-concurrent-replication-targets" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The maximum number of target members that we replicate the CRDT states
+                        to in one period. A higher count will lead to states being disseminated
+                        more rapidly at the expense of burst-like behaviour - one update to a
+                        CRDT will lead to a sudden burst in the number of replication messages
+                        in a short time interval.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="hot-restart">
+        <xs:all>
+            <xs:element name="fsync" type="xs:boolean" default="false">
+                <xs:annotation>
+                    <xs:documentation>
+                        If set to true, when each update operation on this structure completes,
+                        it is guaranteed that it has already been persisted.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+
+        <xs:attribute name="enabled" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    True if Hot Restart Persistence is enabled, false otherwise. Only available on Hazelcast Enterprise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="event-journal">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration for an event journal. The event journal keeps events related
+                to a specific partition and data structure. For instance, it could keep
+                map or cache add, update, remove, merge events along with the key, old value,
+                new value and so on.
+                This configuration is not tied to a specific data structure and can be reused.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="mapName" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the map to which this config applies.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="cacheName" type="xs:string" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the cache to which this config applies.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="capacity" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The capacity of the event journal. The capacity is the total number of items that the event journal
+                        can hold at any moment. The actual number of items contained in the journal can be lower.
+                        Its default value is 10000. The capacity is shared equally between all partitions.
+                        This is done by assigning each partition {@code getCapacity() / partitionCount}
+                        available slots in the event journal. Because of this, the effective total
+                        capacity may be somewhat lower and you must take into account that the
+                        configured capacity is at least greater than the partition count.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="time-to-live-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Maximum number of seconds for each entry to stay in the event journal.
+                        Entries that are older than &lt;time-to-live-seconds&gt; are evicted from the journal.
+                        Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    True if the event journal is enabled, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="merkle-tree">
+        <xs:annotation>
+            <xs:documentation>
+                Configuration for a merkle tree.
+                The merkle tree is a data structure used for efficient comparison of the
+                difference in the contents of large data structures. The precision of
+                such a comparison mechanism is defined by the depth of the merkle tree.
+                A larger depth means that a data synchronization mechanism will be able
+                to pinpoint a smaller subset of the data structure contents in which a
+                change occurred. This causes the synchronization mechanism to be more
+                efficient. On the other hand, a larger tree depth means the merkle tree
+                will consume more memory.
+                A smaller depth means the data synchronization mechanism will have to
+                transfer larger chunks of the data structure in which a possible change
+                happened. On the other hand, a shallower tree consumes less memory.
+                The depth must be between 2 and 27 (exclusive).
+                As the comparison mechanism is iterative, a larger depth will also prolong
+                the duration of the comparison mechanism. Care must be taken to not have
+                large tree depths if the latency of the comparison operation is high.
+                The default depth is 10.
+                This configuration is not tied to a specific data structure and can be
+                reused.
+                See https://en.wikipedia.org/wiki/Merkle_tree.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="mapName" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the map to which this config applies.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="depth" type="xs:unsignedInt" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        The depth of the merkle tree.
+                        A larger depth means that a data synchronization mechanism will be able
+                        to pinpoint a smaller subset of the data structure contents in which a
+                        change occurred. This causes the synchronization mechanism to be more
+                        efficient. On the other hand, a larger tree depth means the merkle tree
+                        will consume more memory.
+                        A smaller depth means the data synchronization mechanism will have to
+                        transfer larger chunks of the data structure in which a possible change
+                        happened. On the other hand, a shallower tree consumes less memory.
+                        The depth must be between 2 and 27 (exclusive). The default depth is 10.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="enabled" type="xs:boolean" default="true">
+            <xs:annotation>
+                <xs:documentation>
+                    True if the merkle tree is enabled, false otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="wan-replication-ref-filters">
+        <xs:sequence>
+            <xs:element name="filter-impl" type="xs:string" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="wan-ack-type">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="ACK_ON_RECEIPT"/>
+            <xs:enumeration value="ACK_ON_OPERATION_COMPLETE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="wan-queue-full-behavior">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="DISCARD_AFTER_MUTATION"/>
+            <xs:enumeration value="THROW_EXCEPTION"/>
+            <xs:enumeration value="THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="flake-id-generator">
+        <xs:all>
+            <xs:element name="prefetch-count" minOccurs="0" default="100">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets how many IDs are pre-fetched on the background when one call to
+                        FlakeIdGenerator.newId() is made. Value must be in the range 1..100,000, default
+                        is 100.
+
+                        This setting pertains only to newId() calls made on the member that configured it.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:int">
+                        <xs:minInclusive value="1" />
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:element>
+
+            <xs:element name="prefetch-validity-millis" type="xs:long" minOccurs="0" default="600000">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets for how long the pre-fetched IDs can be used. If this time elapses, a new batch of IDs
+                        will be fetched. Time unit is milliseconds, default is 600,000 (10 minutes).
+
+                        The IDs contain timestamp component, which ensures rough global ordering of IDs. If an
+                        ID is assigned to an object that was created much later, it will be much out of order. If you
+                        don't care about ordering, set this value to 0.
+
+                        This setting pertains only to newId() calls made on the member that configured it.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+
+            <xs:element name="id-offset" type="xs:long" minOccurs="0" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the offset that will be added to the returned IDs. Default value is 0. Setting might be
+                        useful when migrating from IdGenerator, default value works for all green-field projects.
+
+                        For example: Largest ID returned from IdGenerator is 150. FlakeIdGenerator now returns
+                        100. If you configure idOffset of 50 and stop using the IdGenerator, the next ID from
+                        FlakeIdGenerator will be 151 or larger and no duplicate IDs will be generated. In real-life,
+                        the IDs are much larger. You also need to add a reserve to the offset because the IDs
+                        from FlakeIdGenerator are only roughly ordered. Recommended reserve is 2^38, that is
+                        274877906944.
+
+                        Negative values are allowed to increase the lifespan of the generator, however keep in
+                        mind that the generated IDs might also be negative.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+
+            <xs:element name="node-id-offset" type="xs:long" minOccurs="0" default="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Sets the offset that will be added to the node ID assigned to cluster member for this generator.
+                        Might be useful in A/B deployment scenarios where you have cluster A which you want to upgrade.
+                        You create cluster B and for some time both will generate IDs and you want to have them unique.
+                        In this case, configure node ID offset for generators on cluster B.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+
+
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the Flake ID Generator, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the ID generator.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="pn-counter">
+        <xs:all>
+            <xs:element name="replica-count" type="crdt-replica-count" minOccurs="0" maxOccurs="1" default="2147483647">
+                <xs:annotation>
+                    <xs:documentation>
+                        Number of replicas on which the CRDT state will be kept. The updates are replicated
+                        asynchronously between replicas.
+                        The number must be greater than 1 and up to 2147483647 (Integer.MAX_VALUE).
+                        The default value is 2147483647 (Integer.MAX_VALUE).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="quorum-ref" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        Adds the Split Brain Protection for this data-structure which you configure using the quorum element.
+                        You should set the quorum-ref's value as the quorum's name.
+                        IMPORTANT: The term "quorum" simply refers to the count of members in the cluster required for an operation to succeed.
+                        It does NOT refer to an implementation of Paxos or Raft protocols as used in many NoSQL and distributed systems.
+                        The mechanism it provides in Hazelcast protects the user in case the number of nodes in a cluster drops below the
+                        specified one.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="statistics-enabled" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true">
+                <xs:annotation>
+                    <xs:documentation>
+                        True (default) if statistics gathering is enabled on the PN counter, false otherwise.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="optional" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    Name of the PN counter.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:simpleType name="initial-publisher-state">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="REPLICATING"/>
+            <xs:enumeration value="PAUSED"/>
+            <xs:enumeration value="STOPPED"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="consistency-check-strategy">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="MERKLE_TREES"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
The 3.12 XSDs should have been created by the release scripts along with the version bump (eg see https://github.com/hazelcast/hazelcast/commit/b97fff122712eeb1a26137063f00a9c2c1439850) however they are not yet present in the repository -> all tests that rely on parsing XML configuration currently fail.