### PR TITLE
Return status of WAN config add from REST API

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -29,6 +29,7 @@ import com.hazelcast.internal.management.request.UpdatePermissionConfigRequest;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.security.SecurityService;
 import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.util.JsonUtil;
 import com.hazelcast.util.StringUtil;
 import com.hazelcast.version.Version;
 import com.hazelcast.wan.AddWanConfigResult;
@@ -36,8 +37,6 @@ import com.hazelcast.wan.WanReplicationService;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.util.Collection;
-import java.util.Iterator;
 
 import static com.hazelcast.util.StringUtil.bytesToString;
 import static com.hazelcast.util.StringUtil.lowerCaseInternal;
@@ -635,52 +634,11 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
                 final String key = attributes[i++].toString();
                 final Object value = attributes[i++];
                 if (value != null) {
-                    builder.append(String.format(",\"%s\":%s", key, jsonLiteral(value)));
+                    builder.append(String.format(",\"%s\":%s", key, JsonUtil.toJson(value)));
                 }
             }
         }
         return builder.append("}").toString();
-    }
-
-    private static String jsonLiteral(Object value) {
-        if (value instanceof String) {
-            return '"' + (String) value + '"';
-        } else if (value instanceof Collection) {
-            return "[" + toJson((Collection) value) + "]";
-        } else {
-            throw new IllegalArgumentException("Unsupported ");
-        }
-    }
-
-    /**
-     * Serializes a collection of objects into its JSON representation.
-     *
-     * @param objects collection of items to be serialized into JSON
-     * @return the serialized JSON
-     */
-    public static String toJson(Collection objects) {
-        Iterator iterator = objects.iterator();
-        if (!iterator.hasNext()) {
-            return "";
-        }
-        final Object first = iterator.next();
-        if (!iterator.hasNext()) {
-            return jsonLiteral(first);
-        }
-
-        final StringBuilder buf = new StringBuilder();
-        if (first != null) {
-            buf.append(jsonLiteral(first));
-        }
-
-        while (iterator.hasNext()) {
-            buf.append(',');
-            final Object obj = iterator.next();
-            if (obj != null) {
-                buf.append(jsonLiteral(obj));
-            }
-        }
-        return buf.toString();
     }
 
     private enum ResponseType {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -646,14 +646,20 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         if (value instanceof String) {
             return '"' + (String) value + '"';
         } else if (value instanceof Collection) {
-            return "[" + join((Collection) value, ",") + "]";
+            return "[" + toJson((Collection) value) + "]";
         } else {
             throw new IllegalArgumentException("Unsupported ");
         }
     }
 
-    public static String join(Collection strings, final String separator) {
-        Iterator iterator = strings.iterator();
+    /**
+     * Serializes a collection of objects into its JSON representation.
+     *
+     * @param objects collection of items to be serialized into JSON
+     * @return the serialized JSON
+     */
+    public static String toJson(Collection objects) {
+        Iterator iterator = objects.iterator();
         if (!iterator.hasNext()) {
             return "";
         }
@@ -668,9 +674,7 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         }
 
         while (iterator.hasNext()) {
-            if (separator != null) {
-                buf.append(separator);
-            }
+            buf.append(',');
             final Object obj = iterator.next();
             if (obj != null) {
                 buf.append(jsonLiteral(obj));

--- a/hazelcast/src/main/java/com/hazelcast/util/JsonUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/JsonUtil.java
@@ -21,7 +21,9 @@ import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -319,4 +321,50 @@ public final class JsonUtil {
         }
     }
 
+    /**
+     * Returns the JSON representation of the provided {@code value}
+     *
+     * @param value the value to serialize to JSON
+     * @return the serialized value
+     */
+    public static String toJson(Object value) {
+        if (value instanceof String) {
+            return '"' + (String) value + '"';
+        } else if (value instanceof Collection) {
+            return "[" + toJsonCollection((Collection) value) + "]";
+        } else {
+            throw new IllegalArgumentException("Unable to convert " + value + " to JSON");
+        }
+    }
+
+    /**
+     * Serializes a collection of objects into its JSON representation.
+     *
+     * @param objects collection of items to be serialized into JSON
+     * @return the serialized JSON
+     */
+    private static String toJsonCollection(Collection objects) {
+        Iterator iterator = objects.iterator();
+        if (!iterator.hasNext()) {
+            return "";
+        }
+        final Object first = iterator.next();
+        if (!iterator.hasNext()) {
+            return toJson(first);
+        }
+
+        final StringBuilder buf = new StringBuilder();
+        if (first != null) {
+            buf.append(toJson(first));
+        }
+
+        while (iterator.hasNext()) {
+            buf.append(',');
+            final Object obj = iterator.next();
+            if (obj != null) {
+                buf.append(toJson(obj));
+            }
+        }
+        return buf.toString();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/wan/AddWanConfigResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/AddWanConfigResult.java
@@ -17,6 +17,7 @@
 package com.hazelcast.wan;
 
 import com.hazelcast.config.WanReplicationConfig;
+import com.hazelcast.util.Preconditions;
 
 import java.util.Collection;
 
@@ -32,15 +33,25 @@ public class AddWanConfigResult {
 
     public AddWanConfigResult(Collection<String> addedPublisherIds,
                               Collection<String> ignoredPublisherIds) {
+        Preconditions.checkNotNull(addedPublisherIds, "Added publisher IDs must not be null");
+        Preconditions.checkNotNull(ignoredPublisherIds, "Ignored publisher IDs must not be null");
         this.addedPublisherIds = addedPublisherIds;
         this.ignoredPublisherIds = ignoredPublisherIds;
     }
 
 
+    /**
+     * Returns the IDs for the WAN publishers which were added to the
+     * configuration.
+     */
     public Collection<String> getAddedPublisherIds() {
         return addedPublisherIds;
     }
 
+    /**
+     * Returns the IDs for the WAN publishers which were ignored and not added
+     * to the configuration.
+     */
     public Collection<String> getIgnoredPublisherIds() {
         return ignoredPublisherIds;
     }

--- a/hazelcast/src/main/java/com/hazelcast/wan/AddWanConfigResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/AddWanConfigResult.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wan;
+
+import com.hazelcast.config.WanReplicationConfig;
+
+import java.util.Collection;
+
+/**
+ * The result of adding WAN configuration.
+ *
+ * @see WanReplicationService#addWanReplicationConfig(WanReplicationConfig)
+ */
+public class AddWanConfigResult {
+
+    private final Collection<String> addedPublisherIds;
+    private final Collection<String> ignoredPublisherIds;
+
+    public AddWanConfigResult(Collection<String> addedPublisherIds,
+                              Collection<String> ignoredPublisherIds) {
+        this.addedPublisherIds = addedPublisherIds;
+        this.ignoredPublisherIds = ignoredPublisherIds;
+    }
+
+
+    public Collection<String> getAddedPublisherIds() {
+        return addedPublisherIds;
+    }
+
+    public Collection<String> getIgnoredPublisherIds() {
+        return ignoredPublisherIds;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/wan/AddWanConfigResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/AddWanConfigResult.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.wan;
 
-import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.util.Preconditions;
 
 import java.util.Collection;
@@ -24,7 +23,7 @@ import java.util.Collection;
 /**
  * The result of adding WAN configuration.
  *
- * @see WanReplicationService#addWanReplicationConfig(WanReplicationConfig)
+ * @see WanReplicationService#addWanReplicationConfig(com.hazelcast.config.WanReplicationConfig)
  */
 public class AddWanConfigResult {
 

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -154,11 +154,18 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
      * name. Such configs will be merged into the existing WAN replication
      * config by adding publishers with publisher IDs which are not already part
      * of the existing configuration.
+     * The return value is a best-effort guess at the result of adding WAN
+     * replication config based on the existing local WAN replication config.
+     * An exact result is difficult to calculate since not all members might
+     * have the same existing configuration and there might be a concurrent
+     * request to add overlapping WAN replication config.
      *
+     * @param wanConfig the WAN replication config to add
+     * @return a best-effort guess at the result of adding WAN replication config
      * @throws UnsupportedOperationException if invoked on OS
      * @see #addWanReplicationConfigLocally(WanReplicationConfig)
      */
-    void addWanReplicationConfig(WanReplicationConfig wanConfig);
+    AddWanConfigResult addWanReplicationConfig(WanReplicationConfig wanConfig);
 
     /**
      * Returns current status of WAN sync operation or {@code null} when there

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.management.events.WanSyncIgnoredEvent;
 import com.hazelcast.monitor.LocalWanStats;
 import com.hazelcast.monitor.WanSyncState;
 import com.hazelcast.util.ConstructorFunction;
+import com.hazelcast.wan.AddWanConfigResult;
 import com.hazelcast.wan.WanReplicationEndpoint;
 import com.hazelcast.wan.WanReplicationPublisher;
 import com.hazelcast.wan.WanReplicationService;
@@ -160,7 +161,7 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
-    public void addWanReplicationConfig(WanReplicationConfig wanConfig) {
+    public AddWanConfigResult addWanReplicationConfig(WanReplicationConfig wanConfig) {
         node.getManagementCenterService().log(AddWanConfigIgnoredEvent.enterpriseOnly(wanConfig.getName()));
 
         throw new UnsupportedOperationException("Adding new WAN config is not supported.");


### PR DESCRIPTION
Returns the status of WAN config addition on REST API. The status is
best-effort since the config may be added concurrently with other
configurations and some members might have different configurations
than others. This is good enough for most cases.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2599