### PR TITLE
Minor AuthenticationBaseMessageTask cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -24,7 +24,6 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Member;
 import com.hazelcast.instance.Node;
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionType;
@@ -40,6 +39,10 @@ import javax.security.auth.login.LoginException;
 import java.security.Permission;
 import java.util.Collections;
 import java.util.List;
+
+import static com.hazelcast.client.impl.protocol.AuthenticationStatus.AUTHENTICATED;
+import static com.hazelcast.client.impl.protocol.AuthenticationStatus.CREDENTIALS_FAILED;
+import static com.hazelcast.client.impl.protocol.AuthenticationStatus.SERIALIZATION_VERSION_MISMATCH;
 
 /**
  * Base authentication task
@@ -68,80 +71,62 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClu
         return prepareAuthenticatedClientMessage();
     }
 
-
     protected void doRun() throws Throwable {
         initializeAndProcessMessage();
     }
 
     @Override
     public void processMessage() throws Throwable {
-        byte serializationServiceVersion = serializationService.getVersion();
-        AuthenticationStatus authenticationStatus;
-        if (clientSerializationVersion != serializationServiceVersion) {
-            sendClientMessage(prepareSerializationVersionMismatchClientMessage());
-            return;
-        }
-
-        authenticationStatus = authenticate();
-        if (authenticationStatus == AuthenticationStatus.CREDENTIALS_FAILED) {
-            sendClientMessage(prepareUnauthenticatedClientMessage());
-            return;
-        }
-
-        if (!isOwnerConnection()) {
-            prepareAndSendResponse(authenticationStatus);
-            return;
-        }
-        String uuid = getUuid();
-        String localMemberUUID = clientEngine.getThisUuid();
-        principal = new ClientPrincipal(uuid, localMemberUUID);
-        if (logger.isFineEnabled()) {
-            logger.fine("Processing owner authentication with principal " + principal);
-        }
-        super.processMessage();
-    }
-
-    private void prepareAndSendResponse(AuthenticationStatus authenticationStatus) {
-        boolean isNotMember = clientEngine.getClusterService().getMember(principal.getOwnerUuid()) == null;
-        if (isNotMember) {
-            logger.warning("Member having UUID " + principal.getOwnerUuid()
-                    + " is not part of the cluster. Client Authentication rejected.");
-            authenticationStatus = AuthenticationStatus.CREDENTIALS_FAILED;
-        }
-
-        switch (authenticationStatus) {
-            case AUTHENTICATED:
-                sendClientMessage(prepareAuthenticatedClientMessage());
+        switch (authenticate()) {
+            case SERIALIZATION_VERSION_MISMATCH:
+                sendClientMessage(prepareSerializationVersionMismatchClientMessage());
                 break;
             case CREDENTIALS_FAILED:
                 sendClientMessage(prepareUnauthenticatedClientMessage());
                 break;
-            case SERIALIZATION_VERSION_MISMATCH:
-                sendClientMessage(prepareSerializationVersionMismatchClientMessage());
+            case AUTHENTICATED:
+                if (isOwnerConnection()) {
+                    principal = new ClientPrincipal(getUuid(), clientEngine.getThisUuid());
+                    if (logger.isFineEnabled()) {
+                        logger.fine("Processing owner authentication with principal " + principal);
+                    }
+                    super.processMessage();
+                } else {
+                    sendClientMessage(prepareAuthenticatedClientMessage());
+                }
                 break;
             default:
-                sendClientMessage(new IllegalStateException("Unsupported authentication status: " + authenticationStatus));
+                throw new IllegalStateException("Unhandled authentication result");
         }
     }
 
     private AuthenticationStatus authenticate() {
-        ILogger logger = clientEngine.getLogger(getClass());
-        AuthenticationStatus status;
-        if (credentials == null) {
-            status = AuthenticationStatus.CREDENTIALS_FAILED;
+        if (clientSerializationVersion != serializationService.getVersion()) {
+            return SERIALIZATION_VERSION_MISMATCH;
+        }
+
+        if (!isOwnerConnection() && !isMember(principal)) {
+            logger.warning("Member having UUID " + principal.getOwnerUuid()
+                    + " is not part of the cluster. Client Authentication rejected.");
+            return CREDENTIALS_FAILED;
+        } else if (credentials == null) {
             logger.severe("Could not retrieve Credentials object!");
+            return CREDENTIALS_FAILED;
         } else if (clientEngine.getSecurityContext() != null) {
-            status = authenticate(clientEngine.getSecurityContext());
+            return authenticate(clientEngine.getSecurityContext());
         } else if (credentials instanceof UsernamePasswordCredentials) {
             UsernamePasswordCredentials usernamePasswordCredentials = (UsernamePasswordCredentials) credentials;
-            status = authenticate(usernamePasswordCredentials);
+            return authenticate(usernamePasswordCredentials);
         } else {
-            status = AuthenticationStatus.CREDENTIALS_FAILED;
             logger.severe("Hazelcast security is disabled.\nUsernamePasswordCredentials or cluster "
                     + "group-name and group-password should be used for authentication!\n" + "Current credentials type is: "
                     + credentials.getClass().getName());
+            return CREDENTIALS_FAILED;
         }
-        return status;
+    }
+
+    private boolean isMember(ClientPrincipal principal) {
+        return clientEngine.getClusterService().getMember(principal.getOwnerUuid()) != null;
     }
 
     private AuthenticationStatus authenticate(SecurityContext securityContext) {
@@ -151,10 +136,10 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClu
             LoginContext lc = securityContext.createClientLoginContext(credentials);
             lc.login();
             endpoint.setLoginContext(lc);
-            return AuthenticationStatus.AUTHENTICATED;
+            return AUTHENTICATED;
         } catch (LoginException e) {
             logger.warning(e);
-            return AuthenticationStatus.CREDENTIALS_FAILED;
+            return CREDENTIALS_FAILED;
         }
     }
 
@@ -162,25 +147,23 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClu
         GroupConfig groupConfig = nodeEngine.getConfig().getGroupConfig();
         String nodeGroupName = groupConfig.getName();
         boolean usernameMatch = nodeGroupName.equals(credentials.getUsername());
-        return usernameMatch ? AuthenticationStatus.AUTHENTICATED : AuthenticationStatus.CREDENTIALS_FAILED;
+        return usernameMatch ? AUTHENTICATED : CREDENTIALS_FAILED;
     }
 
     private ClientMessage prepareUnauthenticatedClientMessage() {
         Connection connection = endpoint.getConnection();
-        ILogger logger = clientEngine.getLogger(getClass());
         logger.warning("Received auth from " + connection + " with principal " + principal + ", authentication failed");
-        byte status = AuthenticationStatus.CREDENTIALS_FAILED.getId();
+        byte status = CREDENTIALS_FAILED.getId();
         return encodeAuth(status, null, null, null, serializationService.getVersion(), null);
     }
 
     private ClientMessage prepareSerializationVersionMismatchClientMessage() {
-        return encodeAuth(AuthenticationStatus.SERIALIZATION_VERSION_MISMATCH.getId(), null, null, null,
+        return encodeAuth(SERIALIZATION_VERSION_MISMATCH.getId(), null, null, null,
                 serializationService.getVersion(), null);
     }
 
     private ClientMessage prepareAuthenticatedClientMessage() {
         Connection connection = endpoint.getConnection();
-        ILogger logger = clientEngine.getLogger(getClass());
 
         endpoint.authenticated(principal, credentials, isOwnerConnection(), clientVersion, clientMessage.getCorrelationId());
         setConnectionType();
@@ -191,7 +174,7 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClu
         }
 
         final Address thisAddress = clientEngine.getThisAddress();
-        byte status = AuthenticationStatus.AUTHENTICATED.getId();
+        byte status = AUTHENTICATED.getId();
         return encodeAuth(status, thisAddress, principal.getUuid(), principal.getOwnerUuid(),
                 serializationService.getVersion(), Collections.<Member>emptyList());
     }
@@ -213,7 +196,7 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClu
         } else if (ClientTypes.GO.equals(type)) {
             connection.setType(ConnectionType.GO_CLIENT);
         } else {
-            clientEngine.getLogger(getClass()).info("Unknown client type: " + type);
+            logger.info("Unknown client type: " + type);
             connection.setType(ConnectionType.BINARY_CLIENT);
         }
     }
@@ -231,7 +214,6 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClu
         }
         return UuidUtil.createClientUuid(endpoint.getConnection().getEndPoint());
     }
-
 
     @Override
     public Permission getRequiredPermission() {


### PR DESCRIPTION
- the processMessage method is simplified to a single
  switch case that reacts on the authenication result
- authenticate method deals with serialization mismatch as
  that is one of the authentication values. Helps to make the
  authentication method self contained
- moved the isNotMember logic that validates that authentication
  has failed into the authenticate method so that the authenticate
  method is self contained.
- removal of getLogger since the logger is already set on
  parent class.
- static imports for some enums