### PR TITLE
Reduced visibility of ClientConnectionManagerImpl.getClusterConnector

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -523,7 +523,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         return clusterConnector.getPossibleMemberAddresses();
     }
 
-    public ClusterConnector getClusterConnector() {
+    ClusterConnector getClusterConnector() {
         return clusterConnector;
     }
 


### PR DESCRIPTION
No need to have it public