### PR TITLE
Removed InternalSerializationService casts in client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -152,7 +152,6 @@ import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.topic.impl.TopicService;
 import com.hazelcast.topic.impl.reliable.ReliableTopicService;
 import com.hazelcast.transaction.HazelcastXAResource;
@@ -209,7 +208,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private final MetricsRegistryImpl metricsRegistry;
     private final Statistics statistics;
     private final Diagnostics diagnostics;
-    private final SerializationService serializationService;
+    private final InternalSerializationService serializationService;
     private final ClientICacheManager hazelcastCacheManager;
     private final ClientLockReferenceIdGenerator lockReferenceIdGenerator;
     private final ClientExceptionFactory clientExceptionFactory;
@@ -889,7 +888,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     @Override
-    public SerializationService getSerializationService() {
+    public InternalSerializationService getSerializationService() {
         return serializationService;
     }
 
@@ -965,7 +964,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         }
         metricsRegistry.shutdown();
         diagnostics.shutdown();
-        ((InternalSerializationService) serializationService).dispose();
+        serializationService.dispose();
     }
 
     public ClientLockReferenceIdGenerator getLockReferenceIdGenerator() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientProxy.java
@@ -47,13 +47,13 @@ import com.hazelcast.crdt.pncounter.PNCounter;
 import com.hazelcast.durableexecutor.DurableExecutorService;
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.instance.TerminatedLifecycleService;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.mapreduce.JobTracker;
 import com.hazelcast.quorum.QuorumService;
 import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.HazelcastXAResource;
 import com.hazelcast.transaction.TransactionContext;
 import com.hazelcast.transaction.TransactionException;
@@ -298,7 +298,7 @@ public class HazelcastClientProxy implements HazelcastInstance, SerializationSer
     }
 
     @Override
-    public SerializationService getSerializationService() {
+    public InternalSerializationService getSerializationService() {
         return getClient().getSerializationService();
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/ClientQueryCacheContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/ClientQueryCacheContext.java
@@ -81,7 +81,7 @@ public class ClientQueryCacheContext implements QueryCacheContext {
 
     @Override
     public InternalSerializationService getSerializationService() {
-        return (InternalSerializationService) clientContext.getSerializationService();
+        return clientContext.getSerializationService();
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
@@ -82,7 +82,7 @@ public class ClientQueryCacheEventService implements QueryCacheEventService {
 
     private final StripedExecutor executor;
     private final ClientListenerService listenerService;
-    private final SerializationService serializationService;
+    private final InternalSerializationService serializationService;
     private final ILogger logger = Logger.getLogger(getClass());
     private final ConcurrentMap<String, QueryCacheToListenerMapper> registrations;
 
@@ -155,8 +155,7 @@ public class ClientQueryCacheEventService implements QueryCacheEventService {
         if (localEntryEventData.getEventType() != EventLostEvent.EVENT_TYPE) {
             Object value = getValueOrOldValue(localEntryEventData);
             Data keyData = localEntryEventData.getKeyData();
-            QueryEntry entry = new QueryEntry((InternalSerializationService) serializationService,
-                    keyData, value, extractors);
+            QueryEntry entry = new QueryEntry(serializationService, keyData, value, extractors);
             return filter.eval(entry);
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1264,8 +1264,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
         MapEntrySetCodec.ResponseParameters resultParameters = MapEntrySetCodec.decodeResponse(response);
 
         InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(resultParameters.response.size());
-        InternalSerializationService serializationService = ((InternalSerializationService) getContext()
-                .getSerializationService());
+        InternalSerializationService serializationService = getContext().getSerializationService();
         for (Entry<Data, Data> row : resultParameters.response) {
             LazyMapEntry<K, V> entry = new LazyMapEntry<K, V>(row.getKey(), row.getValue(), serializationService);
             setBuilder.add(entry);
@@ -1322,8 +1321,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
         MapEntriesWithPredicateCodec.ResponseParameters resultParameters = MapEntriesWithPredicateCodec.decodeResponse(response);
 
         InflatableSet.Builder<Entry<K, V>> setBuilder = InflatableSet.newBuilder(resultParameters.response.size());
-        InternalSerializationService serializationService = ((InternalSerializationService) getContext()
-                .getSerializationService());
+        InternalSerializationService serializationService = getContext().getSerializationService();
         for (Entry<Data, Data> row : resultParameters.response) {
             LazyMapEntry<K, V> entry = new LazyMapEntry<K, V>(row.getKey(), row.getValue(), serializationService);
             setBuilder.add(entry);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
@@ -29,12 +29,12 @@ import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.nearcache.impl.invalidation.InvalidationMetaDataFetcher;
 import com.hazelcast.internal.nearcache.impl.invalidation.MinimalPartitionService;
 import com.hazelcast.internal.nearcache.impl.invalidation.RepairingTask;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.properties.HazelcastProperties;
-import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ConstructorFunction;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,7 +49,7 @@ import static java.lang.String.format;
 public final class ClientContext {
 
     private String localUuid;
-    private final SerializationService serializationService;
+    private final InternalSerializationService serializationService;
     private final ClientClusterService clusterService;
     private final ClientPartitionService partitionService;
     private final ClientInvocationService invocationService;
@@ -160,7 +160,7 @@ public final class ClientContext {
         return proxyManager.getHazelcastInstance();
     }
 
-    public SerializationService getSerializationService() {
+    public InternalSerializationService getSerializationService() {
         return serializationService;
     }
 


### PR DESCRIPTION
So instead of casting, InternalSerializationService is directly
used. InternalSerializationService is the internal API for serialization
and it is fine to rely on that.