### PR TITLE
Removed Extractors.empty method, introduced Extractors builder

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPagingPredicateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPagingPredicateTest.java
@@ -346,8 +346,9 @@ public class ClientPagingPredicateTest extends HazelcastTestSupport {
             set = map.entrySet(pagingPredicate);
             for (Map.Entry<Integer, Employee> entry : set) {
                 Employee e = entry.getValue();
-                QueryEntry qe = new QueryEntry((InternalSerializationService) serializationService,
-                        serializationService.toData(e.getId()), e, Extractors.empty());
+                InternalSerializationService ss = (InternalSerializationService) serializationService;
+                QueryEntry qe = new QueryEntry(ss,
+                        ss.toData(e.getId()), e, Extractors.newBuilder(ss).build());
                 assertTrue(predicate.apply(qe));
                 results.add(e);
             }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractFilteringStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractFilteringStrategy.java
@@ -25,7 +25,6 @@ import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
 import com.hazelcast.spi.EventFilter;
-import com.hazelcast.spi.serialization.SerializationService;
 
 /**
  * A common abstract class to support implementations of filtering strategies.
@@ -35,10 +34,11 @@ import com.hazelcast.spi.serialization.SerializationService;
  */
 public abstract class AbstractFilteringStrategy implements FilteringStrategy {
 
-    protected final SerializationService serializationService;
+    protected final InternalSerializationService serializationService;
     protected final MapServiceContext mapServiceContext;
 
-    public AbstractFilteringStrategy(SerializationService serializationService, MapServiceContext mapServiceContext) {
+    public AbstractFilteringStrategy(InternalSerializationService serializationService,
+                                     MapServiceContext mapServiceContext) {
         this.serializationService = serializationService;
         this.mapServiceContext = mapServiceContext;
     }
@@ -72,7 +72,7 @@ public abstract class AbstractFilteringStrategy implements FilteringStrategy {
     protected boolean evaluateQueryEventFilter(EventFilter filter, Data dataKey, Object testValue, String mapNameOrNull) {
         Extractors extractors = getExtractorsForMapName(mapNameOrNull);
         QueryEventFilter queryEventFilter = (QueryEventFilter) filter;
-        QueryableEntry entry = new CachedQueryEntry((InternalSerializationService) serializationService,
+        QueryableEntry entry = new CachedQueryEntry(serializationService,
                 dataKey, testValue, extractors);
         return queryEventFilter.eval(entry);
     }
@@ -83,7 +83,8 @@ public abstract class AbstractFilteringStrategy implements FilteringStrategy {
      */
     private Extractors getExtractorsForMapName(String mapNameOrNull) {
         if (mapNameOrNull == null) {
-            return Extractors.empty();
+            return Extractors.newBuilder(serializationService)
+                    .build();
         }
         return mapServiceContext.getExtractors(mapNameOrNull);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/DefaultEntryEventFilteringStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/DefaultEntryEventFilteringStrategy.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.event;
 
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.EntryEventFilter;
 import com.hazelcast.map.impl.EventListenerFilter;
 import com.hazelcast.map.impl.MapPartitionLostEventFilter;
@@ -26,7 +27,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
-import com.hazelcast.spi.serialization.SerializationService;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -49,7 +49,8 @@ import static com.hazelcast.core.EntryEventType.REMOVED;
  */
 public class DefaultEntryEventFilteringStrategy extends AbstractFilteringStrategy {
 
-    public DefaultEntryEventFilteringStrategy(SerializationService serializationService, MapServiceContext mapServiceContext) {
+    public DefaultEntryEventFilteringStrategy(InternalSerializationService serializationService,
+                                              MapServiceContext mapServiceContext) {
         super(serializationService, mapServiceContext);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheNaturalFilteringStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheNaturalFilteringStrategy.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.event;
 
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.EntryEventFilter;
 import com.hazelcast.map.impl.EventListenerFilter;
 import com.hazelcast.map.impl.MapPartitionLostEventFilter;
@@ -27,7 +28,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.impl.eventservice.impl.TrueEventFilter;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.collection.Int2ObjectHashMap;
 
 import java.util.Collection;
@@ -82,7 +82,8 @@ public class QueryCacheNaturalFilteringStrategy extends AbstractFilteringStrateg
     // Default capacity of event-type > EventData map.
     private static final int EVENT_DATA_MAP_CAPACITY = 4;
 
-    public QueryCacheNaturalFilteringStrategy(SerializationService serializationService, MapServiceContext mapServiceContext) {
+    public QueryCacheNaturalFilteringStrategy(InternalSerializationService serializationService,
+                                              MapServiceContext mapServiceContext) {
         super(serializationService, mapServiceContext);
     }
 
@@ -154,8 +155,12 @@ public class QueryCacheNaturalFilteringStrategy extends AbstractFilteringStrateg
         return "QueryCacheNaturalFilteringStrategy";
     }
 
-    private int processQueryEventFilterWithAlternativeEventType(EventFilter filter, EntryEventType eventType,
-                                                Data dataKey, Object dataOldValue, Object dataValue, String mapNameOrNull) {
+    private int processQueryEventFilterWithAlternativeEventType(EventFilter filter,
+                                                                EntryEventType eventType,
+                                                                Data dataKey,
+                                                                Object dataOldValue,
+                                                                Object dataValue,
+                                                                String mapNameOrNull) {
         if (eventType == UPDATED) {
             // need to evaluate the filter on both old and new value and morph accordingly the event type
             boolean newValueMatches = evaluateQueryEventFilter(filter, dataKey, dataValue, mapNameOrNull);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -58,7 +58,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
     protected final QueryCacheRecordStore recordStore;
     protected final PartitioningStrategy partitioningStrategy;
     protected final InternalSerializationService serializationService;
-    protected final Extractors extractors = Extractors.empty();
+    protected final Extractors extractors;
     /**
      * ID of registered listener on publisher side.
      */
@@ -79,6 +79,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
         this.indexes = Indexes.newBuilder(serializationService, COPY_ON_READ).build();
         this.includeValue = isIncludeValue();
         this.partitioningStrategy = getPartitioningStrategy();
+        this.extractors = Extractors.newBuilder(serializationService).build();
         this.recordStore = new DefaultQueryCacheRecordStore(serializationService, indexes,
                 queryCacheConfig, getEvictionListener(), extractors);
 

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/DistinctValuesAggregation.java
@@ -29,6 +29,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.query.impl.getters.Extractors;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -206,6 +207,7 @@ public class DistinctValuesAggregation<Key, Value, DistinctType>
             entry.setKey(key);
             entry.setValue(value);
             entry.setSerializationService(((DefaultContext) context).getSerializationService());
+            entry.setExtractors(Extractors.newBuilder(((DefaultContext) context).getSerializationService()).build());
             DistinctType valueOut = supplier.apply(entry);
             if (valueOut != null) {
                 context.emit(mappingKey, valueOut);

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
@@ -16,13 +16,10 @@
 
 package com.hazelcast.mapreduce.aggregation.impl;
 
-import com.hazelcast.config.MapAttributeConfig;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
-
-import java.util.Collections;
 
 /**
  * Internal implementation of an map entry with changeable value to prevent
@@ -31,14 +28,12 @@ import java.util.Collections;
  * @param <K> key type
  * @param <V> value type
  */
-final class SimpleEntry<K, V>
-        extends QueryableEntry<K, V> {
+final class SimpleEntry<K, V> extends QueryableEntry<K, V> {
 
     private K key;
     private V value;
 
     public SimpleEntry() {
-        this.extractors = new Extractors(Collections.<MapAttributeConfig>emptyList(), null);
     }
 
     @Override
@@ -83,4 +78,7 @@ final class SimpleEntry<K, V>
         this.serializationService = serializationService;
     }
 
+    void setExtractors(Extractors extractors) {
+        this.extractors = extractors;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SupplierConsumingMapper.java
@@ -24,6 +24,7 @@ import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.query.impl.getters.Extractors;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -56,6 +57,7 @@ class SupplierConsumingMapper<Key, ValueIn, ValueOut>
         entry.setKey(key);
         entry.setValue(value);
         entry.setSerializationService(((DefaultContext) context).getSerializationService());
+        entry.setExtractors(Extractors.newBuilder(((DefaultContext) context).getSerializationService()).build());
         ValueOut valueOut = supplier.apply(entry);
         if (valueOut != null) {
             context.emit(key, valueOut);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -66,7 +66,7 @@ public class Indexes {
         this.serializationService = serializationService;
         this.usesCachedQueryableEntries = usesCachedQueryableEntries;
         this.stats = createStats(global, statisticsEnabled);
-        this.extractors = extractors == null ? Extractors.empty() : extractors;
+        this.extractors = extractors == null ? Extractors.newBuilder(serializationService).build() : extractors;
         this.indexProvider = indexProvider == null ? new DefaultIndexProvider() : indexProvider;
         this.queryContextProvider = createQueryContextProvider(this, global, statisticsEnabled);
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
@@ -79,7 +79,7 @@ public abstract class QueryableEntry<K, V> implements Extractable, Map.Entry<K, 
             boolean isKey = startsWithKeyConstant(attributeName);
             attributeName = getAttributeName(isKey, attributeName);
             Object target = getTargetObject(isKey);
-            result = extractAttributeValueFromTargetObject(extractors, serializationService, attributeName, target);
+            result = extractAttributeValueFromTargetObject(extractors, attributeName, target);
         }
         return result;
     }
@@ -108,7 +108,7 @@ public abstract class QueryableEntry<K, V> implements Extractable, Map.Entry<K, 
             boolean isKey = startsWithKeyConstant(attributeName);
             attributeName = getAttributeName(isKey, attributeName);
             Object target = isKey ? key : value;
-            result = extractAttributeValueFromTargetObject(extractors, serializationService, attributeName, target);
+            result = extractAttributeValueFromTargetObject(extractors, attributeName, target);
         }
         return result;
     }
@@ -139,9 +139,8 @@ public abstract class QueryableEntry<K, V> implements Extractable, Map.Entry<K, 
     }
 
     private static Object extractAttributeValueFromTargetObject(Extractors extractors,
-                                                                InternalSerializationService serializationService,
                                                                 String attributeName, Object target) {
-        return extractors.extract(serializationService, target, attributeName);
+        return extractors.extract(target, attributeName);
     }
 
     private AttributeType extractAttributeType(String attributeName) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -23,6 +23,7 @@ import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.extractor.ValueExtractor;
 import com.hazelcast.query.impl.DefaultArgumentParser;
+import com.hazelcast.util.Preconditions;
 
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +31,7 @@ import java.util.Map;
 
 import static com.hazelcast.query.impl.getters.ExtractorHelper.extractArgumentsFromAttributeName;
 import static com.hazelcast.query.impl.getters.ExtractorHelper.extractAttributeNameNameWithoutArguments;
+import static com.hazelcast.query.impl.getters.ExtractorHelper.instantiateExtractors;
 
 // one instance per MapContainer
 public final class Extractors {
@@ -41,26 +43,31 @@ public final class Extractors {
     private volatile PortableGetter genericPortableGetter;
 
     /**
-     * Maps the extractorAttributeName WITHOUT the arguments to a ValueExtractor instance.
-     * The name does not contain the argument since it's not allowed to register an extractor under an attribute name
-     * that contains an argument in square brackets.
+     * Maps the extractorAttributeName WITHOUT the arguments to a
+     * ValueExtractor instance. The name does not contain the argument
+     * since it's not allowed to register an extractor under an
+     * attribute name that contains an argument in square brackets.
      */
     private final Map<String, ValueExtractor> extractors;
+    private final InternalSerializationService ss;
     private final EvictableGetterCache getterCache;
     private final DefaultArgumentParser argumentsParser;
 
-    // TODO InternalSerializationService should be passed in constructor
-    public Extractors(List<MapAttributeConfig> mapAttributeConfigs, ClassLoader classLoader) {
-        this.extractors = ExtractorHelper.instantiateExtractors(mapAttributeConfigs, classLoader);
-        this.getterCache = new EvictableGetterCache(MAX_CLASSES_IN_CACHE, MAX_GETTERS_PER_CLASS_IN_CACHE,
-                EVICTION_PERCENTAGE, false);
+    private Extractors(List<MapAttributeConfig> mapAttributeConfigs,
+                       ClassLoader classLoader, InternalSerializationService ss) {
+        this.extractors = mapAttributeConfigs == null
+                ? Collections.<String, ValueExtractor>emptyMap()
+                : instantiateExtractors(mapAttributeConfigs, classLoader);
+        this.getterCache = new EvictableGetterCache(MAX_CLASSES_IN_CACHE,
+                MAX_GETTERS_PER_CLASS_IN_CACHE, EVICTION_PERCENTAGE, false);
         this.argumentsParser = new DefaultArgumentParser();
+        this.ss = ss;
     }
 
-    public Object extract(InternalSerializationService serializationService, Object target, String attributeName) {
-        Object targetObject = getTargetObject(serializationService, target);
+    public Object extract(Object target, String attributeName) {
+        Object targetObject = getTargetObject(target);
         if (targetObject != null) {
-            Getter getter = getGetter(serializationService, targetObject, attributeName);
+            Getter getter = getGetter(targetObject, attributeName);
             try {
                 return getter.getValue(targetObject, attributeName);
             } catch (Exception ex) {
@@ -71,12 +78,13 @@ public final class Extractors {
     }
 
     /**
-     * @return Data (in this case it's portable) or Object (in this case it's non-portable)
+     * @return Data (in this case it's portable) or Object (in this case it's
+     * non-portable)
      */
-    private static Object getTargetObject(InternalSerializationService serializationService, Object target) {
+    private Object getTargetObject(Object target) {
         Data targetData;
         if (target instanceof Portable) {
-            targetData = serializationService.toData(target);
+            targetData = ss.toData(target);
             if (targetData.isPortable()) {
                 return targetData;
             }
@@ -88,17 +96,17 @@ public final class Extractors {
                 return targetData;
             } else {
                 // convert non-portable Data to object
-                return serializationService.toObject(target);
+                return ss.toObject(target);
             }
         }
 
         return target;
     }
 
-    Getter getGetter(InternalSerializationService serializationService, Object targetObject, String attributeName) {
+    Getter getGetter(Object targetObject, String attributeName) {
         Getter getter = getterCache.getGetter(targetObject.getClass(), attributeName);
         if (getter == null) {
-            getter = instantiateGetter(serializationService, targetObject, attributeName);
+            getter = instantiateGetter(targetObject, attributeName);
             if (getter.isCacheable()) {
                 getterCache.putGetter(targetObject.getClass(), attributeName, getter);
             }
@@ -106,18 +114,17 @@ public final class Extractors {
         return getter;
     }
 
-    private Getter instantiateGetter(InternalSerializationService serializationService,
-                                     Object targetObject, String attributeName) {
+    private Getter instantiateGetter(Object targetObject, String attributeName) {
         String attributeNameWithoutArguments = extractAttributeNameNameWithoutArguments(attributeName);
         ValueExtractor valueExtractor = extractors.get(attributeNameWithoutArguments);
         if (valueExtractor != null) {
             Object arguments = argumentsParser.parse(extractArgumentsFromAttributeName(attributeName));
-            return new ExtractorGetter(serializationService, valueExtractor, arguments);
+            return new ExtractorGetter(ss, valueExtractor, arguments);
         } else {
             if (targetObject instanceof Data) {
                 if (genericPortableGetter == null) {
                     // will be initialised a couple of times in the worst case
-                    genericPortableGetter = new PortableGetter(serializationService);
+                    genericPortableGetter = new PortableGetter(ss);
                 }
                 return genericPortableGetter;
             } else {
@@ -126,8 +133,38 @@ public final class Extractors {
         }
     }
 
-    public static Extractors empty() {
-        return new Extractors(Collections.<MapAttributeConfig>emptyList(), null);
+    public static Extractors.Builder newBuilder(InternalSerializationService ss) {
+        return new Extractors.Builder(ss);
     }
 
+    /**
+     * Builder which is used to create a new Extractors object.
+     */
+    public static final class Builder {
+        private ClassLoader classLoader;
+        private List<MapAttributeConfig> mapAttributeConfigs;
+
+        private final InternalSerializationService ss;
+
+        public Builder(InternalSerializationService ss) {
+            this.ss = Preconditions.checkNotNull(ss);
+        }
+
+        public Builder setMapAttributeConfigs(List<MapAttributeConfig> mapAttributeConfigs) {
+            this.mapAttributeConfigs = mapAttributeConfigs;
+            return this;
+        }
+
+        public Builder setClassLoader(ClassLoader classLoader) {
+            this.classLoader = classLoader;
+            return this;
+        }
+
+        /**
+         * @return a new instance of Extractors
+         */
+        public Extractors build() {
+            return new Extractors(mapAttributeConfigs, classLoader, ss);
+        }
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AvgAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AvgAggregationTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.aggregation;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -23,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import javax.annotation.Nonnull;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -56,6 +59,8 @@ public class AvgAggregationTest {
 
     public static final double ERROR = 1e-8;
 
+    private final InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
+
     @Test(timeout = TimeoutInMillis.MINUTE)
     public void testBigDecimalAvg() {
         List<BigDecimal> values = sampleBigDecimals();
@@ -82,7 +87,7 @@ public class AvgAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigDecimal> aggregation = Aggregators.bigDecimalAvg("bigDecimal");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(newExtractableEntryWithValue(value));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigDecimal> resultAggregation
@@ -102,7 +107,7 @@ public class AvgAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testBigDecimalAvg_withAttributePath_withNull() {
         Aggregator<Map.Entry, BigDecimal> aggregation = Aggregators.bigDecimalAvg("bigDecimal");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(newExtractableEntryWithValue(null));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -132,7 +137,7 @@ public class AvgAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigDecimal> aggregation = Aggregators.bigIntegerAvg("bigInteger");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(newExtractableEntryWithValue(value));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigDecimal> resultAggregation
@@ -152,7 +157,7 @@ public class AvgAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testBigIntegerAvg_withAttributePath_withNull() {
         Aggregator<Map.Entry, BigDecimal> aggregation = Aggregators.bigIntegerAvg("bigDecimal");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(newExtractableEntryWithValue(null));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -179,7 +184,7 @@ public class AvgAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> aggregation = Aggregators.doubleAvg("doubleValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(newExtractableEntryWithValue(value));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> resultAggregation = Aggregators.doubleAvg("doubleValue");
@@ -198,7 +203,7 @@ public class AvgAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testDoubleAvg_withAttributePath_withNull() {
         Aggregator<Map.Entry, Double> aggregation = Aggregators.doubleAvg("bigDecimal");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(newExtractableEntryWithValue(null));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -225,7 +230,7 @@ public class AvgAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> aggregation = Aggregators.integerAvg("intValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(newExtractableEntryWithValue(value));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> resultAggregation = Aggregators.integerAvg("intValue");
@@ -244,7 +249,7 @@ public class AvgAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testIntegerAvg_withAttributePath_withNull() {
         Aggregator<Map.Entry, Double> aggregation = Aggregators.integerAvg("bigDecimal");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(newExtractableEntryWithValue(null));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -271,7 +276,7 @@ public class AvgAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> aggregation = Aggregators.longAvg("longValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(newExtractableEntryWithValue(value));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> resultAggregation = Aggregators.longAvg("longValue");
@@ -290,7 +295,7 @@ public class AvgAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testLongAvg_withAttributePath_withNull() {
         Aggregator<Map.Entry, Double> aggregation = Aggregators.longAvg("bigDecimal");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(newExtractableEntryWithValue(null));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -321,7 +326,7 @@ public class AvgAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> aggregation = Aggregators.numberAvg("numberValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(newExtractableEntryWithValue(value));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> resultAggregation = Aggregators.numberAvg("numberValue");
@@ -340,7 +345,12 @@ public class AvgAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testGenericAvg_withAttributePath_withNull() {
         Aggregator<Map.Entry, Double> aggregation = Aggregators.numberAvg("bigDecimal");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(newExtractableEntryWithValue(null));
+    }
+
+    @Nonnull
+    protected Map.Entry<ValueContainer, ValueContainer> newExtractableEntryWithValue(ValueContainer value) {
+        return createExtractableEntryWithValue(value, ss);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/CountAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/CountAggregationTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.aggregation;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -38,6 +40,8 @@ import static org.junit.Assert.assertThat;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class CountAggregationTest {
+
+    private final InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
 
     @Test(timeout = TimeoutInMillis.MINUTE)
     public void testCountAggregator() {
@@ -63,7 +67,7 @@ public class CountAggregationTest {
 
         Aggregator<Map.Entry<Person, Person>, Long> aggregation = Aggregators.count("age");
         for (Person person : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(person));
+            aggregation.accumulate(createExtractableEntryWithValue(person, ss));
         }
 
         Aggregator<Map.Entry<BigDecimal, BigDecimal>, Long> resultAggregation = Aggregators.count("age");
@@ -99,7 +103,7 @@ public class CountAggregationTest {
 
         Aggregator<Map.Entry<Person, Person>, Long> aggregation = Aggregators.count("age");
         for (Person person : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(person));
+            aggregation.accumulate(createExtractableEntryWithValue(person, ss));
         }
 
         Aggregator<Map.Entry<BigDecimal, BigDecimal>, Long> resultAggregation = Aggregators.count("age");

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/DistinctAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/DistinctAggregationTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.aggregation;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -40,6 +42,8 @@ import static org.junit.Assert.assertThat;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class DistinctAggregationTest {
+
+    private final InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
 
     @Test(timeout = TimeoutInMillis.MINUTE)
     public void testCountAggregator() {
@@ -87,7 +91,7 @@ public class DistinctAggregationTest {
 
         Aggregator<Map.Entry<Person, Person>, Set<Double>> aggregation = Aggregators.distinct("age");
         for (Person value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<Person, Person>, Set<Double>> resultAggregation = Aggregators.distinct("age");
@@ -106,7 +110,7 @@ public class DistinctAggregationTest {
 
         Aggregator<Map.Entry<Person, Person>, Set<Double>> aggregation = Aggregators.distinct("age");
         for (Person value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<Person, Person>, Set<Double>> resultAggregation = Aggregators.distinct("age");

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MaxAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MaxAggregationTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.aggregation;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -55,6 +57,8 @@ public class MaxAggregationTest {
 
     public static final double ERROR = 1e-8;
 
+    private final InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
+
     @Test(timeout = TimeoutInMillis.MINUTE)
     public void testBigDecimalMax() {
         List<BigDecimal> values = sampleBigDecimals();
@@ -81,7 +85,7 @@ public class MaxAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigDecimal> aggregation = Aggregators.bigDecimalMax("bigDecimal");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<BigDecimal, BigDecimal>, BigDecimal> resultAggregation = Aggregators.bigDecimalMax("bigDecimal");
@@ -117,7 +121,7 @@ public class MaxAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigInteger> aggregation = Aggregators.bigIntegerMax("bigInteger");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigInteger> resultAggregation
@@ -154,7 +158,7 @@ public class MaxAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> aggregation = Aggregators.doubleMax("doubleValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<Double, Double>, Double> resultAggregation = Aggregators.doubleMax("doubleValue");
@@ -190,7 +194,7 @@ public class MaxAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Integer> aggregation = Aggregators.integerMax("intValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Integer> resultAggregation = Aggregators.integerMax("intValue");
@@ -226,7 +230,7 @@ public class MaxAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Long> aggregation = Aggregators.longMax("longValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Long> resultAggregation = Aggregators.longMax("longValue");
@@ -262,7 +266,7 @@ public class MaxAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, String> aggregation = Aggregators.comparableMax("stringValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, String> resultAggregation
@@ -301,7 +305,7 @@ public class MaxAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, String> aggregation = Aggregators.comparableMax("stringValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, String> resultAggregation
@@ -316,13 +320,13 @@ public class MaxAggregationTest {
     public void testMaxBy_withAttributePath_withNull() {
         List<ValueContainer> values = sampleValueContainers(STRING);
         Collections.sort(values);
-        Map.Entry<ValueContainer, ValueContainer> expectation = createExtractableEntryWithValue(values.get(values.size() - 1));
+        Map.Entry<ValueContainer, ValueContainer> expectation = createExtractableEntryWithValue(values.get(values.size() - 1), ss);
         values.add(null);
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Map.Entry<ValueContainer, ValueContainer>> aggregation
                 = Aggregators.maxBy("stringValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Map.Entry<ValueContainer, ValueContainer>> resultAggregation

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/MinAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/MinAggregationTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.aggregation;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -55,6 +57,8 @@ public class MinAggregationTest {
 
     public static final double ERROR = 1e-8;
 
+    private final InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
+
     @Test(timeout = TimeoutInMillis.MINUTE)
     public void testBigDecimalMin() {
         List<BigDecimal> values = sampleBigDecimals();
@@ -81,7 +85,7 @@ public class MinAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigDecimal> aggregation = Aggregators.bigDecimalMin("bigDecimal");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigDecimal> resultAggregation
@@ -118,7 +122,7 @@ public class MinAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigInteger> aggregation = Aggregators.bigIntegerMin("bigInteger");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigInteger> resultAggregation
@@ -155,7 +159,7 @@ public class MinAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> aggregation = Aggregators.doubleMin("doubleValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> resultAggregation = Aggregators.doubleMin("doubleValue");
@@ -191,7 +195,7 @@ public class MinAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Integer> aggregation = Aggregators.integerMin("intValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Integer> resultAggregation = Aggregators.integerMin("intValue");
@@ -227,7 +231,7 @@ public class MinAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Long> aggregation = Aggregators.longMin("longValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Long> resultAggregation = Aggregators.longMin("longValue");
@@ -263,7 +267,7 @@ public class MinAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, String> aggregation = Aggregators.comparableMin("stringValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, String> resultAggregation
@@ -302,7 +306,7 @@ public class MinAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, String> aggregation = Aggregators.comparableMin("stringValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, String> resultAggregation
@@ -317,13 +321,13 @@ public class MinAggregationTest {
     public void testMinBy_withAttributePath_withNull() {
         List<ValueContainer> values = sampleValueContainers(STRING);
         Collections.sort(values);
-        Map.Entry<ValueContainer, ValueContainer> expectation = createExtractableEntryWithValue(values.get(0));
+        Map.Entry<ValueContainer, ValueContainer> expectation = createExtractableEntryWithValue(values.get(0), ss);
         values.add(null);
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Map.Entry<ValueContainer, ValueContainer>> aggregation
                 = Aggregators.minBy("stringValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Map.Entry<ValueContainer, ValueContainer>> resultAggregation

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/SumAggregationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/SumAggregationTest.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.aggregation;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -56,6 +58,8 @@ public class SumAggregationTest {
 
     public static final double ERROR = 1e-8;
 
+    private final InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
+
     @Test(timeout = TimeoutInMillis.MINUTE)
     public void testBigDecimalSum() {
         List<BigDecimal> values = sampleBigDecimals();
@@ -80,7 +84,7 @@ public class SumAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigDecimal> aggregation = Aggregators.bigDecimalSum("bigDecimal");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigDecimal> resultAggregation
@@ -100,7 +104,7 @@ public class SumAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testBigDecimalSum_withAttributePath_withNull() {
         Aggregator<Map.Entry, BigDecimal> aggregation = Aggregators.bigDecimalSum("numberValue");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(createExtractableEntryWithValue(null, ss));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -127,7 +131,7 @@ public class SumAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigInteger> aggregation = Aggregators.bigIntegerSum("bigInteger");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, BigInteger> resultAggregation
@@ -147,7 +151,7 @@ public class SumAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testBigIntegerSum_withAttributePath_withNull() {
         Aggregator<Map.Entry, BigInteger> aggregation = Aggregators.bigIntegerSum("numberValue");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(createExtractableEntryWithValue(null, ss));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -174,7 +178,7 @@ public class SumAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> aggregation = Aggregators.doubleSum("doubleValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> resultAggregation = Aggregators.doubleSum("doubleValue");
@@ -193,7 +197,7 @@ public class SumAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testDoubleSum_withAttributePath_withNull() {
         Aggregator<Map.Entry, Double> aggregation = Aggregators.doubleSum("numberValue");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(createExtractableEntryWithValue(null, ss));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -220,7 +224,7 @@ public class SumAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Long> aggregation = Aggregators.integerSum("intValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Long> resultAggregation = Aggregators.integerSum("intValue");
@@ -239,7 +243,7 @@ public class SumAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testIntegerSum_withAttributePath_withNull() {
         Aggregator<Map.Entry, Long> aggregation = Aggregators.integerSum("numberValue");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(createExtractableEntryWithValue(null, ss));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -266,7 +270,7 @@ public class SumAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Long> aggregation = Aggregators.longSum("longValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Long> resultAggregation = Aggregators.longSum("longValue");
@@ -285,7 +289,7 @@ public class SumAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testLongSum_withAttributePath_withNull() {
         Aggregator<Map.Entry, Long> aggregation = Aggregators.longSum("numberValue");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(createExtractableEntryWithValue(null, ss));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -316,7 +320,7 @@ public class SumAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Long> aggregation = Aggregators.fixedPointSum("numberValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Long> resultAggregation = Aggregators.fixedPointSum("numberValue");
@@ -335,7 +339,7 @@ public class SumAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testFixedPointSum_withAttributePath_withNull() {
         Aggregator<Map.Entry, Long> aggregation = Aggregators.fixedPointSum("numberValue");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(createExtractableEntryWithValue(null, ss));
     }
 
     @Test(timeout = TimeoutInMillis.MINUTE)
@@ -366,7 +370,7 @@ public class SumAggregationTest {
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> aggregation = Aggregators.floatingPointSum("numberValue");
         for (ValueContainer value : values) {
-            aggregation.accumulate(createExtractableEntryWithValue(value));
+            aggregation.accumulate(createExtractableEntryWithValue(value, ss));
         }
 
         Aggregator<Map.Entry<ValueContainer, ValueContainer>, Double> resultAggregation
@@ -386,7 +390,7 @@ public class SumAggregationTest {
     @Test(timeout = TimeoutInMillis.MINUTE, expected = NullPointerException.class)
     public void testFloatingPointSum_withAttributePath_withNull() {
         Aggregator<Map.Entry, Double> aggregation = Aggregators.floatingPointSum("numberValue");
-        aggregation.accumulate(createExtractableEntryWithValue(null));
+        aggregation.accumulate(createExtractableEntryWithValue(null, ss));
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/TestSamples.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/TestSamples.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.aggregation;
 
-import com.hazelcast.config.MapAttributeConfig;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.map.impl.MapEntrySimple;
 import com.hazelcast.nio.serialization.Data;
@@ -27,7 +26,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -45,8 +43,8 @@ final class TestSamples {
         return new MapEntrySimple<T, T>(value, value);
     }
 
-    static <T> Map.Entry<T, T> createExtractableEntryWithValue(T value) {
-        return new ExtractableEntry<T, T>(value, value);
+    static <T> Map.Entry<T, T> createExtractableEntryWithValue(T value, InternalSerializationService ss) {
+        return new ExtractableEntry<T, T>(value, value, ss);
     }
 
     static List<Integer> sampleIntegers() {
@@ -200,8 +198,8 @@ final class TestSamples {
         private K key;
         private V value;
 
-        ExtractableEntry(K key, V value) {
-            this.extractors = new Extractors(Collections.<MapAttributeConfig>emptyList(), null);
+        ExtractableEntry(K key, V value, InternalSerializationService ss) {
+            this.extractors = Extractors.newBuilder(ss).build();
             this.key = key;
             this.value = value;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorLockTest.java
@@ -178,7 +178,8 @@ public class EntryProcessorLockTest extends HazelcastTestSupport {
     @Test
     public void test_Serialization_LockAwareLazyMapEntry_deserializesAs_LazyMapEntry() throws ExecutionException, InterruptedException {
         InternalSerializationService ss = getSerializationService(createHazelcastInstance(getConfig()));
-        LockAwareLazyMapEntry entry = new LockAwareLazyMapEntry(ss.toData("key"), "value", ss, Extractors.empty(), false);
+        LockAwareLazyMapEntry entry = new LockAwareLazyMapEntry(ss.toData("key"), "value", ss,
+                Extractors.newBuilder(ss).build(), false);
 
         LockAwareLazyMapEntry deserializedEntry = ss.toObject(ss.toData(entry));
 

--- a/hazelcast/src/test/java/com/hazelcast/query/PortablePredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/PortablePredicatesTest.java
@@ -69,7 +69,8 @@ public class PortablePredicatesTest {
     }
 
     private QueryEntry toQueryEntry(Object key, Object value) {
-        return new QueryEntry(serializationService, serializationService.toData(key), value, Extractors.empty());
+        return new QueryEntry(serializationService, serializationService.toData(key), value,
+                Extractors.newBuilder(serializationService).build());
     }
 
     class TestPortableFactory implements PortableFactory {

--- a/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SqlPredicateTest.java
@@ -662,7 +662,11 @@ public class SqlPredicateTest {
     }
 
     private Map.Entry createEntry(final Object key, final Object value) {
-        return new QueryEntry(serializationService, toData(key), value, Extractors.empty());
+        return new QueryEntry(serializationService, toData(key), value, newExtractor());
+    }
+
+    private Extractors newExtractor() {
+        return Extractors.newBuilder(serializationService).build();
     }
 
     private void assertSqlMatching(String s, Object value) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/CachedQueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/CachedQueryEntryTest.java
@@ -69,14 +69,14 @@ public class CachedQueryEntryTest extends QueryEntryTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testInit_whenKeyIsNull_thenThrowIllegalArgumentException() {
-        createEntry(null, new Object(), Extractors.empty());
+        createEntry(null, new Object(), newExtractor());
     }
 
     @Test
     public void testGetKey() {
         String keyObject = "key";
         Data keyData = serializationService.toData(keyObject);
-        QueryableEntry entry = createEntry(keyData, new Object(), Extractors.empty());
+        QueryableEntry entry = createEntry(keyData, new Object(), newExtractor());
 
         Object key = entry.getKey();
         assertEquals(keyObject, key);
@@ -85,7 +85,7 @@ public class CachedQueryEntryTest extends QueryEntryTest {
     @Test
     public void testGetTargetObject_givenKeyDataIsPortable_whenKeyFlagIsTrue_thenReturnKeyData() {
         Data keyData = mockPortableData();
-        QueryableEntry entry = createEntry(keyData, new Object(), Extractors.empty());
+        QueryableEntry entry = createEntry(keyData, new Object(), newExtractor());
 
         Object targetObject = entry.getTargetObject(true);
 
@@ -96,7 +96,7 @@ public class CachedQueryEntryTest extends QueryEntryTest {
     public void testGetTargetObject_givenKeyDataIsNotPortable_whenKeyFlagIsTrue_thenReturnKeyObject() {
         Object keyObject = "key";
         Data keyData = serializationService.toData(keyObject);
-        QueryableEntry entry = createEntry(keyData, new Object(), Extractors.empty());
+        QueryableEntry entry = createEntry(keyData, new Object(), newExtractor());
 
         Object targetObject = entry.getTargetObject(true);
 
@@ -107,7 +107,7 @@ public class CachedQueryEntryTest extends QueryEntryTest {
     public void testGetTargetObject_givenValueIsDataAndPortable_whenKeyFlagIsFalse_thenReturnValueData() {
         Data key = serializationService.toData("indexedKey");
         Data value = serializationService.toData(new PortableEmployee(30, "peter"));
-        QueryableEntry entry = createEntry(key, value, Extractors.empty());
+        QueryableEntry entry = createEntry(key, value, newExtractor());
 
         Object targetObject = entry.getTargetObject(false);
 
@@ -118,7 +118,7 @@ public class CachedQueryEntryTest extends QueryEntryTest {
     public void testGetTargetObject_givenValueIsData_whenKeyFlagIsFalse_thenReturnValueObject() {
         Data key = serializationService.toData("key");
         Data value = serializationService.toData("value");
-        QueryableEntry entry = createEntry(key, value, Extractors.empty());
+        QueryableEntry entry = createEntry(key, value, newExtractor());
 
         Object targetObject = entry.getTargetObject(false);
 
@@ -129,7 +129,7 @@ public class CachedQueryEntryTest extends QueryEntryTest {
     public void testGetTargetObject_givenValueIsPortable_whenKeyFlagIsFalse_thenReturnValueData() {
         Data key = serializationService.toData("indexedKey");
         Portable value = new PortableEmployee(30, "peter");
-        QueryableEntry entry = createEntry(key, value, Extractors.empty());
+        QueryableEntry entry = createEntry(key, value, newExtractor());
 
         Object targetObject = entry.getTargetObject(false);
 
@@ -140,7 +140,7 @@ public class CachedQueryEntryTest extends QueryEntryTest {
     public void testGetTargetObject_givenValueIsNotPortable_whenKeyFlagIsFalse_thenReturnValueObject() {
         Data key = serializationService.toData("key");
         String value = "value";
-        QueryableEntry entry = createEntry(key, value, Extractors.empty());
+        QueryableEntry entry = createEntry(key, value, newExtractor());
 
         Object targetObject = entry.getTargetObject(false);
 
@@ -211,7 +211,12 @@ public class CachedQueryEntryTest extends QueryEntryTest {
 
     private CachedQueryEntry<Object, Object> createEntry(Object key) {
         Data keyData = serializationService.toData(key);
-        return new CachedQueryEntry<Object, Object>(serializationService, keyData, new Object(), Extractors.empty());
+        return new CachedQueryEntry<Object, Object>(serializationService, keyData, new Object(),
+                newExtractor());
+    }
+
+    private Extractors newExtractor() {
+        return Extractors.newBuilder(serializationService).build();
     }
 
     private Data mockPortableData() {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexImplTest.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.query.impl;
 
-import com.hazelcast.config.MapAttributeConfig;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.monitor.impl.PerIndexStats;
 import com.hazelcast.nio.serialization.Data;
@@ -28,8 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -47,7 +44,7 @@ public class IndexImplTest {
     @Before
     public void setUp() {
         InternalSerializationService mockSerializationService = mock(InternalSerializationService.class);
-        Extractors mockExtractors = new Extractors(Collections.<MapAttributeConfig>emptyList(), null);
+        Extractors mockExtractors = Extractors.newBuilder(mockSerializationService).build();
         index = new IndexImpl(ATTRIBUTE_NAME, false, mockSerializationService, mockExtractors, IndexCopyBehavior.COPY_ON_READ,
                 PerIndexStats.EMPTY);
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexTest.java
@@ -107,7 +107,7 @@ public class IndexTest {
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
-        is.saveEntryIndex(new QueryEntry(ss, key, value, Extractors.empty()), null, Index.OperationSource.USER);
+        is.saveEntryIndex(new QueryEntry(ss, key, value, newExtractor()), null, Index.OperationSource.USER);
         assertNotNull(is.getIndex("favoriteCity"));
         Record record = recordFactory.newRecord(value);
         ((AbstractRecord) record).setKey(key);
@@ -121,13 +121,17 @@ public class IndexTest {
         is.addOrGetIndex("favoriteCity", false);
         Data key = ss.toData(1);
         Data value = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.ISTANBUL));
-        is.saveEntryIndex(new QueryEntry(ss, key, value, Extractors.empty()), null, Index.OperationSource.USER);
+        is.saveEntryIndex(new QueryEntry(ss, key, value, newExtractor()), null, Index.OperationSource.USER);
 
         Data newValue = ss.toData(new SerializableWithEnum(SerializableWithEnum.City.KRAKOW));
-        is.saveEntryIndex(new QueryEntry(ss, key, newValue, Extractors.empty()), value, Index.OperationSource.USER);
+        is.saveEntryIndex(new QueryEntry(ss, key, newValue, newExtractor()), value, Index.OperationSource.USER);
 
         assertEquals(0, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.ISTANBUL).size());
         assertEquals(1, is.getIndex("favoriteCity").getRecords(SerializableWithEnum.City.KRAKOW).size());
+    }
+
+    protected Extractors newExtractor() {
+        return Extractors.newBuilder(ss).build();
     }
 
     @Test
@@ -139,7 +143,7 @@ public class IndexTest {
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(i % 2 == 0, -10.34d, "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, value, Extractors.empty()), null, Index.OperationSource.USER);
+            is.saveEntryIndex(new QueryEntry(ss, key, value, newExtractor()), null, Index.OperationSource.USER);
         }
         assertEquals(1000, dIndex.getRecords(-10.34d).size());
         assertEquals(1, strIndex.getRecords("joe23").size());
@@ -150,7 +154,7 @@ public class IndexTest {
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, 11.34d, "joe"));
-            is.saveEntryIndex(new QueryEntry(ss, key, value, Extractors.empty()), null, Index.OperationSource.USER);
+            is.saveEntryIndex(new QueryEntry(ss, key, value, newExtractor()), null, Index.OperationSource.USER);
         }
 
         assertEquals(0, dIndex.getRecords(-10.34d).size());
@@ -164,7 +168,7 @@ public class IndexTest {
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, -1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, value, Extractors.empty()), null, Index.OperationSource.USER);
+            is.saveEntryIndex(new QueryEntry(ss, key, value, newExtractor()), null, Index.OperationSource.USER);
         }
         assertEquals(0, dIndex.getSubRecordsBetween(1d, 1001d).size());
         assertEquals(1000, dIndex.getSubRecordsBetween(-1d, -1001d).size());
@@ -173,7 +177,7 @@ public class IndexTest {
         for (int i = 0; i < 1000; i++) {
             Data key = ss.toData(i);
             Data value = ss.toData(new MainPortable(false, 1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, value, Extractors.empty()), null, Index.OperationSource.USER);
+            is.saveEntryIndex(new QueryEntry(ss, key, value, newExtractor()), null, Index.OperationSource.USER);
         }
         assertEquals(1000, dIndex.getSubRecordsBetween(1d, 1001d).size());
         assertEquals(0, dIndex.getSubRecordsBetween(-1d, -1001d).size());
@@ -199,17 +203,17 @@ public class IndexTest {
 
         Data value = ss.toData(new MainPortable(false, 1, null));
         Data key1 = ss.toData(0);
-        is.saveEntryIndex(new QueryEntry(ss, key1, value, Extractors.empty()), null, Index.OperationSource.USER);
+        is.saveEntryIndex(new QueryEntry(ss, key1, value, newExtractor()), null, Index.OperationSource.USER);
 
         value = ss.toData(new MainPortable(false, 2, null));
         Data key2 = ss.toData(1);
-        is.saveEntryIndex(new QueryEntry(ss, key2, value, Extractors.empty()), null, Index.OperationSource.USER);
+        is.saveEntryIndex(new QueryEntry(ss, key2, value, newExtractor()), null, Index.OperationSource.USER);
 
 
         for (int i = 2; i < 1000; i++) {
             Data key = ss.toData(i);
             value = ss.toData(new MainPortable(false, 1 * (i + 1), "joe" + i));
-            is.saveEntryIndex(new QueryEntry(ss, key, value, Extractors.empty()), null, Index.OperationSource.USER);
+            is.saveEntryIndex(new QueryEntry(ss, key, value, newExtractor()), null, Index.OperationSource.USER);
         }
 
         assertEquals(2, strIndex.getRecords((Comparable) null).size());
@@ -466,7 +470,7 @@ public class IndexTest {
     }
 
     private void testIt(boolean ordered) {
-        IndexImpl index = new IndexImpl(QueryConstants.THIS_ATTRIBUTE_NAME.value(), ordered, ss, Extractors.empty(),
+        IndexImpl index = new IndexImpl(QueryConstants.THIS_ATTRIBUTE_NAME.value(), ordered, ss, newExtractor(),
                 copyBehavior, PerIndexStats.EMPTY);
         assertEquals(0, index.getRecords(0L).size());
         assertEquals(0, index.getSubRecordsBetween(0L, 1000L).size());

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexesTest.java
@@ -70,7 +70,8 @@ public class IndexesTest {
         indexes.addOrGetIndex("salary", true);
         for (int i = 0; i < 100; i++) {
             Employee employee = new Employee(i + "Name", i % 80, (i % 2 == 0), 100 + (i % 1000));
-            indexes.saveEntryIndex(new QueryEntry(serializationService, toData(i), employee, Extractors.empty()), null,
+            indexes.saveEntryIndex(new QueryEntry(serializationService, toData(i), employee,
+                            newExtractor()), null,
                     Index.OperationSource.USER);
         }
         int count = 10;
@@ -93,7 +94,8 @@ public class IndexesTest {
         indexes.addOrGetIndex("salary", true);
         for (int i = 0; i < 2000; i++) {
             Employee employee = new Employee(i + "Name", i % 80, (i % 2 == 0), 100 + (i % 100));
-            indexes.saveEntryIndex(new QueryEntry(serializationService, toData(i), employee, Extractors.empty()), null,
+            indexes.saveEntryIndex(new QueryEntry(serializationService, toData(i), employee,
+                            newExtractor()), null,
                     Index.OperationSource.USER);
         }
 
@@ -108,25 +110,29 @@ public class IndexesTest {
     public void testIndex2() {
         Indexes indexes = Indexes.newBuilder(serializationService, copyBehavior).build();
         indexes.addOrGetIndex("name", false);
-        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(1), new Value("abc"), Extractors.empty()), null,
+        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(1), new Value("abc"), newExtractor()), null,
                 Index.OperationSource.USER);
-        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(2), new Value("xyz"), Extractors.empty()), null,
+        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(2), new Value("xyz"), newExtractor()), null,
                 Index.OperationSource.USER);
-        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(3), new Value("aaa"), Extractors.empty()), null,
+        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(3), new Value("aaa"), newExtractor()), null,
                 Index.OperationSource.USER);
-        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(4), new Value("zzz"), Extractors.empty()), null,
+        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(4), new Value("zzz"), newExtractor()), null,
                 Index.OperationSource.USER);
-        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(5), new Value("klm"), Extractors.empty()), null,
+        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(5), new Value("klm"), newExtractor()), null,
                 Index.OperationSource.USER);
-        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(6), new Value("prs"), Extractors.empty()), null,
+        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(6), new Value("prs"), newExtractor()), null,
                 Index.OperationSource.USER);
-        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(7), new Value("prs"), Extractors.empty()), null,
+        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(7), new Value("prs"), newExtractor()), null,
                 Index.OperationSource.USER);
-        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(8), new Value("def"), Extractors.empty()), null,
+        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(8), new Value("def"), newExtractor()), null,
                 Index.OperationSource.USER);
-        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(9), new Value("qwx"), Extractors.empty()), null,
+        indexes.saveEntryIndex(new QueryEntry(serializationService, toData(9), new Value("qwx"), newExtractor()), null,
                 Index.OperationSource.USER);
         assertEquals(8, new HashSet<QueryableEntry>(indexes.query(new SqlPredicate("name > 'aac'"))).size());
+    }
+
+    protected Extractors newExtractor() {
+        return Extractors.newBuilder(serializationService).build();
     }
 
     /**
@@ -152,7 +158,7 @@ public class IndexesTest {
     private void shouldReturnNull_whenQueryingOnKeys(Indexes indexes) {
         for (int i = 0; i < 50; i++) {
             // passing null value to QueryEntry
-            indexes.saveEntryIndex(new QueryEntry(serializationService, toData(i), null, Extractors.empty()), null,
+            indexes.saveEntryIndex(new QueryEntry(serializationService, toData(i), null, newExtractor()), null,
                     Index.OperationSource.USER);
         }
 
@@ -168,7 +174,7 @@ public class IndexesTest {
 
         for (int i = 0; i < 100; i++) {
             // passing null value to QueryEntry
-            indexes.saveEntryIndex(new QueryEntry(serializationService, toData(i), null, Extractors.empty()), null,
+            indexes.saveEntryIndex(new QueryEntry(serializationService, toData(i), null, newExtractor()), null,
                     Index.OperationSource.USER);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/QueryEntryTest.java
@@ -68,7 +68,7 @@ public class QueryEntryTest extends HazelcastTestSupport {
     public void getAttribute_whenValueIsPortableObject_thenConvertedToData() {
         Data key = serializationService.toData("indexedKey");
         Portable value = new SampleTestObjects.PortableEmployee(30, "peter");
-        QueryableEntry queryEntry = createEntry(key, value, Extractors.empty());
+        QueryableEntry queryEntry = createEntry(key, value, newExtractor());
 
         // in the portable-data, the attribute 'name' is called 'n'. So if we can retrieve on n
         // correctly it shows that we have used the Portable data, not the actual Portable object
@@ -81,7 +81,7 @@ public class QueryEntryTest extends HazelcastTestSupport {
     public void getAttribute_whenKeyIsPortableObject_thenConvertedToData() {
         Data key = serializationService.toData(new SampleTestObjects.PortableEmployee(30, "peter"));
         SerializableObject value = new SerializableObject();
-        QueryableEntry queryEntry = createEntry(key, value, Extractors.empty());
+        QueryableEntry queryEntry = createEntry(key, value, newExtractor());
 
         // in the portable-data, the attribute 'name' is called 'n'. So if we can retrieve on n
         // correctly it shows that we have used the Portable data, not the actual Portable object
@@ -94,7 +94,7 @@ public class QueryEntryTest extends HazelcastTestSupport {
     public void getAttribute_whenKeyPortableObjectThenConvertedToData() {
         Data key = serializationService.toData(new SampleTestObjects.PortableEmployee(30, "peter"));
         SerializableObject value = new SerializableObject();
-        QueryableEntry queryEntry = createEntry(key, value, Extractors.empty());
+        QueryableEntry queryEntry = createEntry(key, value, newExtractor());
 
         Object result = queryEntry.getAttributeValue(QueryConstants.KEY_ATTRIBUTE_NAME.value() + ".n");
 
@@ -106,7 +106,7 @@ public class QueryEntryTest extends HazelcastTestSupport {
         Data key = serializationService.toData(new SerializableObject());
         SerializableObject value = new SerializableObject();
         value.name = "somename";
-        QueryableEntry queryEntry = createEntry(key, value, Extractors.empty());
+        QueryableEntry queryEntry = createEntry(key, value, newExtractor());
 
         Object result = queryEntry.getAttributeValue("name");
 
@@ -117,18 +117,18 @@ public class QueryEntryTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalArgumentException.class)
     public void testInit_whenKeyIsNull_thenThrowIllegalArgumentException() {
-        createEntry(null, new SerializableObject(), Extractors.empty());
+        createEntry(null, new SerializableObject(), newExtractor());
     }
 
     @Test
     public void test_init() {
         Data dataKey = serializationService.toData("dataKey");
         Data dataValue = serializationService.toData("dataValue");
-        QueryableEntry queryEntry = createEntry(dataKey, dataValue, Extractors.empty());
+        QueryableEntry queryEntry = createEntry(dataKey, dataValue, newExtractor());
         Object objectValue = queryEntry.getValue();
         Object objectKey = queryEntry.getKey();
 
-        initEntry(queryEntry, serializationService, serializationService.toData(objectKey), objectValue, Extractors.empty());
+        initEntry(queryEntry, serializationService, serializationService.toData(objectKey), objectValue, newExtractor());
 
         // compare references of objects since they should be cloned after QueryEntry#init call.
         assertTrue("Old dataKey should not be here", dataKey != queryEntry.getKeyData());
@@ -137,12 +137,12 @@ public class QueryEntryTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalArgumentException.class)
     public void test_init_nullKey() {
-        createEntry(null, "value", Extractors.empty());
+        createEntry(null, "value", newExtractor());
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void test_setValue() {
-        QueryableEntry queryEntry = createEntry(mock(Data.class), "value", Extractors.empty());
+        QueryableEntry queryEntry = createEntry(mock(Data.class), "value", newExtractor());
         queryEntry.setValue("anyValue");
     }
 
@@ -243,7 +243,11 @@ public class QueryEntryTest extends HazelcastTestSupport {
     protected QueryableEntry createEntry(String key, String value) {
         return createEntry(serializationService.toData(key),
                 serializationService.toData(value),
-                Extractors.empty());
+                newExtractor());
+    }
+
+    private Extractors newExtractor() {
+        return Extractors.newBuilder(serializationService).build();
     }
 
     protected QueryableEntry createEntry(Data key, Object value, Extractors extractors) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicateTestUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicateTestUtils.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.query.impl.predicates;
 
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.VisitablePredicate;
@@ -97,11 +98,18 @@ public final class PredicateTestUtils {
     }
 
     public static Map.Entry entry(Object value) {
-        return new QueryEntry(new DefaultSerializationServiceBuilder().build(), toData(UuidUtil.newUnsecureUUID()),
-                value, Extractors.empty());
+        InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+        return new QueryEntry(serializationService, toData(UuidUtil.newUnsecureUUID()),
+                value, newExtractor(serializationService));
+    }
+
+    protected static Extractors newExtractor(InternalSerializationService serializationService) {
+        return Extractors.newBuilder(serializationService).build();
     }
 
     public static Map.Entry entry(Object key, Object value) {
-        return new QueryEntry(new DefaultSerializationServiceBuilder().build(), toData(key), value, Extractors.empty());
+        InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+        return new QueryEntry(serializationService, toData(key), value,
+                newExtractor(serializationService));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -313,7 +313,8 @@ public class PredicatesTest extends HazelcastTestSupport {
 
     @Test
     public void testNotEqualsPredicateDoesNotUseIndex() {
-        Index dummyIndex = new IndexImpl("foo", false, ss, Extractors.empty(), COPY_ON_READ, PerIndexStats.EMPTY);
+        Index dummyIndex = new IndexImpl("foo", false, ss,
+                Extractors.newBuilder(ss).build(), COPY_ON_READ, PerIndexStats.EMPTY);
         QueryContext mockQueryContext = mock(QueryContext.class);
         when(mockQueryContext.getIndex(anyString())).thenReturn(dummyIndex);
 
@@ -326,7 +327,7 @@ public class PredicatesTest extends HazelcastTestSupport {
     private class DummyEntry extends QueryEntry {
 
         DummyEntry(Comparable attribute) {
-            super(ss, toData("1"), attribute, Extractors.empty());
+            super(ss, toData("1"), attribute, Extractors.newBuilder(ss).build());
         }
 
         @Override
@@ -398,7 +399,7 @@ public class PredicatesTest extends HazelcastTestSupport {
     }
 
     private Entry createEntry(final Object key, final Object value) {
-        return new QueryEntry(ss, toData(key), value, Extractors.empty());
+        return new QueryEntry(ss, toData(key), value, Extractors.newBuilder(ss).build());
     }
 
     private void assertPredicateTrue(Predicate p, Comparable comparable) {


### PR DESCRIPTION
Extractors.empty gives false assumption as if it returns a static final instance. With this PR, Extractors are created with a builder.

ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/2648