### PR TITLE
Use one instance of Extractors for all query-cache operations

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
@@ -80,11 +80,11 @@ public class ClientQueryCacheEventService implements QueryCacheEventService {
                 }
             };
 
-    private final ILogger logger = Logger.getLogger(getClass());
     private final StripedExecutor executor;
-    private final ConcurrentMap<String, QueryCacheToListenerMapper> registrations;
-    private final SerializationService serializationService;
     private final ClientListenerService listenerService;
+    private final SerializationService serializationService;
+    private final ILogger logger = Logger.getLogger(getClass());
+    private final ConcurrentMap<String, QueryCacheToListenerMapper> registrations;
 
     public ClientQueryCacheEventService(ClientContext clientContext) {
         AbstractClientListenerService listenerService = (AbstractClientListenerService) clientContext.getListenerService();
@@ -116,21 +116,56 @@ public class ClientQueryCacheEventService implements QueryCacheEventService {
     }
 
     @Override
-    public void publish(String mapName, String cacheId, Object event, int orderKey) {
+    public void publish(String mapName, String cacheId, Object event,
+                        int orderKey, Extractors extractors) {
         checkHasText(mapName, "mapName");
         checkHasText(cacheId, "cacheId");
         checkNotNull(event, "event cannot be null");
 
+
         Collection<ListenerInfo> listeners = getListeners(mapName, cacheId);
         for (ListenerInfo info : listeners) {
+            if (!canPassFilter(event, info.getFilter(), extractors)) {
+                continue;
+            }
+
             try {
-                executor.execute(new EventDispatcher(event, info, orderKey, serializationService, EVENT_QUEUE_TIMEOUT_MILLIS));
+                executor.execute(new EventDispatcher(event, info, orderKey,
+                        serializationService, EVENT_QUEUE_TIMEOUT_MILLIS));
             } catch (RejectedExecutionException e) {
                 // TODO Should we notify user when we overloaded?
                 logger.warning("EventQueue overloaded! Can not process IMap=[" + mapName + "]"
                         + ", QueryCache=[ " + cacheId + "]" + ", Event=[" + event + "]");
             }
         }
+    }
+
+    private boolean canPassFilter(Object eventData,
+                                  EventFilter filter, Extractors extractors) {
+        if (filter == null || filter instanceof TrueEventFilter) {
+            return true;
+        }
+
+        if (!(eventData instanceof LocalEntryEventData)) {
+            return true;
+        }
+
+        LocalEntryEventData localEntryEventData = (LocalEntryEventData) eventData;
+
+        if (localEntryEventData.getEventType() != EventLostEvent.EVENT_TYPE) {
+            Object value = getValueOrOldValue(localEntryEventData);
+            Data keyData = localEntryEventData.getKeyData();
+            QueryEntry entry = new QueryEntry((InternalSerializationService) serializationService,
+                    keyData, value, extractors);
+            return filter.eval(entry);
+        }
+
+        return true;
+    }
+
+    private Object getValueOrOldValue(LocalEntryEventData localEntryEventData) {
+        Object value = localEntryEventData.getValue();
+        return value != null ? value : localEntryEventData.getOldValue();
     }
 
     @Override
@@ -277,36 +312,9 @@ public class ClientQueryCacheEventService implements QueryCacheEventService {
             EventData eventData = (EventData) event;
             EventFilter filter = listenerInfo.getFilter();
 
-            if (eventData instanceof LocalEntryEventData
-                    && eventData.getEventType() != EventLostEvent.EVENT_TYPE) {
-
-                LocalEntryEventData localEntryEventData = (LocalEntryEventData) eventData;
-                if (!canPassFilter(localEntryEventData, filter)) {
-                    return;
-                }
-            }
-
             IMapEvent event = createIMapEvent(eventData, filter, null, serializationService);
             ListenerAdapter listenerAdapter = listenerInfo.getListenerAdapter();
             listenerAdapter.onEvent(event);
-        }
-
-
-        private boolean canPassFilter(LocalEntryEventData eventData, EventFilter filter) {
-            if (filter == null || filter instanceof TrueEventFilter) {
-                return true;
-            }
-            Object value = getValueOrOldValue(eventData);
-            Data keyData = eventData.getKeyData();
-            QueryEntry entry = new QueryEntry((InternalSerializationService) serializationService,
-                    keyData, value, Extractors.empty());
-            return filter.eval(entry);
-        }
-
-
-        private Object getValueOrOldValue(LocalEntryEventData localEntryEventData) {
-            Object value = localEntryEventData.getValue();
-            return value != null ? value : localEntryEventData.getOldValue();
         }
 
         @Override
@@ -321,4 +329,3 @@ public class ClientQueryCacheEventService implements QueryCacheEventService {
 
     }
 }
-

--- a/hazelcast/src/main/java/com/hazelcast/map/QueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/QueryCache.java
@@ -26,13 +26,15 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * A concurrent, queryable data structure which is used to cache results of a continuous query executed
- * on an {@code IMap}. It can be also thought of as an always up to date view or snapshot of the {@code IMap}.
- * <p/>
+ * A concurrent, queryable data structure which is used to cache results of
+ * a continuous query executed on an {@code IMap}. It can be also thought
+ * of as an always up to date view or snapshot of the {@code IMap}.
+ *
  * Typically, {@code QueryCache} is used for performance reasons.
- * <p/>
- * This {@code QueryCache} can be configured via {@link com.hazelcast.config.QueryCacheConfig QueryCacheConfig}.
- * <p/>
+ *
+ * This {@code QueryCache} can be configured via {@link
+ * com.hazelcast.config.QueryCacheConfig QueryCacheConfig}.
+ *
  * It can be reached like this:
  * <pre>
  * <code>
@@ -44,34 +46,39 @@ import java.util.Set;
  * </code>
  * </pre>
  * <p/>
- * This cache is evictable. The eviction can be configured with {@link com.hazelcast.config.QueryCacheConfig#evictionConfig
- * evictionConfig}. Events caused by {@code IMap} eviction are not reflected to this cache. But the events published after
- * an explicit call to {@link com.hazelcast.core.IMap#evict} are reflected to this cache.
+ * This cache is evictable. The eviction can be configured with {@link
+ * com.hazelcast.config.QueryCacheConfig#setEvictionConfig}.
+ * Events caused by {@code IMap} eviction are not reflected to this cache.
+ * But the events published after an explicit call to {@link
+ * com.hazelcast.core.IMap#evict} are reflected to this cache.
  * <p/>
  * <b>GOTCHAS</b>
  * <ul>
  * <li>
- * This {@code QueryCache} implementation relies on the eventing system, if a listener is attached to this {@code QueryCache}
- * it may receive same event more than once in case of a system failure. Check out {@link QueryCache#tryRecover()}
+ * This {@code QueryCache} implementation relies on the eventing system, if
+ * a listener is attached to this {@code QueryCache} it may receive same
+ * event more than once in case of a system failure. Check out {@link
+ * QueryCache#tryRecover()}
  * </li>
  * <li>
- * All writes to this {@link QueryCache} is reflected to underlying {@code IMap} and that
- * write operation will eventually be reflected to this {@code QueryCache} after receiving the
- * event of that operation.
+ * All writes to this {@link QueryCache} is reflected to underlying {@code
+ * IMap} and that write operation will eventually be reflected to this
+ * {@code QueryCache} after receiving the event of that operation.
  * </li>
  * <li>
- * Currently, updates performed on the entries are reflected in the indexes in a
- * non-atomic way. Therefore, if there are indexes configured for the query
- * cache, their state may slightly lag behind the state of the entries.
- * Use map listeners if you need to observe the state when the entry store and
- * its indexes are consistent about the state of a particular entry, see
- * {@link IMap#addEntryListener(MapListener, boolean) addEntryListener} for more
- * details.
+ * Currently, updates performed on the entries are reflected in the indexes
+ * in a non-atomic way. Therefore, if there are indexes configured for the
+ * query cache, their state may slightly lag behind the state of the
+ * entries. Use map listeners if you need to observe the state when the
+ * entry store and its indexes are consistent about the state of a
+ * particular entry, see {@link IMap#addEntryListener(MapListener, boolean)
+ * addEntryListener} for more details.
  * </li>
  * <li>
- * There are some gotchas same with underlying {@link com.hazelcast.core.IMap IMap} implementation,
- * one should take care of them before using this {@code QueryCache}.
- * Please check gotchas section in {@link com.hazelcast.core.IMap IMap} class for them.
+ * There are some gotchas same with underlying {@link
+ * com.hazelcast.core.IMap IMap} implementation, one should take care of
+ * them before using this {@code QueryCache}. Please check gotchas section
+ * in {@link com.hazelcast.core.IMap IMap} class for them.
  * </li>
  * </ul>
  * <p/>

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEventFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryEventFilter.java
@@ -28,7 +28,8 @@ import java.io.IOException;
 import java.util.Map;
 
 /**
- * Event filter which mathes map events on a specified entry key and matching a predefined {@link Predicate}.
+ * Event filter which matches map events on a specified entry key and
+ * matching a predefined {@link Predicate}.
  */
 public class QueryEventFilter extends EntryEventFilter {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheEventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/QueryCacheEventService.java
@@ -18,13 +18,14 @@ package com.hazelcast.map.impl.querycache;
 
 import com.hazelcast.map.impl.ListenerAdapter;
 import com.hazelcast.map.listener.MapListener;
+import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.spi.EventFilter;
 
 /**
- * Event service abstraction to allow different type of implementations
- * on query cache subscriber and query cache publisher sides. Runs locally on query-cache
- * subscriber side which may be node or client. Responsible for registering/removing listeners
- * and publishing events locally etc.
+ * Event service abstraction to allow different type of implementations on
+ * query cache subscriber and query cache publisher sides. Runs locally on
+ * query-cache subscriber side which may be node or client. Responsible for
+ * registering/removing listeners and publishing events locally etc.
  *
  * @param <E> type of event to be published.
  */
@@ -33,12 +34,13 @@ public interface QueryCacheEventService<E> {
     /**
      * Publishes query-cache events locally.
      *
-     * @param mapName  underlying map name of query cache
-     * @param cacheId  ID of the query cache
-     * @param event    event to publish
-     * @param orderKey use same order key for events which are required to be ordered
+     * @param mapName    underlying map name of query cache
+     * @param cacheId    ID of the query cache
+     * @param event      event to publish
+     * @param orderKey   use same order key for events which are required to be ordered
+     * @param extractors extractors for the query cache
      */
-    void publish(String mapName, String cacheId, E event, int orderKey);
+    void publish(String mapName, String cacheId, E event, int orderKey, Extractors extractors);
 
     /**
      * Adds the listener to listen underlying IMap on all nodes.
@@ -102,12 +104,13 @@ public interface QueryCacheEventService<E> {
     void removeAllListeners(String mapName, String cacheId);
 
     /**
-     * Returns {@code true} if this query-cache has at least one registered user defined listener
-     * otherwise returns {@code false}.
+     * Returns {@code true} if this query-cache has at least one registered
+     * user defined listener otherwise returns {@code false}.
      *
      * @param mapName underlying IMap name of query-cache
      * @param cacheId ID of the query-cache
-     * @return {@code true} if this query-cache has at least one registered listener otherwise returns {@code false}
+     * @return {@code true} if this query-cache has at least one registered listener
+     * otherwise returns {@code false}
      */
     boolean hasListener(String mapName, String cacheId);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -39,7 +39,6 @@ import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
-import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.util.ContextMutexFactory;
 import com.hazelcast.util.FutureUtil;
@@ -101,7 +100,8 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
                 ? recordStore.add(keyData, valueData) : recordStore.addWithoutEvictionCheck(keyData, valueData);
 
         if (eventType != null) {
-            publishEntryEvent(context, mapName, cacheId, keyData, valueData, oldRecord, eventType);
+            publishEntryEvent(context, mapName, cacheId,
+                    keyData, valueData, oldRecord, eventType, extractors);
         }
     }
 
@@ -116,7 +116,8 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
             return;
         }
         if (eventType != null) {
-            publishEntryEvent(context, mapName, cacheId, keyData, null, oldRecord, eventType);
+            publishEntryEvent(context, mapName, cacheId, keyData,
+                    null, oldRecord, eventType, extractors);
         }
     }
 
@@ -463,13 +464,12 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
         InternalSerializationService serializationService = context.getSerializationService();
 
-        Extractors empty = Extractors.empty();
         Set<Map.Entry<Data, QueryCacheRecord>> entries = recordStore.entrySet();
         for (Map.Entry<Data, QueryCacheRecord> entry : entries) {
             Data keyData = entry.getKey();
             QueryCacheRecord record = entry.getValue();
             Object value = record.getValue();
-            QueryEntry queryable = new QueryEntry(serializationService, keyData, value, empty);
+            QueryEntry queryable = new QueryEntry(serializationService, keyData, value, extractors);
             indexes.saveEntryIndex(queryable, null, Index.OperationSource.USER);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
@@ -20,6 +20,7 @@ import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.QueryCache;
 import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.getters.Extractors;
 
 /**
  * Internal interface which adds some internally used methods
@@ -69,4 +70,9 @@ public interface InternalQueryCache<K, V> extends QueryCache<K, V> {
      * @see com.hazelcast.config.QueryCacheConfig#populate
      */
     boolean reachedMaxCapacity();
+
+    /**
+     * @return extractors of this query cache instance.
+     */
+    Extractors getExtractors();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCache.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.Indexes;
+import com.hazelcast.query.impl.getters.Extractors;
 
 import java.util.Collection;
 import java.util.Map;
@@ -85,6 +86,11 @@ public final class NullQueryCache implements InternalQueryCache {
     @Override
     public boolean reachedMaxCapacity() {
         return false;
+    }
+
+    @Override
+    public Extractors getExtractors() {
+        return null;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
@@ -142,7 +142,8 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
                         currentSequence + 1L, sequence, queryCache.size()));
             }
 
-            publishEventLost(context, info.getMapName(), info.getCacheId(), event.getPartitionId());
+            publishEventLost(context, info.getMapName(), info.getCacheId(),
+                    event.getPartitionId(), queryCache.getExtractors());
         }
     }
 


### PR DESCRIPTION
fixes https://github.com/hazelcast/hazelcast/issues/14191
fixes https://github.com/hazelcast/hazelcast/issues/14192

follow up PR: https://github.com/hazelcast/hazelcast/pull/14233