### PR TITLE
[BACKPORT] PartitionServiceMBean#getActivePartitionCount hostname mismatch

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java
@@ -20,7 +20,6 @@ import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.Address;
 
-import java.net.InetSocketAddress;
 import java.util.Map;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
@@ -57,8 +56,8 @@ public class PartitionServiceMBean extends HazelcastMBean<InternalPartitionServi
     @ManagedAnnotation("activePartitionCount")
     @ManagedDescription("Number of active partitions")
     public int getActivePartitionCount() {
-        InetSocketAddress thisAddress = hazelcastInstance.getCluster().getLocalMember().getSocketAddress();
-        return managedObject.getMemberPartitionsIfAssigned(new Address(thisAddress)).size();
+        Address thisAddress = hazelcastInstance.getCluster().getLocalMember().getAddress();
+        return managedObject.getMemberPartitionsIfAssigned(thisAddress).size();
     }
 
     @ManagedAnnotation("isClusterSafe")


### PR DESCRIPTION
In PartitionServiceMBean#getActivePartitionCount, InetSocketAdress is converted to Address. But, when hostnames are set for members, getMemberPartitionsIfAssigned returns 0 because member host is registered as 127.0.0.1 while partition owner-host is registered as localhost. This situation can be observed for hostnames other than loopback address, too.

By passing local member's Address object directly, we can fix this behavior.

Backport of: https://github.com/hazelcast/hazelcast/pull/14115