### PR TITLE
YAML to W3C DOM adapter

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -97,6 +97,7 @@
     <suppress checks="MethodCount|MethodLength|FileLength" files="com[\\/]hazelcast[\\/]config[\\/]MemberDomConfigProcessor"/>
     <suppress checks="CyclomaticComplexity|ClassFanOutComplexity|ClassDataAbstractionCoupling"
               files="com[\\/]hazelcast[\\/]config[\\/]MemberDomConfigProcessor"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]config[\\/]yaml[\\/]NodeAdapter"/>
 
     <!-- Concurrent -->
     <suppress checks="Javadoc(Method|Type|Variable)" files="com[\\/]hazelcast[\\/]concurrent[\\/]"/>

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/EmptyNamedNodeMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/EmptyNamedNodeMap.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlMapping;
+import com.hazelcast.internal.yaml.YamlNode;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+/**
+ * Empty {@link NamedNodeMap} implementation. Used by {@link NodeAdapter#getAttributes()}
+ * when wrapping {@link YamlNode}s other than {@link YamlMapping}.
+ */
+final class EmptyNamedNodeMap implements NamedNodeMap {
+    private static final NamedNodeMap INSTANCE = new EmptyNamedNodeMap();
+
+    private EmptyNamedNodeMap() {
+    }
+
+    @Override
+    public Node getNamedItem(String name) {
+        return null;
+    }
+
+    @Override
+    public Node setNamedItem(Node arg) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node removeNamedItem(String name) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node item(int index) {
+        return null;
+    }
+
+    @Override
+    public int getLength() {
+        return 0;
+    }
+
+    @Override
+    public Node getNamedItemNS(String namespaceURI, String localName) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node setNamedItemNS(Node arg) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node removeNamedItemNS(String namespaceURI, String localName) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the singleton instance of this class
+     *
+     * @return an empty {@link NamedNodeMap}
+     * @see #INSTANCE
+     */
+    static NamedNodeMap emptyNamedNodeMap() {
+        return INSTANCE;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/EmptyNodeList.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/EmptyNodeList.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlNode;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * Empty {@link NodeList} implementation. Used by {@link NodeAdapter#getChildNodes()}
+ * when wrapping {@link YamlNode}s with no children.
+ */
+final class EmptyNodeList implements NodeList {
+    private static final NodeList INSTANCE = new EmptyNodeList();
+
+    private EmptyNodeList() {
+    }
+
+    @Override
+    public Node item(int index) {
+        return null;
+    }
+
+    @Override
+    public int getLength() {
+        return 0;
+    }
+
+    /**
+     * Returns the singleton instance of this class
+     *
+     * @return an empty {@link NodeList}
+     * @see #INSTANCE
+     */
+    static NodeList emptyNodeList() {
+        return INSTANCE;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/NamedNodeMapAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/NamedNodeMapAdapter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlMapping;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+
+import static com.hazelcast.config.yaml.W3cDomUtil.asW3cNode;
+import static com.hazelcast.config.yaml.YamlOrderedMappingImpl.asOrderedMapping;
+
+/**
+ * Class adapting {@link YamlMapping} to {@link NamedNodeMap}
+ *
+ * @see YamlOrderedMapping
+ */
+class NamedNodeMapAdapter implements NamedNodeMap {
+    private final YamlOrderedMapping yamlMapping;
+
+    NamedNodeMapAdapter(YamlMapping yamlMapping) {
+        this.yamlMapping = asOrderedMapping(yamlMapping);
+    }
+
+    @Override
+    public Node getNamedItem(String name) {
+        return asW3cNode(yamlMapping.child(name));
+    }
+
+    @Override
+    public Node setNamedItem(Node arg) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node removeNamedItem(String name) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node item(int index) {
+        return asW3cNode(yamlMapping.child(index));
+    }
+
+    @Override
+    public int getLength() {
+        return yamlMapping.childCount();
+    }
+
+    @Override
+    public Node getNamedItemNS(String namespaceURI, String localName) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node setNamedItemNS(Node arg) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node removeNamedItemNS(String namespaceURI, String localName) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/NodeAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/NodeAdapter.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlCollection;
+import com.hazelcast.internal.yaml.YamlMapping;
+import com.hazelcast.internal.yaml.YamlNode;
+import com.hazelcast.internal.yaml.YamlScalar;
+import com.hazelcast.internal.yaml.YamlSequence;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.UserDataHandler;
+
+import static com.hazelcast.config.yaml.EmptyNamedNodeMap.emptyNamedNodeMap;
+import static com.hazelcast.config.yaml.EmptyNodeList.emptyNodeList;
+
+class NodeAdapter implements Node {
+    private final YamlNode yamlNode;
+
+    NodeAdapter(YamlNode yamlNode) {
+        this.yamlNode = yamlNode;
+    }
+
+    @Override
+    public String getNodeName() {
+        return yamlNode.nodeName();
+    }
+
+    @Override
+    public String getNodeValue() throws DOMException {
+        if (yamlNode instanceof YamlScalar) {
+            return ((YamlScalar) yamlNode).nodeValue().toString();
+        }
+        return null;
+    }
+
+    @Override
+    public void setNodeValue(String nodeValue) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public short getNodeType() {
+        return Node.ELEMENT_NODE;
+    }
+
+    @Override
+    public Node getParentNode() {
+        return W3cDomUtil.asW3cNode(yamlNode.parent());
+    }
+
+    @Override
+    public NodeList getChildNodes() {
+        if (!(yamlNode instanceof YamlCollection) || ((YamlCollection) yamlNode).childCount() == 0) {
+            return emptyNodeList();
+        }
+
+        if (yamlNode instanceof YamlMapping) {
+            return new NodeListMappingAdapter((YamlMapping) yamlNode);
+        }
+
+        return new NodeListSequenceAdapter((YamlSequence) yamlNode);
+    }
+
+    @Override
+    public Node getFirstChild() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node getLastChild() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node getPreviousSibling() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node getNextSibling() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public NamedNodeMap getAttributes() {
+        if (yamlNode instanceof YamlMapping) {
+            return new NamedNodeMapAdapter((YamlMapping) yamlNode);
+        }
+        return emptyNamedNodeMap();
+    }
+
+    @Override
+    public Document getOwnerDocument() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node insertBefore(Node newChild, Node refChild) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node replaceChild(Node newChild, Node oldChild) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node removeChild(Node oldChild) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node appendChild(Node newChild) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasChildNodes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node cloneNode(boolean deep) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void normalize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSupported(String feature, String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getNamespaceURI() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPrefix() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setPrefix(String prefix) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalName() {
+        return getNodeName();
+    }
+
+    @Override
+    public boolean hasAttributes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getBaseURI() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public short compareDocumentPosition(Node other) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getTextContent() throws DOMException {
+        return getNodeValue();
+    }
+
+    @Override
+    public void setTextContent(String textContent) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSameNode(Node other) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String lookupPrefix(String namespaceURI) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDefaultNamespace(String namespaceURI) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String lookupNamespaceURI(String prefix) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEqualNode(Node arg) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getFeature(String feature, String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object setUserData(String key, Object data, UserDataHandler handler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getUserData(String key) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/NodeListMappingAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/NodeListMappingAdapter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlMapping;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import static com.hazelcast.config.yaml.W3cDomUtil.asW3cNode;
+import static com.hazelcast.config.yaml.YamlOrderedMappingImpl.asOrderedMapping;
+
+class NodeListMappingAdapter implements NodeList {
+    private final YamlOrderedMapping yamlMapping;
+
+    NodeListMappingAdapter(YamlMapping yamlMapping) {
+        this.yamlMapping = asOrderedMapping(yamlMapping);
+    }
+
+    @Override
+    public Node item(int index) {
+        return asW3cNode(yamlMapping.child(index));
+    }
+
+    @Override
+    public int getLength() {
+        return yamlMapping.childCount();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/NodeListSequenceAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/NodeListSequenceAdapter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlSequence;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import static com.hazelcast.config.yaml.W3cDomUtil.asW3cNode;
+
+class NodeListSequenceAdapter implements NodeList {
+    private final YamlSequence yamlSequence;
+
+    NodeListSequenceAdapter(YamlSequence yamlSequence) {
+        this.yamlSequence = yamlSequence;
+    }
+
+    @Override
+    public Node item(int index) {
+        return asW3cNode(yamlSequence.child(index));
+    }
+
+    @Override
+    public int getLength() {
+        return yamlSequence.childCount();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/W3cDomUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/W3cDomUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlNode;
+import org.w3c.dom.Node;
+
+/**
+ * Utility methods for YAML to W3C adaptors
+ */
+public final class W3cDomUtil {
+    private W3cDomUtil() {
+    }
+
+    /**
+     * Returns an adapted W3C {@link Node} view of the provided {@link YamlNode}
+     *
+     * @param yamlNode The YAML node to adapt
+     * @return the adapted W3C Node or {@code null} if the provided YAML node is {@code null}
+     */
+    public static Node asW3cNode(YamlNode yamlNode) {
+        if (yamlNode == null) {
+            return null;
+        }
+
+        return new NodeAdapter(yamlNode);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlOrderedMapping.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlOrderedMapping.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlMapping;
+import com.hazelcast.internal.yaml.YamlNode;
+
+/**
+ * An ordered view of a {@link YamlMapping}
+ */
+interface YamlOrderedMapping extends YamlMapping {
+
+    /**
+     * Gets a child node by its index
+     *
+     * @param index the index of the child node
+     * @return the child node with the given index if exists,
+     * {@code null} otherwise
+     */
+    YamlNode child(int index);
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlOrderedMappingImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlOrderedMappingImpl.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlMapping;
+import com.hazelcast.internal.yaml.YamlNode;
+import com.hazelcast.internal.yaml.YamlScalar;
+import com.hazelcast.internal.yaml.YamlSequence;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class YamlOrderedMappingImpl implements YamlOrderedMapping {
+    private final YamlMapping wrappedMapping;
+    private final List<YamlNode> randomAccessChildren;
+
+    private YamlOrderedMappingImpl(YamlMapping wrappedMapping) {
+        this.wrappedMapping = wrappedMapping;
+
+        randomAccessChildren = new ArrayList<YamlNode>(wrappedMapping.childCount());
+        copyChildren();
+    }
+
+    @Override
+    public YamlNode child(String name) {
+        return wrappedMapping.child(name);
+    }
+
+    @Override
+    public YamlMapping childAsMapping(String name) {
+        return wrappedMapping.childAsMapping(name);
+    }
+
+    @Override
+    public YamlSequence childAsSequence(String name) {
+        return wrappedMapping.childAsSequence(name);
+    }
+
+    @Override
+    public YamlScalar childAsScalar(String name) {
+        return wrappedMapping.childAsScalar(name);
+    }
+
+    @Override
+    public <T> T childAsScalarValue(String name) {
+        return wrappedMapping.childAsScalarValue(name);
+    }
+
+    @Override
+    public <T> T childAsScalarValue(String name, Class<T> type) {
+        return wrappedMapping.childAsScalarValue(name, type);
+    }
+
+    @Override
+    public Iterable<YamlNode> children() {
+        return wrappedMapping.children();
+    }
+
+    @Override
+    public int childCount() {
+        return wrappedMapping.childCount();
+    }
+
+    @Override
+    public YamlNode parent() {
+        return wrappedMapping.parent();
+    }
+
+    @Override
+    public String nodeName() {
+        return wrappedMapping.nodeName();
+    }
+
+    @Override
+    public YamlNode child(int index) {
+        if (index >= randomAccessChildren.size()) {
+            return null;
+        }
+
+        return randomAccessChildren.get(index);
+    }
+
+    static YamlOrderedMappingImpl asOrderedMapping(YamlMapping yamlMapping) {
+        return new YamlOrderedMappingImpl(yamlMapping);
+    }
+
+    private void copyChildren() {
+        for (YamlNode child : wrappedMapping.children()) {
+            randomAccessChildren.add(child);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains adapter and utility classes needed to adapt YAML DOM classes
+ * as W3C DOM ones, making config builders that accept W3C DOM able to
+ * build the config structure from YAML.
+ * <p/>
+ * This package intentionally lacks fully implementing the  functionality
+ * of the W3C DOM model. Only the parts that required by the Hazelcast
+ * config processors are implemented.
+ * <p/>
+ * The package contains the following adapters:
+ * <ul>
+ * <li>{@link com.hazelcast.internal.yaml.YamlNode} to {@link org.w3c.dom.Node}</li>
+ * <li>{@link com.hazelcast.internal.yaml.YamlCollection} to {@link org.w3c.dom.NodeList}</li>
+ * <li>{@link com.hazelcast.internal.yaml.YamlMapping} to {@link org.w3c.dom.NamedNodeMap}</li>
+ * </ul>
+ */
+package com.hazelcast.config.yaml;

--- a/hazelcast/src/test/java/com/hazelcast/config/yaml/W3cDomTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/yaml/W3cDomTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlLoader;
+import com.hazelcast.internal.yaml.YamlNode;
+import com.hazelcast.internal.yaml.YamlTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.io.InputStream;
+
+import static com.hazelcast.config.yaml.EmptyNamedNodeMap.emptyNamedNodeMap;
+import static com.hazelcast.config.yaml.EmptyNodeList.emptyNodeList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A modified copy of the of the main test case of {@link YamlTest} that
+ * verifies the behavior of the W3C DOM adapters' supported methods.
+ * <p/>
+ * These tests utilize that we work with the node adapters with which we
+ * can access the mapping via getAttributes().
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class W3cDomTest {
+    private static final int NOT_EXISTING = 42;
+
+    @Test
+    public void testYamlExtendedTestFromInputStream() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map-extended.yaml");
+        YamlNode yamlRoot = YamlLoader.load(inputStream, "root-map");
+        Node domRoot = W3cDomUtil.asW3cNode(yamlRoot);
+
+        NamedNodeMap rootAttributes = domRoot.getAttributes();
+        Node embeddedMap = rootAttributes.getNamedItem("embedded-map");
+        NamedNodeMap embeddedMapAttributes = embeddedMap.getAttributes();
+        String scalarString = embeddedMapAttributes.getNamedItem("scalar-str").getTextContent();
+        int scalarInt = Integer.parseInt(embeddedMapAttributes.getNamedItem("scalar-int").getTextContent());
+        double scalarDouble = Double.parseDouble(embeddedMapAttributes.getNamedItem("scalar-double").getTextContent());
+        boolean scalarBool = Boolean.parseBoolean(embeddedMapAttributes.getNamedItem("scalar-bool").getTextContent());
+
+        Node embeddedListNode = embeddedMapAttributes.getNamedItem("embedded-list");
+        NodeList embeddedList = embeddedListNode.getChildNodes();
+        String elItem0 = embeddedList.item(0).getTextContent();
+        Node elItem0AsNode = embeddedList.item(0);
+        int elItem1 = Integer.parseInt(embeddedList.item(1).getTextContent());
+        double elItem2 = Double.parseDouble(embeddedList.item(2).getTextContent());
+        boolean elItem3 = Boolean.parseBoolean(embeddedList.item(3).getTextContent());
+
+        NodeList embeddedList2 = embeddedMapAttributes.getNamedItem("embedded-list2").getChildNodes();
+        String el2Item0 = embeddedList2.item(0).getTextContent();
+        double el2Item1 = Double.parseDouble(embeddedList2.item(1).getTextContent());
+
+        String keysValue = embeddedList.item(4).getAttributes().getNamedItem("key").getTextContent();
+        String multilineStr = domRoot.getAttributes().getNamedItem("multiline-str").getTextContent();
+
+        assertEquals("embedded-map", embeddedMap.getNodeName());
+        assertEquals("scalar-str", embeddedMap.getChildNodes().item(0).getNodeName());
+        assertNull(embeddedMap.getChildNodes().item(NOT_EXISTING));
+        assertNull(embeddedMap.getTextContent());
+        assertEquals("embedded-list", embeddedMapAttributes.item(4).getNodeName());
+        assertEquals("embedded-list", embeddedListNode.getNodeName());
+        assertEquals("embedded-map", embeddedListNode.getParentNode().getNodeName());
+        assertSame(emptyNamedNodeMap(), embeddedListNode.getAttributes());
+
+        assertEquals(6, embeddedMap.getAttributes().getLength());
+
+        // root-map/embedded-map/scalars
+        assertEquals(6, embeddedMap.getChildNodes().getLength());
+        assertEquals("h4z3lc4st", scalarString);
+        assertEquals(123, scalarInt);
+        assertEquals(123.12312D, scalarDouble, 10E-5);
+        assertTrue(scalarBool);
+
+        // root-map/embedded-map/embedded-list
+        assertEquals("value1", elItem0);
+        assertEquals(NOT_EXISTING, elItem1);
+        assertEquals(42.42D, elItem2, 10E-2);
+        assertFalse(elItem3);
+        assertSame(emptyNodeList(), elItem0AsNode.getChildNodes());
+        assertEquals("value1", elItem0AsNode.getNodeValue());
+
+        // root-map/embedded-map/embedded-list2
+        assertEquals(2, embeddedList2.getLength());
+        assertEquals("value2", el2Item0);
+        assertEquals(1D, el2Item1, 10E-1);
+
+        assertEquals("value", keysValue);
+
+        assertEquals("Hazelcast IMDG\n"
+                + "The Leading Open Source In-Memory Data Grid:\n"
+                + "Distributed Computing, Simplified.\n", multilineStr);
+
+    }
+}


### PR DESCRIPTION
Classes adapt YamlNode tree as W3C Node tree.
See package-info.java for more details.

Depends on https://github.com/hazelcast/hazelcast/pull/14237