### PR TITLE
[FORWARD PORT] Improve MC script execution error reporting (#14221)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/ScriptExecutorOperation.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.management.ScriptEngineManagerContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.impl.Versioned;
-import com.hazelcast.util.ExceptionUtil;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -66,7 +65,10 @@ public class ScriptExecutorOperation extends AbstractManagementOperation impleme
         try {
             this.result = engine.eval(script);
         } catch (ScriptException e) {
-            throw new HazelcastException(ExceptionUtil.toString(e));
+            // ScriptException's cause is not serializable - we don't need the cause
+            HazelcastException hazelcastException = new HazelcastException(e.getMessage());
+            hazelcastException.setStackTrace(e.getStackTrace());
+            throw hazelcastException;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ExecuteScriptRequest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.management.request;
 
+import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ScriptExecutorOperation;
 import com.hazelcast.internal.json.JsonArray;
@@ -77,7 +78,7 @@ public class ExecuteScriptRequest implements ConsoleRequest {
             try {
                 addSuccessResponse(responseJson, address, prettyPrint(future.get()));
             } catch (ExecutionException e) {
-                addErrorResponse(responseJson, address, e);
+                addErrorResponse(responseJson, address, e.getCause());
             } catch (InterruptedException e) {
                 addErrorResponse(responseJson, address, e);
                 Thread.currentThread().interrupt();
@@ -121,19 +122,18 @@ public class ExecuteScriptRequest implements ConsoleRequest {
     }
 
     private static void addSuccessResponse(JsonObject root, Address address, String result) {
-
-        addResponse(root, address, true, result);
+        addResponse(root, address, true, result, null);
     }
 
-    private static void addErrorResponse(JsonObject root, Address address, Exception e) {
-        addResponse(root, address, false, ExceptionUtil.toString(e));
+    private static void addErrorResponse(JsonObject root, Address address, Throwable e) {
+        addResponse(root, address, false, e.getMessage(), ExceptionUtil.toString(e));
     }
 
-    private static void addResponse(JsonObject root, Address address, boolean success, String result) {
-
+    private static void addResponse(JsonObject root, Address address, boolean success, String result, String stackTrace) {
         JsonObject json = new JsonObject();
         json.add("success", success);
         json.add("result", result);
+        json.add("stackTrace", stackTrace != null ? Json.value(stackTrace) : Json.NULL);
         root.add(address.toString(), json);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ExecuteScriptRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ExecuteScriptRequestTest.java
@@ -39,6 +39,7 @@ import static com.hazelcast.util.JsonUtil.getString;
 import static java.util.Collections.singleton;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -104,7 +105,8 @@ public class ExecuteScriptRequestTest extends HazelcastTestSupport {
         JsonObject result = (JsonObject) jsonObject.get("result");
         JsonObject json = getObject(result, nodeAddressWithBrackets);
         assertFalse(getBoolean(json, "success"));
-        assertContains(getString(json, "result"), "IllegalArgumentException");
+        assertNotNull(getString(json, "result"));
+        assertContains(getString(json, "stackTrace"), "IllegalArgumentException");
     }
 
     @Test
@@ -118,6 +120,7 @@ public class ExecuteScriptRequestTest extends HazelcastTestSupport {
         JsonObject result = (JsonObject) jsonObject.get("result");
         JsonObject json = getObject(result, nodeAddressWithBrackets);
         assertFalse(getBoolean(json, "success"));
-        assertContains(getString(json, "result"), "ScriptException");
+        assertNotNull(getString(json, "result"));
+        assertContains(getString(json, "stackTrace"), "ScriptException");
     }
 }


### PR DESCRIPTION
Currently, only the stacktrace is reported to MC. With this change,
exception message and stacktrace are reported separately. This way,
MC will report the exception message to the user on the UI and log the
stacktrace to provide more detailed info when needed.

Forward port of #14221