### PR TITLE
Cleanup. AddressProvider list is removed.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -119,7 +119,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     private volatile Credentials lastCredentials;
 
     public ClientConnectionManagerImpl(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator,
-                                       Collection<AddressProvider> addressProviders) {
+                                       AddressProvider addressProvider) {
         allowInvokeWhenDisconnected = client.getProperties().getBoolean(ALLOW_INVOCATIONS_WHEN_DISCONNECTED);
         this.client = client;
 
@@ -146,7 +146,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         this.heartbeat = new HeartbeatManager(this, client);
         this.authenticationTimeout = heartbeat.getHeartbeatTimeout();
 
-        this.clusterConnector = new ClusterConnector(client, this, connectionStrategy, addressProviders);
+        this.clusterConnector = new ClusterConnector(client, this, connectionStrategy, addressProvider);
     }
 
     private Collection<Integer> getOutboundPorts(ClientNetworkConfig networkConfig) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientConnectionManagerFactory.java
@@ -20,11 +20,9 @@ import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.client.connection.ClientConnectionManager;
 
-import java.util.Collection;
-
 public interface ClientConnectionManagerFactory {
 
     ClientConnectionManager createConnectionManager(HazelcastClientInstanceImpl client,
                                                     AddressTranslator addressTranslator,
-                                                    Collection<AddressProvider> addressProviders);
+                                                    AddressProvider addressProvider);
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientConnectionManagerFactory.java
@@ -21,8 +21,6 @@ import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
 
-import java.util.Collection;
-
 public class DefaultClientConnectionManagerFactory implements ClientConnectionManagerFactory {
 
     public DefaultClientConnectionManagerFactory() {
@@ -31,9 +29,9 @@ public class DefaultClientConnectionManagerFactory implements ClientConnectionMa
     @Override
     public ClientConnectionManager createConnectionManager(HazelcastClientInstanceImpl client,
                                                            AddressTranslator addressTranslator,
-                                                           Collection<AddressProvider> addressProviders) {
+                                                           AddressProvider addressProvider) {
 
 
-        return new ClientConnectionManagerImpl(client, addressTranslator, addressProviders);
+        return new ClientConnectionManagerImpl(client, addressTranslator, addressProvider);
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
@@ -33,17 +33,15 @@ import java.util.List;
 public class DefaultAddressProvider implements AddressProvider {
 
     private ClientNetworkConfig networkConfig;
-    private boolean noOtherAddressProviderExist;
 
-    public DefaultAddressProvider(ClientNetworkConfig networkConfig, boolean noOtherAddressProviderExist) {
+    public DefaultAddressProvider(ClientNetworkConfig networkConfig) {
         this.networkConfig = networkConfig;
-        this.noOtherAddressProviderExist = noOtherAddressProviderExist;
     }
 
     @Override
     public Collection<Address> loadAddresses() {
         final List<String> addresses = networkConfig.getAddresses();
-        if (addresses.isEmpty() && noOtherAddressProviderExist) {
+        if (addresses.isEmpty()) {
             addresses.add("127.0.0.1");
         }
         final List<Address> possibleAddresses = new LinkedList<Address>();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
@@ -52,11 +52,11 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
     public void setup() throws Exception {
         Hazelcast.newHazelcastInstance();
         HazelcastInstance client = HazelcastClient.newHazelcastClient();
-        Collection<AddressProvider> list = Collections.<AddressProvider>singletonList(new TestAddressProvider());
+        TestAddressProvider testAddressProvider = new TestAddressProvider();
 
         TestAddressTranslator translator = new TestAddressTranslator();
         clientConnectionManager =
-                new ClientConnectionManagerImpl(getHazelcastClientInstanceImpl(client), translator, list);
+                new ClientConnectionManagerImpl(getHazelcastClientInstanceImpl(client), translator, testAddressProvider);
         clientConnectionManager.start(new ClientContext(getHazelcastClientInstanceImpl(client)));
         clientConnectionManager.connectToCluster();
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -46,7 +46,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -84,8 +83,8 @@ class TestClientRegistry {
         @Override
         public ClientConnectionManager createConnectionManager(HazelcastClientInstanceImpl client,
                                                                AddressTranslator addressTranslator,
-                                                               Collection<AddressProvider> addressProviders) {
-            return new MockClientConnectionManager(client, addressTranslator, addressProviders, host, ports);
+                                                               AddressProvider addressProvider) {
+            return new MockClientConnectionManager(client, addressTranslator, addressProvider, host, ports);
         }
     }
 
@@ -98,8 +97,8 @@ class TestClientRegistry {
         private final AtomicInteger ports;
 
         MockClientConnectionManager(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator,
-                                    Collection<AddressProvider> addressProviders, String host, AtomicInteger ports) {
-            super(client, addressTranslator, addressProviders);
+                                    AddressProvider addressProvider, String host, AtomicInteger ports) {
+            super(client, addressTranslator, addressProvider);
             this.client = client;
             this.host = host;
             this.ports = ports;


### PR DESCRIPTION
There can be only one addressTranlastor and addressProvider
active at a time.

This pr cleans up the places where a list of address providers
are used.