### PR TITLE
Improve/fix multicast related tests to work on macOS

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
@@ -71,6 +71,13 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
             String group = getOrDefault(MulticastProperties.GROUP, DEFAULT_MULTICAST_GROUP);
             multicastSocket = new MulticastSocket(null);
             multicastSocket.bind(new InetSocketAddress(port));
+            if (discoveryNode != null) {
+                // See MulticastService.createMulticastService(...)
+                InetAddress inetAddress = discoveryNode.getPrivateAddress().getInetAddress();
+                if (!inetAddress.isLoopbackAddress()) {
+                    multicastSocket.setInterface(inetAddress);
+                }
+            }
             multicastSocket.setReuseAddress(true);
             multicastSocket.setTimeToLive(SOCKET_TIME_TO_LIVE);
             multicastSocket.setReceiveBufferSize(DATA_OUTPUT_BUFFER_SIZE);

--- a/hazelcast/src/test/java/com/hazelcast/cluster/ClusterJoinConfigCheckTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/ClusterJoinConfigCheckTest.java
@@ -19,18 +19,20 @@ package com.hazelcast.cluster;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.TestUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterSize;
+import static com.hazelcast.test.OverridePropertyRule.clear;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -42,12 +44,15 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class ClusterJoinConfigCheckTest {
 
+    @Rule
+    public final OverridePropertyRule ruleSysPropHazelcastLocalAddress = clear("hazelcast.local.localAddress");
+
     private static final int BASE_PORT = 7777;
 
     @Before
     @After
-    public void killAllHazelcastInstances() throws IOException {
-        Hazelcast.shutdownAll();
+    public void killAllHazelcastInstances() {
+        HazelcastInstanceFactory.terminateAll();
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/LiteMemberJoinTest.java
@@ -27,9 +27,11 @@ import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,11 +44,15 @@ import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventuall
 import static com.hazelcast.test.HazelcastTestSupport.closeConnectionBetween;
 import static com.hazelcast.test.HazelcastTestSupport.getNode;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
+import static com.hazelcast.test.OverridePropertyRule.clear;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class LiteMemberJoinTest {
+
+    @Rule
+    public final OverridePropertyRule ruleSysPropHazelcastLocalAddress = clear("hazelcast.local.localAddress");
 
     private final String name = randomString();
 

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MulticastDeserializationTest.java
@@ -24,9 +24,11 @@ import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.internal.serialization.impl.SerializationConstants;
 import com.hazelcast.nio.Packet;
 import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.annotation.QuickTest;
 import example.serialization.TestDeserialized;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -40,6 +42,7 @@ import java.net.MulticastSocket;
 import java.nio.ByteBuffer;
 
 import static com.hazelcast.nio.IOUtil.closeResource;
+import static com.hazelcast.test.OverridePropertyRule.clear;
 import static org.junit.Assert.assertFalse;
 
 /**
@@ -48,6 +51,9 @@ import static org.junit.Assert.assertFalse;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class MulticastDeserializationTest {
+
+    @Rule
+    public final OverridePropertyRule ruleSysPropHazelcastLocalAddress = clear("hazelcast.local.localAddress");
 
     private static final int MULTICAST_PORT = 53535;
     private static final String MULTICAST_GROUP = "224.0.0.219";
@@ -108,6 +114,7 @@ public class MulticastDeserializationTest {
         MulticastSocket multicastSocket = null;
         try {
             multicastSocket = new MulticastSocket(MULTICAST_PORT);
+            multicastSocket.setInterface(InetAddress.getLocalHost());
             multicastSocket.setTimeToLive(MULTICAST_TTL);
             InetAddress group = InetAddress.getByName(MULTICAST_GROUP);
             multicastSocket.joinGroup(group);

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 
 import java.io.InputStream;
 
+import static com.hazelcast.test.OverridePropertyRule.clear;
 import static com.hazelcast.test.OverridePropertyRule.set;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -44,6 +45,8 @@ public class MemberToMemberDiscoveryTest extends HazelcastTestSupport {
     public final OverridePropertyRule overrideJoinWaitSecondsRule = set("hazelcast.wait.seconds.before.join", "10");
     @Rule
     public final OverridePropertyRule overridePreferIpv4Rule = set("java.net.preferIPv4Stack", "true");
+    @Rule
+    public final OverridePropertyRule overrideHazelcastLocalAddressRule = clear("hazelcast.local.localAddress");
 
     private Config config;
 

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -74,13 +73,6 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
         final String threadDumpOnFailure = System.getProperty("hazelcast.test.threadDumpOnFailure");
         THREAD_DUMP_ON_FAILURE = threadDumpOnFailure != null
                 ? Boolean.parseBoolean(threadDumpOnFailure) : JenkinsDetector.isOnJenkins();
-
-        // randomize multicast group
-        Random rand = new Random();
-        int g1 = rand.nextInt(255);
-        int g2 = rand.nextInt(255);
-        int g3 = rand.nextInt(255);
-        System.setProperty("hazelcast.multicast.group", "224." + g1 + "." + g2 + "." + g3);
 
         ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
 


### PR DESCRIPTION
Multicast group randomization in `AbstractHazelcastClassRunner` is removed
It's not needed anymore since tests which are using real network
are run serially.