### PR TITLE
Minor doc/toString cleanup iobalancer

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/IOBalancer.java
@@ -46,7 +46,7 @@ import static com.hazelcast.spi.properties.GroupProperty.IO_THREAD_COUNT;
  * {@link NioInboundPipeline} and {@link NioOutboundPipeline} between {@link NioThread}
  * instances.
  *
- * It measures number of events serviced by each pipeline in a given interval and
+ * It measures load serviced by each pipeline in a given interval and
  * if imbalance is detected then it schedules pipeline migration to fix the situation.
  * The exact migration strategy can be customized via
  * {@link com.hazelcast.internal.networking.nio.iobalancer.MigrationStrategy}.
@@ -159,7 +159,7 @@ public class IOBalancer {
                     logger.finest("There is at most 1 pipeline associated with each thread. "
                             + "There is nothing to balance");
                 } else {
-                    logger.finest("No imbalance has been detected. Max. events: " + max + " Min events: " + min + ".");
+                    logger.finest("No imbalance has been detected. Max. load: " + max + " Min load: " + min + ".");
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadImbalance.java
@@ -31,9 +31,9 @@ import java.util.Set;
  * {@link NioPipeline} should be migrated.
  */
 class LoadImbalance {
-    //number of events recorded by the busiest NioThread
+    //load recorded by the busiest NioThread
     long maximumLoad;
-    //number of events recorded by the least busy NioThread
+    //load recorded by the least busy NioThread
     long minimumLoad;
     //busiest NioThread
     NioThread srcOwner;

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/iobalancer/LoadTracker.java
@@ -42,12 +42,12 @@ class LoadTracker {
     private final NioThread[] ioThreads;
     private final Map<NioThread, Set<MigratablePipeline>> ownerToPipelines;
 
-    //no. of events per pipeline since an instance started
+    //load per pipeline since an instance started
     private final ItemCounter<MigratablePipeline> lastLoadCounter = new ItemCounter<MigratablePipeline>();
 
-    //no. of events per NioThread since last calculation
+    //load per NioThread since last calculation
     private final ItemCounter<NioThread> ownerLoad = new ItemCounter<NioThread>();
-    //no. of events per pipeline since last calculation
+    //load per pipeline since last calculation
     private final ItemCounter<MigratablePipeline> pipelineLoadCount = new ItemCounter<MigratablePipeline>();
 
     //contains all known pipelines
@@ -121,7 +121,6 @@ class LoadTracker {
         }
     }
 
-
     private void updateNewWorkingImbalance() {
         for (MigratablePipeline pipeline : pipelines) {
             updatePipelineState(pipeline);
@@ -158,7 +157,7 @@ class LoadTracker {
         pipelines.add(pipeline);
     }
 
-    public void removePipeline(MigratablePipeline pipeline) {
+    void removePipeline(MigratablePipeline pipeline) {
         pipelines.remove(pipeline);
         pipelineLoadCount.remove(pipeline);
         lastLoadCounter.remove(pipeline);
@@ -181,9 +180,9 @@ class LoadTracker {
 
         sb.append("Min NioThread ")
                 .append(minThread)
-                .append(" received ")
+                .append(" receive-load ")
                 .append(loadPerOwner)
-                .append(" events. ");
+                .append(" load. ");
         sb.append("It contains following pipelines: ").
                 append(LINE_SEPARATOR);
         appendSelectorInfo(minThread, ownerToPipelines, sb);
@@ -191,9 +190,8 @@ class LoadTracker {
         loadPerOwner = ownerLoad.get(maxThread);
         sb.append("Max NioThread ")
                 .append(maxThread)
-                .append(" received ")
-                .append(loadPerOwner)
-                .append(" events. ");
+                .append(" receive-load ")
+                .append(loadPerOwner);
         sb.append("It contains following pipelines: ")
                 .append(LINE_SEPARATOR);
         appendSelectorInfo(maxThread, ownerToPipelines, sb);
@@ -232,6 +230,4 @@ class LoadTracker {
         }
         sb.append(LINE_SEPARATOR);
     }
-
-
 }


### PR DESCRIPTION
In the past iobalancer used to work with events, but this
has been changed to 'load' quite some time ago. However some
javadoc/strings are still pointing to events. This pr fixes that.