### PR TITLE
[wip] Improved implementation of isEmpty method.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelAccumulationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelAccumulationExecutor.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.query.impl.predicates.AndPredicate.sizeOf;
 import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
 import static com.hazelcast.util.FutureUtil.returnWithDeadline;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -88,12 +89,12 @@ public class ParallelAccumulationExecutor implements AccumulationExecutor {
     }
 
     private Collection<QueryableEntry>[] split(Collection<QueryableEntry> entries, int chunkCount) {
-        if (entries.size() < chunkCount * 2) {
+        if (sizeOf(entries) < chunkCount * 2) {
             return null;
         }
         int counter = 0;
         Collection<QueryableEntry>[] entriesSplit = new Collection[chunkCount];
-        int entriesPerChunk = entries.size() / chunkCount;
+        int entriesPerChunk = sizeOf(entries) / chunkCount;
         for (int i = 0; i < chunkCount; i++) {
             entriesSplit[i] = new ArrayList<QueryableEntry>(entriesPerChunk);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -61,7 +61,6 @@ import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.Preconditions.checkNoNullInside;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -338,17 +337,15 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
     public Set<K> keySet(Predicate predicate) {
         checkNotNull(predicate, "Predicate cannot be null!");
 
-        final Set<K> resultingSet;
+        Set<K> resultingSet = new HashSet<K>();
 
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
-            resultingSet = createHashSet(query.size());
             for (QueryableEntry entry : query) {
                 K key = (K) entry.getKey();
                 resultingSet.add(key);
             }
         } else {
-            resultingSet = new HashSet<K>();
             doFullKeyScan(predicate, resultingSet);
         }
 
@@ -359,19 +356,14 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
     public Set<Map.Entry<K, V>> entrySet(Predicate predicate) {
         checkNotNull(predicate, "Predicate cannot be null!");
 
-        Set<Map.Entry<K, V>> resultingSet;
+        Set<Map.Entry<K, V>> resultingSet = new HashSet<Map.Entry<K, V>>();
 
-        Set<QueryableEntry> query = indexes.query(predicate);
-        if (query != null) {
-            if (query.isEmpty()) {
-                return Collections.emptySet();
-            }
-            resultingSet = createHashSet(query.size());
-            for (QueryableEntry entry : query) {
+        Set<QueryableEntry> indexResultSet = indexes.query(predicate);
+        if (indexResultSet != null) {
+            for (QueryableEntry entry : indexResultSet) {
                 resultingSet.add(entry);
             }
         } else {
-            resultingSet = new HashSet<Map.Entry<K, V>>();
             doFullEntryScan(predicate, resultingSet);
         }
         return resultingSet;
@@ -385,16 +377,14 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
             return Collections.emptySet();
         }
 
-        final Set<V> resultingSet;
+        Set<V> resultingSet = new HashSet<V>();
 
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
-            resultingSet = createHashSet(query.size());
             for (QueryableEntry entry : query) {
                 resultingSet.add((V) entry.getValue());
             }
         } else {
-            resultingSet = new HashSet<V>();
             doFullValueScan(predicate, resultingSet);
         }
         return resultingSet;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AndResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AndResultSet.java
@@ -145,7 +145,7 @@ public class AndResultSet extends AbstractSet<QueryableEntry> {
 
     @Override
     public int size() {
-        throw new UnsupportedOperationException("no size");
+        throw new UnsupportedOperationException("size() is an unsupported method");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AndResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AndResultSet.java
@@ -39,7 +39,8 @@ public class AndResultSet extends AbstractSet<QueryableEntry> {
     private final List<Predicate> lsNoIndexPredicates;
     private int cachedSize;
 
-    public AndResultSet(Set<QueryableEntry> setSmallest, List<Set<QueryableEntry>> otherIndexedResults,
+    public AndResultSet(Set<QueryableEntry> setSmallest,
+                        List<Set<QueryableEntry>> otherIndexedResults,
                         List<Predicate> lsNoIndexPredicates) {
         this.setSmallest = isNotNull(setSmallest, "setSmallest");
         this.otherIndexedResults = otherIndexedResults;
@@ -144,14 +145,12 @@ public class AndResultSet extends AbstractSet<QueryableEntry> {
 
     @Override
     public int size() {
-        if (cachedSize == SIZE_UNINITIALIZED) {
-            int calculatedSize = 0;
-            for (Iterator<QueryableEntry> it = iterator(); it.hasNext(); it.next()) {
-                calculatedSize++;
-            }
-            cachedSize = calculatedSize;
-        }
-        return cachedSize;
+        throw new UnsupportedOperationException("no size");
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return !iterator().hasNext();
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/FastMultiResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/FastMultiResultSet.java
@@ -134,4 +134,14 @@ public class FastMultiResultSet extends AbstractSet<QueryableEntry> implements M
         }
         return size;
     }
+
+    @Override
+    public boolean isEmpty() {
+        for (Map<Data, QueryableEntry> resultSet : resultSets) {
+            if (!resultSet.isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/OrResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/OrResultSet.java
@@ -75,19 +75,23 @@ public class OrResultSet extends AbstractSet<QueryableEntry> {
     }
 
     private Set<QueryableEntry> getEntries() {
-        if (entries == null) {
-            if (indexedResults.isEmpty()) {
-                entries = Collections.emptySet();
-            } else {
-                if (indexedResults.size() == 1) {
-                    entries = new HashSet<QueryableEntry>(indexedResults.get(0));
-                } else {
-                    entries = createHashSet(Math.max(ENTRY_MIN_SIZE, indexedResults.size() * ENTRY_MULTIPLE));
-                    for (Set<QueryableEntry> result : indexedResults) {
-                        entries.addAll(result);
-                    }
-                }
-            }
+        if (entries != null) {
+            return entries;
+        }
+
+        if (indexedResults.isEmpty()) {
+            entries = Collections.emptySet();
+            return entries;
+        }
+
+        if (indexedResults.size() == 1) {
+            entries = new HashSet<QueryableEntry>(indexedResults.get(0));
+            return entries;
+        }
+
+        entries = createHashSet(Math.max(ENTRY_MIN_SIZE, indexedResults.size() * ENTRY_MULTIPLE));
+        for (Set<QueryableEntry> result : indexedResults) {
+            entries.addAll(result);
         }
         return entries;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
@@ -32,6 +32,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -110,7 +111,7 @@ public final class AndPredicate
         return list;
     }
 
-    private static int sizeOf(Set<QueryableEntry> result) {
+    public static int sizeOf(Collection<QueryableEntry> result) {
         // In case of AndResultSet and OrResultSet calling size() may be very expensive so quicker estimatedSize() is used
         if (result instanceof AndResultSet) {
             return ((AndResultSet) result).estimatedSize();

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
@@ -40,7 +40,6 @@ import java.util.Set;
 
 import static java.util.Collections.singletonList;
 import static org.codehaus.groovy.runtime.InvokerHelper.asList;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -59,77 +58,6 @@ public class AndResultSetTest extends HazelcastTestSupport {
         boolean result = it.hasNext();
 
         assertFalse(result);
-    }
-
-    @Test
-    // https://github.com/hazelcast/hazelcast/issues/9614
-    public void size_nonMatchingPredicate() {
-        Set<QueryableEntry> entries = generateEntries(100000);
-        AndResultSet resultSet = new AndResultSet(entries, null, asList(new FalsePredicate()));
-
-        int size = resultSet.size();
-        int countedSize = 0;
-        for (QueryableEntry queryableEntry : resultSet) {
-            countedSize++;
-        }
-
-        assertEquals(0, countedSize);
-        assertEquals(size, countedSize);
-    }
-
-    @Test
-    // https://github.com/hazelcast/hazelcast/issues/9614
-    public void size_matchingPredicate_notInResult() {
-        Set<QueryableEntry> entries = generateEntries(100000);
-        List<Set<QueryableEntry>> otherIndexedResults = new ArrayList<Set<QueryableEntry>>();
-        otherIndexedResults.add(Collections.<QueryableEntry>emptySet());
-        AndResultSet resultSet = new AndResultSet(entries, otherIndexedResults, asList(new TruePredicate()));
-
-        int size = resultSet.size();
-        int countedSize = 0;
-        for (QueryableEntry queryableEntry : resultSet) {
-            countedSize++;
-        }
-
-        assertEquals(0, countedSize);
-        assertEquals(size, countedSize);
-    }
-
-    @Test
-    // https://github.com/hazelcast/hazelcast/issues/9614
-    public void size_matchingPredicate_noOtherResult() {
-        Set<QueryableEntry> entries = generateEntries(100000);
-        List<Set<QueryableEntry>> otherIndexedResults = new ArrayList<Set<QueryableEntry>>();
-        AndResultSet resultSet = new AndResultSet(entries, otherIndexedResults, asList(new TruePredicate()));
-
-        int size = resultSet.size();
-        int countedSize = 0;
-        for (QueryableEntry queryableEntry : resultSet) {
-            countedSize++;
-        }
-
-        assertEquals(100000, countedSize);
-        assertEquals(size, countedSize);
-    }
-
-    @Test
-    // https://github.com/hazelcast/hazelcast/issues/9614
-    public void size_matchingPredicate_inOtherResult() {
-        Set<QueryableEntry> entries = generateEntries(100000);
-        Set<QueryableEntry> otherIndexResult = new HashSet<QueryableEntry>();
-        otherIndexResult.add(entries.iterator().next());
-        List<Set<QueryableEntry>> otherIndexedResults = new ArrayList<Set<QueryableEntry>>();
-        otherIndexedResults.add(otherIndexResult);
-        AndResultSet resultSet = new AndResultSet(entries, otherIndexedResults, asList(new TruePredicate()));
-
-        int size = resultSet.size();
-        int countedSize = 0;
-        for (QueryableEntry queryableEntry : resultSet) {
-            countedSize++;
-        }
-
-        assertEquals(1, countedSize);
-        assertEquals(size, countedSize);
     }
 
     @Test
@@ -192,7 +120,6 @@ public class AndResultSetTest extends HazelcastTestSupport {
         AndResultSet resultSet = new AndResultSet(entries, otherIndexedResults, asList(new TruePredicate()));
 
         assertTrue(resultSet.isEmpty());
-        assertEquals(0, resultSet.size());
     }
 
     @Test
@@ -218,7 +145,14 @@ public class AndResultSetTest extends HazelcastTestSupport {
                 listOfIndexSearchResults, asList(new TruePredicate()));
 
         assertFalse(resultSet.isEmpty());
-        assertEquals(10, resultSet.size());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void size_throws_unsupported_operation_exception() {
+        AndResultSet resultSet = new AndResultSet(Collections.<QueryableEntry>emptySet(),
+                Collections.<Set<QueryableEntry>>emptyList(), asList(new TruePredicate()));
+
+        resultSet.size();
     }
 
     private static Set<QueryableEntry> generateEntries(int count) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
@@ -33,13 +33,16 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Collections.singletonList;
 import static org.codehaus.groovy.runtime.InvokerHelper.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -180,6 +183,42 @@ public class AndResultSetTest extends HazelcastTestSupport {
         AndResultSet resultSet = new AndResultSet(entries, null, asList(new TruePredicate()));
 
         resultSet.remove(resultSet.iterator().next());
+    }
+
+    @Test
+    public void is_empty_returns_true_when_result_set_has_no_entry() {
+        Set<QueryableEntry> entries = Collections.emptySet();
+        List<Set<QueryableEntry>> otherIndexedResults = Collections.emptyList();
+        AndResultSet resultSet = new AndResultSet(entries, otherIndexedResults, asList(new TruePredicate()));
+
+        assertTrue(resultSet.isEmpty());
+        assertEquals(0, resultSet.size());
+    }
+
+    @Test
+    public void is_empty_returns_false_when_result_set_has_entries() {
+        // 1. prepare matchingEntries
+        Set<QueryableEntry> matchingEntries = generateEntries(100);
+
+        // 2. prepare list of matchingEntries from indexes
+        Set<QueryableEntry> indexSearchResult = new HashSet<QueryableEntry>();
+        int count = 0;
+        for (QueryableEntry entry : matchingEntries) {
+            if (count == 10) {
+                break;
+            }
+            indexSearchResult.add(entry);
+            count++;
+        }
+        List<Set<QueryableEntry>> listOfIndexSearchResults
+                = new LinkedList<Set<QueryableEntry>>(singletonList(indexSearchResult));
+
+        // 3. add all results to result set
+        AndResultSet resultSet = new AndResultSet(matchingEntries,
+                listOfIndexSearchResults, asList(new TruePredicate()));
+
+        assertFalse(resultSet.isEmpty());
+        assertEquals(10, resultSet.size());
     }
 
     private static Set<QueryableEntry> generateEntries(int count) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/FastMultiResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/FastMultiResultSetTest.java
@@ -30,7 +30,9 @@ import java.util.concurrent.ConcurrentMap;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -114,6 +116,18 @@ public class FastMultiResultSetTest {
         addEntry(entry(data()));
 
         assertThat(result.isEmpty(), is(false));
+    }
+
+    @Test
+    public void is_empty_returns_true_when_result_set_has_no_entry() {
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void is_empty_returns_false_when_result_set_has_entries() {
+        addEntry(entry(data()));
+
+        assertFalse(result.isEmpty());
     }
 
     public QueryableEntry entry(Data data) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.instance.TestUtil.toData;
+import static com.hazelcast.query.impl.predicates.AndPredicate.sizeOf;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -181,9 +182,9 @@ public class IndexTest {
         assertEquals(401, dIndex.getSubRecords(ComparisonType.GREATER_EQUAL, 600d).size());
         assertEquals(9, dIndex.getSubRecords(ComparisonType.LESSER, 10d).size());
         assertEquals(10, dIndex.getSubRecords(ComparisonType.LESSER_EQUAL, 10d).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1d), new EqualPredicate("bool", "false"))).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", 1), new EqualPredicate("bool", Boolean.FALSE))).size());
-        assertEquals(1, is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false))).size());
+        assertEquals(1, sizeOf(is.query(new AndPredicate(new EqualPredicate("d", 1d), new EqualPredicate("bool", "false")))));
+        assertEquals(1, sizeOf(is.query(new AndPredicate(new EqualPredicate("d", 1), new EqualPredicate("bool", Boolean.FALSE)))));
+        assertEquals(1, sizeOf(is.query(new AndPredicate(new EqualPredicate("d", "1"), new EqualPredicate("bool", false)))));
     }
 
     private void clearIndexes(Index... indexes) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -148,8 +148,7 @@ public class IndexesTest {
      * throw exception.
      */
     @Test
-    public void shouldNotThrowException_withNullValues_whenIndexAddedForValueField
-    () {
+    public void shouldNotThrowException_withNullValues_whenIndexAddedForValueField() {
         Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
         indexes.addOrGetIndex("name", false);
 
@@ -157,15 +156,13 @@ public class IndexesTest {
     }
 
     @Test
-    public void shouldNotThrowException_withNullValues_whenNoIndexAdded
-            () {
+    public void shouldNotThrowException_withNullValues_whenNoIndexAdded() {
         Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
 
         shouldReturnNull_whenQueryingOnKeys(indexes);
     }
 
-    private void shouldReturnNull_whenQueryingOnKeys(Indexes
-                                                             indexes) {
+    private void shouldReturnNull_whenQueryingOnKeys(Indexes indexes) {
         for (int i = 0; i < 50; i++) {
             // passing null value to QueryEntry
             indexes.saveEntryIndex(new QueryEntry(serializationService, toData(i), null, Extractors.empty()), null,
@@ -178,8 +175,7 @@ public class IndexesTest {
     }
 
     @Test
-    public void shouldNotThrowException_withNullValue_whenIndexAddedForKeyField
-            () {
+    public void shouldNotThrowException_withNullValue_whenIndexAddedForKeyField() {
         Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
         indexes.addOrGetIndex("__key", false);
 


### PR DESCRIPTION
Calling isEmpty over AndResultSet was making use of size
method. Size is calculated via full scan and this was
making isEmpty check inefficient for the first call.