### PR TITLE
Cleaned up ResultProcessorRegistry

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ResultProcessorRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ResultProcessorRegistry.java
@@ -24,11 +24,8 @@ import java.util.Map;
  */
 public class ResultProcessorRegistry {
 
-    private final Map<Class<? extends Result>, ResultProcessor> processors;
-
-    public ResultProcessorRegistry() {
-        this.processors = new HashMap<Class<? extends Result>, ResultProcessor>();
-    }
+    private final Map<Class<? extends Result>, ResultProcessor> processors
+            = new HashMap<Class<? extends Result>, ResultProcessor>();
 
     public void registerProcessor(Class<? extends Result> clazz, ResultProcessor processor) {
         processors.put(clazz, processor);


### PR DESCRIPTION
no need for an explicit constructor.