### PR TITLE
Single util method for all get config classes.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfig.java
@@ -29,9 +29,11 @@ import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.internal.config.ConfigUtils;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.security.Credentials;
+import com.hazelcast.util.function.BiConsumer;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -42,7 +44,6 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.internal.config.ConfigUtils.lookupByPattern;
 import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 import static com.hazelcast.util.Preconditions.checkFalse;
@@ -256,12 +257,13 @@ public class ClientConfig {
      * @return the found config. If none is found, a default configured one is returned.
      */
     public ClientReliableTopicConfig getReliableTopicConfig(String name) {
-        ClientReliableTopicConfig reliableTopicConfig = lookupByPattern(configPatternMatcher, reliableTopicConfigMap, name);
-        if (reliableTopicConfig == null) {
-            reliableTopicConfig = new ClientReliableTopicConfig(name);
-            addReliableTopicConfig(reliableTopicConfig);
-        }
-        return reliableTopicConfig;
+        return ConfigUtils.getConfig(configPatternMatcher, reliableTopicConfigMap, name,
+                ClientReliableTopicConfig.class, new BiConsumer<ClientReliableTopicConfig, String>() {
+                    @Override
+                    public void accept(ClientReliableTopicConfig clientReliableTopicConfig, String name) {
+                        clientReliableTopicConfig.setName(name);
+                    }
+                });
     }
 
     /**
@@ -330,7 +332,6 @@ public class ClientConfig {
                 nearCacheConfig = new NearCacheConfig(nearCacheConfig);
             }
         }
-        initDefaultMaxSizeForOnHeapMaps(nearCacheConfig);
         return nearCacheConfig;
     }
 
@@ -422,20 +423,13 @@ public class ClientConfig {
      * @see #getConfigPatternMatcher()
      */
     public ClientFlakeIdGeneratorConfig getFlakeIdGeneratorConfig(String name) {
-        String baseName = getBaseName(name);
-        ClientFlakeIdGeneratorConfig config = lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigMap, baseName);
-        if (config != null) {
-            return config;
-        }
-        ClientFlakeIdGeneratorConfig defConfig = flakeIdGeneratorConfigMap.get("default");
-        if (defConfig == null) {
-            defConfig = new ClientFlakeIdGeneratorConfig("default");
-            flakeIdGeneratorConfigMap.put(defConfig.getName(), defConfig);
-        }
-        config = new ClientFlakeIdGeneratorConfig(defConfig);
-        config.setName(name);
-        flakeIdGeneratorConfigMap.put(config.getName(), config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, getFlakeIdGeneratorConfigMap(), name,
+                ClientFlakeIdGeneratorConfig.class, new BiConsumer<ClientFlakeIdGeneratorConfig, String>() {
+                    @Override
+                    public void accept(ClientFlakeIdGeneratorConfig flakeIdGeneratorConfig, String name) {
+                        flakeIdGeneratorConfig.setName(name);
+                    }
+                });
     }
 
     /**

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientReliableTopicConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientReliableTopicConfig.java
@@ -58,6 +58,18 @@ public class ClientReliableTopicConfig {
     }
 
     /**
+     * Create a clone of given reliable topic
+     *
+     * @param reliableTopicConfig topic
+     */
+    public ClientReliableTopicConfig(ClientReliableTopicConfig reliableTopicConfig) {
+        this.executor = reliableTopicConfig.executor;
+        this.readBatchSize = reliableTopicConfig.readBatchSize;
+        this.name = reliableTopicConfig.name;
+        this.topicOverloadPolicy = reliableTopicConfig.topicOverloadPolicy;
+    }
+
+    /**
      * Gets the name of the reliable topic.
      *
      * @return the name of the reliable topic.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientExtension.java
@@ -54,6 +54,7 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.function.Supplier;
 
+import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.internal.config.ConfigValidator.checkNearCacheConfig;
 import static com.hazelcast.spi.properties.GroupProperty.SOCKET_CLIENT_BUFFER_DIRECT;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
@@ -162,6 +163,7 @@ public class DefaultClientExtension implements ClientExtension {
                 NearCacheConfig nearCacheConfig = clientConfig.getNearCacheConfig(id);
                 if (nearCacheConfig != null) {
                     checkNearCacheConfig(id, nearCacheConfig, clientConfig.getNativeMemoryConfig(), true);
+                    initDefaultMaxSizeForOnHeapMaps(nearCacheConfig);
                     return new NearCachedClientMapProxy(MapService.SERVICE_NAME, id, context);
                 } else {
                     return new ClientMapProxy(MapService.SERVICE_NAME, id, context);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/ClientConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/ClientConfigTest.java
@@ -98,4 +98,15 @@ public class ClientConfigTest {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setUserContext(null);
     }
+
+    @Test
+    public void testReliableTopic() {
+        ClientConfig clientConfig = new ClientConfig();
+        ClientReliableTopicConfig defaultReliableTopicConfig = new ClientReliableTopicConfig("default");
+        defaultReliableTopicConfig.setReadBatchSize(100);
+        clientConfig.addReliableTopicConfig(defaultReliableTopicConfig);
+        ClientReliableTopicConfig newConfig = clientConfig.getReliableTopicConfig("newConfig");
+
+        assertEquals(100, newConfig.getReadBatchSize());
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractBasicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractBasicConfig.java
@@ -29,7 +29,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 @SuppressWarnings("WeakerAccess")
 public abstract class AbstractBasicConfig<T extends AbstractBasicConfig>
-        implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable {
+        implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, NamedConfig {
 
     protected String name;
     protected String quorumName;

--- a/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CacheSimpleConfig.java
@@ -40,7 +40,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  * CacheConfig depends on the JCache API. If the JCache API is not in the classpath,
  * you can use CacheSimpleConfig as a communicator between the code and CacheConfig.
  */
-public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable {
+public class CacheSimpleConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, NamedConfig {
 
     /**
      * The minimum number of backups.

--- a/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CardinalityEstimatorConfig.java
@@ -33,7 +33,7 @@ import static java.lang.String.format;
 /**
  * Configuration options for the {@link com.hazelcast.cardinality.CardinalityEstimator}
  */
-public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, Versioned {
+public class CardinalityEstimatorConfig implements IdentifiedDataSerializable, Versioned, NamedConfig {
 
     /**
      * The number of sync backups per estimator

--- a/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CollectionConfig.java
@@ -39,7 +39,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * @param <T> Type of Collection such as List, Set
  */
 public abstract class CollectionConfig<T extends CollectionConfig>
-        implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned {
+        implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned, NamedConfig {
 
     /**
      * Default maximum size for the Configuration.

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -2948,7 +2948,16 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public MerkleTreeConfig getMapMerkleTreeConfig(String name) {
-        return ConfigUtils.getConfig(configPatternMatcher, mapMerkleTreeConfigs, name, MerkleTreeConfig.class);
+        return ConfigUtils.getConfig(configPatternMatcher, mapMerkleTreeConfigs, name, MerkleTreeConfig.class,
+                new BiConsumer<MerkleTreeConfig, String>() {
+                    @Override
+                    public void accept(MerkleTreeConfig merkleTreeConfig, String name) {
+                        merkleTreeConfig.setMapName(name);
+                        if ("default".equals(name)) {
+                            merkleTreeConfig.setEnabled(false);
+                        }
+                    }
+                });
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -20,11 +20,13 @@ import com.hazelcast.config.matcher.MatchingPointConfigPatternMatcher;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ManagedContext;
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
+import com.hazelcast.internal.config.ConfigUtils;
 import com.hazelcast.internal.journal.EventJournal;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.util.StringUtil;
+import com.hazelcast.util.function.BiConsumer;
 
 import java.io.File;
 import java.net.URL;
@@ -232,7 +234,7 @@ public class Config {
      * @return property value
      * @see #setProperty(String, String)
      * @see <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#system-properties">
-     *     Hazelcast System Properties</a>
+     * Hazelcast System Properties</a>
      */
     public String getProperty(String name) {
         String value = properties.getProperty(name);
@@ -246,7 +248,7 @@ public class Config {
      * @param value value of the property
      * @return this config instance
      * @see <a href="http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#system-properties">
-     *     Hazelcast System Properties</a>
+     * Hazelcast System Properties</a>
      */
     public Config setProperty(String name, String value) {
         properties.put(name, value);
@@ -447,22 +449,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public MapConfig getMapConfig(String name) {
-        name = getBaseName(name);
-        MapConfig config = lookupByPattern(configPatternMatcher, mapConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        MapConfig defConfig = mapConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new MapConfig();
-            defConfig.setName("default");
-            initDefaultMaxSizeForOnHeapMaps(defConfig.getNearCacheConfig());
-            mapConfigs.put(defConfig.getName(), defConfig);
-        }
-        config = new MapConfig(defConfig);
-        config.setName(name);
-        mapConfigs.put(config.getName(), config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, mapConfigs, name, MapConfig.class);
     }
 
     /**
@@ -575,21 +562,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public CacheSimpleConfig getCacheConfig(String name) {
-        name = getBaseName(name);
-        CacheSimpleConfig config = lookupByPattern(configPatternMatcher, cacheConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        CacheSimpleConfig defConfig = cacheConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new CacheSimpleConfig();
-            defConfig.setName("default");
-            addCacheConfig(defConfig);
-        }
-        config = new CacheSimpleConfig(defConfig);
-        config.setName(name);
-        addCacheConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, cacheConfigs, name, CacheSimpleConfig.class);
     }
 
     /**
@@ -687,21 +660,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public QueueConfig getQueueConfig(String name) {
-        name = getBaseName(name);
-        QueueConfig config = lookupByPattern(configPatternMatcher, queueConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        QueueConfig defConfig = queueConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new QueueConfig();
-            defConfig.setName("default");
-            addQueueConfig(defConfig);
-        }
-        config = new QueueConfig(defConfig);
-        config.setName(name);
-        addQueueConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, queueConfigs, name, QueueConfig.class);
     }
 
     /**
@@ -799,21 +758,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public LockConfig getLockConfig(String name) {
-        name = getBaseName(name);
-        LockConfig config = lookupByPattern(configPatternMatcher, lockConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        LockConfig defConfig = lockConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new LockConfig();
-            defConfig.setName("default");
-            addLockConfig(defConfig);
-        }
-        config = new LockConfig(defConfig);
-        config.setName(name);
-        addLockConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, lockConfigs, name, LockConfig.class);
     }
 
     /**
@@ -911,21 +856,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public ListConfig getListConfig(String name) {
-        name = getBaseName(name);
-        ListConfig config = lookupByPattern(configPatternMatcher, listConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        ListConfig defConfig = listConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new ListConfig();
-            defConfig.setName("default");
-            addListConfig(defConfig);
-        }
-        config = new ListConfig(defConfig);
-        config.setName(name);
-        addListConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, listConfigs, name, ListConfig.class);
     }
 
     /**
@@ -1023,21 +954,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public SetConfig getSetConfig(String name) {
-        name = getBaseName(name);
-        SetConfig config = lookupByPattern(configPatternMatcher, setConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        SetConfig defConfig = setConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new SetConfig();
-            defConfig.setName("default");
-            addSetConfig(defConfig);
-        }
-        config = new SetConfig(defConfig);
-        config.setName(name);
-        addSetConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, setConfigs, name, SetConfig.class);
     }
 
     /**
@@ -1135,21 +1052,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public MultiMapConfig getMultiMapConfig(String name) {
-        name = getBaseName(name);
-        MultiMapConfig config = lookupByPattern(configPatternMatcher, multiMapConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        MultiMapConfig defConfig = multiMapConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new MultiMapConfig();
-            defConfig.setName("default");
-            addMultiMapConfig(defConfig);
-        }
-        config = new MultiMapConfig(defConfig);
-        config.setName(name);
-        addMultiMapConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, multiMapConfigs, name, MultiMapConfig.class);
     }
 
     /**
@@ -1248,21 +1151,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public ReplicatedMapConfig getReplicatedMapConfig(String name) {
-        name = getBaseName(name);
-        ReplicatedMapConfig config = lookupByPattern(configPatternMatcher, replicatedMapConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        ReplicatedMapConfig defConfig = replicatedMapConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new ReplicatedMapConfig();
-            defConfig.setName("default");
-            addReplicatedMapConfig(defConfig);
-        }
-        config = new ReplicatedMapConfig(defConfig);
-        config.setName(name);
-        addReplicatedMapConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, replicatedMapConfigs, name, ReplicatedMapConfig.class);
     }
 
     /**
@@ -1361,19 +1250,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public RingbufferConfig getRingbufferConfig(String name) {
-        name = getBaseName(name);
-        RingbufferConfig config = lookupByPattern(configPatternMatcher, ringbufferConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        RingbufferConfig defConfig = ringbufferConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new RingbufferConfig("default");
-            addRingBufferConfig(defConfig);
-        }
-        config = new RingbufferConfig(name, defConfig);
-        addRingBufferConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, ringbufferConfigs, name, RingbufferConfig.class);
     }
 
     /**
@@ -1469,21 +1346,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public AtomicLongConfig getAtomicLongConfig(String name) {
-        name = getBaseName(name);
-        AtomicLongConfig config = lookupByPattern(configPatternMatcher, atomicLongConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        AtomicLongConfig defConfig = atomicLongConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new AtomicLongConfig();
-            defConfig.setName("default");
-            addAtomicLongConfig(defConfig);
-        }
-        config = new AtomicLongConfig(defConfig);
-        config.setName(name);
-        addAtomicLongConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, atomicLongConfigs, name, AtomicLongConfig.class);
     }
 
     /**
@@ -1577,21 +1440,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public AtomicReferenceConfig getAtomicReferenceConfig(String name) {
-        name = getBaseName(name);
-        AtomicReferenceConfig config = lookupByPattern(configPatternMatcher, atomicReferenceConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        AtomicReferenceConfig defConfig = atomicReferenceConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new AtomicReferenceConfig();
-            defConfig.setName("default");
-            addAtomicReferenceConfig(defConfig);
-        }
-        config = new AtomicReferenceConfig(defConfig);
-        config.setName(name);
-        addAtomicReferenceConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, atomicReferenceConfigs, name, AtomicReferenceConfig.class);
     }
 
     /**
@@ -1685,21 +1534,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public CountDownLatchConfig getCountDownLatchConfig(String name) {
-        name = getBaseName(name);
-        CountDownLatchConfig config = lookupByPattern(configPatternMatcher, countDownLatchConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        CountDownLatchConfig defConfig = countDownLatchConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new CountDownLatchConfig();
-            defConfig.setName("default");
-            addCountDownLatchConfig(defConfig);
-        }
-        config = new CountDownLatchConfig(defConfig);
-        config.setName(name);
-        addCountDownLatchConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, countDownLatchConfigs, name, CountDownLatchConfig.class);
     }
 
     /**
@@ -1795,21 +1630,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public TopicConfig getTopicConfig(String name) {
-        name = getBaseName(name);
-        TopicConfig config = lookupByPattern(configPatternMatcher, topicConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        TopicConfig defConfig = topicConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new TopicConfig();
-            defConfig.setName("default");
-            addTopicConfig(defConfig);
-        }
-        config = new TopicConfig(defConfig);
-        config.setName(name);
-        addTopicConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, topicConfigs, name, TopicConfig.class);
     }
 
     /**
@@ -1879,19 +1700,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public ReliableTopicConfig getReliableTopicConfig(String name) {
-        name = getBaseName(name);
-        ReliableTopicConfig config = lookupByPattern(configPatternMatcher, reliableTopicConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        ReliableTopicConfig defConfig = reliableTopicConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new ReliableTopicConfig("default");
-            addReliableTopicConfig(defConfig);
-        }
-        config = new ReliableTopicConfig(defConfig, name);
-        addReliableTopicConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, reliableTopicConfigs, name, ReliableTopicConfig.class);
     }
 
     /**
@@ -2118,21 +1927,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public ExecutorConfig getExecutorConfig(String name) {
-        name = getBaseName(name);
-        ExecutorConfig config = lookupByPattern(configPatternMatcher, executorConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        ExecutorConfig defConfig = executorConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new ExecutorConfig();
-            defConfig.setName("default");
-            addExecutorConfig(defConfig);
-        }
-        config = new ExecutorConfig(defConfig);
-        config.setName(name);
-        addExecutorConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, executorConfigs, name, ExecutorConfig.class);
     }
 
     /**
@@ -2164,21 +1959,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public DurableExecutorConfig getDurableExecutorConfig(String name) {
-        name = getBaseName(name);
-        DurableExecutorConfig config = lookupByPattern(configPatternMatcher, durableExecutorConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        DurableExecutorConfig defConfig = durableExecutorConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new DurableExecutorConfig();
-            defConfig.setName("default");
-            addDurableExecutorConfig(defConfig);
-        }
-        config = new DurableExecutorConfig(defConfig);
-        config.setName(name);
-        addDurableExecutorConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, durableExecutorConfigs, name, DurableExecutorConfig.class);
     }
 
     /**
@@ -2210,21 +1991,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public ScheduledExecutorConfig getScheduledExecutorConfig(String name) {
-        name = getBaseName(name);
-        ScheduledExecutorConfig config = lookupByPattern(configPatternMatcher, scheduledExecutorConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        ScheduledExecutorConfig defConfig = scheduledExecutorConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new ScheduledExecutorConfig();
-            defConfig.setName("default");
-            addScheduledExecutorConfig(defConfig);
-        }
-        config = new ScheduledExecutorConfig(defConfig);
-        config.setName(name);
-        addScheduledExecutorConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, scheduledExecutorConfigs, name, ScheduledExecutorConfig.class);
     }
 
     /**
@@ -2256,21 +2023,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public CardinalityEstimatorConfig getCardinalityEstimatorConfig(String name) {
-        name = getBaseName(name);
-        CardinalityEstimatorConfig config = lookupByPattern(configPatternMatcher, cardinalityEstimatorConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        CardinalityEstimatorConfig defConfig = cardinalityEstimatorConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new CardinalityEstimatorConfig();
-            defConfig.setName("default");
-            addCardinalityEstimatorConfig(defConfig);
-        }
-        config = new CardinalityEstimatorConfig(defConfig);
-        config.setName(name);
-        addCardinalityEstimatorConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, cardinalityEstimatorConfigs, name, CardinalityEstimatorConfig.class);
     }
 
     /**
@@ -2302,21 +2055,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public PNCounterConfig getPNCounterConfig(String name) {
-        name = getBaseName(name);
-        PNCounterConfig config = lookupByPattern(configPatternMatcher, pnCounterConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        PNCounterConfig defConfig = pnCounterConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new PNCounterConfig();
-            defConfig.setName("default");
-            addPNCounterConfig(defConfig);
-        }
-        config = new PNCounterConfig(defConfig);
-        config.setName(name);
-        addPNCounterConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, pnCounterConfigs, name, PNCounterConfig.class);
     }
 
     /**
@@ -2581,21 +2320,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public SemaphoreConfig getSemaphoreConfig(String name) {
-        name = getBaseName(name);
-        SemaphoreConfig config = lookupByPattern(configPatternMatcher, semaphoreConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        SemaphoreConfig defConfig = semaphoreConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new SemaphoreConfig();
-            defConfig.setName("default");
-            addSemaphoreConfig(defConfig);
-        }
-        config = new SemaphoreConfig(defConfig);
-        config.setName(name);
-        addSemaphoreConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, semaphoreConfigs, name, SemaphoreConfig.class);
     }
 
     /**
@@ -2751,21 +2476,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public JobTrackerConfig getJobTrackerConfig(String name) {
-        name = getBaseName(name);
-        JobTrackerConfig config = lookupByPattern(configPatternMatcher, jobTrackerConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        JobTrackerConfig defConfig = jobTrackerConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new JobTrackerConfig();
-            defConfig.setName("default");
-            addJobTrackerConfig(defConfig);
-        }
-        config = new JobTrackerConfig(defConfig);
-        config.setName(name);
-        addJobTrackerConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, jobTrackerConfigs, name, JobTrackerConfig.class);
     }
 
     /**
@@ -2849,21 +2560,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public QuorumConfig getQuorumConfig(String name) {
-        name = getBaseName(name);
-        QuorumConfig config = lookupByPattern(configPatternMatcher, quorumConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        QuorumConfig defConfig = quorumConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new QuorumConfig();
-            defConfig.setName("default");
-            addQuorumConfig(defConfig);
-        }
-        config = new QuorumConfig(defConfig);
-        config.setName(name);
-        addQuorumConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, quorumConfigs, name, QuorumConfig.class);
     }
 
     /**
@@ -3110,19 +2807,16 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public EventJournalConfig getMapEventJournalConfig(String name) {
-        name = getBaseName(name);
-        EventJournalConfig config = lookupByPattern(configPatternMatcher, mapEventJournalConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        EventJournalConfig defConfig = mapEventJournalConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new EventJournalConfig().setMapName("default").setEnabled(false);
-            addEventJournalConfig(defConfig);
-        }
-        config = new EventJournalConfig(defConfig).setMapName(name);
-        addEventJournalConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, mapEventJournalConfigs, name, EventJournalConfig.class,
+                new BiConsumer<EventJournalConfig, String>() {
+                    @Override
+                    public void accept(EventJournalConfig eventJournalConfig, String name) {
+                        eventJournalConfig.setMapName(name);
+                        if ("default".equals(name)) {
+                            eventJournalConfig.setEnabled(false);
+                        }
+                    }
+                });
     }
 
     /**
@@ -3156,19 +2850,16 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public EventJournalConfig getCacheEventJournalConfig(String name) {
-        name = getBaseName(name);
-        EventJournalConfig config = lookupByPattern(configPatternMatcher, cacheEventJournalConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        EventJournalConfig defConfig = cacheEventJournalConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new EventJournalConfig().setCacheName("default").setEnabled(false);
-            addEventJournalConfig(defConfig);
-        }
-        config = new EventJournalConfig(defConfig).setCacheName(name);
-        addEventJournalConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, cacheEventJournalConfigs, name, EventJournalConfig.class,
+                new BiConsumer<EventJournalConfig, String>() {
+                    @Override
+                    public void accept(EventJournalConfig eventJournalConfig, String name) {
+                        eventJournalConfig.setCacheName(name);
+                        if ("default".equals(name)) {
+                            eventJournalConfig.setEnabled(false);
+                        }
+                    }
+                });
     }
 
     /**
@@ -3257,19 +2948,7 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public MerkleTreeConfig getMapMerkleTreeConfig(String name) {
-        name = getBaseName(name);
-        MerkleTreeConfig config = lookupByPattern(configPatternMatcher, mapMerkleTreeConfigs, name);
-        if (config != null) {
-            return config;
-        }
-        MerkleTreeConfig defConfig = mapMerkleTreeConfigs.get("default");
-        if (defConfig == null) {
-            defConfig = new MerkleTreeConfig().setMapName("default").setEnabled(false);
-            addMerkleTreeConfig(defConfig);
-        }
-        config = new MerkleTreeConfig(defConfig).setMapName(name);
-        addMerkleTreeConfig(config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, mapMerkleTreeConfigs, name, MerkleTreeConfig.class);
     }
 
     /**
@@ -3354,20 +3033,13 @@ public class Config {
      * @see #getConfigPatternMatcher()
      */
     public FlakeIdGeneratorConfig getFlakeIdGeneratorConfig(String name) {
-        String baseName = getBaseName(name);
-        FlakeIdGeneratorConfig config = lookupByPattern(configPatternMatcher, flakeIdGeneratorConfigMap, baseName);
-        if (config != null) {
-            return config;
-        }
-        FlakeIdGeneratorConfig defConfig = flakeIdGeneratorConfigMap.get("default");
-        if (defConfig == null) {
-            defConfig = new FlakeIdGeneratorConfig("default");
-            flakeIdGeneratorConfigMap.put(defConfig.getName(), defConfig);
-        }
-        config = new FlakeIdGeneratorConfig(defConfig);
-        config.setName(name);
-        flakeIdGeneratorConfigMap.put(config.getName(), config);
-        return config;
+        return ConfigUtils.getConfig(configPatternMatcher, flakeIdGeneratorConfigMap, name,
+                FlakeIdGeneratorConfig.class, new BiConsumer<FlakeIdGeneratorConfig, String>() {
+                    @Override
+                    public void accept(FlakeIdGeneratorConfig flakeIdGeneratorConfig, String name) {
+                        flakeIdGeneratorConfig.setName(name);
+                    }
+                });
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/CountDownLatchConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/CountDownLatchConfig.java
@@ -31,7 +31,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  *
  * @since 3.10
  */
-public class CountDownLatchConfig implements IdentifiedDataSerializable, Versioned {
+public class CountDownLatchConfig implements IdentifiedDataSerializable, Versioned, NamedConfig {
 
     private transient CountDownLatchConfigReadOnly readOnly;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DurableExecutorConfig.java
@@ -30,7 +30,7 @@ import static com.hazelcast.util.Preconditions.checkPositive;
 /**
  * Contains the configuration for an {@link DurableExecutorService}.
  */
-public class DurableExecutorConfig implements IdentifiedDataSerializable, Versioned {
+public class DurableExecutorConfig implements IdentifiedDataSerializable, Versioned, NamedConfig {
 
     /**
      * The number of executor threads per Member for the Executor based on this configuration.

--- a/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ExecutorConfig.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 /**
  * Contains the configuration for an {@link com.hazelcast.core.IExecutorService}.
  */
-public class ExecutorConfig implements IdentifiedDataSerializable, Versioned {
+public class ExecutorConfig implements IdentifiedDataSerializable, Versioned, NamedConfig {
 
     /**
      * The number of executor threads per Member for the Executor based on this configuration.

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
@@ -207,10 +207,9 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
      * You create cluster B and for some time both will generate IDs and you want to have them unique.
      * In this case, configure node ID offset for generators on cluster B.
      *
-     * @see FlakeIdGenerator for the node id logic
-     *
      * @param nodeIdOffset the value added to the node id
      * @return this instance for fluent API
+     * @see FlakeIdGenerator for the node id logic
      */
     public FlakeIdGeneratorConfig setNodeIdOffset(long nodeIdOffset) {
         checkNotNegative(nodeIdOffset, "node id offset must be non-negative");
@@ -230,7 +229,7 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
      * {@link LocalFlakeIdGeneratorStats}.
      *
      * @param statisticsEnabled {@code true} if statistics gathering is enabled
-     *        (which is also the default), {@code false} otherwise
+     *                          (which is also the default), {@code false} otherwise
      * @return this instance for fluent API
      */
     public FlakeIdGeneratorConfig setStatisticsEnabled(boolean statisticsEnabled) {
@@ -259,7 +258,7 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(new Object[] { name, prefetchCount, prefetchValidityMillis, idOffset, statisticsEnabled });
+        return Arrays.hashCode(new Object[]{name, prefetchCount, prefetchValidityMillis, idOffset, statisticsEnabled});
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/JobTrackerConfig.java
@@ -22,7 +22,7 @@ import com.hazelcast.mapreduce.TopologyChangedStrategy;
 /**
  * Contains the configuration for an {@link com.hazelcast.mapreduce.JobTracker}.
  */
-public class JobTrackerConfig {
+public class JobTrackerConfig implements NamedConfig {
 
     /**
      * Default size of thread.

--- a/hazelcast/src/main/java/com/hazelcast/config/LockConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/LockConfig.java
@@ -28,7 +28,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 /**
  * Contains the configuration for the {@link com.hazelcast.core.ILock}.
  */
-public class LockConfig implements IdentifiedDataSerializable {
+public class LockConfig implements IdentifiedDataSerializable, NamedConfig {
 
     private String name;
     private String quorumName;

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -42,7 +42,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 /**
  * Contains the configuration for an {@link com.hazelcast.core.IMap}.
  */
-public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned {
+public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned, NamedConfig {
 
     /**
      * The minimum number of backups

--- a/hazelcast/src/main/java/com/hazelcast/config/MerkleTreeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MerkleTreeConfig.java
@@ -54,7 +54,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * @since 3.11
  */
 @Beta
-public class MerkleTreeConfig implements IdentifiedDataSerializable {
+public class MerkleTreeConfig implements IdentifiedDataSerializable, NamedConfig {
     /**
      * Minimal depth of the merkle tree.
      */
@@ -228,6 +228,16 @@ public class MerkleTreeConfig implements IdentifiedDataSerializable {
         result = 31 * result + depth;
         result = 31 * result + (mapName != null ? mapName.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    public MerkleTreeConfig setName(String name) {
+        return setMapName(name);
+    }
+
+    @Override
+    public String getName() {
+        return getMapName();
     }
 
     // not private for testing

--- a/hazelcast/src/main/java/com/hazelcast/config/MerkleTreeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MerkleTreeConfig.java
@@ -54,7 +54,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * @since 3.11
  */
 @Beta
-public class MerkleTreeConfig implements IdentifiedDataSerializable, NamedConfig {
+public class MerkleTreeConfig implements IdentifiedDataSerializable {
     /**
      * Minimal depth of the merkle tree.
      */
@@ -228,16 +228,6 @@ public class MerkleTreeConfig implements IdentifiedDataSerializable, NamedConfig
         result = 31 * result + depth;
         result = 31 * result + (mapName != null ? mapName.hashCode() : 0);
         return result;
-    }
-
-    @Override
-    public MerkleTreeConfig setName(String name) {
-        return setMapName(name);
-    }
-
-    @Override
-    public String getName() {
-        return getMapName();
     }
 
     // not private for testing

--- a/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MultiMapConfig.java
@@ -36,7 +36,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * Configuration for MultiMap.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class MultiMapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned {
+public class MultiMapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned, NamedConfig {
 
     /**
      * The default number of synchronous backups for this MultiMap.

--- a/hazelcast/src/main/java/com/hazelcast/config/NamedConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NamedConfig.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Interface for hazelcast data structures with name
+ */
+public interface NamedConfig {
+
+    NamedConfig setName(String name);
+
+    String getName();
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCacheConfig.java
@@ -32,7 +32,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
  * Contains the configuration for a Near Cache.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class NearCacheConfig implements IdentifiedDataSerializable, Serializable {
+public class NearCacheConfig implements IdentifiedDataSerializable, Serializable, NamedConfig {
 
     /**
      * Default value for the in-memory format.

--- a/hazelcast/src/main/java/com/hazelcast/config/PNCounterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PNCounterConfig.java
@@ -31,7 +31,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * @since 3.10
  */
 @Beta
-public class PNCounterConfig implements IdentifiedDataSerializable {
+public class PNCounterConfig implements IdentifiedDataSerializable, NamedConfig {
     /**
      * The default number of replicas on which state for this CRDT is kept
      */

--- a/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueueConfig.java
@@ -37,7 +37,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * Contains the configuration for an {@link com.hazelcast.core.IQueue}.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class QueueConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned {
+public class QueueConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned , NamedConfig {
 
     /**
      * Default value for the maximum size of the Queue.

--- a/hazelcast/src/main/java/com/hazelcast/config/QuorumConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QuorumConfig.java
@@ -62,7 +62,7 @@ import static com.hazelcast.quorum.QuorumType.READ_WRITE;
  * @see com.hazelcast.quorum.impl.ProbabilisticQuorumFunction
  * @see com.hazelcast.quorum.impl.RecentlyActiveQuorumFunction
  */
-public class QuorumConfig implements IdentifiedDataSerializable {
+public class QuorumConfig implements IdentifiedDataSerializable, NamedConfig {
 
     private String name;
     private boolean enabled;

--- a/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReliableTopicConfig.java
@@ -49,7 +49,7 @@ import static com.hazelcast.util.Preconditions.checkPositive;
  * messages.
  */
 @Beta
-public class ReliableTopicConfig implements IdentifiedDataSerializable {
+public class ReliableTopicConfig implements IdentifiedDataSerializable, NamedConfig {
 
     /**
      * The default read batch size.

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfig.java
@@ -37,7 +37,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * Contains the configuration for an {@link com.hazelcast.core.ReplicatedMap}
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class ReplicatedMapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned {
+public class ReplicatedMapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned, NamedConfig {
 
     /**
      * Default value of concurrency level

--- a/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RingbufferConfig.java
@@ -42,7 +42,7 @@ import static com.hazelcast.util.Preconditions.checkPositive;
  * in the cluster and its backup in another member in the cluster.
  */
 @Beta
-public class RingbufferConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned {
+public class RingbufferConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned, NamedConfig {
 
     /**
      * Default value of capacity of the RingBuffer.

--- a/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ScheduledExecutorConfig.java
@@ -32,7 +32,8 @@ import static com.hazelcast.util.Preconditions.checkPositive;
 /**
  * Configuration options for the {@link com.hazelcast.scheduledexecutor.IScheduledExecutorService}.
  */
-public class ScheduledExecutorConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable, Versioned {
+public class ScheduledExecutorConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSerializable,
+        Versioned, NamedConfig {
 
     /**
      * The number of executor threads per Member for the Executor based on this configuration.
@@ -196,19 +197,19 @@ public class ScheduledExecutorConfig implements SplitBrainMergeTypeProvider, Ide
 
 
     /**
-    * Gets the {@link MergePolicyConfig} for the scheduler.
-    *
-    * @return the {@link MergePolicyConfig} for the scheduler
-    */
+     * Gets the {@link MergePolicyConfig} for the scheduler.
+     *
+     * @return the {@link MergePolicyConfig} for the scheduler
+     */
     public MergePolicyConfig getMergePolicyConfig() {
         return mergePolicyConfig;
     }
 
     /**
-    * Sets the {@link MergePolicyConfig} for the scheduler.
-    *
-    * @return this executor config instance
-    */
+     * Sets the {@link MergePolicyConfig} for the scheduler.
+     *
+     * @return this executor config instance
+     */
     public ScheduledExecutorConfig setMergePolicyConfig(MergePolicyConfig mergePolicyConfig) {
         this.mergePolicyConfig = checkNotNull(mergePolicyConfig, "mergePolicyConfig cannot be null");
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SemaphoreConfig.java
@@ -31,7 +31,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 /**
  * Contains the configuration for an {@link com.hazelcast.core.ISemaphore}.
  */
-public class SemaphoreConfig implements IdentifiedDataSerializable, Versioned {
+public class SemaphoreConfig implements IdentifiedDataSerializable, Versioned, NamedConfig {
 
     /**
      * Default synchronous backup count.

--- a/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/TopicConfig.java
@@ -32,7 +32,7 @@ import static com.hazelcast.util.Preconditions.isNotNull;
 /**
  * Contains the configuration for a {@link com.hazelcast.core.ITopic}.
  */
-public class TopicConfig implements IdentifiedDataSerializable {
+public class TopicConfig implements IdentifiedDataSerializable, NamedConfig {
 
     /**
      * Default global ordering configuration.

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigUtils.java
@@ -18,10 +18,18 @@ package com.hazelcast.internal.config;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.ConfigPatternMatcher;
+import com.hazelcast.config.ConfigurationException;
+import com.hazelcast.config.NamedConfig;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
+import com.hazelcast.partition.strategy.StringPartitioningStrategy;
+import com.hazelcast.util.function.BiConsumer;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+
+import static com.hazelcast.partition.strategy.StringPartitioningStrategy.getBaseName;
 
 /**
  * Utility class to access configuration.
@@ -29,6 +37,12 @@ import java.util.Map;
 public final class ConfigUtils {
 
     private static final ILogger LOGGER = Logger.getLogger(Config.class);
+    private static final BiConsumer<NamedConfig, String> DEFAULT_NAME_SETTER = new BiConsumer<NamedConfig, String>() {
+        @Override
+        public void accept(NamedConfig namedConfig, String name) {
+            namedConfig.setName(name);
+        }
+    };
 
     private ConfigUtils() {
     }
@@ -48,4 +62,86 @@ public final class ConfigUtils {
         }
         return null;
     }
+
+    /**
+     * Returns a config for the given name, creating one
+     * if necessary and adding it to the collection of known configurations.
+     * <p>
+     * The configuration is found by matching the configuration name
+     * pattern to the provided {@code name} without the partition qualifier
+     * (the part of the name after {@code '@'}).
+     * If no configuration matches, it will create one by cloning the
+     * {@code "default"} configuration and add it to the configuration
+     * collection.
+     * <p>
+     * This method is intended to easily and fluently create and add
+     * configurations more specific than the default configuration without
+     * explicitly adding it by invoking addXConfig(..)
+     * <p>
+     * Because it adds new configurations if they are not already present,
+     * this method is intended to be used before this config is used to
+     * create a hazelcast instance. Afterwards, newly added configurations
+     * may be ignored.
+     *
+     * @param name name of the lock config
+     * @return the lock configuration
+     * @throws ConfigurationException if ambiguous configurations are found
+     * @see StringPartitioningStrategy#getBaseName(java.lang.String)
+     * @see Config#setConfigPatternMatcher(ConfigPatternMatcher)
+     * @see Config##getConfigPatternMatcher()
+     */
+    public static <T extends NamedConfig> T getConfig(ConfigPatternMatcher configPatternMatcher,
+                                                      Map<String, T> configs, String name,
+                                                      Class clazz) {
+        return getConfig(configPatternMatcher, configs, name, clazz, (BiConsumer<T, String>) DEFAULT_NAME_SETTER);
+    }
+
+    /**
+     * Similar to {@link ConfigUtils#getConfig(ConfigPatternMatcher, Map, String, Class)}
+     * This method is introduced specifically for solving problem of EventJournalConfig
+     * use {@link ConfigUtils#getConfig(ConfigPatternMatcher, Map, String, Class)} along with {@link NamedConfig}
+     * where possible
+     */
+    public static <T> T getConfig(ConfigPatternMatcher configPatternMatcher,
+                                  Map<String, T> configs, String name,
+                                  Class clazz, BiConsumer<T, String> nameSetter) {
+        name = getBaseName(name);
+        T config = lookupByPattern(configPatternMatcher, configs, name);
+        if (config != null) {
+            return config;
+        }
+        T defConfig = configs.get("default");
+        try {
+            if (defConfig == null) {
+                Constructor constructor = clazz.getDeclaredConstructor();
+                constructor.setAccessible(true);
+                defConfig = (T) constructor.newInstance();
+                nameSetter.accept(defConfig, "default");
+                configs.put("default", defConfig);
+            }
+            Constructor copyConstructor = clazz.getDeclaredConstructor(clazz);
+            copyConstructor.setAccessible(true);
+            config = (T) copyConstructor.newInstance(defConfig);
+            nameSetter.accept(config, name);
+            configs.put(name, config);
+            return config;
+        } catch (NoSuchMethodException e) {
+            LOGGER.severe("Could not create class " + clazz.getName());
+            assert false;
+            return null;
+        } catch (InstantiationException e) {
+            LOGGER.severe("Could not create class " + clazz.getName());
+            assert false;
+            return null;
+        } catch (IllegalAccessException e) {
+            LOGGER.severe("Could not create class " + clazz.getName());
+            assert false;
+            return null;
+        } catch (InvocationTargetException e) {
+            LOGGER.severe("Could not create class " + clazz.getName());
+            assert false;
+            return null;
+        }
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/config/ConfigUtils.java
@@ -83,8 +83,8 @@ public final class ConfigUtils {
      * create a hazelcast instance. Afterwards, newly added configurations
      * may be ignored.
      *
-     * @param name name of the lock config
-     * @return the lock configuration
+     * @param name name of the config
+     * @return the configuration
      * @throws ConfigurationException if ambiguous configurations are found
      * @see StringPartitioningStrategy#getBaseName(java.lang.String)
      * @see Config#setConfigPatternMatcher(ConfigPatternMatcher)

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapRemoteService.java
@@ -25,6 +25,7 @@ import com.hazelcast.map.merge.MergePolicyProvider;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.RemoteService;
 
+import static com.hazelcast.config.NearCacheConfigAccessor.initDefaultMaxSizeForOnHeapMaps;
 import static com.hazelcast.internal.config.ConfigValidator.checkMapConfig;
 import static com.hazelcast.internal.config.ConfigValidator.checkNearCacheConfig;
 import static com.hazelcast.internal.config.MergePolicyValidator.checkMergePolicySupportsInMemoryFormat;
@@ -56,6 +57,7 @@ class MapRemoteService implements RemoteService {
                 true, nodeEngine.getLogger(getClass()));
 
         if (mapConfig.isNearCacheEnabled()) {
+            initDefaultMaxSizeForOnHeapMaps(mapConfig.getNearCacheConfig());
             checkNearCacheConfig(name, mapConfig.getNearCacheConfig(), config.getNativeMemoryConfig(), false);
             return new NearCachedMapProxyImpl(name, mapServiceContext.getService(), nodeEngine, mapConfig);
         } else {


### PR DESCRIPTION
Main purpose is to remove code duplication.
Also some of the getConfig methods were not using same logic
like client.getReliableTopic. It is fixed with this pr.

fixes https://github.com/hazelcast/hazelcast/issues/13880