### PR TITLE
QueryEntryFactory gets proper dependencies

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -124,11 +124,12 @@ public class MapContainer {
         this.quorumName = mapConfig.getQuorumName();
         this.serializationService = nodeEngine.getSerializationService();
         this.recordFactoryConstructor = createRecordFactoryConstructor(serializationService);
-        this.queryEntryFactory = new QueryEntryFactory(mapConfig.getCacheDeserializedValues());
         this.objectNamespace = MapService.getObjectNamespace(name);
         initWanReplication(nodeEngine);
         ClassLoader classloader = mapServiceContext.getNodeEngine().getConfigClassLoader();
         this.extractors = new Extractors(mapConfig.getMapAttributeConfigs(), classloader);
+        this.queryEntryFactory = new QueryEntryFactory(mapConfig.getCacheDeserializedValues(),
+                (InternalSerializationService) serializationService, extractors);
         if (shouldUseGlobalIndex(mapConfig)) {
             this.globalIndexes = createIndexes(true);
         } else {
@@ -371,7 +372,7 @@ public class MapContainer {
     }
 
     public QueryableEntry newQueryEntry(Data key, Object value) {
-        return queryEntryFactory.newEntry((InternalSerializationService) serializationService, key, value, extractors);
+        return queryEntryFactory.newEntry(key, value);
     }
 
     public Evictor getEvictor() {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEntryFactory.java
@@ -27,13 +27,18 @@ import com.hazelcast.query.impl.getters.Extractors;
 public final class QueryEntryFactory {
 
     private final CacheDeserializedValues cacheDeserializedValues;
+    private final InternalSerializationService serializationService;
+    private final Extractors extractors;
 
-    public QueryEntryFactory(CacheDeserializedValues cacheDeserializedValues) {
+    public QueryEntryFactory(CacheDeserializedValues cacheDeserializedValues,
+                             InternalSerializationService serializationService,
+                             Extractors extractors) {
         this.cacheDeserializedValues = cacheDeserializedValues;
+        this.serializationService = serializationService;
+        this.extractors = extractors;
     }
 
-    public QueryableEntry newEntry(InternalSerializationService serializationService,
-                                   Data key, Object value, Extractors extractors) {
+    public QueryableEntry newEntry(Data key, Object value) {
         switch (cacheDeserializedValues) {
             case NEVER:
                 return new QueryEntry(serializationService, key, value, extractors);


### PR DESCRIPTION
Instead of having some dependencies set through the constructor
and the rest passed as argument, they are now all set through the
constructor.