### PR TITLE
Channel.close closes socket immediately

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/AbstractChannel.java
@@ -171,8 +171,7 @@ public abstract class AbstractChannel implements Channel {
     }
 
     /**
-     * Template method that is called when the socket channel closed. It is
-     * called before the {@code socketChannel} is closed.
+     * Template method that is called when the Channel is closed.
      *
      * It will be called only once.
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Channel.java
@@ -173,20 +173,7 @@ public interface Channel extends Closeable {
      */
     void start();
 
-    /**
-     * Closes the Channel.
-     *
-     * It could be that the actual closing of the Channel is executed asynchronous
-     * and completes at some point in the future. This is important for e.g. TLS
-     * goodbye handshake.
-     *
-     * This method is thread-safe.
-     *
-     * When the channel already is closed, the call is ignored.
-     */
-    void close() throws IOException;
-
-    /**
+      /**
      * Connects the channel.
      *
      * This call should only be made once and is not threadsafe.
@@ -205,6 +192,18 @@ public interface Channel extends Closeable {
      * @throws IOException if connecting fails.
      */
     void connect(InetSocketAddress address, int timeoutMillis) throws IOException;
+
+    /**
+     * Closes the Channel.
+     *
+     * This method is thread-safe.
+     *
+     * This method can safely be called from an IO thread. Close-listeners will not
+     * be executed on an IO thread.
+     *
+     * When the channel already is closed, the call is ignored.
+     */
+    void close() throws IOException;
 
     /**
      * Checks if this Channel is closed. This method is very cheap to make.
@@ -227,7 +226,10 @@ public interface Channel extends Closeable {
      * Checks if this side is the Channel is in client mode or server mode.
      *
      * A channel is in client-mode if it initiated the connection, and in
-     * server-mode if it was the one accepting the connection.
+     * server-mode if it was the one accepting the connection. Client mode isn't related
+     * to Hazelcast clients (although a Hazelcast client will always have clientMode=true).
+     * A connection from one member to another member can also have clientMode=true if that
+     * member connected to the other member.
      *
      * One of the reasons this property is valuable is for protocol/handshaking
      * so that it is clear distinction between the side that initiated the connection,

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/ChannelHandler.java
@@ -133,19 +133,4 @@ public abstract class ChannelHandler<H extends ChannelHandler, S, D> {
      */
     public void interceptError(Throwable error) throws Throwable {
     }
-
-    /**
-     * Asks handler to trigger the closing process.
-     *
-     * Only has meaning currently for TLS. Probably this method will be replaced
-     * by some kind of general purpose event handler. An event can be thrown
-     * in the pipeline and will be pushed through each handler and it is up
-     * to the handler to respond (or not). SO we could have a close event, but
-     * also other events like handlers sending messages to each other which requires
-     * custom exchange logic currently.
-     *
-     * @throws Exception
-     */
-    public void requestClose() throws Exception {
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -275,12 +275,10 @@ public final class NioOutboundPipeline
         //System.out.println(channel+" bytes written:"+written);
     }
 
-    @Override
-    public void requestClose() {
+    void drainWriteQueues() {
         writeQueue.clear();
         priorityWriteQueue.clear();
-        super.requestClose();
-   }
+    }
 
     @Override
     protected void publishMetrics() {

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -130,8 +130,6 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
         System.setProperty("hazelcast.wait.seconds.before.join", "1");
         System.setProperty("hazelcast.local.localAddress", "127.0.0.1");
         System.setProperty("java.net.preferIPv4Stack", "true");
-        // speed up closing connections in com.hazelcast.internal.networking.nio.NioChannel.doClose()
-        System.setProperty("hazelcast.channel.close.delayMs", "0");
     }
 
 


### PR DESCRIPTION
This fix removed the 200ms delay when closing a Channel. 

So the channel (and underlying socket) is immediately closed without waiting. 

For Enterprise counterpart see https://github.com/hazelcast/hazelcast-enterprise/pull/2563

For backport see 
https://github.com/hazelcast/hazelcast/pull/14206