### PR TITLE
Fix a bug causing partition table to be modified while PASSIVE

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cluster/ClusterState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/ClusterState.java
@@ -71,7 +71,7 @@ public enum ClusterState {
      * In {@code ACTIVE} state, cluster will continue to operate without any restriction.
      * All operations are allowed. This is default state of a cluster.
      */
-    ACTIVE(true, true),
+    ACTIVE(true, true, true),
 
     /**
      * In {@code NO_MIGRATION} state of the cluster, migrations (partition rebalancing) and backup replications
@@ -90,7 +90,7 @@ public enum ClusterState {
      *
      * @since 3.9
      */
-    NO_MIGRATION(true, false),
+    NO_MIGRATION(true, false, true),
 
     /**
      * In {@code FROZEN} state of the cluster:
@@ -119,7 +119,7 @@ public enum ClusterState {
      * </li>
      * </ul>
      */
-    FROZEN(false, false),
+    FROZEN(false, false, false),
 
     /**
      * In {@code PASSIVE} state of the cluster:
@@ -144,7 +144,7 @@ public enum ClusterState {
      * </li>
      * </ul>
      */
-    PASSIVE(false, false),
+    PASSIVE(false, false, false),
 
     /**
      * Shows that ClusterState is in transition. When a state change transaction is started,
@@ -165,14 +165,16 @@ public enum ClusterState {
      * </li>
      * </ul>
      */
-    IN_TRANSITION(false, false);
+    IN_TRANSITION(false, false, false);
 
     private final boolean joinAllowed;
     private final boolean migrationAllowed;
+    private final boolean partitionPromotionAllowed;
 
-    ClusterState(boolean joinAllowed, boolean migrationAllowed) {
+    ClusterState(boolean joinAllowed, boolean migrationAllowed, boolean partitionPromotionAllowed) {
         this.joinAllowed = joinAllowed;
         this.migrationAllowed = migrationAllowed;
+        this.partitionPromotionAllowed = partitionPromotionAllowed;
     }
 
     /**
@@ -189,5 +191,13 @@ public enum ClusterState {
      */
     public boolean isMigrationAllowed() {
         return migrationAllowed;
+    }
+
+    /**
+     * Shows whether partition promotions are allowed.
+     * @return true when partition promotions are allowed, false otherwise
+     */
+    public boolean isPartitionPromotionAllowed() {
+        return partitionPromotionAllowed;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -408,25 +408,21 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             migrationManager.onMemberRemove(member);
             replicaManager.cancelReplicaSyncRequestsTo(member.getAddress());
 
-            if (!node.getClusterService().getClusterState().isJoinAllowed()) {
-                // If join is not allowed, partition table cannot be modified and we should have
-                // the most recent partition table already. Because cluster state cannot be changed
-                // when our partition table is stale.
-                return;
-            }
+            ClusterState clusterState = node.getClusterService().getClusterState();
+            if (clusterState.isMigrationAllowed() || clusterState.isPartitionPromotionAllowed()) {
+                partitionStateManager.updateMemberGroupsSize();
 
-            partitionStateManager.updateMemberGroupsSize();
-
-            boolean isThisNodeNewMaster = node.isMaster() && !node.getThisAddress().equals(lastMaster);
-            if (isThisNodeNewMaster) {
-                assert !shouldFetchPartitionTables : "SOMETHING IS WRONG! Removed member: " + member;
-                shouldFetchPartitionTables = true;
+                boolean isThisNodeNewMaster = node.isMaster() && !node.getThisAddress().equals(lastMaster);
+                if (isThisNodeNewMaster) {
+                    assert !shouldFetchPartitionTables;
+                    shouldFetchPartitionTables = true;
+                }
+                if (node.isMaster()) {
+                    migrationManager.triggerControlTask();
+                }
             }
 
             lastMaster = node.getClusterService().getMasterAddress();
-            if (node.isMaster()) {
-                migrationManager.triggerControlTask();
-            }
         } finally {
             lock.unlock();
         }
@@ -565,7 +561,7 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
             return;
         }
 
-        if (!isMigrationAllowed()) {
+        if (!areMigrationTasksAllowed()) {
             // migration is disabled because of a member leave, wait till enabled!
             return;
         }
@@ -1042,8 +1038,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         migrationManager.resumeMigration();
     }
 
-    public boolean isMigrationAllowed() {
-        return migrationManager.isMigrationAllowed();
+    public boolean areMigrationTasksAllowed() {
+        return migrationManager.areMigrationTasksAllowed();
     }
 
     @Override
@@ -1222,6 +1218,16 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
         private PartitionRuntimeState newState;
 
         public void run() {
+            ClusterState clusterState = node.getClusterService().getClusterState();
+            if (!clusterState.isMigrationAllowed() && !clusterState.isPartitionPromotionAllowed()) {
+                // If migrations and promotions are not allowed, partition table cannot be modified and we should have
+                // the most recent partition table already. Because cluster state cannot be changed
+                // when our partition table is stale.
+                logger.fine("No need to fetch the latest partition table. "
+                        + "Cluster state does not allow to modify partition table.");
+                shouldFetchPartitionTables = false;
+                return;
+            }
             maxVersion = partitionStateManager.getVersion();
             logger.info("Fetching most recent partition table! my version: " + maxVersion);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationThread.java
@@ -86,7 +86,7 @@ class MigrationThread extends Thread implements Runnable {
     private void doRun() throws InterruptedException {
         boolean migrating = false;
         for (; ; ) {
-            if (!migrationManager.isMigrationAllowed()) {
+            if (!migrationManager.areMigrationTasksAllowed()) {
                 break;
             }
             MigrationRunnable runnable = queue.poll(1, TimeUnit.SECONDS);
@@ -106,7 +106,7 @@ class MigrationThread extends Thread implements Runnable {
                 logger.info("All migration tasks have been completed, queues are empty.");
             }
             Thread.sleep(sleepTime);
-        } else if (!migrationManager.isMigrationAllowed()) {
+        } else if (!migrationManager.areMigrationTasksAllowed()) {
             Thread.sleep(sleepTime);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -139,7 +139,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
             return;
         }
 
-        if (!partitionService.isMigrationAllowed()) {
+        if (!partitionService.areMigrationTasksAllowed()) {
             logger.finest("Cannot send sync replica request for partitionId=" + partitionId + ", replicaIndex=" + replicaIndex
                     + ", namespaces=" + namespaces + ". Sync is not allowed.");
             return;
@@ -433,7 +433,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
         @Override
         public void run() {
             if (!node.isRunning() || !node.getNodeExtension().isStartCompleted()
-                    || !partitionService.isMigrationAllowed()) {
+                    || !partitionService.areMigrationTasksAllowed()) {
                 return;
             }
             nodeEngine.getOperationService().executeOnPartitions(new PartitionAntiEntropyTaskFactory(), getLocalPartitions());

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
@@ -39,7 +39,7 @@ class PublishPartitionRuntimeStateTask implements Runnable {
     public void run() {
         if (node.isMaster()) {
             MigrationManager migrationManager = partitionService.getMigrationManager();
-            boolean migrationAllowed = migrationManager.isMigrationAllowed()
+            boolean migrationAllowed = migrationManager.areMigrationTasksAllowed()
                     && !partitionService.isFetchMostRecentPartitionTableTaskRequired();
             if (!migrationAllowed) {
                 logger.fine("Not publishing partition runtime state since migration is not allowed.");

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
@@ -87,7 +87,7 @@ public final class PartitionReplicaSyncRequest extends AbstractPartitionOperatio
         int partitionId = getPartitionId();
         int replicaIndex = getReplicaIndex();
 
-        if (!partitionService.isMigrationAllowed()) {
+        if (!partitionService.areMigrationTasksAllowed()) {
             ILogger logger = getLogger();
             if (logger.isFinestEnabled()) {
                 logger.finest("Migration is paused! Cannot run replica sync -> " + toString());


### PR DESCRIPTION
When cluster is FROZEN or PASSIVE, partition table should not change in any case.
But due a bug introduced during another fix (https://github.com/hazelcast/hazelcast/pull/13445),
terminated members were being removed from partition table when an existing member restarts.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/1839