### PR TITLE
Allow to disable scripting on members

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -2899,6 +2899,7 @@
             <xs:element name="mutual-auth" type="mutual-auth" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
         <xs:attribute name="enabled" type="xs:string" default="false" use="optional"/>
+        <xs:attribute name="scripting-enabled" type="xs:boolean" use="optional"/>
         <xs:attribute name="url" type="xs:string" use="optional"/>
         <xs:attribute name="update-interval" type="xs:string" default="3" use="optional"/>
     </xs:complexType>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1099,6 +1099,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         ManagementCenterConfig managementCenterConfig = config.getManagementCenterConfig();
         assertNotNull(managementCenterConfig);
         assertTrue(managementCenterConfig.isEnabled());
+        assertFalse(managementCenterConfig.isScriptingEnabled());
         assertEquals("myserver:80", managementCenterConfig.getUrl());
         assertEquals(2, managementCenterConfig.getUpdateInterval());
         assertTrue(managementCenterConfig.getMutualAuthConfig().isEnabled());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -24,7 +24,7 @@
         http://www.hazelcast.com/schema/sample
         hazelcast-sample-service.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.11.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
@@ -42,7 +42,7 @@
                     name="${cluster.group.name}"
                     password="${cluster.group.password}"/>
             <hz:license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</hz:license-key>
-            <hz:management-center enabled="true" update-interval="2">
+            <hz:management-center enabled="true" update-interval="2" scripting-enabled="false">
                 <hz:url>myserver:80</hz:url>
                 <hz:mutual-auth enabled="true">
                     <hz:factory-class-name>who.let.the.cat.out.class</hz:factory-class-name>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -174,6 +174,7 @@ public class ConfigXmlGenerator {
             ManagementCenterConfig mcConfig = config.getManagementCenterConfig();
             gen.open("management-center",
                     "enabled", mcConfig.isEnabled(),
+                    "scripting-enabled", mcConfig.isScriptingEnabled(),
                     "update-interval", mcConfig.getUpdateInterval());
             gen.node("url", mcConfig.getUrl());
             if (mcConfig.getUrl() != null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ManagementCenterConfig.java
@@ -18,6 +18,8 @@ package com.hazelcast.config;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
+import com.hazelcast.instance.BuildInfoProvider;
+
 /**
  * Contains the configuration for a Management Center.
  */
@@ -26,6 +28,8 @@ public class ManagementCenterConfig {
     static final int UPDATE_INTERVAL = 3;
 
     private boolean enabled;
+
+    private boolean scriptingEnabled = ! BuildInfoProvider.getBuildInfo().isEnterprise();
 
     private String url;
 
@@ -48,6 +52,30 @@ public class ManagementCenterConfig {
      */
     public boolean isEnabled() {
         return enabled;
+    }
+
+    /**
+     * Enables/disables scripting on the member. Management center allows to send a script for execution to a member. The script
+     * can access the unerlying system Hazelcast member is running on with permissions of user running the member. Disabling
+     * scripting improves the member security.
+     * <p>
+     * Default value for this config element depends on Hazelcast edition: {@code false} for Hazelcast Enterprise, {@code true}
+     * for Hazelcast (open source).
+     *
+     * @param scriptingEnabled {@code true} to allow scripting on the member, {@code false} to disallow
+     * @return this management center config instance
+     * @since 3.12
+     */
+    public ManagementCenterConfig setScriptingEnabled(final boolean scriptingEnabled) {
+        this.scriptingEnabled = scriptingEnabled;
+        return this;
+    }
+
+    /**
+     * Returns if scripting is allowed ({@code true}) or disallowed ({@code false}).
+     */
+    public boolean isScriptingEnabled() {
+        return scriptingEnabled;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -2295,6 +2295,15 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
         managementCenterConfig.setEnabled(enabled);
         managementCenterConfig.setUpdateInterval(interval);
 
+        Node scriptingEnabledNode = attrs.getNamedItem("scripting-enabled");
+        if (scriptingEnabledNode != null) {
+            managementCenterConfig.setScriptingEnabled(getBooleanValue(getTextContent(scriptingEnabledNode)));
+        }
+
+        handleManagementCenterChildElements(node, managementCenterConfig);
+    }
+
+    private void handleManagementCenterChildElements(Node node, ManagementCenterConfig managementCenterConfig) {
         // < 3.9 - Backwards compatibility
         boolean isComplexType = false;
         List<String> complexTypeElements = Arrays.asList("url", "mutual-auth");

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberState.java
@@ -45,6 +45,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
     boolean sslEnabled;
     boolean lite;
     boolean socketInterceptorEnabled;
+    boolean scriptingEnabled;
 
     public List<String> getMemberList() {
         return memberList;
@@ -110,6 +111,14 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         this.socketInterceptorEnabled = socketInterceptorEnabled;
     }
 
+    public boolean isScriptingEnabled() {
+        return scriptingEnabled;
+    }
+
+    public void setScriptingEnabled(boolean scriptingEnabled) {
+        this.scriptingEnabled = scriptingEnabled;
+    }
+
     @Override
     public TimedMemberState clone() throws CloneNotSupportedException {
         TimedMemberState state = (TimedMemberState) super.clone();
@@ -121,6 +130,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         state.setSslEnabled(sslEnabled);
         state.setLite(lite);
         state.setSocketInterceptorEnabled(socketInterceptorEnabled);
+        state.setScriptingEnabled(scriptingEnabled);
         return state;
     }
 
@@ -141,6 +151,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         root.add("sslEnabled", sslEnabled);
         root.add("lite", lite);
         root.add("socketInterceptorEnabled", socketInterceptorEnabled);
+        root.add("scriptingEnabled", scriptingEnabled);
         return root;
     }
 
@@ -160,6 +171,7 @@ public final class TimedMemberState implements Cloneable, JsonSerializable {
         sslEnabled = getBoolean(json, "sslEnabled", false);
         lite = getBoolean(json, "lite");
         socketInterceptorEnabled = getBoolean(json, "socketInterceptorEnabled");
+        scriptingEnabled = getBoolean(json, "scriptingEnabled");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -65,6 +65,7 @@ import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.partition.IPartition;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 import com.hazelcast.wan.WanReplicationService;
@@ -141,6 +142,9 @@ public class TimedMemberStateFactory {
 
         SocketInterceptorConfig interceptorConfig = instance.getConfig().getNetworkConfig().getSocketInterceptorConfig();
         timedMemberState.setSocketInterceptorEnabled(interceptorConfig != null && interceptorConfig.isEnabled());
+
+        boolean scriptingEnabled = instance.node.getProperties().getBoolean(GroupProperty.SCRIPTING_ENABLED);
+        timedMemberState.setScriptingEnabled(scriptingEnabled);
 
         return timedMemberState;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/TimedMemberStateFactory.java
@@ -23,6 +23,7 @@ import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.GroupConfig;
+import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.core.Client;
@@ -65,7 +66,6 @@ import com.hazelcast.spi.StatisticsAwareService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.partition.IPartition;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 import com.hazelcast.wan.WanReplicationService;
@@ -143,8 +143,8 @@ public class TimedMemberStateFactory {
         SocketInterceptorConfig interceptorConfig = instance.getConfig().getNetworkConfig().getSocketInterceptorConfig();
         timedMemberState.setSocketInterceptorEnabled(interceptorConfig != null && interceptorConfig.isEnabled());
 
-        boolean scriptingEnabled = instance.node.getProperties().getBoolean(GroupProperty.SCRIPTING_ENABLED);
-        timedMemberState.setScriptingEnabled(scriptingEnabled);
+        ManagementCenterConfig managementCenterConfig = instance.node.getConfig().getManagementCenterConfig();
+        timedMemberState.setScriptingEnabled(managementCenterConfig.isScriptingEnabled());
 
         return timedMemberState;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -22,12 +22,15 @@ import com.hazelcast.internal.management.ScriptEngineManagerContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.impl.Versioned;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.ExceptionUtil;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import java.io.IOException;
+import java.security.AccessControlException;
 
 import static com.hazelcast.internal.cluster.Versions.V3_10;
 
@@ -51,6 +54,10 @@ public class ScriptExecutorOperation extends AbstractManagementOperation impleme
 
     @Override
     public void run() {
+        HazelcastProperties hzProperties = getNodeEngine().getProperties();
+        if (! hzProperties.getBoolean(GroupProperty.SCRIPTING_ENABLED)) {
+            throw new AccessControlException("Using ScriptEngine is not allowed on this Hazelcast member.");
+        }
         ScriptEngineManager scriptEngineManager = ScriptEngineManagerContext.getScriptEngineManager();
         ScriptEngine engine = scriptEngineManager.getEngineByName(engineName);
         if (engine == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -16,14 +16,13 @@
 
 package com.hazelcast.internal.management.operation;
 
+import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.management.ManagementDataSerializerHook;
 import com.hazelcast.internal.management.ScriptEngineManagerContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.impl.Versioned;
-import com.hazelcast.spi.properties.GroupProperty;
-import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.util.ExceptionUtil;
 
 import javax.script.ScriptEngine;
@@ -54,8 +53,8 @@ public class ScriptExecutorOperation extends AbstractManagementOperation impleme
 
     @Override
     public void run() {
-        HazelcastProperties hzProperties = getNodeEngine().getProperties();
-        if (! hzProperties.getBoolean(GroupProperty.SCRIPTING_ENABLED)) {
+        ManagementCenterConfig managementCenterConfig = getNodeEngine().getConfig().getManagementCenterConfig();
+        if (!managementCenterConfig.isScriptingEnabled()) {
             throw new AccessControlException("Using ScriptEngine is not allowed on this Hazelcast member.");
         }
         ScriptEngineManager scriptEngineManager = ScriptEngineManagerContext.getScriptEngineManager();

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -657,6 +657,17 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.slow.operation.detector.stacktrace.logging.enabled", false);
 
     /**
+     * Allows to enable/disable using Script engines from the
+     * {@link com.hazelcast.internal.management.operation.ScriptExecutorOperation}. Default value differs between Hazelcast
+     * ({@code true}) and Hazelcast Enterprise ({@code false}).
+     *
+     * @deprecated This property will be replaced by a field in ManagementCenterConfig in Hazelcast 3.12.
+     */
+    @Deprecated
+    public static final HazelcastProperty SCRIPTING_ENABLED = new HazelcastProperty("hazelcast.mancenter.scripting.enabled",
+            ! BuildInfoProvider.getBuildInfo().isEnterprise());
+
+    /**
      * Property isn't used anymore.
      */
     @Deprecated

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -657,17 +657,6 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.slow.operation.detector.stacktrace.logging.enabled", false);
 
     /**
-     * Allows to enable/disable using Script engines from the
-     * {@link com.hazelcast.internal.management.operation.ScriptExecutorOperation}. Default value differs between Hazelcast
-     * ({@code true}) and Hazelcast Enterprise ({@code false}).
-     *
-     * @deprecated This property will be replaced by a field in ManagementCenterConfig in Hazelcast 3.12.
-     */
-    @Deprecated
-    public static final HazelcastProperty SCRIPTING_ENABLED = new HazelcastProperty("hazelcast.mancenter.scripting.enabled",
-            ! BuildInfoProvider.getBuildInfo().isEnterprise());
-
-    /**
      * Property isn't used anymore.
      */
     @Deprecated

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -2626,6 +2626,13 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="scripting-enabled" type="xs:boolean" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    True to allow scripting on the member, false to disallow.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="update-interval" type="xs:integer" default="3" use="optional">
             <xs:annotation>
                 <xs:documentation>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -114,7 +114,7 @@
         at most 2 members in your cluster. To use it for more members, you need to have either a Management Center,
         Hazelcast Enterprise or Hazelcast Enterprise HD license.
     -->
-    <management-center enabled="true" update-interval="2">http://localhost:8080/hazelcast-mancenter</management-center>
+    <management-center enabled="true" scripting-enabled="false" update-interval="2">http://localhost:8080/hazelcast-mancenter</management-center>
     <!--
         The <properties> element lets you add properties to some of the Hazelcast elements used to configure some of
         the Hazelcast modules.

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1303,6 +1303,7 @@ public class ConfigCompatibilityChecker {
             boolean c1Disabled = c1 == null || !c1.isEnabled();
             boolean c2Disabled = c2 == null || !c2.isEnabled();
             return c1 == c2 || (c1Disabled && c2Disabled) || (c1 != null && c2 != null
+                    && (c1.isScriptingEnabled() == c2.isScriptingEnabled())
                     && nullSafeEqual(c1.getUrl(), c2.getUrl())
                     && nullSafeEqual(c1.getUpdateInterval(), c2.getUpdateInterval()));
         }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -419,6 +419,7 @@ public class ConfigXmlGeneratorTest {
     public void testManagementCenterConfigGenerator() {
         ManagementCenterConfig managementCenterConfig = new ManagementCenterConfig()
                 .setEnabled(true)
+                .setScriptingEnabled(false)
                 .setUpdateInterval(8)
                 .setUrl("http://foomybar.ber")
                 .setMutualAuthConfig(
@@ -437,6 +438,7 @@ public class ConfigXmlGeneratorTest {
 
         ManagementCenterConfig xmlManCenterConfig = xmlConfig.getManagementCenterConfig();
         assertEquals(managementCenterConfig.isEnabled(), xmlManCenterConfig.isEnabled());
+        assertEquals(managementCenterConfig.isScriptingEnabled(), xmlManCenterConfig.isScriptingEnabled());
         assertEquals(managementCenterConfig.getUpdateInterval(), xmlManCenterConfig.getUpdateInterval());
         assertEquals(managementCenterConfig.getUrl(), xmlManCenterConfig.getUrl());
         assertEquals(managementCenterConfig.getMutualAuthConfig().isEnabled(), xmlManCenterConfig.getMutualAuthConfig().isEnabled());

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -759,7 +759,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
     @Test
     public void testManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
-                + "<management-center enabled=\"true\">"
+                + "<management-center enabled=\"true\" scripting-enabled='false'>"
                 + "someUrl"
                 + "</management-center>"
                 + HAZELCAST_END_TAG;
@@ -768,6 +768,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
 
         assertTrue(manCenterCfg.isEnabled());
+        assertFalse(manCenterCfg.isScriptingEnabled());
         assertEquals("someUrl", manCenterCfg.getUrl());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ScriptingProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ScriptingProtectionTest.java
@@ -36,7 +36,6 @@ import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.internal.management.operation.ScriptExecutorOperation;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.spi.InternalCompletableFuture;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -133,10 +132,9 @@ public class ScriptingProtectionTest extends HazelcastTestSupport {
         return op;
     }
 
-    @SuppressWarnings("deprecation")
     protected Config createConfig(boolean scriptingEnabled) {
         Config config = new Config();
-        config.setProperty(GroupProperty.SCRIPTING_ENABLED.getName(), String.valueOf(scriptingEnabled));
+        config.getManagementCenterConfig().setScriptingEnabled(scriptingEnabled);
         return config;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ScriptingProtectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ScriptingProtectionTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management;
+
+import static org.junit.Assert.assertEquals;
+
+import java.security.AccessControlException;
+import java.util.concurrent.ExecutionException;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.internal.management.operation.ScriptExecutorOperation;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.spi.InternalCompletableFuture;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Tests possibility to disable scripting on members.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({ QuickTest.class, ParallelTest.class })
+public class ScriptingProtectionTest extends HazelcastTestSupport {
+
+    private static final String SCRIPT_RETURN_VAL = "John";
+    private static final String SCRIPT = "\"" + SCRIPT_RETURN_VAL + "\"";
+    // Let's use Groovy on classpath, because Azul Zulu 6-7 doesn't include the JavaScript engine (Rhino)
+    private static final String ENGINE = "groovy";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @BeforeClass
+    @AfterClass
+    public static void killAllHazelcastInstances() {
+        HazelcastInstanceFactory.terminateAll();
+    }
+
+    @Test
+    public void testScritpingDisabled() throws InterruptedException, ExecutionException {
+        testInternal(false, false);
+    }
+
+    @Test
+    public void testScritpingDisabledOnSrc() throws InterruptedException, ExecutionException {
+        testInternal(false, true);
+    }
+
+    @Test
+    public void testScritpingDisabledOnDest() throws InterruptedException, ExecutionException {
+        testInternal(true, false);
+    }
+
+    @Test
+    public void testScritpingEnabled() throws InterruptedException, ExecutionException {
+        testInternal(true, true);
+    }
+
+    @Test
+    public void testDefaultValue() throws InterruptedException, ExecutionException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        ScriptExecutorOperation op = createScriptExecutorOp();
+        InternalCompletableFuture<Object> result = getOperationService(hz1).invokeOnTarget(MapService.SERVICE_NAME, op,
+                getAddress(hz2));
+        if (!getScriptingEnabledDefaultValue()) {
+            expectedException.expect(ExecutionException.class);
+            expectedException.expectCause(CoreMatchers.<Throwable>instanceOf(AccessControlException.class));
+        }
+        assertEquals(SCRIPT_RETURN_VAL, result.get());
+    }
+
+    /**
+     * @return true if the scripting should be enabled by default
+     */
+    protected boolean getScriptingEnabledDefaultValue() {
+        return true;
+    }
+
+    /**
+     * Tests scripting protection on 2 nodes cluster. The source node sends a {@link ScriptExecutorOperation} to the destination
+     * one. If the destination node has scripting disabled, an exception is thrown, otherwise the source gets correct script
+     * execution result.
+     *
+     * @param srcEnabled scripting enabled on source node (it's value should have no effect on the test)
+     * @param destEnabled scripting enabled on destination node
+     */
+    protected void testInternal(boolean srcEnabled, boolean destEnabled) throws InterruptedException, ExecutionException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        HazelcastInstance hz1 = factory.newHazelcastInstance(createConfig(srcEnabled));
+        HazelcastInstance hz2 = factory.newHazelcastInstance(createConfig(destEnabled));
+        ScriptExecutorOperation op = createScriptExecutorOp();
+        InternalCompletableFuture<Object> result = getOperationService(hz1).invokeOnTarget(MapService.SERVICE_NAME, op,
+                getAddress(hz2));
+        if (!destEnabled) {
+            expectedException.expect(ExecutionException.class);
+            expectedException.expectCause(CoreMatchers.<Throwable>instanceOf(AccessControlException.class));
+        }
+        assertEquals(SCRIPT_RETURN_VAL, result.get());
+    }
+
+    protected ScriptExecutorOperation createScriptExecutorOp() {
+        ScriptExecutorOperation op = new ScriptExecutorOperation(ENGINE, SCRIPT);
+        return op;
+    }
+
+    @SuppressWarnings("deprecation")
+    protected Config createConfig(boolean scriptingEnabled) {
+        Config config = new Config();
+        config.setProperty(GroupProperty.SCRIPTING_ENABLED.getName(), String.valueOf(scriptingEnabled));
+        return config;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.management;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -103,7 +102,7 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
     private void testScripting(Boolean enabled) {
         Config config = getConfig();
         if (enabled != null) {
-            config.setProperty(GroupProperty.SCRIPTING_ENABLED.getName(), String.valueOf(enabled));
+            config.getManagementCenterConfig().setScriptingEnabled(enabled);
         }
 
         HazelcastInstance hz = createHazelcastInstance(config);

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateIntegrationTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.management;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -27,7 +28,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -83,5 +83,34 @@ public class TimedMemberStateIntegrationTest extends HazelcastTestSupport {
 
         TimedMemberState timedMemberState = factory.createTimedMemberState();
         assertEquals(enabled, timedMemberState.sslEnabled);
+    }
+
+    @Test
+    public void testScripting_defaultValue() {
+        testScripting(null);
+    }
+
+    @Test
+    public void testScripting_enabled() {
+        testScripting(true);
+    }
+
+    @Test
+    public void testScripting_disabled() {
+        testScripting(false);
+    }
+
+    private void testScripting(Boolean enabled) {
+        Config config = getConfig();
+        if (enabled != null) {
+            config.setProperty(GroupProperty.SCRIPTING_ENABLED.getName(), String.valueOf(enabled));
+        }
+
+        HazelcastInstance hz = createHazelcastInstance(config);
+        TimedMemberStateFactory factory = new TimedMemberStateFactory(getHazelcastInstanceImpl(hz));
+
+        TimedMemberState timedMemberState = factory.createTimedMemberState();
+        boolean expected = enabled == null ? true : enabled;
+        assertEquals(expected, timedMemberState.scriptingEnabled);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/TimedMemberStateTest.java
@@ -29,8 +29,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -51,6 +51,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         timedMemberState.setTime(1827731);
         timedMemberState.setSslEnabled(true);
         timedMemberState.setLite(true);
+        timedMemberState.setScriptingEnabled(false);
     }
 
     @Test
@@ -63,6 +64,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         assertNotNull(cloned.getMemberState());
         assertTrue(cloned.isSslEnabled());
         assertTrue(cloned.isLite());
+        assertFalse(cloned.isScriptingEnabled());
         assertNotNull(cloned.toString());
     }
 
@@ -78,6 +80,7 @@ public class TimedMemberStateTest extends HazelcastTestSupport {
         assertNotNull(deserialized.getMemberState());
         assertTrue(deserialized.isSslEnabled());
         assertTrue(deserialized.isLite());
+        assertFalse(deserialized.isScriptingEnabled());
         assertNotNull(deserialized.toString());
     }
 

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -44,7 +44,7 @@
     </group>
     <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>
     <instance-name>dummy</instance-name>
-    <management-center enabled="true" update-interval="5">
+    <management-center enabled="true" update-interval="5" scripting-enabled="false">
         <url>http://mywebserver:8080</url>
         <mutual-auth enabled="true">
             <factory-class-name>com.hazelcast.examples.MySSLContextFactory</factory-class-name>


### PR DESCRIPTION
Backport to 3.11.z: #14116

This PR introduces a feature which allows to disable (or enable) scripting on the member. 
The scripting is available from Hazelcast Management Center. As it can access underlying system with privileges of user running the Hazelcast, administrators may want to disable this feature for security reasons.

The feature is controlled by a new optional attribute `scripting-enabled` under the `<management-center/>` in `hazelcast.xml`:

```xml
<management-center enabled="true" scripting-enabled="false" update-interval="2">
http://localhost:8080/hazelcast-mancenter
</management-center>
```

**Default value** of the `scripting-enabled` attribute is **`false` in Hazelcast Enterprise and `true` in Hazelcast OS**.

**Implementation details**
New check is added to the `ScriptExecutorOperation.run()`. It throws `AccessControlException` if the scripting is not explicitly allowed.