### PR TITLE
Test Hazelcast factory: allow custom node extension priorities

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestHazelcastInstanceFactory.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.DefaultNodeContext;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.NodeContext;
 import com.hazelcast.nio.Address;
@@ -62,20 +63,24 @@ public class TestHazelcastInstanceFactory {
         this(0);
     }
 
-    public TestHazelcastInstanceFactory(int count) {
-        fillAddressMap(count);
-        this.count = count;
-        this.registry = createRegistry();
+    public TestHazelcastInstanceFactory(int initialPort, String... addresses) {
+        fillAddressMap(initialPort, addresses);
+        this.count = addresses.length;
+        this.registry = isMockNetwork ? createRegistry() : null;
     }
 
     public TestHazelcastInstanceFactory(String... addresses) {
         this(-1, addresses);
     }
 
-    public TestHazelcastInstanceFactory(int initialPort, String... addresses) {
-        fillAddressMap(initialPort, addresses);
-        this.count = addresses.length;
-        this.registry = createRegistry();
+    public TestHazelcastInstanceFactory(int count) {
+        fillAddressMap(count);
+        this.count = count;
+        this.registry = isMockNetwork ? createRegistry() : null;
+    }
+
+    protected TestNodeRegistry createRegistry() {
+        return new TestNodeRegistry(getKnownAddresses(), DefaultNodeContext.EXTENSION_PRIORITY_LIST);
     }
 
     public int getCount() {
@@ -317,10 +322,6 @@ public class TestHazelcastInstanceFactory {
                 }
             }
         }
-    }
-
-    private TestNodeRegistry createRegistry() {
-        return isMockNetwork ? new TestNodeRegistry(getKnownAddresses()) : null;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -34,32 +34,37 @@ import com.hazelcast.test.compatibility.SamplingNodeExtension;
 import java.lang.reflect.Constructor;
 import java.nio.channels.ServerSocketChannel;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
-@SuppressWarnings("WeakerAccess")
 public class MockNodeContext implements NodeContext {
 
     private final TestNodeRegistry registry;
     private final Address thisAddress;
     private final Set<Address> initiallyBlockedAddresses;
+    private final List<String> nodeExtensionPriorityList;
 
     protected MockNodeContext(TestNodeRegistry registry, Address thisAddress) {
-        this(registry, thisAddress, Collections.<Address>emptySet());
+        this(registry, thisAddress, Collections.<Address>emptySet(), DefaultNodeContext.EXTENSION_PRIORITY_LIST);
     }
 
-    protected MockNodeContext(TestNodeRegistry registry, Address thisAddress, Set<Address> initiallyBlockedAddresses) {
+    protected MockNodeContext(
+            TestNodeRegistry registry, Address thisAddress, Set<Address> initiallyBlockedAddresses,
+            List<String> nodeExtensionPriorityList
+    ) {
         this.registry = registry;
         this.thisAddress = thisAddress;
         this.initiallyBlockedAddresses = initiallyBlockedAddresses;
+        this.nodeExtensionPriorityList = nodeExtensionPriorityList;
     }
 
     @Override
     public NodeExtension createNodeExtension(Node node) {
         return TestEnvironment.isRecordingSerializedClassNames()
                 ? constructSamplingNodeExtension(node)
-                : NodeExtensionFactory.create(node, DefaultNodeContext.EXTENSION_PRIORITY_LIST);
+                : NodeExtensionFactory.create(node, nodeExtensionPriorityList);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/TestNodeRegistry.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,9 +44,11 @@ public final class TestNodeRegistry {
 
     private final ConcurrentMap<Address, Node> nodes = new ConcurrentHashMap<Address, Node>(10);
     private final Collection<Address> joinAddresses;
+    private final List<String> nodeExtensionPriorityList;
 
-    public TestNodeRegistry(Collection<Address> addresses) {
+    public TestNodeRegistry(Collection<Address> addresses, List<String> nodeExtensionPriorityList) {
         this.joinAddresses = addresses;
+        this.nodeExtensionPriorityList = nodeExtensionPriorityList;
     }
 
     public NodeContext createNodeContext(Address address) {
@@ -64,7 +67,7 @@ public final class TestNodeRegistry {
             });
             nodes.remove(address, node);
         }
-        return new MockNodeContext(this, address, initiallyBlockedAddresses);
+        return new MockNodeContext(this, address, initiallyBlockedAddresses, nodeExtensionPriorityList);
     }
 
     public HazelcastInstance getInstance(Address address) {


### PR DESCRIPTION
This is a followup to #14133, adding the missing extension points in the test Hazelcast instance factory.