### PR TITLE
Changes that allow Jet to react to cluster state changes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -38,18 +38,26 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.channels.ServerSocketChannel;
+import java.util.List;
 import java.util.Properties;
 
 import static com.hazelcast.spi.properties.GroupProperty.IO_BALANCER_INTERVAL_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.IO_INPUT_THREAD_COUNT;
 import static com.hazelcast.spi.properties.GroupProperty.IO_OUTPUT_THREAD_COUNT;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 
 @PrivateApi
 public class DefaultNodeContext implements NodeContext {
 
+    public static final List<String> EXTENSION_PRIORITY_LIST = unmodifiableList(asList(
+            "com.hazelcast.instance.EnterpriseNodeExtension",
+            "com.hazelcast.instance.DefaultNodeExtension"
+    ));
+
     @Override
     public NodeExtension createNodeExtension(Node node) {
-        return NodeExtensionFactory.create(node);
+        return NodeExtensionFactory.create(node, EXTENSION_PRIORITY_LIST);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -326,12 +326,20 @@ public class DefaultNodeExtension implements NodeExtension {
     }
 
     @Override
+    public void beforeClusterStateChange(ClusterState currState, ClusterState requestedState, boolean isTransient) {
+    }
+
+    @Override
     public void onClusterStateChange(ClusterState newState, boolean isTransient) {
         ServiceManager serviceManager = node.getNodeEngine().getServiceManager();
         List<ClusterStateListener> listeners = serviceManager.getServices(ClusterStateListener.class);
         for (ClusterStateListener listener : listeners) {
             listener.onClusterStateChange(newState);
         }
+    }
+
+    @Override
+    public void afterClusterStateChange(ClusterState oldState, ClusterState newState, boolean isTransient) {
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -247,7 +247,7 @@ public class Node {
         }
     }
 
-    private ClassLoader getConfigClassloader(Config config) {
+    private static ClassLoader getConfigClassloader(Config config) {
         UserCodeDeploymentConfig userCodeDeploymentConfig = config.getUserCodeDeploymentConfig();
         ClassLoader classLoader;
         if (userCodeDeploymentConfig.isEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtensionFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtensionFactory.java
@@ -16,45 +16,90 @@
 
 package com.hazelcast.instance;
 
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.ExceptionUtil;
 import com.hazelcast.util.ServiceLoader;
 
-import java.lang.reflect.Constructor;
 import java.util.Iterator;
+import java.util.List;
 
 @PrivateApi
 public final class NodeExtensionFactory {
 
-    private static final String FACTORY_ID = "com.hazelcast.instance.NodeExtension";
+    private static final String NODE_EXTENSION_FACTORY_ID = "com.hazelcast.instance.NodeExtension";
 
     private NodeExtensionFactory() {
     }
 
-    public static NodeExtension create(Node node) {
+    /**
+     * Uses the Hazelcast ServiceLoader to discover all registered {@link
+     * NodeExtension} classes and identify the one to instantiate and use as
+     * the provided {@code node}'s extension. It chooses the class based on
+     * the provided priority list of class names, these are the rules:
+     * <ol><li>
+     *     A class's priority is its zero-based index in the list.
+     * </li><li>
+     *     Lower number means higher priority.
+     * </li><li>
+     *     A class that doesn't appear in the list doesn't qualify for selection.
+     * </li></ol>
+     * <p>
+     * The dynamic selection of the node extension allows Hazelcast
+     * Enterprise's JAR to be swapped in for the core Hazelcast JAR with no
+     * changes to user's code or configuration. Hazelcast core code can call
+     * this method with a priority list naming both the default and the
+     * enterprise node extension and it will automatically prefer the
+     * Enterprise one when present.
+     * <p>
+     * The explicit priority list is necessary because a Hazelcast Jet JAR
+     * contains both the default node extension and the Jet node extension,
+     * but the one to choose depends on whether the user is requesting to
+     * start an IMDG or a Jet instance.
+     *
+     * @param node Hazelcast node whose extension this method must provide
+     * @param extensionPriorityList priority list of fully qualified extension class names
+     * @return the selected node extension
+     */
+    public static NodeExtension create(Node node, List<String> extensionPriorityList) {
         try {
             ClassLoader classLoader = node.getConfigClassLoader();
-            Iterator<Class<NodeExtension>> iter = ServiceLoader.classIterator(NodeExtension.class, FACTORY_ID, classLoader);
-            while (iter.hasNext()) {
-                Class<NodeExtension> clazz = iter.next();
-                if (!(clazz.equals(DefaultNodeExtension.class))) {
-                    if (clazz.getName().equals(DefaultNodeExtension.class.getName())) {
-                        Logger.getLogger(NodeExtensionFactory.class).warning(
-                                "DefaultNodeExtension class has been loaded by two different class-loaders. "
-                                        + "Classloader 1: " + NodeExtensionFactory.class.getClassLoader() + ", "
-                                        + "Classloader 2: " + clazz.getClassLoader() + ". "
-                                        + "Are you running Hazelcast in an OSGi environment? "
-                                        + "If so, set the bundle class-loader in the Config using the setClassloader() method");
-                    }
-                    Constructor<NodeExtension> constructor = clazz
-                            .getDeclaredConstructor(new Class[]{Node.class});
-                    return constructor.newInstance(node);
+            Class<NodeExtension> chosenExtension = null;
+            int chosenPriority = Integer.MAX_VALUE;
+            for (Iterator<Class<NodeExtension>> iter =
+                 ServiceLoader.classIterator(NodeExtension.class, NODE_EXTENSION_FACTORY_ID, classLoader);
+                 iter.hasNext();
+            ) {
+                Class<NodeExtension> currExt = iter.next();
+                warnIfDuplicate(currExt);
+                int currPriority = extensionPriorityList.indexOf(currExt.getName());
+                if (currPriority == -1) {
+                    continue;
+                }
+                if (currPriority < chosenPriority) {
+                    chosenPriority = currPriority;
+                    chosenExtension = currExt;
                 }
             }
+            if (chosenExtension == null) {
+                throw new HazelcastException("ServiceLoader didn't find any services registered under "
+                        + NODE_EXTENSION_FACTORY_ID);
+            }
+            return chosenExtension.getConstructor(Node.class).newInstance(node);
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
         }
-        return new DefaultNodeExtension(node);
+   }
+
+    private static void warnIfDuplicate(Class<NodeExtension> klass) {
+        if (!klass.equals(DefaultNodeExtension.class) && klass.getName().equals(DefaultNodeExtension.class.getName())) {
+            Logger.getLogger(NodeExtensionFactory.class).warning(
+                    "DefaultNodeExtension class has been loaded by two different class-loaders.\n"
+                            + "Classloader 1: " + NodeExtensionFactory.class.getClassLoader() + '\n'
+                            + "Classloader 2: " + klass.getClassLoader() + '\n'
+                            + "Are you running Hazelcast Jet in an OSGi environment?"
+                            + " If so, set the bundle class-loader in the Config using the setClassloader() method");
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateChange.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateChange.java
@@ -49,8 +49,12 @@ public class ClusterStateChange<T> implements IdentifiedDataSerializable {
         return newState;
     }
 
-    public <T> boolean isOfType(Class<T> type) {
+    public <T_SUGGESTED> boolean isOfType(Class<T_SUGGESTED> type) {
         return this.type.equals(type);
+    }
+
+    public ClusterState getClusterStateOrNull() {
+        return isOfType(ClusterState.class) ? (ClusterState) newState : null;
     }
 
     public void validate() {

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -158,8 +158,18 @@ public class SamplingNodeExtension implements NodeExtension {
     }
 
     @Override
+    public void beforeClusterStateChange(ClusterState currState, ClusterState requestedState, boolean isTransient) {
+        nodeExtension.beforeClusterStateChange(currState, requestedState, isTransient);
+    }
+
+    @Override
     public void onClusterStateChange(ClusterState newState, boolean isTransient) {
         nodeExtension.onClusterStateChange(newState, isTransient);
+    }
+
+    @Override
+    public void afterClusterStateChange(ClusterState oldState, ClusterState newState, boolean isTransient) {
+        nodeExtension.afterClusterStateChange(oldState, newState, isTransient);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -83,7 +83,7 @@ public class MockNodeContext implements NodeContext {
      * @return {@code NodeExtension} suitable for sampling serialized objects in OSS or EE environment
      */
     @SuppressWarnings("unchecked")
-    private NodeExtension constructSamplingNodeExtension(Node node) {
+    private static NodeExtension constructSamplingNodeExtension(Node node) {
         if (BuildInfoProvider.getBuildInfo().isEnterprise()) {
             try {
                 Class<? extends NodeExtension> klass = (Class<? extends NodeExtension>)

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -19,6 +19,7 @@ package com.hazelcast.test.mocknetwork;
 import com.hazelcast.cluster.Joiner;
 import com.hazelcast.instance.AddressPicker;
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.DefaultNodeContext;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeContext;
 import com.hazelcast.instance.NodeExtension;
@@ -56,11 +57,9 @@ public class MockNodeContext implements NodeContext {
 
     @Override
     public NodeExtension createNodeExtension(Node node) {
-        if (TestEnvironment.isRecordingSerializedClassNames()) {
-            return constructSamplingNodeExtension(node);
-        } else {
-            return NodeExtensionFactory.create(node);
-        }
+        return TestEnvironment.isRecordingSerializedClassNames()
+                ? constructSamplingNodeExtension(node)
+                : NodeExtensionFactory.create(node, DefaultNodeContext.EXTENSION_PRIORITY_LIST);
     }
 
     @Override
@@ -95,7 +94,7 @@ public class MockNodeContext implements NodeContext {
                 throw rethrow(e);
             }
         } else {
-            NodeExtension wrapped = NodeExtensionFactory.create(node);
+            NodeExtension wrapped = NodeExtensionFactory.create(node, DefaultNodeContext.EXTENSION_PRIORITY_LIST);
             return new SamplingNodeExtension(wrapped);
         }
     }


### PR DESCRIPTION
### Explicit priorities to select NodeExtension

The algorithm that goes through the list of classes registered as `NodeExtension` and chooses the one to instantiate works correctly only if just one other than `DefaultNodeExtension` is registered. It arbitrarily chooses the first such class it encounters.

Since now Jet has its `JetNodeExtension` and `JetEntepriseNodeExtension`, this algorithm has become inadequate. This PR introduces an explicit list of priorities to guide the class resolution so we can supply a different one when creating Jet.

### Cluster state change callbacks

Added `beforeClusterStateChange` and `afterClusterStateChange`.