### PR TITLE
Remove outdated Jackson dependency

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
@@ -37,6 +36,8 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.Serializable;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -1254,9 +1255,11 @@ public class ClientMapBasicTest extends AbstractClientMapTest {
             test.put(i, i);
         }
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        String result = objectMapper.writeValueAsString(test.values(new TestPagingPredicate(1000)));
-        assertNotNull(result);
+        Collection<Integer> values = test.values(new TestPagingPredicate(100));
+        Type genericSuperClass = values.getClass().getGenericSuperclass();
+        Type actualType = ((ParameterizedType) genericSuperClass).getActualTypeArguments()[0];
+        // Raw class is expected. ParameterizedType-s cause troubles to Jackson serializer.
+        assertInstanceOf(Class.class, actualType);
     }
 
     private static class TestPagingPredicate extends PagingPredicate {

--- a/pom.xml
+++ b/pom.xml
@@ -1263,12 +1263,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.7.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
             <version>1.7.8</version>


### PR DESCRIPTION
This PR removes dependency on outdated Jackson library. 
The library was only used for regression testing which we can also accomplish by a direct type check.

The regression test was introduced within PR #11550.