### PR TITLE
[FORWARD-PORT] Return status of WAN config add from REST API (#14139)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpPostCommandProcessor.java
@@ -29,8 +29,10 @@ import com.hazelcast.internal.management.request.UpdatePermissionConfigRequest;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.security.SecurityService;
 import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.util.JsonUtil;
 import com.hazelcast.util.StringUtil;
 import com.hazelcast.version.Version;
+import com.hazelcast.wan.AddWanConfigResult;
 import com.hazelcast.wan.WanReplicationService;
 
 import java.io.UnsupportedEncodingException;
@@ -484,10 +486,13 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
             WanReplicationConfigDTO dto = new WanReplicationConfigDTO(new WanReplicationConfig());
             dto.fromJson(Json.parse(wanConfigJson).asObject());
 
-            textCommandService.getNode().getNodeEngine()
-                              .getWanReplicationService()
-                              .addWanReplicationConfig(dto.getConfig());
-            res = response(ResponseType.SUCCESS, "message", "WAN configuration added.");
+            AddWanConfigResult result = textCommandService.getNode().getNodeEngine()
+                                                          .getWanReplicationService()
+                                                          .addWanReplicationConfig(dto.getConfig());
+            res = response(ResponseType.SUCCESS,
+                    "message", "WAN configuration added.",
+                    "addedPublisherIds", result.getAddedPublisherIds(),
+                    "ignoredPublisherIds", result.getIgnoredPublisherIds());
         } catch (Exception ex) {
             logger.warning("Error occurred while adding WAN config", ex);
             res = exceptionResponse(ex);
@@ -621,15 +626,15 @@ public class HttpPostCommandProcessor extends HttpCommandProcessor<HttpPostComma
         return response(ResponseType.FAIL, "message", throwable.getMessage());
     }
 
-    private static String response(ResponseType type, String... attributes) {
+    private static String response(ResponseType type, Object... attributes) {
         final StringBuilder builder = new StringBuilder("{");
         builder.append("\"status\":\"").append(type).append("\"");
         if (attributes.length > 0) {
             for (int i = 0; i < attributes.length; ) {
-                final String key = attributes[i++];
-                final String value = attributes[i++];
+                final String key = attributes[i++].toString();
+                final Object value = attributes[i++];
                 if (value != null) {
-                    builder.append(String.format(",\"%s\":\"%s\"", key, value));
+                    builder.append(String.format(",\"%s\":%s", key, JsonUtil.toJson(value)));
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/util/JsonUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/JsonUtil.java
@@ -21,7 +21,9 @@ import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -319,4 +321,50 @@ public final class JsonUtil {
         }
     }
 
+    /**
+     * Returns the JSON representation of the provided {@code value}
+     *
+     * @param value the value to serialize to JSON
+     * @return the serialized value
+     */
+    public static String toJson(Object value) {
+        if (value instanceof String) {
+            return '"' + (String) value + '"';
+        } else if (value instanceof Collection) {
+            return "[" + toJsonCollection((Collection) value) + "]";
+        } else {
+            throw new IllegalArgumentException("Unable to convert " + value + " to JSON");
+        }
+    }
+
+    /**
+     * Serializes a collection of objects into its JSON representation.
+     *
+     * @param objects collection of items to be serialized into JSON
+     * @return the serialized JSON
+     */
+    private static String toJsonCollection(Collection objects) {
+        Iterator iterator = objects.iterator();
+        if (!iterator.hasNext()) {
+            return "";
+        }
+        final Object first = iterator.next();
+        if (!iterator.hasNext()) {
+            return toJson(first);
+        }
+
+        final StringBuilder buf = new StringBuilder();
+        if (first != null) {
+            buf.append(toJson(first));
+        }
+
+        while (iterator.hasNext()) {
+            buf.append(',');
+            final Object obj = iterator.next();
+            if (obj != null) {
+                buf.append(toJson(obj));
+            }
+        }
+        return buf.toString();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/wan/AddWanConfigResult.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/AddWanConfigResult.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wan;
+
+import com.hazelcast.util.Preconditions;
+
+import java.util.Collection;
+
+/**
+ * The result of adding WAN configuration.
+ *
+ * @see WanReplicationService#addWanReplicationConfig(com.hazelcast.config.WanReplicationConfig)
+ */
+public class AddWanConfigResult {
+
+    private final Collection<String> addedPublisherIds;
+    private final Collection<String> ignoredPublisherIds;
+
+    public AddWanConfigResult(Collection<String> addedPublisherIds,
+                              Collection<String> ignoredPublisherIds) {
+        Preconditions.checkNotNull(addedPublisherIds, "Added publisher IDs must not be null");
+        Preconditions.checkNotNull(ignoredPublisherIds, "Ignored publisher IDs must not be null");
+        this.addedPublisherIds = addedPublisherIds;
+        this.ignoredPublisherIds = ignoredPublisherIds;
+    }
+
+
+    /**
+     * Returns the IDs for the WAN publishers which were added to the
+     * configuration.
+     */
+    public Collection<String> getAddedPublisherIds() {
+        return addedPublisherIds;
+    }
+
+    /**
+     * Returns the IDs for the WAN publishers which were ignored and not added
+     * to the configuration.
+     */
+    public Collection<String> getIgnoredPublisherIds() {
+        return ignoredPublisherIds;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/WanReplicationService.java
@@ -154,11 +154,18 @@ public interface WanReplicationService extends CoreService, StatisticsAwareServi
      * name. Such configs will be merged into the existing WAN replication
      * config by adding publishers with publisher IDs which are not already part
      * of the existing configuration.
+     * The return value is a best-effort guess at the result of adding WAN
+     * replication config based on the existing local WAN replication config.
+     * An exact result is difficult to calculate since not all members might
+     * have the same existing configuration and there might be a concurrent
+     * request to add overlapping WAN replication config.
      *
+     * @param wanConfig the WAN replication config to add
+     * @return a best-effort guess at the result of adding WAN replication config
      * @throws UnsupportedOperationException if invoked on OS
      * @see #addWanReplicationConfigLocally(WanReplicationConfig)
      */
-    void addWanReplicationConfig(WanReplicationConfig wanConfig);
+    AddWanConfigResult addWanReplicationConfig(WanReplicationConfig wanConfig);
 
     /**
      * Returns current status of WAN sync operation or {@code null} when there

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationServiceImpl.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.management.events.WanSyncIgnoredEvent;
 import com.hazelcast.monitor.LocalWanStats;
 import com.hazelcast.monitor.WanSyncState;
 import com.hazelcast.util.ConstructorFunction;
+import com.hazelcast.wan.AddWanConfigResult;
 import com.hazelcast.wan.WanReplicationEndpoint;
 import com.hazelcast.wan.WanReplicationPublisher;
 import com.hazelcast.wan.WanReplicationService;
@@ -160,7 +161,7 @@ public class WanReplicationServiceImpl implements WanReplicationService {
     }
 
     @Override
-    public void addWanReplicationConfig(WanReplicationConfig wanConfig) {
+    public AddWanConfigResult addWanReplicationConfig(WanReplicationConfig wanConfig) {
         node.getManagementCenterService().log(AddWanConfigIgnoredEvent.enterpriseOnly(wanConfig.getName()));
 
         throw new UnsupportedOperationException("Adding new WAN config is not supported.");


### PR DESCRIPTION
Return status of WAN config add from REST API

Returns the status of WAN config addition on REST API. The status is
best-effort since the config may be added concurrently with other
configurations and some members might have different configurations
than others. This is good enough for most cases.

(cherry picked from commit f1ed355)
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2620