### PR TITLE
Removes EOFException stacktrace from log when connection closed

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnection.java
@@ -234,7 +234,9 @@ public class TcpIpConnection implements Connection {
             message += "Socket explicitly closed";
         }
 
-        if (closeCause == null) {
+        if (Level.FINEST.equals(logLevel)) {
+            logger.log(logLevel, message, closeCause);
+        } else if (closeCause == null || closeCause instanceof EOFException || closeCause instanceof CancelledKeyException) {
             logger.log(logLevel, message);
         } else {
             logger.log(logLevel, message, closeCause);


### PR DESCRIPTION
This regression introduced in
https://github.com/hazelcast/hazelcast/pull/13743

If exception is EOFException or cancelledKeyException we were not
logging the stack-trace, unless logging is FINEST.

I restored the behaviour by keeping the intended fix(do not create the message
if not necessary).

fixes https://github.com/hazelcast/hazelcast/issues/14244