### PR TITLE
Removing unused timeout field from xsd.

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.12.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.12.xsd
@@ -235,7 +235,6 @@
                 <xs:element name="keep-alive" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
                 <xs:element name="reuse-address" type="xs:boolean" minOccurs="0" maxOccurs="1" default="true"/>
                 <xs:element name="linger-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="3"/>
-                <xs:element name="timeout" type="xs:int" minOccurs="0" maxOccurs="1" default="-1"/>
                 <xs:element name="buffer-size" minOccurs="0" maxOccurs="1" default="128">
                     <xs:simpleType>
                         <xs:restriction base="xs:unsignedInt">

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -79,7 +79,6 @@
             <keep-alive>true</keep-alive>
             <reuse-address>true</reuse-address>
             <linger-seconds>3</linger-seconds>
-            <timeout>-1</timeout>
             <buffer-size>128</buffer-size>
         </socket-options>
         <socket-interceptor enabled="true">


### PR DESCRIPTION
This is a leftover. Old xsd definitions are also have same problem.
I am not changing them since they are already released.

fixes https://github.com/hazelcast/hazelcast/issues/14068