### PR TITLE
Removed size() calls on result sets. First size method calls

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelAccumulationExecutor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/ParallelAccumulationExecutor.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
+import static com.hazelcast.query.impl.predicates.PredicateUtils.estimatedSizeOf;
 import static com.hazelcast.util.FutureUtil.RETHROW_EVERYTHING;
 import static com.hazelcast.util.FutureUtil.returnWithDeadline;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -88,12 +89,13 @@ public class ParallelAccumulationExecutor implements AccumulationExecutor {
     }
 
     private Collection<QueryableEntry>[] split(Collection<QueryableEntry> entries, int chunkCount) {
-        if (entries.size() < chunkCount * 2) {
+        int estimatedSize = estimatedSizeOf(entries);
+        if (estimatedSize < chunkCount * 2) {
             return null;
         }
         int counter = 0;
         Collection<QueryableEntry>[] entriesSplit = new Collection[chunkCount];
-        int entriesPerChunk = entries.size() / chunkCount;
+        int entriesPerChunk = estimatedSize / chunkCount;
         for (int i = 0; i < chunkCount; i++) {
             entriesSplit[i] = new ArrayList<QueryableEntry>(entriesPerChunk);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -61,7 +61,6 @@ import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.Preconditions.checkNoNullInside;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static com.hazelcast.util.SetUtil.createHashSet;
 import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -338,17 +337,15 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
     public Set<K> keySet(Predicate predicate) {
         checkNotNull(predicate, "Predicate cannot be null!");
 
-        final Set<K> resultingSet;
+        Set<K> resultingSet = new HashSet<K>();
 
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
-            resultingSet = createHashSet(query.size());
             for (QueryableEntry entry : query) {
                 K key = (K) entry.getKey();
                 resultingSet.add(key);
             }
         } else {
-            resultingSet = new HashSet<K>();
             doFullKeyScan(predicate, resultingSet);
         }
 
@@ -359,19 +356,14 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
     public Set<Map.Entry<K, V>> entrySet(Predicate predicate) {
         checkNotNull(predicate, "Predicate cannot be null!");
 
-        Set<Map.Entry<K, V>> resultingSet;
+        Set<Map.Entry<K, V>> resultingSet = new HashSet<Map.Entry<K, V>>();
 
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
-            if (query.isEmpty()) {
-                return Collections.emptySet();
-            }
-            resultingSet = createHashSet(query.size());
             for (QueryableEntry entry : query) {
                 resultingSet.add(entry);
             }
         } else {
-            resultingSet = new HashSet<Map.Entry<K, V>>();
             doFullEntryScan(predicate, resultingSet);
         }
         return resultingSet;
@@ -385,16 +377,14 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
             return Collections.emptySet();
         }
 
-        final Set<V> resultingSet;
+        Set<V> resultingSet = new HashSet<V>();
 
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
-            resultingSet = createHashSet(query.size());
             for (QueryableEntry entry : query) {
                 resultingSet.add((V) entry.getValue());
             }
         } else {
-            resultingSet = new HashSet<V>();
             doFullValueScan(predicate, resultingSet);
         }
         return resultingSet;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AndResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AndResultSet.java
@@ -155,7 +155,8 @@ public class AndResultSet extends AbstractSet<QueryableEntry> {
     }
 
     /**
-     * @return returns estimated size without calculating the full result set in full-result scan.
+     * @return returns estimated size without calculating the full
+     * result set in full-result scan.
      */
     public int estimatedSize() {
         if (cachedSize == SIZE_UNINITIALIZED) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/AndPredicate.java
@@ -25,7 +25,6 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;
 import com.hazelcast.query.impl.AndResultSet;
 import com.hazelcast.query.impl.Indexes;
-import com.hazelcast.query.impl.OrResultSet;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -38,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.hazelcast.internal.serialization.impl.FactoryIdHelper.PREDICATE_DS_FACTORY_ID;
+import static com.hazelcast.query.impl.predicates.PredicateUtils.estimatedSizeOf;
 
 /**
  * And Predicate
@@ -79,7 +79,7 @@ public final class AndPredicate
                 Set<QueryableEntry> currentResultSet = ((IndexAwarePredicate) predicate).filter(queryContext);
                 if (smallestResultSet == null) {
                     smallestResultSet = currentResultSet;
-                } else if (sizeOf(currentResultSet) < sizeOf(smallestResultSet)) {
+                } else if (estimatedSizeOf(currentResultSet) < estimatedSizeOf(smallestResultSet)) {
                     otherResultSets = initOrGetListOf(otherResultSets);
                     otherResultSets.add(smallestResultSet);
                     smallestResultSet = currentResultSet;
@@ -108,16 +108,6 @@ public final class AndPredicate
             list = new LinkedList<T>();
         }
         return list;
-    }
-
-    private static int sizeOf(Set<QueryableEntry> result) {
-        // In case of AndResultSet and OrResultSet calling size() may be very expensive so quicker estimatedSize() is used
-        if (result instanceof AndResultSet) {
-            return ((AndResultSet) result).estimatedSize();
-        } else if (result instanceof OrResultSet) {
-            return ((OrResultSet) result).estimatedSize();
-        }
-        return result.size();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.predicates;
+
+import com.hazelcast.query.impl.AndResultSet;
+import com.hazelcast.query.impl.OrResultSet;
+import com.hazelcast.query.impl.QueryableEntry;
+
+import java.util.Collection;
+
+public final class PredicateUtils {
+
+    private PredicateUtils() {
+    }
+
+    /**
+     * In case of AndResultSet and OrResultSet calling size() may be very
+     * expensive so quicker estimatedSize() is used.
+     *
+     * @param result result of a predicated search
+     * @return size or estimated size
+     *
+     * @see AndResultSet#estimatedSize()
+     * @see OrResultSet#estimatedSize()
+     */
+    public static int estimatedSizeOf(Collection<QueryableEntry> result) {
+        if (result instanceof AndResultSet) {
+            return ((AndResultSet) result).estimatedSize();
+        } else if (result instanceof OrResultSet) {
+            return ((OrResultSet) result).estimatedSize();
+        }
+        return result.size();
+    }
+}


### PR DESCRIPTION
on And or Or result sets are expensive.

closes https://github.com/hazelcast/hazelcast/issues/14177