### PR TITLE
fix handling of rest urls

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -37,7 +37,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
     public static final byte[] RES_200 = stringToBytes("HTTP/1.1 200 OK\r\n");
     public static final byte[] RES_400 = stringToBytes("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
     public static final byte[] RES_403 = stringToBytes("HTTP/1.1 403 Forbidden\r\n\r\n");
-    public static final byte[] RES_404 = stringToBytes("HTTP/1.1 404 Not Found\r\n\r\n");
+    public static final byte[] RES_404 = stringToBytes("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
     public static final byte[] RES_100 = stringToBytes("HTTP/1.1 100 Continue\r\n\r\n");
     public static final byte[] RES_204 = stringToBytes("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n");
     public static final byte[] RES_503 = stringToBytes("HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\n\r\n");
@@ -73,6 +73,14 @@ public abstract class HttpCommand extends AbstractTextCommand {
 
     public void send400() {
         this.response = ByteBuffer.wrap(RES_400);
+    }
+
+    public void send404() {
+        this.response = ByteBuffer.wrap(RES_404);
+    }
+
+    public void send500() {
+        this.response = ByteBuffer.wrap(RES_500);
     }
 
     public void setResponse(byte[] value) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpDeleteCommandProcessor.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.ascii.rest;
 
 import com.hazelcast.internal.ascii.TextCommandService;
-
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_PLAIN_TEXT;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
@@ -29,13 +28,19 @@ public class HttpDeleteCommandProcessor extends HttpCommandProcessor<HttpDeleteC
 
     @Override
     public void handle(HttpDeleteCommand command) {
-        String uri = command.getURI();
-        if (uri.startsWith(URI_MAPS)) {
-            handleMap(command, uri);
-        } else if (uri.startsWith(URI_QUEUES)) {
-            handleQueue(command, uri);
-        } else {
+        try {
+            String uri = command.getURI();
+            if (uri.startsWith(URI_MAPS)) {
+                handleMap(command, uri);
+            } else if (uri.startsWith(URI_QUEUES)) {
+                handleQueue(command, uri);
+            } else {
+                command.send404();
+            }
+        } catch (IndexOutOfBoundsException e) {
             command.send400();
+        } catch (Exception e) {
+            command.send500();
         }
         textCommandService.sendResponse(command);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -47,20 +47,27 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
 
     @Override
     public void handle(HttpGetCommand command) {
-        String uri = command.getURI();
-        if (uri.startsWith(URI_MAPS)) {
-            handleMap(command, uri);
-        } else if (uri.startsWith(URI_QUEUES)) {
-            handleQueue(command, uri);
-        } else if (uri.startsWith(URI_CLUSTER)) {
-            handleCluster(command);
-        } else if (uri.startsWith(URI_HEALTH_URL)) {
-            handleHealthcheck(command, uri);
-        } else if (uri.startsWith(URI_CLUSTER_VERSION_URL)) {
-            handleGetClusterVersion(command);
-        } else {
+        try {
+            String uri = command.getURI();
+            if (uri.startsWith(URI_MAPS)) {
+                handleMap(command, uri);
+            } else if (uri.startsWith(URI_QUEUES)) {
+                handleQueue(command, uri);
+            } else if (uri.startsWith(URI_CLUSTER)) {
+                handleCluster(command);
+            } else if (uri.startsWith(URI_HEALTH_URL)) {
+                handleHealthcheck(command, uri);
+            } else if (uri.startsWith(URI_CLUSTER_VERSION_URL)) {
+                handleGetClusterVersion(command);
+            } else {
+                command.send404();
+            }
+        } catch (IndexOutOfBoundsException e) {
             command.send400();
+        } catch (Exception e) {
+            command.send500();
         }
+
         textCommandService.sendResponse(command);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpHeadCommandProcessor.java
@@ -46,7 +46,7 @@ public class HttpHeadCommandProcessor extends HttpCommandProcessor<HttpHeadComma
         } else if (uri.startsWith(URI_CLUSTER_VERSION_URL)) {
             command.send200();
         } else {
-            command.send400();
+            command.send404();
         }
         textCommandService.sendResponse(command);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -109,10 +109,12 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
             } else if (uri.startsWith(URI_UPDATE_PERMISSIONS)) {
                 handleUpdatePermissions(command);
             } else {
-                command.setResponse(HttpCommand.RES_400);
+                command.send404();
             }
+        } catch (IndexOutOfBoundsException e) {
+            command.send400();
         } catch (Exception e) {
-            command.setResponse(HttpCommand.RES_500);
+            command.send500();
         }
         textCommandService.sendResponse(command);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -160,12 +160,12 @@ public class HTTPCommunicator {
 
     public int mapDeleteAll(String mapName) throws IOException {
         String url = address + "maps/" + mapName;
-        return doDelete(url);
+        return doDelete(url).responseCode;
     }
 
     public int mapDelete(String mapName, String key) throws IOException {
         String url = address + "maps/" + mapName + "/" + key;
-        return doDelete(url);
+        return doDelete(url).responseCode;
     }
 
     public int shutdownCluster(String groupName, String groupPassword) throws IOException {
@@ -373,14 +373,17 @@ public class HTTPCommunicator {
         }
     }
 
-    private int doDelete(String url) throws IOException {
+    private ConnectionResponse doDelete(String url) throws IOException {
         CloseableHttpClient client = newClient();
         CloseableHttpResponse response = null;
         try {
             HttpDelete request = new HttpDelete(url);
             request.setHeader("Content-type", "text/xml; charset=" + "UTF-8");
             response = client.execute(request);
-            return response.getStatusLine().getStatusCode();
+            int responseCode = response.getStatusLine().getStatusCode();
+            HttpEntity entity = response.getEntity();
+            String responseStr = entity != null ? EntityUtils.toString(entity, "UTF-8") : "";
+            return new ConnectionResponse(responseStr, responseCode);
         } finally {
             IOUtil.closeResource(response);
             IOUtil.closeResource(client);
@@ -426,9 +429,38 @@ public class HTTPCommunicator {
         return doHead(url);
     }
 
+    public ConnectionResponse getRequestToUndefinedURI() throws IOException {
+        String url = address + "undefined";
+        return doGet(url);
+    }
+
+    public ConnectionResponse postRequestToUndefinedURI() throws IOException {
+        String url = address + "undefined";
+        return doPost(url);
+    }
+    public ConnectionResponse deleteRequestToUndefinedURI() throws IOException {
+        String url = address + "undefined";
+        return doDelete(url);
+    }
+
     public ConnectionResponse headRequestToClusterInfoURI() throws IOException {
         String url = address + "cluster";
         return doHead(url);
+    }
+
+    public ConnectionResponse getBadRequestURI() throws IOException {
+        String url = address + "maps/name";
+        return doGet(url);
+    }
+
+    public ConnectionResponse postBadRequestURI() throws IOException {
+        String url = address + "maps/name";
+        return doPost(url);
+    }
+
+    public ConnectionResponse deleteBadRequestURI() throws IOException {
+        String url = address + "queues/name";
+        return doDelete(url);
     }
 
     public ConnectionResponse headRequestToClusterHealthURI() throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -44,6 +44,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -305,6 +306,43 @@ public class RestTest extends HazelcastTestSupport {
     @Test
     public void testUndefined_HeadRequest() throws IOException {
         int response = communicator.headRequestToUndefinedURI().responseCode;
+        assertEquals(HTTP_NOT_FOUND, response);
+    }
+
+    @Test
+    public void testUndefined_GetRequest() throws IOException {
+        int response = communicator.getRequestToUndefinedURI().responseCode;
+        assertEquals(HTTP_NOT_FOUND, response);
+    }
+
+    @Test
+    public void testUndefined_PostRequest() throws IOException {
+        int response = communicator.postRequestToUndefinedURI().responseCode;
+        assertEquals(HTTP_NOT_FOUND, response);
+    }
+
+    @Test
+    public void testUndefined_DeleteRequest() throws IOException {
+        int response = communicator.deleteRequestToUndefinedURI().responseCode;
+        assertEquals(HTTP_NOT_FOUND, response);
+    }
+
+    @Test
+    public void testBad_GetRequest() throws IOException {
+        int response = communicator.getBadRequestURI().responseCode;
         assertEquals(HTTP_BAD_REQUEST, response);
     }
+
+    @Test
+    public void testBad_PostRequest() throws IOException {
+        int response = communicator.postBadRequestURI().responseCode;
+        assertEquals(HTTP_BAD_REQUEST, response);
+    }
+
+    @Test
+    public void testBad_DeleteRequest() throws IOException {
+        int response = communicator.deleteBadRequestURI().responseCode;
+        assertEquals(HTTP_BAD_REQUEST, response);
+    }
+
 }


### PR DESCRIPTION
When a given url doesnt exist 404 error code should be returned instead of 400.
Also if there is any error during handling 500 error code should be returned.
If there is index out of errors it means that name of data structure cannot be
extracted because of missing `/`, in that case 400 is returned.