### PR TITLE
Cleaned up ClientConnecionManager connectToCluster

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -24,7 +24,6 @@ import com.hazelcast.nio.ConnectionListenable;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.concurrent.Future;
 
 /**
  * Responsible for managing {@link com.hazelcast.client.connection.nio.ClientConnection} objects.
@@ -66,8 +65,4 @@ public interface ClientConnectionManager extends ConnectionListenable {
     ClientPrincipal getPrincipal();
 
     ClientConnection getOwnerConnection();
-
-    void connectToCluster();
-
-    Future<Void> connectToClusterAsync();
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionStrategy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionStrategy.java
@@ -39,17 +39,14 @@ public abstract class ClientConnectionStrategy {
      * Initialize this strategy with client context and config
      * @param clientContext hazelcast client context to access internal services
      */
-    public final void init(ClientContext clientContext) {
+    public void init(ClientContext clientContext) {
         this.clientContext = clientContext;
         this.clientConnectionStrategyConfig = clientContext.getClientConfig().getConnectionStrategyConfig();
         this.logger = clientContext.getLoggingService().getLogger(ClientConnectionStrategy.class);
     }
 
     /**
-     * Called after {@link ClientConnectionManager} started.
-     * Connecting to cluster can be triggered from this method using one of
-     * {@link ClientConnectionManager#connectToCluster} or
-     * {@link ClientConnectionManager#connectToClusterAsync}
+     * Starts the ClientConnectionStrategy; this will trigger connecting to the cluster.
      */
     public abstract void start();
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -71,7 +71,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -121,32 +120,24 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
     public ClientConnectionManagerImpl(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator,
                                        AddressProvider addressProvider) {
-        allowInvokeWhenDisconnected = client.getProperties().getBoolean(ALLOW_INVOCATIONS_WHEN_DISCONNECTED);
+        this.allowInvokeWhenDisconnected = client.getProperties().getBoolean(ALLOW_INVOCATIONS_WHEN_DISCONNECTED);
         this.client = client;
         this.attributes = Collections.unmodifiableMap(client.getClientConfig().getAttributes());
         this.addressTranslator = addressTranslator;
-
         this.logger = client.getLoggingService().getLogger(ClientConnectionManager.class);
-
         ClientNetworkConfig networkConfig = client.getClientConfig().getNetworkConfig();
 
         final int connTimeout = networkConfig.getConnectionTimeout();
         this.connectionTimeoutMillis = connTimeout == 0 ? Integer.MAX_VALUE : connTimeout;
-
         this.executionService = client.getClientExecutionService();
-
         this.networking = initNetworking(client);
-
         this.socketInterceptor = initSocketInterceptor(networkConfig.getSocketInterceptorConfig());
-
         this.credentialsFactory = client.getCredentialsFactory();
         this.connectionStrategy = initializeStrategy(client);
-
         this.outboundPorts.addAll(getOutboundPorts(networkConfig));
         this.outboundPortCount = outboundPorts.size();
         this.heartbeat = new HeartbeatManager(this, client);
         this.authenticationTimeout = heartbeat.getHeartbeatTimeout();
-
         this.clusterConnector = new ClusterConnector(client, this, connectionStrategy, addressProvider);
     }
 
@@ -532,14 +523,8 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         return clusterConnector.getPossibleMemberAddresses();
     }
 
-    @Override
-    public void connectToCluster() {
-        clusterConnector.connectToCluster();
-    }
-
-    @Override
-    public Future<Void> connectToClusterAsync() {
-        return clusterConnector.connectToClusterAsync();
+    public ClusterConnector getClusterConnector() {
+        return clusterConnector;
     }
 
     private class TimeoutAuthenticationTask implements Runnable {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
@@ -46,7 +46,7 @@ import static java.lang.String.format;
 /**
  * Context holding all the required services, managers and the configuration for a Hazelcast client.
  */
-public final class ClientContext {
+public class ClientContext {
 
     private String localUuid;
     private final InternalSerializationService serializationService;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
@@ -39,6 +39,8 @@ import java.util.Collection;
 import java.util.Collections;
 
 import static junit.framework.TestCase.assertNotNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -57,8 +59,9 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
         TestAddressTranslator translator = new TestAddressTranslator();
         clientConnectionManager =
                 new ClientConnectionManagerImpl(getHazelcastClientInstanceImpl(client), translator, testAddressProvider);
-        clientConnectionManager.start(new ClientContext(getHazelcastClientInstanceImpl(client)));
-        clientConnectionManager.connectToCluster();
+        ClientContext clientContext = spy(new ClientContext(getHazelcastClientInstanceImpl(client)));
+        when(clientContext.getConnectionManager()).thenReturn(clientConnectionManager);
+        clientConnectionManager.start(clientContext);
 
         translator.shouldTranslate = true;
 


### PR DESCRIPTION
these methods have been removed from the ClientConnectionManager
since they were forwarded to the ConnectionStrategy which forwards
to the ClusterConnector.

The original logic was confusing:
```
ClientConnectionManager.start -> connectionStrategy.start() -> connectionManager.connectToCluster()->clusterConnector.connectToCluster()
```
So the fact that the ClientConnectionManager indirectly calls itself and then forwards to the right class was  confusing.

So this PR changes that to:

```
ClientConnectionManager.start -> connectionStrategy.start() -> clusterConnector.connectToCluster()
```
Now it is more obvious what the flow is. It also removes noise from the ClientConnectionManager interface.