### PR TITLE
[3.11.1] Add possibility to disable scripting on members.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberState.java
@@ -45,6 +45,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
     boolean sslEnabled;
     boolean lite;
     boolean socketInterceptorEnabled;
+    boolean scriptingEnabled;
 
     public List<String> getMemberList() {
         return memberList;
@@ -110,6 +111,14 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         this.socketInterceptorEnabled = socketInterceptorEnabled;
     }
 
+    public boolean isScriptingEnabled() {
+        return scriptingEnabled;
+    }
+
+    public void setScriptingEnabled(boolean scriptingEnabled) {
+        this.scriptingEnabled = scriptingEnabled;
+    }
+
     @Override
     public TimedMemberState clone() throws CloneNotSupportedException {
         TimedMemberState state = (TimedMemberState) super.clone();
@@ -121,6 +130,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         state.setSslEnabled(sslEnabled);
         state.setLite(lite);
         state.setSocketInterceptorEnabled(socketInterceptorEnabled);
+        state.setScriptingEnabled(scriptingEnabled);
         return state;
     }
 
@@ -141,6 +151,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         root.add("sslEnabled", sslEnabled);
         root.add("lite", lite);
         root.add("socketInterceptorEnabled", socketInterceptorEnabled);
+        root.add("scriptingEnabled", scriptingEnabled);
         return root;
     }
 
@@ -160,6 +171,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         sslEnabled = getBoolean(json, "sslEnabled", false);
         lite = getBoolean(json, "lite");
         socketInterceptorEnabled = getBoolean(json, "socketInterceptorEnabled");
+        scriptingEnabled = getBoolean(json, "scriptingEnabled");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -65,6 +65,7 @@ import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 import com.hazelcast.wan.WanReplicationService;
@@ -141,6 +142,9 @@ public class TimedMemberStateFactory {
 
         SocketInterceptorConfig interceptorConfig = instance.getConfig().getNetworkConfig().getSocketInterceptorConfig();
         timedMemberState.setSocketInterceptorEnabled(interceptorConfig != null && interceptorConfig.isEnabled());
+
+        boolean scriptingEnabled = instance.node.getProperties().getBoolean(GroupProperty.SCRIPTING_ENABLED);
+        timedMemberState.setScriptingEnabled(scriptingEnabled);
 
         return timedMemberState;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -22,12 +22,15 @@ import com.hazelcast.internal.management.ScriptEngineManagerContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.impl.Versioned;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.ExceptionUtil;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import java.io.IOException;
+import java.security.AccessControlException;
 
 import static com.hazelcast.internal.cluster.Versions.V3_10;
 
@@ -51,6 +54,10 @@ public class ScriptExecutorOperation extends AbstractManagementOperation impleme
 
     @Override
     public void run() {
+        HazelcastProperties hzProperties = getNodeEngine().getProperties();
+        if (! hzProperties.getBoolean(GroupProperty.SCRIPTING_ENABLED)) {
+            throw new AccessControlException("Using ScriptEngine is not allowed on this Hazelcast member.");
+        }
         ScriptEngineManager scriptEngineManager = ScriptEngineManagerContext.getScriptEngineManager();
         ScriptEngine engine = scriptEngineManager.getEngineByName(engineName);
         if (engine == null) {

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -657,6 +657,17 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.slow.operation.detector.stacktrace.logging.enabled", false);
 
     /**
+     * Allows to enable/disable using Script engines from the
+     * {@link com.hazelcast.internal.management.operation.ScriptExecutorOperation}. Default value differs between Hazelcast
+     * ({@code true}) and Hazelcast Enterprise ({@code false}).
+     *
+     * @deprecated This property will be replaced by a field in ManagementCenterConfig in Hazelcast 3.12.
+     */
+    @Deprecated
+    public static final HazelcastProperty SCRIPTING_ENABLED = new HazelcastProperty("hazelcast.mancenter.scripting.enabled",
+            ! BuildInfoProvider.getBuildInfo().isEnterprise());
+
+    /**
      * Property isn't used anymore.
      */
     @Deprecated

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ScriptingProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ScriptingProtectionTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management;
+
+import static org.junit.Assert.assertEquals;
+
+import java.security.AccessControlException;
+import java.util.concurrent.ExecutionException;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.internal.management.operation.ScriptExecutorOperation;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Tests possibility to disable scripting on members.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({ QuickTest.class, ParallelTest.class })
+public class ScriptingProtectionTest extends HazelcastTestSupport {
+
+    private static final String SCRIPT_RETURN_VAL = "John";
+    private static final String SCRIPT = "\"" + SCRIPT_RETURN_VAL + "\"";
+    // Let's use Groovy on classpath, because Azul Zulu 6-7 doesn't include the JavaScript engine (Rhino)
+    private static final String ENGINE = "groovy";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @BeforeClass
+    @AfterClass
+    public static void killAllHazelcastInstances() {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testScritpingDisabled() throws InterruptedException, ExecutionException {
+        testInternal(false, false);
+    }
+
+    @Test
+    public void testScritpingDisabledOnSrc() throws InterruptedException, ExecutionException {
+        testInternal(false, true);
+    }
+
+    @Test
+    public void testScritpingDisabledOnDest() throws InterruptedException, ExecutionException {
+        testInternal(true, false);
+    }
+
+    @Test
+    public void testScritpingEnabled() throws InterruptedException, ExecutionException {
+        testInternal(true, true);
+    }
+
+    @Test
+    public void testDefaultValue() throws InterruptedException, ExecutionException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        ScriptExecutorOperation op = createScriptExecutorOp();
+        InternalCompletableFuture<Object> result = getOperationService(hz1).invokeOnTarget(MapService.SERVICE_NAME, op,
+                getAddress(hz2));
+        if (!getScriptingEnabledDefaultValue()) {
+            expectedException.expect(ExecutionException.class);
+            expectedException.expectCause(CoreMatchers.<Throwable>instanceOf(AccessControlException.class));
+        }
+        assertEquals(SCRIPT_RETURN_VAL, result.get());
+    }
+
+    /**
+     * @return true if the scripting should be enabled by default
+     */
+    protected boolean getScriptingEnabledDefaultValue() {
+        return true;
+    }
+
+    /**
+     * Tests scripting protection on 2 nodes cluster. The source node sends a {@link ScriptExecutorOperation} to the destination
+     * one. If the destination node has scripting disabled, an exception is thrown, otherwise the source gets correct script
+     * execution result.
+     *
+     * @param srcEnabled scripting enabled on source node (it's value should have no effect on the test)
+     * @param destEnabled scripting enabled on destination node
+     */
+    protected void testInternal(boolean srcEnabled, boolean destEnabled) throws InterruptedException, ExecutionException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance hz1 = factory.newHazelcastInstance(createConfig(srcEnabled));
+        HazelcastInstance hz2 = factory.newHazelcastInstance(createConfig(destEnabled));
+        ScriptExecutorOperation op = createScriptExecutorOp();
+        InternalCompletableFuture<Object> result = getOperationService(hz1).invokeOnTarget(MapService.SERVICE_NAME, op,
+                getAddress(hz2));
+        if (!destEnabled) {
+            expectedException.expect(ExecutionException.class);
+            expectedException.expectCause(CoreMatchers.<Throwable>instanceOf(AccessControlException.class));
+        }
+        assertEquals(SCRIPT_RETURN_VAL, result.get());
+    }
+
+    protected ScriptExecutorOperation createScriptExecutorOp() {
+        ScriptExecutorOperation op = new ScriptExecutorOperation(ENGINE, SCRIPT);
+        return op;
+    }
+
+    @SuppressWarnings("deprecation")
+    protected Config createConfig(boolean scriptingEnabled) {
+        Config config = new Config();
+        config.setProperty(GroupProperty.SCRIPTING_ENABLED.getName(), String.valueOf(scriptingEnabled));
+        return config;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.management;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -27,7 +28,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -83,5 +83,34 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
 
         TimedMemberState timedMemberState = factory.createTimedMemberState();
         assertEquals(enabled, timedMemberState.sslEnabled);
+    }
+
+    @Test
+    public void testScripting_defaultValue() {
+        testScripting(null);
+    }
+
+    @Test
+    public void testScripting_enabled() {
+        testScripting(true);
+    }
+
+    @Test
+    public void testScripting_disabled() {
+        testScripting(false);
+    }
+
+    private void testScripting(Boolean enabled) {
+        Config config = getConfig();
+        if (enabled != null) {
+            config.setProperty(GroupProperty.SCRIPTING_ENABLED.getName(), String.valueOf(enabled));
+        }
+
+        HazelcastInstance hz = createHazelcastInstance(config);
+        TimedMemberStateFactory factory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
+
+        TimedMemberState timedMemberState = factory.createTimedMemberState();
+        boolean expected = enabled == null ? true : enabled;
+        assertEquals(expected, timedMemberState.scriptingEnabled);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -51,6 +51,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         timedMemberState.setTime(1827731);
         timedMemberState.setSslEnabled(true);
         timedMemberState.setLite(true);
+        timedMemberState.setScriptingEnabled(false);
     }
 
     @Test
@@ -63,6 +64,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         assertNotNull(cloned.getMemberState());
         assertTrue(cloned.isSslEnabled());
         assertTrue(cloned.isLite());
+        assertFalse(cloned.isScriptingEnabled());
         assertNotNull(cloned.toString());
     }
 
@@ -78,6 +80,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         assertNotNull(deserialized.getMemberState());
         assertTrue(deserialized.isSslEnabled());
         assertTrue(deserialized.isLite());
+        assertFalse(deserialized.isScriptingEnabled());
         assertNotNull(deserialized.toString());
     }
 


### PR DESCRIPTION
Upstream PR: #14140

This PR differs from the upstream in the configuration part. As we don't change XSDs in the micro versions, the protection attribute is configured by a new Hazelcast group property `hazelcast.mancenter.scripting.enabled`:

```xml
<properties>
    <property name="hazelcast.mancenter.scripting.enabled">false</property>
</properties>
```

The property will only be supported in 3.11.z patch stream. Users switching to 3.12 will have to use proper configuration - i.e. use attribute under the `<management-center/>` configuration element.