### PR TITLE
Skip serializing DiscoveryStrategyFactory

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -33,6 +33,10 @@ import java.util.Map;
  */
 public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
     private String className;
+    // we skip serialization since this may be a user-supplied object and
+    // it may not be serializable. Since we send the WAN config in the
+    // FinalizeJoinOp, this may prevent a node from sending it to a joining
+    // member
     private transient DiscoveryStrategyFactory discoveryStrategyFactory;
     private Map<String, Comparable> properties;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -33,7 +33,7 @@ import java.util.Map;
  */
 public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
     private String className;
-    private DiscoveryStrategyFactory discoveryStrategyFactory;
+    private transient DiscoveryStrategyFactory discoveryStrategyFactory;
     private Map<String, Comparable> properties;
 
     public DiscoveryStrategyConfig() {

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -125,7 +125,6 @@ public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(className);
-        out.writeObject(discoveryStrategyFactory);
 
         out.writeInt(properties.size());
         for (Map.Entry<String, Comparable> entry : properties.entrySet()) {
@@ -137,7 +136,6 @@ public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         className = in.readUTF();
-        discoveryStrategyFactory = in.readObject();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             properties.put(in.readUTF(), (Comparable) in.readObject());


### PR DESCRIPTION
The object might be supplied by the user and it might not be
serializable since we didn't enforce this until now. Trying to serialize
it might break existing deployments since the WAN configuration is sent
during node join and a non-serializable object will prevent sending a
PostJoinOperation.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2573