### PR TITLE
Closing all connections when heartbeat timeout

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl;
 
 import com.hazelcast.core.ClientType;
+import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.spi.ExecutionService;
@@ -92,9 +93,10 @@ public class ClientHeartbeatMonitor implements Runnable {
     }
 
     private void monitor(ClientEndpoint clientEndpoint) {
-        // C++ client does not send heartbeat over its owner connection
-        // We are skipping checking heartbeat for cpp owner connection
-        if (clientEndpoint.isOwnerConnection() && ClientType.CPP.equals(clientEndpoint.getClientType())) {
+        // C++ client does not send heartbeat over its owner connection for versions before 3.10
+        // We are skipping checking heartbeat for cpp owner connection on those versions.
+        if (clientEndpoint.isOwnerConnection() && ClientType.CPP.equals(clientEndpoint.getClientType())
+                && clientEndpoint.getClientVersion() < BuildInfo.calculateVersion("3.10")) {
             return;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientHeartbeatMonitor.java
@@ -92,9 +92,9 @@ public class ClientHeartbeatMonitor implements Runnable {
     }
 
     private void monitor(ClientEndpoint clientEndpoint) {
-        // C++ client sends heartbeat over its non-owner connections
-        // For other client types, disregard non-owner connections for heartbeat monitoring purposes
-        if (clientEndpoint.isOwnerConnection() == ClientType.CPP.equals(clientEndpoint.getClientType())) {
+        // C++ client does not send heartbeat over its owner connection
+        // We are skipping checking heartbeat for cpp owner connection
+        if (clientEndpoint.isOwnerConnection() && ClientType.CPP.equals(clientEndpoint.getClientType())) {
             return;
         }
 


### PR DESCRIPTION
This was actually addressed in following pr.
Members and clients disconnect the connection as soon as
heartbeat timeout is detected.

https://github.com/hazelcast/hazelcast/pull/12765

This pr fixes member side heartbeat monitor. It was not closing
the connections if the connection is not an owner connection.

fixes #14094

(cherry picked from commit 17e598ccd92bd5892b830fde4b55fa7828da103e)