### PR TITLE
No need to trigger partition table initialization if cluster startup is not completed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -265,14 +265,11 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
     /** Sends a {@link AssignPartitions} to the master to assign partitions. */
     private void triggerMasterToAssignPartitions() {
-        if (partitionStateManager.isInitialized()) {
+        if (!shouldTriggerMasterToAssignPartitions()) {
             return;
         }
 
         ClusterServiceImpl clusterService = node.getClusterService();
-        if (!clusterService.isJoined()) {
-            return;
-        }
 
         ClusterState clusterState = clusterService.getClusterState();
         if (!clusterState.isMigrationAllowed()) {
@@ -310,6 +307,11 @@ public class InternalPartitionServiceImpl implements InternalPartitionService, M
 
             masterTrigger.executeWithDelay();
         }
+    }
+
+    private boolean shouldTriggerMasterToAssignPartitions() {
+        ClusterServiceImpl clusterService = node.getClusterService();
+        return !partitionStateManager.isInitialized() && clusterService.isJoined() && node.getNodeExtension().isStartCompleted();
     }
 
     private void resetMasterTriggeredFlag() {


### PR DESCRIPTION
It is a no-op change on the OS side and it is preventing excessive logging in the EE tests.