### PR TITLE
Reduce complexity of handling QC map-wide events

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
@@ -146,7 +146,7 @@ class SubscriberAccumulatorHandler implements AccumulatorHandler<QueryCacheEvent
      */
     private boolean noMissingMapWideEvent(AtomicReferenceArray<Queue<Integer>> removedCountHolders) {
         for (int i = 0; i < partitionCount; i++) {
-            if (removedCountHolders.get(i).size() < 1) {
+            if (removedCountHolders.get(i).isEmpty()) {
                 // means we still have not-received map-wide event for this partition
                 return false;
             }


### PR DESCRIPTION
Before this change query caches were using ConcurrentLinkedQueue.size to
check for emptiness of event queues, the method has O(n) time complexity.
As a result, QueryCacheNoEventLossTest was spending about 70% of its
total CPU time just computing queue sizes.

This change fixes that by utilizing ConcurrentLinkedQueue.isEmpty, which
has O(1) complexity. That should reduce the stress induced by
QueryCacheNoEventLossTest (and probably by other tests) on the system.

Potentially fixes: https://github.com/hazelcast/hazelcast/issues/13982