### PR TITLE
Use fixed past base time for Record timestamps

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/record/AbstractRecord.java
@@ -35,8 +35,14 @@ public abstract class AbstractRecord<V> implements Record<V> {
     /**
      * Base time to be used for storing time values as diffs (int) rather than full blown epoch based vals (long)
      * This allows for a space in seconds, of roughly 68 years.
+     *
+     * Reference value (1514764800000) - Monday, January 1, 2018 12:00:00 AM
+     *
+     * The fixed time in the past (instead of {@link System#currentTimeMillis()} prevents any
+     * time discrepancies among nodes, mis-translated as diffs of -1 ie. {@link Record#NOT_AVAILABLE} values.
+     * (see. https://github.com/hazelcast/hazelcast-enterprise/issues/2527)
      */
-    public static final long EPOCH_TIME = zeroOutMs(System.currentTimeMillis());
+    public static final long EPOCH_TIME = zeroOutMs(1514764800000L);
 
     private static final int NUMBER_OF_LONGS = 2;
     private static final int NUMBER_OF_INTS = 5;


### PR DESCRIPTION
Static import lazy initialised upon setter invocation, causing the base time to be ahead of the mock creation time. This time difference translates to `-1` -> `NOT_AVAILABLE` and therefore any subsequent read was returning 0.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2527

---

This behaviour would also be possible, among separate nodes with slightly drifted wall times. 
eg.
Using `System.currentTimeMillis()`

**Node A.**
Record base time: 1514764802000

**Node B.**
Record base time: 1514764801000

Creating a record on Node B when `currentTimeMillis` is 1514764801000, the creation_time delta would be 0 (diff of base & now). If we migrate that record to Node A, then the creation_time would be, 1514764801000 - 1514764802000 = -1; aka `NOT_AVAILABLE`