### PR TITLE
[BACKPORT] Always cache field and method getters

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/EvictableGetterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/EvictableGetterCache.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.getters;
 
+import com.hazelcast.util.ConcurrentReferenceHashMap.ReferenceType;
 import com.hazelcast.util.ConstructorFunction;
 import com.hazelcast.util.SampleableConcurrentHashMap;
 
@@ -34,8 +35,10 @@ class EvictableGetterCache {
     private final int maxGetterPerClassCount;
     private final int afterEvictionGetterPerClassCount;
 
-    EvictableGetterCache(int maxClassCount, final int maxGetterPerClassCount, float evictPercentage) {
-        getterCache = new SampleableConcurrentHashMap<Class, SampleableConcurrentHashMap<String, Getter>>(maxClassCount);
+    EvictableGetterCache(int maxClassCount, final int maxGetterPerClassCount, float evictPercentage, boolean strongReferences) {
+        ReferenceType referenceType = strongReferences ? ReferenceType.STRONG : ReferenceType.SOFT;
+        getterCache = new SampleableConcurrentHashMap<Class, SampleableConcurrentHashMap<String, Getter>>(maxClassCount,
+                referenceType, referenceType);
         getterCacheConstructor = new ConstructorFunction<Class, SampleableConcurrentHashMap<String, Getter>>() {
             @Override
             public SampleableConcurrentHashMap<String, Getter> createNew(Class arg) {
@@ -74,6 +77,7 @@ class EvictableGetterCache {
      * It works on best effort basis. If multi-threaded calls involved it may evict all elements, but it's unlikely.
      */
     private void evictMap(SampleableConcurrentHashMap<?, ?> map, int triggeringEvictionSize, int afterEvictionSize) {
+        map.purgeStaleEntries();
         int mapSize = map.size();
         if (mapSize - triggeringEvictionSize >= 0) {
             for (SampleableConcurrentHashMap.SamplingEntry entry : map.getRandomSamples(mapSize - afterEvictionSize)) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -53,7 +53,7 @@ public final class Extractors {
     public Extractors(List<MapAttributeConfig> mapAttributeConfigs, ClassLoader classLoader) {
         this.extractors = ExtractorHelper.instantiateExtractors(mapAttributeConfigs, classLoader);
         this.getterCache = new EvictableGetterCache(MAX_CLASSES_IN_CACHE, MAX_GETTERS_PER_CLASS_IN_CACHE,
-                EVICTION_PERCENTAGE);
+                EVICTION_PERCENTAGE, false);
         this.argumentsParser = new DefaultArgumentParser();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/FieldGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/FieldGetter.java
@@ -34,7 +34,7 @@ public class FieldGetter extends AbstractMultiValueGetter {
 
     @Override
     boolean isCacheable() {
-        return ReflectionHelper.THIS_CL.equals(field.getDeclaringClass().getClassLoader());
+        return true;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/MethodGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/MethodGetter.java
@@ -35,7 +35,7 @@ final class MethodGetter extends AbstractMultiValueGetter {
 
     @Override
     boolean isCacheable() {
-        return ReflectionHelper.THIS_CL.equals(method.getDeclaringClass().getClassLoader());
+        return true;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ReflectionHelper.java
@@ -42,8 +42,6 @@ import static com.hazelcast.util.EmptyStatement.ignore;
  * Scans your classpath, indexes the metadata, allows you to query it on runtime.
  */
 public final class ReflectionHelper {
-    static final ClassLoader THIS_CL = ReflectionHelper.class.getClassLoader();
-
     private static final int INITIAL_CAPACITY = 3;
 
     // we don't want instances

--- a/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
@@ -40,12 +40,16 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
     private static final float LOAD_FACTOR = 0.91f;
 
     public SampleableConcurrentHashMap(int initialCapacity) {
-        // Concurrency level 1 is important for fetch-method to function properly.
-        // Moreover partitions are single threaded and higher concurrency has not much gain
-        this(initialCapacity, LOAD_FACTOR, 1, ReferenceType.STRONG, ReferenceType.STRONG, null);
+        this(initialCapacity, ReferenceType.STRONG, ReferenceType.STRONG);
     }
 
-    public SampleableConcurrentHashMap(int initialCapacity, float loadFactor, int concurrencyLevel,
+    public SampleableConcurrentHashMap(int initialCapacity, ReferenceType keyType, ReferenceType valueType) {
+        // Concurrency level 1 is important for fetch-method to function properly.
+        // Moreover partitions are single threaded and higher concurrency has not much gain
+        this(initialCapacity, LOAD_FACTOR, 1, keyType, valueType, null);
+    }
+
+    private SampleableConcurrentHashMap(int initialCapacity, float loadFactor, int concurrencyLevel,
                                        ReferenceType keyType, ReferenceType valueType, EnumSet<Option> options) {
         super(initialCapacity, loadFactor, concurrencyLevel, keyType, valueType, options);
     }
@@ -257,7 +261,7 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
                             V value = mostRecentlyReturnedEntry.value();
                             K key = mostRecentlyReturnedEntry.key();
 
-                            if (isValidForSampling(value)) {
+                            if (isValidForSampling(key, value)) {
                                 currentSample = createSamplingEntry(key, value);
                                 // If we reached end of entries, advance current bucket index
                                 returnedEntryCount++;
@@ -306,7 +310,7 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
         }
     }
 
-    protected boolean isValidForSampling(V value) {
-        return value != null;
+    protected boolean isValidForSampling(K key, V value) {
+        return key != null && value != null;
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/EvictableGetterCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/EvictableGetterCacheTest.java
@@ -37,7 +37,7 @@ public class EvictableGetterCacheTest {
     @Test
     public void get_put_correctResult() {
         // GIVEN
-        EvictableGetterCache cache = new EvictableGetterCache(10, 10, 0.5f);
+        EvictableGetterCache cache = new EvictableGetterCache(10, 10, 0.5f, true);
         Getter x = mock(Getter.class);
         Getter y = mock(Getter.class);
 
@@ -53,7 +53,7 @@ public class EvictableGetterCacheTest {
     @Test
     public void get_put_correctSize() {
         // GIVEN
-        EvictableGetterCache cache = new EvictableGetterCache(10, 10, 0.5f);
+        EvictableGetterCache cache = new EvictableGetterCache(10, 10, 0.5f, true);
         Getter x = mock(Getter.class);
         Getter y = mock(Getter.class);
 
@@ -72,7 +72,7 @@ public class EvictableGetterCacheTest {
         // GIVEN
         int getterCacheSize = 10;
         float evictPercentage = 0.3f;
-        EvictableGetterCache cache = new EvictableGetterCache(10, getterCacheSize, evictPercentage);
+        EvictableGetterCache cache = new EvictableGetterCache(10, getterCacheSize, evictPercentage, true);
 
         // WHEN
         for (int i = 0; i < getterCacheSize - 1; i++) {
@@ -89,7 +89,7 @@ public class EvictableGetterCacheTest {
         // GIVEN
         int getterCacheSize = 10;
         float evictPercentage = 0.3f;
-        EvictableGetterCache cache = new EvictableGetterCache(10, getterCacheSize, evictPercentage);
+        EvictableGetterCache cache = new EvictableGetterCache(10, getterCacheSize, evictPercentage, true);
 
         // WHEN
         for (int i = 0; i < getterCacheSize; i++) {
@@ -107,7 +107,7 @@ public class EvictableGetterCacheTest {
         // GIVEN
         int classCacheSize = 10;
         float evictPercentage = 0.3f;
-        EvictableGetterCache cache = new EvictableGetterCache(classCacheSize, 10, evictPercentage);
+        EvictableGetterCache cache = new EvictableGetterCache(classCacheSize, 10, evictPercentage, true);
         Class[] classes = {
                 String.class, Character.class, Integer.class, Double.class, Byte.class, Long.class,
                 Number.class, Float.class, BigDecimal.class, BigInteger.class,
@@ -127,7 +127,7 @@ public class EvictableGetterCacheTest {
         // GIVEN
         int classCacheSize = 10;
         float evictPercentage = 0.3f;
-        EvictableGetterCache cache = new EvictableGetterCache(classCacheSize, 10, evictPercentage);
+        EvictableGetterCache cache = new EvictableGetterCache(classCacheSize, 10, evictPercentage, true);
         Class[] classes = {
                 String.class, Character.class, Integer.class, Double.class, Byte.class, Long.class,
                 Number.class, Float.class, BigDecimal.class, BigInteger.class,


### PR DESCRIPTION
Previously, field and method getters were not cached for classes loaded
by a class loader different from the one by which HZ classes were
loaded. In a multiple class loaders environment (e.g. OSGi) this caused
a slowdown in the full-scan queries execution by about 10 times.

This change fixes that by utilizing soft references to simultaneously
allow the caching for such classes and their garbage collection.

(cherry-picked from d2f5563481ab61a340f0a41de65decf625e030b9)

Fixes: https://github.com/hazelcast/hazelcast/issues/13785