### PR TITLE
Returned http 404 response code when there is no matching request uri

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -317,6 +317,6 @@ public class RestClusterTest extends HazelcastTestSupport {
     public void testHeadRequest_GarbageClusterHealth() throws Exception {
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, communicator.headRequestToGarbageClusterHealthURI().responseCode);
+        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, communicator.headRequestToGarbageClusterHealthURI().responseCode);
     }
 }


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/14193