### PR TITLE
Replace abstract method with concrete one in AbstractNearCacheStore

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheDataRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheDataRecordStore.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.nearcache.impl.record.NearCacheDataRecord;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 
-import static com.hazelcast.internal.nearcache.NearCache.CACHED_AS_NULL;
 import static com.hazelcast.internal.nearcache.NearCacheRecord.TIME_NOT_SET;
 import static com.hazelcast.internal.nearcache.impl.record.AbstractNearCacheRecord.NUMBER_OF_INTEGER_FIELD_TYPES;
 import static com.hazelcast.internal.nearcache.impl.record.AbstractNearCacheRecord.NUMBER_OF_LONG_FIELD_TYPES;
@@ -79,7 +78,7 @@ public class NearCacheDataRecordStore<K, V> extends BaseHeapNearCacheRecordStore
     }
 
     @Override
-    protected NearCacheDataRecord valueToRecord(V value) {
+    protected NearCacheDataRecord createRecord(V value) {
         Data dataValue = toData(value);
         long creationTime = currentTimeMillis();
         if (timeToLiveMillis > 0) {
@@ -87,14 +86,6 @@ public class NearCacheDataRecordStore<K, V> extends BaseHeapNearCacheRecordStore
         } else {
             return new NearCacheDataRecord(dataValue, creationTime, TIME_NOT_SET);
         }
-    }
-
-    @Override
-    protected V recordToValue(NearCacheDataRecord record) {
-        if (record.getValue() == null) {
-            return (V) CACHED_AS_NULL;
-        }
-        return toValue(record.getValue());
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheObjectRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/store/NearCacheObjectRecordStore.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.internal.nearcache.impl.record.NearCacheObjectRecord;
 import com.hazelcast.spi.serialization.SerializationService;
 
-import static com.hazelcast.internal.nearcache.NearCache.CACHED_AS_NULL;
 import static com.hazelcast.internal.nearcache.NearCacheRecord.TIME_NOT_SET;
 import static com.hazelcast.util.Clock.currentTimeMillis;
 
@@ -53,7 +52,7 @@ public class NearCacheObjectRecordStore<K, V> extends BaseHeapNearCacheRecordSto
     }
 
     @Override
-    protected NearCacheObjectRecord<V> valueToRecord(V value) {
+    protected NearCacheObjectRecord<V> createRecord(V value) {
         value = toValue(value);
         long creationTime = currentTimeMillis();
         if (timeToLiveMillis > 0) {
@@ -66,13 +65,5 @@ public class NearCacheObjectRecordStore<K, V> extends BaseHeapNearCacheRecordSto
     @Override
     protected void updateRecordValue(NearCacheObjectRecord<V> record, V value) {
         record.setValue(toValue(value));
-    }
-
-    @Override
-    protected V recordToValue(NearCacheObjectRecord<V> record) {
-        if (record.getValue() == null) {
-            return (V) CACHED_AS_NULL;
-        }
-        return record.getValue();
     }
 }


### PR DESCRIPTION
RecordToValue method doesnt have to be abstract as the subclasses that implement it have the same functionality.
ValueToRecord is renamed as createRecordFromValue as the name does not reflect the behavior of the method.