### PR TITLE
[DO NOT MERGE] WIP: Performance monitor for junit tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -123,7 +123,7 @@ public class BasicMapTest extends HazelcastTestSupport {
             thread.start();
         }
 
-        sleepAtLeastSeconds(30);
+        sleepAtLeastSeconds(90);
 
         stopRequested.set(true);
         workersFinishedLatch.await();

--- a/hazelcast/src/test/java/com/hazelcast/test/PerformanceMonitor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/PerformanceMonitor.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+import org.HdrHistogram.Histogram;
+import org.HdrHistogram.Recorder;
+
+import java.io.Closeable;
+
+import static com.hazelcast.util.Preconditions.checkHasText;
+
+/**
+ * Utility to monitor performance in tests.
+ *
+ * This is not meant to replace proper benchmarking, but to provide a quick feedback
+ * while changing parts of Hazelcast. It can also be used to check a test is making any progress at all.
+ *
+ * Internally it uses a histogram and it can provide both throughput and latency numbers.
+ *
+ * The monitor has to be explicitly closed otherwise it will leave a dangling thread.
+ *
+ * The monitor is thread-safe in a sense multiple threads can use a single instance of the monitor to record
+ * performance data. However only a single (arbitrary) thread can close the monitor.
+ *
+ * Possible improvement: Introduce a concept of warm-up.
+ *
+ */
+public final class PerformanceMonitor implements Closeable {
+    private final static long MONITORING_DISABLED = -1;
+
+    private final Thread monitoringThread;
+    private final Histogram deltaHistogram = new Histogram(5);
+    private final Histogram totalHistogram = new Histogram(5);
+    private final String name;
+    private final long monitoringIntervalMillis;
+
+    private Recorder recorder = new Recorder(5);
+    private ThreadLocal<Long> lastIteration = new ThreadLocal<Long>();
+
+    private volatile boolean stopRequested;
+
+    /**
+     * Create a new performance monitor.
+     *
+     * @param monitorName name of the monitor. The name is used a prefix when dumping data.
+     * @param monitoringIntervalMillis how often to dump performance data. It can be -1 to disable it.
+     */
+    public PerformanceMonitor(String monitorName, long monitoringIntervalMillis) {
+        checkHasText(monitorName, "missing monitor name");
+        if (monitoringIntervalMillis <= 0) {
+            if (monitoringIntervalMillis != MONITORING_DISABLED) {
+                throw new IllegalArgumentException("Monitoring interval must be either a positive integer or "
+                        + MONITORING_DISABLED + " to disable monitoring altogether");
+            }
+        }
+
+        this.name = monitorName;
+        this.monitoringIntervalMillis = monitoringIntervalMillis;
+        monitoringThread = new MonitoringThread();
+        if (monitoringIntervalMillis > 0) {
+            monitoringThread.start();
+        }
+    }
+
+    /**
+     * Indicate an iteration finished. Latency is automatically calculated as an elapsed time between 2 subsequent
+     * calls made by the same thread. This is the simplest way to use the performance monitor, it's well suitable
+     * for testing blocking calls.
+     *
+     */
+    public void iterationFinished() {
+        long now = System.nanoTime();
+        Long lastIterationSnapshot = lastIteration.get();
+        lastIteration.set(now);
+        if (lastIterationSnapshot == null) {
+            return;
+        }
+
+        long deltaNanos = now - lastIterationSnapshot;
+        recorder.recordValue(deltaNanos);
+    }
+
+    /**
+     * Record externally measured latency. This is an alternative to {@link #iterationFinished()}, it's a bit more
+     * complicated to use - as the user code is responsible for measuring latency - but it's more flexible.
+     *
+     * The most common use-case: measuring performance of async calls.
+     *
+     * @param latencyNanos latency in nanos to be recorded.
+     */
+    public void recordLatency(long latencyNanos) {
+        recorder.recordValue(latencyNanos);
+    }
+
+    /**
+     * Close the monitor and stop monitoring thread.
+     *
+     */
+    @Override
+    public void close() {
+        if (monitoringIntervalMillis == MONITORING_DISABLED) {
+            return;
+        }
+        if (stopRequested) {
+            return;
+        }
+        stopRequested = true;
+        monitoringThread.interrupt();
+        try {
+            monitoringThread.join();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for monitoring thread to finish");
+        }
+    }
+
+    /**
+     * Close the monitor, stop the monitoring thread and return a histogram with all recorded values.
+     *
+     * @return histogram will all recorded values
+     */
+    public Histogram closeAndGetHistogram() {
+        close();
+        updateHistograms();
+        return totalHistogram;
+    }
+
+    private class MonitoringThread extends Thread {
+        @Override
+        public void run() {
+            final long startedTimestamp = System.nanoTime();
+            long lastTimestamp = startedTimestamp;
+            while (!stopRequested) {
+                waitForNextInterval();
+                long now = System.nanoTime();
+                long totalElapsedNanos = now - startedTimestamp;
+                long deltaElapsedNanos = now - lastTimestamp;
+                lastTimestamp = now;
+                updateHistograms();
+                printHistograms(totalElapsedNanos, deltaElapsedNanos);
+            }
+        }
+
+        private void waitForNextInterval() {
+            try {
+                Thread.sleep(monitoringIntervalMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void printHistograms(double totalElapsedNanos, double deltaElapsedNanos) {
+        long totalCount = totalHistogram.getTotalCount();
+        long deltaCount = deltaHistogram.getTotalCount();
+        double totalThroughput = ((double)totalCount) / (totalElapsedNanos / 1000000000);
+        double deltaThroughput = ((double)deltaCount) / (deltaElapsedNanos / 1000000000);
+
+        System.out.printf(name + ": Total throughput: %10.1f ops/s, Delta throughput: %10.1f ops/s, "
+                + "Total count: %8s ops, Delta count: %8s ops %n",
+                totalThroughput, deltaThroughput, totalCount, deltaCount);
+    }
+
+    private void updateHistograms() {
+        recorder.getIntervalHistogramInto(deltaHistogram);
+        totalHistogram.add(deltaHistogram);
+    }
+}


### PR DESCRIPTION
Example usage:
```java
    @Test
    public void testPerformance() throws InterruptedException {
        String mapName = randomMapName();
        int threadCount = 2;
        final IMap<Integer, Long> map = getInstance().getMap(mapName);
        final PerformanceMonitor performanceMonitor = new PerformanceMonitor("put", 5000);

        final AtomicBoolean stopRequested = new AtomicBoolean();
        final CountDownLatch workersFinishedLatch = new CountDownLatch(threadCount);
        for (int i = 0; i < threadCount; i++) {
            Thread thread = new Thread() {
                @Override
                public void run() {
                    for (long i = 0; !stopRequested.get(); i++) {
                        int key = (int) (i % 10000);
                        map.put(key, i);
                        performanceMonitor.iterationFinished();
                    }
                    workersFinishedLatch.countDown();
                }
            };
            thread.start();
        }
        
        sleepAtLeastSeconds(30);

        stopRequested.set(true);
        workersFinishedLatch.await();

        Histogram histogram = performanceMonitor.closeAndGetHistogram();
        histogram.outputPercentileDistribution(System.out, 1000.0);
    }
```

Example output:
```
put: Total throughput:     6480.9 ops/s, Delta throughput:     6480.9 ops/s, Total count:    32405 ops, Delta count:    32405 ops 
put: Total throughput:    10556.4 ops/s, Delta throughput:    14575.2 ops/s, Total count:   106308 ops, Delta count:    73903 ops 
put: Total throughput:    12251.8 ops/s, Delta throughput:    15643.2 ops/s, Total count:   185063 ops, Delta count:    78755 ops 
put: Total throughput:    13010.4 ops/s, Delta throughput:    15287.6 ops/s, Total count:   261985 ops, Delta count:    76922 ops 
put: Total throughput:    13511.3 ops/s, Delta throughput:    15515.5 ops/s, Total count:   340083 ops, Delta count:    78098 ops 
put: Total throughput:    13841.7 ops/s, Delta throughput:    15562.8 ops/s, Total count:   415256 ops, Delta count:    75173 ops 
```

It can also return a full histogram:
```
   Value     Percentile TotalCount 1/(1-Percentile)

    42.80900 0.000000000000          1           1.00
    51.23500 0.100000000000      41588           1.11
    52.95500 0.200000000000      83161           1.25
    54.45100 0.300000000000     124743           1.43
    56.04700 0.400000000000     166311           1.67
    58.25400 0.500000000000     207883           2.00
    60.16300 0.550000000000     228665           2.22
    64.51700 0.600000000000     249462           2.50
    71.46400 0.650000000000     270241           2.86
    74.21600 0.700000000000     291028           3.33
    76.28400 0.750000000000     311820           4.00
    77.27100 0.775000000000     322209           4.44
    78.27100 0.800000000000     332603           5.00
    79.33900 0.825000000000     342997           5.71
    80.54300 0.850000000000     353396           6.67
    81.98500 0.875000000000     363787           8.00
    82.85200 0.887500000000     368983           8.89
    83.92000 0.900000000000     374182          10.00
    85.33100 0.912500000000     379374          11.43
    87.35300 0.925000000000     384571          13.33
    90.60900 0.937500000000     389769          16.00
    93.29000 0.943750000000     392367          17.78
    97.35500 0.950000000000     394966          20.00
   103.84200 0.956250000000     397564          22.86
   116.26300 0.962500000000     400162          26.67
   140.24200 0.968750000000     402760          32.00
   154.78600 0.971875000000     404059          35.56
   168.79700 0.975000000000     405359          40.00
   182.05300 0.978125000000     406658          45.71
   197.77600 0.981250000000     407957          53.33
   215.15900 0.984375000000     409256          64.00
   223.88100 0.985937500000     409906          71.11
   233.34900 0.987500000000     410556          80.00
   244.69300 0.989062500000     411205          91.43
   259.51200 0.990625000000     411855         106.67
   278.55100 0.992187500000     412504         128.00
   293.01100 0.992968750000     412829         142.22
   312.44500 0.993750000000     413154         160.00
   341.64700 0.994531250000     413479         182.86
   382.64500 0.995312500000     413804         213.33
   431.50700 0.996093750000     414128         256.00
   462.85900 0.996484375000     414291         284.44
   495.85900 0.996875000000     414453         320.00
   523.56900 0.997265625000     414616         365.71
   562.11500 0.997656250000     414778         426.67
   611.79900 0.998046875000     414940         512.00
   637.79100 0.998242187500     415022         568.89
   668.99100 0.998437500000     415103         640.00
   702.39100 0.998632812500     415184         731.43
   747.85900 0.998828125000     415265         853.33
   801.39500 0.999023437500     415346        1024.00
   828.01100 0.999121093750     415387        1137.78
   879.14300 0.999218750000     415428        1280.00
   925.01100 0.999316406250     415468        1462.86
   976.55500 0.999414062500     415509        1706.67
  1053.27100 0.999511718750     415549        2048.00
  1110.38300 0.999560546875     415570        2275.56
  1214.67100 0.999609375000     415590        2560.00
  1381.55900 0.999658203125     415610        2925.71
  1736.13500 0.999707031250     415631        3413.33
  2180.75100 0.999755859375     415651        4096.00
  2576.31900 0.999780273438     415661        4551.11
  3182.12700 0.999804687500     415671        5120.00
  3674.86300 0.999829101563     415681        5851.43
  4475.67900 0.999853515625     415692        6826.67
  4796.60700 0.999877929688     415702        8192.00
  5080.57500 0.999890136719     415707        9102.22
  5305.24700 0.999902343750     415712       10240.00
  5952.60700 0.999914550781     415717       11702.86
  6539.45500 0.999926757813     415722       13653.33
  7656.99100 0.999938964844     415727       16384.00
  8102.14300 0.999945068359     415730       18204.44
  8649.85500 0.999951171875     415732       20480.00
  9943.93500 0.999957275391     415735       23405.71
  9989.05500 0.999963378906     415737       27306.67
 10202.55900 0.999969482422     415740       32768.00
 11007.74300 0.999972534180     415741       36408.89
 11229.50300 0.999975585938     415742       40960.00
 13210.23900 0.999978637695     415744       46811.43
 13251.39100 0.999981689453     415745       54613.33
 13444.41500 0.999984741211     415746       65536.00
 13561.66300 0.999986267090     415747       72817.78
 13561.66300 0.999987792969     415747       81920.00
 13765.63100 0.999989318848     415748       93622.86
 14652.79900 0.999990844727     415749      109226.67
 14652.79900 0.999992370605     415749      131072.00
 16251.64700 0.999993133545     415750      145635.56
 16251.64700 0.999993896484     415750      163840.00
 16251.64700 0.999994659424     415750      187245.71
 21464.19100 0.999995422363     415751      218453.33
 21464.19100 0.999996185303     415751      262144.00
 21464.19100 0.999996566772     415751      291271.11
 21464.19100 0.999996948242     415751      327680.00
 21464.19100 0.999997329712     415751      374491.43
 32716.15900 0.999997711182     415752      436906.67
 32716.15900 1.000000000000     415752
#[Mean    =     72.06523, StdDeviation   =    128.61891]
#[Max     =  32716.15900, Total count    =       415752]
#[Buckets =            8, SubBuckets     =       262144]
```