### PR TITLE
Handle HazelcastClientOfflineException in reliable topic

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableMessageRunner.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientReliableMessageRunner.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.proxy;
 
+import com.hazelcast.client.HazelcastClientOfflineException;
 import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.ringbuffer.Ringbuffer;
@@ -58,6 +59,18 @@ public class ClientReliableMessageRunner<E> extends MessageRunner<E> {
             member = new com.hazelcast.client.impl.MemberImpl(m.getPublisherAddress(), MemberVersion.UNKNOWN);
         }
         return member;
+    }
+
+    @Override
+    protected boolean handleInternalException(Throwable t) {
+        if (t instanceof HazelcastClientOfflineException) {
+            if (logger.isFinestEnabled()) {
+                logger.finest("MessageListener " + listener + " on topic: " + topicName + " got exception: " + t
+                        + ". Continuing from last known sequence: " + sequence);
+            }
+            return true;
+        }
+        return super.handleInternalException(t);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/ClientReliableTopicTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.client.topic;
 
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientConnectionStrategyConfig;
 import com.hazelcast.client.proxy.ClientReliableTopicProxy;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
@@ -28,8 +30,10 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.impl.reliable.DurableSubscriptionTest;
 import com.hazelcast.topic.impl.reliable.ReliableMessageListenerMock;
 import com.hazelcast.util.Clock;
+import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -297,4 +301,49 @@ public class ClientReliableTopicTest extends HazelcastTestSupport {
 
         topic.getLocalTopicStats();
     }
+
+    @Test
+    public void shouldNotBeTerminated_whenClientIsOffline() {
+        final HazelcastInstance ownerMember = hazelcastFactory.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        clientConfig.getConnectionStrategyConfig().setReconnectMode(ClientConnectionStrategyConfig.ReconnectMode.ASYNC);
+        String topicName = "topic";
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        int publishCount = 1000;
+
+        final CountDownLatch messageArrived = new CountDownLatch(publishCount);
+        ITopic<String> topic = client.getReliableTopic(topicName);
+        final String id = topic.addMessageListener(new DurableSubscriptionTest.DurableMessageListener<String>() {
+            @Override
+            public void onMessage(Message<String> message) {
+                messageArrived.countDown();
+            }
+
+        });
+
+        HazelcastInstance member2 = hazelcastFactory.newHazelcastInstance();
+        waitAllForSafeState(ownerMember, member2);
+
+        ITopic<Object> reliableTopic = member2.getReliableTopic(topicName);
+
+        //kill the the owner member, while messages are coming
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                sleepMillis(1);
+                ownerMember.shutdown();
+            }
+        }).start();
+
+        for (int i = 0; i < publishCount; i++) {
+            reliableTopic.publish("msg " + (i + 100));
+        }
+
+        assertOpenEventually(messageArrived);
+        TestCase.assertTrue(topic.removeMessageListener(id));
+    }
+
 }


### PR DESCRIPTION
ReliableTopic was getting terminated in case of
HazelcastClientOfflineException. With this pr, relieable
topic continues from last known sequence id, in case
of `HazelcastClientOfflineException`.

fixes https://github.com/hazelcast/hazelcast/issues/14123

(cherry picked from commit 1be1e4339f0b246df3db79a5c89eb8f98bf631d5)