### PR TITLE
Fix permit acquire/release mismatch in partition anti-entropy mechanism

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -72,7 +72,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
     private final Set<ReplicaFragmentSyncInfo> replicaSyncRequests;
     private final EntryTaskScheduler<ReplicaFragmentSyncInfo, Void> replicaSyncTimeoutScheduler;
     @Probe
-    private final Semaphore replicaSyncProcessLock;
+    private final Semaphore replicaSyncSemaphore;
     @Probe
     private final MwCounter replicaSyncRequestsCounter = newMwCounter();
 
@@ -91,7 +91,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
         HazelcastProperties properties = node.getProperties();
         partitionMigrationTimeout = properties.getMillis(GroupProperty.PARTITION_MIGRATION_TIMEOUT);
         maxParallelReplications = properties.getInteger(GroupProperty.PARTITION_MAX_PARALLEL_REPLICATIONS);
-        replicaSyncProcessLock = new Semaphore(maxParallelReplications);
+        replicaSyncSemaphore = new Semaphore(maxParallelReplications);
 
         replicaVersions = new PartitionReplicaVersions[partitionCount];
         for (int i = 0; i < replicaVersions.length; i++) {
@@ -190,30 +190,38 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
      * was not removed while the cluster was not active. Also cancel any currently scheduled sync requests for the given
      * partition and schedule a new sync request that is to be run in the case of timeout
      */
-    private void sendSyncReplicaRequest(int partitionId, Collection<ServiceNamespace> syncNamespaces,
+    private void sendSyncReplicaRequest(int partitionId, Collection<ServiceNamespace> requestedNamespaces,
             int replicaIndex, Address target) {
         if (node.clusterService.isMemberRemovedInNotJoinableState(target)) {
             return;
         }
 
-        if (!tryToAcquireReplicaSyncPermit()) {
+        int permits = tryAcquireReplicaSyncPermits(requestedNamespaces.size());
+        if (permits == 0) {
             if (logger.isFinestEnabled()) {
-                logger.finest("Cannot send sync replica request for partitionId=" + partitionId + ", replicaIndex=" + replicaIndex
-                        + ", namespaces=" + syncNamespaces + ". No permits available!");
+                logger.finest("Cannot send sync replica request for partitionId=" + partitionId
+                        + ", replicaIndex=" + replicaIndex + ", namespaces=" + requestedNamespaces
+                        + ". No permits available!");
             }
             return;
         }
 
-        Collection<ServiceNamespace> namespaces = registerSyncInfoFor(partitionId, syncNamespaces, replicaIndex, target);
+        // Select only permitted number of namespaces
+        List<ServiceNamespace> namespaces =
+                registerSyncInfoForNamespaces(partitionId, requestedNamespaces, replicaIndex, target, permits);
+
+        // release unused permits
+        if (namespaces.size() != permits) {
+            releaseReplicaSyncPermits(permits - namespaces.size());
+        }
+
         if (namespaces.isEmpty()) {
-            releaseReplicaSyncPermit();
             return;
         }
 
         if (logger.isFinestEnabled()) {
             logger.finest("Sending sync replica request for partitionId=" + partitionId + ", replicaIndex=" + replicaIndex
                     + ", namespaces=" + namespaces);
-
         }
         replicaSyncRequestsCounter.inc();
 
@@ -221,24 +229,35 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
         nodeEngine.getOperationService().send(syncRequest, target);
     }
 
-    private Collection<ServiceNamespace> registerSyncInfoFor(int partitionId,
-            Collection<ServiceNamespace> requestedNamespaces, int replicaIndex, Address target) {
+    private List<ServiceNamespace> registerSyncInfoForNamespaces(int partitionId,
+            Collection<ServiceNamespace> requestedNamespaces, int replicaIndex, Address target, int permits) {
 
-        // namespaces arg may not support removal
-        Collection<ServiceNamespace> namespaces = new ArrayList<ServiceNamespace>(requestedNamespaces);
-        Iterator<ServiceNamespace> iter = namespaces.iterator();
-        while (iter.hasNext()) {
-            ServiceNamespace namespace = iter.next();
-            ReplicaFragmentSyncInfo syncInfo = new ReplicaFragmentSyncInfo(partitionId, namespace, replicaIndex, target);
-            if (!replicaSyncRequests.add(syncInfo)) {
-                logger.finest("Cannot send sync replica request for " + syncInfo + ". Sync is already in progress!");
-                iter.remove();
-                continue;
+        List<ServiceNamespace> namespaces = new ArrayList<ServiceNamespace>(permits);
+        for (ServiceNamespace namespace : requestedNamespaces) {
+            if (namespaces.size() == permits) {
+                if (logger.isFinestEnabled()) {
+                    logger.finest("Cannot send sync replica request for " + partitionId + ", replicaIndex=" + replicaIndex
+                            + ", namespace=" + namespace + ". No permits available!");
+                    continue;
+                }
+                break;
+            } else if (registerSyncInfoFor(partitionId, namespace, replicaIndex, target)) {
+                namespaces.add(namespace);
             }
-
-            replicaSyncTimeoutScheduler.schedule(partitionMigrationTimeout, syncInfo, null);
         }
         return namespaces;
+    }
+
+    private boolean registerSyncInfoFor(int partitionId, ServiceNamespace namespace, int replicaIndex, Address target) {
+        ReplicaFragmentSyncInfo syncInfo = new ReplicaFragmentSyncInfo(partitionId, namespace, replicaIndex, target);
+        if (!replicaSyncRequests.add(syncInfo)) {
+            if (logger.isFinestEnabled()) {
+                logger.finest("Cannot send sync replica request for " + syncInfo + ". Sync is already in progress!");
+            }
+            return false;
+        }
+        replicaSyncTimeoutScheduler.schedule(partitionMigrationTimeout, syncInfo, null);
+        return true;
     }
 
     @Override
@@ -329,7 +348,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
             logger.finest("Clearing sync replica request for partitionId=" + partitionId + ", replicaIndex="
                     + replicaIndex + ", namespace=" + namespace);
         }
-        releaseReplicaSyncPermit();
+        releaseReplicaSyncPermits(1);
         replicaSyncTimeoutScheduler.cancelIfExists(syncInfo, null);
     }
 
@@ -340,7 +359,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
             if (deadAddress.equals(syncInfo.target)) {
                 iter.remove();
                 replicaSyncTimeoutScheduler.cancel(syncInfo);
-                releaseReplicaSyncPermit();
+                releaseReplicaSyncPermits(1);
             }
         }
     }
@@ -352,17 +371,55 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
             if (syncInfo.partitionId == partitionId) {
                 iter.remove();
                 replicaSyncTimeoutScheduler.cancel(syncInfo);
-                releaseReplicaSyncPermit();
+                releaseReplicaSyncPermits(1);
             }
         }
     }
 
-    public boolean tryToAcquireReplicaSyncPermit() {
-        return replicaSyncProcessLock.tryAcquire();
+    /**
+     * Tries to acquire requested permits. Less than requested permits may be acquired,
+     * if insufficient permits are available. Number of actually acquired permits will be
+     * returned to the caller. Acquired permits will be in the range of {@code [0, requestedPermits]}.
+     *
+     * @param requestedPermits number of requested permits
+     * @return number of actually acquired permits.
+     */
+    public int tryAcquireReplicaSyncPermits(int requestedPermits) {
+        assert requestedPermits > 0 : "Invalid permits: " + requestedPermits;
+
+        int permits = requestedPermits;
+        while (permits > 0 && !replicaSyncSemaphore.tryAcquire(permits)) {
+            permits--;
+        }
+
+        if (permits > 0 && logger.isFinestEnabled()) {
+            logger.finest("Acquired " + permits + " replica sync permits, requested permits was " + requestedPermits
+                    + ". Remaining permits: " + replicaSyncSemaphore.availablePermits());
+        }
+        return permits;
     }
 
-    public void releaseReplicaSyncPermit() {
-        replicaSyncProcessLock.release();
+    /**
+     * Releases the previously acquired permits.
+     *
+     * @param permits number of permits
+     */
+    public void releaseReplicaSyncPermits(int permits) {
+        assert permits > 0 : "Invalid permits: " + permits;
+        replicaSyncSemaphore.release(permits);
+        if (logger.isFinestEnabled()) {
+            logger.finest("Released " + permits + " replica sync permits. Available permits: "
+                        + replicaSyncSemaphore.availablePermits());
+        }
+        assert availableReplicaSyncPermits() <= maxParallelReplications
+                : "Number of replica sync permits exceeded the configured number!";
+    }
+
+    /**
+     * Returns the number of available permits.
+     */
+    public int availableReplicaSyncPermits() {
+        return replicaSyncSemaphore.availablePermits();
     }
 
     /**
@@ -392,8 +449,8 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
         replicaSyncTimeoutScheduler.cancelAll();
         // this is not sync with possibly running sync process
         // permit count can exceed allowed parallelization count.
-        replicaSyncProcessLock.drainPermits();
-        replicaSyncProcessLock.release(maxParallelReplications);
+        replicaSyncSemaphore.drainPermits();
+        replicaSyncSemaphore.release(maxParallelReplications);
     }
 
     void scheduleReplicaVersionSync(ExecutionService executionService) {
@@ -423,7 +480,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
             for (ScheduledEntry<ReplicaFragmentSyncInfo, Void> entry : entries) {
                 ReplicaFragmentSyncInfo syncInfo = entry.getKey();
                 if (replicaSyncRequests.remove(syncInfo)) {
-                    releaseReplicaSyncPermit();
+                    releaseReplicaSyncPermits(1);
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
@@ -37,12 +37,13 @@ import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.PartitionReplicationEvent;
 import com.hazelcast.spi.ServiceNamespace;
-import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * The request sent from a replica to the partition owner to synchronize the replica data. The partition owner can send a
@@ -59,20 +60,20 @@ import java.util.Collections;
 public final class PartitionReplicaSyncRequest extends AbstractPartitionOperation
         implements PartitionAwareOperation, MigrationCycleOperation, Versioned {
 
-    private Collection<ServiceNamespace> allNamespaces;
+    private List<ServiceNamespace> namespaces;
 
     public PartitionReplicaSyncRequest() {
-        allNamespaces = Collections.emptySet();
+        namespaces = Collections.emptyList();
     }
 
-    public PartitionReplicaSyncRequest(int partitionId, Collection<ServiceNamespace> namespaces, int replicaIndex) {
-        this.allNamespaces = namespaces;
+    public PartitionReplicaSyncRequest(int partitionId, List<ServiceNamespace> namespaces, int replicaIndex) {
+        this.namespaces = namespaces;
         setPartitionId(partitionId);
         setReplicaIndex(replicaIndex);
     }
 
     @Override
-    public void beforeRun() throws Exception {
+    public void beforeRun() {
         int syncReplicaIndex = getReplicaIndex();
         if (syncReplicaIndex < 1 || syncReplicaIndex > InternalPartition.MAX_BACKUP_COUNT) {
             throw new IllegalArgumentException("Replica index " + syncReplicaIndex
@@ -81,42 +82,72 @@ public final class PartitionReplicaSyncRequest extends AbstractPartitionOperatio
     }
 
     @Override
-    public void run() throws Exception {
-        NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) nodeEngine.getPartitionService();
-        int partitionId = getPartitionId();
-        int replicaIndex = getReplicaIndex();
-
+    public void run() {
+        InternalPartitionServiceImpl partitionService = getService();
         if (!partitionService.areMigrationTasksAllowed()) {
             ILogger logger = getLogger();
             if (logger.isFinestEnabled()) {
-                logger.finest("Migration is paused! Cannot run replica sync -> " + toString());
+                logger.finest("Migration is paused! Cannot process request. partitionId="
+                        + getPartitionId() + ", replicaIndex=" + getReplicaIndex() + ", namespaces=" + namespaces);
             }
             sendRetryResponse();
             return;
         }
 
-        if (!preCheckReplicaSync(nodeEngine, partitionId, replicaIndex)) {
+        if (!checkPartitionOwner()) {
+            sendRetryResponse();
             return;
         }
 
-        try {
-            PartitionReplicationEvent event = new PartitionReplicationEvent(partitionId, replicaIndex);
-            if (allNamespaces.remove(NonFragmentedServiceNamespace.INSTANCE)) {
-                Collection<Operation> operations = createNonFragmentedReplicationOperations(event);
-                sendOperations(operations, NonFragmentedServiceNamespace.INSTANCE);
-            }
+        int permits = partitionService.getReplicaManager().tryAcquireReplicaSyncPermits(namespaces.size());
+        if (permits == 0) {
+            logNotEnoughPermits();
+            sendRetryResponse();
+            return;
+        }
 
-            for (ServiceNamespace namespace : allNamespaces) {
-                Collection<Operation> operations = createFragmentReplicationOperations(event, namespace);
-                sendOperations(operations, namespace);
-            }
-        } finally {
-            partitionService.getReplicaManager().releaseReplicaSyncPermit();
+        sendOperationsForNamespaces(permits);
+
+        // send retry response for remaining namespaces
+        if (!namespaces.isEmpty()) {
+            logNotEnoughPermits();
+            sendRetryResponse();
         }
     }
 
-    private void sendOperations(Collection<Operation> operations, ServiceNamespace ns) throws Exception {
+    private void logNotEnoughPermits() {
+        ILogger logger = getLogger();
+        if (logger.isFinestEnabled()) {
+            logger.finest("Not enough permits available! Cannot process request. partitionId="
+                    + getPartitionId() + ", replicaIndex=" + getReplicaIndex() + ", namespaces=" + namespaces);
+        }
+    }
+
+    /**
+     * Send responses for first number of {@code permits} namespaces and remove them from the list.
+     */
+    private void sendOperationsForNamespaces(int permits) {
+        InternalPartitionServiceImpl partitionService = getService();
+        try {
+            PartitionReplicationEvent event = new PartitionReplicationEvent(getPartitionId(), getReplicaIndex());
+            Iterator<ServiceNamespace> iterator = namespaces.iterator();
+            for (int i = 0; i < permits; i++) {
+                ServiceNamespace namespace = iterator.next();
+                Collection<Operation> operations;
+                if (NonFragmentedServiceNamespace.INSTANCE.equals(namespace)) {
+                    operations = createNonFragmentedReplicationOperations(event);
+                } else {
+                    operations = createFragmentReplicationOperations(event, namespace);
+                }
+                sendOperations(operations, namespace);
+                iterator.remove();
+            }
+        } finally {
+            partitionService.getReplicaManager().releaseReplicaSyncPermits(permits);
+        }
+    }
+
+    private void sendOperations(Collection<Operation> operations, ServiceNamespace ns) {
         if (operations.isEmpty()) {
             logNoReplicaDataFound(getPartitionId(), ns, getReplicaIndex());
             sendResponse(null, ns);
@@ -125,28 +156,20 @@ public final class PartitionReplicaSyncRequest extends AbstractPartitionOperatio
         }
     }
 
-    /** Checks if we can continue with the replication or not. Can send a retry or empty response to the replica in some cases */
-    private boolean preCheckReplicaSync(NodeEngineImpl nodeEngine, int partitionId, int replicaIndex) throws IOException {
-        InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) nodeEngine.getPartitionService();
+    /** Checks if we are the primary owner of the partition. */
+    private boolean checkPartitionOwner() {
+        InternalPartitionServiceImpl partitionService = getService();
         PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
-        InternalPartitionImpl partition = partitionStateManager.getPartitionImpl(partitionId);
+        InternalPartitionImpl partition = partitionStateManager.getPartitionImpl(getPartitionId());
         Address owner = partition.getOwnerOrNull();
 
-        ILogger logger = getLogger();
+        NodeEngine nodeEngine = getNodeEngine();
         if (!nodeEngine.getThisAddress().equals(owner)) {
+            ILogger logger = getLogger();
             if (logger.isFinestEnabled()) {
-                logger.finest("Wrong target! " + toString() + " cannot be processed! Target should be: " + owner);
+                logger.finest("This node is not owner partition. Cannot process request. partitionId="
+                        + getPartitionId() + ", replicaIndex=" + getReplicaIndex() + ", namespaces=" + namespaces);
             }
-            sendRetryResponse();
-            return false;
-        }
-
-        if (!partitionService.getReplicaManager().tryToAcquireReplicaSyncPermit()) {
-            if (logger.isFinestEnabled()) {
-                logger.finest(
-                        "Max parallel replication process limit exceeded! Could not run replica sync -> " + toString());
-            }
-            sendRetryResponse();
             return false;
         }
         return true;
@@ -158,7 +181,7 @@ public final class PartitionReplicaSyncRequest extends AbstractPartitionOperatio
         int partitionId = getPartitionId();
         int replicaIndex = getReplicaIndex();
 
-        PartitionReplicaSyncRetryResponse response = new PartitionReplicaSyncRetryResponse(allNamespaces);
+        PartitionReplicaSyncRetryResponse response = new PartitionReplicaSyncRetryResponse(namespaces);
         response.setPartitionId(partitionId).setReplicaIndex(replicaIndex);
         Address target = getCallerAddress();
         OperationService operationService = nodeEngine.getOperationService();
@@ -166,7 +189,7 @@ public final class PartitionReplicaSyncRequest extends AbstractPartitionOperatio
     }
 
     /** Send a synchronization response to the caller replica containing the replication operations to be executed */
-    private void sendResponse(Collection<Operation> operations, ServiceNamespace ns) throws IOException {
+    private void sendResponse(Collection<Operation> operations, ServiceNamespace ns) {
         NodeEngine nodeEngine = getNodeEngine();
 
         PartitionReplicaSyncResponse syncResponse = createResponse(operations, ns);
@@ -231,8 +254,8 @@ public final class PartitionReplicaSyncRequest extends AbstractPartitionOperatio
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeInt(allNamespaces.size());
-        for (ServiceNamespace namespace : allNamespaces) {
+        out.writeInt(namespaces.size());
+        for (ServiceNamespace namespace : namespaces) {
             out.writeObject(namespace);
         }
     }
@@ -240,10 +263,10 @@ public final class PartitionReplicaSyncRequest extends AbstractPartitionOperatio
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int len = in.readInt();
-        allNamespaces = new ArrayList<ServiceNamespace>(len);
+        namespaces = new ArrayList<ServiceNamespace>(len);
         for (int i = 0; i < len; i++) {
             ServiceNamespace ns = in.readObject();
-            allNamespaces.add(ns);
+            namespaces.add(ns);
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
@@ -60,7 +60,7 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSupport {
 
-    private static final int PARALLEL_REPLICATIONS = 10;
+    protected static final int PARALLEL_REPLICATIONS = 10;
     private static final int BACKUP_SYNC_INTERVAL = 1;
 
     private static final String[] NAMESPACES = {"ns1", "ns2"};


### PR DESCRIPTION
With the fragmented migration/replication change, backup replica synchronization
is handled per-namespace. So, for each namespace synchronization, a single permit
should be acquired. Sync requests for multiple namespaces are sent
in a single batch request to avoid multiple request/response cycles.

Problem is, a single permit was being acquired for a batch request
and but after sync completed, one permit for each namespace was released.
So, in total more than acquired permits were released after each batch.

To fix that, now a batch request will acquire permits equal to number
of namespaces that batch includes.