### PR TITLE
Fixes QueryCache returning internal objects

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -164,7 +164,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
             boolean valid = predicate.apply(queryEntry);
             if (valid) {
                 Object keyObject = queryEntry.getKey();
-                Object valueObject = queryEntry.getValue();
+                Object valueObject = toObject(queryEntry.getValueData());
                 Map.Entry simpleEntry = new AbstractMap.SimpleEntry(keyObject, valueObject);
                 resultingSet.add(simpleEntry);
             }
@@ -185,7 +185,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
 
             boolean valid = predicate.apply(queryEntry);
             if (valid) {
-                Object valueObject = queryEntry.getValue();
+                Object valueObject = toObject(queryEntry.getValueData());
                 resultingSet.add((V) valueObject);
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -35,6 +35,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
+import com.hazelcast.query.impl.CachedQueryEntry;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryEntry;
@@ -343,7 +344,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
             for (QueryableEntry entry : query) {
-                K key = (K) entry.getKey();
+                K key = toObject(entry.getKeyData());
                 resultingSet.add(key);
             }
         } else {
@@ -362,7 +363,9 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
             for (QueryableEntry entry : query) {
-                resultingSet.add(entry);
+                Map.Entry<K, V> copyEntry = new CachedQueryEntry<K, V>(serializationService, entry.getKeyData(),
+                        entry.getValueData(), null);
+                resultingSet.add(copyEntry);
             }
         } else {
             doFullEntryScan(predicate, resultingSet);
@@ -383,7 +386,7 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
             for (QueryableEntry entry : query) {
-                resultingSet.add((V) entry.getValue());
+                resultingSet.add((V) toObject(entry.getValueData()));
             }
         } else {
             doFullValueScan(predicate, resultingSet);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -41,6 +41,7 @@ import com.hazelcast.query.impl.Indexes;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.spi.EventFilter;
+import com.hazelcast.spi.impl.UnmodifiableLazyList;
 import com.hazelcast.util.ContextMutexFactory;
 import com.hazelcast.util.FutureUtil;
 import com.hazelcast.util.MapUtil;
@@ -381,17 +382,17 @@ class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
             return Collections.emptySet();
         }
 
-        Set<V> resultingSet = new HashSet<V>();
+        List<Data> resultingList = new ArrayList<Data>();
 
         Set<QueryableEntry> query = indexes.query(predicate);
         if (query != null) {
             for (QueryableEntry entry : query) {
-                resultingSet.add((V) toObject(entry.getValueData()));
+                resultingList.add(entry.getValueData());
             }
         } else {
-            doFullValueScan(predicate, resultingSet);
+            doFullValueScan(predicate, resultingList);
         }
-        return resultingSet;
+        return new UnmodifiableLazyList<V>(resultingList, serializationService);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/AbstractQueryCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/AbstractQueryCacheTestSupport.java
@@ -17,6 +17,7 @@
 package com.hazelcast.map.impl.querycache;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
@@ -32,6 +33,10 @@ public abstract class AbstractQueryCacheTestSupport extends HazelcastTestSupport
     protected String mapName = randomString();
     protected String cacheName = randomString();
     protected TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(3);
+
+    InMemoryFormat getInMemoryFormat() {
+        return InMemoryFormat.BINARY;
+    }
 
     void populateMap(IMap<Integer, Employee> map, int count) {
         populateMap(map, 0, count);
@@ -64,6 +69,7 @@ public abstract class AbstractQueryCacheTestSupport extends HazelcastTestSupport
 
         QueryCacheConfig queryCacheConfig = new QueryCacheConfig(cacheName);
         queryCacheConfig.getPredicateConfig().setImplementation(predicate);
+        queryCacheConfig.setInMemoryFormat(getInMemoryFormat());
         config.getMapConfig(mapName).addQueryCacheConfig(queryCacheConfig);
 
         return factory.newInstances(config)[0].getMap(mapName);

--- a/hazelcast/src/test/java/com/hazelcast/mapreduce/helpers/Employee.java
+++ b/hazelcast/src/test/java/com/hazelcast/mapreduce/helpers/Employee.java
@@ -69,6 +69,10 @@ public class Employee implements Serializable, Comparable<Employee> {
         return age;
     }
 
+    public void setAge(int age) {
+        this.age = age;
+    }
+
     public double getSalary() {
         return salary;
     }


### PR DESCRIPTION
QueryCache must return copies of found objects by its contract. This PR fixes the issue where user modifies the objects returned from QueryCache and they are modified in QueryCache too. For this, QueryCache methods values(), entrySet() and keySet() create a copy of the values by deserializing them from their serialized form.

fixes https://github.com/hazelcast/hazelcast/issues/14280