### PR TITLE
Fixes user code deployment provider sending wrong nested class defini…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassSource.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/usercodedeployment/impl/ClassSource.java
@@ -70,6 +70,11 @@ public final class ClassSource extends ClassLoader {
         return classDefinitions.get(name);
     }
 
+    // for testing purposes
+    void addClassDefinition(String name, byte[] bytes) {
+        classDefinitions.put(name, bytes);
+    }
+
     Class getClazz(String name) {
         return classes.get(name);
     }
@@ -78,6 +83,11 @@ public final class ClassSource extends ClassLoader {
         ClassData classData = new ClassData();
         HashMap<String, byte[]> innerClassDefinitions = new HashMap<String, byte[]>(this.classDefinitions);
         byte[] mainClassDefinition = innerClassDefinitions.remove(className);
+        if (mainClassDefinition == null) {
+            // sometimes an inner class may be cached within its main class.
+            // However it does not mean another inner class within the same main class is cached too.
+            return null;
+        }
         classData.setInnerClassDefinitions(innerClassDefinitions);
         classData.setMainClassDefinition(mainClassDefinition);
         return classData;

--- a/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/ClassDataProviderTest.java
@@ -82,6 +82,8 @@ public class ClassDataProviderTest {
     }
 
     private static ClassSource newMockClassSource() {
-        return new ClassSource(null, null);
+        ClassSource classSource = new ClassSource(null, null);
+        classSource.addClassDefinition("className", new byte[4]);
+        return classSource;
     }
 }

--- a/hazelcast/src/test/java/usercodedeployment/ClassWithTwoInnerClasses.java
+++ b/hazelcast/src/test/java/usercodedeployment/ClassWithTwoInnerClasses.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package usercodedeployment;
+
+import com.hazelcast.map.AbstractEntryProcessor;
+
+import java.io.Serializable;
+import java.util.Map;
+
+public class ClassWithTwoInnerClasses implements Serializable {
+    public static class StaticNestedIncrementingEntryProcessor extends AbstractEntryProcessor<Integer, Integer> {
+        @Override
+        public Object process(Map.Entry<Integer, Integer> entry) {
+            Integer origValue = entry.getValue();
+            Integer newValue = origValue + 1;
+            entry.setValue(newValue);
+            return newValue;
+        }
+    }
+
+    public static class StaticNestedDecrementingEntryProcessor extends AbstractEntryProcessor<Integer, Integer> {
+        @Override
+        public Object process(Map.Entry<Integer, Integer> entry) {
+            Integer origValue = entry.getValue();
+            Integer newValue = origValue - 1;
+            entry.setValue(newValue);
+            return newValue;
+        }
+    }
+}


### PR DESCRIPTION
…tion

When class definition for a nested class is requested, provider only sends the nested class, not the siblings. The requesting server caches this. Later if another member asks for the sibling of the cached class, the first server falsely sends the class it has. This causes the second requesting server to fail loading the class. This PR adds a check before sending the cached class to see if the cached class is the requested one.

fixes https://github.com/hazelcast/hazelcast/issues/14105