### PR TITLE
Upgrade JaCoCo plugin to support Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
         <maven.spotbugs.plugin.version>3.1.6</maven.spotbugs.plugin.version>
         <maven.sonar.plugin.version>3.3.0.603</maven.sonar.plugin.version>
-        <maven.jacoco.plugin.version>0.7.9</maven.jacoco.plugin.version>
+        <maven.jacoco.plugin.version>0.8.2</maven.jacoco.plugin.version>
         <maven.failsafe.plugin.version>2.22.0</maven.failsafe.plugin.version>
         <maven.cobertura.plugin.version>2.6</maven.cobertura.plugin.version>
 


### PR DESCRIPTION
To support Java 11, JaCoCo maven plugin version should be upgraded to 0.8.2.
This is required to be able to use `parallelTest` maven profile with Java 11.

See https://github.com/jacoco/jacoco/issues/663