### PR TITLE
Check excluded members before cluster state

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -279,17 +279,13 @@ public class ClusterJoinManager {
             return true;
         }
 
-        if (checkClusterStateBeforeJoin(target, targetUuid)) {
-            return true;
-        }
-
         if (joinRequest.getExcludedMemberUuids().contains(clusterService.getThisUuid())) {
             logger.warning("cannot join " + target + " since this node is excluded in its list...");
             hotRestartService.handleExcludedMemberUuids(target, joinRequest.getExcludedMemberUuids());
             return true;
         }
 
-        return false;
+        return checkClusterStateBeforeJoin(target, targetUuid);
     }
 
     private boolean checkClusterStateBeforeJoin(Address target, String uuid) {


### PR DESCRIPTION
Excluded members will restart with a new UUID. When cluster state
does not allow new members to join, a force-started member cannot join
the cluster and member rejecting the join request cannot learn it's excluded.

This is a change required after https://github.com/hazelcast/hazelcast/pull/14218