### PR TITLE
Json support

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -281,6 +281,13 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.9.7</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>${hamcrest.version}</version>

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastJsonValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastJsonValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastJsonValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastJsonValue.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.core;
+
+/**
+ * HazelcastJsonValue is a wrapper for Json formatted strings. It is preferred
+ * to store HazelcastJsonValue instead of Strings for Json formatted strings.
+ * Users can run predicates and use indexes on the attributes of the underlying
+ * Json strings.
+ *
+ * HazelcastJsonValue is queried using Hazelcast's querying language.
+ * See {@link com.hazelcast.query.Predicates}.
+ *
+ * In terms of querying, numbers in Json strings are treated as either
+ * {@code Long} or {@code Double}. Strings, booleans and null are treated as
+ * their Java counterparts.
+ *
+ * HazelcastJsonValue keeps given string as it is.
+ *
+ * See {@link com.hazelcast.json.HazelcastJson#fromString(String)}
+ */
+public interface HazelcastJsonValue {
+
+    @Override
+    String toString();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/json/JsonArray.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/json/JsonArray.java
@@ -21,14 +21,14 @@
  ******************************************************************************/
 package com.hazelcast.internal.json;
 
+import com.hazelcast.nio.serialization.SerializableByConvention;
+
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
-import com.hazelcast.nio.serialization.SerializableByConvention;
 
 /**
  * Represents a JSON array, an ordered collection of JSON values.

--- a/hazelcast/src/main/java/com/hazelcast/internal/json/JsonLiteral.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/json/JsonLiteral.java
@@ -21,9 +21,9 @@
  ******************************************************************************/
 package com.hazelcast.internal.json;
 
-import java.io.IOException;
-
 import com.hazelcast.nio.serialization.SerializableByConvention;
+
+import java.io.IOException;
 
 @SuppressWarnings("serial") // use default serial UID
 @SerializableByConvention

--- a/hazelcast/src/main/java/com/hazelcast/internal/json/JsonNumber.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/json/JsonNumber.java
@@ -21,9 +21,9 @@
  ******************************************************************************/
 package com.hazelcast.internal.json;
 
-import java.io.IOException;
-
 import com.hazelcast.nio.serialization.SerializableByConvention;
+
+import java.io.IOException;
 
 @SuppressWarnings("serial") // use default serial UID
 @SerializableByConvention

--- a/hazelcast/src/main/java/com/hazelcast/internal/json/JsonObject.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/json/JsonObject.java
@@ -21,6 +21,9 @@
  ******************************************************************************/
 package com.hazelcast.internal.json;
 
+import com.hazelcast.internal.json.JsonObject.Member;
+import com.hazelcast.nio.serialization.SerializableByConvention;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Reader;
@@ -28,9 +31,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-
-import com.hazelcast.internal.json.JsonObject.Member;
-import com.hazelcast.nio.serialization.SerializableByConvention;
 
 
 /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/json/JsonString.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/json/JsonString.java
@@ -21,9 +21,9 @@
  ******************************************************************************/
 package com.hazelcast.internal.json;
 
-import java.io.IOException;
-
 import com.hazelcast.nio.serialization.SerializableByConvention;
+
+import java.io.IOException;
 
 @SuppressWarnings("serial") // use default serial UID
 @SerializableByConvention

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/HeapData.java
@@ -163,6 +163,11 @@ public class HeapData implements Data {
     }
 
     @Override
+    public boolean isJson() {
+        return SerializationConstants.JAVASCRIPT_JSON_SERIALIZATION_TYPE == getType();
+    }
+
+    @Override
     public String toString() {
         return "HeapData{"
                 + "type=" + getType()

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.serialization.impl;
 
+import com.hazelcast.core.HazelcastJsonValue;
+import com.hazelcast.json.HazelcastJson;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.ClassNameFilter;
@@ -37,6 +39,7 @@ import java.util.Date;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVASCRIPT_JSON_SERIALIZATION_TYPE;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_BIG_DECIMAL;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_BIG_INTEGER;
 import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVA_DEFAULT_TYPE_CLASS;
@@ -319,6 +322,24 @@ public final class JavaDefaultSerializers {
 
             String name = in.readUTF();
             return Enum.valueOf(clazz, name);
+        }
+    }
+
+    public static final class JsonStringSerializer extends SingletonSerializer<HazelcastJsonValue> {
+
+        @Override
+        public void write(ObjectDataOutput out, HazelcastJsonValue object) throws IOException {
+            out.writeUTF(object.toString());
+        }
+
+        @Override
+        public HazelcastJsonValue read(ObjectDataInput in) throws IOException {
+            return HazelcastJson.fromString(in.readUTF());
+        }
+
+        @Override
+        public int getTypeId() {
+            return JAVASCRIPT_JSON_SERIALIZATION_TYPE;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.PortableContext;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.BooleanSerializer;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.ByteSerializer;
 import com.hazelcast.internal.serialization.impl.ConstantSerializers.StringArraySerializer;
+import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.nio.BufferObjectDataInput;
 import com.hazelcast.nio.ClassNameFilter;
 import com.hazelcast.nio.ObjectDataInput;
@@ -73,6 +74,7 @@ import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.C
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.DateSerializer;
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.EnumSerializer;
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.JavaSerializer;
+import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.JsonStringSerializer;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createSerializerAdapter;
 import static com.hazelcast.util.MapUtil.createHashMap;
 
@@ -179,6 +181,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
 
         safeRegister(Serializable.class, javaSerializerAdapter);
         safeRegister(Externalizable.class, javaExternalizableAdapter);
+        safeRegister(HazelcastJsonValue.class, new JsonStringSerializer());
     }
 
     public void registerClassDefinitions(Collection<ClassDefinition> classDefinitions, boolean checkClassDefErrors) {

--- a/hazelcast/src/main/java/com/hazelcast/json/HazelcastJson.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/HazelcastJson.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/json/HazelcastJson.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/HazelcastJson.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json;
+
+
+import com.hazelcast.core.HazelcastJsonValue;
+
+/**
+ * Utility class for creating {@link HazelcastJsonValue}
+ */
+public final class HazelcastJson {
+
+    private HazelcastJson() {
+        // not meant to be instantiated
+    }
+
+    /**
+     * Create a HazelcastJsonValue from a string. This method does not the
+     * validity of the underlying Json string. Invalid Json strings may cause
+     * wrong results in queries.
+     *
+     * @param string
+     * @return
+     */
+    public static HazelcastJsonValue fromString(String string) {
+        return new HazelcastJsonImpl(string);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/json/HazelcastJsonImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/HazelcastJsonImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json;
+
+import com.hazelcast.core.HazelcastJsonValue;
+
+/**
+ *
+ */
+public class HazelcastJsonImpl implements HazelcastJsonValue {
+
+    private String string;
+
+    HazelcastJsonImpl(String string) {
+        this.string = string;
+    }
+
+    @Override
+    public String toString() {
+        return string;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HazelcastJsonImpl that = (HazelcastJsonImpl) o;
+
+        return string != null ? string.equals(that.string) : that.string == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return string != null ? string.hashCode() : 0;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/json/HazelcastJsonImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/HazelcastJsonImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,7 @@ package com.hazelcast.json;
 
 import com.hazelcast.core.HazelcastJsonValue;
 
-/**
- *
- */
-public class HazelcastJsonImpl implements HazelcastJsonValue {
+class HazelcastJsonImpl implements HazelcastJsonValue {
 
     private String string;
 

--- a/hazelcast/src/main/java/com/hazelcast/json/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/json/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains Json interface
+ *
+ */
+package com.hazelcast.json;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalGCStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalGCStatsImpl.java
@@ -16,13 +16,12 @@
 
 package com.hazelcast.monitor.impl;
 
+import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.memory.GarbageCollectorStats;
 import com.hazelcast.monitor.LocalGCStats;
 import com.hazelcast.util.Clock;
 
 import static com.hazelcast.util.JsonUtil.getLong;
-
-import com.hazelcast.internal.json.JsonObject;
 
 public class LocalGCStatsImpl implements LocalGCStats {
 

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMemoryStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMemoryStatsImpl.java
@@ -16,14 +16,13 @@
 
 package com.hazelcast.monitor.impl;
 
+import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.memory.MemoryStats;
 import com.hazelcast.monitor.LocalGCStats;
 import com.hazelcast.monitor.LocalMemoryStats;
 
 import static com.hazelcast.util.JsonUtil.getLong;
 import static com.hazelcast.util.JsonUtil.getObject;
-
-import com.hazelcast.internal.json.JsonObject;
 
 public class LocalMemoryStatsImpl implements LocalMemoryStats {
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/serialization/Data.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/serialization/Data.java
@@ -113,4 +113,12 @@ public interface Data {
      */
     boolean isPortable();
 
+    /**
+     * Returns true if this Data is created from a {@link com.hazelcast.json.HazelcastJson} object,
+     * false otherwise
+     *
+     * @return true if source object is <tt>HazelcastJson</tt>, false otherwise.
+     */
+    boolean isJson();
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -21,6 +21,8 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.query.impl.getters.Extractors;
 
+import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVASCRIPT_JSON_SERIALIZATION_TYPE;
+
 /**
  * Entry of the Query.
  *
@@ -95,14 +97,14 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
         Object targetObject;
         if (key) {
             // keyData is never null
-            if (keyData.isPortable()) {
+            if (keyData.isPortable() || keyData.getType() == JAVASCRIPT_JSON_SERIALIZATION_TYPE) {
                 targetObject = keyData;
             } else {
                 targetObject = getKey();
             }
         } else {
             if (valueObject == null) {
-                if (valueData.isPortable()) {
+                if (valueData.isPortable() || valueData.getType() == JAVASCRIPT_JSON_SERIALIZATION_TYPE) {
                     targetObject = valueData;
                 } else {
                     targetObject = getValue();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CachedQueryEntry.java
@@ -21,8 +21,6 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.Portable;
 import com.hazelcast.query.impl.getters.Extractors;
 
-import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVASCRIPT_JSON_SERIALIZATION_TYPE;
-
 /**
  * Entry of the Query.
  *
@@ -97,14 +95,14 @@ public class CachedQueryEntry<K, V> extends QueryableEntry<K, V> {
         Object targetObject;
         if (key) {
             // keyData is never null
-            if (keyData.isPortable() || keyData.getType() == JAVASCRIPT_JSON_SERIALIZATION_TYPE) {
+            if (keyData.isPortable() || keyData.isJson()) {
                 targetObject = keyData;
             } else {
                 targetObject = getKey();
             }
         } else {
             if (valueObject == null) {
-                if (valueData.isPortable() || valueData.getType() == JAVASCRIPT_JSON_SERIALIZATION_TYPE) {
+                if (valueData.isPortable() || valueData.isJson()) {
                     targetObject = valueData;
                 } else {
                     targetObject = getValue();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Indexes.java
@@ -53,7 +53,7 @@ public class Indexes {
 
     private volatile boolean hasIndex;
 
-    private Indexes(InternalSerializationService serializationService,
+    Indexes(InternalSerializationService serializationService,
                     IndexCopyBehavior indexCopyBehavior,
                     Extractors extractors,
                     IndexProvider indexProvider,

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
@@ -187,11 +187,12 @@ public abstract class QueryableEntry<K, V> implements Extractable, Map.Entry<K, 
 
     private AttributeType extractAttributeTypeFromJsonValue(JsonValue value) {
         if (value.isNumber()) {
-            try {
-                value.asLong();
-                return AttributeType.LONG;
-            } catch (NumberFormatException e) {
+            // toString method does not do any encoding in number case, it just returns stored string.
+            if (value.toString().contains(".")) {
+                // floating point number
                 return AttributeType.DOUBLE;
+            } else {
+                return AttributeType.LONG;
             }
         } else if (value.isBoolean()) {
             return AttributeType.BOOLEAN;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractJsonGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractJsonGetter.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.nio.serialization.HazelcastSerializationException;
+
+import java.io.IOException;
+
+public abstract class AbstractJsonGetter extends Getter {
+
+    private static final String DELIMITER = "\\.|\\[";
+
+    public AbstractJsonGetter(Getter parent) {
+        super(parent);
+    }
+
+    public static Object convertFromJsonValue(JsonValue value) {
+        if (value == null) {
+            return null;
+        } else if (value.isNumber()) {
+            try {
+                return value.asLong();
+            } catch (NumberFormatException e) {
+                return value.asDouble();
+            }
+        } else if (value.isBoolean()) {
+            return value.asBoolean();
+        } else if (value.isNull()) {
+            return null;
+        } else if (value.isString()) {
+            return value.asString();
+        }
+        throw new HazelcastSerializationException("Unknown Json type: " + value);
+    }
+
+    protected String[] getPath(String attributePath) {
+        return attributePath.split(DELIMITER);
+    }
+
+    @Override
+    Object getValue(Object obj) throws Exception {
+        throw new HazelcastException("Path agnostic value extraction is not supported");
+
+    }
+
+    @Override
+    Object getValue(Object obj, String attributePath) throws Exception {
+        String[] paths = getPath(attributePath);
+        JsonParser parser = createParser(obj);
+
+        parser.nextToken();
+        for (int i = 0; i < paths.length; i++) {
+            String path = paths[i];
+            String arrayIndexText = getIndexTextOrNull(path);
+            if (arrayIndexText == null) {
+                // non array case
+
+
+                if (!findAttribute(parser, path)) {
+                    return null;
+                }
+            } else {
+                // array case
+                if ("any".equals(arrayIndexText)) {
+                    String lastPath = i + 1 < paths.length ? paths[i + 1] : null;
+                    return getMultiValue(parser, lastPath);
+                } else {
+                    JsonToken token = parser.getCurrentToken();
+                    if (token != JsonToken.START_ARRAY) {
+                        return null;
+                    }
+                    token = parser.nextToken();
+                    int arrayIndex = Integer.parseInt(arrayIndexText);
+                    for (int j = 0; j < arrayIndex; j++) {
+                        if (token == JsonToken.END_ARRAY) {
+                            return null;
+                        }
+                        parser.skipChildren();
+                        token = parser.nextToken();
+                    }
+                }
+            }
+        }
+        Object ret = convertJsonTokenToValue(parser);
+        parser.close();
+        return ret;
+    }
+
+    abstract JsonParser createParser(Object obj) throws IOException;
+
+    private boolean findAttribute(JsonParser parser, String path) throws IOException {
+        JsonToken token = parser.getCurrentToken();
+        if (token != JsonToken.START_OBJECT) {
+            return false;
+        }
+        parser.getCurrentToken();
+        while (true) {
+            token = parser.nextToken();
+            if (token == JsonToken.END_OBJECT) {
+                return false;
+            }
+            if (path.equals(parser.getCurrentName())) {
+                parser.nextToken();
+                return true;
+            } else {
+                parser.nextToken();
+                parser.skipChildren();
+            }
+        }
+    }
+
+    private MultiResult getMultiValue(JsonParser parser, String lastPath) throws IOException {
+        MultiResult<Object> multiResult = new MultiResult<Object>();
+
+        JsonToken currentToken = parser.currentToken();
+        if (currentToken != JsonToken.START_ARRAY) {
+            return null;
+        }
+        while (true) {
+            currentToken = parser.nextToken();
+            if (currentToken == JsonToken.END_ARRAY) {
+                break;
+            }
+            if (currentToken.isScalarValue()) {
+                multiResult.add(convertJsonTokenToValue(parser));
+            } else {
+                if (lastPath != null && findAttribute(parser, lastPath)) {
+                    multiResult.add(convertJsonTokenToValue(parser));
+                }
+                while (parser.getCurrentToken() != JsonToken.END_OBJECT) {
+                    if (parser.currentToken().isStructStart()) {
+                        parser.skipChildren();
+                    }
+                    parser.nextToken();
+                }
+            }
+            parser.skipChildren();
+        }
+        return multiResult;
+    }
+
+    @Override
+    Class getReturnType() {
+        return null;
+    }
+
+    @Override
+    boolean isCacheable() {
+        return false;
+    }
+
+    private String getIndexTextOrNull(String path) {
+        if (path.charAt(path.length() - 1) == ']') {
+            return path.substring(0, path.length() - 1);
+        } else {
+            return null;
+        }
+    }
+
+    private Object convertJsonTokenToValue(JsonParser parser) throws IOException {
+        int token = parser.getCurrentTokenId();
+        switch (token) {
+            case JsonTokenId.ID_STRING:
+                return parser.getValueAsString();
+            case JsonTokenId.ID_NUMBER_INT:
+                return parser.getIntValue();
+            case JsonTokenId.ID_NUMBER_FLOAT:
+                return parser.getValueAsDouble();
+            case JsonTokenId.ID_TRUE:
+                return true;
+            case JsonTokenId.ID_FALSE:
+                return false;
+            default:
+                return null;
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractJsonGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractJsonGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,18 +29,34 @@ public abstract class AbstractJsonGetter extends Getter {
 
     private static final String DELIMITER = "\\.|\\[";
 
-    public AbstractJsonGetter(Getter parent) {
+    AbstractJsonGetter(Getter parent) {
         super(parent);
     }
 
+    /**
+     * Converts a JsonValue object to its corresponding Java object.
+     * Type mappings are as shown below
+     * <ul>
+     *     <li>{@link com.hazelcast.internal.json.JsonString} to {@link String}</li>
+     *     <li>{@link com.hazelcast.internal.json.Json.NULL} to {@code null}</li>
+     *     <li>{@link com.hazelcast.internal.json.Json.TRUE} to {@code true}</li>
+     *     <li>{@link com.hazelcast.internal.json.Json.FALSE} to {@code false}</li>
+     *     <li>
+     *         {@link com.hazelcast.internal.json.JsonNumber} to either
+     *         {@code long} or {@code double}
+     *     </li>
+     * </ul>
+     * @param value
+     * @return
+     */
     public static Object convertFromJsonValue(JsonValue value) {
         if (value == null) {
             return null;
         } else if (value.isNumber()) {
-            try {
-                return value.asLong();
-            } catch (NumberFormatException e) {
+            if (value.toString().contains(".")) {
                 return value.asDouble();
+            } else {
+                return value.asLong();
             }
         } else if (value.isBoolean()) {
             return value.asBoolean();
@@ -52,12 +68,8 @@ public abstract class AbstractJsonGetter extends Getter {
         throw new HazelcastSerializationException("Unknown Json type: " + value);
     }
 
-    protected String[] getPath(String attributePath) {
-        return attributePath.split(DELIMITER);
-    }
-
     @Override
-    Object getValue(Object obj) throws Exception {
+    Object getValue(Object obj) {
         throw new HazelcastException("Path agnostic value extraction is not supported");
 
     }
@@ -67,52 +79,72 @@ public abstract class AbstractJsonGetter extends Getter {
         String[] paths = getPath(attributePath);
         JsonParser parser = createParser(obj);
 
-        parser.nextToken();
-        for (int i = 0; i < paths.length; i++) {
-            String path = paths[i];
-            String arrayIndexText = getIndexTextOrNull(path);
-            if (arrayIndexText == null) {
-                // non array case
-
-
-                if (!findAttribute(parser, path)) {
-                    return null;
-                }
-            } else {
-                // array case
-                if ("any".equals(arrayIndexText)) {
-                    String lastPath = i + 1 < paths.length ? paths[i + 1] : null;
-                    return getMultiValue(parser, lastPath);
-                } else {
-                    JsonToken token = parser.getCurrentToken();
-                    if (token != JsonToken.START_ARRAY) {
+        try {
+            parser.nextToken();
+            for (int i = 0; i < paths.length; i++) {
+                String path = paths[i];
+                String arrayIndexText = getIndexTextOrNull(path);
+                if (arrayIndexText == null) {
+                    // non array case
+                    if (!findAttribute(parser, path)) {
                         return null;
                     }
-                    token = parser.nextToken();
-                    int arrayIndex = Integer.parseInt(arrayIndexText);
-                    for (int j = 0; j < arrayIndex; j++) {
-                        if (token == JsonToken.END_ARRAY) {
+                } else {
+                    // array case
+                    if ("any".equals(arrayIndexText)) {
+                        String lastPath = i + 1 < paths.length ? paths[i + 1] : null;
+                        return getMultiValue(parser, lastPath);
+                    } else {
+                        JsonToken token = parser.currentToken();
+                        if (token != JsonToken.START_ARRAY) {
                             return null;
                         }
-                        parser.skipChildren();
                         token = parser.nextToken();
+                        int arrayIndex = Integer.parseInt(arrayIndexText);
+                        for (int j = 0; j < arrayIndex; j++) {
+                            if (token == JsonToken.END_ARRAY) {
+                                return null;
+                            }
+                            parser.skipChildren();
+                            token = parser.nextToken();
+                        }
                     }
                 }
             }
+            return convertJsonTokenToValue(parser);
+        } finally {
+            parser.close();
         }
-        Object ret = convertJsonTokenToValue(parser);
-        parser.close();
-        return ret;
+    }
+
+    @Override
+    Class getReturnType() {
+        throw new IllegalArgumentException("Non applicable for Json getters");
+    }
+
+    @Override
+    boolean isCacheable() {
+        return false;
     }
 
     abstract JsonParser createParser(Object obj) throws IOException;
 
+    /**
+     * Looks for the attribute with the given name only in current object. If found, parser points to the value
+     * of the given attribute when this method returns. If given {@code path} does not exist in the current level,
+     * then parser points to matching {@code JsonToken.END_OBJECT} of the current object.
+     *
+     * Assumes the parser points to a {@code JsonToken.START_OBJECT}
+     * @param parser
+     * @param path
+     * @return {@code true} if given attribute name exists in the current object
+     * @throws IOException
+     */
     private boolean findAttribute(JsonParser parser, String path) throws IOException {
         JsonToken token = parser.getCurrentToken();
         if (token != JsonToken.START_OBJECT) {
             return false;
         }
-        parser.getCurrentToken();
         while (true) {
             token = parser.nextToken();
             if (token == JsonToken.END_OBJECT) {
@@ -128,6 +160,20 @@ public abstract class AbstractJsonGetter extends Getter {
         }
     }
 
+    /**
+     * Traverses given array. If {@code lastPath} is {@code null}, this
+     * method adds all the scalar values in current array to the result.
+     * Otherwise, it traverses all objects in given array and adds their
+     * scalar values named {@code lastPath} to the result.
+     *
+     * Assumes the parser points to an array.
+     *
+     * @param parser
+     * @param lastPath
+     * @return All matches in the current array that conform to
+     *          [any].lastPath search
+     * @throws IOException
+     */
     private MultiResult getMultiValue(JsonParser parser, String lastPath) throws IOException {
         MultiResult<Object> multiResult = new MultiResult<Object>();
 
@@ -140,34 +186,34 @@ public abstract class AbstractJsonGetter extends Getter {
             if (currentToken == JsonToken.END_ARRAY) {
                 break;
             }
-            if (currentToken.isScalarValue()) {
-                multiResult.add(convertJsonTokenToValue(parser));
-            } else {
-                if (lastPath != null && findAttribute(parser, lastPath)) {
+            if (lastPath == null) {
+                if (currentToken.isScalarValue()) {
                     multiResult.add(convertJsonTokenToValue(parser));
+                } else {
+                    parser.skipChildren();
                 }
-                while (parser.getCurrentToken() != JsonToken.END_OBJECT) {
-                    if (parser.currentToken().isStructStart()) {
-                        parser.skipChildren();
+            } else {
+                if (currentToken == JsonToken.START_OBJECT && findAttribute(parser, lastPath)) {
+                    multiResult.add(convertJsonTokenToValue(parser));
+                    while (parser.getCurrentToken() != JsonToken.END_OBJECT) {
+                        if (parser.currentToken().isStructStart()) {
+                            parser.skipChildren();
+                        }
+                        parser.nextToken();
                     }
-                    parser.nextToken();
+                } else if (currentToken == JsonToken.START_ARRAY) {
+                    parser.skipChildren();
                 }
             }
-            parser.skipChildren();
         }
         return multiResult;
     }
 
-    @Override
-    Class getReturnType() {
-        return null;
-    }
-
-    @Override
-    boolean isCacheable() {
-        return false;
-    }
-
+    /**
+     * Extracts path name from a query if query is in the form of [pathName].*
+     * @param path
+     * @return path name of {@code null}
+     */
     private String getIndexTextOrNull(String path) {
         if (path.charAt(path.length() - 1) == ']') {
             return path.substring(0, path.length() - 1);
@@ -177,7 +223,7 @@ public abstract class AbstractJsonGetter extends Getter {
     }
 
     private Object convertJsonTokenToValue(JsonParser parser) throws IOException {
-        int token = parser.getCurrentTokenId();
+        int token = parser.currentTokenId();
         switch (token) {
             case JsonTokenId.ID_STRING:
                 return parser.getValueAsString();
@@ -192,5 +238,9 @@ public abstract class AbstractJsonGetter extends Getter {
             default:
                 return null;
         }
+    }
+
+    private String[] getPath(String attributePath) {
+        return attributePath.split(DELIMITER);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -17,8 +17,8 @@
 package com.hazelcast.query.impl.getters;
 
 import com.hazelcast.config.MapAttributeConfig;
-import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.core.HazelcastJsonValue;
+import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.HazelcastSerializationException;
 import com.hazelcast.nio.serialization.Portable;
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static com.hazelcast.internal.serialization.impl.SerializationConstants.JAVASCRIPT_JSON_SERIALIZATION_TYPE;
 import static com.hazelcast.query.impl.getters.ExtractorHelper.extractArgumentsFromAttributeName;
 import static com.hazelcast.query.impl.getters.ExtractorHelper.extractAttributeNameNameWithoutArguments;
 import static com.hazelcast.query.impl.getters.ExtractorHelper.instantiateExtractors;
@@ -81,8 +80,15 @@ public final class Extractors {
     }
 
     /**
-     * @return Data (in this case it's portable) or Object (in this case it's
-     * non-portable)
+     * Returns the form of this data that is queryable.
+     * Returns {@link Data} if {@code target} is
+     * <ul>
+     *     <li>a portable object either in Data form or Object form</li>
+     *     <li>a {@link HazelcastJsonValue} in Data form</li>
+     * </ul>
+     * Otherwise, returns object form.
+     *
+     * @return Data or Object
      */
     private Object getTargetObject(Object target) {
         Data targetData;
@@ -94,7 +100,7 @@ public final class Extractors {
         }
         if (target instanceof Data) {
             targetData = (Data) target;
-            if (targetData.isPortable() || targetData.getType() == JAVASCRIPT_JSON_SERIALIZATION_TYPE) {
+            if (targetData.isPortable() || targetData.isJson()) {
                 return targetData;
             } else {
                 // convert non-portable Data to object
@@ -131,7 +137,7 @@ public final class Extractors {
                         genericPortableGetter = new PortableGetter(ss);
                     }
                     return genericPortableGetter;
-                } else if (((Data) targetObject).getType() == JAVASCRIPT_JSON_SERIALIZATION_TYPE) {
+                } else if (((Data) targetObject).isJson()) {
                     return JsonDataGetter.INSTANCE;
                 } else {
                     throw new HazelcastSerializationException("No Data getter found for type " + ((Data) targetObject).getType());

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Getter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Getter.java
@@ -40,7 +40,23 @@ abstract class Getter {
         return getValue(obj);
     }
 
+    /**
+     * Returns extracted object type for non-generic getters. It is only applicable when
+     * extracted object type can be determined before running the getter.
+     *
+     * @return The type of extracted attribute
+     */
     abstract Class getReturnType();
 
+    /**
+     * A getter instance may be re-used for all predicates that has the same target object
+     * type and attribute path.
+     *
+     * Generic getters such as {@link PortableGetter} should not be cached because the same
+     * getter is used for all entries regardless of attribute path. Instead, generic getters
+     * should use a singleton instance.
+     *
+     * @return {@code true} if this getter is cacheable, {@code false} otherwise.
+     */
     abstract boolean isCacheable();
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonDataGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonDataGetter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.hazelcast.nio.serialization.Data;
+
+import java.io.IOException;
+
+import static com.hazelcast.internal.serialization.impl.HeapData.HEAP_DATA_OVERHEAD;
+
+@SuppressWarnings("checkstyle:magicnumber")
+public final class JsonDataGetter extends AbstractJsonGetter {
+
+    public static final JsonDataGetter INSTANCE = new JsonDataGetter();
+
+    private JsonFactory factory = new JsonFactory();
+
+    private JsonDataGetter() {
+        super(null);
+    }
+
+    protected JsonParser createParser(Object obj) throws IOException {
+        Data data = (Data) obj;
+        return factory.createParser(data.toByteArray(), HEAP_DATA_OVERHEAD + 4, data.dataSize() - 4);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonDataGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonDataGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,11 @@ import java.io.IOException;
 
 import static com.hazelcast.internal.serialization.impl.HeapData.HEAP_DATA_OVERHEAD;
 
-@SuppressWarnings("checkstyle:magicnumber")
 public final class JsonDataGetter extends AbstractJsonGetter {
 
     public static final JsonDataGetter INSTANCE = new JsonDataGetter();
+
+    private static final int UTF_CHARACTER_COUNT_FIELD_SIZE = 4;
 
     private JsonFactory factory = new JsonFactory();
 
@@ -37,6 +38,8 @@ public final class JsonDataGetter extends AbstractJsonGetter {
 
     protected JsonParser createParser(Object obj) throws IOException {
         Data data = (Data) obj;
-        return factory.createParser(data.toByteArray(), HEAP_DATA_OVERHEAD + 4, data.dataSize() - 4);
+        return factory.createParser(data.toByteArray(),
+                HEAP_DATA_OVERHEAD + UTF_CHARACTER_COUNT_FIELD_SIZE,
+                data.dataSize() - UTF_CHARACTER_COUNT_FIELD_SIZE);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonGetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonGetter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+
+import java.io.IOException;
+
+public final class JsonGetter extends AbstractJsonGetter {
+
+    public static final JsonGetter INSTANCE = new JsonGetter();
+
+    private JsonFactory factory = new JsonFactory();
+
+    protected JsonGetter() {
+        super(null);
+    }
+
+    @Override
+    JsonParser createParser(Object obj) throws IOException {
+        return factory.createParser(obj.toString());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/json/JsonArray_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/json/JsonArray_Test.java
@@ -21,11 +21,11 @@
  ******************************************************************************/
 package com.hazelcast.internal.json;
 
-import static com.hazelcast.internal.json.TestUtil.assertException;
-import static com.hazelcast.internal.json.TestUtil.serializeAndDeserialize;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InOrder;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -33,18 +33,14 @@ import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.mockito.InOrder;
-
-import com.hazelcast.internal.json.Json;
-import com.hazelcast.internal.json.JsonArray;
-import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.internal.json.JsonWriter;
-import com.hazelcast.internal.json.ParseException;
-import com.hazelcast.test.annotation.QuickTest;
+import static com.hazelcast.internal.json.TestUtil.assertException;
+import static com.hazelcast.internal.json.TestUtil.serializeAndDeserialize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 
 @Category(QuickTest.class)
 public class JsonArray_Test {

--- a/hazelcast/src/test/java/com/hazelcast/internal/json/JsonObject_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/json/JsonObject_Test.java
@@ -21,11 +21,13 @@
  ******************************************************************************/
 package com.hazelcast.internal.json;
 
-import static com.hazelcast.internal.json.TestUtil.assertException;
-import static com.hazelcast.internal.json.TestUtil.serializeAndDeserialize;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
+import com.hazelcast.internal.json.JsonObject.HashIndexTable;
+import com.hazelcast.internal.json.JsonObject.Member;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.InOrder;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -34,20 +36,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.mockito.InOrder;
-
-import com.hazelcast.internal.json.Json;
-import com.hazelcast.internal.json.JsonArray;
-import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.internal.json.JsonWriter;
-import com.hazelcast.internal.json.ParseException;
-import com.hazelcast.internal.json.JsonObject.HashIndexTable;
-import com.hazelcast.internal.json.JsonObject.Member;
-import com.hazelcast.test.annotation.QuickTest;
+import static com.hazelcast.internal.json.TestUtil.assertException;
+import static com.hazelcast.internal.json.TestUtil.serializeAndDeserialize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 
 @Category(QuickTest.class)
 public class JsonObject_Test {

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/ToHeapDataConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/ToHeapDataConverterTest.java
@@ -100,5 +100,10 @@ public class ToHeapDataConverterTest {
         public boolean isPortable() {
             return false;
         }
+
+        @Override
+        public boolean isJson() {
+            return false;
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/json/JsonValueSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/JsonValueSerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/json/JsonValueSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/JsonValueSerializationTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json;
+
+import com.hazelcast.core.HazelcastJsonValue;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class JsonValueSerializationTest {
+
+    private InternalSerializationService serializationService;
+
+    @Before
+    public void setup() {
+        serializationService = new DefaultSerializationServiceBuilder().build();
+    }
+
+    @Test
+    public void testSerializeDeserializeJsonValue() {
+        HazelcastJsonValue jsonValue = HazelcastJson.fromString("{ \"key\": \"value\" }");
+        Data jsonData = serializationService.toData(jsonValue);
+        HazelcastJsonValue jsonDeserialized = serializationService.toObject(jsonData);
+        assertEquals(jsonValue, jsonDeserialized);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonMixedTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonMixedTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonMixedTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonMixedTypeTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json;
+
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastJsonValue;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapPredicateJsonMixedTypeTest extends HazelcastTestSupport {
+
+    @Parameterized.Parameters(name = "inMemoryFormat:{0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.OBJECT},
+                {InMemoryFormat.BINARY}
+        });
+    }
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    TestHazelcastInstanceFactory factory;
+    HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        factory = createHazelcastInstanceFactory(3);
+        factory.newInstances(getConfig(), 3);
+        instance = factory.getAllHazelcastInstances().iterator().next();
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = super.getConfig();
+        config.getMapConfig("default").setInMemoryFormat(inMemoryFormat);
+        config.getSerializationConfig().addPortableFactory(1, new PortableFactory() {
+            @Override
+            public Portable create(int classId) {
+                if (classId == 1) {
+                    return new Person();
+                }
+                return null;
+            };
+        });
+        return config;
+    }
+
+    private HazelcastJsonValue createNameAgeOnDuty(String name, int age, boolean onDuty) {
+        JsonObject object = Json.object();
+        object.add("name", name);
+        object.add("age", age);
+        object.add("onDuty", onDuty);
+        return HazelcastJson.fromString(object.toString());
+    }
+
+    @Test
+    public void testPutGet() {
+        IMap map = instance.getMap(randomMapName());
+
+        map.put("k_int", 5);
+        map.put("k_json", HazelcastJson.fromString("10"));
+        map.put("k_int_2", 11);
+
+        assertEquals(5, map.get("k_int"));
+        assertEquals(10, Json.parse(map.get("k_json").toString()).asInt());
+        assertEquals(11, map.get("k_int_2"));
+    }
+
+    @Test
+    public void testThisPredicate() {
+        IMap map = instance.getMap(randomMapName());
+
+        map.put("k_int", 5);
+        map.put("k_json", HazelcastJson.fromString("10"));
+        map.put("k_int_2", 11);
+
+        Collection vals = map.values(Predicates.greaterEqual("this", 8));
+        assertEquals(2, vals.size());
+        assertContains(vals, HazelcastJson.fromString("10"));
+        assertContains(vals, 11);
+    }
+
+    @Test
+    public void testPortableWithSamePath() {
+        IMap map = instance.getMap(randomMapName());
+
+        map.put("k_1", new Person("a", 15, false));
+        map.put("k_2", new Person("b", 27, true));
+        map.put("k_3", createNameAgeOnDuty("c", 4, false));
+        map.put("k_4", createNameAgeOnDuty("d", 77, false));
+
+        Collection vals = map.keySet(Predicates.greaterEqual("age", 20));
+        assertEquals(2, vals.size());
+        assertContains(vals, "k_2");
+        assertContains(vals, "k_4");
+    }
+
+    public static class Person implements Portable {
+
+        private String name;
+        private int age;
+        private boolean onDuty;
+
+        public Person() {
+        }
+
+        public Person(String name, int age, boolean onDuty) {
+            this.name = name;
+            this.age = age;
+            this.onDuty = onDuty;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return 1;
+        }
+
+        @Override
+        public int getClassId() {
+            return 1;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writeUTF("name", this.name);
+            writer.writeInt("age", this.age);
+            writer.writeBoolean("onDuty", this.onDuty);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            this.name = reader.readUTF("name");
+            this.age = reader.readInt("age");
+            this.onDuty = reader.readBoolean("onDuty");
+
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
@@ -1,0 +1,629 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastJsonValue;
+import com.hazelcast.core.IMap;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonArray;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.nio.serialization.Portable;
+import com.hazelcast.nio.serialization.PortableFactory;
+import com.hazelcast.nio.serialization.PortableReader;
+import com.hazelcast.nio.serialization.PortableWriter;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class MapPredicateJsonTest extends HazelcastTestSupport {
+
+    TestHazelcastInstanceFactory factory;
+    HazelcastInstance instance;
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameters(name = "inMemoryFormat: {0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][] {{InMemoryFormat.BINARY}, {InMemoryFormat.OBJECT}});
+    }
+
+    @Before
+    public void setup() {
+        factory = createHazelcastInstanceFactory(3);
+        factory.newInstances(getConfig(), 3);
+        instance = factory.getAllHazelcastInstances().iterator().next();
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = super.getConfig();
+        config.getMapConfig("default").setInMemoryFormat(inMemoryFormat);
+        config.getSerializationConfig().addPortableFactory(1, new PortableFactory() {
+            @Override
+            public Portable create(int classId) {
+                if (classId == 1) {
+                    return new MyPortable();
+                } else if (classId == 2) {
+                    return new LittlePortable();
+                }
+                return null;
+            }
+        });
+        return config;
+    }
+
+    private JsonObject createNameAgeOnDuty(String name, int age, boolean onDuty) {
+        JsonObject object = Json.object();
+        object.add("name", name);
+        object.add("age", age);
+        object.add("onDuty", onDuty);
+        return object;
+    }
+
+    private HazelcastJsonValue putJsonString(Map map, String name, int age, boolean onDuty) {
+        String f = createNameAgeOnDuty(name, age, onDuty).toString();
+        HazelcastJsonValue json = HazelcastJson.fromString(f);
+        map.put(name, json);
+        return json;
+    }
+
+    private String putWithJsonStringKey(Map map, String name, int age, boolean onDuty) {
+        String f = createNameAgeOnDuty(name, age, onDuty).toString();
+        HazelcastJsonValue json = HazelcastJson.fromString(f);
+        map.put(json, name);
+        return name;
+    }
+
+    private HazelcastJsonValue putJsonString(Map map, String key, JsonValue value) {
+        HazelcastJsonValue hazelcastJson = HazelcastJson.fromString(value.toString());
+        map.put(key, hazelcastJson);
+        return hazelcastJson;
+    }
+
+    private String putWithJsonStringKey(Map map, JsonValue key, String value) {
+        HazelcastJsonValue lazyKey = HazelcastJson.fromString(key.toString());
+        map.put(lazyKey, value);
+        return value;
+    }
+
+    @Test
+    public void testQueryOnNumberProperty() {
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+
+        HazelcastJsonValue p1 = putJsonString(map, "a", 30, true);
+        HazelcastJsonValue p2 = putJsonString(map, "b", 20, false);
+        HazelcastJsonValue p3 = putJsonString(map, "c", 10, true);
+
+        Collection<JsonValue> vals = map.values(Predicates.greaterEqual("age", 20));
+
+        assertEquals(2, vals.size());
+        assertTrue(vals.contains(p1));
+        assertTrue(vals.contains(p2));
+    }
+
+    @Test
+    public void testQueryOnNumberPropertyOnKey() {
+        IMap<JsonValue, String> map = instance.getMap(randomMapName());
+
+        String p1 = putWithJsonStringKey(map, "a", 30, true);
+        String p2 = putWithJsonStringKey(map, "b", 20, false);
+        String p3 = putWithJsonStringKey(map, "c", 10, true);
+
+        Collection<String> vals = map.values(Predicates.greaterEqual("__key.age", 20));
+
+        assertEquals(2, vals.size());
+        assertTrue(vals.contains(p1));
+        assertTrue(vals.contains(p2));
+    }
+
+    @Test
+    public void testQueryOnNumberProperty_whenSomeEntriesDoNotHaveTheField_shouldNotFail() {
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+
+        JsonValue val1 = createNameAgeOnDuty("a", 30, true);
+        val1.asObject().add("email", "a@aa.com");
+        JsonValue val2 = createNameAgeOnDuty("b", 20, false);
+        JsonValue val3 = createNameAgeOnDuty("c", 10, true);
+
+        HazelcastJsonValue p1 = putJsonString(map, "a", val1);
+        HazelcastJsonValue p2 = putJsonString(map, "b", val2);
+        HazelcastJsonValue p3 = putJsonString(map, "c", val3);
+
+        Collection<JsonValue> vals = map.values(Predicates.equal("email", "a@aa.com"));
+
+        assertEquals(1, vals.size());
+        assertTrue(vals.contains(p1));
+    }
+
+    @Test
+    public void testQueryOnNumberPropertyOnKey_whenSomeEntriesDoNotHaveTheField_shouldNotFail() {
+        IMap<JsonValue, String> map = instance.getMap(randomMapName());
+
+        JsonValue val1 = createNameAgeOnDuty("a", 30, true);
+        val1.asObject().add("email", "a@aa.com");
+        JsonValue val2 = createNameAgeOnDuty("b", 20, false);
+        JsonValue val3 = createNameAgeOnDuty("c", 10, true);
+
+        String p1 = putWithJsonStringKey(map, val1, "a");
+        String p2 = putWithJsonStringKey(map, val2, "b");
+        String p3 = putWithJsonStringKey(map, val3, "c");
+
+        Collection<String> vals = map.values(Predicates.equal("__key.email", "a@aa.com"));
+
+        assertEquals(1, vals.size());
+        assertTrue(vals.contains(p1));
+    }
+
+    @Test
+    public void testQueryOnStringProperty() {
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+
+        HazelcastJsonValue p1 = putJsonString(map, "a", 30, true);
+        HazelcastJsonValue p2 = putJsonString(map, "b", 20, false);
+        HazelcastJsonValue p3 = putJsonString(map, "c", 10, true);
+
+        Collection<JsonValue> vals = map.values(Predicates.greaterEqual("name", "b"));
+
+        assertEquals(2, vals.size());
+        assertTrue(vals.contains(p2));
+        assertTrue(vals.contains(p3));
+    }
+
+    @Test
+    public void testQueryOnBooleanProperty() {
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+
+        HazelcastJsonValue p1 = putJsonString(map, "a", 30, true);
+        HazelcastJsonValue p2 = putJsonString(map, "b", 20, false);
+        HazelcastJsonValue p3 = putJsonString(map, "c", 10, true);
+
+        Collection<JsonValue> vals = map.values(Predicates.equal("onDuty", true));
+
+        assertEquals(2, vals.size());
+        assertTrue(vals.contains(p1));
+        assertTrue(vals.contains(p3));
+    }
+
+    @Test
+    public void testQueryOnArrayIndex() {
+        JsonObject value1 = Json.object();
+        JsonObject value2 = Json.object();
+        JsonObject value3 = Json.object();
+        JsonArray array1 = Json.array(new int[]{1, 2, 3, 4, 5});
+        JsonArray array2 = Json.array(new int[]{10, 20, 30, 40, 50});
+        JsonArray array3 = Json.array(new int[]{100, 200, 300, 400, 500});
+        value1.add("numbers", array1);
+        value2.add("numbers", array2);
+        value3.add("numbers", array3);
+
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+        HazelcastJsonValue p1 = putJsonString(map, "one", value1);
+        HazelcastJsonValue p2 = putJsonString(map, "two", value2);
+        HazelcastJsonValue p3 = putJsonString(map, "three", value3);
+
+        Collection<String> vals = map.keySet(Predicates.greaterEqual("numbers[1]", 20));
+        assertEquals(2, vals.size());
+        assertTrue(vals.contains("two"));
+        assertTrue(vals.contains("three"));
+    }
+
+    @Test
+    public void testQueryOnArrayIndexOnKey() {
+        JsonObject value1 = Json.object();
+        JsonObject value2 = Json.object();
+        JsonObject value3 = Json.object();
+        JsonArray array1 = Json.array(new int[]{1, 2, 3, 4, 5});
+        JsonArray array2 = Json.array(new int[]{10, 20, 30, 40, 50});
+        JsonArray array3 = Json.array(new int[]{100, 200, 300, 400, 500});
+        value1.add("numbers", array1);
+        value2.add("numbers", array2);
+        value3.add("numbers", array3);
+
+        IMap<JsonValue, String> map = instance.getMap(randomMapName());
+        String p1 = putWithJsonStringKey(map, value1, "one");
+        String p2 = putWithJsonStringKey(map, value2, "two");
+        String p3 = putWithJsonStringKey(map, value3, "three");
+
+        Collection<String> vals = map.values(Predicates.greaterEqual("__key.numbers[1]", 20));
+        assertEquals(2, vals.size());
+        assertTrue(vals.contains(p2));
+        assertTrue(vals.contains(p3));
+    }
+
+    @Test
+    public void testNestedQuery() {
+        JsonObject object1 = Json.object();
+        JsonObject nested1 = Json.object();
+        JsonObject object2 = Json.object();
+        JsonObject nested2 = Json.object();
+
+        nested1.add("lim", 5);
+        nested2.add("lim", 6);
+
+        object1.add("inner", nested1);
+        object2.add("inner", nested2);
+
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+        HazelcastJsonValue p1 = putJsonString(map, "one", object1);
+        HazelcastJsonValue p2 = putJsonString(map, "two", object2);
+
+        Collection<JsonValue> vals = map.values(Predicates.greaterEqual("inner.lim", 6));
+        assertEquals(1, vals.size());
+        assertTrue(vals.contains(p2));
+    }
+
+    @Test
+    public void testNestedQuery_whenOneObjectMissingFirstLevelProperty() {
+        JsonObject object1 = Json.object();
+        JsonObject nested1 = Json.object();
+        JsonObject object2 = Json.object();
+        JsonObject nested2 = Json.object();
+
+        nested1.add("lim", 5);
+        nested2.add("someotherlim", 6);
+
+        object1.add("inner", nested1);
+        object2.add("inner", nested2);
+
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+        HazelcastJsonValue p1 = putJsonString(map, "one", object1);
+        HazelcastJsonValue p2 = putJsonString(map, "two", object2);
+
+        Collection<JsonValue> vals = map.values(Predicates.lessEqual("inner.lim", 6));
+        assertEquals(1, vals.size());
+        assertTrue(vals.contains(p1));
+    }
+
+    @Test
+    public void testArrayInNestedQuery() {
+        JsonObject object1 = Json.object();
+        JsonObject nested1 = Json.object();
+        JsonObject object2 = Json.object();
+        JsonObject nested2 = Json.object();
+        JsonArray array1 = Json.array(new int[]{1, 2, 3, 4, 5, 6});
+        JsonArray array2 = Json.array(new int[]{10, 20, 30, 40, 50, 60});
+
+        nested1.add("arr", array1);
+        nested2.add("arr", array2);
+
+        object1.add("inner", nested1);
+        object2.add("inner", nested2);
+
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+        HazelcastJsonValue p1 = putJsonString(map, "one", object1);
+        HazelcastJsonValue p2 = putJsonString(map, "two", object2);
+
+        Collection<JsonValue> vals = map.values(Predicates.greaterEqual("inner.arr[2]", 20));
+        assertEquals(1, vals.size());
+        assertTrue(vals.contains(p2));
+    }
+
+    @Test
+    public void testArrayInNestedQuery_whenOneArrayIsShort_shouldNotThrow() {
+        JsonObject object1 = Json.object();
+        JsonObject nested1 = Json.object();
+        JsonObject object2 = Json.object();
+        JsonObject nested2 = Json.object();
+        JsonArray array1 = Json.array(new int[]{1, 2, 3, 4, 5, 6});
+        JsonArray array2 = Json.array(new int[]{10});
+
+        nested1.add("arr", array1);
+        nested2.add("arr", array2);
+
+        object1.add("inner", nested1);
+        object2.add("inner", nested2);
+
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+        HazelcastJsonValue p1 = putJsonString(map, "one", object1);
+        putJsonString(map, "two", object2);
+
+        Collection<JsonValue> vals = map.values(Predicates.lessEqual("inner.arr[2]", 20));
+        assertEquals(1, vals.size());
+        assertTrue(vals.contains(p1));
+    }
+
+    @Test
+    public void testNestedQueryInArray() {
+        JsonValue array1 = Json.array();
+        array1.asArray().add(createNameAgeOnDuty("a", 50, false))
+                .add(createNameAgeOnDuty("b", 30, true))
+                .add(createNameAgeOnDuty("c", 32, true))
+                .add(createNameAgeOnDuty("d", 17, false));
+        JsonValue array2 = Json.array();
+        array2.asArray().add(createNameAgeOnDuty("e", 10, false))
+                .add(createNameAgeOnDuty("f", 20, true))
+                .add(createNameAgeOnDuty("g", 30, true))
+                .add(createNameAgeOnDuty("h", 40, false));
+        JsonValue array3 = Json.array();
+        array3.asArray().add(createNameAgeOnDuty("i", 26, false))
+                .add(createNameAgeOnDuty("j", 24, true))
+                .add(createNameAgeOnDuty("k", 1, true))
+                .add(createNameAgeOnDuty("l", 90, false));
+        JsonObject obj1 = Json.object();
+        obj1.add("arr", array1);
+        JsonObject obj2 = Json.object();
+        obj2.add("arr", array2);
+        JsonObject obj3 = Json.object();
+        obj3.add("arr", array3);
+
+        HazelcastJsonValue p1 = HazelcastJson.fromString(obj1.toString());
+        HazelcastJsonValue p2 = HazelcastJson.fromString(obj2.toString());
+        HazelcastJsonValue p3 = HazelcastJson.fromString(obj3.toString());
+
+        IMap<String, HazelcastJsonValue> map = instance.getMap(randomMapName());
+        map.put("one", p1);
+        map.put("two", p2);
+        map.put("three", p3);
+
+        Collection<HazelcastJsonValue> vals = map.values(Predicates.greaterEqual("arr[2].age", 20));
+        assertEquals(2, vals.size());
+        assertTrue(vals.contains(p1));
+        assertTrue(vals.contains(p2));
+    }
+
+    @Test
+    public void testQueryOnArray_whenAnyIsUsed() {
+        JsonObject value1 = Json.object();
+        JsonObject value2 = Json.object();
+        JsonObject value3 = Json.object();
+        JsonArray array1 = Json.array(new int[]{1, 2, 3, 4, 20});
+        JsonArray array2 = Json.array(new int[]{10, 20, 30});
+        JsonArray array3 = Json.array(new int[]{100, 200, 300, 400});
+        value1.add("numbers", array1);
+        value2.add("numbers", array2);
+        value3.add("numbers", array3);
+
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+        putJsonString(map, "one", value1);
+        HazelcastJsonValue p2 = putJsonString(map, "two", value2);
+        HazelcastJsonValue p3 = putJsonString(map, "three", value3);
+
+        Collection<JsonValue> vals = map.values(Predicates.greaterThan("numbers[any]", 20));
+        assertEquals(2, vals.size());
+        assertTrue(vals.contains(p2));
+        assertTrue(vals.contains(p3));
+    }
+
+    @Test
+    public void testJsonValueIsJustANumber() {
+        IMap<Integer, HazelcastJsonValue> map = instance.getMap(randomMapName());
+        for (int i = 0; i < 10; i++) {
+            map.put(i, HazelcastJson.fromString(Json.value(i).toString()));
+        }
+        Collection<HazelcastJsonValue> vals = map.values(Predicates.greaterEqual("this", 3));
+        assertEquals(7, vals.size());
+        for (HazelcastJsonValue value : vals) {
+            int intValue = Json.parse(value.toString()).asInt();
+            assertTrue(intValue >= 3);
+            assertGreaterOrEquals("predicate result ", intValue, 3);
+        }
+    }
+
+    @Test
+    public void testJsonValueIsJustAString() {
+        IMap<Integer, HazelcastJsonValue> map = instance.getMap(randomMapName());
+        for (int i = 0; i < 10; i++) {
+            map.put(i, HazelcastJson.fromString(Json.value("s" + i).toString()));
+        }
+        Collection<HazelcastJsonValue> vals = map.values(Predicates.greaterEqual("this", "s3"));
+        assertEquals(7, vals.size());
+        for (HazelcastJsonValue value : vals) {
+            String stringVal = Json.parse(value.toString()).asString();
+            assertTrue(stringVal.compareTo("s3") >= 0);
+        }
+    }
+
+    @Test
+    public void testJsonValueIsJustABoolean() {
+        IMap<Integer, HazelcastJsonValue> map = instance.getMap(randomMapName());
+        for (int i = 0; i < 10; i++) {
+            map.put(i, HazelcastJson.fromString(Json.value(i < 7).toString()));
+        }
+        Collection<Map.Entry<Integer, HazelcastJsonValue>> vals = map.entrySet(Predicates.equal("this", true));
+        assertEquals(7, vals.size());
+        for (Map.Entry<Integer, HazelcastJsonValue> entry : vals) {
+            assertTrue(entry.getKey() < 7);
+            assertEquals("true", entry.getValue().toString());
+        }
+
+    }
+
+    @Test
+    public void testNestedQueryInArray_whenAnyMatchesMultipleNestedObjects_shouldReturnAllMatching() {
+        JsonValue array1 = Json.array();
+        array1.asArray().add(createNameAgeOnDuty("a", 50, false))
+                .add(createNameAgeOnDuty("b", 30, true))
+                .add(createNameAgeOnDuty("c", 32, true))
+                .add(createNameAgeOnDuty("d", 17, false));
+        JsonValue array2 = Json.array();
+        array2.asArray().add(createNameAgeOnDuty("e", 10, false))
+                .add(createNameAgeOnDuty("f", 20, true))
+                .add(createNameAgeOnDuty("g", 30, true))
+                .add(createNameAgeOnDuty("h", 40, false));
+        JsonValue array3 = Json.array();
+        array3.asArray().add(createNameAgeOnDuty("i", 26, false))
+                .add(createNameAgeOnDuty("j", 24, true))
+                .add(createNameAgeOnDuty("k", 1, true))
+                .add(createNameAgeOnDuty("l", 90, false));
+        JsonObject obj1 = Json.object();
+        obj1.add("arr", array1);
+        JsonObject obj2 = Json.object();
+        obj2.add("arr", array2);
+        JsonObject obj3 = Json.object();
+        obj3.add("arr", array3);
+
+        IMap<String, HazelcastJsonValue> map = instance.getMap(randomMapName());
+        HazelcastJsonValue p1 = putJsonString(map, "one", obj1);
+        HazelcastJsonValue p2 = putJsonString(map, "two", obj2);
+        HazelcastJsonValue p3 = putJsonString(map, "three", obj3);
+
+        Collection<HazelcastJsonValue> vals = map.values(Predicates.greaterThan("arr[any].age", 40));
+        assertEquals(2, vals.size());
+        assertTrue(vals.contains(p1));
+        assertTrue(vals.contains(p3));
+    }
+
+    @Test
+    public void testArrayInsideArray() {
+        JsonValue array1 = Json.array();
+        array1.asArray().add(Json.array(new int[]{1, 2, 3, 4})).add(Json.array(new int[]{10, 20, 30, 40}));
+        JsonObject obj1 = Json.object();
+        obj1.add("arr", array1);
+
+        System.out.println(obj1);
+
+        IMap<String, JsonValue> map = instance.getMap(randomMapName());
+        HazelcastJsonValue p1 = putJsonString(map, "one", obj1);
+
+        Collection<JsonValue> vals = map.values(Predicates.greaterEqual("arr[1][3]", 20));
+        assertEquals(1, vals.size());
+        assertTrue(vals.contains(p1));
+    }
+
+    @Test
+    public void testJsonPredicateOnKey() {
+        JsonValue array1 = Json.array();
+        array1.asArray().add(createNameAgeOnDuty("a", 50, false))
+                .add(createNameAgeOnDuty("b", 30, true))
+                .add(createNameAgeOnDuty("c", 32, true))
+                .add(createNameAgeOnDuty("d", 17, false));
+        JsonValue array2 = Json.array();
+        array2.asArray().add(createNameAgeOnDuty("e", 10, false))
+                .add(createNameAgeOnDuty("f", 20, true))
+                .add(createNameAgeOnDuty("g", 30, true))
+                .add(createNameAgeOnDuty("h", 40, false));
+        JsonValue array3 = Json.array();
+        array3.asArray().add(createNameAgeOnDuty("i", 26, false))
+                .add(createNameAgeOnDuty("j", 24, true))
+                .add(createNameAgeOnDuty("k", 1, true))
+                .add(createNameAgeOnDuty("l", 90, false));
+        JsonObject obj1 = Json.object();
+        obj1.add("arr", array1);
+        JsonObject obj2 = Json.object();
+        obj2.add("arr", array2);
+        JsonObject obj3 = Json.object();
+        obj3.add("arr", array3);
+
+        HazelcastJsonValue p1 = HazelcastJson.fromString(obj1.toString());
+        HazelcastJsonValue p2 = HazelcastJson.fromString(obj2.toString());
+        HazelcastJsonValue p3 = HazelcastJson.fromString(obj3.toString());
+
+        IMap<HazelcastJsonValue, String> map = instance.getMap(randomMapName());
+        map.put(p1, "one");
+        map.put(p2, "two");
+        map.put(p3, "three");
+
+        Collection<String> vals = map.values(Predicates.greaterEqual("__key.arr[2].age", 20));
+        assertEquals(2, vals.size());
+        assertTrue(vals.contains("one"));
+        assertTrue(vals.contains("two"));
+    }
+
+    public static class MyPortable implements Portable {
+
+        private LittlePortable[] littlePortables;
+
+        public MyPortable() {
+
+        }
+
+        public MyPortable(LittlePortable[] littlePortables) {
+            this.littlePortables = littlePortables;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return 1;
+        }
+
+        @Override
+        public int getClassId() {
+            return 1;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writePortableArray("littlePortables", this.littlePortables);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            this.littlePortables = (LittlePortable[]) reader.readPortableArray("littlePortables");
+        }
+    }
+
+    public static class LittlePortable implements Portable {
+
+        private int real;
+        private int[] tempReals;
+
+        public LittlePortable() {
+
+        }
+
+        public LittlePortable(int real, int[] tempReals) {
+            this.real = real;
+            this.tempReals = tempReals;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return 1;
+        }
+
+        @Override
+        public int getClassId() {
+            return 2;
+        }
+
+        @Override
+        public void writePortable(PortableWriter writer) throws IOException {
+            writer.writeInt("real", this.real);
+            writer.writeIntArray("tempReals", this.tempReals);
+        }
+
+        @Override
+        public void readPortable(PortableReader reader) throws IOException {
+            this.real = reader.readInt("real");
+            this.tempReals = reader.readIntArray("tempReals");
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -26,6 +26,9 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IBiFunction;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.json.HazelcastJson;
+import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.test.AssertTask;
@@ -1290,6 +1293,17 @@ public class BasicMapTest extends HazelcastTestSupport {
         map.setTtl("tempKey", -1, TimeUnit.SECONDS);
         sleepAtLeastMillis(1000);
         assertNull(map.get("tempKey"));
+    }
+
+    @Test
+    public void testJsonPutGet() {
+        final IMap<String, HazelcastJsonValue> map = getInstance().getMap(randomMapName());
+        HazelcastJsonValue value = HazelcastJson.fromString("{ \"age\": 4 }");
+        map.put("item1", value);
+        HazelcastJsonValue retrieved = map.get("item1");
+
+        assertEquals(value, retrieved);
+        assertEquals(4, Json.parse(retrieved.toString()).asObject().get("age").asInt());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexJsonTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.json.HazelcastJson;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.query.impl.getters.Extractors;
+import com.hazelcast.query.impl.predicates.AndPredicate;
+import com.hazelcast.query.impl.predicates.EqualPredicate;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
+public class IndexJsonTest {
+
+    @Parameter(0)
+    public IndexCopyBehavior copyBehavior;
+
+    @Parameters(name = "copyBehavior: {0}")
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][]{
+                {IndexCopyBehavior.COPY_ON_READ},
+                {IndexCopyBehavior.COPY_ON_WRITE},
+                {IndexCopyBehavior.NEVER},
+        });
+    }
+
+    final InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
+
+    @Test
+    public void testJsonIndex() {
+        InternalSerializationService ss = new DefaultSerializationServiceBuilder().build();
+        Indexes is = new Indexes(ss, copyBehavior, Extractors.newBuilder(ss).build(), new DefaultIndexProvider(), true, true, true);
+        Index numberIndex = is.addOrGetIndex("age", false);
+        Index boolIndex = is.addOrGetIndex("active", false);
+        Index stringIndex = is.addOrGetIndex("name", false);
+
+        for (int i = 0; i < 1001; i++) {
+            Data key = ss.toData(i);
+            String jsonString = "{\"age\" : " + i + "  , \"name\" : \"sancar\" , \"active\" :  " + (i % 2 == 0) + " } ";
+            is.saveEntryIndex(new QueryEntry(ss, key, HazelcastJson.fromString(jsonString), Extractors.newBuilder(ss).build()), null, Index.OperationSource.USER);
+        }
+
+        assertEquals(1, numberIndex.getRecords(10).size());
+        assertEquals(0, numberIndex.getRecords(-1).size());
+        assertEquals(1001, stringIndex.getRecords("sancar").size());
+        assertEquals(501, boolIndex.getRecords(true).size());
+        assertEquals(501, is.query(new AndPredicate(new EqualPredicate("name", "sancar"), new EqualPredicate("active", "true"))).size());
+        assertEquals(300, is.query(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true))).size());
+        assertEquals(1001, is.query(new SqlPredicate("name == sancar")).size());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl;
+
+import com.hazelcast.config.CacheDeserializedValues;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.json.HazelcastJson;
+import com.hazelcast.core.HazelcastJsonValue;
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.impl.MapContainer;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category(QuickTest.class)
+public class JsonIndexIntegrationTest extends HazelcastTestSupport {
+
+    private static final String MAP_NAME = "map";
+
+    @Parameterized.Parameter(0)
+    public InMemoryFormat inMemoryFormat;
+
+    @Parameterized.Parameter(1)
+    public CacheDeserializedValues cacheDeserializedValues;
+
+    @Parameterized.Parameters(name = "inMemoryFormat: {0}, cacheDeserializedValues: {1}")
+    public static Collection<Object[]> parametersInMemoryFormat() {
+        List<Object[]> parameters = new ArrayList<Object[]>();
+        for (InMemoryFormat imf: new InMemoryFormat[]{InMemoryFormat.OBJECT, InMemoryFormat.BINARY}) {
+            for (CacheDeserializedValues cdv: CacheDeserializedValues.values()) {
+                parameters.add(new Object[] {imf, cdv});
+            }
+        }
+        return parameters;
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = super.getConfig();
+        config.getMapConfig(MAP_NAME)
+                .setInMemoryFormat(inMemoryFormat)
+                .setCacheDeserializedValues(cacheDeserializedValues);
+        return config;
+    }
+
+    @Test
+    public void testViaAccessingInternalIndexes() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap<Integer, HazelcastJsonValue> map = instance.getMap(MAP_NAME);
+        map.addIndex("age", false);
+        map.addIndex("active", false);
+        map.addIndex("name", false);
+
+        for (int i = 0; i < 1000; i++) {
+            String jsonString = "{\"age\" : " + i + "  , \"name\" : \"sancar\" , \"active\" :  " + (i % 2 == 0) + " } ";
+            map.put(i, HazelcastJson.fromString(jsonString));
+        }
+
+        Set<QueryableEntry> records = getRecords(instance, MAP_NAME, "age", 40);
+        assertEquals(1, records.size());
+
+        records = getRecords(instance, MAP_NAME, "active", true);
+        assertEquals(500, records.size());
+
+        records = getRecords(instance, MAP_NAME, "name", "sancar");
+        assertEquals(1000, records.size());
+    }
+
+    @Test
+    public void testIndex_viaQueries() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap<Integer, HazelcastJsonValue> map = instance.getMap(MAP_NAME);
+        map.addIndex("age", false);
+        map.addIndex("active", false);
+        map.addIndex("name", false);
+
+        for (int i = 0; i < 1000; i++) {
+            String jsonString = "{\"age\" : " + i + "  , \"name\" : \"sancar\" , \"active\" :  " + (i % 2 == 0) + " } ";
+            map.put(i, HazelcastJson.fromString(jsonString));
+        }
+
+        assertEquals(500, map.values(Predicates.and(Predicates.equal("name", "sancar"), Predicates.equal("active", "true"))).size());
+        assertEquals(299, map.values(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true))).size());
+        assertEquals(1000, map.values(new SqlPredicate("name == sancar")).size());
+
+    }
+
+    @Test
+    public void testEntryProcessorChanges_viaQueries() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap<Integer, HazelcastJsonValue> map = instance.getMap(MAP_NAME);
+        map.addIndex("age", false);
+        map.addIndex("active", false);
+        map.addIndex("name", false);
+
+        for (int i = 0; i < 1000; i++) {
+            String jsonString = "{\"age\" : " + i + "  , \"name\" : \"sancar\" , \"active\" :  " + (i % 2 == 0) + " } ";
+            map.put(i, HazelcastJson.fromString(jsonString));
+        }
+
+        assertEquals(500, map.values(Predicates.and(Predicates.equal("name", "sancar"), Predicates.equal("active", "true"))).size());
+        assertEquals(299, map.values(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true))).size());
+        assertEquals(1000, map.values(new SqlPredicate("name == sancar")).size());
+        map.executeOnEntries(new JsonEntryProcessor());
+        assertEquals(1000, map.values(Predicates.and(Predicates.equal("name", "sancar"), Predicates.equal("active", false))).size());
+        assertEquals(0, map.values(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", false))).size());
+        assertEquals(1000, map.values(new SqlPredicate("name == sancar")).size());
+
+    }
+
+    @Test
+    public void testEntryProcessorChanges_viaQueries_withoutIndex() {
+        HazelcastInstance instance = createHazelcastInstance();
+        IMap<Integer, HazelcastJsonValue> map = instance.getMap(MAP_NAME);
+
+        for (int i = 0; i < 1000; i++) {
+            String jsonString = "{\"age\" : " + i + "  , \"name\" : \"sancar\" , \"active\" :  " + (i % 2 == 0) + " } ";
+            map.put(i, HazelcastJson.fromString(jsonString));
+        }
+
+        assertEquals(500, map.values(Predicates.and(Predicates.equal("name", "sancar"), Predicates.equal("active", "true"))).size());
+        assertEquals(299, map.values(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", true))).size());
+        assertEquals(1000, map.values(new SqlPredicate("name == sancar")).size());
+        map.executeOnEntries(new JsonEntryProcessor());
+        assertEquals(1000, map.values(Predicates.and(Predicates.equal("name", "sancar"), Predicates.equal("active", false))).size());
+        assertEquals(0, map.values(Predicates.and(Predicates.greaterThan("age", 400), Predicates.equal("active", false))).size());
+        assertEquals(1000, map.values(new SqlPredicate("name == sancar")).size());
+
+    }
+
+    private static class JsonEntryProcessor implements EntryProcessor<Integer, HazelcastJsonValue> {
+
+        @Override
+        public Object process(Map.Entry<Integer, HazelcastJsonValue> entry) {
+            JsonObject jsonObject = Json.parse(entry.getValue().toString()).asObject();
+            jsonObject.set("age", 0);
+            jsonObject.set("active", false);
+
+            entry.setValue(HazelcastJson.fromString(jsonObject.toString()));
+            return "anyResult";
+        }
+
+        @Override
+        public EntryBackupProcessor<Integer, HazelcastJsonValue> getBackupProcessor() {
+            return new EntryBackupProcessor<Integer, HazelcastJsonValue>() {
+                @Override
+                public void processBackup(Map.Entry<Integer, HazelcastJsonValue> entry) {
+                    process(entry);
+                }
+            };
+        }
+    }
+
+    private Set<QueryableEntry> getRecords(HazelcastInstance instance, String mapName, String attribute, Comparable value) {
+        List<Index> indexes = getIndexOfAttributeForMap(instance, mapName, attribute);
+        Set<QueryableEntry> records = new HashSet<QueryableEntry>();
+        for (Index index : indexes) {
+            records.addAll(index.getRecords(value));
+        }
+        return records;
+    }
+
+    private static List<Index> getIndexOfAttributeForMap(HazelcastInstance instance, String mapName, String attribute) {
+        Node node = getNode(instance);
+        MapService service = node.nodeEngine.getService(MapService.SERVICE_NAME);
+        MapServiceContext mapServiceContext = service.getMapServiceContext();
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+
+        List<Index> result = new ArrayList<Index>();
+        for (int partitionId : mapServiceContext.getOwnedPartitions()) {
+            Indexes indexes = mapContainer.getIndexes(partitionId);
+            result.add(indexes.getIndex(attribute));
+        }
+        return result;
+    }
+}
+
+
+
+

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorAbstractTest.java
@@ -19,9 +19,9 @@ package com.hazelcast.spi.impl.operationexecutor.slowoperationdetector;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.internal.management.TimedMemberStateFactory;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.management.TimedMemberStateFactory;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.spi.Operation;
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.instance.TestUtil.getHazelcastInstanceImpl;
 import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static org.junit.Assert.assertFalse;

--- a/pom.xml
+++ b/pom.xml
@@ -1249,11 +1249,5 @@
             <version>1.7.8</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.9.7</version>
-        </dependency>
-
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1249,5 +1249,11 @@
             <version>1.7.8</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.9.7</version>
+        </dependency>
+
     </dependencies>
 </project>


### PR DESCRIPTION
Basic Json support.
Introduces `HazelcastJsonValue` which is a wrapper around a string.
Serialized form of json strings is just a utf8 string. At query time this string is queried either from Data form or deserialized "String" form. This is a foundation for fast querying work. Fast querying is going to be added with later PRs.

Introduces `JsonDataGetter` and `JsonGetter`

Adds tests for querying of Json strings.

User supplies `HazelcastJson.fromString()` method with their json formatted string. Then they can put this object into maps and query it in both BINARY and OBJECT form.

This  PR includes both the above mentioned functionality and Jackson Streaming Parser. For ease of review: The first commit is the functinality. The second one is entirely Jackson Streaming Parser.