### PR TITLE
Correcting the exception thrown when the client is not active

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -242,7 +242,7 @@ public class ClientInvocation implements Runnable {
         try {
             execute();
         } catch (RejectedExecutionException e) {
-            clientInvocationFuture.complete(exception);
+            clientInvocationFuture.complete(new HazelcastClientNotActiveException("Client is shutting down", exception));
         }
 
     }


### PR DESCRIPTION
When a client invocation is retried and client is shutting down,
we can get rejected from execution service.
In that case, we need to throw HazelcastClientNotActiveException
instead of last exception that invocation gets.

There is actually a `lifecycleService.isRunning()` check before
to throw `HazelcastClientNotActiveException` to user. It could be
the case that executionService is closed after the check. But is
guaranteed that when we get rejected from executionService `isRunning`
will return false.

fixes https://github.com/hazelcast/hazelcast/issues/13970

(cherry picked from commit dc928b73a9bdc844d95a9602d55814416084d675)