### PR TITLE
add user-lib to classpath

### DIFF
--- a/hazelcast/src/main/resources/start.bat
+++ b/hazelcast/src/main/resources/start.bat
@@ -23,7 +23,7 @@ if NOT "%MAX_HEAP_SIZE%" == "" (
 	set JAVA_OPTS=%JAVA_OPTS% -Xmx%MAX_HEAP_SIZE%
 )
 
-set "CLASSPATH=%~dp0..\lib\hazelcast-all-${project.version}.jar"
+set "CLASSPATH=%~dp0..\lib\hazelcast-all-${project.version}.jar;%~dp0..\user-lib;%~dp0..\user-lib\*"
 
 FOR /F "tokens=2 delims=," %%F in ('tasklist /NH /FI "WINDOWTITLE eq hazelcast %CLASSPATH%" /fo csv') DO (
 SET PID=%%F

--- a/hazelcast/src/main/resources/start.sh
+++ b/hazelcast/src/main/resources/start.sh
@@ -40,7 +40,7 @@ if [ "x$MAX_HEAP_SIZE" != "x" ]; then
 	JAVA_OPTS="$JAVA_OPTS -Xmx${MAX_HEAP_SIZE}"
 fi
 
-export CLASSPATH="$HAZELCAST_HOME/lib/hazelcast-all-${project.version}.jar"
+export CLASSPATH="$HAZELCAST_HOME/lib/hazelcast-all-${project.version}.jar:$HAZELCAST_HOME/user-lib:$HAZELCAST_HOME/user-lib/*"
 
 echo "########################################"
 echo "# RUN_JAVA=$RUN_JAVA"


### PR DESCRIPTION
This PR changes the member start scripts. It simplifies the classpath setting for user libraries.

Example `EntryProcessor` use case for a Node.js user:

- Download `hazelcast-[version].jar` and extract
- Add the compiled Java equivalent of `EntryProcessor` and its factory to the `user-lib` folder
- Run `sh start.sh` in `bin` folder
