### PR TITLE
Renamed MapQueryEngine to QueryEngine

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContext.java
@@ -28,7 +28,7 @@ import com.hazelcast.map.impl.eviction.MapClearExpiredRecordsTask;
 import com.hazelcast.map.impl.journal.MapEventJournal;
 import com.hazelcast.map.impl.nearcache.MapNearCacheManager;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
-import com.hazelcast.map.impl.query.MapQueryEngine;
+import com.hazelcast.map.impl.query.QueryEngine;
 import com.hazelcast.map.impl.query.PartitionScanRunner;
 import com.hazelcast.map.impl.query.QueryRunner;
 import com.hazelcast.map.impl.query.ResultProcessorRegistry;
@@ -145,7 +145,7 @@ public interface MapServiceContext extends MapServiceContextInterceptorSupport, 
 
     MapEventJournal getEventJournal();
 
-    MapQueryEngine getMapQueryEngine(String name);
+    QueryEngine getQueryEngine(String name);
 
     QueryRunner getMapQueryRunner(String name);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -48,8 +48,8 @@ import com.hazelcast.map.impl.query.AggregationResult;
 import com.hazelcast.map.impl.query.AggregationResultProcessor;
 import com.hazelcast.map.impl.query.CallerRunsAccumulationExecutor;
 import com.hazelcast.map.impl.query.CallerRunsPartitionScanExecutor;
-import com.hazelcast.map.impl.query.MapQueryEngine;
-import com.hazelcast.map.impl.query.MapQueryEngineImpl;
+import com.hazelcast.map.impl.query.QueryEngine;
+import com.hazelcast.map.impl.query.QueryEngineImpl;
 import com.hazelcast.map.impl.query.ParallelAccumulationExecutor;
 import com.hazelcast.map.impl.query.ParallelPartitionScanExecutor;
 import com.hazelcast.map.impl.query.PartitionScanExecutor;
@@ -146,7 +146,7 @@ class MapServiceContextImpl implements MapServiceContext {
     protected final MapNearCacheManager mapNearCacheManager;
     protected final LocalMapStatsProvider localMapStatsProvider;
     protected final MergePolicyProvider mergePolicyProvider;
-    protected final MapQueryEngine mapQueryEngine;
+    protected final QueryEngine queryEngine;
     protected final QueryRunner mapQueryRunner;
     protected final PartitionScanRunner partitionScanRunner;
     protected final QueryOptimizer queryOptimizer;
@@ -178,7 +178,7 @@ class MapServiceContextImpl implements MapServiceContext {
         this.queryOptimizer = newOptimizer(nodeEngine.getProperties());
         this.resultProcessorRegistry = createResultProcessorRegistry(serializationService);
         this.partitionScanRunner = createPartitionScanRunner();
-        this.mapQueryEngine = createMapQueryEngine();
+        this.queryEngine = createMapQueryEngine();
         this.mapQueryRunner = createMapQueryRunner(nodeEngine, queryOptimizer, resultProcessorRegistry, partitionScanRunner);
         this.eventService = nodeEngine.getEventService();
         this.operationProviders = createOperationProviders();
@@ -219,8 +219,8 @@ class MapServiceContextImpl implements MapServiceContext {
         return new LocalMapStatsProvider(this);
     }
 
-    private MapQueryEngineImpl createMapQueryEngine() {
-        return new MapQueryEngineImpl(this);
+    private QueryEngineImpl createMapQueryEngine() {
+        return new QueryEngineImpl(this);
     }
 
     private PartitionScanRunner createPartitionScanRunner() {
@@ -531,8 +531,8 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     @Override
-    public MapQueryEngine getMapQueryEngine(String mapName) {
-        return mapQueryEngine;
+    public QueryEngine getQueryEngine(String mapName) {
+        return queryEngine;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -55,7 +55,7 @@ import com.hazelcast.map.impl.operation.IsPartitionLoadedOperationFactory;
 import com.hazelcast.map.impl.operation.MapOperation;
 import com.hazelcast.map.impl.operation.MapOperationProvider;
 import com.hazelcast.map.impl.operation.RemoveInterceptorOperation;
-import com.hazelcast.map.impl.query.MapQueryEngine;
+import com.hazelcast.map.impl.query.QueryEngine;
 import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryEventFilter;
 import com.hazelcast.map.impl.query.Result;
@@ -328,8 +328,8 @@ abstract class MapProxySupport<K, V>
         return mapConfig.getBackupCount() + mapConfig.getAsyncBackupCount();
     }
 
-    protected MapQueryEngine getMapQueryEngine() {
-        return mapServiceContext.getMapQueryEngine(name);
+    protected QueryEngine getMapQueryEngine() {
+        return mapServiceContext.getQueryEngine(name);
     }
 
     protected boolean isMapStoreEnabled() {
@@ -1304,7 +1304,7 @@ abstract class MapProxySupport<K, V>
 
     protected <T extends Result> T executeQueryInternal(Predicate predicate, Aggregator aggregator, Projection projection,
                                                         IterationType iterationType, Target target) {
-        MapQueryEngine queryEngine = getMapQueryEngine();
+        QueryEngine queryEngine = getMapQueryEngine();
         Predicate userPredicate = predicate;
 
         if (predicate instanceof PartitionPredicate) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngine.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.query;
 /**
  * Responsible for executing queries on the IMap.
  */
-public interface MapQueryEngine {
+public interface QueryEngine {
 
     /**
      * Executes the given query on the given target.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEngineImpl.java
@@ -54,7 +54,7 @@ import static com.hazelcast.util.ExceptionUtil.rethrow;
  * - QueryDispatcher invokes query operations on the given members and partitions
  * - QueryRunner -> runs the query logic in the calling thread (so like evaluates the predicates and asks the index)
  */
-public class MapQueryEngineImpl implements MapQueryEngine {
+public class QueryEngineImpl implements QueryEngine {
 
     protected final MapServiceContext mapServiceContext;
     protected final NodeEngine nodeEngine;
@@ -67,7 +67,7 @@ public class MapQueryEngineImpl implements MapQueryEngine {
     protected final QueryDispatcher queryDispatcher;
     protected final ResultProcessorRegistry resultProcessorRegistry;
 
-    public MapQueryEngineImpl(MapServiceContext mapServiceContext) {
+    public QueryEngineImpl(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
         this.nodeEngine = mapServiceContext.getNodeEngine();
         this.serializationService = (InternalSerializationService) nodeEngine.getSerializationService();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/PublisherCreateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/PublisherCreateOperation.java
@@ -19,7 +19,7 @@ package com.hazelcast.map.impl.querycache.subscriber.operation;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.MapOperation;
-import com.hazelcast.map.impl.query.MapQueryEngine;
+import com.hazelcast.map.impl.query.QueryEngine;
 import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultRow;
@@ -155,7 +155,7 @@ public class PublisherCreateOperation extends MapOperation {
     }
 
     private QueryResult runInitialQuery() {
-        MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
+        QueryEngine queryEngine = mapServiceContext.getQueryEngine(name);
         IterationType iterationType = info.isIncludeValue() ? IterationType.ENTRY : IterationType.KEY;
         Query query = Query.of().mapName(name).predicate(info.getPredicate()).iterationType(iterationType).build();
         return queryEngine.execute(query, Target.LOCAL_NODE);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/tx/TransactionalMapProxy.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.tx;
 
 import com.hazelcast.core.TransactionalMap;
 import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.query.MapQueryEngine;
+import com.hazelcast.map.impl.query.QueryEngine;
 import com.hazelcast.map.impl.query.Query;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultUtils;
@@ -357,7 +357,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(predicate, "Predicate should not be null!");
         checkNotInstanceOf(PagingPredicate.class, predicate, "Paging is not supported for Transactional queries!");
 
-        MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
+        QueryEngine queryEngine = mapServiceContext.getQueryEngine(name);
 
         Query query = Query.of().mapName(name).predicate(predicate).iterationType(IterationType.KEY).build();
         QueryResult queryResult = queryEngine.execute(query, Target.ALL_NODES);
@@ -401,7 +401,7 @@ public class TransactionalMapProxy extends TransactionalMapProxySupport implemen
         checkNotNull(predicate, "Predicate can not be null!");
         checkNotInstanceOf(PagingPredicate.class, predicate, "Paging is not supported for Transactional queries");
 
-        MapQueryEngine queryEngine = mapServiceContext.getMapQueryEngine(name);
+        QueryEngine queryEngine = mapServiceContext.getQueryEngine(name);
 
         Query query = Query.of().mapName(name).predicate(predicate).iterationType(IterationType.ENTRY).build();
         QueryResult queryResult = queryEngine.execute(query, Target.ALL_NODES);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngineImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngineImplTest.java
@@ -40,11 +40,11 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class})
-public class MapQueryEngineImplTest extends HazelcastTestSupport {
+public class QueryEngineImplTest extends HazelcastTestSupport {
 
     private HazelcastInstance instance;
     private IMap<String, String> map;
-    private MapQueryEngine queryEngine;
+    private QueryEngine queryEngine;
 
     private int partitionId;
     private String key;
@@ -55,7 +55,7 @@ public class MapQueryEngineImplTest extends HazelcastTestSupport {
         instance = createHazelcastInstance();
         map = instance.getMap(randomName());
         MapService mapService = getNodeEngineImpl(instance).getService(MapService.SERVICE_NAME);
-        queryEngine = mapService.getMapServiceContext().getMapQueryEngine(map.getName());
+        queryEngine = mapService.getMapServiceContext().getQueryEngine(map.getName());
 
         partitionId = 100;
         key = generateKeyForPartition(instance, partitionId);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngineImpl_queryLocalPartition_resultSizeLimitTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -37,66 +38,68 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({SlowTest.class, ParallelTest.class})
-public class MapQueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends HazelcastTestSupport {
+public class QueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends HazelcastTestSupport {
 
-    private static final long RESULT_SIZE_LIMIT = QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT + 4223;
-    private static final int PARTITION_COUNT = 271;
+    private static final int RESULT_SIZE_LIMIT = QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT + 2342;
+    private static final int PARTITION_COUNT = 2;
+    private static final int PARTITION_ID = 0;
 
+    private HazelcastInstance hz;
     private IMap<String, String> map;
-    private MapQueryEngineImpl queryEngine;
+    private QueryEngineImpl queryEngine;
     private int limit;
 
     @Before
     public void setup() {
         Config config = new Config();
+        // we reduce the number of partitions to speed up content generation
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "" + PARTITION_COUNT);
         config.setProperty(GroupProperty.QUERY_RESULT_SIZE_LIMIT.getName(), "" + RESULT_SIZE_LIMIT);
 
-        HazelcastInstance hz = createHazelcastInstance(config);
+        hz = createHazelcastInstance(config);
         map = hz.getMap(randomName());
 
         MapService mapService = getNodeEngineImpl(hz).getService(MapService.SERVICE_NAME);
-        queryEngine = new MapQueryEngineImpl(mapService.getMapServiceContext());
+        queryEngine = new QueryEngineImpl(mapService.getMapServiceContext());
 
-        // we fill all partitions, so we get the NodeResultLimit for all partitions as well
+        // we just fill a single partition, so we get the NodeResultLimit for a single partition as well
         QueryResultSizeLimiter resultSizeLimiter = queryEngine.getQueryResultSizeLimiter();
-        limit = (int) resultSizeLimiter.getNodeResultLimit(PARTITION_COUNT);
+        limit = (int) resultSizeLimiter.getNodeResultLimit(1);
     }
 
     @Test
     public void checkResultSize_limitNotExceeded() throws Exception {
-        fillMap(limit - 1);
+        fillPartition(limit - 1);
 
-        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE)
-                .iterationType(ENTRY).build();
+        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE).iterationType(ENTRY).build();
         QueryResult result = (QueryResult) queryEngine.execute(query, Target.LOCAL_NODE);
 
         assertEquals(limit - 1, result.size());
     }
 
     @Test
-    public void checkResultSize_limitEquals() throws Exception {
-        fillMap(limit);
+    public void checkResultSize_limitNotEquals() throws Exception {
+        fillPartition(limit);
 
-        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE)
-                .iterationType(ENTRY).build();
+        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE).iterationType(ENTRY).build();
         QueryResult result = (QueryResult) queryEngine.execute(query, Target.LOCAL_NODE);
 
         assertEquals(limit, result.size());
     }
 
+    @Ignore
     @Test(expected = QueryResultSizeExceededException.class)
     public void checkResultSize_limitExceeded() throws Exception {
-        fillMap(limit + 1);
+        fillPartition(limit + 1);
 
-        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE)
-                .iterationType(ENTRY).build();
+        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE).iterationType(ENTRY).build();
         queryEngine.execute(query, Target.LOCAL_NODE);
     }
 
-    private void fillMap(long count) {
-        for (long i = 0; i < count; i++) {
-            map.put(i + randomString(), "");
+    private void fillPartition(int count) {
+        for (int i = 0; i < count; i++) {
+            String key = generateKeyForPartition(hz, PARTITION_ID);
+            map.put(key, "");
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngineImpl_queryLocalPartitions_resultSizeLimitTest.java
@@ -28,7 +28,6 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.SlowTest;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -38,68 +37,66 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({SlowTest.class, ParallelTest.class})
-public class MapQueryEngineImpl_queryLocalPartition_resultSizeLimitTest extends HazelcastTestSupport {
+public class QueryEngineImpl_queryLocalPartitions_resultSizeLimitTest extends HazelcastTestSupport {
 
-    private static final int RESULT_SIZE_LIMIT = QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT + 2342;
-    private static final int PARTITION_COUNT = 2;
-    private static final int PARTITION_ID = 0;
+    private static final long RESULT_SIZE_LIMIT = QueryResultSizeLimiter.MINIMUM_MAX_RESULT_LIMIT + 4223;
+    private static final int PARTITION_COUNT = 271;
 
-    private HazelcastInstance hz;
     private IMap<String, String> map;
-    private MapQueryEngineImpl queryEngine;
+    private QueryEngineImpl queryEngine;
     private int limit;
 
     @Before
     public void setup() {
         Config config = new Config();
-        // we reduce the number of partitions to speed up content generation
         config.setProperty(GroupProperty.PARTITION_COUNT.getName(), "" + PARTITION_COUNT);
         config.setProperty(GroupProperty.QUERY_RESULT_SIZE_LIMIT.getName(), "" + RESULT_SIZE_LIMIT);
 
-        hz = createHazelcastInstance(config);
+        HazelcastInstance hz = createHazelcastInstance(config);
         map = hz.getMap(randomName());
 
         MapService mapService = getNodeEngineImpl(hz).getService(MapService.SERVICE_NAME);
-        queryEngine = new MapQueryEngineImpl(mapService.getMapServiceContext());
+        queryEngine = new QueryEngineImpl(mapService.getMapServiceContext());
 
-        // we just fill a single partition, so we get the NodeResultLimit for a single partition as well
+        // we fill all partitions, so we get the NodeResultLimit for all partitions as well
         QueryResultSizeLimiter resultSizeLimiter = queryEngine.getQueryResultSizeLimiter();
-        limit = (int) resultSizeLimiter.getNodeResultLimit(1);
+        limit = (int) resultSizeLimiter.getNodeResultLimit(PARTITION_COUNT);
     }
 
     @Test
     public void checkResultSize_limitNotExceeded() throws Exception {
-        fillPartition(limit - 1);
+        fillMap(limit - 1);
 
-        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE).iterationType(ENTRY).build();
+        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE)
+                .iterationType(ENTRY).build();
         QueryResult result = (QueryResult) queryEngine.execute(query, Target.LOCAL_NODE);
 
         assertEquals(limit - 1, result.size());
     }
 
     @Test
-    public void checkResultSize_limitNotEquals() throws Exception {
-        fillPartition(limit);
+    public void checkResultSize_limitEquals() throws Exception {
+        fillMap(limit);
 
-        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE).iterationType(ENTRY).build();
+        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE)
+                .iterationType(ENTRY).build();
         QueryResult result = (QueryResult) queryEngine.execute(query, Target.LOCAL_NODE);
 
         assertEquals(limit, result.size());
     }
 
-    @Ignore
     @Test(expected = QueryResultSizeExceededException.class)
     public void checkResultSize_limitExceeded() throws Exception {
-        fillPartition(limit + 1);
+        fillMap(limit + 1);
 
-        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE).iterationType(ENTRY).build();
+        Query query = Query.of().mapName(map.getName()).predicate(TruePredicate.INSTANCE)
+                .iterationType(ENTRY).build();
         queryEngine.execute(query, Target.LOCAL_NODE);
     }
 
-    private void fillPartition(int count) {
-        for (int i = 0; i < count; i++) {
-            String key = generateKeyForPartition(hz, PARTITION_ID);
-            map.put(key, "");
+    private void fillMap(long count) {
+        for (long i = 0; i < count; i++) {
+            map.put(i + randomString(), "");
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest.java
@@ -34,10 +34,10 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest extends HazelcastTestSupport {
+public class QueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest extends HazelcastTestSupport {
 
     private IMap<Object, Object> map;
-    private MapQueryEngineImpl queryEngine;
+    private QueryEngineImpl queryEngine;
 
     @Before
     public void setup() {
@@ -45,7 +45,7 @@ public class MapQueryEngineImpl_queryLocalPartitions_resultSizeNoLimitTest exten
         map = hz.getMap(randomName());
 
         MapService mapService = getNodeEngineImpl(hz).getService(MapService.SERVICE_NAME);
-        queryEngine = new MapQueryEngineImpl(mapService.getMapServiceContext());
+        queryEngine = new QueryEngineImpl(mapService.getMapServiceContext());
     }
 
     @Test


### PR DESCRIPTION
the package name already implies it is for the map.
Also the other classes in the same package do not use
Map as prefix.

No EE change needed.