### PR TITLE
Support for Java 9+ in all surefire maven profiles

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/JavaVersion.java
@@ -43,6 +43,16 @@ public enum JavaVersion {
         return isAtLeast(CURRENT_VERSION, version);
     }
 
+    /**
+     * Check if the current runtime version is at most the given version.
+     *
+     * @param version version to be compared against the current runtime version
+     * @return Return true if current runtime version of Java is the same or less than given version.
+     */
+    public static boolean isAtMost(JavaVersion version) {
+        return isAtMost(CURRENT_VERSION, version);
+    }
+
     private static JavaVersion detectCurrentVersion() {
         String version = System.getProperty("java.version");
         return parseVersion(version);
@@ -78,5 +88,9 @@ public enum JavaVersion {
 
     static boolean isAtLeast(JavaVersion currentVersion, JavaVersion minVersion) {
         return currentVersion.ordinal() >= minVersion.ordinal();
+    }
+
+    static boolean isAtMost(JavaVersion currentVersion, JavaVersion minVersion) {
+        return currentVersion.ordinal() <= minVersion.ordinal();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/JavaVersionTest.java
@@ -16,6 +16,14 @@
 
 package com.hazelcast.internal.util;
 
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
 import static com.hazelcast.internal.util.JavaVersion.JAVA_10;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_11;
 import static com.hazelcast.internal.util.JavaVersion.JAVA_12;
@@ -28,21 +36,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-
-import com.hazelcast.test.HazelcastSerialClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.ParallelTest;
-import com.hazelcast.test.annotation.QuickTest;
-
 @RunWith(HazelcastSerialClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class JavaVersionTest extends HazelcastTestSupport {
 
     @Test
-    public void parseVersion() throws Exception {
+    public void parseVersion() {
         assertEquals(UNKNOWN, JavaVersion.parseVersion("foo"));
         assertEquals(JAVA_1_6, JavaVersion.parseVersion("1.6"));
         assertEquals(JAVA_1_7, JavaVersion.parseVersion("1.7"));
@@ -130,5 +129,22 @@ public class JavaVersionTest extends HazelcastTestSupport {
         assertFalse(JavaVersion.isAtLeast(JAVA_9, JAVA_10));
         assertFalse(JavaVersion.isAtLeast(JAVA_10, JAVA_11));
         assertFalse(JavaVersion.isAtLeast(JAVA_11, JAVA_12));
+    }
+
+    @Test
+    public void testIsAtMostSequence() {
+        assertTrue(JavaVersion.isAtMost(JAVA_1_6, JAVA_1_6));
+        assertTrue(JavaVersion.isAtMost(JAVA_1_6, JAVA_1_7));
+        assertTrue(JavaVersion.isAtMost(JAVA_1_8, JAVA_9));
+        assertTrue(JavaVersion.isAtMost(JAVA_9, JAVA_10));
+        assertTrue(JavaVersion.isAtMost(JAVA_11, JAVA_12));
+        assertTrue(JavaVersion.isAtMost(JAVA_12, JAVA_12));
+
+        assertFalse(JavaVersion.isAtMost(JAVA_1_7, JAVA_1_6));
+        assertFalse(JavaVersion.isAtMost(JAVA_1_8, JAVA_1_7));
+        assertFalse(JavaVersion.isAtMost(JAVA_9, JAVA_1_8));
+        assertFalse(JavaVersion.isAtMost(JAVA_10, JAVA_9));
+        assertFalse(JavaVersion.isAtMost(JAVA_11, JAVA_10));
+        assertFalse(JavaVersion.isAtMost(JAVA_12, JAVA_11));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/HazelcastOSGiIntegrationTest.java
@@ -24,7 +24,6 @@ import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.Configuration;
 import org.ops4j.pax.exam.junit.ExamReactorStrategy;
-import org.ops4j.pax.exam.junit.JUnit4TestRunner;
 import org.ops4j.pax.exam.options.CompositeOption;
 import org.ops4j.pax.exam.options.UrlProvisionOption;
 import org.ops4j.pax.exam.spi.reactors.AllConfinedStagedReactorFactory;
@@ -42,7 +41,7 @@ import static org.ops4j.pax.exam.CoreOptions.bundle;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
 import static org.ops4j.pax.exam.CoreOptions.options;
 
-@RunWith(JUnit4TestRunner.class)
+@RunWith(PaxExamTestRunner.class)
 @Category(QuickTest.class)
 @ExamReactorStrategy(AllConfinedStagedReactorFactory.class)
 public class HazelcastOSGiIntegrationTest {

--- a/hazelcast/src/test/java/com/hazelcast/osgi/PaxExamTestRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/osgi/PaxExamTestRunner.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.osgi;
+
+import com.hazelcast.internal.util.JavaVersion;
+import org.junit.Assume;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+import org.ops4j.pax.exam.junit.JUnit4TestRunner;
+
+/**
+ * An outdated PaxRunner used by the OSGi test prevents executing on Java 9+.
+ * This JUnit runner assumes Java version is at most 1.8. Otherwise test is ignored.
+ *
+ * TODO: Remove this assumption once we have a proper fix in the test class.
+ */
+public class PaxExamTestRunner extends JUnit4TestRunner {
+
+    public PaxExamTestRunner(Class<?> klass) throws Exception {
+        super(klass);
+    }
+
+    @Override
+    protected Statement methodInvoker(FrameworkMethod method, Object test) {
+        final Statement statement = super.methodInvoker(method, test);
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Assume.assumeTrue(JavaVersion.isAtMost(JavaVersion.JAVA_1_8));
+                statement.evaluate();
+            }
+        };
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,11 @@
 
         <h2.version>1.3.160</h2.version>
         <atomikos.version>3.9.3</atomikos.version>
+        <!-- Additional JVM system arguments -->
         <extraVmArgs/>
         <vmHeapSettings>-Xms512m -Xmx2G -XX:MaxPermSize=1024M</vmHeapSettings>
+        <!-- Java 9+ module system args to be appended during surefire/failsafe executions. -->
+        <javaModuleArgs/>
     </properties>
     <licenses>
         <license>
@@ -252,6 +255,7 @@
                     <!-- JaCoCo will use the argLine set here. Test profiles override it. -->
                     <argLine>
                         ${vmHeapSettings}
+                        ${javaModuleArgs}
                         -Dhazelcast.phone.home.enabled=false
                         -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.test.use.network=false
@@ -282,6 +286,7 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <argLine>
                         ${vmHeapSettings}
+                        ${javaModuleArgs}
                         -Dhazelcast.phone.home.enabled=false
                         -Dhazelcast.mancenter.enabled=false
                         -Dhazelcast.logging.type=none
@@ -360,6 +365,7 @@
                                     <reuseForks>true</reuseForks>
                                     <argLine>
                                         ${vmHeapSettings}
+                                        ${javaModuleArgs}
                                         -ea
                                         -Dhazelcast.phone.home.enabled=false
                                         -Dhazelcast.mancenter.enabled=false
@@ -403,6 +409,7 @@
                                     <useFile>false</useFile>
                                     <argLine>
                                         ${vmHeapSettings}
+                                        ${javaModuleArgs}
                                         -Dhazelcast.phone.home.enabled=false
                                         -Dhazelcast.mancenter.enabled=false
                                         -Dhazelcast.logging.type=none
@@ -451,6 +458,7 @@
                             <trimStackTrace>false</trimStackTrace>
                             <argLine>
                                 ${vmHeapSettings}
+                                ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
@@ -482,6 +490,7 @@
                             <useFile>false</useFile>
                             <argLine>
                                 ${vmHeapSettings}
+                                ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false
@@ -547,6 +556,7 @@
                             <testFailureIgnore>true</testFailureIgnore>
                             <argLine>
                                 ${vmHeapSettings}
+                                ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
@@ -577,6 +587,7 @@
             <properties>
                 <argLine>
                     ${vmHeapSettings}
+                    ${javaModuleArgs}
                     -Dhazelcast.phone.home.enabled=false
                     -Dhazelcast.mancenter.enabled=false
                     -Dhazelcast.logging.type=none
@@ -647,6 +658,7 @@
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <argLine>
                                 ${vmHeapSettings}
+                                ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
@@ -877,6 +889,7 @@
                             <trimStackTrace>false</trimStackTrace>
                             <argLine>
                                 ${vmHeapSettings}
+                                ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
@@ -906,6 +919,7 @@
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <argLine>
                                 ${vmHeapSettings}
+                                ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
@@ -948,6 +962,7 @@
                             <parallel>none</parallel>
                             <argLine>
                                 ${vmHeapSettings}
+                                ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
@@ -978,6 +993,7 @@
                             <redirectTestOutputToFile>true</redirectTestOutputToFile>
                             <argLine>
                                 ${vmHeapSettings}
+                                ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.logging.type=none
@@ -1011,68 +1027,32 @@
             <activation>
                 <jdk>[9,)</jdk>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${maven.surefire.plugin.version}</version>
-                        <configuration combine.self="override">
-                            <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                            <useFile>false</useFile>
-                            <trimStackTrace>false</trimStackTrace>
-                            <!--
-                            Allow access to Operating system metrics:
-                                open jdk.management/com.sun.management.internal
+            <properties>
+                <!--
+                Allow access to Operating system metrics:
+                   open jdk.management/com.sun.management.internal
 
-                            Avoid warnings caused by reflection in
-                            SelectorOptimizer:
-                                open java.base/sun.nio.ch
-                            FilteringClassLoader:
-                                open java.base/java.lang
-                            TimedMemberStateFactoryHelper:
-                                open java.management/sun.management
+                Avoid warnings caused by reflection in
+                SelectorOptimizer:
+                   open java.base/sun.nio.ch
+                FilteringClassLoader:
+                   open java.base/java.lang
+                TimedMemberStateFactoryHelper:
+                   open java.management/sun.management
 
-                            Powermock issue workaround (https://github.com/powermock/powermock/issues/905):
-                                export java.xml/jdk.xml.internal
-                             -->
-                            <argLine>
-                                ${vmHeapSettings}
-                                --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
-                                --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-                                --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-                                --add-opens java.base/java.lang=ALL-UNNAMED
-                                --add-opens java.management/sun.management=ALL-UNNAMED
-                                --add-exports java.xml/jdk.xml.internal=ALL-UNNAMED
-                                --illegal-access=warn
-                                -Dhazelcast.phone.home.enabled=false
-                                -Dhazelcast.mancenter.enabled=false
-                                -Dhazelcast.test.use.network=false
-                                -Dlog4j.skipJansi=true
-                                ${extraVmArgs}
-                            </argLine>
-                            <includes>
-                                <include>**/**.java</include>
-                            </includes>
-                            <excludes>
-                                <exclude>**/jsr/**.java</exclude>
-                                <exclude>**/**IT.java</exclude>
-                                <exclude>**/mapreduce/**/*.java</exclude>
-                                <!--
-                                  An outdated PaxRunner used by the OSGi test prevents executing on Java 9+.
-                                  TODO: remove this exclude once we have a proper fix in the test class.
-                                -->
-                                <exclude>**/HazelcastOSGiIntegrationTest.java</exclude>
-                            </excludes>
-                            <groups>com.hazelcast.test.annotation.QuickTest</groups>
-                            <excludedGroups>
-                                com.hazelcast.test.annotation.SlowTest,
-                                com.hazelcast.test.annotation.NightlyTest
-                            </excludedGroups>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+                Powermock issue workaround (https://github.com/powermock/powermock/issues/905):
+                   export java.xml/jdk.xml.internal
+                -->
+                <javaModuleArgs>
+                    --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
+                    --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
+                    --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+                    --add-opens java.base/java.lang=ALL-UNNAMED
+                    --add-opens java.management/sun.management=ALL-UNNAMED
+                    --add-exports java.xml/jdk.xml.internal=ALL-UNNAMED
+                    --illegal-access=warn
+                </javaModuleArgs>
+            </properties>
             <modules>
                 <module>modulepath-tests</module>
             </modules>
@@ -1103,6 +1083,7 @@
                             <runOrder>failedfirst</runOrder>
                             <argLine>
                                 ${vmHeapSettings}
+                                ${javaModuleArgs}
                                 -Dhazelcast.phone.home.enabled=false
                                 -Dhazelcast.mancenter.enabled=false
                                 -Dhazelcast.test.use.network=false


### PR DESCRIPTION
Instead of having a surefire configuration in Java 9+ profile,
added a new property named `javaModuleArgs` to append Java module
configurations when runtime is Java 9+.

Additionally, ignored `HazelcastOSGiIntegrationTest` for Java 9+ versions
using JUnit assumption, instead of maven profile.