### PR TITLE
[BACKPORT] Add serialization support for WAN configuration classes

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientAwsConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientAwsConfig.java
@@ -17,6 +17,8 @@
 package com.hazelcast.client.config;
 
 import com.hazelcast.config.AwsConfig;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
 
 /**
  * The AWSConfig contains the configuration for client to connect to nodes in aws environment.
@@ -69,5 +71,25 @@ public class ClientAwsConfig
             super.setProperty(name, value);
         }
         return this;
+    }
+
+    @Override
+    public int getFactoryId() {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
+    }
+
+    @Override
+    public int getId() {
+        throw new UnsupportedOperationException(getClass().getName() + " is only used locally!");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfig.java
@@ -16,15 +16,22 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Configuration for discovery strategy aliases, e.g. {@literal <gcp>}.
  *
  * @param <T> Subclass that extends {@link AliasedDiscoveryConfig}.
  */
-public abstract class AliasedDiscoveryConfig<T extends AliasedDiscoveryConfig<T>> {
+public abstract class AliasedDiscoveryConfig<T extends AliasedDiscoveryConfig<T>>
+        implements IdentifiedDataSerializable {
     private static final String USE_PUBLIC_IP_PROPERTY = "use-public-ip";
     private static final String ENABLED_PROPERTY = "enabled";
 
@@ -124,5 +131,32 @@ public abstract class AliasedDiscoveryConfig<T extends AliasedDiscoveryConfig<T>
     public String toString() {
         return "AliasedDiscoveryConfig{" + "tag='" + tag + '\'' + ", enabled=" + enabled + ", usePublicIp=" + usePublicIp
                 + ", properties=" + properties + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeBoolean(enabled);
+        out.writeBoolean(usePublicIp);
+        out.writeInt(properties.size());
+        for (Entry<String, String> entry : properties.entrySet()) {
+            out.writeUTF(entry.getKey());
+            out.writeUTF(entry.getValue());
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        enabled = in.readBoolean();
+        usePublicIp = in.readBoolean();
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            properties.put(in.readUTF(), in.readUTF());
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AwsConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AwsConfig.java
@@ -302,4 +302,9 @@ public class AwsConfig
         super.setEnabled(enabled);
         return this;
     }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.AWS_CONFIG;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AzureConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AzureConfig.java
@@ -24,4 +24,9 @@ public class AzureConfig
     public AzureConfig() {
         super("azure");
     }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.AZURE_CONFIG;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigDataSerializerHook.java
@@ -95,8 +95,15 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
     public static final int PN_COUNTER_CONFIG = 53;
     public static final int MERKLE_TREE_CONFIG = 54;
     public static final int WAN_SYNC_CONFIG = 55;
+    public static final int KUBERNETES_CONFIG = 56;
+    public static final int EUREKA_CONFIG = 57;
+    public static final int GCP_CONFIG = 58;
+    public static final int AZURE_CONFIG = 59;
+    public static final int AWS_CONFIG = 60;
+    public static final int DISCOVERY_CONFIG = 61;
+    public static final int DISCOVERY_STRATEGY_CONFIG = 62;
 
-    private static final int LEN = WAN_SYNC_CONFIG + 1;
+    private static final int LEN = DISCOVERY_STRATEGY_CONFIG + 1;
 
     @Override
     public int getFactoryId() {
@@ -453,6 +460,55 @@ public final class ConfigDataSerializerHook implements DataSerializerHook {
                     @Override
                     public IdentifiedDataSerializable createNew(Integer arg) {
                         return new WanSyncConfig();
+                    }
+                };
+        constructors[KUBERNETES_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new KubernetesConfig();
+                    }
+                };
+        constructors[EUREKA_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new EurekaConfig();
+                    }
+                };
+        constructors[GCP_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new GcpConfig();
+                    }
+                };
+        constructors[AZURE_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new AzureConfig();
+                    }
+                };
+        constructors[AWS_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new AwsConfig();
+                    }
+                };
+        constructors[DISCOVERY_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new DiscoveryConfig();
+                    }
+                };
+        constructors[DISCOVERY_STRATEGY_CONFIG] =
+                new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+                    @Override
+                    public IdentifiedDataSerializable createNew(Integer arg) {
+                        return new DiscoveryStrategyConfig();
                     }
                 };
         return new ArrayDataSerializableFactory(constructors);

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
@@ -16,10 +16,14 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.discovery.DiscoveryStrategy;
 import com.hazelcast.spi.discovery.NodeFilter;
 import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -28,7 +32,7 @@ import java.util.List;
  * This configuration class describes the top-level config of the discovery
  * SPI and its discovery strategies.
  */
-public class DiscoveryConfig {
+public class DiscoveryConfig implements IdentifiedDataSerializable {
 
     private List<DiscoveryStrategyConfig> discoveryStrategyConfigs = new ArrayList<DiscoveryStrategyConfig>();
     private DiscoveryServiceProvider discoveryServiceProvider;
@@ -91,9 +95,9 @@ public class DiscoveryConfig {
     }
 
     /**
-     * Returns the defined {@link DiscoveryStrategy}
-     * configurations. This collection does not include deactivated configurations
-     * since those are automatically skipped while reading the configuration file.
+     * Returns the defined {@link DiscoveryStrategy} configurations.
+     * This collection does not include deactivated configurations since those
+     * are automatically skipped while reading the configuration file.
      * <p>
      * All returned configurations are expected to be active, this is to remember
      * when building custom {@link com.hazelcast.config.Config} instances.
@@ -104,8 +108,15 @@ public class DiscoveryConfig {
         return discoveryStrategyConfigs;
     }
 
+    /**
+     * Sets the strategy configurations for this discovery config.
+     *
+     * @param discoveryStrategyConfigs the strategy configurations
+     */
     public void setDiscoveryStrategyConfigs(List<DiscoveryStrategyConfig> discoveryStrategyConfigs) {
-        this.discoveryStrategyConfigs = discoveryStrategyConfigs;
+        this.discoveryStrategyConfigs = discoveryStrategyConfigs == null
+                ? new ArrayList<DiscoveryStrategyConfig>(1)
+                : discoveryStrategyConfigs;
     }
 
     /**
@@ -128,5 +139,31 @@ public class DiscoveryConfig {
                 + ", nodeFilter=" + nodeFilter
                 + ", nodeFilterClass='" + nodeFilterClass + '\''
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.DISCOVERY_CONFIG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(discoveryStrategyConfigs);
+        out.writeObject(discoveryServiceProvider);
+        out.writeObject(nodeFilter);
+        out.writeUTF(nodeFilterClass);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        discoveryStrategyConfigs = in.readObject();
+        discoveryServiceProvider = in.readObject();
+        nodeFilter = in.readObject();
+        nodeFilterClass = in.readUTF();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -33,7 +33,11 @@ import java.util.Map;
  */
 public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
     private String className;
-    private DiscoveryStrategyFactory discoveryStrategyFactory;
+    // we skip serialization since this may be a user-supplied object and
+    // it may not be serializable. Since we send the WAN config in the
+    // FinalizeJoinOp, this may prevent a node from sending it to a joining
+    // member
+    private transient DiscoveryStrategyFactory discoveryStrategyFactory;
     private Map<String, Comparable> properties;
 
     public DiscoveryStrategyConfig() {
@@ -125,7 +129,6 @@ public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(className);
-        out.writeObject(discoveryStrategyFactory);
 
         out.writeInt(properties.size());
         for (Map.Entry<String, Comparable> entry : properties.entrySet()) {
@@ -137,7 +140,6 @@ public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         className = in.readUTF();
-        discoveryStrategyFactory = in.readObject();
         int size = in.readInt();
         for (int i = 0; i < size; i++) {
             properties.put(in.readUTF(), (Comparable) in.readObject());

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryStrategyConfig.java
@@ -16,8 +16,13 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.discovery.DiscoveryStrategyFactory;
+import com.hazelcast.util.MapUtil;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,13 +31,13 @@ import java.util.Map;
  * This configuration class describes a {@link com.hazelcast.spi.discovery.DiscoveryStrategy}
  * based on a parsed XML or configured manually using the config API
  */
-public class DiscoveryStrategyConfig {
+public class DiscoveryStrategyConfig implements IdentifiedDataSerializable {
     private String className;
     private DiscoveryStrategyFactory discoveryStrategyFactory;
     private Map<String, Comparable> properties;
 
     public DiscoveryStrategyConfig() {
-        properties = new HashMap<String, Comparable>();
+        properties = MapUtil.createHashMap(1);
     }
 
     public DiscoveryStrategyConfig(String className) {
@@ -42,7 +47,9 @@ public class DiscoveryStrategyConfig {
     public DiscoveryStrategyConfig(String className,
                                    Map<String, Comparable> properties) {
         this.className = className;
-        this.properties = new HashMap<String, Comparable>(properties);
+        this.properties = properties == null
+                ? MapUtil.<String, Comparable>createHashMap(1)
+                : new HashMap<String, Comparable>(properties);
         this.discoveryStrategyFactory = null;
     }
 
@@ -53,7 +60,9 @@ public class DiscoveryStrategyConfig {
 
     public DiscoveryStrategyConfig(DiscoveryStrategyFactory discoveryStrategyFactory, Map<String, Comparable> properties) {
         this.className = null;
-        this.properties = new HashMap<String, Comparable>(properties);
+        this.properties = properties == null
+                ? MapUtil.<String, Comparable>createHashMap(1)
+                : new HashMap<String, Comparable>(properties);
         this.discoveryStrategyFactory = discoveryStrategyFactory;
     }
 
@@ -84,7 +93,9 @@ public class DiscoveryStrategyConfig {
     }
 
     public DiscoveryStrategyConfig setProperties(Map<String, Comparable> properties) {
-        this.properties = properties;
+        this.properties = properties == null
+                ? MapUtil.<String, Comparable>createHashMap(1)
+                : new HashMap<String, Comparable>(properties);
         return this;
     }
 
@@ -99,5 +110,37 @@ public class DiscoveryStrategyConfig {
                 + ", className='" + className + '\''
                 + ", discoveryStrategyFactory=" + discoveryStrategyFactory
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return ConfigDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.DISCOVERY_STRATEGY_CONFIG;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeUTF(className);
+        out.writeObject(discoveryStrategyFactory);
+
+        out.writeInt(properties.size());
+        for (Map.Entry<String, Comparable> entry : properties.entrySet()) {
+            out.writeUTF(entry.getKey());
+            out.writeObject(entry.getValue());
+        }
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        className = in.readUTF();
+        discoveryStrategyFactory = in.readObject();
+        int size = in.readInt();
+        for (int i = 0; i < size; i++) {
+            properties.put(in.readUTF(), (Comparable) in.readObject());
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/EurekaConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EurekaConfig.java
@@ -24,4 +24,9 @@ public class EurekaConfig
     public EurekaConfig() {
         super("eureka");
     }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.EUREKA_CONFIG;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/GcpConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/GcpConfig.java
@@ -24,4 +24,9 @@ public class GcpConfig
     public GcpConfig() {
         super("gcp");
     }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.GCP_CONFIG;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/KubernetesConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/KubernetesConfig.java
@@ -24,4 +24,9 @@ public class KubernetesConfig
     public KubernetesConfig() {
         super("kubernetes");
     }
+
+    @Override
+    public int getId() {
+        return ConfigDataSerializerHook.KUBERNETES_CONFIG;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -459,8 +459,8 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
             out.writeObject(wanSyncConfig);
             out.writeUTF(publisherId);
         }
-        // RU_COMPAT_3_11
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+        // RU_COMPAT_3_10
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             out.writeObject(awsConfig);
             out.writeObject(gcpConfig);
             out.writeObject(azureConfig);
@@ -488,8 +488,8 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
             wanSyncConfig = in.readObject();
             publisherId = in.readUTF();
         }
-        // RU_COMPAT_3_11
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+        // RU_COMPAT_3_10
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             awsConfig = in.readObject();
             gcpConfig = in.readObject();
             azureConfig = in.readObject();

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -459,6 +459,15 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
             out.writeObject(wanSyncConfig);
             out.writeUTF(publisherId);
         }
+        // RU_COMPAT_3_11
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+            out.writeObject(awsConfig);
+            out.writeObject(gcpConfig);
+            out.writeObject(azureConfig);
+            out.writeObject(kubernetesConfig);
+            out.writeObject(eurekaConfig);
+            out.writeObject(discoveryConfig);
+        }
     }
 
     @Override
@@ -478,6 +487,15 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
             initialPublisherState = WanPublisherState.getByType(in.readByte());
             wanSyncConfig = in.readObject();
             publisherId = in.readUTF();
+        }
+        // RU_COMPAT_3_11
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+            awsConfig = in.readObject();
+            gcpConfig = in.readObject();
+            azureConfig = in.readObject();
+            kubernetesConfig = in.readObject();
+            eurekaConfig = in.readObject();
+            discoveryConfig = in.readObject();
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -149,8 +149,8 @@ public class WanReplicationConfig implements IdentifiedDataSerializable, Version
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
 
-        // RU_COMPAT_3_11
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+        // RU_COMPAT_3_10
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             // using this method is nicer since the object
             // can implement Versioned and have a version injected
             out.writeObject(wanConsumerConfig);
@@ -166,8 +166,8 @@ public class WanReplicationConfig implements IdentifiedDataSerializable, Version
         int publisherCount = wanPublisherConfigs.size();
         out.writeInt(publisherCount);
         for (WanPublisherConfig wanPublisherConfig : wanPublisherConfigs) {
-            // RU_COMPAT_3_11
-            if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+            // RU_COMPAT_3_10
+            if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
                 // using this method is nicer since the object
                 // can implement Versioned and have a version injected
                 out.writeObject(wanPublisherConfig);
@@ -181,8 +181,8 @@ public class WanReplicationConfig implements IdentifiedDataSerializable, Version
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readUTF();
 
-        // RU_COMPAT_3_11
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+        // RU_COMPAT_3_10
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             wanConsumerConfig = in.readObject();
         } else {
             boolean consumerConfigExists = in.readBoolean();
@@ -197,8 +197,8 @@ public class WanReplicationConfig implements IdentifiedDataSerializable, Version
         for (int i = 0; i < publisherCount; i++) {
             WanPublisherConfig publisherConfig;
 
-            // RU_COMPAT_3_11
-            if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+            // RU_COMPAT_3_10
+            if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
                 publisherConfig = in.readObject();
             } else {
                 publisherConfig = new WanPublisherConfig();

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,11 +43,16 @@ import java.util.List;
  * consumer. The WAN consumer is in charge of consuming (processing) incoming
  * WAN events. Usually when defining a custom consumer you need to define a
  * custom WAN publisher as well.
+ * <p>
+ * NOTE:
+ * Implements Versioned since it serialized WanConsumerConfig directly by
+ * invoking writeData. This means that, even though WanConsumerConfig is
+ * Versioned, the version will not be injected.
  *
  * @see MapConfig#setWanReplicationRef
  * @see CacheConfig#setWanReplicationRef
  */
-public class WanReplicationConfig implements IdentifiedDataSerializable {
+public class WanReplicationConfig implements IdentifiedDataSerializable, Versioned {
 
     private String name;
     private WanConsumerConfig wanConsumerConfig;
@@ -141,32 +148,62 @@ public class WanReplicationConfig implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(name);
-        if (wanConsumerConfig != null) {
-            out.writeBoolean(true);
-            wanConsumerConfig.writeData(out);
+
+        // RU_COMPAT_3_11
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+            // using this method is nicer since the object
+            // can implement Versioned and have a version injected
+            out.writeObject(wanConsumerConfig);
         } else {
-            out.writeBoolean(false);
+            if (wanConsumerConfig != null) {
+                out.writeBoolean(true);
+                wanConsumerConfig.writeData(out);
+            } else {
+                out.writeBoolean(false);
+            }
         }
+
         int publisherCount = wanPublisherConfigs.size();
         out.writeInt(publisherCount);
         for (WanPublisherConfig wanPublisherConfig : wanPublisherConfigs) {
-            wanPublisherConfig.writeData(out);
+            // RU_COMPAT_3_11
+            if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+                // using this method is nicer since the object
+                // can implement Versioned and have a version injected
+                out.writeObject(wanPublisherConfig);
+            } else {
+                wanPublisherConfig.writeData(out);
+            }
         }
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         name = in.readUTF();
-        boolean consumerConfigExists = in.readBoolean();
-        if (consumerConfigExists) {
-            WanConsumerConfig consumerConfig = new WanConsumerConfig();
-            consumerConfig.readData(in);
-            wanConsumerConfig = consumerConfig;
+
+        // RU_COMPAT_3_11
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+            wanConsumerConfig = in.readObject();
+        } else {
+            boolean consumerConfigExists = in.readBoolean();
+            if (consumerConfigExists) {
+                WanConsumerConfig consumerConfig = new WanConsumerConfig();
+                consumerConfig.readData(in);
+                wanConsumerConfig = consumerConfig;
+            }
         }
+
         int publisherCount = in.readInt();
         for (int i = 0; i < publisherCount; i++) {
-            WanPublisherConfig publisherConfig = new WanPublisherConfig();
-            publisherConfig.readData(in);
+            WanPublisherConfig publisherConfig;
+
+            // RU_COMPAT_3_11
+            if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+                publisherConfig = in.readObject();
+            } else {
+                publisherConfig = new WanPublisherConfig();
+                publisherConfig.readData(in);
+            }
             wanPublisherConfigs.add(publisherConfig);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AddWanConfigLegacyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AddWanConfigLegacyOperation.java
@@ -57,8 +57,8 @@ public class AddWanConfigLegacyOperation extends AbstractManagementOperation imp
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        // RU_COMPAT_3_11
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+        // RU_COMPAT_3_10
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             // using this method is nicer since the object
             // can implement Versioned and have a version injected
             out.writeObject(wanReplicationConfig);
@@ -69,8 +69,8 @@ public class AddWanConfigLegacyOperation extends AbstractManagementOperation imp
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        // RU_COMPAT_3_11
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+        // RU_COMPAT_3_10
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
             wanReplicationConfig = in.readObject();
         } else {
             wanReplicationConfig = new WanReplicationConfig();

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AddWanConfigLegacyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/AddWanConfigLegacyOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.management.operation;
 
 import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -56,13 +57,25 @@ public class AddWanConfigLegacyOperation extends AbstractManagementOperation imp
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        wanReplicationConfig.writeData(out);
+        // RU_COMPAT_3_11
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+            // using this method is nicer since the object
+            // can implement Versioned and have a version injected
+            out.writeObject(wanReplicationConfig);
+        } else {
+            wanReplicationConfig.writeData(out);
+        }
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        wanReplicationConfig = new WanReplicationConfig();
-        wanReplicationConfig.readData(in);
+        // RU_COMPAT_3_11
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+            wanReplicationConfig = in.readObject();
+        } else {
+            wanReplicationConfig = new WanReplicationConfig();
+            wanReplicationConfig.readData(in);
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/AliasedDiscoveryConfigUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AliasedDiscoveryConfigUtilsTest.java
@@ -46,8 +46,9 @@ public class AliasedDiscoveryConfigUtilsTest {
     public void tagFor() {
         assertEquals("gcp", AliasedDiscoveryConfigUtils.tagFor(new GcpConfig()));
         assertEquals("aws", AliasedDiscoveryConfigUtils.tagFor(new AwsConfig()));
-        assertEquals("aws", AliasedDiscoveryConfigUtils.tagFor(new AwsConfig() { }));
-        assertNull(AliasedDiscoveryConfigUtils.tagFor(new AliasedDiscoveryConfig(null) { }));
+        assertEquals("aws", AliasedDiscoveryConfigUtils.tagFor(new AwsConfig() {
+        }));
+        assertNull(AliasedDiscoveryConfigUtils.tagFor(new DummyAliasedDiscoveryConfig(null)));
     }
 
     @Test
@@ -132,7 +133,7 @@ public class AliasedDiscoveryConfigUtilsTest {
     @Test(expected = InvalidConfigurationException.class)
     public void validateUnknownEnvironments() {
         // given
-        AliasedDiscoveryConfig aliasedDiscoveryConfig = new AliasedDiscoveryConfig("invalid-tag") {
+        AliasedDiscoveryConfig aliasedDiscoveryConfig = new DummyAliasedDiscoveryConfig("invalid-tag") {
         }.setEnabled(true);
         List<AliasedDiscoveryConfig<?>> configs = new ArrayList<AliasedDiscoveryConfig<?>>();
         configs.add(aliasedDiscoveryConfig);
@@ -230,5 +231,16 @@ public class AliasedDiscoveryConfigUtilsTest {
 
         // then
         assertFalse(result);
+    }
+
+    private static class DummyAliasedDiscoveryConfig extends AliasedDiscoveryConfig {
+        protected DummyAliasedDiscoveryConfig(String tag) {
+            super(tag);
+        }
+
+        @Override
+        public int getId() {
+            throw new UnsupportedOperationException("Deserialization not supported!");
+        }
     }
 }


### PR DESCRIPTION
Add serialization support for WAN configuration classes

Note to reviewers - there is a third commit which changes RU checks from 3.12 to 3.11. Since this is a custom release based on the 3.11 branch, the user waives compliance with our patch level compatibilities but we try and allow the user to RU from 3.10.x to this custom release, thus keeping the RU checks but checking for cluster version 3.11. Since the WAN config is sent in the `FinalizeJoinOp`, members running the new serialisation can't join existing 3.11 clusters and they won't accept older 3.11 members. This will be noted in the TDD, documentation and release notes.

1:1 backport of:
https://github.com/hazelcast/hazelcast/pull/13986
https://github.com/hazelcast/hazelcast/pull/14085