### PR TITLE
Faster shutdown of client ClusterConnector

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
@@ -25,7 +25,6 @@ import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.ClientConnectionStrategy;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.clientside.LifecycleServiceImpl;
-import com.hazelcast.client.spi.impl.ClientExecutionServiceImpl;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
@@ -46,6 +45,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.client.spi.impl.ClientExecutionServiceImpl.shutdownNowExecutor;
 import static com.hazelcast.client.spi.properties.ClientProperty.SHUFFLE_MEMBER_LIST;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
@@ -282,7 +282,9 @@ class ClusterConnector {
     }
 
     public void shutdown() {
-        ClientExecutionServiceImpl.shutdownExecutor("cluster", clusterConnectionExecutor, logger);
+        // since the connector is shutting down, we don't care about any remaining
+        // task. So we want to shutdown fast.
+        shutdownNowExecutor("cluster", clusterConnectionExecutor, logger);
     }
 
     interface WaitStrategy {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientExecutionServiceImpl.java
@@ -112,7 +112,7 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService,
         return userExecutor;
     }
 
-    @Probe (level = MANDATORY)
+    @Probe(level = MANDATORY)
     public int getUserExecutorQueueSize() {
         return ((ThreadPoolExecutor) userExecutor).getQueue().size();
     }
@@ -123,7 +123,19 @@ public final class ClientExecutionServiceImpl implements ClientExecutionService,
     }
 
     public static void shutdownExecutor(String name, ExecutorService executor, ILogger logger) {
-        executor.shutdown();
+        shutdownExecutor(name, executor, logger, false);
+    }
+
+    public static void shutdownNowExecutor(String name, ExecutorService executor, ILogger logger) {
+        shutdownExecutor(name, executor, logger, true);
+    }
+
+    private static void shutdownExecutor(String name, ExecutorService executor, ILogger logger, boolean shutdownNow) {
+        if (shutdownNow) {
+            executor.shutdownNow();
+        } else {
+            executor.shutdown();
+        }
         try {
             boolean success = executor.awaitTermination(TERMINATE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
             if (!success) {


### PR DESCRIPTION
So instead of calling the executor.shutdown, the shutdown now
is called. The difference is that the shutdown will drain the work
queue and will try to interrupt any task that is running.