### PR TITLE
 Adds missing client permission types to config XSDs

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -2951,7 +2951,7 @@
             </xs:element>
             <xs:element name="client-permissions" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
-                    <xs:sequence>
+                    <xs:choice minOccurs="1" maxOccurs="unbounded">
                         <xs:element name="all-permissions" type="base-permission" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="map-permission" type="instance-permission" minOccurs="0"
                                     maxOccurs="unbounded"/>
@@ -2975,6 +2975,8 @@
                                     maxOccurs="unbounded"/>
                         <xs:element name="id-generator-permission" type="instance-permission" minOccurs="0"
                                     maxOccurs="unbounded"/>
+                        <xs:element name="flake-id-generator-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
                         <xs:element name="executor-service-permission" type="instance-permission" minOccurs="0"
                                     maxOccurs="unbounded"/>
                         <xs:element name="durable-executor-service-permission" type="instance-permission" minOccurs="0"
@@ -2988,8 +2990,10 @@
                         <xs:element name="transaction-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="cache-permission" type="instance-permission" minOccurs="0"
                                     maxOccurs="unbounded"/>
+                        <xs:element name="user-code-deployment-permission" type="instance-permission" minOccurs="0"
+                                    maxOccurs="unbounded"/>
                         <xs:element name="config-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
-                    </xs:sequence>
+                    </xs:choice>
                 </xs:complexType>
             </xs:element>
             <xs:element name="security-interceptors" type="interceptors" minOccurs="0" maxOccurs="1"/>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -138,6 +138,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
 import com.hazelcast.wan.WanReplicationEndpoint;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -151,9 +152,11 @@ import javax.annotation.Resource;
 import java.io.File;
 import java.net.InetSocketAddress;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -568,12 +571,16 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         final Set<PermissionConfig> clientPermissionConfigs = config.getSecurityConfig().getClientPermissionConfigs();
         assertFalse(config.getSecurityConfig().getClientBlockUnmappedActions());
         assertTrue(isNotEmpty(clientPermissionConfigs));
-        assertEquals(1, clientPermissionConfigs.size());
+        assertEquals(22, clientPermissionConfigs.size());
         final PermissionConfig pnCounterPermission = new PermissionConfig(PermissionType.PN_COUNTER, "pnCounterPermission", "*")
                 .addAction("create")
                 .setEndpoints(Collections.<String>emptySet());
-
         assertContains(clientPermissionConfigs, pnCounterPermission);
+        Set<PermissionType> permTypes = new HashSet<PermissionType>(Arrays.asList(PermissionType.values()));
+        for (PermissionConfig pc : clientPermissionConfigs) {
+            permTypes.remove(pc.getType());
+        }
+        assertTrue("All permission types should be listed in fullConfig. Not found ones: " + permTypes, permTypes.isEmpty());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -633,6 +633,109 @@
                             <hz:action>create</hz:action>
                         </hz:actions>
                     </hz:pn-counter-permission>
+                    <hz:all-permissions principal="admin">
+                        <hz:endpoints>
+                            <hz:endpoint>127.0.0.1</hz:endpoint>
+                        </hz:endpoints>
+                    </hz:all-permissions>
+                    <hz:config-permission principal="deployer"/>
+                    <hz:transaction-permission principal="deployer"/>
+                    <hz:map-permission name="custom" principal="dev">
+                        <hz:endpoints>
+                            <hz:endpoint>127.0.0.1</hz:endpoint>
+                        </hz:endpoints>
+                        <hz:actions>
+                            <hz:action>create</hz:action>
+                            <hz:action>destroy</hz:action>
+                            <hz:action>put</hz:action>
+                            <hz:action>read</hz:action>
+                        </hz:actions>
+                    </hz:map-permission>
+                    <hz:queue-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:queue-permission>
+                    <hz:topic-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:topic-permission>
+                    <hz:multimap-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:multimap-permission>
+                    <hz:list-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:list-permission>
+                    <hz:set-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:set-permission>
+                    <hz:id-generator-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:id-generator-permission>
+                    <hz:flake-id-generator-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:flake-id-generator-permission>
+                    <hz:lock-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:lock-permission>
+                    <hz:atomic-long-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:atomic-long-permission>
+                    <hz:countdown-latch-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:countdown-latch-permission>
+                    <hz:semaphore-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:semaphore-permission>
+                    <hz:executor-service-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:executor-service-permission>
+                    <hz:durable-executor-service-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:durable-executor-service-permission>
+                    <hz:cardinality-estimator-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:cardinality-estimator-permission>
+                    <hz:scheduled-executor-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:scheduled-executor-permission>
+                    <hz:cache-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:cache-permission>
+                    <hz:user-code-deployment-permission name="*">
+                        <hz:actions>
+                            <hz:action>all</hz:action>
+                        </hz:actions>
+                    </hz:user-code-deployment-permission>
                 </hz:client-permissions>
                 <hz:client-block-unmapped-actions>false</hz:client-block-unmapped-actions>
             </hz:security>

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -2507,7 +2507,7 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
                 type = PermissionType.PN_COUNTER;
             } else if ("cache-permission".equals(nodeName)) {
                 type = PermissionType.CACHE;
-            } else if ("user-code-deployment".equals(nodeName)) {
+            } else if ("user-code-deployment-permission".equals(nodeName)) {
                 type = PermissionType.USER_CODE_DEPLOYMENT;
             } else if (PermissionType.CONFIG.getNodeName().equals(nodeName)) {
                 type = PermissionType.CONFIG;

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -2760,6 +2760,7 @@
                         maxOccurs="unbounded"/>
             <xs:element name="semaphore-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="id-generator-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="flake-id-generator-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="executor-service-permission" type="instance-permission" minOccurs="0"
                         maxOccurs="unbounded"/>
             <xs:element name="durable-executor-service-permission" type="instance-permission" minOccurs="0"
@@ -2769,6 +2770,7 @@
             <xs:element name="pn-counter-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="transaction-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
             <xs:element name="cache-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="user-code-deployment-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="config-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
         </xs:choice>
     </xs:complexType>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2114,6 +2114,16 @@
                     <endpoint>127.0.0.1</endpoint>
                 </endpoints>
             </all-permissions>
+            <config-permission>
+                <actions>
+                    <action>all</action>
+                </actions>
+            </config-permission>
+            <transaction-permission>
+                <actions>
+                    <action>all</action>
+                </actions>
+            </transaction-permission>
             <map-permission name="custom" principal="dev">
                 <endpoints>
                     <endpoint>127.0.0.1</endpoint>
@@ -2125,6 +2135,96 @@
                     <action>read</action>
                 </actions>
             </map-permission>
+            <queue-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </queue-permission>
+            <topic-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </topic-permission>
+            <multimap-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </multimap-permission>
+            <list-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </list-permission>
+            <set-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </set-permission>
+            <id-generator-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </id-generator-permission>
+            <flake-id-generator-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </flake-id-generator-permission>
+            <lock-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </lock-permission>
+            <atomic-long-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </atomic-long-permission>
+            <countdown-latch-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </countdown-latch-permission>
+            <semaphore-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </semaphore-permission>
+            <executor-service-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </executor-service-permission>
+            <durable-executor-service-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </durable-executor-service-permission>
+            <cardinality-estimator-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </cardinality-estimator-permission>
+            <scheduled-executor-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </scheduled-executor-permission>
+            <cache-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </cache-permission>
+            <user-code-deployment-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </user-code-deployment-permission>
+            <pn-counter-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </pn-counter-permission>
         </client-permissions>
         <client-block-unmapped-actions>true</client-block-unmapped-actions>
         <security-interceptors>

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -16,10 +16,12 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.config.PermissionConfig.PermissionType;
 import com.hazelcast.config.helpers.DummyMapStore;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.nio.IOUtil;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.quorum.impl.ProbabilisticQuorumFunction;
 import com.hazelcast.quorum.impl.RecentlyActiveQuorumFunction;
@@ -46,10 +48,13 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.URL;
 import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
 import static com.hazelcast.config.EvictionPolicy.LRU;
@@ -2784,6 +2789,23 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         PermissionConfig expected = new PermissionConfig(CONFIG, "*", "dev");
         expected.getEndpoints().add("127.0.0.1");
         assertPermissionConfig(expected, config);
+    }
+
+    @Test
+    public void testAllPermissionsCovered() {
+        InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream("hazelcast-fullconfig.xml");
+        Config config = null;
+        try {
+            config = new XmlConfigBuilder(xmlResource).build();
+        } finally {
+            IOUtil.closeResource(xmlResource);
+        }
+        Set<PermissionType> permTypes = new HashSet<PermissionType>(Arrays.asList(PermissionType.values()));
+        for (PermissionConfig pc : config.getSecurityConfig().getClientPermissionConfigs()) {
+            permTypes.remove(pc.getType());
+        }
+        assertTrue("All permission types should be listed in hazelcast-fullconfig.xml. Not found ones: " + permTypes,
+                permTypes.isEmpty());
     }
 
     @Test(expected = InvalidConfigurationException.class)

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -758,14 +758,8 @@
                     <endpoint>127.0.0.1</endpoint>
                 </endpoints>
             </all-permissions>
-            <map-permission name="default" principal="dev">
-                <actions>
-                    <action>create</action>
-                    <action>destroy</action>
-                    <action>put</action>
-                    <action>read</action>
-                </actions>
-            </map-permission>
+            <config-permission principal="deployer"/>
+            <transaction-permission principal="deployer"/>
             <map-permission name="custom" principal="dev">
                 <endpoints>
                     <endpoint>127.0.0.1</endpoint>
@@ -777,34 +771,96 @@
                     <action>read</action>
                 </actions>
             </map-permission>
-            <queue-permission name="default" principal="dev">
-                <endpoints>
-                    <endpoint>127.0.0.1</endpoint>
-                </endpoints>
+            <queue-permission name="*">
                 <actions>
-                    <action>create</action>
-                    <action>destroy</action>
-                    <action>add</action>
-                    <action>remove</action>
+                    <action>all</action>
                 </actions>
             </queue-permission>
-            <transaction-permission/>
-            <cache-permission name="/hz/cachemanager1/cache1" principal="dev">
-                <endpoints>
-                    <endpoint>127.0.0.1</endpoint>
-                </endpoints>
+            <topic-permission name="*">
                 <actions>
-                    <action>create</action>
-                    <action>destroy</action>
-                    <action>add</action>
-                    <action>remove</action>
+                    <action>all</action>
+                </actions>
+            </topic-permission>
+            <multimap-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </multimap-permission>
+            <list-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </list-permission>
+            <set-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </set-permission>
+            <id-generator-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </id-generator-permission>
+            <flake-id-generator-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </flake-id-generator-permission>
+            <lock-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </lock-permission>
+            <atomic-long-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </atomic-long-permission>
+            <countdown-latch-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </countdown-latch-permission>
+            <semaphore-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </semaphore-permission>
+            <executor-service-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </executor-service-permission>
+            <durable-executor-service-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </durable-executor-service-permission>
+            <cardinality-estimator-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </cardinality-estimator-permission>
+            <scheduled-executor-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </scheduled-executor-permission>
+            <cache-permission name="*">
+                <actions>
+                    <action>all</action>
                 </actions>
             </cache-permission>
-            <config-permission principal="dev">
-                <endpoints>
-                    <endpoint>127.0.0.1</endpoint>
-                </endpoints>
-            </config-permission>
+            <user-code-deployment-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </user-code-deployment-permission>
+            <pn-counter-permission name="*">
+                <actions>
+                    <action>all</action>
+                </actions>
+            </pn-counter-permission>
         </client-permissions>
         <client-block-unmapped-actions>true</client-block-unmapped-actions>
     </security>


### PR DESCRIPTION
Fixes #14309.

This PR adds missing client permission types to `hazelcast-config` and `hazelcast-spring` XSDs. It also improves test coverage in this area.