### PR TITLE
Lock cleanup operations should not check for quorum

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LocalLockCleanupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LocalLockCleanupOperation.java
@@ -26,22 +26,20 @@ import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.Notifier;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.QuorumCheckAwareOperation;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.partition.IPartitionService;
 
 import java.io.IOException;
 
-public class LocalLockCleanupOperation extends UnlockOperation implements Notifier, BackupAwareOperation {
+/**
+ * Locally executed operation which unlocks a lock if it is held by a
+ * specific owner.
+ */
+public class LocalLockCleanupOperation extends UnlockOperation
+        implements Notifier, BackupAwareOperation, QuorumCheckAwareOperation {
 
     private final String uuid;
-
-    /**
-     * This constructor should not be used to obtain an instance of this class; it exists to fulfill IdentifiedDataSerializable
-     * coding conventions.
-     */
-    public LocalLockCleanupOperation() {
-        uuid = "";
-    }
 
     public LocalLockCleanupOperation(ObjectNamespace namespace, Data key, String uuid) {
         super(namespace, key, -1, true);
@@ -73,16 +71,21 @@ public class LocalLockCleanupOperation extends UnlockOperation implements Notifi
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("LocalLockCleanupOperation is local only.");
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException("LocalLockCleanupOperation is local only.");
     }
 
     @Override
     public int getId() {
         throw new UnsupportedOperationException("LocalLockCleanupOperation is local only.");
+    }
+
+    @Override
+    public boolean shouldCheckQuorum() {
+        return false;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LocalLockCleanupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/LocalLockCleanupOperation.java
@@ -41,6 +41,14 @@ public class LocalLockCleanupOperation extends UnlockOperation
 
     private final String uuid;
 
+    /**
+     * This constructor should not be used to obtain an instance of this class; it exists to fulfill IdentifiedDataSerializable
+     * coding conventions.
+     */
+    public LocalLockCleanupOperation() {
+        uuid = "";
+    }
+
     public LocalLockCleanupOperation(ObjectNamespace namespace, Data key, String uuid) {
         super(namespace, key, -1, true);
         this.uuid = uuid;

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockIfLeaseExpiredOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/UnlockIfLeaseExpiredOperation.java
@@ -25,12 +25,13 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.ObjectNamespace;
+import com.hazelcast.spi.impl.QuorumCheckAwareOperation;
 import com.hazelcast.spi.partition.IPartition;
 import com.hazelcast.spi.partition.IPartitionService;
 
 import java.io.IOException;
 
-public final class UnlockIfLeaseExpiredOperation extends UnlockOperation {
+public final class UnlockIfLeaseExpiredOperation extends UnlockOperation implements QuorumCheckAwareOperation {
 
     private int version;
 
@@ -43,7 +44,7 @@ public final class UnlockIfLeaseExpiredOperation extends UnlockOperation {
     }
 
     @Override
-    public void run() throws Exception {
+    public void run() {
         LockStoreImpl lockStore = getLockStore();
         int lockVersion = lockStore.getVersion(key);
         ILogger logger = getLogger();
@@ -93,5 +94,10 @@ public final class UnlockIfLeaseExpiredOperation extends UnlockOperation {
     @Override
     public int getId() {
         return LockDataSerializerHook.UNLOCK_IF_LEASE_EXPIRED;
+    }
+
+    @Override
+    public boolean shouldCheckQuorum() {
+        return false;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/QuorumCheckAwareOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/QuorumCheckAwareOperation.java
@@ -19,16 +19,21 @@ package com.hazelcast.spi.impl;
 import com.hazelcast.spi.annotation.Beta;
 
 /**
- * Marker interface for operations that change state/data.
- * Used for quorum to reject operations if the quorum size not satisfied.
- * <p>
- * Operations implementing {@link com.hazelcast.spi.BackupOperation} should
- * not be marked with this interface.
+ * Marker interface for operations which need to control whether the check
+ * for quorum will be performed. Internal operations (not triggered by the
+ * user) may need to skip the quorum check to conserve consistency of data.
  *
  * @see com.hazelcast.config.QuorumConfig
  * @see QuorumCheckAwareOperation
  * @see com.hazelcast.spi.ReadonlyOperation
  */
 @Beta
-public interface MutatingOperation {
+public interface QuorumCheckAwareOperation {
+
+    /**
+     * Returns {@code true} if the quorum check should be performed. Operations
+     * which require a quorum check may get rejected if there are not enough
+     * members in the cluster.
+     */
+    boolean shouldCheckQuorum();
 }

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.concurrent.lock;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.ILock;
@@ -24,6 +25,7 @@ import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.spi.ObjectNamespace;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -62,6 +64,29 @@ public class LockAdvancedTest extends HazelcastTestSupport {
     @Test(expected = HazelcastInstanceNotActiveException.class)
     public void testShutDownNodeWhenOtherWaitingOnLockRemoteKey() throws InterruptedException {
         testShutDownNodeWhenOtherWaitingOnLock(false);
+    }
+
+    @Test
+    public void testCleanupOperationIgnoresQuorum() {
+        Config config = getConfig();
+        QuorumConfig quorum = new QuorumConfig("quorum", true, 2).setType(QuorumType.WRITE);
+        config.getQuorumConfigs().put("quorum", quorum);
+        config.getLockConfig("default").setQuorumName("quorum");
+
+        TestHazelcastInstanceFactory nodeFactory = createHazelcastInstanceFactory(2);
+        HazelcastInstance[] instances = nodeFactory.newInstances(config);
+
+        String lockName = "lock";
+        HazelcastInstance i1 = instances[0];
+        HazelcastInstance i2 = instances[1];
+        ILock l1 = i1.getLock(lockName);
+        ILock l2 = i2.getLock(lockName);
+        l2.lock();
+        assertTrue(l1.isLocked());
+        assertTrue(l2.isLocked());
+
+        i2.shutdown();
+        assertFalse(l1.isLocked());
     }
 
     private void testShutDownNodeWhenOtherWaitingOnLock(boolean localKey) throws InterruptedException {
@@ -504,6 +529,11 @@ public class LockAdvancedTest extends HazelcastTestSupport {
         }, 30);
     }
 
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfig();
+    }
+
     private static class SlowLockOperation extends Operation {
 
         Data key;
@@ -546,5 +576,4 @@ public class LockAdvancedTest extends HazelcastTestSupport {
             ns = new InternalLockNamespace(in.readUTF());
         }
     }
-
 }


### PR DESCRIPTION
Lock cleanup operations when a the lock owner is removed should not
check for quorum. Introduced a new interface for operations -
QuorumCheckAwareOperation which allows each operation to control whether
the quorum check is performed, regardless of its other interfaces which
might be inherited.

Fixes: https://github.com/hazelcast/hazelcast/issues/14215