### PR TITLE
Shutdown hazelcast instances on test failure

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/starter/HazelcastClientStarterTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/starter/HazelcastClientStarterTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.starter.HazelcastStarter;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -33,30 +34,31 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
 public class HazelcastClientStarterTest {
+
+    private HazelcastInstance memberInstance;
+
+    @After
+    public void tearDown() {
+        if (memberInstance != null) {
+            memberInstance.shutdown();
+        }
+    }
+
     @Test
     public void testClientLifecycle() {
-        HazelcastInstance member = null;
-        try {
-            member = HazelcastStarter.newHazelcastInstance("3.7");
+        memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
 
-            for (int i = 1; i < 6; i++) {
-                String version = "3.7." + i;
-                System.out.println("Starting client " + version);
-                HazelcastInstance instance = HazelcastClientStarter.newHazelcastClient(version, false);
-                System.out.println("Stopping client " + version);
-                instance.shutdown();
-            }
-
-        } finally {
-            if (member != null) {
-                member.shutdown();
-            }
+        for (int i = 1; i < 6; i++) {
+            String version = "3.7." + i;
+            System.out.println("Starting client " + version);
+            HazelcastInstance instance = HazelcastClientStarter.newHazelcastClient(version, false);
+            System.out.println("Stopping client " + version);
+            instance.shutdown();
         }
     }
 
     @Test
     public void testClientMap() {
-        HazelcastInstance memberInstance = null;
         HazelcastInstance clientInstance = null;
         try {
             memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
@@ -69,9 +71,6 @@ public class HazelcastClientStarterTest {
 
             assertEquals(2, (int) memberMap.get(1));
         } finally {
-            if (memberInstance != null) {
-                memberInstance.shutdown();
-            }
             if (clientInstance != null) {
                 clientInstance.shutdown();
             }
@@ -80,25 +79,16 @@ public class HazelcastClientStarterTest {
 
     @Test
     public void testAdvancedClientMap() {
-        HazelcastInstance memberInstance = null;
+        memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
+        HazelcastInstance clientInstance = HazelcastClientStarter.newHazelcastClient("3.7.2", false);
 
-        try {
-            memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
-            HazelcastInstance clientInstance = HazelcastClientStarter.newHazelcastClient("3.7.2", false);
-
-            System.out.println("About to terminate the client");
-            clientInstance.getLifecycleService().terminate();
-            System.out.println("Client terminated");
-        } finally {
-            if (memberInstance != null) {
-                memberInstance.shutdown();
-            }
-        }
+        System.out.println("About to terminate the client");
+        clientInstance.getLifecycleService().terminate();
+        System.out.println("Client terminated");
     }
 
     @Test
     public void testClientMap_async() throws InterruptedException, ExecutionException {
-        HazelcastInstance memberInstance = null;
         HazelcastInstance clientInstance = null;
         try {
             memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
@@ -111,9 +101,6 @@ public class HazelcastClientStarterTest {
 
             assertEquals(1, value);
         } finally {
-            if (memberInstance != null) {
-                memberInstance.shutdown();
-            }
             if (clientInstance != null) {
                 clientInstance.shutdown();
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/starter/HazelcastClientStarterTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/starter/HazelcastClientStarterTest.java
@@ -33,63 +33,90 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(SlowTest.class)
 public class HazelcastClientStarterTest {
-
     @Test
     public void testClientLifecycle() {
-        HazelcastInstance member = HazelcastStarter.newHazelcastInstance("3.7");
+        HazelcastInstance member = null;
+        try {
+            member = HazelcastStarter.newHazelcastInstance("3.7");
 
-        for (int i = 1; i < 6; i++) {
-            String version = "3.7." + i;
-            System.out.println("Starting client " + version);
-            HazelcastInstance instance = HazelcastClientStarter.newHazelcastClient(version, false);
-            System.out.println("Stopping client " + version);
-            instance.shutdown();
+            for (int i = 1; i < 6; i++) {
+                String version = "3.7." + i;
+                System.out.println("Starting client " + version);
+                HazelcastInstance instance = HazelcastClientStarter.newHazelcastClient(version, false);
+                System.out.println("Stopping client " + version);
+                instance.shutdown();
+            }
+
+        } finally {
+            if (member != null) {
+                member.shutdown();
+            }
         }
-
-        member.shutdown();
     }
 
     @Test
     public void testClientMap() {
-        HazelcastInstance memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
-        HazelcastInstance clientInstance = HazelcastClientStarter.newHazelcastClient("3.7.2", false);
+        HazelcastInstance memberInstance = null;
+        HazelcastInstance clientInstance = null;
+        try {
+            memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
+            clientInstance = HazelcastClientStarter.newHazelcastClient("3.7.2", false);
 
-        IMap<Integer, Integer> clientMap = clientInstance.getMap("myMap");
-        IMap<Integer, Integer> memberMap = memberInstance.getMap("myMap");
+            IMap<Integer, Integer> clientMap = clientInstance.getMap("myMap");
+            IMap<Integer, Integer> memberMap = memberInstance.getMap("myMap");
 
-        clientMap.put(1, 2);
+            clientMap.put(1, 2);
 
-        assertEquals(2, (int) memberMap.get(1));
-
-        clientInstance.shutdown();
-        memberInstance.shutdown();
+            assertEquals(2, (int) memberMap.get(1));
+        } finally {
+            if (memberInstance != null) {
+                memberInstance.shutdown();
+            }
+            if (clientInstance != null) {
+                clientInstance.shutdown();
+            }
+        }
     }
 
     @Test
     public void testAdvancedClientMap() {
-        HazelcastInstance memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
-        HazelcastInstance clientInstance = HazelcastClientStarter.newHazelcastClient("3.7.2", false);
+        HazelcastInstance memberInstance = null;
 
-        System.out.println("About to terminate the client");
-        clientInstance.getLifecycleService().terminate();
-        System.out.println("Client terminated");
+        try {
+            memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
+            HazelcastInstance clientInstance = HazelcastClientStarter.newHazelcastClient("3.7.2", false);
 
-        memberInstance.shutdown();
+            System.out.println("About to terminate the client");
+            clientInstance.getLifecycleService().terminate();
+            System.out.println("Client terminated");
+        } finally {
+            if (memberInstance != null) {
+                memberInstance.shutdown();
+            }
+        }
     }
 
     @Test
     public void testClientMap_async() throws InterruptedException, ExecutionException {
-        HazelcastInstance memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
-        HazelcastInstance clientInstance = HazelcastClientStarter.newHazelcastClient("3.7.2", false);
+        HazelcastInstance memberInstance = null;
+        HazelcastInstance clientInstance = null;
+        try {
+            memberInstance = HazelcastStarter.newHazelcastInstance("3.7");
+            clientInstance = HazelcastClientStarter.newHazelcastClient("3.7.2", false);
 
-        IMap<Integer, Integer> clientMap = clientInstance.getMap("myMap");
-        clientMap.put(0, 1);
-        ICompletableFuture<Integer> async = clientMap.getAsync(0);
-        int value = async.get();
+            IMap<Integer, Integer> clientMap = clientInstance.getMap("myMap");
+            clientMap.put(0, 1);
+            ICompletableFuture<Integer> async = clientMap.getAsync(0);
+            int value = async.get();
 
-        assertEquals(1, value);
-
-        clientInstance.shutdown();
-        memberInstance.shutdown();
+            assertEquals(1, value);
+        } finally {
+            if (memberInstance != null) {
+                memberInstance.shutdown();
+            }
+            if (clientInstance != null) {
+                clientInstance.shutdown();
+            }
+        }
     }
 }


### PR DESCRIPTION
After a HazelcastClientStarterTest fails, the member instance might not
get shut down.

Fixes: https://github.com/hazelcast/hazelcast/issues/14027