### PR TITLE
Fix operation stats for map and replicatedMap

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStatsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStatsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.LocalMapStatsTest;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientMapStatsTest extends LocalMapStatsTest {
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    private String mapName = "mapName";
+    private HazelcastInstance client;
+    private HazelcastInstance member;
+
+    @Before
+    public void setUp() {
+        member = factory.newHazelcastInstance();
+        client = factory.newHazelcastClient();
+    }
+
+    @After
+    public void cleanup() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected LocalMapStats geMapStats() {
+        return member.getMap(mapName).getLocalMapStats();
+    }
+
+    @Override
+    protected <K, V> IMap<K, V> getMap() {
+        return client.getMap(mapName);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapStatisticsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapStatisticsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapStatisticsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapStatisticsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.replicatedmap;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ReplicatedMap;
+import com.hazelcast.monitor.LocalReplicatedMapStats;
+import com.hazelcast.replicatedmap.ReplicatedMapStatsTest;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientReplicatedMapStatisticsTest extends ReplicatedMapStatsTest {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+    private String replicatedMapName = "replicatedMap";
+    private HazelcastInstance client;
+    private HazelcastInstance member;
+
+    @Before
+    public void setUp() {
+        member = factory.newHazelcastInstance();
+        client = factory.newHazelcastClient();
+    }
+
+    @After
+    public void cleanup() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected <K, V> ReplicatedMap<K, V> getReplicatedMap() {
+        return client.getReplicatedMap(replicatedMapName);
+    }
+
+    @Override
+    protected LocalReplicatedMapStats getReplicatedMapStats() {
+        return member.getReplicatedMap(replicatedMapName).getReplicatedMapStats();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapGetAllMessageTask.java
@@ -34,7 +34,7 @@ import java.security.Permission;
 public class MapGetAllMessageTask
         extends AbstractPartitionMessageTask<MapGetAllCodec.RequestParameters> {
 
-    private long startTimeNanos;
+    private volatile long startTimeNanos;
 
     public MapGetAllMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPutAllMessageTask.java
@@ -37,7 +37,7 @@ import static com.hazelcast.util.MapUtil.createHashMap;
 public class MapPutAllMessageTask
         extends AbstractMapPartitionMessageTask<MapPutAllCodec.RequestParameters> {
 
-    private long startTimeNanos;
+    private volatile long startTimeNanos;
 
     public MapPutAllMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
@@ -32,7 +32,7 @@ import java.security.Permission;
 public class ReplicatedMapGetMessageTask
         extends AbstractPartitionMessageTask<ReplicatedMapGetCodec.RequestParameters> {
 
-    private long startTimeNanos;
+    private volatile long startTimeNanos;
 
     public ReplicatedMapGetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/ReplicatedMapGetMessageTask.java
@@ -32,6 +32,8 @@ import java.security.Permission;
 public class ReplicatedMapGetMessageTask
         extends AbstractPartitionMessageTask<ReplicatedMapGetCodec.RequestParameters> {
 
+    private long startTimeNanos;
+
     public ReplicatedMapGetMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
@@ -44,6 +46,21 @@ public class ReplicatedMapGetMessageTask
     @Override
     protected ReplicatedMapGetCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
         return ReplicatedMapGetCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected void beforeProcess() {
+        startTimeNanos = System.nanoTime();
+    }
+
+    @Override
+    protected void beforeResponse() {
+        long latencyNanos = System.nanoTime() - startTimeNanos;
+        ReplicatedMapService replicatedMapService = getService(ReplicatedMapService.SERVICE_NAME);
+
+        if (replicatedMapService.getReplicatedMapConfig(parameters.name).isStatisticsEnabled()) {
+            replicatedMapService.getLocalMapStatsImpl(parameters.name).incrementGets(latencyNanos);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ClearOperation.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.core.EntryEventType;
+import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
@@ -49,8 +50,16 @@ public class ClearOperation extends MapOperation implements BackupAwareOperation
         shouldBackup = true;
     }
 
+    private void updateStatistics() {
+        if (mapContainer.getMapConfig().isStatisticsEnabled()) {
+            LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
+            localMapStatsProvider.getLocalMapStatsImpl(name).incrementOtherOperations();
+        }
+    }
+
     @Override
     public void afterRun() throws Exception {
+        updateStatistics();
         super.afterRun();
         invalidateAllKeysInNearCaches();
         hintMapEvent();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsKeyOperation.java
@@ -18,6 +18,7 @@ package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.concurrent.lock.LockWaitNotifyKey;
 import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.BlockingOperation;
@@ -38,6 +39,10 @@ public class ContainsKeyOperation extends ReadonlyKeyBasedMapOperation implement
     @Override
     public void run() {
         containsKey = recordStore.containsKey(dataKey, getCallerAddress());
+        if (mapContainer.getMapConfig().isStatisticsEnabled()) {
+            LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
+            localMapStatsProvider.getLocalMapStatsImpl(name).incrementOtherOperations();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/operation/ClearOperation.java
@@ -67,7 +67,7 @@ public class ClearOperation extends AbstractNamedSerializableOperation implement
         if (store == null) {
             return;
         }
-        response = store.size();
+        response = store.getStorage().size();
 
         if (replicateClear) {
             store.clear();

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsMultipleNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsMultipleNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsMultipleNodeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsMultipleNodeTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.EvictionPolicy;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MaxSizeConfig;
+import com.hazelcast.config.MemberGroupConfig;
+import com.hazelcast.config.PartitionGroupConfig;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.MultiMap;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.monitor.LocalMapStats;
+import com.hazelcast.nio.Address;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LocalMapStatsMultipleNodeTest extends HazelcastTestSupport {
+
+    @Test
+    public void testHits_whenMultipleNodes() throws InterruptedException {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        final HazelcastInstance[] instances = factory.newInstances(getConfig());
+        MultiMap<Object, Object> multiMap0 = instances[0].getMultiMap("testHits_whenMultipleNodes");
+        MultiMap<Object, Object> multiMap1 = instances[1].getMultiMap("testHits_whenMultipleNodes");
+
+        // InternalPartitionService is used in order to determine owners of these keys that we will use.
+        InternalPartitionService partitionService = getNode(instances[0]).getPartitionService();
+        Address address = partitionService.getPartitionOwner(partitionService.getPartitionId("test1"));
+
+        boolean inFirstInstance = address.equals(getNode(instances[0]).getThisAddress());
+        multiMap0.get("test0");
+
+        multiMap0.put("test1", 1);
+        multiMap1.get("test1");
+
+        assertEquals(inFirstInstance ? 1 : 0, multiMap0.getLocalMultiMapStats().getHits());
+        assertEquals(inFirstInstance ? 0 : 1, multiMap1.getLocalMultiMapStats().getHits());
+
+        multiMap0.get("test1");
+        multiMap1.get("test1");
+        assertEquals(inFirstInstance ? 0 : 3, multiMap1.getLocalMultiMapStats().getHits());
+    }
+
+    @Test
+    public void testPutStats_afterPutAll() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
+        final HazelcastInstance[] instances = factory.newInstances(getConfig());
+        Map<Integer, Integer> map = new HashMap<Integer, Integer>();
+        for (int i = 1; i <= 5000; i++) {
+            map.put(i, i);
+        }
+
+        IMap<Integer, Integer> iMap = instances[0].getMap("example");
+        iMap.putAll(map);
+        final LocalMapStats localMapStats = iMap.getLocalMapStats();
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertEquals(5000, localMapStats.getPutOperationCount());
+            }
+        });
+    }
+
+    @Test
+    public void testLocalMapStats_withMemberGroups() throws Exception {
+        final String mapName = randomMapName();
+        final String[] firstMemberGroup = {"127.0.0.1", "127.0.0.2"};
+        final String[] secondMemberGroup = {"127.0.0.3"};
+
+        final Config config = createConfig(mapName, firstMemberGroup, secondMemberGroup);
+        final String[] addressArray = concatenateArrays(firstMemberGroup, secondMemberGroup);
+
+        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(addressArray);
+        final HazelcastInstance node1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance node2 = factory.newHazelcastInstance(config);
+        final HazelcastInstance node3 = factory.newHazelcastInstance(config);
+
+        final IMap<Object, Object> test = node3.getMap(mapName);
+        test.put(1, 1);
+
+        assertBackupEntryCount(1, mapName, factory.getAllHazelcastInstances());
+    }
+
+    @Test
+    public void testLocalMapStats_preservedAfterEviction() {
+        String mapName = randomMapName();
+        Config config = new Config();
+        config.getProperties().setProperty(GroupProperty.PARTITION_COUNT.getName(), "5");
+        MapConfig mapConfig = config.getMapConfig(mapName);
+        mapConfig.setEvictionPolicy(EvictionPolicy.LRU);
+        MaxSizeConfig maxSizeConfig = mapConfig.getMaxSizeConfig();
+        maxSizeConfig.setMaxSizePolicy(MaxSizeConfig.MaxSizePolicy.PER_PARTITION);
+        maxSizeConfig.setSize(25);
+
+        HazelcastInstance instance = createHazelcastInstance(config);
+        IMap<Object, Object> map = instance.getMap(mapName);
+        final CountDownLatch entryEvictedLatch = new CountDownLatch(700);
+        map.addEntryListener(new EntryEvictedListener() {
+            @Override
+            public void entryEvicted(EntryEvent event) {
+                entryEvictedLatch.countDown();
+            }
+        }, true);
+        for (int i = 0; i < 1000; i++) {
+            map.put(i, i);
+            assertEquals(i, map.get(i));
+        }
+        LocalMapStats localMapStats = map.getLocalMapStats();
+        assertEquals(1000, localMapStats.getHits());
+        assertEquals(1000, localMapStats.getPutOperationCount());
+        assertEquals(1000, localMapStats.getGetOperationCount());
+        assertOpenEventually(entryEvictedLatch);
+        localMapStats = map.getLocalMapStats();
+        assertEquals(1000, localMapStats.getHits());
+        assertEquals(1000, localMapStats.getPutOperationCount());
+        assertEquals(1000, localMapStats.getGetOperationCount());
+    }
+
+    private void assertBackupEntryCount(final long expectedBackupEntryCount, final String mapName,
+                                        final Collection<HazelcastInstance> nodes) {
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                long backup = 0;
+                for (HazelcastInstance node : nodes) {
+                    final IMap<Object, Object> map = node.getMap(mapName);
+                    backup += getBackupEntryCount(map);
+                }
+                assertEquals(expectedBackupEntryCount, backup);
+            }
+        });
+    }
+
+    private long getBackupEntryCount(IMap<Object, Object> map) {
+        final LocalMapStats localMapStats = map.getLocalMapStats();
+        return localMapStats.getBackupEntryCount();
+    }
+
+    private String[] concatenateArrays(String[]... arrays) {
+        int len = 0;
+        for (String[] array : arrays) {
+            len += array.length;
+        }
+        String[] result = new String[len];
+        int destPos = 0;
+        for (String[] array : arrays) {
+            System.arraycopy(array, 0, result, destPos, array.length);
+            destPos += array.length;
+        }
+        return result;
+    }
+
+    private Config createConfig(String mapName, String[] firstGroup, String[] secondGroup) {
+        final MemberGroupConfig firstGroupConfig = createGroupConfig(firstGroup);
+        final MemberGroupConfig secondGroupConfig = createGroupConfig(secondGroup);
+
+        Config config = getConfig();
+        config.getPartitionGroupConfig().setEnabled(true)
+                .setGroupType(PartitionGroupConfig.MemberGroupType.CUSTOM);
+        config.getPartitionGroupConfig().addMemberGroupConfig(firstGroupConfig);
+        config.getPartitionGroupConfig().addMemberGroupConfig(secondGroupConfig);
+        config.getNetworkConfig().getInterfaces().addInterface("127.0.0.*");
+
+        config.getMapConfig(mapName).setBackupCount(2);
+
+        return config;
+    }
+
+    private MemberGroupConfig createGroupConfig(String[] addressArray) {
+        final MemberGroupConfig memberGroupConfig = new MemberGroupConfig();
+        for (String address : addressArray) {
+            memberGroupConfig.addInterface(address);
+        }
+        return memberGroupConfig;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -16,45 +16,52 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.config.EvictionPolicy;
-import com.hazelcast.config.MapConfig;
-import com.hazelcast.config.MaxSizeConfig;
-import com.hazelcast.config.MemberGroupConfig;
-import com.hazelcast.config.PartitionGroupConfig;
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.core.MultiMap;
-import com.hazelcast.internal.partition.InternalPartitionService;
-import com.hazelcast.map.listener.EntryEvictedListener;
 import com.hazelcast.monitor.LocalMapStats;
-import com.hazelcast.nio.Address;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.Clock;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class LocalMapStatsTest extends HazelcastTestSupport {
+
+    private static final int OPERATION_COUNT = 10;
+    private static final int DEFAULT_PARTITION_COUNT = Integer.valueOf(PARTITION_COUNT.getDefaultValue());
+
+    private HazelcastInstance instance;
+    private String mapName = "mapName";
+
+    @Before
+    public void setUp() {
+        instance = createHazelcastInstance(getConfig());
+    }
+
+    protected LocalMapStats geMapStats() {
+        return instance.getMap(mapName).getLocalMapStats();
+    }
+
+    protected <K, V> IMap<K, V> getMap() {
+        warmUpPartitions(instance);
+        return instance.getMap(mapName);
+    }
 
     @Test
     public void testHitsGenerated() throws Exception {
@@ -63,7 +70,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.put(i, i);
             map.get(i);
         }
-        LocalMapStats localMapStats = map.getLocalMapStats();
+        LocalMapStats localMapStats = geMapStats();
         assertEquals(100, localMapStats.getHits());
     }
 
@@ -74,7 +81,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.put(i, i);
             map.get(i);
         }
-        LocalMapStats localMapStats = map.getLocalMapStats();
+        LocalMapStats localMapStats = geMapStats();
         assertEquals(100, localMapStats.getPutOperationCount());
         assertEquals(100, localMapStats.getHits());
     }
@@ -85,7 +92,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         for (int i = 0; i < 100; i++) {
             map.putAsync(i, i);
         }
-        final LocalMapStats localMapStats = map.getLocalMapStats();
+        final LocalMapStats localMapStats = geMapStats();
         assertTrueEventually(new AssertTask() {
             @Override
             public void run()
@@ -102,7 +109,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.put(i, i);
             map.get(i);
         }
-        LocalMapStats localMapStats = map.getLocalMapStats();
+        LocalMapStats localMapStats = geMapStats();
         assertEquals(100, localMapStats.getGetOperationCount());
         assertEquals(100, localMapStats.getHits());
     }
@@ -116,7 +123,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             putMap.put(100 + i, 100 + i);
             map.putAll(putMap);
         }
-        LocalMapStats localMapStats = map.getLocalMapStats();
+        LocalMapStats localMapStats = geMapStats();
         assertEquals(200, localMapStats.getPutOperationCount());
     }
 
@@ -132,7 +139,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             keys.add(100 + i);
             map.getAll(keys);
         }
-        LocalMapStats localMapStats = map.getLocalMapStats();
+        LocalMapStats localMapStats = geMapStats();
         assertEquals(200, localMapStats.getGetOperationCount());
     }
 
@@ -148,7 +155,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             @Override
             public void run()
                     throws Exception {
-                final LocalMapStats localMapStats = map.getLocalMapStats();
+                final LocalMapStats localMapStats = geMapStats();
                 assertEquals(100, localMapStats.getGetOperationCount());
                 assertEquals(100, localMapStats.getHits());
             }
@@ -162,7 +169,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.put(i, i);
             map.remove(i);
         }
-        LocalMapStats localMapStats = map.getLocalMapStats();
+        LocalMapStats localMapStats = geMapStats();
         assertEquals(100, localMapStats.getRemoveOperationCount());
     }
 
@@ -173,7 +180,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.put(i, i);
             map.removeAsync(i);
         }
-        final LocalMapStats localMapStats = map.getLocalMapStats();
+        final LocalMapStats localMapStats = geMapStats();
         assertTrueEventually(new AssertTask() {
             @Override
             public void run()
@@ -191,7 +198,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             map.put(i, i);
             map.get(i);
         }
-        final LocalMapStats localMapStats = map.getLocalMapStats();
+        final LocalMapStats localMapStats = geMapStats();
         final long initialHits = localMapStats.getHits();
 
         new Thread(new Runnable() {
@@ -200,7 +207,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
                 for (int i = 0; i < actionCount; i++) {
                     map.get(i);
                 }
-                map.getLocalMapStats(); // causes the local stats object to update
+                geMapStats(); // causes the local stats object to update
             }
         }).start();
 
@@ -224,12 +231,12 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         map.put(key, "value");
         map.get(key);
 
-        long lastAccessTime = map.getLocalMapStats().getLastAccessTime();
+        long lastAccessTime = geMapStats().getLastAccessTime();
         assertTrue(lastAccessTime >= startTime);
 
         Thread.sleep(5);
         map.put(key, "value2");
-        long lastAccessTime2 = map.getLocalMapStats().getLastAccessTime();
+        long lastAccessTime2 = geMapStats().getLastAccessTime();
         assertTrue(lastAccessTime2 > lastAccessTime);
     }
 
@@ -242,7 +249,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         map.put(key, "value");
         map.put(key, "value");
 
-        final LocalMapStats localMapStats = map.getLocalMapStats();
+        final LocalMapStats localMapStats = geMapStats();
         final long lastUpdateTime = localMapStats.getLastUpdateTime();
 
         new Thread(new Runnable() {
@@ -250,7 +257,7 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
             public void run() {
                 sleepAtLeastMillis(1);
                 map.put(key, "value2");
-                map.getLocalMapStats(); // causes the local stats object to update
+                geMapStats(); // causes the local stats object to update
             }
         }).start();
 
@@ -270,171 +277,105 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         map.put("key", "value");
         map.evictAll();
 
-        final long heapCost = map.getLocalMapStats().getHeapCost();
+        final long heapCost = geMapStats().getHeapCost();
 
         assertEquals(0L, heapCost);
     }
 
+
     @Test
-    public void testHits_whenMultipleNodes() throws InterruptedException {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        final HazelcastInstance[] instances = factory.newInstances(getConfig());
-        MultiMap<Object, Object> multiMap0 = instances[0].getMultiMap("testHits_whenMultipleNodes");
-        MultiMap<Object, Object> multiMap1 = instances[1].getMultiMap("testHits_whenMultipleNodes");
+    public void testOtherOperationCount_containsKey() {
+        Map map = getMap();
 
-        // InternalPartitionService is used in order to determine owners of these keys that we will use.
-        InternalPartitionService partitionService = getNode(instances[0]).getPartitionService();
-        Address address = partitionService.getPartitionOwner(partitionService.getPartitionId("test1"));
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.containsKey(i);
+        }
 
-        boolean inFirstInstance = address.equals(getNode(instances[0]).getThisAddress());
-        multiMap0.get("test0");
-
-        multiMap0.put("test1", 1);
-        multiMap1.get("test1");
-
-        assertEquals(inFirstInstance ? 1 : 0, multiMap0.getLocalMultiMapStats().getHits());
-        assertEquals(inFirstInstance ? 0 : 1, multiMap1.getLocalMultiMapStats().getHits());
-
-        multiMap0.get("test1");
-        multiMap1.get("test1");
-        assertEquals(inFirstInstance ? 0 : 3, multiMap1.getLocalMultiMapStats().getHits());
+        LocalMapStats stats = geMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
     }
 
     @Test
-    public void testPutStats_afterPutAll() {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
-        final HazelcastInstance[] instances = factory.newInstances(getConfig());
-        Map<Integer, Integer> map = new HashMap<Integer, Integer>();
-        for (int i = 1; i <= 5000; i++) {
-            map.put(i, i);
+    public void testOtherOperationCount_entrySet() {
+        Map map = getMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.entrySet();
         }
 
-        IMap<Integer, Integer> iMap = instances[0].getMap("example");
-        iMap.putAll(map);
-        final LocalMapStats localMapStats = iMap.getLocalMapStats();
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertEquals(5000, localMapStats.getPutOperationCount());
-            }
-        });
+        LocalMapStats stats = geMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
     }
 
     @Test
-    public void testLocalMapStats_withMemberGroups() throws Exception {
-        final String mapName = randomMapName();
-        final String[] firstMemberGroup = {"127.0.0.1", "127.0.0.2"};
-        final String[] secondMemberGroup = {"127.0.0.3"};
+    public void testOtherOperationCount_keySet() {
+        Map map = getMap();
 
-        final Config config = createConfig(mapName, firstMemberGroup, secondMemberGroup);
-        final String[] addressArray = concatenateArrays(firstMemberGroup, secondMemberGroup);
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.keySet();
+        }
 
-        final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(addressArray);
-        final HazelcastInstance node1 = factory.newHazelcastInstance(config);
-        final HazelcastInstance node2 = factory.newHazelcastInstance(config);
-        final HazelcastInstance node3 = factory.newHazelcastInstance(config);
-
-        final IMap<Object, Object> test = node3.getMap(mapName);
-        test.put(1, 1);
-
-        assertBackupEntryCount(1, mapName, factory.getAllHazelcastInstances());
+        LocalMapStats stats = geMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
     }
 
     @Test
-    public void testLocalMapStats_preservedAfterEviction() {
-        String mapName = randomMapName();
-        Config config = new Config();
-        config.getProperties().setProperty(GroupProperty.PARTITION_COUNT.getName(), "5");
-        MapConfig mapConfig = config.getMapConfig(mapName);
-        mapConfig.setEvictionPolicy(EvictionPolicy.LRU);
-        MaxSizeConfig maxSizeConfig = mapConfig.getMaxSizeConfig();
-        maxSizeConfig.setMaxSizePolicy(MaxSizeConfig.MaxSizePolicy.PER_PARTITION);
-        maxSizeConfig.setSize(25);
+    public void testOtherOperationCount_values() {
+        Map map = getMap();
 
-        HazelcastInstance instance = createHazelcastInstance(config);
-        IMap<Object, Object> map = instance.getMap(mapName);
-        final CountDownLatch entryEvictedLatch = new CountDownLatch(700);
-        map.addEntryListener(new EntryEvictedListener() {
-            @Override
-            public void entryEvicted(EntryEvent event) {
-                entryEvictedLatch.countDown();
-            }
-        }, true);
-        for (int i = 0; i < 1000; i++) {
-            map.put(i, i);
-            assertEquals(i, map.get(i));
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.values();
         }
-        LocalMapStats localMapStats = map.getLocalMapStats();
-        assertEquals(1000, localMapStats.getHits());
-        assertEquals(1000, localMapStats.getPutOperationCount());
-        assertEquals(1000, localMapStats.getGetOperationCount());
-        assertOpenEventually(entryEvictedLatch);
-        localMapStats = map.getLocalMapStats();
-        assertEquals(1000, localMapStats.getHits());
-        assertEquals(1000, localMapStats.getPutOperationCount());
-        assertEquals(1000, localMapStats.getGetOperationCount());
+
+        LocalMapStats stats = geMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
     }
 
-    private void assertBackupEntryCount(final long expectedBackupEntryCount, final String mapName,
-                                        final Collection<HazelcastInstance> nodes) {
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                long backup = 0;
-                for (HazelcastInstance node : nodes) {
-                    final IMap<Object, Object> map = node.getMap(mapName);
-                    backup += getBackupEntryCount(map);
-                }
-                assertEquals(expectedBackupEntryCount, backup);
-            }
-        });
-    }
+    @Test
+    public void testOtherOperationCount_clear() {
+        Map map = getMap();
 
-    private long getBackupEntryCount(IMap<Object, Object> map) {
-        final LocalMapStats localMapStats = map.getLocalMapStats();
-        return localMapStats.getBackupEntryCount();
-    }
-
-    private String[] concatenateArrays(String[]... arrays) {
-        int len = 0;
-        for (String[] array : arrays) {
-            len += array.length;
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.clear();
         }
-        String[] result = new String[len];
-        int destPos = 0;
-        for (String[] array : arrays) {
-            System.arraycopy(array, 0, result, destPos, array.length);
-            destPos += array.length;
+
+        LocalMapStats stats = geMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_containsValue() {
+        Map map = getMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.containsValue(1);
         }
-        return result;
+
+        LocalMapStats stats = geMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
     }
 
-    private Config createConfig(String mapName, String[] firstGroup, String[] secondGroup) {
-        final MemberGroupConfig firstGroupConfig = createGroupConfig(firstGroup);
-        final MemberGroupConfig secondGroupConfig = createGroupConfig(secondGroup);
+    @Test
+    public void testOtherOperationCount_isEmpty() {
+        Map map = getMap();
 
-        Config config = getConfig();
-        config.getPartitionGroupConfig().setEnabled(true)
-                .setGroupType(PartitionGroupConfig.MemberGroupType.CUSTOM);
-        config.getPartitionGroupConfig().addMemberGroupConfig(firstGroupConfig);
-        config.getPartitionGroupConfig().addMemberGroupConfig(secondGroupConfig);
-        config.getNetworkConfig().getInterfaces().addInterface("127.0.0.*");
-
-        config.getMapConfig(mapName).setBackupCount(2);
-
-        return config;
-    }
-
-    private MemberGroupConfig createGroupConfig(String[] addressArray) {
-        final MemberGroupConfig memberGroupConfig = new MemberGroupConfig();
-        for (String address : addressArray) {
-            memberGroupConfig.addInterface(address);
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.isEmpty();
         }
-        return memberGroupConfig;
+
+        LocalMapStats stats = geMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
     }
 
-    private <K, V> IMap<K, V> getMap() {
-        HazelcastInstance instance = createHazelcastInstance(getConfig());
-        return instance.getMap(randomString());
+    @Test
+    public void testOtherOperationCount_size() {
+        Map map = getMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.size();
+        }
+
+        LocalMapStats stats = geMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapStatsTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.Clock;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -32,6 +33,7 @@ import org.junit.runner.RunWith;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -39,84 +41,102 @@ import static org.junit.Assert.assertTrue;
 @Category({QuickTest.class, ParallelTest.class})
 public class ReplicatedMapStatsTest extends HazelcastTestSupport {
 
+    private static final int OPERATION_COUNT = 10;
+    private static final int DEFAULT_PARTITION_COUNT = Integer.valueOf(PARTITION_COUNT.getDefaultValue());
+    private HazelcastInstance instance;
+    private String replicatedMapName = "replicatedMap";
+
+    @Before
+    public void setUp() {
+        instance = createHazelcastInstance();
+    }
+
+    protected <K, V> ReplicatedMap<K, V> getReplicatedMap() {
+        warmUpPartitions(instance);
+        return instance.getReplicatedMap(replicatedMapName);
+    }
+
+    protected LocalReplicatedMapStats getReplicatedMapStats() {
+        return instance.getReplicatedMap(replicatedMapName).getReplicatedMapStats();
+    }
+
     @Test
     public void testGetOperationCount() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
         replicatedMap.put(1, 1);
-        int count = 100;
+        int count = OPERATION_COUNT;
         for (int i = 0; i < count; i++) {
             replicatedMap.get(1);
         }
-        LocalReplicatedMapStats stats = replicatedMap.getReplicatedMapStats();
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
         assertEquals(count, stats.getGetOperationCount());
     }
 
     @Test
     public void testPutOperationCount() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
-        int count = 100;
+        int count = OPERATION_COUNT;
         for (int i = 0; i < count; i++) {
             replicatedMap.put(i, i);
         }
-        LocalReplicatedMapStats stats = replicatedMap.getReplicatedMapStats();
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
         assertEquals(count, stats.getPutOperationCount());
     }
 
     @Test
     public void testRemoveOperationCount() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
-        int count = 100;
+        int count = OPERATION_COUNT;
         for (int i = 0; i < count; i++) {
             replicatedMap.put(i, i);
             replicatedMap.remove(i);
         }
-        LocalReplicatedMapStats stats = replicatedMap.getReplicatedMapStats();
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
         assertEquals(count, stats.getRemoveOperationCount());
     }
-
 
     @Test
     public void testHitsGenerated() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < OPERATION_COUNT; i++) {
             replicatedMap.put(i, i);
             replicatedMap.get(i);
         }
-        LocalReplicatedMapStats stats = replicatedMap.getReplicatedMapStats();
-        assertEquals(100, stats.getHits());
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT, stats.getHits());
     }
 
     @Test
     public void testPutAndHitsGenerated() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < OPERATION_COUNT; i++) {
             replicatedMap.put(i, i);
             replicatedMap.get(i);
         }
-        LocalReplicatedMapStats stats = replicatedMap.getReplicatedMapStats();
-        assertEquals(100, stats.getHits());
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT, stats.getHits());
     }
 
     @Test
     public void testGetAndHitsGenerated() {
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < OPERATION_COUNT; i++) {
             replicatedMap.put(i, i);
             replicatedMap.get(i);
         }
-        LocalReplicatedMapStats stats = replicatedMap.getReplicatedMapStats();
-        assertEquals(100, stats.getHits());
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT, stats.getHits());
     }
 
     @Test
     public void testHitsGenerated_updatedConcurrently() {
         final ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
-        final int actionCount = 100;
+        final int actionCount = OPERATION_COUNT;
         for (int i = 0; i < actionCount; i++) {
             replicatedMap.put(i, i);
             replicatedMap.get(i);
         }
-        final LocalReplicatedMapStats stats = replicatedMap.getReplicatedMapStats();
+        final LocalReplicatedMapStats stats = getReplicatedMapStats();
         final long initialHits = stats.getHits();
 
         new Thread(new Runnable() {
@@ -125,7 +145,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
                 for (int i = 0; i < actionCount; i++) {
                     replicatedMap.get(i);
                 }
-                replicatedMap.getReplicatedMapStats(); // causes the local stats object to update
+                getReplicatedMapStats(); // causes the local stats object to update
             }
         }).start();
 
@@ -145,7 +165,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
         String key = "key";
         replicatedMap.put(key, "value");
         replicatedMap.get(key);
-        long lastAccessTime = replicatedMap.getReplicatedMapStats().getLastAccessTime();
+        long lastAccessTime = getReplicatedMapStats().getLastAccessTime();
 
         assertTrue(lastAccessTime >= startTime);
     }
@@ -157,7 +177,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
         final String key = "key";
         map.put(key, "value");
         map.get(key);
-        final LocalReplicatedMapStats stats = map.getReplicatedMapStats();
+        final LocalReplicatedMapStats stats = getReplicatedMapStats();
         final long lastAccessTime = stats.getLastAccessTime();
 
         new Thread(new Runnable() {
@@ -186,12 +206,12 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
         String key = "key";
         replicatedMap.put(key, "value");
 
-        long lastUpdateTime = replicatedMap.getReplicatedMapStats().getLastUpdateTime();
+        long lastUpdateTime = getReplicatedMapStats().getLastUpdateTime();
         assertTrue(lastUpdateTime >= startTime);
 
         sleepAtLeastMillis(5);
         replicatedMap.put(key, "value2");
-        long lastUpdateTime2 = replicatedMap.getReplicatedMapStats().getLastUpdateTime();
+        long lastUpdateTime2 = getReplicatedMapStats().getLastUpdateTime();
         assertTrue(lastUpdateTime2 >= lastUpdateTime);
     }
 
@@ -203,7 +223,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
         final String key = "key";
         map.put(key, "value");
 
-        final LocalReplicatedMapStats stats = map.getReplicatedMapStats();
+        final LocalReplicatedMapStats stats = getReplicatedMapStats();
         final long lastUpdateTime = stats.getLastUpdateTime();
 
         new Thread(new Runnable() {
@@ -211,7 +231,7 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
             public void run() {
                 sleepAtLeastMillis(1);
                 map.put(key, "value2");
-                map.getReplicatedMapStats(); // causes the local stats object to update
+                getReplicatedMapStats(); // causes the local stats object to update
             }
         }).start();
 
@@ -227,24 +247,114 @@ public class ReplicatedMapStatsTest extends HazelcastTestSupport {
     @Test
     public void testPutOperationCount_afterPutAll() {
         Map<Integer, Integer> map = new HashMap<Integer, Integer>();
-        for (int i = 1; i <= 100; i++) {
+        for (int i = 1; i <= OPERATION_COUNT; i++) {
             map.put(i, i);
         }
         ReplicatedMap<Integer, Integer> replicatedMap = getReplicatedMap();
         replicatedMap.putAll(map);
-        final LocalReplicatedMapStats stats = replicatedMap.getReplicatedMapStats();
+        final LocalReplicatedMapStats stats = getReplicatedMapStats();
 
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                assertEquals(100, stats.getPutOperationCount());
+                assertEquals(OPERATION_COUNT, stats.getPutOperationCount());
             }
         });
     }
 
-    private <K, V> ReplicatedMap<K, V> getReplicatedMap() {
-        HazelcastInstance instance = createHazelcastInstance();
-        warmUpPartitions(instance);
-        return instance.getReplicatedMap(randomMapName());
+    @Test
+    public void testOtherOperationCount_containsKey() {
+        ReplicatedMap<Integer, Integer> map = getReplicatedMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.containsKey(i);
+        }
+
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_entrySet() {
+        ReplicatedMap<Integer, Integer> map = getReplicatedMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.entrySet();
+        }
+
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_keySet() {
+        ReplicatedMap<Integer, Integer> map = getReplicatedMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.keySet();
+        }
+
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_values() {
+        ReplicatedMap<Integer, Integer> map = getReplicatedMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.values();
+        }
+
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_clear() {
+        ReplicatedMap<Integer, Integer> map = getReplicatedMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.clear();
+        }
+
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_containsValue() {
+        ReplicatedMap<Integer, Integer> map = getReplicatedMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.containsValue(1);
+        }
+
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_isEmpty() {
+        ReplicatedMap<Integer, Integer> map = getReplicatedMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.isEmpty();
+        }
+
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
+    }
+
+    @Test
+    public void testOtherOperationCount_size() {
+        ReplicatedMap<Integer, Integer> map = getReplicatedMap();
+
+        for (int i = 0; i < OPERATION_COUNT; i++) {
+            map.size();
+        }
+
+        LocalReplicatedMapStats stats = getReplicatedMapStats();
+        assertEquals(OPERATION_COUNT * DEFAULT_PARTITION_COUNT, stats.getOtherOperationCount());
     }
 }


### PR DESCRIPTION
Map.clear and Map.containsKey, ReplicatedMap.get were not updating
the stats.
ReplicatedMap.clear were updating the stats twice.

Fixed the issues above and added tests for member and client.

fixes https://github.com/hazelcast/hazelcast/issues/14143