### PR TITLE
Add support for timing out tests only if no progress

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/DefaultTaskProgress.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DefaultTaskProgress.java
@@ -19,15 +19,15 @@ package com.hazelcast.test;
 public class DefaultTaskProgress implements TaskProgress {
     private final long timestamp = System.currentTimeMillis();
     private final int total;
-    private final int replicated;
+    private final int done;
     private final float progress;
     private final boolean completed;
 
-    public DefaultTaskProgress(int total, int replicated) {
+    public DefaultTaskProgress(int total, int done) {
         this.total = total;
-        this.replicated = replicated;
-        this.progress = ((float) replicated) / total;
-        this.completed = total == replicated;
+        this.done = done;
+        this.progress = ((float) done) / total;
+        this.completed = total == done;
     }
 
     @Override
@@ -47,8 +47,6 @@ public class DefaultTaskProgress implements TaskProgress {
 
     @Override
     public String getProgressString() {
-        return new StringBuilder()
-                .append(replicated).append("/").append(total).append("=").append(progress * 100).append("%")
-                .toString();
+        return String.format("%d/%d=%.2f%%", done, total, progress * 100);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/DefaultTaskProgress.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DefaultTaskProgress.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+public class DefaultTaskProgress implements TaskProgress {
+    private final long timestamp = System.currentTimeMillis();
+    private final int total;
+    private final int replicated;
+    private final float progress;
+    private final boolean completed;
+
+    public DefaultTaskProgress(int total, int replicated) {
+        this.total = total;
+        this.replicated = replicated;
+        this.progress = ((float) replicated) / total;
+        this.completed = total == replicated;
+    }
+
+    @Override
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    @Override
+    public float progress() {
+        return progress;
+    }
+
+    @Override
+    public long timestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String getProgressString() {
+        return new StringBuilder()
+                .append(replicated).append("/").append(total).append("=").append(progress * 100).append("%")
+                .toString();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1370,8 +1370,7 @@ public abstract class HazelcastTestSupport {
                 if (progress.isCompleted()) {
                     return;
                 }
-                long lastProgressTimestampCompare = lastProgressTimestamp;
-                boolean toleranceExceeded = progress.timestamp() > lastProgressTimestampCompare
+                boolean toleranceExceeded = progress.timestamp() > lastProgressTimestamp
                         + SECONDS.toMillis(stallToleranceSeconds);
 
                 // we store current progress if the task advanced or the tolerance exceeded
@@ -1390,12 +1389,12 @@ public abstract class HazelcastTestSupport {
                         String elapsedMillisPadded = String.format("%1$5s", elapsedMillis);
                         sb.append("\t")
                           .append(elapsedMillisPadded).append("ms: ")
-                          .append(progress.getProgressString())
+                          .append(historicProgress.getProgressString())
                           .append("\n");
                     }
                     LOGGER.severe(sb.toString());
                     fail("Stall tolerance " + stallToleranceSeconds
-                            + " seconds has been exceeded without completing the task. " + message);
+                            + " seconds has been exceeded without completing the task. " + message != null ? message : "");
                 }
 
                 sleepMillis(sleepMillis);

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -407,7 +407,7 @@ public abstract class HazelcastTestSupport {
 
     public static void sleepSeconds(int seconds) {
         try {
-            TimeUnit.SECONDS.sleep(seconds);
+            SECONDS.sleep(seconds);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
@@ -984,7 +984,7 @@ public abstract class HazelcastTestSupport {
 
     public static void assertJoinable(long timeoutSeconds, Thread... threads) {
         try {
-            long remainingTimeout = TimeUnit.SECONDS.toMillis(timeoutSeconds);
+            long remainingTimeout = SECONDS.toMillis(timeoutSeconds);
             for (Thread thread : threads) {
                 long start = System.currentTimeMillis();
                 thread.join(remainingTimeout);
@@ -1185,7 +1185,7 @@ public abstract class HazelcastTestSupport {
 
     public static void assertOpenEventually(String message, Latch latch, long timeoutSeconds) {
         try {
-            boolean completed = latch.await(timeoutSeconds, TimeUnit.SECONDS);
+            boolean completed = latch.await(timeoutSeconds, SECONDS);
             if (message == null) {
                 assertTrue(format("CountDownLatch failed to complete within %d seconds, count left: %d", timeoutSeconds,
                         latch.getCount()), completed);
@@ -1329,6 +1329,82 @@ public abstract class HazelcastTestSupport {
         assertTrueEventually(message, task, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }
 
+    public static void assertCompletesEventually(String message, ProgressCheckerTask task) {
+        assertCompletesEventually(message, task, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
+    }
+
+    public static void assertCompletesEventually(ProgressCheckerTask task, long stallToleranceSeconds) {
+        assertCompletesEventually(null, task, stallToleranceSeconds);
+    }
+
+    public static void assertCompletesEventually(ProgressCheckerTask task) {
+        assertCompletesEventually(null, task, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
+    }
+
+    /**
+     * Asserts whether the provided task eventually reports completion.
+     * This form of eventual completion check has no strict time bounds.
+     * Instead, it lets the checked test to continue as long as there is
+     * progress observed within the provided stall tolerance time bound.
+     * <p/>
+     * This check may be useful for tests that can provide progress
+     * information to prevent unnecessary failures due to unexpectedly
+     * slow progress.
+     *
+     * @param task                  The task that checking the progress
+     *                              of some operation
+     * @param stallToleranceSeconds The time in seconds that we tolerate
+     *                              without progressing
+     */
+    public static void assertCompletesEventually(String message, ProgressCheckerTask task, long stallToleranceSeconds) {
+        long taskStartTimestamp = System.currentTimeMillis();
+        // we are going to check five times a second
+        int sleepMillis = 200;
+        List<TaskProgress> progresses = new LinkedList<TaskProgress>();
+        long lastProgressTimestamp = System.currentTimeMillis();
+        float lastProgress = 0;
+
+        while (true) {
+            try {
+                TaskProgress progress = task.checkProgress();
+                if (progress.isCompleted()) {
+                    return;
+                }
+                long lastProgressTimestampCompare = lastProgressTimestamp;
+                boolean toleranceExceeded = progress.timestamp() > lastProgressTimestampCompare
+                        + SECONDS.toMillis(stallToleranceSeconds);
+
+                // we store current progress if the task advanced or the tolerance exceeded
+                if (progress.progress() > lastProgress || toleranceExceeded) {
+                    progresses.add(progress);
+                    lastProgressTimestamp = progress.timestamp();
+                    lastProgress = progress.progress();
+                }
+
+                // if the task exceeded stall tolerance, we fail and log the history of the progress changes
+                if (toleranceExceeded) {
+                    StringBuilder sb = new StringBuilder("Stall tolerance " + stallToleranceSeconds + " seconds has been "
+                            + "exceeded without completing the task. Track of progress:\n");
+                    for (TaskProgress historicProgress : progresses) {
+                        long elapsedMillis = historicProgress.timestamp() - taskStartTimestamp;
+                        String elapsedMillisPadded = String.format("%1$5s", elapsedMillis);
+                        sb.append("\t")
+                          .append(elapsedMillisPadded).append("ms: ")
+                          .append(progress.getProgressString())
+                          .append("\n");
+                    }
+                    LOGGER.severe(sb.toString());
+                    fail("Stall tolerance " + stallToleranceSeconds
+                            + " seconds has been exceeded without completing the task. " + message);
+                }
+
+                sleepMillis(sleepMillis);
+            } catch (Exception e) {
+                throw rethrow(e);
+            }
+        }
+    }
+
     public static void assertTrueEventually(AssertTask task) {
         assertTrueEventually(null, task, ASSERT_TRUE_EVENTUALLY_TIMEOUT);
     }
@@ -1381,7 +1457,7 @@ public abstract class HazelcastTestSupport {
     }
 
     public static void assertExactlyOneSuccessfulRun(AssertTask task) {
-        assertExactlyOneSuccessfulRun(task, ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS);
+        assertExactlyOneSuccessfulRun(task, ASSERT_TRUE_EVENTUALLY_TIMEOUT, SECONDS);
     }
 
     public static void assertExactlyOneSuccessfulRun(AssertTask task, int giveUpTime, TimeUnit timeUnit) {

--- a/hazelcast/src/test/java/com/hazelcast/test/ProgressCheckerTask.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/ProgressCheckerTask.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+/**
+ * A task that can report the completion progress of some other tested
+ * task. Used to write tests that can prolong their execution time in slow
+ * environments as long as there is progress.
+ *
+ * @see HazelcastTestSupport#assertCompletesEventually(ProgressCheckerTask, long)
+ * @see TaskProgress
+ */
+public interface ProgressCheckerTask {
+    /**
+     * Collects and returns progress information
+     *
+     * @return the progress information collected
+     */
+    TaskProgress checkProgress();
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/TaskProgress.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TaskProgress.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.test;
+
+/**
+ * Interface of classes that hold progress information of asserted conditions
+ * in tests. Instances of this interface are meant to be created at each
+ * iteration of eventual completion checks.
+ *
+ * @see ProgressCheckerTask
+ * @see HazelcastTestSupport#assertCompletesEventually(ProgressCheckerTask, long)
+ */
+public interface TaskProgress {
+
+    /**
+     * Tells whether the checked task completed or not
+     *
+     * @return {@code true} if the task completed, {@code false} otherwise
+     */
+    boolean isCompleted();
+
+    /**
+     * Returns the current progress as a fractional number between 0 and 1.
+     *
+     * @return the progress
+     */
+    float progress();
+
+    /**
+     * Returns the timestamp when this progress snapshot was taken
+     *
+     * @return the timestamp of the progress snapshot
+     */
+    long timestamp();
+
+    /**
+     * Returns a formatted progress string with the available information.
+     * Called when the available time for the task to complete exceeded.
+     *
+     * @return the formatted progress string
+     */
+    String getProgressString();
+}


### PR DESCRIPTION
Existing `assert*Eventually` methods work with strict time bounds that may
fail a test even if there is progress, but things happen slower than expected.
This change offers a construct for the tests that can report
progress information, based on which the available time for completion
can be prolonged.

Example usage: https://github.com/hazelcast/hazelcast-enterprise/pull/2639