### PR TITLE
Counted long max-value as infinity.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -176,7 +176,7 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
     }
 
     protected void markRecordStoreExpirable(long ttl, long maxIdle) {
-        if (!isInfiniteTTL(ttl) || isMaxIdleDefined(maxIdle)) {
+        if (isTtlDefined(ttl) || isMaxIdleDefined(maxIdle)) {
             hasEntryWithCustomExpiration = true;
         }
 
@@ -185,17 +185,13 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
         }
     }
 
-    /**
-     * @return {@code true} if the supplied ttl doesn't not represent infinity and as a result entry should be
-     * removed after some time, otherwise return {@code false} to indicate entry should live forever.
-     */
     // this method is overridden on ee
-    protected boolean isInfiniteTTL(long ttl) {
-        return !(ttl > 0L && ttl < Long.MAX_VALUE);
+    protected boolean isTtlDefined(long ttl) {
+        return ttl > 0L && ttl < Long.MAX_VALUE;
     }
 
     protected boolean isMaxIdleDefined(long maxIdle) {
-        return maxIdle > 0L;
+        return maxIdle > 0L && maxIdle < Long.MAX_VALUE;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/AbstractExpirationManagerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/AbstractExpirationManagerTest.java
@@ -148,7 +148,7 @@ public abstract class AbstractExpirationManagerTest extends HazelcastTestSupport
 
     @Test
     public void gets_taskPeriodSeconds_from_config() {
-        Config config = new Config();
+        Config config = getConfig();
         String taskPeriodSeconds = "77";
         config.setProperty(taskPeriodSecondsPropName(), taskPeriodSeconds);
         HazelcastInstance node = createHazelcastInstance(config);
@@ -159,7 +159,7 @@ public abstract class AbstractExpirationManagerTest extends HazelcastTestSupport
 
     @Test
     public void gets_cleanupPercentage_from_config() {
-        Config config = new Config();
+        Config config = getConfig();
         String cleanupPercentage = "99";
         config.setProperty(cleanupPercentagePropName(), cleanupPercentage);
         HazelcastInstance node = createHazelcastInstance(config);
@@ -170,7 +170,7 @@ public abstract class AbstractExpirationManagerTest extends HazelcastTestSupport
 
     @Test
     public void gets_cleanupOperationCount_from_config() {
-        Config config = new Config();
+        Config config = getConfig();
         String cleanupOperationCount = "777";
         config.setProperty(cleanupOperationCountPropName(), cleanupOperationCount);
         HazelcastInstance node = createHazelcastInstance(config);
@@ -181,7 +181,7 @@ public abstract class AbstractExpirationManagerTest extends HazelcastTestSupport
 
     @Test
     public void stops_running_when_clusterState_turns_passive() {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(taskPeriodSecondsPropName(), "1");
         HazelcastInstance node = createHazelcastInstance(config);
 
@@ -198,7 +198,7 @@ public abstract class AbstractExpirationManagerTest extends HazelcastTestSupport
 
     @Test
     public void starts_running_when_clusterState_turns_active() {
-        Config config = new Config();
+        Config config = getConfig();
         config.setProperty(taskPeriodSecondsPropName(), "1");
         HazelcastInstance node = createHazelcastInstance(config);
 


### PR DESCRIPTION
Otherwise unneeded scheduling of expired record cleaner task can be seen after migrations.

ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/2589