### PR TITLE
Fixed expected message string

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -224,7 +224,7 @@ public class RestTest extends HazelcastTestSupport {
         wanConfig.setName("test");
         WanReplicationConfigDTO dto = new WanReplicationConfigDTO(wanConfig);
         String result = communicator.addWanConfig(dto.toJson().toString());
-        assertEquals("{\"status\":\"fail\",\"message\":\"java.lang.UnsupportedOperationException: Adding new WAN config is not supported.\"}", result);
+        assertEquals("{\"status\":\"fail\",\"message\":\"Adding new WAN config is not supported.\"}", result);
     }
 
     @Test


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/14109

Previously, exception was wrapped by `ExecutionException` but due to the latest changes [here](https://github.com/hazelcast/hazelcast/blob/e60bdead859cab32683b26629438494aab5c84e3/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java#L489), we started to throw `UnsupportedOperationException` without any wrapper and this made tests assumption wrong.