### PR TITLE
[BACKPORT] Extend JSON support for WAN config classes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfig.java
@@ -116,7 +116,7 @@ public abstract class AliasedDiscoveryConfig<T extends AliasedDiscoveryConfig<T>
         return usePublicIp;
     }
 
-    String getTag() {
+    public String getTag() {
         return tag;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfigUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfigUtils.java
@@ -184,17 +184,18 @@ public final class AliasedDiscoveryConfigUtils {
     /**
      * Creates new {@link AliasedDiscoveryConfig} by the given {@code tag}.
      */
-    public static AliasedDiscoveryConfig newConfigFor(String tag) {
+    @SuppressWarnings("unchecked")
+    public static <C extends AliasedDiscoveryConfig<C>> C newConfigFor(String tag) {
         if ("aws".equals(tag)) {
-            return new AwsConfig();
+            return (C) new AwsConfig();
         } else if ("gcp".equals(tag)) {
-            return new GcpConfig();
+            return (C) new GcpConfig();
         } else if ("azure".equals(tag)) {
-            return new AzureConfig();
+            return (C) new AzureConfig();
         } else if ("kubernetes".equals(tag)) {
-            return new KubernetesConfig();
+            return (C) new KubernetesConfig();
         } else if ("eureka".equals(tag)) {
-            return new EurekaConfig();
+            return (C) new EurekaConfig();
         } else {
             throw new IllegalArgumentException(String.format("Invalid tag: '%s'", tag));
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfigUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfigUtils.java
@@ -185,17 +185,17 @@ public final class AliasedDiscoveryConfigUtils {
      * Creates new {@link AliasedDiscoveryConfig} by the given {@code tag}.
      */
     @SuppressWarnings("unchecked")
-    public static <C extends AliasedDiscoveryConfig<C>> C newConfigFor(String tag) {
+    public static AliasedDiscoveryConfig newConfigFor(String tag) {
         if ("aws".equals(tag)) {
-            return (C) new AwsConfig();
+            return new AwsConfig();
         } else if ("gcp".equals(tag)) {
-            return (C) new GcpConfig();
+            return new GcpConfig();
         } else if ("azure".equals(tag)) {
-            return (C) new AzureConfig();
+            return new AzureConfig();
         } else if ("kubernetes".equals(tag)) {
-            return (C) new KubernetesConfig();
+            return new KubernetesConfig();
         } else if ("eureka".equals(tag)) {
-            return (C) new EurekaConfig();
+            return new EurekaConfig();
         } else {
             throw new IllegalArgumentException(String.format("Invalid tag: '%s'", tag));
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -1498,10 +1498,10 @@ public class ConfigXmlGenerator {
             return this;
         }
 
-        XmlGenerator appendProperties(Map<String, Comparable> props) {
+        XmlGenerator appendProperties(Map<String, ? extends Comparable> props) {
             if (!MapUtil.isNullOrEmpty(props)) {
                 open("properties");
-                for (Entry<String, Comparable> entry : props.entrySet()) {
+                for (Entry<String, ? extends Comparable> entry : props.entrySet()) {
                     node("property", entry.getValue(), "name", entry.getKey());
                 }
                 close();

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -27,19 +27,22 @@ import java.util.Map;
  * based on a parsed XML or configured manually using the config API
  */
 public class DiscoveryStrategyConfig {
+    private String className;
+    private DiscoveryStrategyFactory discoveryStrategyFactory;
+    private Map<String, Comparable> properties;
 
-    private final Map<String, Comparable> properties = new HashMap<String, Comparable>();
-
-    private final String className;
-    private final DiscoveryStrategyFactory discoveryStrategyFactory;
+    public DiscoveryStrategyConfig() {
+        properties = new HashMap<String, Comparable>();
+    }
 
     public DiscoveryStrategyConfig(String className) {
         this(className, Collections.<String, Comparable>emptyMap());
     }
 
-    public DiscoveryStrategyConfig(String className, Map<String, Comparable> properties) {
+    public DiscoveryStrategyConfig(String className,
+                                   Map<String, Comparable> properties) {
         this.className = className;
-        this.properties.putAll(properties);
+        this.properties = new HashMap<String, Comparable>(properties);
         this.discoveryStrategyFactory = null;
     }
 
@@ -50,12 +53,22 @@ public class DiscoveryStrategyConfig {
 
     public DiscoveryStrategyConfig(DiscoveryStrategyFactory discoveryStrategyFactory, Map<String, Comparable> properties) {
         this.className = null;
-        this.properties.putAll(properties);
+        this.properties = new HashMap<String, Comparable>(properties);
         this.discoveryStrategyFactory = discoveryStrategyFactory;
     }
 
     public String getClassName() {
         return className;
+    }
+
+    public DiscoveryStrategyConfig setClassName(String className) {
+        this.className = className;
+        return this;
+    }
+
+    public DiscoveryStrategyConfig setDiscoveryStrategyFactory(DiscoveryStrategyFactory discoveryStrategyFactory) {
+        this.discoveryStrategyFactory = discoveryStrategyFactory;
+        return this;
     }
 
     public DiscoveryStrategyFactory getDiscoveryStrategyFactory() {
@@ -70,8 +83,13 @@ public class DiscoveryStrategyConfig {
         properties.remove(key);
     }
 
+    public DiscoveryStrategyConfig setProperties(Map<String, Comparable> properties) {
+        this.properties = properties;
+        return this;
+    }
+
     public Map<String, Comparable> getProperties() {
-        return Collections.unmodifiableMap(properties);
+        return properties;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/JsonSerializable.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/JsonSerializable.java
@@ -19,11 +19,23 @@ package com.hazelcast.internal.management;
 import com.hazelcast.internal.json.JsonObject;
 
 /**
- * JsonSerializable is a serialization interface that serializes/de-serializes to/from JSON.
+ * JsonSerializable is a serialization interface that serializes/de-serializes
+ * to/from JSON.
  */
 public interface JsonSerializable {
 
+    /**
+     * Serializes state represented by this object into a {@link JsonObject}.
+     *
+     * @return the JSON representation of this object
+     */
     JsonObject toJson();
 
+    /**
+     * Extracts the state from the given {@code json} object and mutates the
+     * state of this object.
+     *
+     * @param json the JSON object carrying state for this object
+     */
     void fromJson(JsonObject json);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/AliasedDiscoveryConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/AliasedDiscoveryConfigDTO.java
@@ -33,18 +33,17 @@ import static com.hazelcast.util.MapUtil.isNullOrEmpty;
  * A JSON representation of a
  * {@link com.hazelcast.config.AliasedDiscoveryConfig} implementation.
  *
- * @param <C> configuration implementation type
  */
-public class AliasedDiscoveryConfigDTO<C extends AliasedDiscoveryConfig<C>> implements JsonSerializable {
+public class AliasedDiscoveryConfigDTO implements JsonSerializable {
 
     private String tag;
-    private C config;
+    private AliasedDiscoveryConfig config;
 
     public AliasedDiscoveryConfigDTO(String tag) {
         this.tag = tag;
     }
 
-    public AliasedDiscoveryConfigDTO(C config) {
+    public AliasedDiscoveryConfigDTO(AliasedDiscoveryConfig config) {
         this.config = config;
     }
 
@@ -63,7 +62,7 @@ public class AliasedDiscoveryConfigDTO<C extends AliasedDiscoveryConfig<C>> impl
 
     @Override
     public void fromJson(JsonObject json) {
-        config = AliasedDiscoveryConfigUtils.<C>newConfigFor(tag);
+        config = AliasedDiscoveryConfigUtils.newConfigFor(tag);
 
         JsonValue enabled = json.get("enabled");
         if (enabled != null && !enabled.isNull()) {
@@ -81,7 +80,7 @@ public class AliasedDiscoveryConfigDTO<C extends AliasedDiscoveryConfig<C>> impl
         }
     }
 
-    public C getConfig() {
+    public AliasedDiscoveryConfig getConfig() {
         return config;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/AliasedDiscoveryConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/AliasedDiscoveryConfigDTO.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.config.AliasedDiscoveryConfig;
+import com.hazelcast.config.AliasedDiscoveryConfigUtils;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.management.JsonSerializable;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import static com.hazelcast.util.JsonUtil.fromJsonObject;
+import static com.hazelcast.util.JsonUtil.toJsonObject;
+import static com.hazelcast.util.MapUtil.isNullOrEmpty;
+
+/**
+ * A JSON representation of a
+ * {@link com.hazelcast.config.AliasedDiscoveryConfig} implementation.
+ *
+ * @param <C> configuration implementation type
+ */
+public class AliasedDiscoveryConfigDTO<C extends AliasedDiscoveryConfig<C>> implements JsonSerializable {
+
+    private String tag;
+    private C config;
+
+    public AliasedDiscoveryConfigDTO(String tag) {
+        this.tag = tag;
+    }
+
+    public AliasedDiscoveryConfigDTO(C config) {
+        this.config = config;
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject()
+                .add("enabled", config.isEnabled())
+                .add("usePublicIp", config.isUsePublicIp());
+
+        if (!isNullOrEmpty(config.getProperties())) {
+            root.add("properties", toJsonObject(config.getProperties()));
+        }
+
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        config = AliasedDiscoveryConfigUtils.<C>newConfigFor(tag);
+
+        JsonValue enabled = json.get("enabled");
+        if (enabled != null && !enabled.isNull()) {
+            config.setEnabled(enabled.asBoolean());
+        }
+
+        JsonValue usePublicIp = json.get("usePublicIp");
+        if (usePublicIp != null && !usePublicIp.isNull()) {
+            config.setUsePublicIp(usePublicIp.asBoolean());
+        }
+
+        Map<String, Comparable> properties = fromJsonObject((JsonObject) json.get("properties"));
+        for (Entry<String, Comparable> property : properties.entrySet()) {
+            config.setProperty(property.getKey(), (String) property.getValue());
+        }
+    }
+
+    public C getConfig() {
+        return config;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/DiscoveryConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/DiscoveryConfigDTO.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.config.DiscoveryConfig;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.internal.json.JsonArray;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.management.JsonSerializable;
+
+import java.util.Collection;
+
+/**
+ * A JSON representation of {@link DiscoveryConfig}.
+ */
+public class DiscoveryConfigDTO implements JsonSerializable {
+
+    private DiscoveryConfig config;
+
+    public DiscoveryConfigDTO() {
+    }
+
+    public DiscoveryConfigDTO(DiscoveryConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject()
+                .add("nodeFilterClass", config.getNodeFilterClass());
+
+        JsonArray strategies = new JsonArray();
+        for (DiscoveryStrategyConfig strategyConfig : config.getDiscoveryStrategyConfigs()) {
+            DiscoveryStrategyConfigDTO dto = new DiscoveryStrategyConfigDTO(strategyConfig);
+            strategies.add(dto.toJson());
+        }
+        root.add("discoveryStrategy", strategies);
+
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        config = new DiscoveryConfig();
+
+        JsonValue nodeFilterClass = json.get("nodeFilterClass");
+        if (nodeFilterClass != null && !nodeFilterClass.isNull()) {
+            config.setNodeFilterClass(nodeFilterClass.asString());
+        }
+
+        JsonValue discoveryStrategies = json.get("discoveryStrategy");
+        if (discoveryStrategies != null && !discoveryStrategies.isNull()) {
+            Collection<DiscoveryStrategyConfig> strategyConfigs = config.getDiscoveryStrategyConfigs();
+            for (JsonValue strategy : discoveryStrategies.asArray()) {
+                DiscoveryStrategyConfigDTO strategyDTO = new DiscoveryStrategyConfigDTO();
+                strategyDTO.fromJson(strategy.asObject());
+                strategyConfigs.add(strategyDTO.getConfig());
+            }
+        }
+    }
+
+    public DiscoveryConfig getConfig() {
+        return config;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/DiscoveryStrategyConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/DiscoveryStrategyConfigDTO.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.management.JsonSerializable;
+
+import static com.hazelcast.util.JsonUtil.fromJsonObject;
+import static com.hazelcast.util.JsonUtil.toJsonObject;
+import static com.hazelcast.util.MapUtil.isNullOrEmpty;
+
+/**
+ * A JSON representation of {@link com.hazelcast.config.DiscoveryStrategyConfig}.
+ */
+public class DiscoveryStrategyConfigDTO implements JsonSerializable {
+
+    private DiscoveryStrategyConfig config;
+
+    public DiscoveryStrategyConfigDTO() {
+    }
+
+    public DiscoveryStrategyConfigDTO(DiscoveryStrategyConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject();
+
+        if (config.getClassName() != null) {
+            root.add("className", config.getClassName());
+        }
+        if (!isNullOrEmpty(config.getProperties())) {
+            root.add("properties", toJsonObject(config.getProperties()));
+        }
+
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        config = new DiscoveryStrategyConfig();
+
+        JsonValue className = json.get("className");
+        if (className != null && !className.isNull()) {
+            config.setClassName(className.asString());
+        }
+
+        config.setProperties(fromJsonObject((JsonObject) json.get("properties")));
+    }
+
+    public DiscoveryStrategyConfig getConfig() {
+        return config;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanConsumerConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanConsumerConfigDTO.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.config.WanConsumerConfig;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.management.JsonSerializable;
+
+import static com.hazelcast.util.JsonUtil.fromJsonObject;
+import static com.hazelcast.util.JsonUtil.toJsonObject;
+import static com.hazelcast.util.MapUtil.isNullOrEmpty;
+
+/**
+ * A JSON representation of {@link WanConsumerConfig}.
+ */
+public class WanConsumerConfigDTO implements JsonSerializable {
+
+    private WanConsumerConfig config;
+
+    public WanConsumerConfigDTO() {
+    }
+
+    public WanConsumerConfigDTO(WanConsumerConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject()
+                .add("persistWanReplicatedData", config.isPersistWanReplicatedData());
+        if (config.getClassName() != null) {
+            root.add("className", config.getClassName());
+        }
+        if (!isNullOrEmpty(config.getProperties())) {
+            root.add("properties", toJsonObject(config.getProperties()));
+        }
+
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        config = new WanConsumerConfig();
+
+        JsonValue persistWanReplicatedData = json.get("persistWanReplicatedData");
+        if (persistWanReplicatedData != null && !persistWanReplicatedData.isNull()) {
+            config.setPersistWanReplicatedData(persistWanReplicatedData.asBoolean());
+        }
+
+        JsonValue className = json.get("className");
+        if (className != null && !className.isNull()) {
+            config.setClassName(className.asString());
+        }
+
+        config.setProperties(fromJsonObject((JsonObject) json.get("properties")));
+    }
+
+    public WanConsumerConfig getConfig() {
+        return config;
+    }
+
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTO.java
@@ -135,24 +135,24 @@ public class WanPublisherConfigDTO implements JsonSerializable {
             config.setClassName(className.asString());
         }
 
-        AwsConfig awsConfig = this.<AwsConfig>deserializeAliasedDiscoveryConfig(json, "aws");
+        AwsConfig awsConfig = (AwsConfig) this.deserializeAliasedDiscoveryConfig(json, "aws");
         if (awsConfig != null) {
             config.setAwsConfig(awsConfig);
         }
 
-        GcpConfig gcpConfig = this.<GcpConfig>deserializeAliasedDiscoveryConfig(json, "gcp");
+        GcpConfig gcpConfig = (GcpConfig) this.deserializeAliasedDiscoveryConfig(json, "gcp");
         if (gcpConfig != null) {
             config.setGcpConfig(gcpConfig);
         }
-        AzureConfig azureConfig = this.<AzureConfig>deserializeAliasedDiscoveryConfig(json, "azure");
+        AzureConfig azureConfig = (AzureConfig) this.deserializeAliasedDiscoveryConfig(json, "azure");
         if (azureConfig != null) {
             config.setAzureConfig(azureConfig);
         }
-        KubernetesConfig kubernetesConfig = this.<KubernetesConfig>deserializeAliasedDiscoveryConfig(json, "kubernetes");
+        KubernetesConfig kubernetesConfig = (KubernetesConfig) this.deserializeAliasedDiscoveryConfig(json, "kubernetes");
         if (kubernetesConfig != null) {
             config.setKubernetesConfig(kubernetesConfig);
         }
-        EurekaConfig eurekaConfig = this.<EurekaConfig>deserializeAliasedDiscoveryConfig(json, "eureka");
+        EurekaConfig eurekaConfig = (EurekaConfig) this.deserializeAliasedDiscoveryConfig(json, "eureka");
         if (eurekaConfig != null) {
             config.setEurekaConfig(eurekaConfig);
         }
@@ -177,15 +177,14 @@ public class WanPublisherConfigDTO implements JsonSerializable {
      *
      * @param json the JSON object containing the serialized config
      * @param tag  the tag under which the config is nested
-     * @param <C>  the configuration type
      * @return the deserialized config or {@code null} if the serialized config
      * was missing in the JSON object
      */
-    private <C extends AliasedDiscoveryConfig<C>> C deserializeAliasedDiscoveryConfig(
+    private AliasedDiscoveryConfig deserializeAliasedDiscoveryConfig(
             JsonObject json, String tag) {
         JsonValue configJson = json.get(tag);
         if (configJson != null && !configJson.isNull()) {
-            AliasedDiscoveryConfigDTO<C> dto = new AliasedDiscoveryConfigDTO<C>(tag);
+            AliasedDiscoveryConfigDTO dto = new AliasedDiscoveryConfigDTO(tag);
             dto.fromJson(configJson.asObject());
             return dto.getConfig();
         }
@@ -200,12 +199,11 @@ public class WanPublisherConfigDTO implements JsonSerializable {
      * @param object the JSON object to which the config is added
      * @param tag    the tag under which the config is added
      * @param config the configuration
-     * @param <C>    the configuration type
      */
-    private <C extends AliasedDiscoveryConfig<C>> void serializeAliasedDiscoveryConfig(
-            JsonObject object, String tag, C config) {
+    private void serializeAliasedDiscoveryConfig(
+            JsonObject object, String tag, AliasedDiscoveryConfig config) {
         if (config != null) {
-            object.add(tag, new AliasedDiscoveryConfigDTO<C>(config).toJson());
+            object.add(tag, new AliasedDiscoveryConfigDTO(config).toJson());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTO.java
@@ -16,60 +16,196 @@
 
 package com.hazelcast.internal.management.dto;
 
+import com.hazelcast.config.AliasedDiscoveryConfig;
+import com.hazelcast.config.AwsConfig;
+import com.hazelcast.config.AzureConfig;
+import com.hazelcast.config.DiscoveryConfig;
+import com.hazelcast.config.EurekaConfig;
+import com.hazelcast.config.GcpConfig;
+import com.hazelcast.config.KubernetesConfig;
 import com.hazelcast.config.WANQueueFullBehavior;
 import com.hazelcast.config.WanPublisherConfig;
-import com.hazelcast.internal.json.Json;
+import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
 import com.hazelcast.internal.management.JsonSerializable;
 
-import java.util.Map;
+import static com.hazelcast.util.JsonUtil.fromJsonObject;
+import static com.hazelcast.util.JsonUtil.toJsonObject;
+import static com.hazelcast.util.MapUtil.isNullOrEmpty;
 
 /**
- * A {@link JsonSerializable} to be used within {@link WanReplicationConfigDTO}
+ * A JSON representation of {@link WanPublisherConfig}.
  */
 public class WanPublisherConfigDTO implements JsonSerializable {
 
     private WanPublisherConfig config;
+
+    public WanPublisherConfigDTO() {
+    }
 
     public WanPublisherConfigDTO(WanPublisherConfig config) {
         this.config = config;
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
     public JsonObject toJson() {
-        JsonObject object = new JsonObject();
-        object.add("groupName", config.getGroupName());
+        JsonObject root = new JsonObject();
+
+        if (config.getGroupName() != null) {
+            root.add("groupName", config.getGroupName());
+        }
+
         if (config.getPublisherId() != null) {
-            object.add("publisherId", config.getPublisherId());
+            root.add("publisherId", config.getPublisherId());
         }
-        object.add("queueCapacity", config.getQueueCapacity());
-        object.add("className", config.getClassName());
-        object.add("queueFullBehavior", config.getQueueFullBehavior().getId());
-        JsonObject properties = new JsonObject();
-        for (Map.Entry<String, Comparable> property : config.getProperties().entrySet()) {
-            properties.add(property.getKey(), Json.value(property.getValue().toString()));
+
+        root.add("queueCapacity", config.getQueueCapacity());
+
+        if (config.getQueueFullBehavior() != null) {
+            root.add("queueFullBehavior", config.getQueueFullBehavior().getId());
         }
-        object.add("properties", properties);
-        return object;
+        if (config.getInitialPublisherState() != null) {
+            root.add("initialPublisherState", config.getInitialPublisherState().getId());
+        }
+
+        if (!isNullOrEmpty(config.getProperties())) {
+            root.add("properties", toJsonObject(config.getProperties()));
+        }
+
+        if (config.getClassName() != null) {
+            root.add("className", config.getClassName());
+        }
+
+        serializeAliasedDiscoveryConfig(root, "aws", config.getAwsConfig());
+        serializeAliasedDiscoveryConfig(root, "gcp", config.getGcpConfig());
+        serializeAliasedDiscoveryConfig(root, "azure", config.getAzureConfig());
+        serializeAliasedDiscoveryConfig(root, "kubernetes", config.getKubernetesConfig());
+        serializeAliasedDiscoveryConfig(root, "eureka", config.getEurekaConfig());
+
+        DiscoveryConfig discoveryConfig = config.getDiscoveryConfig();
+        if (discoveryConfig != null) {
+            root.add("discovery", new DiscoveryConfigDTO(discoveryConfig).toJson());
+        }
+
+        WanSyncConfig syncConfig = config.getWanSyncConfig();
+        if (syncConfig != null) {
+            root.add("sync", new WanSyncConfigDTO(syncConfig).toJson());
+        }
+        return root;
     }
 
     @Override
+    @SuppressWarnings({"checkstyle:methodlength", "checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
     public void fromJson(JsonObject json) {
         config = new WanPublisherConfig();
-        config.setGroupName(json.get("groupName").asString());
+        JsonValue groupName = json.get("groupName");
+        if (groupName != null && !groupName.isNull()) {
+            config.setGroupName(groupName.asString());
+        }
+
         JsonValue publisherId = json.get("publisherId");
         if (publisherId != null && !publisherId.isNull()) {
             config.setPublisherId(publisherId.asString());
         }
-        config.setQueueCapacity(json.get("queueCapacity").asInt());
-        config.setClassName(json.get("className").asString());
-        int queueFullBehavior = json.get("queueFullBehavior").asInt();
-        config.setQueueFullBehavior(WANQueueFullBehavior.getByType(queueFullBehavior));
-        JsonObject properties = (JsonObject) json.get("properties");
-        Map<String, Comparable> configProperties = config.getProperties();
-        for (String propertyName : properties.names()) {
-            configProperties.put(propertyName, properties.get(propertyName).asString());
+
+        JsonValue queueCapacity = json.get("queueCapacity");
+        if (queueCapacity != null && !queueCapacity.isNull()) {
+            config.setQueueCapacity(queueCapacity.asInt());
+        }
+
+        JsonValue queueFullBehavior = json.get("queueFullBehavior");
+        if (queueFullBehavior != null && !queueFullBehavior.isNull()) {
+            config.setQueueFullBehavior(
+                    WANQueueFullBehavior.getByType(queueFullBehavior.asInt()));
+        }
+
+        JsonValue initialPublisherState = json.get("initialPublisherState");
+        if (initialPublisherState != null && !initialPublisherState.isNull()) {
+            config.setInitialPublisherState(
+                    WanPublisherState.getByType((byte) initialPublisherState.asInt()));
+        }
+
+        config.setProperties(fromJsonObject((JsonObject) json.get("properties")));
+
+        JsonValue className = json.get("className");
+        if (className != null && !className.isNull()) {
+            config.setClassName(className.asString());
+        }
+
+        AwsConfig awsConfig = this.<AwsConfig>deserializeAliasedDiscoveryConfig(json, "aws");
+        if (awsConfig != null) {
+            config.setAwsConfig(awsConfig);
+        }
+
+        GcpConfig gcpConfig = this.<GcpConfig>deserializeAliasedDiscoveryConfig(json, "gcp");
+        if (gcpConfig != null) {
+            config.setGcpConfig(gcpConfig);
+        }
+        AzureConfig azureConfig = this.<AzureConfig>deserializeAliasedDiscoveryConfig(json, "azure");
+        if (azureConfig != null) {
+            config.setAzureConfig(azureConfig);
+        }
+        KubernetesConfig kubernetesConfig = this.<KubernetesConfig>deserializeAliasedDiscoveryConfig(json, "kubernetes");
+        if (kubernetesConfig != null) {
+            config.setKubernetesConfig(kubernetesConfig);
+        }
+        EurekaConfig eurekaConfig = this.<EurekaConfig>deserializeAliasedDiscoveryConfig(json, "eureka");
+        if (eurekaConfig != null) {
+            config.setEurekaConfig(eurekaConfig);
+        }
+
+        JsonValue discoveryJson = json.get("discovery");
+        if (discoveryJson != null && !discoveryJson.isNull()) {
+            DiscoveryConfigDTO discoveryDTO = new DiscoveryConfigDTO();
+            discoveryDTO.fromJson(discoveryJson.asObject());
+            config.setDiscoveryConfig(discoveryDTO.getConfig());
+        }
+
+        JsonValue syncJson = json.get("sync");
+        if (syncJson != null && !syncJson.isNull()) {
+            WanSyncConfigDTO syncDTO = new WanSyncConfigDTO();
+            syncDTO.fromJson(syncJson.asObject());
+            config.setWanSyncConfig(syncDTO.getConfig());
+        }
+    }
+
+    /**
+     * Deserializes the aliased discovery config nested under the {@code tag} in the provided JSON.
+     *
+     * @param json the JSON object containing the serialized config
+     * @param tag  the tag under which the config is nested
+     * @param <C>  the configuration type
+     * @return the deserialized config or {@code null} if the serialized config
+     * was missing in the JSON object
+     */
+    private <C extends AliasedDiscoveryConfig<C>> C deserializeAliasedDiscoveryConfig(
+            JsonObject json, String tag) {
+        JsonValue configJson = json.get(tag);
+        if (configJson != null && !configJson.isNull()) {
+            AliasedDiscoveryConfigDTO<C> dto = new AliasedDiscoveryConfigDTO<C>(tag);
+            dto.fromJson(configJson.asObject());
+            return dto.getConfig();
+        }
+        return null;
+    }
+
+    /**
+     * Serializes the provided aliased discovery config and adds the serialized
+     * contents under the tag in the JSON object if the config is not
+     * {@code null}.
+     *
+     * @param object the JSON object to which the config is added
+     * @param tag    the tag under which the config is added
+     * @param config the configuration
+     * @param <C>    the configuration type
+     */
+    private <C extends AliasedDiscoveryConfig<C>> void serializeAliasedDiscoveryConfig(
+            JsonObject object, String tag, C config) {
+        if (config != null) {
+            object.add(tag, new AliasedDiscoveryConfigDTO<C>(config).toJson());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanSyncConfigDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/WanSyncConfigDTO.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.config.ConsistencyCheckStrategy;
+import com.hazelcast.config.WanSyncConfig;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.management.JsonSerializable;
+
+/**
+ * A JSON representation of {@link WanSyncConfig}.
+ */
+public class WanSyncConfigDTO implements JsonSerializable {
+
+    private WanSyncConfig config;
+
+    public WanSyncConfigDTO() {
+    }
+
+    public WanSyncConfigDTO(WanSyncConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject();
+        if (config.getConsistencyCheckStrategy() != null) {
+            root.add("consistencyCheckStrategy", config.getConsistencyCheckStrategy().getId());
+        }
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        config = new WanSyncConfig();
+
+        JsonValue consistencyCheckStrategy = json.get("consistencyCheckStrategy");
+        if (consistencyCheckStrategy != null && !consistencyCheckStrategy.isNull()) {
+            config.setConsistencyCheckStrategy(ConsistencyCheckStrategy.getById(
+                    (byte) consistencyCheckStrategy.asInt()));
+        }
+    }
+
+    public WanSyncConfig getConfig() {
+        return config;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/util/JsonUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/JsonUtil.java
@@ -16,9 +16,13 @@
 
 package com.hazelcast.util;
 
+import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
+
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Utility class to deal with Json.
@@ -273,6 +277,37 @@ public final class JsonUtil {
         } else {
             return value.asObject();
         }
+    }
+
+    /**
+     * Transforms the provided {@link JsonObject} int a map of name/value pairs.
+     *
+     * @param object the JSON object
+     * @return map from JSON name to value
+     */
+    public static Map<String, Comparable> fromJsonObject(JsonObject object) {
+        if (object == null || object.isNull() || object.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, Comparable> map = MapUtil.createHashMap(object.size());
+        for (String propertyName : object.names()) {
+            map.put(propertyName, object.get(propertyName).asString());
+        }
+        return map;
+    }
+
+    /**
+     * Transforms the provided map of name/value pairs into a {@link JsonObject}.
+     *
+     * @param map map of JSON name-value pairs
+     * @return the JSON object
+     */
+    public static JsonObject toJsonObject(Map<String, ?> map) {
+        JsonObject properties = new JsonObject();
+        for (Map.Entry<String, ?> property : map.entrySet()) {
+            properties.add(property.getKey(), Json.value(property.getValue().toString()));
+        }
+        return properties;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -25,10 +25,11 @@ import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.wan.impl.DistributedServiceWanEventCounters;
 
 /**
- * This is the WAN replications service API core interface. The WanReplicationService needs to
- * be capable of creating the actual {@link com.hazelcast.wan.WanReplicationPublisher} instances
- * to replicate values to other clusters over the wide area network, so it has to deal with long
- * delays, slow uploads and higher latencies.
+ * This is the WAN replications service API core interface. The
+ * WanReplicationService needs to be capable of creating the actual
+ * {@link com.hazelcast.wan.WanReplicationPublisher} instances to replicate
+ * values to other clusters over the wide area network, so it has to deal
+ * with long delays, slow uploads and higher latencies.
  */
 public interface WanReplicationService extends CoreService, StatisticsAwareService<LocalWanStats> {
 
@@ -91,8 +92,10 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
      * @param targetGroupName    the group name on the target cluster
      * @param mapName            the map name
      * @throws UnsupportedOperationException if the operation is not supported (not EE)
-     * @throws InvalidConfigurationException if there is no WAN replication config for {@code wanReplicationName}
-     * @throws SyncFailedException           if there is a anti-entropy request in progress
+     * @throws InvalidConfigurationException if there is no WAN replication
+     *                                       config for {@code wanReplicationName}
+     * @throws SyncFailedException           if there is a anti-entropy request in
+     *                                       progress
      */
     void syncMap(String wanReplicationName, String targetGroupName, String mapName);
 
@@ -103,7 +106,8 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
      * @param wanReplicationName the name of the wan replication config
      * @param targetGroupName    the group name on the target cluster
      * @throws UnsupportedOperationException if the operation is not supported (not EE)
-     * @throws InvalidConfigurationException if there is no WAN replication config for {@code wanReplicationName}
+     * @throws InvalidConfigurationException if there is no WAN replication config for
+     *                                       {@code wanReplicationName}
      * @throws SyncFailedException           if there is a anti-entropy request in progress
      */
     void syncAllMaps(String wanReplicationName, String targetGroupName);
@@ -132,8 +136,8 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
     void clearQueues(String wanReplicationName, String targetGroupName);
 
     /**
-     * Adds a new {@link WanReplicationConfig} to this member and creates the {@link WanReplicationPublisher}s specified
-     * in the config.
+     * Adds a new {@link WanReplicationConfig} to this member and creates the
+     * {@link WanReplicationPublisher}s specified in the config.
      */
     void addWanReplicationConfig(WanReplicationConfig wanConfig);
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -40,7 +40,7 @@ import static java.text.MessageFormat.format;
 import static java.util.Collections.singletonMap;
 import static org.codehaus.groovy.runtime.InvokerHelper.asList;
 
-class ConfigCompatibilityChecker {
+public class ConfigCompatibilityChecker {
 
     /**
      * Checks if two {@link Config} instances are compatible.
@@ -48,7 +48,7 @@ class ConfigCompatibilityChecker {
      * This mostly means that the config values will have the same impact on the behaviour of the system,
      * but are not necessarily the same (e.g. a {@code null} value is sometimes the same as an empty
      * collection or a disabled config).
-     * <p>
+     *
      * <b>Note:</b> This method checks MOST but NOT ALL configuration. As such it is best used in test
      * scenarios to cover as much config checks as possible automatically.
      *
@@ -868,9 +868,9 @@ class ConfigCompatibilityChecker {
         }
     }
 
-    private static class DiscoveryStrategyConfigChecker extends ConfigChecker<DiscoveryStrategyConfig> {
+    public static class DiscoveryStrategyConfigChecker extends ConfigChecker<DiscoveryStrategyConfig> {
         @Override
-        boolean check(DiscoveryStrategyConfig c1, DiscoveryStrategyConfig c2) {
+        public boolean check(DiscoveryStrategyConfig c1, DiscoveryStrategyConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getClassName(), c2.getClassName())
                     && nullSafeEqual(c1.getProperties(), c2.getProperties());
@@ -895,9 +895,9 @@ class ConfigCompatibilityChecker {
         }
     }
 
-    private static class WanSyncConfigChecker extends ConfigChecker<WanSyncConfig> {
+    public static class WanSyncConfigChecker extends ConfigChecker<WanSyncConfig> {
         @Override
-        boolean check(WanSyncConfig c1, WanSyncConfig c2) {
+        public boolean check(WanSyncConfig c1, WanSyncConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getConsistencyCheckStrategy(), c2.getConsistencyCheckStrategy());
         }
@@ -996,9 +996,9 @@ class ConfigCompatibilityChecker {
         }
     }
 
-    private static class DiscoveryConfigChecker extends ConfigChecker<DiscoveryConfig> {
+    public static class DiscoveryConfigChecker extends ConfigChecker<DiscoveryConfig> {
         @Override
-        boolean check(DiscoveryConfig c1, DiscoveryConfig c2) {
+        public boolean check(DiscoveryConfig c1, DiscoveryConfig c2) {
             boolean c1Disabled = c1 == null || !c1.isEnabled();
             boolean c2Disabled = c2 == null || !c2.isEnabled();
             return c1 == c2 || (c1Disabled && c2Disabled) || (c1 != null && c2 != null
@@ -1009,7 +1009,7 @@ class ConfigCompatibilityChecker {
         }
     }
 
-    private static class AliasedDiscoveryConfigsChecker extends ConfigChecker<List<AliasedDiscoveryConfig<?>>> {
+    public static class AliasedDiscoveryConfigsChecker extends ConfigChecker<List<AliasedDiscoveryConfig<?>>> {
 
         @Override
         boolean check(List<AliasedDiscoveryConfig<?>> t1, List<AliasedDiscoveryConfig<?>> t2) {
@@ -1041,7 +1041,7 @@ class ConfigCompatibilityChecker {
             return result;
         }
 
-        private static boolean check(AliasedDiscoveryConfig c1, AliasedDiscoveryConfig c2) {
+        public static boolean check(AliasedDiscoveryConfig c1, AliasedDiscoveryConfig c2) {
             boolean c1Disabled = c1 == null || !c1.isEnabled();
             boolean c2Disabled = c2 == null || !c2.isEnabled();
             return c1 == c2 || (c1Disabled && c2Disabled) || (c1 != null && c2 != null
@@ -1051,17 +1051,22 @@ class ConfigCompatibilityChecker {
         }
     }
 
-    private static class WanReplicationConfigChecker extends ConfigChecker<WanReplicationConfig> {
+    public static class WanReplicationConfigChecker extends ConfigChecker<WanReplicationConfig> {
+        private static final WanConsumerConfigChecker WAN_CONSUMER_CONFIG_CHECKER = new WanConsumerConfigChecker();
+
         @Override
-        boolean check(WanReplicationConfig c1, WanReplicationConfig c2) {
+        public boolean check(WanReplicationConfig c1, WanReplicationConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getName(), c2.getName())
-                    && isCompatible(c1.getWanConsumerConfig(), c2.getWanConsumerConfig())
+                    && WAN_CONSUMER_CONFIG_CHECKER.check(c1.getWanConsumerConfig(), c2.getWanConsumerConfig())
                     && isCollectionCompatible(c1.getWanPublisherConfigs(), c2.getWanPublisherConfigs(),
                     new WanPublisherConfigChecker());
         }
+    }
 
-        private boolean isCompatible(WanConsumerConfig c1, WanConsumerConfig c2) {
+    public static class WanConsumerConfigChecker extends ConfigChecker<WanConsumerConfig> {
+        @Override
+        public boolean check(WanConsumerConfig c1, WanConsumerConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getClassName(), c2.getClassName())
                     && nullSafeEqual(c1.getImplementation(), c2.getImplementation())
@@ -1070,9 +1075,9 @@ class ConfigCompatibilityChecker {
         }
     }
 
-    private static class WanPublisherConfigChecker extends ConfigChecker<WanPublisherConfig> {
+    public static class WanPublisherConfigChecker extends ConfigChecker<WanPublisherConfig> {
         @Override
-        boolean check(WanPublisherConfig c1, WanPublisherConfig c2) {
+        public boolean check(WanPublisherConfig c1, WanPublisherConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.getGroupName(), c2.getGroupName())
                     && nullSafeEqual(c1.getPublisherId(), c2.getPublisherId())

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/AliasedDiscoveryConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/AliasedDiscoveryConfigDTOTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.config.AliasedDiscoveryConfig;
+import com.hazelcast.config.AwsConfig;
+import com.hazelcast.config.AzureConfig;
+import com.hazelcast.config.ConfigCompatibilityChecker.AliasedDiscoveryConfigsChecker;
+import com.hazelcast.config.EurekaConfig;
+import com.hazelcast.config.GcpConfig;
+import com.hazelcast.config.KubernetesConfig;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AliasedDiscoveryConfigDTOTest {
+
+    @Test
+    public void testSerialization() {
+        GcpConfig expected = new GcpConfig().setEnabled(true)
+                                            .setUsePublicIp(true)
+                                            .setProperty("key1", "value1")
+                                            .setProperty("key2", "value2");
+
+        AliasedDiscoveryConfig actual = cloneThroughJson(expected);
+        assertTrue("Expected: " + expected + ", got:" + actual,
+                AliasedDiscoveryConfigsChecker.check(expected, actual));
+    }
+
+    @Test
+    public void testDefault() {
+        testDefault(new GcpConfig());
+        testDefault(new AzureConfig());
+        testDefault(new AwsConfig());
+        testDefault(new EurekaConfig());
+        testDefault(new KubernetesConfig());
+    }
+
+    private static <C extends AliasedDiscoveryConfig<C>> void testDefault(C expected) {
+        C actual = cloneThroughJson(expected);
+        assertTrue("Expected: " + expected + ", got:" + actual,
+                AliasedDiscoveryConfigsChecker.check(expected, actual));
+    }
+
+    private static <C extends AliasedDiscoveryConfig<C>> C cloneThroughJson(C expected) {
+        AliasedDiscoveryConfigDTO<C> dto = new AliasedDiscoveryConfigDTO<C>(expected);
+
+        JsonObject json = dto.toJson();
+        AliasedDiscoveryConfigDTO<C> deserialized = new AliasedDiscoveryConfigDTO<C>(expected.getTag());
+        deserialized.fromJson(json);
+
+        return deserialized.getConfig();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/AliasedDiscoveryConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/AliasedDiscoveryConfigDTOTest.java
@@ -58,17 +58,17 @@ public class AliasedDiscoveryConfigDTOTest {
         testDefault(new KubernetesConfig());
     }
 
-    private static <C extends AliasedDiscoveryConfig<C>> void testDefault(C expected) {
-        C actual = cloneThroughJson(expected);
+    private static void testDefault(AliasedDiscoveryConfig expected) {
+        AliasedDiscoveryConfig actual = cloneThroughJson(expected);
         assertTrue("Expected: " + expected + ", got:" + actual,
                 AliasedDiscoveryConfigsChecker.check(expected, actual));
     }
 
-    private static <C extends AliasedDiscoveryConfig<C>> C cloneThroughJson(C expected) {
-        AliasedDiscoveryConfigDTO<C> dto = new AliasedDiscoveryConfigDTO<C>(expected);
+    private static AliasedDiscoveryConfig cloneThroughJson(AliasedDiscoveryConfig expected) {
+        AliasedDiscoveryConfigDTO dto = new AliasedDiscoveryConfigDTO(expected);
 
         JsonObject json = dto.toJson();
-        AliasedDiscoveryConfigDTO<C> deserialized = new AliasedDiscoveryConfigDTO<C>(expected.getTag());
+        AliasedDiscoveryConfigDTO deserialized = new AliasedDiscoveryConfigDTO(expected.getTag());
         deserialized.fromJson(json);
 
         return deserialized.getConfig();

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/DiscoveryConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/DiscoveryConfigDTOTest.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.config.ConfigCompatibilityChecker.WanReplicationConfigChecker;
-import com.hazelcast.config.WanConsumerConfig;
-import com.hazelcast.config.WanPublisherConfig;
-import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.config.ConfigCompatibilityChecker.DiscoveryConfigChecker;
+import com.hazelcast.config.DiscoveryConfig;
+import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -32,33 +31,39 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class WanReplicationConfigDTOTest {
+public class DiscoveryConfigDTOTest {
 
-    private static final WanReplicationConfigChecker WAN_REPLICATION_CONFIG_CHECKER = new WanReplicationConfigChecker();
+    private static final DiscoveryConfigChecker DISCOVERY_CONFIG_CHECKER = new DiscoveryConfigChecker();
 
     @Test
     public void testSerialization() {
-        WanReplicationConfig expected = new WanReplicationConfig()
-                .setName("myName")
-                .setWanConsumerConfig(new WanConsumerConfig())
-                .addWanPublisherConfig(new WanPublisherConfig()
-                        .setGroupName("group1"))
-                .addWanPublisherConfig(new WanPublisherConfig()
-                        .setGroupName("group2"));
+        DiscoveryConfig expected = new DiscoveryConfig();
+        expected.setNodeFilterClass("myClassName");
+        expected.addDiscoveryStrategyConfig(new DiscoveryStrategyConfig("className1"));
+        expected.addDiscoveryStrategyConfig(new DiscoveryStrategyConfig("className2"));
 
-        WanReplicationConfig actual = cloneThroughJson(expected);
-
+        DiscoveryConfig actual = cloneThroughJson(expected);
         assertTrue("Expected: " + expected + ", got:" + actual,
-                WAN_REPLICATION_CONFIG_CHECKER.check(expected, actual));
+                DISCOVERY_CONFIG_CHECKER.check(expected, actual));
     }
 
-    private WanReplicationConfig cloneThroughJson(WanReplicationConfig expectedConfig) {
-        WanReplicationConfigDTO dto = new WanReplicationConfigDTO(expectedConfig);
+    @Test
+    public void testDefault() {
+        DiscoveryConfig expected = new DiscoveryConfig();
+
+        DiscoveryConfig actual = cloneThroughJson(expected);
+        assertTrue("Expected: " + expected + ", got:" + actual,
+                DISCOVERY_CONFIG_CHECKER.check(expected, actual));
+    }
+
+    private DiscoveryConfig cloneThroughJson(DiscoveryConfig expected) {
+        DiscoveryConfigDTO dto = new DiscoveryConfigDTO(expected);
 
         JsonObject json = dto.toJson();
-        WanReplicationConfigDTO deserialized = new WanReplicationConfigDTO(null);
+        DiscoveryConfigDTO deserialized = new DiscoveryConfigDTO(null);
         deserialized.fromJson(json);
 
         return deserialized.getConfig();
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/DiscoveryStrategyConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/DiscoveryStrategyConfigDTOTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.config.ConfigCompatibilityChecker.DiscoveryStrategyConfigChecker;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DiscoveryStrategyConfigDTOTest {
+    private static final DiscoveryStrategyConfigChecker DISCOVERY_STRATEGY_CONFIG_CHECKER
+            = new DiscoveryStrategyConfigChecker();
+
+    @Test
+    public void testSerialization() {
+        Map<String, Comparable> properties = new HashMap<String, Comparable>();
+        properties.put("key1", "value1");
+        properties.put("key2", "value2");
+
+        DiscoveryStrategyConfig expected = new DiscoveryStrategyConfig()
+                .setProperties(properties)
+                .setClassName("myClassName");
+
+        DiscoveryStrategyConfig actual = cloneThroughJson(expected);
+        assertTrue("Expected: " + expected + ", got:" + actual,
+                DISCOVERY_STRATEGY_CONFIG_CHECKER.check(expected, actual));
+    }
+
+    @Test
+    public void testDefault() {
+        DiscoveryStrategyConfig expected = new DiscoveryStrategyConfig();
+
+        DiscoveryStrategyConfig actual = cloneThroughJson(expected);
+        assertTrue("Expected: " + expected + ", got:" + actual,
+                DISCOVERY_STRATEGY_CONFIG_CHECKER.check(expected, actual));
+    }
+
+    private DiscoveryStrategyConfig cloneThroughJson(DiscoveryStrategyConfig expected) {
+        DiscoveryStrategyConfigDTO dto = new DiscoveryStrategyConfigDTO(expected);
+
+        JsonObject json = dto.toJson();
+        DiscoveryStrategyConfigDTO deserialized = new DiscoveryStrategyConfigDTO(null);
+        deserialized.fromJson(json);
+
+        return deserialized.getConfig();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanConsumerConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanConsumerConfigDTOTest.java
@@ -16,10 +16,8 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.config.ConfigCompatibilityChecker.WanReplicationConfigChecker;
+import com.hazelcast.config.ConfigCompatibilityChecker.WanConsumerConfigChecker;
 import com.hazelcast.config.WanConsumerConfig;
-import com.hazelcast.config.WanPublisherConfig;
-import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -28,37 +26,50 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class WanReplicationConfigDTOTest {
+public class WanConsumerConfigDTOTest {
 
-    private static final WanReplicationConfigChecker WAN_REPLICATION_CONFIG_CHECKER = new WanReplicationConfigChecker();
+    private static final WanConsumerConfigChecker WAN_CONSUMER_CONFIG_CHECKER = new WanConsumerConfigChecker();
 
     @Test
     public void testSerialization() {
-        WanReplicationConfig expected = new WanReplicationConfig()
-                .setName("myName")
-                .setWanConsumerConfig(new WanConsumerConfig())
-                .addWanPublisherConfig(new WanPublisherConfig()
-                        .setGroupName("group1"))
-                .addWanPublisherConfig(new WanPublisherConfig()
-                        .setGroupName("group2"));
+        Map<String, Comparable> properties = new HashMap<String, Comparable>();
+        properties.put("key1", "value1");
+        properties.put("key2", "value2");
 
-        WanReplicationConfig actual = cloneThroughJson(expected);
+        WanConsumerConfig expected = new WanConsumerConfig()
+                .setPersistWanReplicatedData(true)
+                .setProperties(properties)
+                .setClassName("myClassName");
 
+        WanConsumerConfig actual = cloneThroughJson(expected);
         assertTrue("Expected: " + expected + ", got:" + actual,
-                WAN_REPLICATION_CONFIG_CHECKER.check(expected, actual));
+                WAN_CONSUMER_CONFIG_CHECKER.check(expected, actual));
     }
 
-    private WanReplicationConfig cloneThroughJson(WanReplicationConfig expectedConfig) {
-        WanReplicationConfigDTO dto = new WanReplicationConfigDTO(expectedConfig);
+    @Test
+    public void testDefault() {
+        WanConsumerConfig expected = new WanConsumerConfig();
+
+        WanConsumerConfig actual = cloneThroughJson(expected);
+        assertTrue("Expected: " + expected + ", got:" + actual,
+                WAN_CONSUMER_CONFIG_CHECKER.check(expected, actual));
+    }
+
+    private WanConsumerConfig cloneThroughJson(WanConsumerConfig expected) {
+        WanConsumerConfigDTO dto = new WanConsumerConfigDTO(expected);
 
         JsonObject json = dto.toJson();
-        WanReplicationConfigDTO deserialized = new WanReplicationConfigDTO(null);
+        WanConsumerConfigDTO deserialized = new WanConsumerConfigDTO(null);
         deserialized.fromJson(json);
 
         return deserialized.getConfig();
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanPublisherConfigDTOTest.java
@@ -16,8 +16,17 @@
 
 package com.hazelcast.internal.management.dto;
 
+import com.hazelcast.config.AwsConfig;
+import com.hazelcast.config.AzureConfig;
+import com.hazelcast.config.ConfigCompatibilityChecker.WanPublisherConfigChecker;
+import com.hazelcast.config.DiscoveryConfig;
+import com.hazelcast.config.EurekaConfig;
+import com.hazelcast.config.GcpConfig;
+import com.hazelcast.config.KubernetesConfig;
 import com.hazelcast.config.WANQueueFullBehavior;
 import com.hazelcast.config.WanPublisherConfig;
+import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -29,11 +38,13 @@ import org.junit.runner.RunWith;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class WanPublisherConfigDTOTest {
+
+    private static final WanPublisherConfigChecker WAN_PUBLISHER_CONFIG_CHECKER = new WanPublisherConfigChecker();
 
     @Test
     public void testSerialization() {
@@ -45,22 +56,40 @@ public class WanPublisherConfigDTOTest {
                 .setGroupName("myGroupName")
                 .setPublisherId("myPublisherId")
                 .setQueueCapacity(23)
-                .setClassName("myClassName")
                 .setQueueFullBehavior(WANQueueFullBehavior.THROW_EXCEPTION)
-                .setProperties(properties);
+                .setInitialPublisherState(WanPublisherState.STOPPED)
+                .setProperties(properties)
+                .setClassName("myClassName")
+                .setAwsConfig(new AwsConfig().setEnabled(true).setConnectionTimeoutSeconds(20))
+                .setGcpConfig(new GcpConfig().setEnabled(true).setProperty("gcp", "gcp-val"))
+                .setAzureConfig(new AzureConfig().setEnabled(true).setProperty("azure", "azure-val"))
+                .setKubernetesConfig(new KubernetesConfig().setEnabled(true).setProperty("kubernetes", "kubernetes-val"))
+                .setEurekaConfig(new EurekaConfig().setEnabled(true).setProperty("eureka", "eureka-val"))
+                .setDiscoveryConfig(new DiscoveryConfig())
+                .setWanSyncConfig(new WanSyncConfig());
 
+        WanPublisherConfig actual = cloneThroughJson(expected);
+        assertTrue("Expected: " + expected + ", got:" + actual,
+                WAN_PUBLISHER_CONFIG_CHECKER.check(expected, actual));
+    }
+
+    @Test
+    public void testDefault() {
+        WanPublisherConfig expected = new WanPublisherConfig();
+
+        WanPublisherConfig actual = cloneThroughJson(expected);
+        assertTrue("Expected: " + expected + ", got:" + actual,
+                WAN_PUBLISHER_CONFIG_CHECKER.check(expected, actual));
+    }
+
+    private WanPublisherConfig cloneThroughJson(WanPublisherConfig expected) {
         WanPublisherConfigDTO dto = new WanPublisherConfigDTO(expected);
 
         JsonObject json = dto.toJson();
         WanPublisherConfigDTO deserialized = new WanPublisherConfigDTO(null);
         deserialized.fromJson(json);
 
-        WanPublisherConfig actual = deserialized.getConfig();
-        assertEquals(expected.getGroupName(), actual.getGroupName());
-        assertEquals(expected.getPublisherId(), actual.getPublisherId());
-        assertEquals(expected.getQueueCapacity(), actual.getQueueCapacity());
-        assertEquals(expected.getClassName(), actual.getClassName());
-        assertEquals(expected.getQueueFullBehavior(), actual.getQueueFullBehavior());
-        assertEquals(expected.getProperties(), actual.getProperties());
+        return deserialized.getConfig();
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanSyncConfigDTOTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/dto/WanSyncConfigDTOTest.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.internal.management.dto;
 
-import com.hazelcast.config.ConfigCompatibilityChecker.WanReplicationConfigChecker;
-import com.hazelcast.config.WanConsumerConfig;
-import com.hazelcast.config.WanPublisherConfig;
-import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.config.ConfigCompatibilityChecker.WanSyncConfigChecker;
+import com.hazelcast.config.ConsistencyCheckStrategy;
+import com.hazelcast.config.WanSyncConfig;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -32,33 +31,37 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class WanReplicationConfigDTOTest {
+public class WanSyncConfigDTOTest {
 
-    private static final WanReplicationConfigChecker WAN_REPLICATION_CONFIG_CHECKER = new WanReplicationConfigChecker();
+    private static final WanSyncConfigChecker WAN_SYNC_CONFIG_CHECKER = new WanSyncConfigChecker();
 
     @Test
     public void testSerialization() {
-        WanReplicationConfig expected = new WanReplicationConfig()
-                .setName("myName")
-                .setWanConsumerConfig(new WanConsumerConfig())
-                .addWanPublisherConfig(new WanPublisherConfig()
-                        .setGroupName("group1"))
-                .addWanPublisherConfig(new WanPublisherConfig()
-                        .setGroupName("group2"));
+        WanSyncConfig expected = new WanSyncConfig()
+                .setConsistencyCheckStrategy(ConsistencyCheckStrategy.MERKLE_TREES);
 
-        WanReplicationConfig actual = cloneThroughJson(expected);
-
+        WanSyncConfig actual = cloneThroughJson(expected);
         assertTrue("Expected: " + expected + ", got:" + actual,
-                WAN_REPLICATION_CONFIG_CHECKER.check(expected, actual));
+                WAN_SYNC_CONFIG_CHECKER.check(expected, actual));
     }
 
-    private WanReplicationConfig cloneThroughJson(WanReplicationConfig expectedConfig) {
-        WanReplicationConfigDTO dto = new WanReplicationConfigDTO(expectedConfig);
+    @Test
+    public void testDefault() {
+        WanSyncConfig expected = new WanSyncConfig();
+
+        WanSyncConfig actual = cloneThroughJson(expected);
+        assertTrue("Expected: " + expected + ", got:" + actual,
+                WAN_SYNC_CONFIG_CHECKER.check(expected, actual));
+    }
+
+    private WanSyncConfig cloneThroughJson(WanSyncConfig expected) {
+        WanSyncConfigDTO dto = new WanSyncConfigDTO(expected);
 
         JsonObject json = dto.toJson();
-        WanReplicationConfigDTO deserialized = new WanReplicationConfigDTO(null);
+        WanSyncConfigDTO deserialized = new WanSyncConfigDTO(null);
         deserialized.fromJson(json);
 
         return deserialized.getConfig();
     }
+
 }


### PR DESCRIPTION
Covered all WAN replication config classes:
- WanReplicationConfig
- WanPublisherConfig
- WanConsumerConfig
- AliasedDiscoveryConfig
- DiscoveryConfig
- DiscoveryStrategyConfig
- WanSyncConfig

1:1 backport of: 
https://github.com/hazelcast/hazelcast/pull/13727
https://github.com/hazelcast/hazelcast/pull/14043