### PR TITLE
Allow dynamically adding WAN publisher configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementDataSerializerHook.java
@@ -18,7 +18,7 @@ package com.hazelcast.internal.management;
 
 import com.hazelcast.internal.management.dto.MapConfigDTO;
 import com.hazelcast.internal.management.dto.PermissionConfigDTO;
-import com.hazelcast.internal.management.operation.AddWanConfigOperation;
+import com.hazelcast.internal.management.operation.AddWanConfigLegacyOperation;
 import com.hazelcast.internal.management.operation.ScriptExecutorOperation;
 import com.hazelcast.internal.management.operation.UpdateManagementCenterUrlOperation;
 import com.hazelcast.internal.management.operation.UpdateMapConfigOperation;
@@ -81,7 +81,7 @@ public class ManagementDataSerializerHook implements DataSerializerHook {
         constructors[ADD_WAN_CONFIG] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             @Override
             public IdentifiedDataSerializable createNew(Integer arg) {
-                return new AddWanConfigOperation();
+                return new AddWanConfigLegacyOperation();
             }
         };
         constructors[UPDATE_PERMISSION_CONFIG_OPERATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/AddWanConfigIgnoredEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/AddWanConfigIgnoredEvent.java
@@ -30,11 +30,6 @@ public final class AddWanConfigIgnoredEvent extends AbstractEventBase {
         this.reason = reason;
     }
 
-    public static AddWanConfigIgnoredEvent alreadyExists(String wanConfigName) {
-        return new AddWanConfigIgnoredEvent(wanConfigName,
-                "A WAN replication config already exists with the given name.");
-    }
-
     public static AddWanConfigIgnoredEvent enterpriseOnly(String wanConfigName) {
         return new AddWanConfigIgnoredEvent(wanConfigName,
                 "Adding new WAN replication config is supported for enterprise clusters only.");

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/EventMetadata.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/EventMetadata.java
@@ -37,7 +37,8 @@ public final class EventMetadata {
         WAN_SYNC_FINISHED_MERKLE(7),
         WAN_CONFIGURATION_ADDED(8),
         ADD_WAN_CONFIGURATION_IGNORED(9),
-        WAN_SYNC_IGNORED(10);
+        WAN_SYNC_IGNORED(10),
+        WAN_CONFIGURATION_EXTENDED(11);
 
         private final int code;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConfigurationExtendedEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/events/WanConfigurationExtendedEvent.java
@@ -16,40 +16,37 @@
 
 package com.hazelcast.internal.management.events;
 
+import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.events.EventMetadata.EventType;
 
-import static com.hazelcast.internal.management.events.EventMetadata.EventType.ADD_WAN_CONFIGURATION_IGNORED;
+import java.util.Collection;
 
-public final class AddWanConfigIgnoredEvent extends AbstractEventBase {
+import static com.hazelcast.internal.management.events.EventMetadata.EventType.WAN_CONFIGURATION_EXTENDED;
+
+public class WanConfigurationExtendedEvent extends AbstractEventBase {
     private final String wanConfigName;
-    private final String reason;
+    private final Collection<String> wanPublisherIds;
 
-    private AddWanConfigIgnoredEvent(String wanConfigName, String reason) {
+    public WanConfigurationExtendedEvent(String wanConfigName, Collection<String> wanPublisherIds) {
         this.wanConfigName = wanConfigName;
-        this.reason = reason;
-    }
-
-    public static AddWanConfigIgnoredEvent alreadyExists(String wanConfigName) {
-        return new AddWanConfigIgnoredEvent(wanConfigName,
-                "A WAN replication config already exists with the given name.");
-    }
-
-    public static AddWanConfigIgnoredEvent enterpriseOnly(String wanConfigName) {
-        return new AddWanConfigIgnoredEvent(wanConfigName,
-                "Adding new WAN replication config is supported for enterprise clusters only.");
+        this.wanPublisherIds = wanPublisherIds;
     }
 
     @Override
     public EventType getType() {
-        return ADD_WAN_CONFIGURATION_IGNORED;
+        return WAN_CONFIGURATION_EXTENDED;
     }
 
     @Override
     public JsonObject toJson() {
         JsonObject json = new JsonObject();
         json.add("wanConfigName", wanConfigName);
-        json.add("reason", reason);
+        JsonArray publisherIds = new JsonArray();
+        for (String publisherId : wanPublisherIds) {
+            publisherIds.add(publisherId);
+        }
+        json.add("wanPublisherIds", publisherIds);
         return json;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -132,17 +132,37 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
      *
      * @param wanReplicationName the name of the wan replication config
      * @param targetGroupName    the target cluster group name
+     * @throws UnsupportedOperationException if invoked on OS
      */
     void clearQueues(String wanReplicationName, String targetGroupName);
 
     /**
      * Adds a new {@link WanReplicationConfig} to this member and creates the
      * {@link WanReplicationPublisher}s specified in the config.
+     * This method can also accept WAN configs with an existing WAN replication
+     * name. Such configs will be merged into the existing WAN replication
+     * config by adding publishers with publisher IDs which are not already part
+     * of the existing configuration.
+     *
+     * @throws UnsupportedOperationException if invoked on OS
+     */
+    void addWanReplicationConfigLocally(WanReplicationConfig wanConfig);
+
+    /**
+     * Adds a new {@link WanReplicationConfig} to the cluster.
+     * This method can also accept WAN configs with an existing WAN replication
+     * name. Such configs will be merged into the existing WAN replication
+     * config by adding publishers with publisher IDs which are not already part
+     * of the existing configuration.
+     *
+     * @throws UnsupportedOperationException if invoked on OS
+     * @see #addWanReplicationConfigLocally(WanReplicationConfig)
      */
     void addWanReplicationConfig(WanReplicationConfig wanConfig);
 
     /**
-     * Returns current status of WAN sync operation
+     * Returns current status of WAN sync operation or {@code null} when there
+     * is no status.
      */
     WanSyncState getWanSyncState();
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -167,6 +167,11 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
+    public void addWanReplicationConfigLocally(WanReplicationConfig wanConfig) {
+        throw new UnsupportedOperationException("Adding new WAN config is not supported.");
+    }
+
+    @Override
     public Map<String, LocalWanStats> getStats() {
         return null;
     }


### PR DESCRIPTION
We introduce a way for dynamically adding WAN publisher configurations
during cluster operation. This is done on the partition threads so that
the config mutation and publisher initialisation is ordered with other
map and cache mutation operations. Even so, there are some race
conditions related to removing WAN backup events which must be handled
separately.
We also expand the WAN testing framework to allow for adding detached
WAN publisher configurations (those without source or target cluster).

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2571