### PR TITLE
- Refactored expirations tests

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheClearExpiredOperation.java
@@ -93,7 +93,7 @@ public class CacheClearExpiredOperation extends AbstractLocalOperation implement
 
     @Override
     public boolean returnsResponse() {
-        return true;
+        return false;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearExpiredOperation.java
@@ -96,7 +96,7 @@ public class ClearExpiredOperation extends AbstractLocalOperation implements Par
 
     @Override
     public boolean returnsResponse() {
-        return true;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
- Returned false from returnsResponse methods of expired-entry-cleaner-operations

this refactoring is needed after merging https://github.com/hazelcast/hazelcast/pull/13997