### PR TITLE
Make client work when addresses configured via different interface than members

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
@@ -124,7 +124,9 @@ class ClusterConnector {
     }
 
     void setOwnerConnectionAddress(Address ownerConnectionAddress) {
-        this.previousOwnerConnectionAddress = this.ownerConnectionAddress;
+        if (this.ownerConnectionAddress != null) {
+            this.previousOwnerConnectionAddress = this.ownerConnectionAddress;
+        }
         this.ownerConnectionAddress = ownerConnectionAddress;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveAllMessageTask.java
@@ -118,7 +118,9 @@ public class MapRemoveAllMessageTask extends AbstractMapAllPartitionsMessageTask
             // (see PartitionWideEntryWithPredicateOperationFactory.createFactoryOnRunner).
 
             operationFactory = new OperationFactoryWrapper(operationFactory, endpoint.getUuid());
-            operationService.invokeOnPartitionsAsync(getServiceName(), operationFactory, singletonList(partitionId), this);
+            ICompletableFuture<Map<Integer, Object>> future =
+                    operationService.invokeOnPartitionsAsync(getServiceName(), operationFactory, singletonList(partitionId));
+            future.andThen(this);
         }
     }
 


### PR DESCRIPTION
Clients and members were forced to configure use interface when
adding a member address to config.

This prd relaxes rules. As long as hostnames are resolved to same ip
when dns lookup made on the client side following setups are allowed.

1. Member hostname <-> client different hostname
2. Member ip       <-> client different hostname
3. Member hostname <-> client ip