### PR TITLE
MetricsRegistry shutdown executor now

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -340,7 +340,8 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     }
 
     public void shutdown() {
-        scheduledExecutorService.shutdown();
+        // we want to immediately terminate; we don't want to wait till pending tasks have completed.
+        scheduledExecutorService.shutdownNow();
     }
 
     private static class SortedProbeInstances {


### PR DESCRIPTION
We immediately want to terminate the metrics; we don't want to wait
till pending tasks have executed.

This will help to speed up terminating this service