### PR TITLE
Fix partition service compatibility test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/InternalPartitionImplConstructor.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/constructor/InternalPartitionImplConstructor.java
@@ -21,7 +21,9 @@ import com.hazelcast.test.starter.HazelcastStarterConstructor;
 import java.lang.reflect.Array;
 import java.lang.reflect.Constructor;
 
+import static com.hazelcast.internal.partition.PartitionReplica.UNKNOWN_UID;
 import static com.hazelcast.test.starter.HazelcastProxyFactory.proxyArgumentsIfNeeded;
+import static com.hazelcast.test.starter.ReflectionUtils.getAllFieldsByName;
 import static com.hazelcast.test.starter.ReflectionUtils.getFieldValueReflectively;
 
 @HazelcastStarterConstructor(classNames = {"com.hazelcast.internal.partition.impl.InternalPartitionImpl"})
@@ -36,19 +38,67 @@ public class InternalPartitionImplConstructor extends AbstractStarterObjectConst
         ClassLoader classloader = targetClass.getClassLoader();
         Class<?> partitionListenerClass = classloader.loadClass("com.hazelcast.internal.partition.PartitionListener");
         Class<?> replicaClass = classloader.loadClass("com.hazelcast.internal.partition.PartitionReplica");
+        Class<?> addressClass = classloader.loadClass("com.hazelcast.nio.Address");
         Class<?> replicaArrayClass = Array.newInstance(replicaClass, 0).getClass();
         // obtain reference to constructor InternalPartitionImpl(int partitionId, PartitionListener listener,
         //                                                       PartitionReplica localReplica, PartitionReplica[] replicas)
         Constructor<?> constructor = targetClass.getDeclaredConstructor(Integer.TYPE, partitionListenerClass, replicaClass,
                 replicaArrayClass);
 
+        // obtain reference to constructor PartitionReplica(Address address, String uuid)
+        Constructor<?> replicaConstructor = replicaClass.getConstructor(addressClass, String.class);
+
         Integer partitionId = (Integer) getFieldValueReflectively(delegate, "partitionId");
         Object partitionListener = getFieldValueReflectively(delegate, "partitionListener");
-        Object thisAddress = getFieldValueReflectively(delegate, "localReplica");
-        Object replicas = getFieldValueReflectively(delegate, "replicas");
-        Object[] args = new Object[]{partitionId, partitionListener, thisAddress, replicas};
+        Object localReplica = getLocalReplica(delegate, classloader, replicaConstructor);
+        Object replicas = getReplicas(delegate, classloader, replicaConstructor);
 
+        Object[] args = new Object[]{partitionId, partitionListener, localReplica, replicas};
         Object[] proxiedArgs = proxyArgumentsIfNeeded(args, classloader);
+
         return constructor.newInstance(proxiedArgs);
+    }
+
+    private Object getReplicas(Object delegate,
+                               ClassLoader classloader,
+                               Constructor<?> replicaConstructor) throws Exception {
+        // RU_COMPAT_3_11
+        boolean is311Instance = is311Instance(delegate);
+        if (is311Instance) {
+            Object[] addresses = (Object[]) getFieldValueReflectively(delegate, "addresses");
+            Object[] replicas = (Object[]) Array.newInstance(replicaConstructor.getDeclaringClass(), addresses.length);
+            for (int i = 0; i < addresses.length; i++) {
+                replicas[i] = toPartitionReplica(addresses[i], replicaConstructor, classloader);
+            }
+            return replicas;
+        } else {
+            return getFieldValueReflectively(delegate, "replicas");
+        }
+    }
+
+    private Object getLocalReplica(Object delegate, ClassLoader classloader, Constructor<?> replicaConstructor) throws Exception {
+        // RU_COMPAT_3_11
+        boolean is311Instance = is311Instance(delegate);
+        if (is311Instance) {
+            Object thisAddress = getFieldValueReflectively(delegate, "thisAddress");
+            return toPartitionReplica(thisAddress, replicaConstructor, classloader);
+        } else {
+            return getFieldValueReflectively(delegate, "localReplica");
+        }
+    }
+
+    private static boolean is311Instance(Object delegate) {
+        return getAllFieldsByName(delegate.getClass()).containsKey("thisAddress");
+    }
+
+    private Object toPartitionReplica(Object address,
+                                      Constructor<?> replicaConstructor,
+                                      ClassLoader targetClassloader) throws Exception {
+        if (address == null) {
+            return null;
+        }
+        Object[] args = {address, UNKNOWN_UID};
+        Object[] proxiedArgs = proxyArgumentsIfNeeded(args, targetClassloader);
+        return replicaConstructor.newInstance(proxiedArgs);
     }
 }


### PR DESCRIPTION
The InternalPartitionImplConstructor class constructs a proxy for the
InternalPartitionImpl from a previous HZ version. Since we introduced
changes in https://github.com/hazelcast/hazelcast/pull/14218, we must
now translate from the old pre-3.12 InternalPartitionImpl to the new
3.12 InternalPartitionImpl.

Fixes: https://github.com/hazelcast/hazelcast/issues/14320