### PR TITLE
Additional information in case of thread local leak test failure

### DIFF
--- a/hazelcast/src/test/java/classloading/ThreadLocalLeakTestUtils.java
+++ b/hazelcast/src/test/java/classloading/ThreadLocalLeakTestUtils.java
@@ -68,14 +68,14 @@ public final class ThreadLocalLeakTestUtils {
                 threadLocalMap = threadLocalsField.get(thread);
                 if (threadLocalMap != null) {
                     expungeStaleEntriesMethod.invoke(threadLocalMap);
-                    checkThreadLocalMapForLeaks(cl, threadLocalMap, tableField);
+                    checkThreadLocalMapForLeaks(cl, thread, threadLocalMap, tableField);
                 }
 
                 // clear the second map
                 threadLocalMap = inheritableThreadLocalsField.get(thread);
                 if (threadLocalMap != null) {
                     expungeStaleEntriesMethod.invoke(threadLocalMap);
-                    checkThreadLocalMapForLeaks(cl, threadLocalMap, tableField);
+                    checkThreadLocalMapForLeaks(cl, thread, threadLocalMap, tableField);
                 }
             }
         }
@@ -114,7 +114,8 @@ public final class ThreadLocalLeakTestUtils {
      * Analyzes the given thread local map object. Also pass in the field that points
      * to the internal table to save re-calculating it on every call to this method.
      */
-    private static void checkThreadLocalMapForLeaks(ClassLoader cl, Object map, Field internalTableField) throws Exception {
+    private static void checkThreadLocalMapForLeaks(ClassLoader cl, Thread thread,
+                                                    Object map, Field internalTableField) throws Exception {
         if (map == null) {
             return;
         }
@@ -161,23 +162,27 @@ public final class ThreadLocalLeakTestUtils {
                     }
                 }
                 if (valueLoadedByApplication) {
-                    String message = format("Application created a ThreadLocal with key of type [%s] (value [%s]) and a value of"
-                                    + " type [%s] (value [%s) but failed to remove it when the application was stopped.",
-                            args[0], args[1], args[2], args[3]);
+                    String message = format("Application created a ThreadLocal on thread %s with key of"
+                                    + " type [%s] (value [%s]) and a value of type [%s] (value [%s) but failed"
+                                    + " to remove it when the application was stopped.",
+                            describeThread(thread), args[0], args[1], args[2], args[3]);
                     for (String acceptedThreadLocal : ACCEPTED_THREAD_LOCAL_VALUE_TYPES) {
                         if (acceptedThreadLocal.equals(args[2])) {
                             System.out.println(message + " But the value type is explicitly allowed, so this is no failure.");
                             return;
                         }
                     }
+                    message = checkKnownIssues(message, thread, key);
                     fail(message);
                 } else if (value == null) {
-                    System.out.printf("Application created a ThreadLocal with key of type [%s] (value [%s]). The ThreadLocal"
-                            + " has been correctly set to null and the key will be removed by GC.", args[0], args[1]);
+                    System.out.printf("Application created a ThreadLocal on thread %s with key of type [%s]"
+                            + " (value [%s]). The ThreadLocal has been correctly set to null and the key will be removed by GC.",
+                            describeThread(thread), args[0], args[1]);
                 } else {
-                    System.out.printf("Application created a ThreadLocal with key of type [%s] (value [%s]) and a value of type "
-                            + " [%s] (value [%s]). Since keys are only weakly held by the ThreadLocalMap this is not a memory"
-                            + " leak.", args[0], args[1], args[2], args[3]);
+                    System.out.printf("Application created a ThreadLocal on thread %s with key of type [%s] (value [%s])"
+                            + " and a value of type [%s] (value [%s]). Since keys are only weakly held by the"
+                            + " ThreadLocalMap this is not a memory leak.",
+                            describeThread(thread), args[0], args[1], args[2], args[3]);
                 }
             }
         }
@@ -230,5 +235,28 @@ public final class ThreadLocalLeakTestUtils {
             }
         }
         return false;
+    }
+
+    private static String describeThread(Thread thread) {
+        return format("[%s] of type [%s]", thread.getName(), getPrettyClassName(thread.getClass()));
+    }
+
+    // enhance message with information about known thread locals issues
+    private static String checkKnownIssues(String message, Thread thread, Object key) {
+        if (thread != null && key != null) {
+            String threadClassName = getPrettyClassName(thread.getClass());
+            String keyClassName = getPrettyClassName(key.getClass());
+            if (threadClassName.equals("com.hazelcast.internal.networking.nio.NioThread")
+                    && keyClassName.contains("ClientResponseHandlerSupplier$1")) {
+                // ClientResponseHandlerSupplier$AsyncMultiThreadedResponseHandler creates thread local MutableIntegers
+                // on NioThreads. During shutdown, NioThreads are interrupted but not joined in NioNetworking#shutdown
+                // to avoid delay -> rarely the thread local leak detection may execute before a NioThread was joined
+                // and fail the test.
+                return format("%s - consider that this failure may be due to NioNetworking#shutdown not waiting for"
+                        + " NioThread instances to join.", message);
+            }
+        }
+
+        return message;
     }
 }


### PR DESCRIPTION
Adds thread name & type to failure message, along with hints
for known issues.

Closes #14178 
Rationale behind this PR: https://github.com/hazelcast/hazelcast/issues/14178#issuecomment-446170840