### PR TITLE
[FORWARDPORT] Limit parallel test method count for heavy tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/nearcache/AbstractNearCacheBasicTest.java
@@ -32,6 +32,8 @@ import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.query.TruePredicate;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ConfigureParallelRunnerWith;
+import com.hazelcast.test.annotation.HeavilyMultiThreadedTestLimiter;
 import org.junit.Test;
 
 import javax.cache.expiry.ExpiryPolicy;
@@ -85,6 +87,7 @@ import static org.junit.Assert.assertTrue;
  * @param <NK> key type of the tested Near Cache
  * @param <NV> value type of the tested Near Cache
  */
+@ConfigureParallelRunnerWith(HeavilyMultiThreadedTestLimiter.class)
 @SuppressWarnings("WeakerAccess")
 public abstract class AbstractNearCacheBasicTest<NK, NV> extends HazelcastTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -34,6 +34,8 @@ import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ConfigureParallelRunnerWith;
+import com.hazelcast.test.annotation.HeavilyMultiThreadedTestLimiter;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.annotation.SlowTest;
@@ -74,6 +76,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
+@ConfigureParallelRunnerWith(HeavilyMultiThreadedTestLimiter.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class BasicMapTest extends HazelcastTestSupport {
 

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastParallelClassRunner.java
@@ -96,7 +96,7 @@ public class HazelcastParallelClassRunner extends AbstractHazelcastClassRunner {
                 Class<? extends ParallelRunnerOptions> optionsClass = annotation.value();
                 Constructor constructor = optionsClass.getConstructor();
                 ParallelRunnerOptions parallelRunnerOptions = (ParallelRunnerOptions) constructor.newInstance();
-                return parallelRunnerOptions.maxParallelTests();
+                return min(parallelRunnerOptions.maxParallelTests(), DEFAULT_MAX_THREADS);
             } catch (Exception e) {
                 throw new InitializationError(e);
             }

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/HeavilyMultiThreadedTestLimiter.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/HeavilyMultiThreadedTestLimiter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.test.annotation;
 
 import com.hazelcast.test.ParallelRunnerOptions;

--- a/hazelcast/src/test/java/com/hazelcast/test/annotation/HeavilyMultiThreadedTestLimiter.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/annotation/HeavilyMultiThreadedTestLimiter.java
@@ -1,0 +1,15 @@
+package com.hazelcast.test.annotation;
+
+import com.hazelcast.test.ParallelRunnerOptions;
+
+/**
+ * Limits a number of tests running in parallel for heavily multi-threaded tests.
+ */
+public class HeavilyMultiThreadedTestLimiter implements ParallelRunnerOptions {
+
+    @Override
+    public int maxParallelTests() {
+        return Math.max(Runtime.getRuntime().availableProcessors() / 2, 1);
+    }
+
+}


### PR DESCRIPTION
For parallel tests we use Runtime#availableProcessors parallel test
method runners. For most of the tests, it's a reasonable default and it
works well, but for heavily multi-threaded tests we may overload the
system, especially if there are multiple builds running in parallel.

This change puts a more tight limit on BasicMapTest's and
AbstractNearCacheBasicTest's parallel test method count.

(cherry-picked from a183da489df2bd458183e336b46a40f809d63bf1)

Potentially fixes:
https://github.com/hazelcast/hazelcast-enterprise/issues/2297
https://github.com/hazelcast/hazelcast-enterprise/issues/2481