### PR TITLE
Fixes handling of exceptions in all-partitions Cache message tasks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractAllPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractAllPartitionsMessageTask.java
@@ -51,6 +51,10 @@ public abstract class AbstractAllPartitionsMessageTask<P> extends AbstractMessag
 
     @Override
     public final void onResponse(Map<Integer, Object> map) {
-        sendResponse(reduce(map));
+        try {
+            sendResponse(reduce(map));
+        } catch (Exception e) {
+            handleProcessingFailure(e);
+        }
     }
 }


### PR DESCRIPTION
Before #13844, exceptions thrown from `reduce(map)` would be caught
higher up the class hierarchy and handled via `handleProcessingFailure`,
properly sending an exception to the client. Since #13844 these
exceptions are just logged on the member-side. This PR restores handling
of exceptions from `reduce(map)` so the client is properly notified of the
exception.

Fixes #14003