### PR TITLE
WAN test refactoring

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AliasedDiscoveryConfig.java
@@ -159,4 +159,36 @@ public abstract class AliasedDiscoveryConfig<T extends AliasedDiscoveryConfig<T>
             properties.put(in.readUTF(), in.readUTF());
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AliasedDiscoveryConfig<?> that = (AliasedDiscoveryConfig<?>) o;
+
+        if (enabled != that.enabled) {
+            return false;
+        }
+        if (usePublicIp != that.usePublicIp) {
+            return false;
+        }
+        if (!tag.equals(that.tag)) {
+            return false;
+        }
+        return properties.equals(that.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = tag.hashCode();
+        result = 31 * result + (enabled ? 1 : 0);
+        result = 31 * result + (usePublicIp ? 1 : 0);
+        result = 31 * result + properties.hashCode();
+        return result;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DiscoveryConfig.java
@@ -166,4 +166,40 @@ public class DiscoveryConfig implements IdentifiedDataSerializable {
         nodeFilter = in.readObject();
         nodeFilterClass = in.readUTF();
     }
+
+    @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DiscoveryConfig that = (DiscoveryConfig) o;
+
+        if (!discoveryStrategyConfigs.equals(that.discoveryStrategyConfigs)) {
+            return false;
+        }
+
+        if (discoveryServiceProvider != null
+                ? !discoveryServiceProvider.equals(that.discoveryServiceProvider)
+                : that.discoveryServiceProvider != null) {
+            return false;
+        }
+        if (nodeFilter != null ? !nodeFilter.equals(that.nodeFilter) : that.nodeFilter != null) {
+            return false;
+        }
+        return nodeFilterClass != null ? nodeFilterClass.equals(that.nodeFilterClass) : that.nodeFilterClass == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = discoveryStrategyConfigs.hashCode();
+        result = 31 * result + (discoveryServiceProvider != null ? discoveryServiceProvider.hashCode() : 0);
+        result = 31 * result + (nodeFilter != null ? nodeFilter.hashCode() : 0);
+        result = 31 * result + (nodeFilterClass != null ? nodeFilterClass.hashCode() : 0);
+        return result;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanConsumerConfig.java
@@ -192,4 +192,37 @@ public class WanConsumerConfig implements IdentifiedDataSerializable, Versioned 
             persistWanReplicatedData = in.readBoolean();
         }
     }
+
+    @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        WanConsumerConfig that = (WanConsumerConfig) o;
+
+        if (persistWanReplicatedData != that.persistWanReplicatedData) {
+            return false;
+        }
+        if (className != null ? !className.equals(that.className) : that.className != null) {
+            return false;
+        }
+        if (implementation != null ? !implementation.equals(that.implementation) : that.implementation != null) {
+            return false;
+        }
+        return properties != null ? properties.equals(that.properties) : that.properties == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (persistWanReplicatedData ? 1 : 0);
+        result = 31 * result + (className != null ? className.hashCode() : 0);
+        result = 31 * result + (implementation != null ? implementation.hashCode() : 0);
+        result = 31 * result + (properties != null ? properties.hashCode() : 0);
+        return result;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanPublisherConfig.java
@@ -498,4 +498,82 @@ public class WanPublisherConfig implements IdentifiedDataSerializable, Versioned
             discoveryConfig = in.readObject();
         }
     }
+
+    @Override
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity"})
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        WanPublisherConfig that = (WanPublisherConfig) o;
+
+        if (queueCapacity != that.queueCapacity) {
+            return false;
+        }
+        if (groupName != null ? !groupName.equals(that.groupName) : that.groupName != null) {
+            return false;
+        }
+        if (publisherId != null ? !publisherId.equals(that.publisherId) : that.publisherId != null) {
+            return false;
+        }
+        if (queueFullBehavior != that.queueFullBehavior) {
+            return false;
+        }
+        if (initialPublisherState != that.initialPublisherState) {
+            return false;
+        }
+        if (properties != null ? !properties.equals(that.properties) : that.properties != null) {
+            return false;
+        }
+        if (className != null ? !className.equals(that.className) : that.className != null) {
+            return false;
+        }
+        if (implementation != null ? !implementation.equals(that.implementation) : that.implementation != null) {
+            return false;
+        }
+        if (!awsConfig.equals(that.awsConfig)) {
+            return false;
+        }
+        if (!gcpConfig.equals(that.gcpConfig)) {
+            return false;
+        }
+        if (!azureConfig.equals(that.azureConfig)) {
+            return false;
+        }
+        if (!kubernetesConfig.equals(that.kubernetesConfig)) {
+            return false;
+        }
+        if (!eurekaConfig.equals(that.eurekaConfig)) {
+            return false;
+        }
+        if (!discoveryConfig.equals(that.discoveryConfig)) {
+            return false;
+        }
+        return wanSyncConfig != null ? wanSyncConfig.equals(that.wanSyncConfig) : that.wanSyncConfig == null;
+    }
+
+    @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
+    public int hashCode() {
+        int result = groupName != null ? groupName.hashCode() : 0;
+        result = 31 * result + (publisherId != null ? publisherId.hashCode() : 0);
+        result = 31 * result + queueCapacity;
+        result = 31 * result + (queueFullBehavior != null ? queueFullBehavior.hashCode() : 0);
+        result = 31 * result + initialPublisherState.hashCode();
+        result = 31 * result + (properties != null ? properties.hashCode() : 0);
+        result = 31 * result + (className != null ? className.hashCode() : 0);
+        result = 31 * result + (implementation != null ? implementation.hashCode() : 0);
+        result = 31 * result + awsConfig.hashCode();
+        result = 31 * result + gcpConfig.hashCode();
+        result = 31 * result + azureConfig.hashCode();
+        result = 31 * result + kubernetesConfig.hashCode();
+        result = 31 * result + eurekaConfig.hashCode();
+        result = 31 * result + discoveryConfig.hashCode();
+        result = 31 * result + (wanSyncConfig != null ? wanSyncConfig.hashCode() : 0);
+        return result;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanReplicationConfig.java
@@ -207,4 +207,34 @@ public class WanReplicationConfig implements IdentifiedDataSerializable, Version
             wanPublisherConfigs.add(publisherConfig);
         }
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        WanReplicationConfig that = (WanReplicationConfig) o;
+
+        if (!name.equals(that.name)) {
+            return false;
+        }
+        if (wanConsumerConfig != null
+                ? !wanConsumerConfig.equals(that.wanConsumerConfig)
+                : that.wanConsumerConfig != null) {
+            return false;
+        }
+        return wanPublisherConfigs.equals(that.wanPublisherConfigs);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + (wanConsumerConfig != null ? wanConsumerConfig.hashCode() : 0);
+        result = 31 * result + wanPublisherConfigs.hashCode();
+        return result;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/WanSyncConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/WanSyncConfig.java
@@ -89,4 +89,23 @@ public class WanSyncConfig implements IdentifiedDataSerializable {
                 + "consistencyCheckStrategy=" + consistencyCheckStrategy
                 + '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        WanSyncConfig that = (WanSyncConfig) o;
+
+        return consistencyCheckStrategy == that.consistencyCheckStrategy;
+    }
+
+    @Override
+    public int hashCode() {
+        return consistencyCheckStrategy != null ? consistencyCheckStrategy.hashCode() : 0;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanRESTTest.java
@@ -19,11 +19,7 @@ package com.hazelcast.wan;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.DefaultNodeContext;
-import com.hazelcast.instance.DefaultNodeExtension;
 import com.hazelcast.instance.HazelcastInstanceFactory;
-import com.hazelcast.instance.Node;
-import com.hazelcast.instance.NodeExtension;
 import com.hazelcast.internal.ascii.HTTPCommunicator;
 import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonObject;
@@ -143,34 +139,5 @@ public class WanRESTTest extends HazelcastTestSupport {
     private void assertSuccess(String jsonResult) {
         JsonObject result = Json.parse(jsonResult).asObject();
         assertEquals("success", result.getString("status", null));
-    }
-
-    private static class WanServiceMockingNodeContext extends DefaultNodeContext {
-        private final WanReplicationService wanReplicationService;
-
-        WanServiceMockingNodeContext(WanReplicationService wanReplicationService) {
-            super();
-            this.wanReplicationService = wanReplicationService;
-        }
-
-        @Override
-        public NodeExtension createNodeExtension(Node node) {
-            return new WanServiceMockingNodeExtension(node, wanReplicationService);
-        }
-    }
-
-    private static class WanServiceMockingNodeExtension extends DefaultNodeExtension {
-        private final WanReplicationService wanReplicationService;
-
-        WanServiceMockingNodeExtension(Node node, WanReplicationService wanReplicationService) {
-            super(node);
-            this.wanReplicationService = wanReplicationService;
-        }
-
-        @Override
-        public <T> T createService(Class<T> clazz) {
-            return clazz.isAssignableFrom(WanReplicationService.class)
-                    ? (T) wanReplicationService : super.createService(clazz);
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanServiceMockingNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanServiceMockingNodeContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wan;
+
+import com.hazelcast.instance.DefaultNodeContext;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeExtension;
+
+public class WanServiceMockingNodeContext extends DefaultNodeContext {
+    private final WanReplicationService wanReplicationService;
+
+    public WanServiceMockingNodeContext(WanReplicationService wanReplicationService) {
+        super();
+        this.wanReplicationService = wanReplicationService;
+    }
+
+    @Override
+    public NodeExtension createNodeExtension(Node node) {
+        return new WanServiceMockingNodeExtension(node, wanReplicationService);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/wan/WanServiceMockingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/wan/WanServiceMockingNodeExtension.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.wan;
+
+import com.hazelcast.instance.DefaultNodeExtension;
+import com.hazelcast.instance.Node;
+
+class WanServiceMockingNodeExtension extends DefaultNodeExtension {
+    private final WanReplicationService wanReplicationService;
+
+    WanServiceMockingNodeExtension(Node node, WanReplicationService wanReplicationService) {
+        super(node);
+        this.wanReplicationService = wanReplicationService;
+    }
+
+    @Override
+    public <T> T createService(Class<T> clazz) {
+        return clazz.isAssignableFrom(WanReplicationService.class)
+                ? (T) wanReplicationService : super.createService(clazz);
+    }
+}


### PR DESCRIPTION
- add equals and hashCode implementations to config classes to be able
to compare then in REST tests
- refactor REST tests to mock the WAN service and test only the request
parsing and response format
- add new test cases to API tests, now covering both merkle tree and
full sync strategy

This not only improves testing of WAN functionalities (because of more
tests in MapWanSyncAPITest) but also clearly separates testing REST and
testing WAN functionalities. Previously, WAN REST tests were copies of
WAN API tests, only using REST.
There are further possible refactorings, such as moving existing tests
to use the newer WAN testing framework. This may be part of a separate
PR.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2621