### PR TITLE
[BACKPORT] Allow exceptions inside delegated executors to escape (#14158)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegateAndSkipOnConcurrentExecutionDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegateAndSkipOnConcurrentExecutionDecorator.java
@@ -19,6 +19,8 @@ package com.hazelcast.spi.impl.executionservice.impl;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+
 /**
  * Decorator to delegate task to an executor and prevent concurrent task execution.
  *
@@ -30,6 +32,7 @@ public class DelegateAndSkipOnConcurrentExecutionDecorator implements Runnable {
     private final AtomicBoolean isAlreadyRunning = new AtomicBoolean();
     private final Runnable runnable;
     private final Executor executor;
+    private volatile Throwable throwable;
 
     public DelegateAndSkipOnConcurrentExecutionDecorator(Runnable runnable, Executor executor) {
         this.runnable = new DelegateDecorator(runnable);
@@ -39,6 +42,13 @@ public class DelegateAndSkipOnConcurrentExecutionDecorator implements Runnable {
     @Override
     public void run() {
         if (isAlreadyRunning.compareAndSet(false, true)) {
+            if (throwable != null) {
+                // Capturing & throwing the exception to propagate the failure to the scheduler (suppress future executions)
+                // instead of hiding in the delegated executor.
+                rethrow(throwable);
+                return;
+            }
+
             executor.execute(runnable);
         }
     }
@@ -49,6 +59,7 @@ public class DelegateAndSkipOnConcurrentExecutionDecorator implements Runnable {
                 + "isAlreadyRunning=" + isAlreadyRunning
                 + ", runnable=" + runnable
                 + ", executor=" + executor
+                + ", throwable=" + throwable
                 + '}';
     }
 
@@ -64,6 +75,8 @@ public class DelegateAndSkipOnConcurrentExecutionDecorator implements Runnable {
         public void run() {
             try {
                 runnable.run();
+            } catch (Throwable t) {
+                throwable = t;
             } finally {
                 isAlreadyRunning.set(false);
             }

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -297,6 +297,15 @@ public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
         }
     }
 
+    static class ErroneousRunnableTask implements Runnable, Serializable {
+
+        @Override
+        public void run() {
+            throw new IllegalStateException("Erroneous task");
+        }
+
+    }
+
     static class PlainPartitionAwareCallableTask implements Callable<Double>, Serializable, PartitionAware<String> {
 
         @Override


### PR DESCRIPTION
ScheduledExecutor owner of the task shall be able to suppress subsequent runs
upon exceptional execution, as the Javadoc defines.

Fixes: #14142 

(cherry picked from commit 17f2b721529646de35ce970bc9a71dd50c6ca9eb)