### PR TITLE
Renamed ClusterConnector.onConnectToCluster

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionStrategy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionStrategy.java
@@ -85,7 +85,7 @@ public abstract class ClientConnectionStrategy {
      * If a cluster connection is established, this method will be called.
      * if an exception is thrown, the already established connection will be closed.
      */
-    public abstract void onConnectToCluster();
+    public abstract void onClusterConnect();
 
     /**
      * If the cluster connection is lost for any reason, this method will be called.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
@@ -134,7 +134,7 @@ class ClusterConnector {
             connection = connectionManager.getOrConnect(address, true);
             client.onClusterConnect(connection);
             fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
-            connectionStrategy.onConnectToCluster();
+            connectionStrategy.onClusterConnect();
         } catch (Exception e) {
             logger.warning("Exception during initial connection to " + address + ", exception " + e);
             if (null != connection) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/DefaultClientConnectionStrategy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/DefaultClientConnectionStrategy.java
@@ -83,7 +83,7 @@ public class DefaultClientConnectionStrategy extends ClientConnectionStrategy {
     }
 
     @Override
-    public void onConnectToCluster() {
+    public void onClusterConnect() {
     }
 
     @Override


### PR DESCRIPTION
The client has 2 method names in to signal that the client
has connected to the cluster.
- onClusterConnect
- onConnectToCluster

Now they are merged to a single name.