### PR TITLE
Removed IDS from Result subclasses

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/AggregationResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/AggregationResult.java
@@ -20,7 +20,6 @@ import com.hazelcast.aggregation.Aggregator;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.serialization.SerializationService;
@@ -35,7 +34,7 @@ import java.util.Map;
  * <p>
  * At the end of the aggregation execution path all AggregationResults are merged into one AggregationResult.
  */
-public class AggregationResult implements Result<AggregationResult>, IdentifiedDataSerializable {
+public class AggregationResult implements Result<AggregationResult> {
 
     private Aggregator aggregator;
     private Collection<Integer> partitionIds;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResult.java
@@ -21,7 +21,6 @@ import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.projection.Projection;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -59,7 +58,7 @@ import java.util.Map;
  * QueryResultRow rows} and no further conversion is performed.
  * </ol>
  */
-public class QueryResult implements Result<QueryResult>, IdentifiedDataSerializable, Iterable<QueryResultRow> {
+public class QueryResult implements Result<QueryResult>, Iterable<QueryResultRow> {
 
     private List rows = new LinkedList();
 


### PR DESCRIPTION
The Result already implements IDS, no need to repeat
it at the children