### PR TITLE
Remove updating backup count config via MC

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateMapConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/operation/UpdateMapConfigOperation.java
@@ -54,8 +54,6 @@ public class UpdateMapConfigOperation extends AbstractManagementOperation {
         newConfig.setEvictionPercentage(mapConfig.getEvictionPercentage());
         newConfig.setMinEvictionCheckMillis(mapConfig.getMinEvictionCheckMillis());
         newConfig.setReadBackupData(mapConfig.isReadBackupData());
-        newConfig.setBackupCount(mapConfig.getBackupCount());
-        newConfig.setAsyncBackupCount(mapConfig.getAsyncBackupCount());
         newConfig.setMaxSizeConfig(mapConfig.getMaxSizeConfig());
         MapContainer mapContainer = service.getMapServiceContext().getMapContainer(mapName);
         mapContainer.setMapConfig(newConfig.getAsReadOnly());


### PR DESCRIPTION
New backups are not created when the backup counts are updated. For
this reason, option to update backup counts are removed from MC user
interface.

For more information, see the following:

https://github.com/hazelcast/management-center/issues/784
https://github.com/hazelcast/management-center/pull/1388