### PR TITLE
Track indexed partitions to avoid unnecessary reindexing

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientIndexStatsTest.java
@@ -23,11 +23,6 @@ import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.LocalIndexStatsTest;
-import com.hazelcast.map.impl.MapContainer;
-import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.MapServiceContext;
-import com.hazelcast.map.impl.PartitionContainer;
-import com.hazelcast.map.impl.proxy.MapProxyImpl;
 import com.hazelcast.monitor.LocalIndexStats;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.monitor.impl.LocalIndexStatsImpl;
@@ -36,9 +31,6 @@ import com.hazelcast.monitor.impl.PerIndexStats;
 import com.hazelcast.query.PartitionPredicate;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.spi.NodeEngine;
-import com.hazelcast.spi.partition.IPartition;
-import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -51,7 +43,6 @@ import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -191,38 +182,6 @@ public class ClientIndexStatsTest extends LocalIndexStatsTest {
         combinedStats.setIndexStats(combinedIndexStatsMap);
 
         return combinedStats;
-    }
-
-    private static List<Indexes> getAllIndexes(IMap map) {
-        MapProxyImpl mapProxy = (MapProxyImpl) map;
-        String mapName = mapProxy.getName();
-        NodeEngine nodeEngine = mapProxy.getNodeEngine();
-        IPartitionService partitionService = nodeEngine.getPartitionService();
-        MapService mapService = nodeEngine.getService(MapService.SERVICE_NAME);
-        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-
-        Indexes maybeGlobalIndexes = mapContainer.getIndexes();
-        if (maybeGlobalIndexes != null) {
-            return Collections.singletonList(maybeGlobalIndexes);
-        }
-
-        PartitionContainer[] partitionContainers = mapServiceContext.getPartitionContainers();
-        List<Indexes> allIndexes = new ArrayList<Indexes>();
-        for (PartitionContainer partitionContainer : partitionContainers) {
-            IPartition partition = partitionService.getPartition(partitionContainer.getPartitionId());
-            if (!partition.isLocal()) {
-                continue;
-            }
-
-            Indexes partitionIndexes = partitionContainer.getIndexes().get(mapName);
-            if (partitionIndexes == null) {
-                continue;
-            }
-            assert !partitionIndexes.isGlobal();
-            allIndexes.add(partitionIndexes);
-        }
-        return allIndexes;
     }
 
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPartitionIndexingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPartitionIndexingTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.IMap;
+import com.hazelcast.query.impl.PartitionIndexingTest;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientPartitionIndexingTest extends PartitionIndexingTest {
+
+    @Parameterized.Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{{InMemoryFormat.OBJECT}, {InMemoryFormat.BINARY}});
+    }
+
+    @Override
+    protected TestHazelcastInstanceFactory createFactory() {
+        return new TestHazelcastFactory();
+    }
+
+    @Override
+    protected IMap<Integer, Integer> createClientFor(IMap<Integer, Integer> map) {
+        return ((TestHazelcastFactory) factory).newHazelcastClient().getMap(map.getName());
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapMigrationAwareService.java
@@ -26,6 +26,7 @@ import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.FragmentedMigrationAwareService;
 import com.hazelcast.spi.ObjectNamespace;
@@ -274,6 +275,7 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
                 continue;
             }
 
+            final InternalIndex[] indexesSnapshot = indexes.getIndexes();
             final Iterator<Record> iterator = recordStore.iterator(now, false);
             while (iterator.hasNext()) {
                 final Record record = iterator.next();
@@ -285,6 +287,7 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
                     indexes.saveEntryIndex(queryEntry, null, Index.OperationSource.SYSTEM);
                 }
             }
+            Indexes.markPartitionAsIndexed(event.getPartitionId(), indexesSnapshot);
         }
     }
 
@@ -309,6 +312,7 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
                 continue;
             }
 
+            final InternalIndex[] indexesSnapshot = indexes.getIndexes();
             final Iterator<Record> iterator = recordStore.iterator(now, false);
             while (iterator.hasNext()) {
                 final Record record = iterator.next();
@@ -317,6 +321,7 @@ class MapMigrationAwareService implements FragmentedMigrationAwareService {
                 final Object value = Records.getValueOrCachedValue(record, serializationService);
                 indexes.removeEntryIndex(key, value, Index.OperationSource.SYSTEM);
             }
+            Indexes.markPartitionAsUnindexed(event.getPartitionId(), indexesSnapshot);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -31,6 +31,7 @@ import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.IndexInfo;
 import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.query.impl.MapIndexInfo;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.ObjectNamespace;
@@ -134,6 +135,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
         }
     }
 
+    @SuppressWarnings("checkstyle:npathcomplexity")
     void applyState() {
         ThreadUtil.assertRunningOnPartitionThread();
 
@@ -164,6 +166,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
                     indexes.clearAll();
                 }
 
+                final InternalIndex[] indexesSnapshot = indexes.getIndexes();
                 for (RecordReplicationInfo recordReplicationInfo : recordReplicationInfos) {
                     Data key = recordReplicationInfo.getKey();
                     final Data value = recordReplicationInfo.getValue();
@@ -186,6 +189,10 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable, Ve
                         break;
                     }
                     recordStore.disposeDeferredBlocks();
+                }
+
+                if (indexesMustBePopulated) {
+                    Indexes.markPartitionAsIndexed(partitionContainer.getPartitionId(), indexesSnapshot);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -47,6 +47,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.InternalIndex;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
@@ -1308,10 +1309,12 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
      * partition full-scan.
      */
     private void fullScanLocalDataToClear(Indexes indexes) {
+        InternalIndex[] indexesSnapshot = indexes.getIndexes();
         for (Record record : storage.values()) {
             Data key = record.getKey();
             Object value = Records.getValueOrCachedValue(record, serializationService);
             indexes.removeEntryIndex(key, value, Index.OperationSource.SYSTEM);
         }
+        Indexes.markPartitionAsUnindexed(partitionId, indexesSnapshot);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AbstractIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AbstractIndex.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.core.TypeConverter;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.monitor.impl.IndexOperationStats;
+import com.hazelcast.monitor.impl.PerIndexStats;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static com.hazelcast.query.impl.TypeConverters.NULL_CONVERTER;
+import static com.hazelcast.util.SetUtil.createHashSet;
+
+/**
+ * Provides an abstract base for indexes.
+ */
+public abstract class AbstractIndex implements InternalIndex {
+
+    public static final NullObject NULL = new NullObject();
+
+    protected final InternalSerializationService ss;
+    protected final Extractors extractors;
+    protected final IndexStore indexStore;
+    protected final IndexCopyBehavior copyBehavior;
+
+    private final String attributeName;
+    private final boolean ordered;
+    private final PerIndexStats stats;
+
+    private volatile TypeConverter converter;
+
+    public AbstractIndex(String attributeName, boolean ordered, InternalSerializationService ss, Extractors extractors,
+                         IndexCopyBehavior copyBehavior, PerIndexStats stats) {
+        this.attributeName = attributeName;
+        this.ordered = ordered;
+        this.ss = ss;
+        this.extractors = extractors;
+        this.copyBehavior = copyBehavior;
+        this.indexStore = createIndexStore(ordered, stats);
+        this.stats = stats;
+    }
+
+    protected abstract IndexStore createIndexStore(boolean ordered, PerIndexStats stats);
+
+    @Override
+    public void saveEntryIndex(QueryableEntry entry, Object oldRecordValue, OperationSource operationSource) {
+        long timestamp = stats.makeTimestamp();
+        IndexOperationStats operationStats = stats.createOperationStats();
+
+        /*
+         * At first, check if converter is not initialized, initialize it before saving an entry index
+         * Because, if entity index is saved before,
+         * that thread can be blocked before executing converter setting code block,
+         * another thread can query over indexes without knowing the converter and
+         * this causes to class cast exceptions.
+         */
+        if (converter == null || converter == NULL_CONVERTER) {
+            converter = entry.getConverter(attributeName);
+        }
+
+        Object newAttributeValue = extractAttributeValue(entry.getKeyData(), entry.getTargetObject(false));
+        if (oldRecordValue == null) {
+            indexStore.newIndex(newAttributeValue, entry, operationStats);
+            stats.onInsert(timestamp, operationStats, operationSource);
+        } else {
+            Object oldAttributeValue = extractAttributeValue(entry.getKeyData(), oldRecordValue);
+            indexStore.updateIndex(oldAttributeValue, newAttributeValue, entry, operationStats);
+            stats.onUpdate(timestamp, operationStats, operationSource);
+        }
+    }
+
+    @Override
+    public void removeEntryIndex(Data key, Object value, OperationSource operationSource) {
+        long timestamp = stats.makeTimestamp();
+        IndexOperationStats operationStats = stats.createOperationStats();
+
+        Object attributeValue = extractAttributeValue(key, value);
+        indexStore.removeIndex(attributeValue, key, operationStats);
+        stats.onRemove(timestamp, operationStats, operationSource);
+    }
+
+    private Object extractAttributeValue(Data key, Object value) {
+        return QueryableEntry.extractAttributeValue(extractors, ss, attributeName, key, value);
+    }
+
+    @Override
+    public Set<QueryableEntry> getRecords(Comparable[] values) {
+        if (values.length == 1) {
+            return getRecords(values[0]);
+        } else {
+            long timestamp = stats.makeTimestamp();
+
+            if (converter != null) {
+                Set<Comparable> convertedValues = createHashSet(values.length);
+                for (Comparable value : values) {
+                    convertedValues.add(convert(value));
+                }
+                Set<QueryableEntry> result = indexStore.getRecords(convertedValues);
+                stats.onIndexHit(timestamp, result.size());
+                return result;
+            }
+
+            stats.onIndexHit(timestamp, 0);
+            return Collections.emptySet();
+        }
+    }
+
+    @Override
+    public Set<QueryableEntry> getRecords(Comparable attributeValue) {
+        long timestamp = stats.makeTimestamp();
+
+        if (converter == null) {
+            stats.onIndexHit(timestamp, 0);
+            return new SingleResultSet(null);
+        }
+
+        Set<QueryableEntry> result = indexStore.getRecords(convert(attributeValue));
+        stats.onIndexHit(timestamp, result.size());
+        return result;
+    }
+
+    @Override
+    public Set<QueryableEntry> getSubRecords(ComparisonType comparisonType, Comparable searchedAttributeValue) {
+        long timestamp = stats.makeTimestamp();
+
+        if (converter == null) {
+            stats.onIndexHit(timestamp, 0);
+            return Collections.emptySet();
+        }
+
+        Set<QueryableEntry> result = indexStore.getSubRecords(comparisonType, convert(searchedAttributeValue));
+        stats.onIndexHit(timestamp, result.size());
+        return result;
+    }
+
+    @Override
+    public Set<QueryableEntry> getSubRecordsBetween(Comparable fromAttributeValue, Comparable toAttributeValue) {
+        long timestamp = stats.makeTimestamp();
+
+        if (converter == null) {
+            stats.onIndexHit(timestamp, 0);
+            return Collections.emptySet();
+        }
+
+        Set<QueryableEntry> result = indexStore.getSubRecordsBetween(convert(fromAttributeValue), convert(toAttributeValue));
+        stats.onIndexHit(timestamp, result.size());
+        return result;
+    }
+
+    /**
+     * Note: the fact that the given attributeValue is of type Comparable doesn't mean that this value is of the same
+     * type as the one that's stored in the index, thus the conversion is needed.
+     *
+     * @param attributeValue to be converted from given type to the type of the attribute that's stored in the index
+     * @return converted value that may be compared with the value that's stored in the index
+     */
+    private Comparable convert(Comparable attributeValue) {
+        return converter.convert(attributeValue);
+    }
+
+    /**
+     * Provides comparable null object.
+     */
+    @Override
+    public TypeConverter getConverter() {
+        return converter;
+    }
+
+    @Override
+    public void clear() {
+        indexStore.clear();
+        converter = null;
+        stats.onClear();
+    }
+
+    @Override
+    public void destroy() {
+        stats.onClear();
+    }
+
+    @Override
+    public String getAttributeName() {
+        return attributeName;
+    }
+
+    @Override
+    public boolean isOrdered() {
+        return ordered;
+    }
+
+    @Override
+    public PerIndexStats getPerIndexStats() {
+        return stats;
+    }
+
+    public static final class NullObject implements Comparable, IdentifiedDataSerializable {
+        @Override
+        public int compareTo(Object o) {
+            if (o == this || o instanceof NullObject) {
+                return 0;
+            }
+            return -1;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) {
+
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) {
+
+        }
+
+        @Override
+        public int getFactoryId() {
+            return PredicateDataSerializerHook.F_ID;
+        }
+
+        @Override
+        public int getId() {
+            return PredicateDataSerializerHook.NULL_OBJECT;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/GlobalQueryContextWithStats.java
@@ -157,6 +157,21 @@ public class GlobalQueryContextWithStats extends QueryContext {
         }
 
         @Override
+        public boolean hasPartitionIndexed(int partitionId) {
+            return delegate.hasPartitionIndexed(partitionId);
+        }
+
+        @Override
+        public void markPartitionAsIndexed(int partitionId) {
+            delegate.markPartitionAsIndexed(partitionId);
+        }
+
+        @Override
+        public void markPartitionAsUnindexed(int partitionId) {
+            delegate.markPartitionAsUnindexed(partitionId);
+        }
+
+        @Override
         public PerIndexStats getPerIndexStats() {
             return delegate.getPerIndexStats();
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/IndexImpl.java
@@ -16,247 +16,51 @@
 
 package com.hazelcast.query.impl;
 
-import com.hazelcast.core.TypeConverter;
 import com.hazelcast.internal.serialization.InternalSerializationService;
-import com.hazelcast.monitor.impl.IndexOperationStats;
 import com.hazelcast.monitor.impl.PerIndexStats;
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.impl.getters.Extractors;
-import com.hazelcast.query.impl.predicates.PredicateDataSerializerHook;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
-import static com.hazelcast.query.impl.TypeConverters.NULL_CONVERTER;
-import static com.hazelcast.util.SetUtil.createHashSet;
+/**
+ * Provides implementation of on-heap indexes.
+ */
+public class IndexImpl extends AbstractIndex {
 
-public class IndexImpl implements InternalIndex {
-
-    public static final NullObject NULL = new NullObject();
-
-    protected final InternalSerializationService ss;
-    protected final Extractors extractors;
-    protected final IndexStore indexStore;
-
-    private final String attributeName;
-    private final boolean ordered;
-    private final IndexCopyBehavior copyBehavior;
-    private final PerIndexStats stats;
-
-    private volatile TypeConverter converter;
+    private final Set<Integer> indexedPartitions = Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>());
 
     public IndexImpl(String attributeName, boolean ordered, InternalSerializationService ss, Extractors extractors,
                      IndexCopyBehavior copyBehavior, PerIndexStats stats) {
-        this.attributeName = attributeName;
-        this.ordered = ordered;
-        this.ss = ss;
-        this.extractors = extractors;
-        this.copyBehavior = copyBehavior;
-        this.indexStore = createIndexStore(ordered, stats);
-        this.stats = stats;
+        super(attributeName, ordered, ss, extractors, copyBehavior, stats);
     }
 
+    @Override
     protected IndexStore createIndexStore(boolean ordered, PerIndexStats stats) {
         return ordered ? new SortedIndexStore(copyBehavior) : new UnsortedIndexStore(copyBehavior);
     }
 
     @Override
-    public void saveEntryIndex(QueryableEntry entry, Object oldRecordValue, OperationSource operationSource) {
-        long timestamp = stats.makeTimestamp();
-        IndexOperationStats operationStats = stats.createOperationStats();
-
-        /*
-         * At first, check if converter is not initialized, initialize it before saving an entry index
-         * Because, if entity index is saved before,
-         * that thread can be blocked before executing converter setting code block,
-         * another thread can query over indexes without knowing the converter and
-         * this causes to class cast exceptions.
-         */
-        if (converter == null || converter == NULL_CONVERTER) {
-            converter = entry.getConverter(attributeName);
-        }
-
-        Object newAttributeValue = extractAttributeValue(entry.getKeyData(), entry.getTargetObject(false));
-        if (oldRecordValue == null) {
-            indexStore.newIndex(newAttributeValue, entry, operationStats);
-            stats.onInsert(timestamp, operationStats, operationSource);
-        } else {
-            Object oldAttributeValue = extractAttributeValue(entry.getKeyData(), oldRecordValue);
-            indexStore.updateIndex(oldAttributeValue, newAttributeValue, entry, operationStats);
-            stats.onUpdate(timestamp, operationStats, operationSource);
-        }
+    public boolean hasPartitionIndexed(int partitionId) {
+        return indexedPartitions.contains(partitionId);
     }
 
     @Override
-    public void removeEntryIndex(Data key, Object value, OperationSource operationSource) {
-        long timestamp = stats.makeTimestamp();
-        IndexOperationStats operationStats = stats.createOperationStats();
-
-        Object attributeValue = extractAttributeValue(key, value);
-        indexStore.removeIndex(attributeValue, key, operationStats);
-        stats.onRemove(timestamp, operationStats, operationSource);
-    }
-
-    private Object extractAttributeValue(Data key, Object value) {
-        return QueryableEntry.extractAttributeValue(extractors, ss, attributeName, key, value);
+    public void markPartitionAsIndexed(int partitionId) {
+        assert !indexedPartitions.contains(partitionId);
+        indexedPartitions.add(partitionId);
     }
 
     @Override
-    public Set<QueryableEntry> getRecords(Comparable[] values) {
-        if (values.length == 1) {
-            return getRecords(values[0]);
-        } else {
-            long timestamp = stats.makeTimestamp();
-
-            if (converter != null) {
-                Set<Comparable> convertedValues = createHashSet(values.length);
-                for (Comparable value : values) {
-                    convertedValues.add(convert(value));
-                }
-                Set<QueryableEntry> result = indexStore.getRecords(convertedValues);
-                stats.onIndexHit(timestamp, result.size());
-                return result;
-            }
-
-            stats.onIndexHit(timestamp, 0);
-            return Collections.emptySet();
-        }
-    }
-
-    @Override
-    public Set<QueryableEntry> getRecords(Comparable attributeValue) {
-        long timestamp = stats.makeTimestamp();
-
-        if (converter == null) {
-            stats.onIndexHit(timestamp, 0);
-            return new SingleResultSet(null);
-        }
-
-        Set<QueryableEntry> result = indexStore.getRecords(convert(attributeValue));
-        stats.onIndexHit(timestamp, result.size());
-        return result;
-    }
-
-    @Override
-    public Set<QueryableEntry> getSubRecords(ComparisonType comparisonType, Comparable searchedAttributeValue) {
-        long timestamp = stats.makeTimestamp();
-
-        if (converter == null) {
-            stats.onIndexHit(timestamp, 0);
-            return Collections.emptySet();
-        }
-
-        Set<QueryableEntry> result = indexStore.getSubRecords(comparisonType, convert(searchedAttributeValue));
-        stats.onIndexHit(timestamp, result.size());
-        return result;
-    }
-
-    @Override
-    public Set<QueryableEntry> getSubRecordsBetween(Comparable fromAttributeValue, Comparable toAttributeValue) {
-        long timestamp = stats.makeTimestamp();
-
-        if (converter == null) {
-            stats.onIndexHit(timestamp, 0);
-            return Collections.emptySet();
-        }
-
-        Set<QueryableEntry> result = indexStore.getSubRecordsBetween(convert(fromAttributeValue), convert(toAttributeValue));
-        stats.onIndexHit(timestamp, result.size());
-        return result;
-    }
-
-    /**
-     * Note: the fact that the given attributeValue is of type Comparable doesn't mean that this value is of the same
-     * type as the one that's stored in the index, thus the conversion is needed.
-     *
-     * @param attributeValue to be converted from given type to the type of the attribute that's stored in the index
-     * @return converted value that may be compared with the value that's stored in the index
-     */
-    private Comparable convert(Comparable attributeValue) {
-        return converter.convert(attributeValue);
-    }
-
-    /**
-     * Provides comparable null object.
-     */
-    @Override
-    public TypeConverter getConverter() {
-        return converter;
+    public void markPartitionAsUnindexed(int partitionId) {
+        indexedPartitions.remove(partitionId);
     }
 
     @Override
     public void clear() {
-        indexStore.clear();
-        converter = null;
-        stats.onClear();
+        super.clear();
+        indexedPartitions.clear();
     }
 
-    @Override
-    public void destroy() {
-        stats.onClear();
-    }
-
-    @Override
-    public String getAttributeName() {
-        return attributeName;
-    }
-
-    @Override
-    public boolean isOrdered() {
-        return ordered;
-    }
-
-    @Override
-    public PerIndexStats getPerIndexStats() {
-        return stats;
-    }
-
-    public static final class NullObject implements Comparable, IdentifiedDataSerializable {
-        @Override
-        public int compareTo(Object o) {
-            if (o == this || o instanceof NullObject) {
-                return 0;
-            }
-            return -1;
-        }
-
-        @Override
-        public int hashCode() {
-            return 0;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public void writeData(ObjectDataOutput out) {
-
-        }
-
-        @Override
-        public void readData(ObjectDataInput in) {
-
-        }
-
-        @Override
-        public int getFactoryId() {
-            return PredicateDataSerializerHook.F_ID;
-        }
-
-        @Override
-        public int getId() {
-            return PredicateDataSerializerHook.NULL_OBJECT;
-        }
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -88,6 +88,30 @@ public class Indexes {
     }
 
     /**
+     * Marks the given partition as indexed by the given indexes.
+     *
+     * @param partitionId the ID of the partition to mark as indexed.
+     * @param indexes     the indexes by which the given partition is indexed.
+     */
+    public static void markPartitionAsIndexed(int partitionId, InternalIndex[] indexes) {
+        for (InternalIndex index : indexes) {
+            index.markPartitionAsIndexed(partitionId);
+        }
+    }
+
+    /**
+     * Marks the given partition as unindexed by the given indexes.
+     *
+     * @param partitionId the ID of the partition to mark as unindexed.
+     * @param indexes     the indexes by which the given partition is unindexed.
+     */
+    public static void markPartitionAsUnindexed(int partitionId, InternalIndex[] indexes) {
+        for (InternalIndex index : indexes) {
+            index.markPartitionAsUnindexed(partitionId);
+        }
+    }
+
+    /**
      * Obtains the existing index or creates a new one (if an index doesn't exist
      * yet) for the given attribute in this indexes instance.
      *

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/InternalIndex.java
@@ -24,6 +24,26 @@ import com.hazelcast.monitor.impl.PerIndexStats;
 public interface InternalIndex extends Index {
 
     /**
+     * Returns {@code true} if the given partition is indexed by this index,
+     * {@code false} otherwise.
+     */
+    boolean hasPartitionIndexed(int partitionId);
+
+    /**
+     * Marks the given partition as indexed by this index.
+     *
+     * @param partitionId the ID of the partition to mark as indexed.
+     */
+    void markPartitionAsIndexed(int partitionId);
+
+    /**
+     * Marks the given partition as unindexed by this index.
+     *
+     * @param partitionId the ID of the partition to mark as unindexed.
+     */
+    void markPartitionAsUnindexed(int partitionId);
+
+    /**
      * Returns the index stats associated with this index.
      */
     PerIndexStats getPerIndexStats();

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/PartitionIndexingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/PartitionIndexingTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.config.ServiceConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.spi.MigrationAwareService;
+import com.hazelcast.spi.Operation;
+import com.hazelcast.spi.PartitionMigrationEvent;
+import com.hazelcast.spi.PartitionReplicationEvent;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PartitionIndexingTest extends HazelcastTestSupport {
+
+    private static final int ENTRIES = 10000;
+    private static final String MAP_NAME = "map";
+
+    @Parameterized.Parameters(name = "format:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{{InMemoryFormat.OBJECT}, {InMemoryFormat.BINARY}});
+    }
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    protected TestHazelcastInstanceFactory factory;
+
+    private MigrationFailingService migrationFailingService = new MigrationFailingService();
+
+    protected TestHazelcastInstanceFactory createFactory() {
+        return createHazelcastInstanceFactory();
+    }
+
+    @Before
+    public void before() {
+        factory = createFactory();
+    }
+
+    @After
+    public void after() {
+        factory.shutdownAll();
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = super.getConfig();
+        config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "101");
+        config.getMapConfig(MAP_NAME).setInMemoryFormat(inMemoryFormat);
+        config.getServicesConfig().addServiceConfig(
+                new ServiceConfig().setEnabled(true).setImplementation(migrationFailingService)
+                                   .setName(MigrationFailingService.class.getName()));
+        return config;
+    }
+
+    protected IMap<Integer, Integer> createClientFor(IMap<Integer, Integer> map) {
+        return map;
+    }
+
+    @Test
+    public void testOnPreConfiguredIndexes() {
+        Config config = getConfig();
+        config.getMapConfig(MAP_NAME).addMapIndexConfig(new MapIndexConfig("this", false));
+        config.getMapConfig(MAP_NAME).addMapIndexConfig(new MapIndexConfig("__key", true));
+
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        int expectedPartitions = getPartitionService(instance1).getPartitionCount();
+
+        IMap<Integer, Integer> map1 = instance1.getMap(MAP_NAME);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1);
+
+        IMap<Integer, Integer> client1 = createClientFor(map1);
+        for (int i = 0; i < ENTRIES; ++i) {
+            client1.put(i, i);
+        }
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1);
+
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        IMap<Integer, Integer> map2 = instance2.getMap(MAP_NAME);
+        waitAllForSafeState(instance1, instance2);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map2);
+
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+        IMap<Integer, Integer> map3 = instance3.getMap(MAP_NAME);
+        waitAllForSafeState(instance1, instance2, instance3);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map2, map3);
+
+        instance2.shutdown();
+        waitAllForSafeState(instance1, instance3);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map3);
+
+        migrationFailingService.fail = true;
+        HazelcastInstance instance4 = factory.newHazelcastInstance(config);
+        IMap<Integer, Integer> map4 = instance4.getMap(MAP_NAME);
+        waitAllForSafeState(instance1, instance3, instance4);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map3, map4);
+        assertTrue(migrationFailingService.rolledBack);
+    }
+
+    @Test
+    public void testOnProgrammaticallyAddedIndexes() {
+        Config config = getConfig();
+
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        int expectedPartitions = getPartitionService(instance1).getPartitionCount();
+
+        IMap<Integer, Integer> map1 = instance1.getMap(MAP_NAME);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1);
+
+        IMap<Integer, Integer> client1 = createClientFor(map1);
+        for (int i = 0; i < ENTRIES; ++i) {
+            client1.put(i, i);
+        }
+        client1.addIndex("this", false);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1);
+
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        IMap<Integer, Integer> map2 = instance2.getMap(MAP_NAME);
+        waitAllForSafeState(instance1, instance2);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map2);
+
+        HazelcastInstance instance3 = factory.newHazelcastInstance(config);
+        IMap<Integer, Integer> map3 = instance3.getMap(MAP_NAME);
+        waitAllForSafeState(instance1, instance2, instance3);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map2, map3);
+
+        instance2.shutdown();
+        waitAllForSafeState(instance1, instance3);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map3);
+
+        IMap<Integer, Integer> client3 = createClientFor(map3);
+        client3.addIndex("__key", true);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map3);
+
+        migrationFailingService.fail = true;
+        HazelcastInstance instance4 = factory.newHazelcastInstance(config);
+        IMap<Integer, Integer> map4 = instance4.getMap(MAP_NAME);
+        waitAllForSafeState(instance1, instance3, instance4);
+        assertPartitionsIndexedCorrectly(expectedPartitions, map1, map3, map4);
+        assertTrue(migrationFailingService.rolledBack);
+    }
+
+    private static void assertPartitionsIndexedCorrectly(int expectedPartitions, IMap... maps) {
+        Map<String, BitSet> indexToPartitions = new HashMap<String, BitSet>();
+
+        for (IMap map : maps) {
+            for (Indexes indexes : getAllIndexes(map)) {
+                for (InternalIndex index : indexes.getIndexes()) {
+                    String indexName = index.getAttributeName();
+                    BitSet indexPartitions = indexToPartitions.get(indexName);
+                    if (indexPartitions == null) {
+                        indexPartitions = new BitSet();
+                        indexToPartitions.put(indexName, indexPartitions);
+                    }
+
+                    for (int partition = 0; partition < expectedPartitions; ++partition) {
+                        if (index.hasPartitionIndexed(partition)) {
+                            assertFalse("partition #" + partition + " is already indexed by " + indexName,
+                                    indexPartitions.get(partition));
+                            indexPartitions.set(partition);
+                        }
+                    }
+                }
+            }
+        }
+
+        for (Map.Entry<String, BitSet> indexEntry : indexToPartitions.entrySet()) {
+            String indexName = indexEntry.getKey();
+            BitSet indexPartitions = indexEntry.getValue();
+
+            int actualPartitions = indexPartitions.cardinality();
+            assertEquals(indexName + " is missing " + (expectedPartitions - actualPartitions) + " partitions", expectedPartitions,
+                    actualPartitions);
+        }
+    }
+
+    private static class MigrationFailingService implements MigrationAwareService {
+        public volatile boolean fail = false;
+        public volatile boolean rolledBack = false;
+
+        @Override
+        public Operation prepareReplicationOperation(PartitionReplicationEvent event) {
+            return null;
+        }
+
+        @Override
+        public void beforeMigration(PartitionMigrationEvent event) {
+            if (fail && !rolledBack) {
+                throw new RuntimeException("migration intentionally failed");
+            }
+        }
+
+        @Override
+        public void commitMigration(PartitionMigrationEvent event) {
+        }
+
+        @Override
+        public void rollbackMigration(PartitionMigrationEvent event) {
+            rolledBack = true;
+        }
+    }
+
+}


### PR DESCRIPTION
EE part: https://github.com/hazelcast/hazelcast-enterprise/pull/2543

This change fixes the following issues:

1. When a user invokes IMap.addIndex, AddIndexOperation is sent to all
members and the index in question is fully rebuilt even if it's already
populated. Typically, such addIndex invocations are performed from user
code for each member joining a cluster during the member initialization.
If the cluster is storing a lot of data, rebuilding all of the indexes
may be a very costly operation.

2. When a new member joins a cluster, a local map proxy object is
created on that new member. During the proxy initialization,
AddIndexOperation is sent to all cluster members for each index
configured by the new member XML configuration to ensure the indexes
are present on all members (see MapProxySupport.initializeIndexes).
Basically, we are rebuilding all of the indexes on all of the members.

This change tracks a set of partitions indexed by each index. If a
partition is already indexed by a certain index, the reindexing is
skipped.

Fixes: https://github.com/hazelcast/hazelcast/issues/13964