### PR TITLE
Blue/Green feature for clients

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/ClientExtension.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/ClientExtension.java
@@ -16,8 +16,11 @@
 
 package com.hazelcast.client;
 
+import com.hazelcast.client.config.SocketOptions;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.ClientProxyFactory;
+import com.hazelcast.config.SSLConfig;
+import com.hazelcast.config.SocketInterceptorConfig;
 import com.hazelcast.internal.nearcache.NearCacheManager;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -59,7 +62,22 @@ public interface ClientExtension {
      */
     SocketInterceptor createSocketInterceptor();
 
+    /**
+     * Create socket interceptor according to given config
+     *
+     * @param socketInterceptorConfig config for socket interceptor
+     * @return socket interceptor if it is able to created, null otherwise
+     */
+    SocketInterceptor createSocketInterceptor(SocketInterceptorConfig socketInterceptorConfig);
+
     ChannelInitializer createChannelInitializer();
+
+    /**
+     * @param sslConfig     ssl config for channel initializer
+     * @param socketOptions socket options for channel initializer
+     * @return @return ChannelInitializer created from given configs
+     */
+    ChannelInitializer createChannelInitializer(SSLConfig sslConfig, SocketOptions socketOptions);
 
     /**
      * Creates a {@link NearCacheManager} instance to be used by this client.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/ClientNotAllowedInClusterException.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/ClientNotAllowedInClusterException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * A {@link HazelcastException} that is thrown when client can not use this cluster. Example;
+ * - Cluster blacklisted client
+ * - Client and cluster partition count is different
+ */
+public class ClientNotAllowedInClusterException extends HazelcastException {
+
+    /**
+     * Creates a AuthenticationException with the given message.
+     *
+     * @param message the message.
+     */
+    public ClientNotAllowedInClusterException(String message) {
+        super(message);
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientFailoverConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientFailoverConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Config class to configure multiple client configs to be used by single client instance
+ * The client will try to connect them in given order.
+ * When the connected cluster fails or the client blacklisted from the cluster via the management center, the client will
+ * search for alternative clusters with given configs.
+ */
+public class ClientFailoverConfig {
+
+    private int tryCount = Integer.MAX_VALUE;
+    private List<ClientConfig> clientConfigs = new LinkedList<ClientConfig>();
+
+    public ClientFailoverConfig() {
+
+    }
+
+    public ClientFailoverConfig addClientConfig(ClientConfig clientConfig) {
+        clientConfigs.add(clientConfig);
+        return this;
+    }
+
+    public ClientFailoverConfig setTryCount(int tryCount) {
+        this.tryCount = tryCount;
+        return this;
+    }
+
+    public List<ClientConfig> getClientConfigs() {
+        return clientConfigs;
+    }
+
+    public ClientFailoverConfig setClientConfigs(List<ClientConfig> clientConfigs) {
+        this.clientConfigs = clientConfigs;
+        return this;
+    }
+
+    public int getTryCount() {
+        return tryCount;
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientFailoverConfigSections.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientFailoverConfigSections.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+/**
+ * Configuration sections for the clients shared by XML and YAML based
+ * configurations
+ */
+enum ClientFailoverConfigSections {
+    CLIENT_FAILOVER("hazelcast-client-failover", false),
+    CLIENTS("clients", false),
+    TRY_COUNT("try-count", false);
+
+    final String name;
+    final boolean multipleOccurrence;
+
+    ClientFailoverConfigSections(String name, boolean multipleOccurrence) {
+        this.name = name;
+        this.multipleOccurrence = multipleOccurrence;
+    }
+
+    public static boolean canOccurMultipleTimes(String name) {
+        for (ClientFailoverConfigSections element : values()) {
+            if (name.equals(element.name)) {
+                return element.multipleOccurrence;
+            }
+        }
+        return true;
+    }
+
+    public boolean isEqual(String name) {
+        return this.name.equals(name);
+    }
+
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientFailoverDomConfigProcessor.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientFailoverDomConfigProcessor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.config.AbstractDomConfigProcessor;
+import com.hazelcast.config.InvalidConfigurationException;
+import org.w3c.dom.Node;
+
+import java.io.IOException;
+
+import static com.hazelcast.client.config.ClientFailoverConfigSections.CLIENTS;
+import static com.hazelcast.client.config.ClientFailoverConfigSections.TRY_COUNT;
+import static com.hazelcast.client.config.ClientFailoverConfigSections.canOccurMultipleTimes;
+import static com.hazelcast.config.DomConfigHelper.childElements;
+import static com.hazelcast.config.DomConfigHelper.cleanNodeName;
+
+
+class ClientFailoverDomConfigProcessor extends AbstractDomConfigProcessor {
+
+    private final ClientFailoverConfig clientFailoverConfig;
+
+    ClientFailoverDomConfigProcessor(boolean domLevel3, ClientFailoverConfig clientFailoverConfig) {
+        super(domLevel3);
+        this.clientFailoverConfig = clientFailoverConfig;
+    }
+
+    @Override
+    public void buildConfig(Node rootNode) {
+        for (Node node : childElements(rootNode)) {
+            String nodeName = cleanNodeName(node);
+            if (occurrenceSet.contains(nodeName)) {
+                throw new InvalidConfigurationException("Duplicate '" + nodeName + "' definition found in XML configuration");
+            }
+            handleXmlNode(node, nodeName);
+            if (!canOccurMultipleTimes(nodeName)) {
+                occurrenceSet.add(nodeName);
+            }
+        }
+    }
+
+    private void handleXmlNode(Node node, String nodeName) {
+        if (CLIENTS.isEqual(nodeName)) {
+            handleClients(node);
+        } else if (TRY_COUNT.isEqual(nodeName)) {
+            handleTryCount(node);
+        }
+    }
+
+    private void handleClients(Node node) {
+        for (Node child : childElements(node)) {
+            if ("client".equals(cleanNodeName(child))) {
+                String clientPath = getTextContent(child);
+                try {
+                    ClientConfig config = new XmlClientConfigBuilder(clientPath).build();
+                    clientFailoverConfig.addClientConfig(config);
+                } catch (IOException e) {
+                    throw new InvalidConfigurationException("Could not create the config from given path : " + clientPath, e);
+                }
+            }
+        }
+    }
+
+    private void handleTryCount(Node node) {
+        int tryCount = Integer.parseInt(getTextContent(node));
+        clientFailoverConfig.setTryCount(tryCount);
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -40,7 +40,6 @@ import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 /**
  * Loads the {@link com.hazelcast.client.config.ClientConfig} using XML.
  */
-@SuppressWarnings("checkstyle:methodcount")
 public class XmlClientConfigBuilder extends AbstractXmlConfigBuilder {
 
     private static final ILogger LOGGER = Logger.getLogger(XmlClientConfigBuilder.class);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.config.AbstractXmlConfigBuilder;
+import com.hazelcast.config.ConfigLoader;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.util.ExceptionUtil;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
+
+/**
+ * Loads the {@link com.hazelcast.client.config.ClientFailoverConfig} using XML.
+ */
+public class XmlClientFailoverConfigBuilder extends AbstractXmlConfigBuilder {
+
+    private static final ILogger LOGGER = Logger.getLogger(XmlClientFailoverConfigBuilder.class);
+    private final InputStream in;
+
+    public XmlClientFailoverConfigBuilder(String resource) throws IOException {
+        URL url = ConfigLoader.locateConfig(resource);
+        if (url == null) {
+            throw new IllegalArgumentException("Could not load " + resource);
+        }
+        this.in = url.openStream();
+    }
+
+    public XmlClientFailoverConfigBuilder(File file) throws IOException {
+        if (file == null) {
+            throw new NullPointerException("File is null!");
+        }
+        this.in = new FileInputStream(file);
+    }
+
+    public XmlClientFailoverConfigBuilder(URL url) throws IOException {
+        if (url == null) {
+            throw new NullPointerException("URL is null!");
+        }
+        this.in = url.openStream();
+    }
+
+    public XmlClientFailoverConfigBuilder(InputStream in) {
+        this.in = in;
+    }
+
+    /**
+     * Loads the client config using the following resolution mechanism:
+     * <ol>
+     * <li>first it checks if a system property 'hazelcast.client.failover.config' is set. If it exist and it begins with
+     * 'classpath:', then a classpath resource is loaded. Else it will assume it is a file reference</li>
+     * <li>it checks if a hazelcast-client-failover.xml is available in the working dir</li>
+     * <li>it checks if a hazelcast-client-failover.xml is available on the classpath</li>
+     * <li>if none available build throws HazelcastException </li>
+     * </ol>
+     */
+    public XmlClientFailoverConfigBuilder() {
+        XmlClientFailoverConfigLocator locator = new XmlClientFailoverConfigLocator();
+        boolean located = locator.locateEverywhere();
+        if (!located) {
+            throw new HazelcastException("Failed to load ClientFailoverConfig");
+        }
+        this.in = locator.getIn();
+    }
+
+    @Override
+    protected Document parse(InputStream inputStream) throws Exception {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        DocumentBuilder builder = dbf.newDocumentBuilder();
+        try {
+            return builder.parse(inputStream);
+        } catch (Exception e) {
+            String msg = "Failed to parse Failover Config Stream"
+                    + LINE_SEPARATOR + "Exception: " + e.getMessage()
+                    + LINE_SEPARATOR + "HazelcastClient startup interrupted.";
+            LOGGER.severe(msg);
+            throw new InvalidConfigurationException(e.getMessage(), e);
+        } finally {
+            IOUtil.closeResource(inputStream);
+        }
+    }
+
+    @Override
+    protected ConfigType getConfigType() {
+        return ConfigType.CLIENT_FAILOVER;
+    }
+
+    public ClientFailoverConfig build() {
+        ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
+        try {
+            parseAndBuildConfig(clientFailoverConfig);
+        } catch (Exception e) {
+            throw ExceptionUtil.rethrow(e);
+        } finally {
+            IOUtil.closeResource(in);
+        }
+        return clientFailoverConfig;
+    }
+
+    private void parseAndBuildConfig(ClientFailoverConfig clientFailoverConfig) throws Exception {
+        Document doc = parse(in);
+        Element root = doc.getDocumentElement();
+        checkRootElement(root);
+        try {
+            root.getTextContent();
+        } catch (Throwable e) {
+            domLevel3 = false;
+        }
+        process(root);
+        schemaValidation(root.getOwnerDocument());
+        new ClientFailoverDomConfigProcessor(domLevel3, clientFailoverConfig).buildConfig(root);
+    }
+
+    private void checkRootElement(Element root) {
+        String rootNodeName = root.getNodeName();
+        if (!ClientFailoverConfigSections.CLIENT_FAILOVER.isEqual(rootNodeName)) {
+            throw new InvalidConfigurationException("Invalid root element in xml configuration! "
+                    + "Expected: <hazelcast-client-failover>, Actual: <" + rootNodeName + ">.");
+        }
+    }
+}
+

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigLocator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigLocator.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.config.AbstractConfigLocator;
+
+class XmlClientFailoverConfigLocator extends AbstractConfigLocator {
+
+    @Override
+    public boolean locateFromSystemProperty() {
+        return loadFromSystemProperty("hazelcast.client.failover.config", "xml");
+    }
+
+    @Override
+    protected boolean locateInWorkDir() {
+        return loadFromWorkingDirectory("hazelcast-client-failover.xml");
+    }
+
+    @Override
+    protected boolean locateOnClasspath() {
+        return loadConfigurationFromClasspath("hazelcast-client-failover.xml");
+    }
+
+    @Override
+    public boolean locateDefault() {
+        return false;
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionManager.java
@@ -18,6 +18,8 @@ package com.hazelcast.client.connection;
 
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.client.ClientPrincipal;
+import com.hazelcast.client.impl.clientside.CandidateClusterContext;
+import com.hazelcast.client.spi.ClusterSwitchAwareService;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ConnectionListenable;
@@ -28,7 +30,7 @@ import java.util.Collection;
 /**
  * Responsible for managing {@link com.hazelcast.client.connection.nio.ClientConnection} objects.
  */
-public interface ClientConnectionManager extends ConnectionListenable {
+public interface ClientConnectionManager extends ConnectionListenable, ClusterSwitchAwareService {
 
     /**
      * Check if client connection manager is alive.
@@ -65,4 +67,6 @@ public interface ClientConnectionManager extends ConnectionListenable {
     ClientPrincipal getPrincipal();
 
     ClientConnection getOwnerConnection();
+
+    void setCandidateClusterContext(CandidateClusterContext context);
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionStrategy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/ClientConnectionStrategy.java
@@ -107,7 +107,7 @@ public abstract class ClientConnectionStrategy {
     public abstract void onDisconnect(ClientConnection connection);
 
     /**
-     * The {@link ClientConnectionManager} will call this method as a last step of its shutdown.
+     * This will be called as the last step of the HazelcastClient's shutdown.
      */
     public abstract void shutdown();
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnectorService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnectorService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.connection.nio;
+
+import java.util.concurrent.Future;
+
+/**
+ * Helper to ClientConnectionManager.
+ * selecting owner connection, connecting and disconnecting from cluster implemented in this class.
+ */
+public interface ClusterConnectorService {
+
+    void connectToCluster();
+
+    Future<Void> connectToClusterAsync();
+
+    boolean isClusterAvailable();
+
+    void shutdown();
+
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/DefaultClientConnectionStrategy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/DefaultClientConnectionStrategy.java
@@ -35,13 +35,12 @@ public class DefaultClientConnectionStrategy extends ClientConnectionStrategy {
     private volatile boolean disconnectedFromCluster;
     private boolean asyncStart;
     private ClientConnectionStrategyConfig.ReconnectMode reconnectMode;
-    private ClusterConnector connector;
+    private ClusterConnectorService clusterConnectorService;
 
     @Override
     public void init(ClientContext clientContext) {
         super.init(clientContext);
-        ClientConnectionManagerImpl connectionManager = (ClientConnectionManagerImpl) clientContext.getConnectionManager();
-        this.connector = connectionManager.getClusterConnector();
+        this.clusterConnectorService = clientContext.getClusterConnectorService();
         this.asyncStart = clientConnectionStrategyConfig.isAsyncStart();
         this.reconnectMode = clientConnectionStrategyConfig.getReconnectMode();
     }
@@ -49,15 +48,15 @@ public class DefaultClientConnectionStrategy extends ClientConnectionStrategy {
     @Override
     public void start() {
         if (asyncStart) {
-            connector.connectToClusterAsync();
+            clusterConnectorService.connectToClusterAsync();
         } else {
-            connector.connectToCluster();
+            clusterConnectorService.connectToCluster();
         }
     }
 
     @Override
     public void beforeGetConnection(Address target) {
-        if (isClusterAvailable()) {
+        if (clusterConnectorService.isClusterAvailable()) {
             return;
         }
         if (asyncStart && !disconnectedFromCluster) {
@@ -70,7 +69,7 @@ public class DefaultClientConnectionStrategy extends ClientConnectionStrategy {
 
     @Override
     public void beforeOpenConnection(Address target) {
-        if (isClusterAvailable()) {
+        if (clusterConnectorService.isClusterAvailable()) {
             return;
         }
         if (reconnectMode == ASYNC && disconnectedFromCluster) {
@@ -95,7 +94,7 @@ public class DefaultClientConnectionStrategy extends ClientConnectionStrategy {
         }
         if (clientContext.getLifecycleService().isRunning()) {
             try {
-                connector.connectToClusterAsync();
+                clusterConnectorService.connectToClusterAsync();
             } catch (RejectedExecutionException r) {
                 shutdownWithExternalThread();
             }
@@ -127,7 +126,4 @@ public class DefaultClientConnectionStrategy extends ClientConnectionStrategy {
     public void shutdown() {
     }
 
-    private boolean isClusterAvailable() {
-        return clientContext.getConnectionManager().getOwnerConnectionAddress() != null;
-    }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/CandidateClusterContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/CandidateClusterContext.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.clientside;
+
+import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.client.connection.AddressTranslator;
+import com.hazelcast.internal.networking.ChannelInitializerProvider;
+import com.hazelcast.nio.SocketInterceptor;
+import com.hazelcast.security.ICredentialsFactory;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+
+/**
+ * Carries the information that is specific to one cluster
+ */
+public class CandidateClusterContext {
+
+    private final AddressProvider addressProvider;
+    private final AddressTranslator addressTranslator;
+    private final DiscoveryService discoveryService;
+    private final ICredentialsFactory credentialsFactory;
+    private final SocketInterceptor socketInterceptor;
+    private final ChannelInitializerProvider channelInitializerProvider;
+
+    public CandidateClusterContext(AddressProvider addressProvider, AddressTranslator addressTranslator,
+                                   DiscoveryService discoveryService, ICredentialsFactory credentialsFactory,
+                                   SocketInterceptor socketInterceptor, ChannelInitializerProvider channelInitializerProvider) {
+        this.addressProvider = addressProvider;
+        this.addressTranslator = addressTranslator;
+        this.discoveryService = discoveryService;
+        this.credentialsFactory = credentialsFactory;
+        this.socketInterceptor = socketInterceptor;
+        this.channelInitializerProvider = channelInitializerProvider;
+    }
+
+    public void start() {
+        if (discoveryService != null) {
+            discoveryService.start();
+        }
+    }
+
+    public ICredentialsFactory getCredentialsFactory() {
+        return credentialsFactory;
+    }
+
+    public void destroy() {
+        if (discoveryService != null) {
+            discoveryService.destroy();
+        }
+    }
+
+    public AddressProvider getAddressProvider() {
+        return addressProvider;
+    }
+
+    public AddressTranslator getAddressTranslator() {
+        return addressTranslator;
+    }
+
+    public SocketInterceptor getSocketInterceptor() {
+        return socketInterceptor;
+    }
+
+    public String getName() {
+        return credentialsFactory.newCredentials().getPrincipal();
+    }
+
+    public ChannelInitializerProvider getChannelInitializerProvider() {
+        return channelInitializerProvider;
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientConnectionManagerFactory.java
@@ -16,13 +16,9 @@
 
 package com.hazelcast.client.impl.clientside;
 
-import com.hazelcast.client.connection.AddressProvider;
-import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.client.connection.ClientConnectionManager;
 
 public interface ClientConnectionManagerFactory {
 
-    ClientConnectionManager createConnectionManager(HazelcastClientInstanceImpl client,
-                                                    AddressTranslator addressTranslator,
-                                                    AddressProvider addressProvider);
+    ClientConnectionManager createConnectionManager(HazelcastClientInstanceImpl client);
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDiscoveryService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDiscoveryService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.clientside;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class ClientDiscoveryService implements Iterator<CandidateClusterContext> {
+
+    private final ArrayList<CandidateClusterContext> discoveryServices;
+    private final long size;
+    private final int configsMaxTryCount;
+    private long head;
+    private long currentTryCount;
+
+    public ClientDiscoveryService(int configsTryCount, ArrayList<CandidateClusterContext> discoveryServices) {
+        this.discoveryServices = discoveryServices;
+        this.size = discoveryServices.size();
+        this.configsMaxTryCount = configsTryCount;
+    }
+
+    public void resetSearch() {
+        currentTryCount = 0;
+    }
+
+    public boolean hasNext() {
+        return currentTryCount != configsMaxTryCount;
+    }
+
+    public CandidateClusterContext current() {
+        return discoveryServices.get((int) (head % size));
+    }
+
+    public CandidateClusterContext next() {
+        if (currentTryCount == configsMaxTryCount) {
+            throw new NoSuchElementException("Has no alternative cluster");
+        }
+        CandidateClusterContext candidateClusterContext = discoveryServices.get((int) (head % size));
+        head++;
+        if (head % size == 0) {
+            currentTryCount++;
+        }
+        return candidateClusterContext;
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+
+    public void shutdown() {
+        for (CandidateClusterContext discoveryService : discoveryServices) {
+            discoveryService.getCredentialsFactory().destroy();
+        }
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDiscoveryServiceBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDiscoveryServiceBuilder.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.clientside;
+
+import com.hazelcast.client.ClientExtension;
+import com.hazelcast.client.config.ClientAliasedDiscoveryConfigUtils;
+import com.hazelcast.client.config.ClientCloudConfig;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.ClientSecurityConfig;
+import com.hazelcast.client.config.SocketOptions;
+import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.client.connection.AddressTranslator;
+import com.hazelcast.client.connection.nio.DefaultCredentialsFactory;
+import com.hazelcast.client.spi.impl.DefaultAddressProvider;
+import com.hazelcast.client.spi.impl.DefaultAddressTranslator;
+import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressProvider;
+import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressTranslator;
+import com.hazelcast.client.spi.impl.discovery.HazelcastCloudAddressProvider;
+import com.hazelcast.client.spi.impl.discovery.HazelcastCloudAddressTranslator;
+import com.hazelcast.client.spi.impl.discovery.HazelcastCloudDiscovery;
+import com.hazelcast.client.spi.properties.ClientProperty;
+import com.hazelcast.config.CredentialsFactoryConfig;
+import com.hazelcast.config.DiscoveryConfig;
+import com.hazelcast.config.DiscoveryStrategyConfig;
+import com.hazelcast.config.SSLConfig;
+import com.hazelcast.config.SocketInterceptorConfig;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.internal.networking.ChannelInitializer;
+import com.hazelcast.internal.networking.ChannelInitializerProvider;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.nio.ClassLoaderUtil;
+import com.hazelcast.nio.SocketInterceptor;
+import com.hazelcast.security.ICredentialsFactory;
+import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.integration.DiscoveryMode;
+import com.hazelcast.spi.discovery.integration.DiscoveryService;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
+import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
+import com.hazelcast.spi.properties.HazelcastProperties;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static com.hazelcast.client.spi.properties.ClientProperty.DISCOVERY_SPI_ENABLED;
+import static com.hazelcast.client.spi.properties.ClientProperty.HAZELCAST_CLOUD_DISCOVERY_TOKEN;
+import static com.hazelcast.config.AliasedDiscoveryConfigUtils.allUsePublicAddress;
+import static com.hazelcast.util.ExceptionUtil.rethrow;
+
+class ClientDiscoveryServiceBuilder {
+
+    private final LoggingService loggingService;
+    private final AddressProvider externalAddressProvider;
+    private final HazelcastProperties properties;
+    private final ClientExtension clientExtension;
+    private final Collection<ClientConfig> configs;
+    private final int configsTryCount;
+
+    ClientDiscoveryServiceBuilder(int configsTryCount, List<ClientConfig> configs, LoggingService loggingService,
+                                  AddressProvider externalAddressProvider, HazelcastProperties properties,
+                                  ClientExtension clientExtension) {
+        this.configsTryCount = configsTryCount;
+        this.configs = configs;
+        this.loggingService = loggingService;
+        this.externalAddressProvider = externalAddressProvider;
+        this.properties = properties;
+        this.clientExtension = clientExtension;
+    }
+
+    public ClientDiscoveryService build() {
+        ArrayList<CandidateClusterContext> contexts = new ArrayList<CandidateClusterContext>();
+        for (ClientConfig config : configs) {
+            ClientNetworkConfig networkConfig = config.getNetworkConfig();
+            SocketInterceptor interceptor = initSocketInterceptor(networkConfig.getSocketInterceptorConfig());
+            ICredentialsFactory credentialsFactory = initCredentialsFactory(config);
+            DiscoveryService discoveryService = initDiscoveryService(config);
+            AddressProvider provider = createAddressProvider(config, discoveryService, externalAddressProvider);
+            AddressTranslator translator = createAddressTranslator(config, discoveryService);
+            final SSLConfig sslConfig = networkConfig.getSSLConfig();
+            final SocketOptions socketOptions = networkConfig.getSocketOptions();
+            contexts.add(new CandidateClusterContext(provider, translator, discoveryService,
+                    credentialsFactory, interceptor, new ChannelInitializerProvider() {
+                @Override
+                public ChannelInitializer provide(EndpointQualifier qualifier) {
+                    return clientExtension.createChannelInitializer(sslConfig, socketOptions);
+                }
+            }));
+        }
+        return new ClientDiscoveryService(configsTryCount, contexts);
+    }
+
+    private AddressProvider createAddressProvider(ClientConfig clientConfig,
+                                                  DiscoveryService discoveryService, AddressProvider externalAddressProvider) {
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+
+
+        if (externalAddressProvider != null) {
+            return externalAddressProvider;
+        }
+
+        if (discoveryService != null) {
+            return new DiscoveryAddressProvider(discoveryService);
+        }
+
+        HazelcastCloudAddressProvider cloudAddressProvider = initCloudAddressProvider(clientConfig);
+        if (cloudAddressProvider != null) {
+            return cloudAddressProvider;
+        }
+
+        return new DefaultAddressProvider(networkConfig);
+    }
+
+    private HazelcastCloudAddressProvider initCloudAddressProvider(ClientConfig clientConfig) {
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+        ClientCloudConfig cloudConfig = networkConfig.getCloudConfig();
+
+        if (cloudConfig.isEnabled()) {
+            String discoveryToken = cloudConfig.getDiscoveryToken();
+            String cloudUrlBase = properties.getString(HazelcastCloudDiscovery.CLOUD_URL_BASE_PROPERTY);
+            String urlEndpoint = HazelcastCloudDiscovery.createUrlEndpoint(cloudUrlBase, discoveryToken);
+            return new HazelcastCloudAddressProvider(urlEndpoint, getConnectionTimeoutMillis(networkConfig), loggingService);
+        }
+
+        String cloudToken = properties.getString(ClientProperty.HAZELCAST_CLOUD_DISCOVERY_TOKEN);
+        if (cloudToken != null) {
+            String cloudUrlBase = properties.getString(HazelcastCloudDiscovery.CLOUD_URL_BASE_PROPERTY);
+            String urlEndpoint = HazelcastCloudDiscovery.createUrlEndpoint(cloudUrlBase, cloudToken);
+            return new HazelcastCloudAddressProvider(urlEndpoint, getConnectionTimeoutMillis(networkConfig), loggingService);
+        }
+        return null;
+    }
+
+    private AddressTranslator createAddressTranslator(ClientConfig clientConfig, DiscoveryService discoveryService) {
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+        ClientCloudConfig cloudConfig = networkConfig.getCloudConfig();
+
+        List<String> addresses = networkConfig.getAddresses();
+        boolean addressListProvided = addresses.size() != 0;
+        boolean awsDiscoveryEnabled = networkConfig.getAwsConfig() != null && networkConfig.getAwsConfig().isEnabled();
+        boolean gcpDiscoveryEnabled = networkConfig.getGcpConfig() != null && networkConfig.getGcpConfig().isEnabled();
+        boolean azureDiscoveryEnabled = networkConfig.getAzureConfig() != null && networkConfig.getAzureConfig().isEnabled();
+        boolean kubernetesDiscoveryEnabled = networkConfig.getKubernetesConfig() != null
+                && networkConfig.getKubernetesConfig().isEnabled();
+        boolean eurekaDiscoveryEnabled = networkConfig.getEurekaConfig() != null && networkConfig.getEurekaConfig().isEnabled();
+        boolean discoverySpiEnabled = discoverySpiEnabled(networkConfig);
+        String cloudDiscoveryToken = properties.getString(HAZELCAST_CLOUD_DISCOVERY_TOKEN);
+        if (cloudDiscoveryToken != null && cloudConfig.isEnabled()) {
+            throw new IllegalStateException("Ambiguous hazelcast.cloud configuration. "
+                    + "Both property based and client configuration based settings are provided for "
+                    + "Hazelcast cloud discovery together. Use only one.");
+        }
+        boolean hazelcastCloudEnabled = cloudDiscoveryToken != null || cloudConfig.isEnabled();
+        isDiscoveryConfigurationConsistent(addressListProvided, awsDiscoveryEnabled, gcpDiscoveryEnabled, azureDiscoveryEnabled,
+                kubernetesDiscoveryEnabled, eurekaDiscoveryEnabled, discoverySpiEnabled, hazelcastCloudEnabled);
+
+        if (discoveryService != null) {
+            return new DiscoveryAddressTranslator(discoveryService, usePublicAddress(clientConfig));
+        } else if (hazelcastCloudEnabled) {
+            String discoveryToken;
+            if (cloudConfig.isEnabled()) {
+                discoveryToken = cloudConfig.getDiscoveryToken();
+            } else {
+                discoveryToken = cloudDiscoveryToken;
+            }
+            String cloudUrlBase = properties.getString(HazelcastCloudDiscovery.CLOUD_URL_BASE_PROPERTY);
+            String urlEndpoint = HazelcastCloudDiscovery.createUrlEndpoint(cloudUrlBase, discoveryToken);
+            return new HazelcastCloudAddressTranslator(urlEndpoint, getConnectionTimeoutMillis(networkConfig), loggingService);
+        }
+
+        return new DefaultAddressTranslator();
+    }
+
+    private boolean discoverySpiEnabled(ClientNetworkConfig networkConfig) {
+        return (networkConfig.getDiscoveryConfig() != null && networkConfig.getDiscoveryConfig().isEnabled())
+                || Boolean.parseBoolean(properties.getString(DISCOVERY_SPI_ENABLED));
+    }
+
+    private boolean usePublicAddress(ClientConfig config) {
+        return properties.getBoolean(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED)
+                || allUsePublicAddress(ClientAliasedDiscoveryConfigUtils.aliasedDiscoveryConfigsFrom(config));
+    }
+
+    @SuppressWarnings({"checkstyle:booleanexpressioncomplexity", "checkstyle:npathcomplexity"})
+    private void isDiscoveryConfigurationConsistent(boolean addressListProvided, boolean awsDiscoveryEnabled,
+                                                    boolean gcpDiscoveryEnabled, boolean azureDiscoveryEnabled,
+                                                    boolean kubernetesDiscoveryEnabled, boolean eurekaDiscoveryEnabled,
+                                                    boolean discoverySpiEnabled, boolean hazelcastCloudEnabled) {
+        int count = 0;
+        if (addressListProvided) {
+            count++;
+        }
+        if (awsDiscoveryEnabled) {
+            count++;
+        }
+        if (gcpDiscoveryEnabled) {
+            count++;
+        }
+        if (azureDiscoveryEnabled) {
+            count++;
+        }
+        if (kubernetesDiscoveryEnabled) {
+            count++;
+        }
+        if (eurekaDiscoveryEnabled) {
+            count++;
+        }
+        if (discoverySpiEnabled) {
+            count++;
+        }
+        if (hazelcastCloudEnabled) {
+            count++;
+        }
+        if (count > 1) {
+            throw new IllegalStateException("Only one discovery method can be enabled at a time. "
+                    + "cluster members given explicitly : " + addressListProvided
+                    + ", aws discovery: " + awsDiscoveryEnabled
+                    + ", gcp discovery: " + gcpDiscoveryEnabled
+                    + ", azure discovery: " + azureDiscoveryEnabled
+                    + ", kubernetes discovery: " + kubernetesDiscoveryEnabled
+                    + ", eureka discovery: " + eurekaDiscoveryEnabled
+                    + ", discovery spi enabled : " + discoverySpiEnabled
+                    + ", hazelcast.cloud enabled : " + hazelcastCloudEnabled);
+        }
+    }
+
+    private DiscoveryService initDiscoveryService(ClientConfig config) {
+        // Prevent confusing behavior where the DiscoveryService is started
+        // and strategies are resolved but the AddressProvider is never registered
+        List<DiscoveryStrategyConfig> aliasedDiscoveryConfigs =
+                ClientAliasedDiscoveryConfigUtils.createDiscoveryStrategyConfigs(config);
+
+        if (!properties.getBoolean(ClientProperty.DISCOVERY_SPI_ENABLED) && aliasedDiscoveryConfigs.isEmpty()) {
+            return null;
+        }
+
+        ILogger logger = loggingService.getLogger(DiscoveryService.class);
+        ClientNetworkConfig networkConfig = config.getNetworkConfig();
+        DiscoveryConfig discoveryConfig = networkConfig.getDiscoveryConfig().getAsReadOnly();
+
+        DiscoveryServiceProvider factory = discoveryConfig.getDiscoveryServiceProvider();
+        if (factory == null) {
+            factory = new DefaultDiscoveryServiceProvider();
+        }
+
+        DiscoveryServiceSettings settings = new DiscoveryServiceSettings()
+                .setConfigClassLoader(config.getClassLoader())
+                .setLogger(logger)
+                .setDiscoveryMode(DiscoveryMode.Client)
+                .setAliasedDiscoveryConfigs(aliasedDiscoveryConfigs)
+                .setDiscoveryConfig(discoveryConfig);
+
+        DiscoveryService discoveryService = factory.newDiscoveryService(settings);
+        discoveryService.start();
+        return discoveryService;
+    }
+
+    private ICredentialsFactory initCredentialsFactory(ClientConfig config) {
+        ClientSecurityConfig securityConfig = config.getSecurityConfig();
+        validateSecurityConfig(securityConfig);
+        ICredentialsFactory c = getCredentialsFromFactory(config);
+        if (c == null) {
+            return new DefaultCredentialsFactory(securityConfig, config.getGroupConfig(), config.getClassLoader());
+        }
+        return c;
+    }
+
+    private void validateSecurityConfig(ClientSecurityConfig securityConfig) {
+        boolean configuredViaCredentials = securityConfig.getCredentials() != null
+                || securityConfig.getCredentialsClassname() != null;
+
+        CredentialsFactoryConfig factoryConfig = securityConfig.getCredentialsFactoryConfig();
+        boolean configuredViaCredentialsFactory = factoryConfig.getClassName() != null
+                || factoryConfig.getImplementation() != null;
+
+        if (configuredViaCredentials && configuredViaCredentialsFactory) {
+            throw new IllegalStateException("Ambiguous Credentials config. Set only one of Credentials or ICredentialsFactory");
+        }
+    }
+
+    private ICredentialsFactory getCredentialsFromFactory(ClientConfig config) {
+        CredentialsFactoryConfig credentialsFactoryConfig = config.getSecurityConfig().getCredentialsFactoryConfig();
+        ICredentialsFactory factory = credentialsFactoryConfig.getImplementation();
+        if (factory == null) {
+            String factoryClassName = credentialsFactoryConfig.getClassName();
+            if (factoryClassName != null) {
+                try {
+                    factory = ClassLoaderUtil.newInstance(config.getClassLoader(), factoryClassName);
+                } catch (Exception e) {
+                    throw rethrow(e);
+                }
+            }
+        }
+        if (factory == null) {
+            return null;
+        }
+        factory.configure(config.getGroupConfig(), credentialsFactoryConfig.getProperties());
+        return factory;
+    }
+
+    private SocketInterceptor initSocketInterceptor(SocketInterceptorConfig sic) {
+        if (sic != null && sic.isEnabled()) {
+            return clientExtension.createSocketInterceptor(sic);
+        }
+        return null;
+    }
+
+    private int getConnectionTimeoutMillis(ClientNetworkConfig networkConfig) {
+        int connTimeout = networkConfig.getConnectionTimeout();
+        return connTimeout == 0 ? Integer.MAX_VALUE : connTimeout;
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientConnectionManagerFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/DefaultClientConnectionManagerFactory.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.client.impl.clientside;
 
-import com.hazelcast.client.connection.AddressProvider;
-import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
 
@@ -27,11 +25,7 @@ public class DefaultClientConnectionManagerFactory implements ClientConnectionMa
     }
 
     @Override
-    public ClientConnectionManager createConnectionManager(HazelcastClientInstanceImpl client,
-                                                           AddressTranslator addressTranslator,
-                                                           AddressProvider addressProvider) {
-
-
-        return new ClientConnectionManagerImpl(client, addressTranslator, addressProvider);
+    public ClientConnectionManager createConnectionManager(HazelcastClientInstanceImpl client) {
+        return new ClientConnectionManagerImpl(client);
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.clientside;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientFailoverConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.config.XmlClientConfigBuilder;
+import com.hazelcast.client.config.XmlClientConfigLocator;
+import com.hazelcast.client.config.XmlClientFailoverConfigBuilder;
+import com.hazelcast.client.config.YamlClientConfigBuilder;
+import com.hazelcast.client.config.YamlClientConfigLocator;
+import com.hazelcast.config.InvalidConfigurationException;
+
+import java.util.List;
+
+
+/**
+ * Static methods to resolve and validate multiple client configs for blue green feature
+ */
+public final class FailoverClientConfigSupport {
+
+    private FailoverClientConfigSupport() {
+    }
+
+    /**
+     * If clientFailoverConfig passed null, then we try to load config via system property.
+     * If still could no create HazelcastException is thrown.
+     *
+     * @param clientFailoverConfig provided via HazelcastClient.newHazelcastClient(ClientFailoverConfig config)
+     * @return resolvedConfigs
+     * @throws InvalidConfigurationException when given config is not valid
+     */
+    public static ClientFailoverConfig resolveClientConfig(ClientFailoverConfig clientFailoverConfig) {
+        if (clientFailoverConfig == null) {
+            XmlClientFailoverConfigBuilder configBuilder = new XmlClientFailoverConfigBuilder();
+            clientFailoverConfig = configBuilder.build();
+        }
+        checkValidAlternative(clientFailoverConfig.getClientConfigs());
+        return clientFailoverConfig;
+    }
+
+    /**
+     * Returns a ClientFailoverConfig with single client config. If clientConfig is null,
+     * We create it via XmlClientConfigBuilder().build()
+     *
+     * @param config provided via HazelcastClient.newHazelcastClient(ClientConfig config)
+     * @return resolvedConfigs
+     * @throws InvalidConfigurationException when given config is not valid
+     */
+    public static ClientFailoverConfig resolveClientConfig(ClientConfig config) {
+        if (config == null) {
+            config = createDefaultClientConfig();
+        }
+        ClientFailoverConfig resolvedConfig = new ClientFailoverConfig();
+        resolvedConfig.addClientConfig(config);
+        resolvedConfig.setTryCount(1);
+        return resolvedConfig;
+    }
+
+    private static ClientConfig createDefaultClientConfig() {
+        ClientConfig config;
+        XmlClientConfigLocator xmlConfigLocator = new XmlClientConfigLocator();
+        YamlClientConfigLocator yamlConfigLocator = new YamlClientConfigLocator();
+
+        if (xmlConfigLocator.locateFromSystemProperty()) {
+            // 1. Try loading XML config if provided in system property
+            config = new XmlClientConfigBuilder(xmlConfigLocator).build();
+
+        } else if (yamlConfigLocator.locateFromSystemProperty()) {
+            // 2. Try loading YAML config if provided in system property
+            config = new YamlClientConfigBuilder(yamlConfigLocator).build();
+
+        } else if (xmlConfigLocator.locateInWorkDirOrOnClasspath()) {
+            // 3. Try loading XML config from the working directory or from the classpath
+            config = new XmlClientConfigBuilder(xmlConfigLocator).build();
+
+        } else if (yamlConfigLocator.locateInWorkDirOrOnClasspath()) {
+            // 4. Try loading YAML config from the working directory or from the classpath
+            config = new YamlClientConfigBuilder(yamlConfigLocator).build();
+
+        } else {
+            // 5. Loading the default XML configuration file
+            xmlConfigLocator.locateDefault();
+            config = new XmlClientConfigBuilder(xmlConfigLocator).build();
+        }
+        return config;
+    }
+
+    /**
+     * Creates ClientFailoverConfig is created which is equivalent of single client config.
+     *
+     * used with HazelcastClient.newHazelcastClient()
+     *
+     * @return resolved configs
+     */
+    public static ClientFailoverConfig resolveClientConfig() {
+        ClientFailoverConfig resolvedConfig = new ClientFailoverConfig();
+
+        ClientConfig config = createDefaultClientConfig();
+        resolvedConfig.addClientConfig(config);
+        resolvedConfig.setTryCount(1);
+        return resolvedConfig;
+    }
+
+    /**
+     * For a client to be valid alternative, all configurations should be equal except
+     * GroupConfig
+     * SecurityConfig
+     * Discovery related parts of NetworkConfig
+     * Credentials related configs
+     *
+     * @param alternativeClientConfigs to check if they are valid alternative for a single client two switch between clusters
+     * @throws InvalidConfigurationException when given configs are not valid
+     */
+    private static void checkValidAlternative(List<ClientConfig> alternativeClientConfigs) {
+        if (alternativeClientConfigs.isEmpty()) {
+            throw new InvalidConfigurationException("ClientFailoverConfig should have at least one client config.");
+        }
+        ClientConfig mainConfig = alternativeClientConfigs.get(0);
+        for (ClientConfig alternativeClientConfig : alternativeClientConfigs.subList(1, alternativeClientConfigs.size())) {
+            checkValidAlternative(mainConfig, alternativeClientConfig);
+        }
+
+    }
+
+    private static void throwInvalidConfigurationException(String rootClusterName, String clusterName, String configName) {
+        throw new InvalidConfigurationException("Alternative config with cluster name " + clusterName
+                + " has a different config than the initial config with cluster name " + rootClusterName + " for " + configName);
+    }
+
+    /**
+     * @return false when both objects are null or they are equal, true otherwise
+     */
+    private static boolean notEqual(Object l, Object r) {
+        return l != null ? !l.equals(r) : r != null;
+    }
+
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity", "checkstyle:methodlength"})
+    private static void checkValidAlternative(ClientConfig mainConfig, ClientConfig alternativeConfig) {
+        String mainClusterName = mainConfig.getGroupConfig().getName();
+        String alterNativeClusterName = alternativeConfig.getGroupConfig().getName();
+
+        checkValidAlternativeForNetwork(mainConfig, alternativeConfig);
+
+        if (mainConfig.getExecutorPoolSize() != alternativeConfig.getExecutorPoolSize()) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "executorPoolSize");
+        }
+        if (notEqual(mainConfig.getProperties(), alternativeConfig.getProperties())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "properties");
+        }
+        if (notEqual(mainConfig.getLoadBalancer(), alternativeConfig.getLoadBalancer())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "loadBalancer");
+        }
+        if (notEqual(mainConfig.getListenerConfigs(), alternativeConfig.getListenerConfigs())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "listeners");
+        }
+        if (notEqual(mainConfig.getInstanceName(), alternativeConfig.getInstanceName())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "instanceName");
+        }
+        if (notEqual(mainConfig.getConfigPatternMatcher(), alternativeConfig.getConfigPatternMatcher())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "configPatternMatcher");
+        }
+        if (notEqual(mainConfig.getNearCacheConfigMap(), alternativeConfig.getNearCacheConfigMap())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "nearCache");
+        }
+        if (notEqual(mainConfig.getReliableTopicConfigMap(), alternativeConfig.getReliableTopicConfigMap())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "reliableTopic");
+        }
+        if (notEqual(mainConfig.getQueryCacheConfigs(), alternativeConfig.getQueryCacheConfigs())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "queryCacheConfigs");
+        }
+        if (notEqual(mainConfig.getSerializationConfig(), alternativeConfig.getSerializationConfig())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "serializationConfig");
+        }
+        if (notEqual(mainConfig.getNativeMemoryConfig(), alternativeConfig.getNativeMemoryConfig())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "nativeMemory");
+        }
+        if (notEqual(mainConfig.getProxyFactoryConfigs(), alternativeConfig.getProxyFactoryConfigs())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "proxyFactory");
+        }
+        if (notEqual(mainConfig.getManagedContext(), alternativeConfig.getManagedContext())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "managedContext");
+        }
+        if (notEqual(mainConfig.getClassLoader(), alternativeConfig.getClassLoader())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "classLoader");
+        }
+        if (notEqual(mainConfig.getLicenseKey(), alternativeConfig.getLicenseKey())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "licenseKey");
+        }
+        if (notEqual(mainConfig.getConnectionStrategyConfig(), alternativeConfig.getConnectionStrategyConfig())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "connectionStrategy");
+        }
+        if (notEqual(mainConfig.getUserCodeDeploymentConfig(), alternativeConfig.getUserCodeDeploymentConfig())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "userCodeDeployment");
+        }
+        if (notEqual(mainConfig.getFlakeIdGeneratorConfigMap(), alternativeConfig.getFlakeIdGeneratorConfigMap())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "flakeIdGenerator");
+        }
+        if (notEqual(mainConfig.getLabels(), alternativeConfig.getLabels())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "labels");
+        }
+        if (notEqual(mainConfig.getUserContext(), alternativeConfig.getUserContext())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "userContext");
+        }
+    }
+
+    @SuppressWarnings({"checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity", "checkstyle:methodlength"})
+    private static void checkValidAlternativeForNetwork(ClientConfig mainConfig, ClientConfig alternativeConfig) {
+        String mainClusterName = mainConfig.getGroupConfig().getName();
+        String alterNativeClusterName = alternativeConfig.getGroupConfig().getName();
+
+        ClientNetworkConfig mainNetworkConfig = mainConfig.getNetworkConfig();
+        ClientNetworkConfig alternativeNetworkConfig = alternativeConfig.getNetworkConfig();
+
+        if (mainNetworkConfig == null && alternativeNetworkConfig == null) {
+            return;
+        }
+
+        if (mainNetworkConfig == null || alternativeNetworkConfig == null) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network");
+        }
+
+        if (mainNetworkConfig.isSmartRouting() != alternativeNetworkConfig.isSmartRouting()) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:smartRouting");
+        }
+        if (mainNetworkConfig.isRedoOperation() != alternativeNetworkConfig.isRedoOperation()) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:redoOperation");
+        }
+        if (mainNetworkConfig.getConnectionTimeout() != alternativeNetworkConfig.getConnectionTimeout()) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:connectionTimeout");
+        }
+        if (mainNetworkConfig.getConnectionAttemptLimit() != alternativeNetworkConfig.getConnectionAttemptLimit()) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:connectionAttemptLimit");
+        }
+        if (mainNetworkConfig.getConnectionAttemptPeriod() != alternativeNetworkConfig.getConnectionAttemptPeriod()) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:connectionAttemptPeriod");
+        }
+        if (notEqual(mainNetworkConfig.getSocketOptions(), alternativeNetworkConfig.getSocketOptions())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:socketOptions");
+        }
+        if (notEqual(mainNetworkConfig.getOutboundPortDefinitions(), alternativeNetworkConfig.getOutboundPortDefinitions())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:outboundPortDefinitions");
+        }
+        if (notEqual(mainNetworkConfig.getOutboundPorts(), alternativeNetworkConfig.getOutboundPorts())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:smartRouting");
+        }
+        if (notEqual(mainNetworkConfig.getClientIcmpPingConfig(), alternativeNetworkConfig.getClientIcmpPingConfig())) {
+            throwInvalidConfigurationException(mainClusterName, alterNativeClusterName, "network:clientIcmp");
+        }
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -22,19 +22,20 @@ import com.hazelcast.cardinality.impl.CardinalityEstimatorService;
 import com.hazelcast.client.ClientExtension;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.LoadBalancer;
-import com.hazelcast.client.config.ClientAliasedDiscoveryConfigUtils;
-import com.hazelcast.client.config.ClientCloudConfig;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientFailoverConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
-import com.hazelcast.client.config.ClientSecurityConfig;
 import com.hazelcast.client.connection.AddressProvider;
-import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.client.connection.ClientConnectionStrategy;
 import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
-import com.hazelcast.client.connection.nio.DefaultCredentialsFactory;
+import com.hazelcast.client.connection.nio.ClusterConnectorService;
+import com.hazelcast.client.connection.nio.ClusterConnectorServiceImpl;
+import com.hazelcast.client.connection.nio.DefaultClientConnectionStrategy;
 import com.hazelcast.client.impl.client.DistributedObjectInfo;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientGetDistributedObjectsCodec;
+import com.hazelcast.client.impl.querycache.ClientQueryCacheContext;
 import com.hazelcast.client.impl.statistics.Statistics;
 import com.hazelcast.client.proxy.ClientClusterProxy;
 import com.hazelcast.client.proxy.PartitionServiceProxy;
@@ -53,19 +54,11 @@ import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientPartitionServiceImpl;
 import com.hazelcast.client.spi.impl.ClientTransactionManagerServiceImpl;
 import com.hazelcast.client.spi.impl.ClientUserCodeDeploymentService;
-import com.hazelcast.client.spi.impl.DefaultAddressProvider;
-import com.hazelcast.client.spi.impl.DefaultAddressTranslator;
 import com.hazelcast.client.spi.impl.NonSmartClientInvocationService;
 import com.hazelcast.client.spi.impl.SmartClientInvocationService;
-import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressProvider;
-import com.hazelcast.client.spi.impl.discovery.DiscoveryAddressTranslator;
-import com.hazelcast.client.spi.impl.discovery.HazelcastCloudAddressProvider;
-import com.hazelcast.client.spi.impl.discovery.HazelcastCloudAddressTranslator;
-import com.hazelcast.client.spi.impl.discovery.HazelcastCloudDiscovery;
 import com.hazelcast.client.spi.impl.listener.AbstractClientListenerService;
 import com.hazelcast.client.spi.impl.listener.NonSmartClientListenerService;
 import com.hazelcast.client.spi.impl.listener.SmartClientListenerService;
-import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.util.RoundRobinLB;
 import com.hazelcast.collection.impl.list.ListService;
 import com.hazelcast.collection.impl.queue.QueueService;
@@ -77,9 +70,6 @@ import com.hazelcast.concurrent.idgen.IdGeneratorService;
 import com.hazelcast.concurrent.lock.LockServiceImpl;
 import com.hazelcast.concurrent.semaphore.SemaphoreService;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.CredentialsFactoryConfig;
-import com.hazelcast.config.DiscoveryConfig;
-import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientService;
@@ -143,12 +133,6 @@ import com.hazelcast.ringbuffer.Ringbuffer;
 import com.hazelcast.ringbuffer.impl.RingbufferService;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService;
-import com.hazelcast.security.ICredentialsFactory;
-import com.hazelcast.spi.discovery.impl.DefaultDiscoveryServiceProvider;
-import com.hazelcast.spi.discovery.integration.DiscoveryMode;
-import com.hazelcast.spi.discovery.integration.DiscoveryService;
-import com.hazelcast.spi.discovery.integration.DiscoveryServiceProvider;
-import com.hazelcast.spi.discovery.integration.DiscoveryServiceSettings;
 import com.hazelcast.spi.impl.SerializationServiceSupport;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
@@ -172,9 +156,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.hazelcast.client.spi.properties.ClientProperty.DISCOVERY_SPI_ENABLED;
-import static com.hazelcast.client.spi.properties.ClientProperty.HAZELCAST_CLOUD_DISCOVERY_TOKEN;
-import static com.hazelcast.config.AliasedDiscoveryConfigUtils.allUsePublicAddress;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.StringUtil.isNullOrEmpty;
@@ -188,6 +169,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private final HazelcastProperties properties;
     private final int id = CLIENT_ID.getAndIncrement();
     private final String instanceName;
+    private final ClientFailoverConfig clientFailoverConfig;
     private final ClientConfig config;
     private final LifecycleServiceImpl lifecycleService;
     private final ClientConnectionManagerImpl connectionManager;
@@ -202,22 +184,25 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private final ConcurrentMap<String, Object> userContext;
     private final LoadBalancer loadBalancer;
     private final ClientExtension clientExtension;
-    private final ICredentialsFactory credentialsFactory;
-    private final DiscoveryService discoveryService;
+    private final ClusterConnectorService clusterConnectorService;
+    private final ClientConnectionStrategy clientConnectionStrategy;
     private final LoggingService loggingService;
     private final MetricsRegistryImpl metricsRegistry;
     private final Statistics statistics;
     private final Diagnostics diagnostics;
     private final InternalSerializationService serializationService;
     private final ClientICacheManager hazelcastCacheManager;
+    private final ClientQueryCacheContext queryCacheContext;
     private final ClientLockReferenceIdGenerator lockReferenceIdGenerator;
     private final ClientExceptionFactory clientExceptionFactory;
     private final ClientUserCodeDeploymentService userCodeDeploymentService;
+    private final ClientDiscoveryService clientDiscoveryService;
 
-    public HazelcastClientInstanceImpl(ClientConfig config,
+    public HazelcastClientInstanceImpl(ClientFailoverConfig clientFailoverConfig,
                                        ClientConnectionManagerFactory clientConnectionManagerFactory,
                                        AddressProvider externalAddressProvider) {
-        this.config = config;
+        this.config = clientFailoverConfig.getClientConfigs().get(0);
+        this.clientFailoverConfig = clientFailoverConfig;
         if (config.getInstanceName() != null) {
             instanceName = config.getInstanceName();
         } else {
@@ -232,37 +217,29 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         ClassLoader classLoader = config.getClassLoader();
         clientExtension = createClientInitializer(classLoader);
         clientExtension.beforeStart(this);
-
-        credentialsFactory = initCredentialsFactory(config);
         lifecycleService = new LifecycleServiceImpl(this);
         properties = new HazelcastProperties(config.getProperties());
-
         metricsRegistry = initMetricsRegistry();
         serializationService = clientExtension.createSerializationService((byte) -1);
         metricsRegistry.collectMetrics(clientExtension);
-
         proxyManager = new ProxyManager(this);
         executionService = initExecutionService();
         metricsRegistry.collectMetrics(executionService);
         loadBalancer = initLoadBalancer(config);
         transactionManager = new ClientTransactionManagerServiceImpl(this, loadBalancer);
         partitionService = new ClientPartitionServiceImpl(this);
-        discoveryService = initDiscoveryService(config);
-        AddressProvider addressProvider = createAddressProvider(externalAddressProvider);
-        AddressTranslator addressTranslator = createAddressTranslator();
-        connectionManager = (ClientConnectionManagerImpl) clientConnectionManagerFactory
-                .createConnectionManager(this, addressTranslator, addressProvider);
+        clientDiscoveryService = initClientDiscoveryService(externalAddressProvider);
+        clientConnectionStrategy = initializeStrategy();
+        connectionManager = (ClientConnectionManagerImpl) clientConnectionManagerFactory.createConnectionManager(this);
+        clusterConnectorService = initClusterConnectorService();
         clusterService = new ClientClusterServiceImpl(this);
-
-
         invocationService = initInvocationService();
         listenerService = initListenerService();
         userContext = new ConcurrentHashMap<String, Object>();
         userContext.putAll(config.getUserContext());
         diagnostics = initDiagnostics();
-
         hazelcastCacheManager = new ClientICacheManager(this);
-
+        queryCacheContext = new ClientQueryCacheContext(this);
         lockReferenceIdGenerator = new ClientLockReferenceIdGenerator();
         nearCacheManager = clientExtension.createNearCacheManager();
         clientExceptionFactory = initClientExceptionFactory();
@@ -270,10 +247,36 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         userCodeDeploymentService = new ClientUserCodeDeploymentService(config.getUserCodeDeploymentConfig(), classLoader);
     }
 
-    private int getConnectionTimeoutMillis() {
-        ClientNetworkConfig networkConfig = config.getNetworkConfig();
-        int connTimeout = networkConfig.getConnectionTimeout();
-        return connTimeout == 0 ? Integer.MAX_VALUE : connTimeout;
+    private ClusterConnectorService initClusterConnectorService() {
+        ClusterConnectorServiceImpl service = new ClusterConnectorServiceImpl(this, connectionManager,
+                clientConnectionStrategy, clientDiscoveryService);
+        connectionManager.addConnectionListener(service);
+        return service;
+    }
+
+    private ClientConnectionStrategy initializeStrategy() {
+        ClientConnectionStrategy strategy;
+        //internal property
+        String className = properties.get("hazelcast.client.connection.strategy.classname");
+        if (className != null) {
+            try {
+                ClassLoader configClassLoader = config.getClassLoader();
+                return ClassLoaderUtil.newInstance(configClassLoader, className);
+            } catch (Exception e) {
+                throw rethrow(e);
+            }
+        } else {
+            strategy = new DefaultClientConnectionStrategy();
+        }
+        return strategy;
+    }
+
+    private ClientDiscoveryService initClientDiscoveryService(AddressProvider externalAddressProvider) {
+        int tryCount = clientFailoverConfig.getTryCount();
+        List<ClientConfig> configs = clientFailoverConfig.getClientConfigs();
+        ClientDiscoveryServiceBuilder builder = new ClientDiscoveryServiceBuilder(tryCount, configs, loggingService,
+                externalAddressProvider, properties, clientExtension);
+        return builder.build();
     }
 
     private Diagnostics initDiagnostics() {
@@ -296,216 +299,12 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return metricsRegistry;
     }
 
-    private AddressProvider createAddressProvider(AddressProvider externalAddressProvider) {
-        ClientNetworkConfig networkConfig = getClientConfig().getNetworkConfig();
-
-        if (externalAddressProvider != null) {
-            return externalAddressProvider;
-        }
-
-        if (discoveryService != null) {
-            return new DiscoveryAddressProvider(discoveryService, loggingService);
-        }
-
-        ClientCloudConfig cloudConfig = networkConfig.getCloudConfig();
-        HazelcastCloudAddressProvider cloudAddressProvider = initCloudAddressProvider(cloudConfig);
-        if (cloudAddressProvider != null) {
-            return cloudAddressProvider;
-        }
-
-        return new DefaultAddressProvider(networkConfig);
-    }
-
-    private HazelcastCloudAddressProvider initCloudAddressProvider(ClientCloudConfig cloudConfig) {
-        if (cloudConfig.isEnabled()) {
-            String discoveryToken = cloudConfig.getDiscoveryToken();
-            String cloudUrlBase = getProperties().getString(HazelcastCloudDiscovery.CLOUD_URL_BASE_PROPERTY);
-            String urlEndpoint = HazelcastCloudDiscovery.createUrlEndpoint(cloudUrlBase, discoveryToken);
-            return new HazelcastCloudAddressProvider(urlEndpoint, getConnectionTimeoutMillis(), loggingService);
-        }
-
-        String cloudToken = properties.getString(ClientProperty.HAZELCAST_CLOUD_DISCOVERY_TOKEN);
-        if (cloudToken != null) {
-            String cloudUrlBase = getProperties().getString(HazelcastCloudDiscovery.CLOUD_URL_BASE_PROPERTY);
-            String urlEndpoint = HazelcastCloudDiscovery.createUrlEndpoint(cloudUrlBase, cloudToken);
-            return new HazelcastCloudAddressProvider(urlEndpoint, getConnectionTimeoutMillis(), loggingService);
-        }
-        return null;
-    }
-
-    private AddressTranslator createAddressTranslator() {
-        ClientNetworkConfig networkConfig = getClientConfig().getNetworkConfig();
-        ClientCloudConfig cloudConfig = networkConfig.getCloudConfig();
-
-        List<String> addresses = networkConfig.getAddresses();
-        boolean addressListProvided = addresses.size() != 0;
-        boolean awsDiscoveryEnabled = networkConfig.getAwsConfig() != null && networkConfig.getAwsConfig().isEnabled();
-        boolean gcpDiscoveryEnabled = networkConfig.getGcpConfig() != null && networkConfig.getGcpConfig().isEnabled();
-        boolean azureDiscoveryEnabled = networkConfig.getAzureConfig() != null && networkConfig.getAzureConfig().isEnabled();
-        boolean kubernetesDiscoveryEnabled = networkConfig.getKubernetesConfig() != null
-                && networkConfig.getKubernetesConfig().isEnabled();
-        boolean eurekaDiscoveryEnabled = networkConfig.getEurekaConfig() != null && networkConfig.getEurekaConfig().isEnabled();
-        boolean discoverySpiEnabled = discoverySpiEnabled(networkConfig);
-        String cloudDiscoveryToken = properties.getString(HAZELCAST_CLOUD_DISCOVERY_TOKEN);
-        if (cloudDiscoveryToken != null && cloudConfig.isEnabled()) {
-            throw new IllegalStateException("Ambiguous hazelcast.cloud configuration. "
-                    + "Both property based and client configuration based settings are provided for "
-                    + "Hazelcast cloud discovery together. Use only one.");
-        }
-        boolean hazelcastCloudEnabled = cloudDiscoveryToken != null || cloudConfig.isEnabled();
-        isDiscoveryConfigurationConsistent(addressListProvided, awsDiscoveryEnabled, gcpDiscoveryEnabled, azureDiscoveryEnabled,
-                kubernetesDiscoveryEnabled, eurekaDiscoveryEnabled, discoverySpiEnabled, hazelcastCloudEnabled);
-
-        if (discoveryService != null) {
-            return new DiscoveryAddressTranslator(discoveryService, usePublicAddress(config));
-        } else if (hazelcastCloudEnabled) {
-            String discoveryToken;
-            if (cloudConfig.isEnabled()) {
-                discoveryToken = cloudConfig.getDiscoveryToken();
-            } else {
-                discoveryToken = cloudDiscoveryToken;
-            }
-            String cloudUrlBase = getProperties().getString(HazelcastCloudDiscovery.CLOUD_URL_BASE_PROPERTY);
-            String urlEndpoint = HazelcastCloudDiscovery.createUrlEndpoint(cloudUrlBase, discoveryToken);
-            return new HazelcastCloudAddressTranslator(urlEndpoint, getConnectionTimeoutMillis(), loggingService);
-        }
-
-        return new DefaultAddressTranslator();
-    }
-
-    private boolean discoverySpiEnabled(ClientNetworkConfig networkConfig) {
-        return (networkConfig.getDiscoveryConfig() != null && networkConfig.getDiscoveryConfig().isEnabled())
-                || Boolean.parseBoolean(properties.getString(DISCOVERY_SPI_ENABLED));
-    }
-
-    private boolean usePublicAddress(ClientConfig config) {
-        return getProperties().getBoolean(ClientProperty.DISCOVERY_SPI_PUBLIC_IP_ENABLED)
-                || allUsePublicAddress(ClientAliasedDiscoveryConfigUtils.aliasedDiscoveryConfigsFrom(config));
-    }
-
-    @SuppressWarnings({"checkstyle:booleanexpressioncomplexity", "checkstyle:npathcomplexity"})
-    private void isDiscoveryConfigurationConsistent(boolean addressListProvided, boolean awsDiscoveryEnabled,
-                                                    boolean gcpDiscoveryEnabled, boolean azureDiscoveryEnabled,
-                                                    boolean kubernetesDiscoveryEnabled, boolean eurekaDiscoveryEnabled,
-                                                    boolean discoverySpiEnabled, boolean hazelcastCloudEnabled) {
-        int count = 0;
-        if (addressListProvided) {
-            count++;
-        }
-        if (awsDiscoveryEnabled) {
-            count++;
-        }
-        if (gcpDiscoveryEnabled) {
-            count++;
-        }
-        if (azureDiscoveryEnabled) {
-            count++;
-        }
-        if (kubernetesDiscoveryEnabled) {
-            count++;
-        }
-        if (eurekaDiscoveryEnabled) {
-            count++;
-        }
-        if (discoverySpiEnabled) {
-            count++;
-        }
-        if (hazelcastCloudEnabled) {
-            count++;
-        }
-        if (count > 1) {
-            throw new IllegalStateException("Only one discovery method can be enabled at a time. "
-                    + "cluster members given explicitly : " + addressListProvided
-                    + ", aws discovery: " + awsDiscoveryEnabled
-                    + ", gcp discovery: " + gcpDiscoveryEnabled
-                    + ", azure discovery: " + azureDiscoveryEnabled
-                    + ", kubernetes discovery: " + kubernetesDiscoveryEnabled
-                    + ", eureka discovery: " + eurekaDiscoveryEnabled
-                    + ", discovery spi enabled : " + discoverySpiEnabled
-                    + ", hazelcast.cloud enabled : " + hazelcastCloudEnabled);
-        }
-    }
-
-    private DiscoveryService initDiscoveryService(ClientConfig config) {
-        // Prevent confusing behavior where the DiscoveryService is started
-        // and strategies are resolved but the AddressProvider is never registered
-        List<DiscoveryStrategyConfig> aliasedDiscoveryConfigs =
-                ClientAliasedDiscoveryConfigUtils.createDiscoveryStrategyConfigs(config);
-
-        if (!properties.getBoolean(ClientProperty.DISCOVERY_SPI_ENABLED) && aliasedDiscoveryConfigs.isEmpty()) {
-            return null;
-        }
-
-        ILogger logger = loggingService.getLogger(DiscoveryService.class);
-        ClientNetworkConfig networkConfig = config.getNetworkConfig();
-        DiscoveryConfig discoveryConfig = networkConfig.getDiscoveryConfig().getAsReadOnly();
-
-        DiscoveryServiceProvider factory = discoveryConfig.getDiscoveryServiceProvider();
-        if (factory == null) {
-            factory = new DefaultDiscoveryServiceProvider();
-        }
-
-        DiscoveryServiceSettings settings = new DiscoveryServiceSettings()
-                .setConfigClassLoader(config.getClassLoader())
-                .setLogger(logger)
-                .setDiscoveryMode(DiscoveryMode.Client)
-                .setAliasedDiscoveryConfigs(aliasedDiscoveryConfigs)
-                .setDiscoveryConfig(discoveryConfig);
-
-        DiscoveryService discoveryService = factory.newDiscoveryService(settings);
-        discoveryService.start();
-        return discoveryService;
-    }
-
     private LoadBalancer initLoadBalancer(ClientConfig config) {
         LoadBalancer lb = config.getLoadBalancer();
         if (lb == null) {
             lb = new RoundRobinLB();
         }
         return lb;
-    }
-
-    private ICredentialsFactory initCredentialsFactory(ClientConfig config) {
-        ClientSecurityConfig securityConfig = config.getSecurityConfig();
-        validateSecurityConfig(securityConfig);
-        ICredentialsFactory c = getCredentialsFromFactory(config);
-        if (c == null) {
-            return new DefaultCredentialsFactory(securityConfig, config.getGroupConfig(), config.getClassLoader());
-        }
-        return c;
-    }
-
-    private void validateSecurityConfig(ClientSecurityConfig securityConfig) {
-        boolean configuredViaCredentials = securityConfig.getCredentials() != null
-                || securityConfig.getCredentialsClassname() != null;
-
-        CredentialsFactoryConfig factoryConfig = securityConfig.getCredentialsFactoryConfig();
-        boolean configuredViaCredentialsFactory = factoryConfig.getClassName() != null
-                || factoryConfig.getImplementation() != null;
-
-        if (configuredViaCredentials && configuredViaCredentialsFactory) {
-            throw new IllegalStateException("Ambiguous Credentials config. Set only one of Credentials or ICredentialsFactory");
-        }
-    }
-
-    private ICredentialsFactory getCredentialsFromFactory(ClientConfig config) {
-        CredentialsFactoryConfig credentialsFactoryConfig = config.getSecurityConfig().getCredentialsFactoryConfig();
-        ICredentialsFactory factory = credentialsFactoryConfig.getImplementation();
-        if (factory == null) {
-            String factoryClassName = credentialsFactoryConfig.getClassName();
-            if (factoryClassName != null) {
-                try {
-                    factory = ClassLoaderUtil.newInstance(config.getClassLoader(), factoryClassName);
-                } catch (Exception e) {
-                    throw rethrow(e);
-                }
-            }
-        }
-        if (factory == null) {
-            return null;
-        }
-        factory.configure(config.getGroupConfig(), credentialsFactoryConfig.getProperties());
-        return factory;
     }
 
     @SuppressWarnings("checkstyle:illegaltype")
@@ -567,7 +366,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         ClientContext clientContext = new ClientContext(this);
         try {
             userCodeDeploymentService.start();
-            connectionManager.start(clientContext);
+            connectionManager.start();
+            clientConnectionStrategy.init(clientContext);
+            clientConnectionStrategy.start();
         } catch (Exception e) {
             throw rethrow(e);
         }
@@ -934,10 +735,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         return clientExtension;
     }
 
-    public ICredentialsFactory getCredentialsFactory() {
-        return credentialsFactory;
-    }
-
     public short getProtocolVersion() {
         return PROTOCOL_VERSION;
     }
@@ -950,6 +747,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     public void doShutdown() {
         proxyManager.destroy();
         connectionManager.shutdown();
+        clientConnectionStrategy.shutdown();
+        clusterConnectorService.shutdown();
+        clientDiscoveryService.shutdown();
         clusterService.shutdown();
         partitionService.stop();
         transactionManager.shutdown();
@@ -957,9 +757,6 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         executionService.shutdown();
         listenerService.shutdown();
         nearCacheManager.destroyAllNearCaches();
-        if (discoveryService != null) {
-            discoveryService.destroy();
-        }
         metricsRegistry.shutdown();
         diagnostics.shutdown();
         serializationService.dispose();
@@ -976,5 +773,25 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     public ClientExceptionFactory getClientExceptionFactory() {
         return clientExceptionFactory;
+    }
+
+    public ClusterConnectorService getClusterConnectorService() {
+        return clusterConnectorService;
+    }
+
+    public ClientDiscoveryService getClientDiscoveryService() {
+        return clientDiscoveryService;
+    }
+
+    public ClientConnectionStrategy getConnectionStrategy() {
+        return clientConnectionStrategy;
+    }
+
+    public ClientFailoverConfig getFailoverConfig() {
+        return clientFailoverConfig;
+    }
+
+    public ClientQueryCacheContext getQueryCacheContext() {
+        return queryCacheContext;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientInvokerWrapper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientInvokerWrapper.java
@@ -18,7 +18,6 @@ package com.hazelcast.client.impl.querycache.subscriber;
 
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.impl.ClientInvocation;
 import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.map.impl.querycache.InvokerWrapper;
@@ -40,11 +39,11 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 public class ClientInvokerWrapper implements InvokerWrapper {
 
     private final QueryCacheContext context;
-    private final ClientContext clientContext;
+    private final HazelcastClientInstanceImpl client;
 
-    public ClientInvokerWrapper(QueryCacheContext context, ClientContext clientContext) {
+    public ClientInvokerWrapper(QueryCacheContext context, HazelcastClientInstanceImpl client) {
         this.context = context;
-        this.clientContext = clientContext;
+        this.client = client;
     }
 
     @Override
@@ -53,7 +52,7 @@ public class ClientInvokerWrapper implements InvokerWrapper {
         checkNotNegative(partitionId, "partitionId");
 
         ClientMessage clientRequest = (ClientMessage) request;
-        ClientInvocation clientInvocation = new ClientInvocation(getClient(), clientRequest, null, partitionId);
+        ClientInvocation clientInvocation = new ClientInvocation(client, clientRequest, null, partitionId);
         return clientInvocation.invoke();
     }
 
@@ -61,7 +60,7 @@ public class ClientInvokerWrapper implements InvokerWrapper {
     public Object invokeOnAllPartitions(Object request) {
         try {
             ClientMessage clientRequest = (ClientMessage) request;
-            final Future future = new ClientInvocation(getClient(), clientRequest, null).invoke();
+            final Future future = new ClientInvocation(client, clientRequest, null).invoke();
             Object result = future.get();
             return context.toObject(result);
         } catch (Exception e) {
@@ -75,7 +74,7 @@ public class ClientInvokerWrapper implements InvokerWrapper {
         checkNotNull(address, "address cannot be null");
 
         ClientMessage clientRequest = (ClientMessage) request;
-        ClientInvocation invocation = new ClientInvocation(getClient(), clientRequest, null, address);
+        ClientInvocation invocation = new ClientInvocation(client, clientRequest, null, address);
         return invocation.invoke();
     }
 
@@ -83,7 +82,7 @@ public class ClientInvokerWrapper implements InvokerWrapper {
     public Object invoke(Object request) {
         checkNotNull(request, "request cannot be null");
 
-        ClientInvocation invocation = new ClientInvocation(getClient(), (ClientMessage) request, null);
+        ClientInvocation invocation = new ClientInvocation(client, (ClientMessage) request, null);
         ClientInvocationFuture future = invocation.invoke();
         try {
             Object result = future.get();
@@ -98,7 +97,4 @@ public class ClientInvokerWrapper implements InvokerWrapper {
         throw new UnsupportedOperationException();
     }
 
-    protected final HazelcastClientInstanceImpl getClient() {
-        return (HazelcastClientInstanceImpl) clientContext.getHazelcastInstance();
-    }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.client.impl.querycache.subscriber;
 
+import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ContinuousQueryAddListenerCodec;
 import com.hazelcast.client.impl.protocol.codec.MapRemoveEntryListenerCodec;
-import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.ClientListenerService;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
@@ -86,10 +86,10 @@ public class ClientQueryCacheEventService implements QueryCacheEventService {
     private final ILogger logger = Logger.getLogger(getClass());
     private final ConcurrentMap<String, QueryCacheToListenerMapper> registrations;
 
-    public ClientQueryCacheEventService(ClientContext clientContext) {
-        AbstractClientListenerService listenerService = (AbstractClientListenerService) clientContext.getListenerService();
+    public ClientQueryCacheEventService(HazelcastClientInstanceImpl client) {
+        AbstractClientListenerService listenerService = (AbstractClientListenerService) client.getListenerService();
         this.listenerService = listenerService;
-        this.serializationService = clientContext.getSerializationService();
+        this.serializationService = client.getSerializationService();
         this.executor = listenerService.getEventExecutor();
         this.registrations = new ConcurrentHashMap<String, QueryCacheToListenerMapper>();
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/statistics/Statistics.java
@@ -145,7 +145,7 @@ public class Statistics {
     }
 
     private boolean isSameWithCachedOwnerAddress(Address currentOwnerAddress) {
-        return cachedOwnerAddress != null && currentOwnerAddress.equals(cachedOwnerAddress);
+        return currentOwnerAddress != null && currentOwnerAddress.equals(cachedOwnerAddress);
     }
 
     /**

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientClusterService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientClusterService.java
@@ -29,7 +29,7 @@ import java.util.Collection;
  *
  * Allows to retrieve Hazelcast members of the cluster, e.g. by their {@link Address} or UUID.
  */
-public interface ClientClusterService {
+public interface ClientClusterService extends ClusterSwitchAwareService {
 
     /**
      * @return The client interface representing the local client.

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientContext.java
@@ -20,6 +20,7 @@ import com.hazelcast.cache.impl.CacheService;
 import com.hazelcast.client.cache.impl.nearcache.invalidation.ClientCacheInvalidationMetaDataFetcher;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.client.connection.nio.ClusterConnectorService;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.querycache.ClientQueryCacheContext;
 import com.hazelcast.client.map.impl.nearcache.invalidation.ClientMapInvalidationMetaDataFetcher;
@@ -56,6 +57,7 @@ public class ClientContext {
     private final ClientExecutionService executionService;
     private final ClientListenerService listenerService;
     private final ClientConnectionManager clientConnectionManager;
+    private final ClusterConnectorService clusterConnectorService;
     private final LifecycleService lifecycleService;
     private final ClientTransactionManagerService transactionManager;
     private final ProxyManager proxyManager;
@@ -84,6 +86,7 @@ public class ClientContext {
         this.executionService = client.getClientExecutionService();
         this.listenerService = client.getListenerService();
         this.clientConnectionManager = client.getConnectionManager();
+        this.clusterConnectorService = client.getClusterConnectorService();
         this.lifecycleService = client.getLifecycleService();
         this.proxyManager = client.getProxyManager();
         this.clientConfig = client.getClientConfig();
@@ -93,7 +96,7 @@ public class ClientContext {
         this.properties = client.getProperties();
         this.localUuid = client.getLocalEndpoint().getUuid();
         this.minimalPartitionService = new ClientMinimalPartitionService();
-        this.queryCacheContext = new ClientQueryCacheContext(this);
+        this.queryCacheContext = client.getQueryCacheContext();
     }
 
     public ClientQueryCacheContext getQueryCacheContext() {
@@ -154,6 +157,10 @@ public class ClientContext {
         public int getPartitionCount() {
             return partitionService.getPartitionCount();
         }
+    }
+
+    public ClusterConnectorService getClusterConnectorService() {
+        return clusterConnectorService;
     }
 
     public HazelcastInstance getHazelcastInstance() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientPartitionService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientPartitionService.java
@@ -25,7 +25,7 @@ import com.hazelcast.nio.serialization.Data;
  *
  * Allows to retrieve information about the partition count, the partition owner or the partitionId of a key.
  */
-public interface ClientPartitionService {
+public interface ClientPartitionService extends ClusterSwitchAwareService {
 
     Address getPartitionOwner(int partitionId);
 
@@ -36,4 +36,11 @@ public interface ClientPartitionService {
     int getPartitionCount();
 
     Partition getPartition(int partitionId);
+
+    /**
+     * @param partitionCount new partition count
+     * @return true if partitions are not checked yet or last partition count is equal to the partition count provided,
+     * otherwise return false
+     */
+    boolean isPartitionCountConsistent(int partitionCount);
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClusterSwitchAwareService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClusterSwitchAwareService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi;
+
+import com.hazelcast.client.impl.clientside.CandidateClusterContext;
+
+/**
+ * Client side services that needs to take action before attempting to connect a new cluster
+ */
+public interface ClusterSwitchAwareService {
+
+    void beforeClusterSwitch(CandidateClusterContext context);
+
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -20,7 +20,8 @@ import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.impl.client.ClientPrincipal;
-import com.hazelcast.client.impl.clientside.ClientImpl;
+import com.hazelcast.client.impl.clientside.CandidateClusterContext;
+import com.hazelcast.client.impl.ClientImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.ClientClusterService;
 import com.hazelcast.config.ListenerConfig;
@@ -256,5 +257,13 @@ public class ClientClusterServiceImpl implements ClientClusterService {
     }
 
     public void shutdown() {
+    }
+
+    @Override
+    public void beforeClusterSwitch(CandidateClusterContext context) {
+        clientMembershipListener.beforeClusterSwitch(context);
+        synchronized (initialMembershipListenerMutex) {
+            members.set(Collections.<Address, Member>emptyMap());
+        }
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.spi.impl;
 
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnection;
+import com.hazelcast.client.impl.clientside.CandidateClusterContext;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientAddPartitionListenerCodec;
@@ -114,7 +115,7 @@ public final class ClientPartitionServiceImpl
     }
 
     private void waitForPartitionsFetchedOnce() {
-        while (partitionCount == 0 && client.getConnectionManager().isAlive()) {
+        while (partitions.isEmpty() && client.getConnectionManager().isAlive()) {
             if (isClusterFormedByOnlyLiteMembers()) {
                 throw new NoDataMemberInClusterException(
                         "Partitions can't be assigned since all nodes in the cluster are lite members");
@@ -199,6 +200,16 @@ public final class ClientPartitionServiceImpl
     @Override
     public Partition getPartition(int partitionId) {
         return new PartitionImpl(partitionId);
+    }
+
+    @Override
+    public boolean isPartitionCountConsistent(int partitionCount) {
+        return this.partitionCount == 0 || partitionCount == this.partitionCount;
+    }
+
+    @Override
+    public void beforeClusterSwitch(CandidateClusterContext context) {
+        partitions.clear();
     }
 
     private final class PartitionImpl implements Partition {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -18,8 +18,6 @@ package com.hazelcast.client.spi.impl.discovery;
 
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.connection.Addresses;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.LoggingService;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
 
@@ -28,12 +26,10 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
 public class DiscoveryAddressProvider
         implements AddressProvider {
 
-    private final ILogger logger;
     private final DiscoveryService discoveryService;
 
-    public DiscoveryAddressProvider(DiscoveryService discoveryService, LoggingService loggingService) {
+    public DiscoveryAddressProvider(DiscoveryService discoveryService) {
         this.discoveryService = discoveryService;
-        logger = loggingService.getLogger(DiscoveryAddressProvider.class);
     }
 
     @Override

--- a/hazelcast-client/src/main/resources/hazelcast-client-failover-config-3.12.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-failover-config-3.12.xsd
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified">
+
+    <xs:element name="hazelcast-client-failover">
+        <xs:complexType>
+            <xs:choice minOccurs="1" maxOccurs="unbounded">
+                <xs:element name="try-count" type="xs:int" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="clients" type="clients" minOccurs="0" maxOccurs="1"/>
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="clients">
+        <xs:sequence>
+            <xs:element name="client" type="client" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:complexType name="client">
+        <xs:annotation>
+            <xs:documentation>Path of the client xml
+            </xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="non-space-string"/>
+        </xs:simpleContent>
+    </xs:complexType>
+
+
+    <xs:simpleType name="non-space-string">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\S.*"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+
+</xs:schema>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -274,7 +274,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         };
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
-        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(clientConfig, addressProvider);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(addressProvider, clientConfig);
 
 
         HazelcastInstance instance2 = Hazelcast.newHazelcastInstance();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientClusterDiscoveryServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientClusterDiscoveryServiceTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.bluegreen;
+
+import com.hazelcast.client.impl.clientside.CandidateClusterContext;
+import com.hazelcast.client.impl.clientside.ClientDiscoveryService;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientClusterDiscoveryServiceTest {
+
+    private CandidateClusterContext createContext() {
+        return new CandidateClusterContext(null, null, null, null, null, null);
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void test_oneIteration() {
+        ArrayList<CandidateClusterContext> arrayList = new ArrayList<CandidateClusterContext>();
+
+        int numberOfCandidates = 10;
+        for (int i = 0; i < numberOfCandidates; i++) {
+            arrayList.add(createContext());
+        }
+        ClientDiscoveryService discoveryService = new ClientDiscoveryService(1, arrayList);
+
+        int count = 0;
+        while (discoveryService.hasNext()) {
+            discoveryService.next();
+            count++;
+        }
+
+        assertEquals(numberOfCandidates, count);
+        discoveryService.next();
+    }
+
+    @Test
+    public void test_continueFromWhereItleftOff() {
+        ArrayList<CandidateClusterContext> arrayList = new ArrayList<CandidateClusterContext>();
+
+        int numberOfCandidates = 10;
+        for (int i = 0; i < numberOfCandidates; i++) {
+            arrayList.add(createContext());
+        }
+        ClientDiscoveryService discoveryService = new ClientDiscoveryService(1, arrayList);
+
+        discoveryService.next();
+        discoveryService.next();
+
+        discoveryService.resetSearch();
+
+        assertEquals(arrayList.get(2), discoveryService.next());
+
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void test_n_iterations() {
+        ArrayList<CandidateClusterContext> arrayList = new ArrayList<CandidateClusterContext>();
+        int n = 15;
+
+        for (int i = 0; i < 10; i++) {
+            arrayList.add(createContext());
+        }
+        ClientDiscoveryService discoveryService = new ClientDiscoveryService(n, arrayList);
+
+        int count = 0;
+        while (discoveryService.hasNext()) {
+            discoveryService.next();
+            count++;
+        }
+
+        assertEquals(10 * n, count);
+        discoveryService.next();
+
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void test_behaviourWhenBlueGreenIsOff() {
+        ArrayList<CandidateClusterContext> arrayList = new ArrayList<CandidateClusterContext>();
+        CandidateClusterContext candidateClusterContext = createContext();
+        arrayList.add(candidateClusterContext);
+
+        ClientDiscoveryService discoveryService = new ClientDiscoveryService(1, arrayList);
+
+        assertEquals(candidateClusterContext, discoveryService.next());
+        assertFalse(discoveryService.hasNext());
+        discoveryService.next();
+
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientSelectorsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientSelectorsTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.bluegreen;
+
+import com.hazelcast.client.impl.ClientImpl;
+import com.hazelcast.client.impl.ClientSelectors;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.InetSocketAddress;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientSelectorsTest extends HazelcastTestSupport {
+
+    @Test
+    public void testAny() {
+        String name = randomString();
+        Set<String> labels = Collections.emptySet();
+        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+        assertTrue(client.toString(), ClientSelectors.any().select(client));
+    }
+
+    @Test
+    public void testNone() {
+        String name = randomString();
+        Set<String> labels = Collections.emptySet();
+        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+        assertFalse(client.toString(), ClientSelectors.none().select(client));
+    }
+
+    @Test
+    public void testNameSelector() {
+        String name = "client1";
+        Set<String> labels = Collections.emptySet();
+
+        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+        assertTrue(client.toString(), ClientSelectors.nameSelector("client1").select(client));
+        assertTrue(client.toString(), ClientSelectors.nameSelector("clie.*").select(client));
+        assertTrue(client.toString(), ClientSelectors.nameSelector(".*lie.*").select(client));
+        assertTrue(client.toString(), ClientSelectors.nameSelector("c.*t1").select(client));
+
+        assertFalse(client.toString(), ClientSelectors.nameSelector("client2").select(client));
+        assertFalse(client.toString(), ClientSelectors.nameSelector("clii.*").select(client));
+        assertFalse(client.toString(), ClientSelectors.nameSelector(".*lii.*").select(client));
+        assertFalse(client.toString(), ClientSelectors.nameSelector("c.*t2").select(client));
+    }
+
+    @Test
+    public void testNameSelectorsWithNullInput() {
+        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), null, null);
+        assertFalse(client.toString(), ClientSelectors.nameSelector("client").select(client));
+    }
+
+    @Test
+    public void testLabelSelector() {
+        String name = randomString();
+        HashSet<String> labels = new HashSet<String>();
+        Collections.addAll(labels, "admin", "foo", "client1");
+
+        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+
+        assertTrue(client.toString(), ClientSelectors.labelSelector("client1").select(client));
+        assertTrue(client.toString(), ClientSelectors.labelSelector("clie.*").select(client));
+        assertTrue(client.toString(), ClientSelectors.labelSelector(".*lie.*").select(client));
+        assertTrue(client.toString(), ClientSelectors.labelSelector("c.*t1").select(client));
+
+        assertFalse(client.toString(), ClientSelectors.labelSelector("client2").select(client));
+        assertFalse(client.toString(), ClientSelectors.labelSelector("clii.*").select(client));
+        assertFalse(client.toString(), ClientSelectors.labelSelector(".*lii.*").select(client));
+        assertFalse(client.toString(), ClientSelectors.labelSelector("c.*t2").select(client));
+    }
+
+    @Test
+    public void testIpSelector_withIpv4() {
+        String name = randomString();
+        Set<String> labels = Collections.emptySet();
+        String ip = "213.129.127.80";
+        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved(ip, 5000), name, labels);
+
+        assertTrue(client.toString(), ClientSelectors.ipSelector("213.129.127.80").select(client));
+        assertTrue(client.toString(), ClientSelectors.ipSelector("213.129.127.*").select(client));
+        assertTrue(client.toString(), ClientSelectors.ipSelector("213.129.*.1-100").select(client));
+        assertFalse(client.toString(), ClientSelectors.ipSelector("213.129.127.70").select(client));
+        assertFalse(client.toString(), ClientSelectors.ipSelector("213.129.126.*").select(client));
+        assertFalse(client.toString(), ClientSelectors.ipSelector("213.129.*.1-10").select(client));
+    }
+
+    @Test
+    public void testIpSelector_withIpv6() {
+        String name = randomString();
+        Set<String> labels = Collections.emptySet();
+        String ip = "fe80:0:0:0:45c5:47ee:fe15:493a";
+        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved(ip, 5000), name, labels);
+        assertTrue(client.toString(), ClientSelectors.ipSelector("fe80:0:0:0:45c5:47ee:fe15:493a").select(client));
+        assertTrue(client.toString(), ClientSelectors.ipSelector("fe80:0:0:0:45c5:47ee:fe15:*").select(client));
+        assertTrue(client.toString(), ClientSelectors.ipSelector("fe80:0:0:0:45c5:47ee:fe15:0-5555").select(client));
+        assertFalse(client.toString(), ClientSelectors.ipSelector("fe80:0:0:0:45c5:47ee:fe15:493b").select(client));
+        assertFalse(client.toString(), ClientSelectors.ipSelector("fe80:0:0:0:45c5:47ee:fe14:*").select(client));
+        assertFalse(client.toString(), ClientSelectors.ipSelector("fe80::223:6cff:fe93:0-4444").select(client));
+    }
+
+    @Test
+    public void testInverse() {
+        String name = "client1";
+        Set<String> labels = Collections.emptySet();
+
+        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+        assertFalse(client.toString(), ClientSelectors.inverse(ClientSelectors.nameSelector("client1")).select(client));
+    }
+
+    @Test
+    public void testCombinationWithOr() {
+        String name = "client1";
+        HashSet<String> labels = new HashSet<String>();
+        Collections.addAll(labels, "admin", "foo", "client1");
+        String ip = "213.129.127.80";
+        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved(ip, 5000), name, labels);
+
+        assertTrue(client.toString(), ClientSelectors.or(ClientSelectors.ipSelector("213.129.*.1-100"),
+                ClientSelectors.nameSelector("clie.*")).select(client));
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.bluegreen;
+
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientFailoverConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.config.CredentialsFactoryConfig;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.resolveClientConfig;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class FailoverConfigTest {
+
+    @Test
+    public void testAllClientConfigsAreHandledInMultipleClientConfigSupport() {
+        Set<String> allClientConfigMethods = new HashSet<String>();
+        Collections.addAll(allClientConfigMethods, "setProperty", "getProperty", "getClassLoader", "getProperties",
+                "setProperties", "getLabels", "getGroupConfig", "getSecurityConfig", "isSmartRouting", "setSmartRouting",
+                "getSocketInterceptorConfig", "setSocketInterceptorConfig", "getConnectionAttemptPeriod",
+                "setConnectionAttemptPeriod", "getConnectionAttemptLimit", "setConnectionAttemptLimit", "getConnectionTimeout",
+                "setConnectionTimeout", "addAddress", "setAddresses", "getAddresses", "isRedoOperation", "setRedoOperation",
+                "getSocketOptions", "setSocketOptions", "setConfigPatternMatcher", "getConfigPatternMatcher", "setSecurityConfig",
+                "getNetworkConfig", "setNetworkConfig", "addReliableTopicConfig", "getReliableTopicConfig", "addNearCacheConfig",
+                "addNearCacheConfig", "addListenerConfig", "addProxyFactoryConfig", "getNearCacheConfig", "getNearCacheConfigMap",
+                "setNearCacheConfigMap", "getFlakeIdGeneratorConfigMap", "findFlakeIdGeneratorConfig",
+                "getFlakeIdGeneratorConfig", "addFlakeIdGeneratorConfig", "setFlakeIdGeneratorConfigMap",
+                "setReliableTopicConfigMap", "getReliableTopicConfigMap", "getCredentials", "setCredentials", "setGroupConfig",
+                "getListenerConfigs", "setListenerConfigs", "getLoadBalancer", "setLoadBalancer", "setClassLoader",
+                "getManagedContext", "setManagedContext", "getExecutorPoolSize", "setExecutorPoolSize", "getProxyFactoryConfigs",
+                "setProxyFactoryConfigs", "getSerializationConfig", "setSerializationConfig", "getNativeMemoryConfig",
+                "setNativeMemoryConfig", "getLicenseKey", "setLicenseKey", "addQueryCacheConfig", "getQueryCacheConfigs",
+                "setQueryCacheConfigs", "getInstanceName", "setInstanceName", "getConnectionStrategyConfig",
+                "setConnectionStrategyConfig", "getUserCodeDeploymentConfig", "setUserCodeDeploymentConfig",
+                "getOrCreateQueryCacheConfig", "getOrNullQueryCacheConfig", "addLabel", "setLabels",
+                "setUserContext", "getUserContext", "equals", "hashCode");
+        Method[] declaredMethods = ClientConfig.class.getDeclaredMethods();
+        for (Method method : declaredMethods) {
+            if (!method.getName().startsWith("$") && !allClientConfigMethods.contains(method.getName())) {
+                throw new IllegalStateException("There is a new method on client config. " + method
+                        + "Handle it on FailoverClientConfigSupport first, and add it to  allClientConfigMethods set above.");
+            }
+        }
+    }
+
+    @Test
+    public void testAllClientNetworkConfigsAreHandledInMultipleClientConfigSupport() {
+        Set<String> allClientNetworkConfigMethods = new HashSet<String>();
+        Collections.addAll(allClientNetworkConfigMethods, "isSmartRouting", "setSmartRouting", "getSocketInterceptorConfig",
+                "setSocketInterceptorConfig", "getConnectionAttemptPeriod", "setConnectionAttemptPeriod",
+                "getConnectionAttemptLimit", "setConnectionAttemptLimit", "getConnectionTimeout", "setConnectionTimeout",
+                "addAddress", "setAddresses", "getAddresses", "isRedoOperation", "setRedoOperation", "getSocketOptions",
+                "setSocketOptions", "getDiscoveryConfig", "setDiscoveryConfig", "getSSLConfig", "setSSLConfig", "setAwsConfig",
+                "getAwsConfig", "setGcpConfig", "getGcpConfig", "setAzureConfig", "getAzureConfig", "setKubernetesConfig",
+                "getKubernetesConfig", "setEurekaConfig", "getEurekaConfig", "getCloudConfig", "setCloudConfig",
+                "getOutboundPortDefinitions", "getOutboundPorts", "setOutboundPortDefinitions", "setOutboundPorts",
+                "addOutboundPort", "addOutboundPortDefinition", "getClientIcmpPingConfig", "setClientIcmpPingConfig",
+                "equals", "hashCode");
+        Method[] declaredMethods = ClientNetworkConfig.class.getDeclaredMethods();
+        for (Method method : declaredMethods) {
+            if (!method.getName().startsWith("$") && !allClientNetworkConfigMethods.contains(method.getName())) {
+                throw new IllegalStateException("There is a new method on client network config. " + method
+                        + "Handle it on FailoverClientConfigSupport first,"
+                        + " and add it to allClientNetworkConfigMethods set above.");
+            }
+        }
+    }
+
+    @Test
+    public void testClientConfigWithSameGroupName() {
+        ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
+        clientFailoverConfig.addClientConfig(new ClientConfig());
+        clientFailoverConfig.addClientConfig(new ClientConfig());
+        resolveClientConfig(clientFailoverConfig);
+    }
+
+    @Test
+    public void testClientConfigWithDifferentGroupName() {
+        ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
+        clientFailoverConfig.addClientConfig(new ClientConfig());
+
+        ClientConfig alternativeConfig = new ClientConfig();
+        alternativeConfig.getGroupConfig().setName("alternative");
+        clientFailoverConfig.addClientConfig(alternativeConfig);
+
+        resolveClientConfig(clientFailoverConfig);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testClientConfigWith_withAnInvalidChange() {
+        ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
+        clientFailoverConfig.addClientConfig(new ClientConfig());
+
+        ClientConfig alternativeConfig = new ClientConfig();
+        alternativeConfig.getGroupConfig().setName("alternative");
+        alternativeConfig.setProperty("newProperty", "newValue");
+        clientFailoverConfig.addClientConfig(alternativeConfig);
+
+        resolveClientConfig(clientFailoverConfig);
+    }
+
+    @Test
+    public void testClientConfigWith_withAValidChange() {
+        ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
+        clientFailoverConfig.addClientConfig(new ClientConfig());
+
+        ClientConfig alternativeConfig = new ClientConfig();
+        alternativeConfig.getGroupConfig().setName("alternative");
+        CredentialsFactoryConfig credentialsFactoryConfig = new CredentialsFactoryConfig();
+        credentialsFactoryConfig.setClassName("CustomCredentials");
+        alternativeConfig.getSecurityConfig().setCredentialsFactoryConfig(credentialsFactoryConfig);
+        clientFailoverConfig.addClientConfig(alternativeConfig);
+
+        resolveClientConfig(clientFailoverConfig);
+    }
+
+    @Test(expected = HazelcastException.class)
+    public void test_throwsException_whenFailoverConfigIsIntended_butPassedNull() {
+        ClientFailoverConfig clientFailoverConfig = resolveClientConfig((ClientFailoverConfig) null);
+        assertEquals(1, clientFailoverConfig.getClientConfigs().size());
+        assertEquals("dev", clientFailoverConfig.getClientConfigs().get(0).getGroupConfig().getName());
+    }
+
+    @Test
+    public void test_returnsDefaultConfigWhen_ClienConfig_passedNull() {
+        ClientFailoverConfig clientFailoverConfig = resolveClientConfig((ClientConfig) null);
+        assertEquals(1, clientFailoverConfig.getClientConfigs().size());
+        assertEquals("dev", clientFailoverConfig.getClientConfigs().get(0).getGroupConfig().getName());
+    }
+
+    @Test
+    public void test_returnsDefaultConfigWhenEmpty() {
+        ClientFailoverConfig clientFailoverConfig = resolveClientConfig();
+        assertEquals(1, clientFailoverConfig.getClientConfigs().size());
+        assertEquals("dev", clientFailoverConfig.getClientConfigs().get(0).getGroupConfig().getName());
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void test_throwsException_whenFailoverConfigIsEmpty() {
+        resolveClientConfig(new ClientFailoverConfig());
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/FailoverTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/FailoverTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.bluegreen;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientFailoverConfig;
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.test.ClientTestSupport;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class FailoverTest extends ClientTestSupport {
+
+    @After
+    public void cleanUp() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testFailoverNotSupportedInCommunityVersion() {
+        Config config1 = new Config();
+        config1.getGroupConfig().setName("dev1");
+        config1.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config1.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
+        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config1);
+
+        Config config2 = new Config();
+        config2.getGroupConfig().setName("dev2");
+        config2.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config2.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true);
+
+        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config2);
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getGroupConfig().setName("dev1");
+        ClientNetworkConfig networkConfig = clientConfig.getNetworkConfig();
+        Member member1 = (Member) instance1.getLocalEndpoint();
+        Address address1 = member1.getAddress();
+        networkConfig.setAddresses(Collections.singletonList(address1.getHost() + ":" + address1.getPort()));
+
+        ClientConfig clientConfig2 = new ClientConfig();
+        clientConfig2.getGroupConfig().setName("dev2");
+        ClientNetworkConfig networkConfig2 = clientConfig2.getNetworkConfig();
+        Member member2 = (Member) instance2.getLocalEndpoint();
+        Address address2 = member2.getAddress();
+        networkConfig2.setAddresses(Collections.singletonList(address2.getHost() + ":" + address2.getPort()));
+
+        ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
+        clientFailoverConfig.addClientConfig(clientConfig).addClientConfig(clientConfig2);
+
+        HazelcastClient.newHazelcastFailoverClient(clientFailoverConfig);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+import java.net.URL;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class XmlClientFailoverConfigBuilderTest {
+
+    private ClientFailoverConfig fullClientConfig;
+
+    @Before
+    public void init() throws Exception {
+        URL schemaResource = XmlClientFailoverConfigBuilderTest.class.
+                getClassLoader().getResource("hazelcast-client-failover-sample.xml");
+        fullClientConfig = new XmlClientFailoverConfigBuilder(schemaResource).build();
+    }
+
+    @After
+    @Before
+    public void beforeAndAfter() {
+        System.clearProperty("hazelcast.client.failover.config");
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testInvalidRootElement() {
+        String xml = "<hazelcast>"
+                + "<group>"
+                + "<name>dev</name>"
+                + "<password>clusterpass</password>"
+                + "</group>"
+                + "</hazelcast>";
+        buildConfig(xml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testExpectsAtLeastOneConfig() {
+        String xml = "<hazelcast-client-failover>"
+                + "    <clients>"
+                + "    </clients>"
+                + "</hazelcast-client-failover>";
+        buildConfig(xml);
+    }
+
+    private static void buildConfig(String xml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
+        XmlClientFailoverConfigBuilder configBuilder = new XmlClientFailoverConfigBuilder(bis);
+        configBuilder.build();
+    }
+
+
+    @Test(expected = HazelcastException.class)
+    public void loadingThroughSystemProperty_nonExistingFile() {
+        System.setProperty("hazelcast.client.failover.config", "idontexist");
+        new XmlClientFailoverConfigBuilder();
+    }
+
+    @Test(expected = HazelcastException.class)
+    public void loadingThroughSystemProperty_nonExistingClasspathResource() {
+        System.setProperty("hazelcast.client.failover.config", "classpath:idontexist");
+        new XmlClientFailoverConfigBuilder();
+    }
+
+    @Test
+    public void loadingThroughSystemProperty_existingClasspathResource() {
+        System.setProperty("hazelcast.client.failover.config", "classpath:hazelcast-client-failover-sample.xml");
+
+        XmlClientFailoverConfigBuilder configBuilder = new XmlClientFailoverConfigBuilder();
+        ClientFailoverConfig config = configBuilder.build();
+        assertEquals(2, config.getClientConfigs().size());
+        assertEquals("cluster1", config.getClientConfigs().get(0).getGroupConfig().getName());
+        assertEquals("cluster2", config.getClientConfigs().get(1).getGroupConfig().getName());
+        assertEquals(4, config.getTryCount());
+    }
+
+    @Test
+    public void testClientFailoverConfig() {
+        List<ClientConfig> clientConfigs = fullClientConfig.getClientConfigs();
+        assertEquals(2, clientConfigs.size());
+        assertEquals("cluster1", clientConfigs.get(0).getGroupConfig().getName());
+        assertEquals("cluster2", clientConfigs.get(1).getGroupConfig().getName());
+        assertEquals(4, fullClientConfig.getTryCount());
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/ConnectMemberListOrderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/ConnectMemberListOrderTest.java
@@ -17,6 +17,8 @@
 package com.hazelcast.client.connection.nio;
 
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.clientside.CandidateClusterContext;
+import com.hazelcast.client.impl.clientside.ClientDiscoveryService;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
@@ -101,8 +103,11 @@ public class ConnectMemberListOrderTest extends ClientTestSupport {
 
     private Collection<Address> getPossibleMemberAddresses(HazelcastInstance client) {
         HazelcastClientInstanceImpl instanceImpl = getHazelcastClientInstanceImpl(client);
-        ClientConnectionManagerImpl connectionManager = (ClientConnectionManagerImpl) instanceImpl.getConnectionManager();
-        return connectionManager.getPossibleMemberAddresses();
+        ClientDiscoveryService clientDiscoveryService = instanceImpl.getClientDiscoveryService();
+        clientDiscoveryService.resetSearch();
+        CandidateClusterContext clusterContext = clientDiscoveryService.next();
+        ClusterConnectorServiceImpl clusterConnectorService = (ClusterConnectorServiceImpl) instanceImpl.getClusterConnectorService();
+        return clusterConnectorService.getPossibleMemberAddresses(clusterContext.getAddressProvider());
     }
 
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -360,6 +360,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         ClientNetworkConfig networkConfig = config.getNetworkConfig();
         networkConfig.setConnectionAttemptLimit(1);
         networkConfig.setConnectionAttemptPeriod(1);
+        networkConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(new DiscoveryStrategyConfig());
         networkConfig.getDiscoveryConfig().setDiscoveryServiceProvider(discoveryServiceProvider);
 
         try {
@@ -377,15 +378,16 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         config.setProperty(GroupProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
 
         final DiscoveryService discoveryService = mock(DiscoveryService.class);
+        when(discoveryService.discoverNodes()).thenReturn(Collections.<DiscoveryNode>emptyList());
         DiscoveryServiceProvider discoveryServiceProvider = new DiscoveryServiceProvider() {
             public DiscoveryService newDiscoveryService(DiscoveryServiceSettings arg0) {
-                when(discoveryService.discoverNodes()).thenReturn(Collections.<DiscoveryNode>emptyList());
                 return discoveryService;
             }
         };
         ClientNetworkConfig networkConfig = config.getNetworkConfig();
         networkConfig.setConnectionAttemptLimit(1);
         networkConfig.setConnectionAttemptPeriod(1);
+        networkConfig.getDiscoveryConfig().addDiscoveryStrategyConfig(new DiscoveryStrategyConfig());
         networkConfig.getDiscoveryConfig().setDiscoveryServiceProvider(discoveryServiceProvider);
 
         try {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ConflictingConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ConflictingConfigTest.java
@@ -16,11 +16,9 @@
 
 package com.hazelcast.client.spi.impl.discovery;
 
-import com.hazelcast.aws.AwsDiscoveryStrategyFactory;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.test.TestHazelcastFactory;
-import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -29,9 +27,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -98,14 +93,10 @@ public class ConflictingConfigTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testAwsEnabled_and_SpiDiscoveryEnabled() {
+    public void testAwsEnabled_and_DiscoverySPIEnabled() {
         ClientConfig config = new ClientConfig();
         config.getNetworkConfig().getAwsConfig().setEnabled(true).setProperty("access-key", "12345").setSecretKey("56789");
-        Map<String, Comparable> properties = new HashMap<String, Comparable>();
-        properties.put("access-key", "my-access-key");
-        properties.put("secret-key", "my-secret-key");
-        config.getNetworkConfig().getDiscoveryConfig().addDiscoveryStrategyConfig(new DiscoveryStrategyConfig(
-                new AwsDiscoveryStrategyFactory(), properties));
+        config.setProperty(ClientProperty.DISCOVERY_SPI_ENABLED.getName(), "true");
         hazelcastFactory.newHazelcastClient(config);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -17,8 +17,6 @@
 package com.hazelcast.client.test;
 
 import com.hazelcast.client.HazelcastClient;
-import com.hazelcast.client.connection.AddressProvider;
-import com.hazelcast.client.connection.AddressTranslator;
 import com.hazelcast.client.connection.ClientConnectionManager;
 import com.hazelcast.client.connection.nio.ClientConnection;
 import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
@@ -82,10 +80,8 @@ class TestClientRegistry {
         }
 
         @Override
-        public ClientConnectionManager createConnectionManager(HazelcastClientInstanceImpl client,
-                                                               AddressTranslator addressTranslator,
-                                                               AddressProvider addressProvider) {
-            return new MockClientConnectionManager(client, addressTranslator, addressProvider, host, ports);
+        public ClientConnectionManager createConnectionManager(HazelcastClientInstanceImpl client) {
+            return new MockClientConnectionManager(client, host, ports);
         }
     }
 
@@ -98,9 +94,8 @@ class TestClientRegistry {
         private final String host;
         private final AtomicInteger ports;
 
-        MockClientConnectionManager(HazelcastClientInstanceImpl client, AddressTranslator addressTranslator,
-                                    AddressProvider addressProvider, String host, AtomicInteger ports) {
-            super(client, addressTranslator, addressProvider);
+        MockClientConnectionManager(HazelcastClientInstanceImpl client, String host, AtomicInteger ports) {
+            super(client);
             this.client = client;
             this.host = host;
             this.ports = ports;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.test;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientAwsConfig;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientFailoverConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.connection.Addresses;
@@ -67,13 +68,17 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
             config = new XmlClientConfigBuilder().build();
         }
 
+        ClientFailoverConfig resolvedConfig = new ClientFailoverConfig();
+        resolvedConfig.addClientConfig(config);
+        resolvedConfig.setTryCount(1);
+
         Thread currentThread = Thread.currentThread();
         ClassLoader tccl = currentThread.getContextClassLoader();
         try {
             if (tccl == ClassLoader.getSystemClassLoader()) {
                 currentThread.setContextClassLoader(HazelcastClient.class.getClassLoader());
             }
-            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(config,
+            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(resolvedConfig,
                     clientRegistry.createClientServiceFactory(), createAddressProvider(config));
             client.start();
             clients.add(client);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnOwnerDisconnectedTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnOwnerDisconnectedTest.java
@@ -84,7 +84,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
         };
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
-        final HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(clientConfig, addressProvider);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(addressProvider, clientConfig);
 
         Hazelcast.newHazelcastInstance();
         final TransactionContext context = client.newTransactionContext();
@@ -132,7 +132,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
         };
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
-        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(clientConfig, addressProvider);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(addressProvider, clientConfig);
 
         Hazelcast.newHazelcastInstance();
 
@@ -180,7 +180,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
         clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), "3");
         clientConfig.setProperty(ClientProperty.ALLOW_INVOCATIONS_WHEN_DISCONNECTED.getName(), "true");
-        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(clientConfig, addressProvider);
+        HazelcastInstance client = HazelcastClientUtil.newHazelcastClient(addressProvider, clientConfig);
 
         Hazelcast.newHazelcastInstance();
 

--- a/hazelcast-client/src/test/resources/hazelcast-client-failover-sample.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-failover-sample.xml
@@ -1,0 +1,7 @@
+<hazelcast-client-failover>
+    <try-count>4</try-count>
+    <clients>
+        <client>hazelcast-client-c1.xml</client>
+        <client>hazelcast-client-c2.xml</client>
+    </clients>
+</hazelcast-client-failover>

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/AbstractHazelcastBeanDefinitionParser.java
@@ -73,7 +73,7 @@ public abstract class AbstractHazelcastBeanDefinitionParser extends AbstractBean
     /**
      * Base Helper class for Spring Xml Builder
      */
-    public abstract class SpringXmlBuilderHelper extends AbstractXmlConfigHelper {
+    public abstract static class SpringXmlBuilderHelper extends AbstractXmlConfigHelper {
 
         protected BeanDefinitionBuilder configBuilder;
 

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -94,7 +94,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
     /**
      * Client bean definition builder
      */
-    public class SpringXmlBuilder extends SpringXmlBuilderHelper {
+    public static class SpringXmlBuilder extends SpringXmlBuilderHelper {
 
         private static final int INITIAL_CAPACITY = 10;
 
@@ -120,11 +120,17 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             configBuilder.addPropertyValue("reliableTopicConfigMap", reliableTopicConfigMap);
         }
 
+       public AbstractBeanDefinition handleClient(Node rootNode) {
+            AbstractBeanDefinition configBean = createConfigBean(rootNode);
+            builder.addConstructorArgValue(configBean);
+            return builder.getBeanDefinition();
+        }
+
         @SuppressWarnings("checkstyle:cyclomaticcomplexity")
-        public AbstractBeanDefinition handleClient(Element element) {
-            handleCommonBeanAttributes(element, builder, parserContext);
-            handleClientAttributes(element);
-            for (Node node : childElements(element)) {
+        AbstractBeanDefinition createConfigBean(Node rootNode) {
+            handleCommonBeanAttributes(rootNode, builder, parserContext);
+            handleClientAttributes(rootNode);
+            for (Node node : childElements(rootNode)) {
                 String nodeName = cleanNodeName(node);
                 if ("group".equals(nodeName)) {
                     createAndFillBeanBuilder(node, GroupConfig.class, "groupConfig", configBuilder);
@@ -165,8 +171,7 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
                     handleLabels(node);
                 }
             }
-            builder.addConstructorArgValue(configBuilder.getBeanDefinition());
-            return builder.getBeanDefinition();
+            return configBuilder.getBeanDefinition();
         }
 
         private void handleSecurity(Node node) {
@@ -250,8 +255,8 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
             configBuilder.addPropertyValue("userCodeDeploymentConfig", userCodeDeploymentConfig.getBeanDefinition());
         }
 
-        private void handleClientAttributes(Element element) {
-            NamedNodeMap attributes = element.getAttributes();
+        private void handleClientAttributes(Node node) {
+            NamedNodeMap attributes = node.getAttributes();
             if (attributes != null) {
                 for (int a = 0; a < attributes.getLength(); a++) {
                     Node att = attributes.item(a);

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastFailoverClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastFailoverClientBeanDefinitionParser.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientFailoverConfig;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.ManagedList;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import static com.hazelcast.config.DomConfigHelper.childElements;
+import static org.springframework.beans.factory.support.BeanDefinitionBuilder.rootBeanDefinition;
+
+/**
+ * BeanDefinitionParser for Hazelcast Client Configuration.
+ *     <hz:client-failover id="blueGreenClient" try-count="5">
+ *         <hz:client>
+ *             <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
+ *             <hz:network>
+ *                 <hz:member>127.0.0.1:5700</hz:member>
+ *                 <hz:member>127.0.0.1:5701</hz:member>
+ *             </hz:network>
+ *         </hz:client>
+ *
+ *         <hz:client>
+ *             <hz:group name="alternativeClusterName" password="${cluster.group.password}"/>
+ *             <hz:network>
+ *                 <hz:member>127.0.0.1:5702</hz:member>
+ *                 <hz:member>127.0.0.1:5703</hz:member>
+ *             </hz:network>
+ *         </hz:client>
+ *
+ *     </hz:client-failover>
+ */
+public class HazelcastFailoverClientBeanDefinitionParser extends  AbstractHazelcastBeanDefinitionParser {
+
+    @Override
+    protected AbstractBeanDefinition parseInternal(Element element, ParserContext parserContext) {
+        SpringXmlBuilder springXmlBuilder = new SpringXmlBuilder(parserContext);
+        return springXmlBuilder.handleMultipleClusterAwareClient(element);
+    }
+
+    class SpringXmlBuilder extends SpringXmlBuilderHelper {
+
+        private final ParserContext parserContext;
+        private final BeanDefinitionBuilder builder;
+        private final  BeanDefinitionBuilder failoverConfigBuilder;
+
+
+        SpringXmlBuilder(ParserContext parserContext) {
+            this(parserContext, rootBeanDefinition(HazelcastClient.class)
+                    .setFactoryMethod("newHazelcastFailoverClient")
+                    .setDestroyMethodName("shutdown"));
+        }
+
+        SpringXmlBuilder(ParserContext parserContext, BeanDefinitionBuilder builder) {
+            this.parserContext = parserContext;
+            this.builder = builder;
+            this.failoverConfigBuilder = rootBeanDefinition(ClientFailoverConfig.class);
+        }
+
+        AbstractBeanDefinition handleMultipleClusterAwareClient(Element element) {
+            handleCommonBeanAttributes(element, builder, parserContext);
+            String attribute = element.getAttribute("try-count");
+            failoverConfigBuilder.addPropertyValue("tryCount", Integer.valueOf(attribute));
+
+            ManagedList<BeanDefinition> configs = new ManagedList<BeanDefinition>();
+            for (Node node : childElements(element)) {
+                HazelcastClientBeanDefinitionParser.SpringXmlBuilder springXmlBuilder =
+                        new HazelcastClientBeanDefinitionParser.SpringXmlBuilder(parserContext);
+                configs.add(springXmlBuilder.createConfigBean(node));
+            }
+
+            failoverConfigBuilder.addPropertyValue("clientConfigs", configs);
+
+            builder.addConstructorArgValue(failoverConfigBuilder.getBeanDefinition());
+            return builder.getBeanDefinition();
+
+        }
+    }
+}

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastNamespaceHandler.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastNamespaceHandler.java
@@ -29,6 +29,8 @@ public class HazelcastNamespaceHandler extends NamespaceHandlerSupport {
         registerBeanDefinitionParser("config", new HazelcastConfigBeanDefinitionParser());
         registerBeanDefinitionParser("hazelcast", new HazelcastInstanceDefinitionParser());
         registerBeanDefinitionParser("client", new HazelcastClientBeanDefinitionParser());
+        registerBeanDefinitionParser("client-failover",
+                new HazelcastFailoverClientBeanDefinitionParser());
         registerBeanDefinitionParser("hibernate-region-factory", new RegionFactoryBeanDefinitionParser());
         registerBeanDefinitionParser("cache-manager", new CacheManagerBeanDefinitionParser());
         String[] types = {
@@ -53,7 +55,7 @@ public class HazelcastNamespaceHandler extends NamespaceHandlerSupport {
                 "lock",
                 "reliableTopic",
                 "PNCounter",
-                };
+        };
         for (String type : types) {
             registerBeanDefinitionParser(type, new HazelcastTypeBeanDefinitionParser(type));
         }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -1914,7 +1914,33 @@
         </xs:complexType>
     </xs:element>
 
-    <xs:element name="client">
+    <xs:element name="client-failover">
+        <xs:annotation>
+            <xs:documentation>
+                Configure the hazelcast client with multiple configs. Client will connect to first one and when disconnected
+                from that it will connect to next available cluster via given alternative configs.
+            </xs:documentation>
+            <xs:appinfo>
+                <tool:annotation>
+                    <tool:exports type="com.hazelcast.core.HazelcastInstance"/>
+                </tool:annotation>
+            </xs:appinfo>
+        </xs:annotation>
+
+        <xs:complexType>
+            <xs:complexContent>
+                <xs:extension base="hazelcast-bean">
+                    <xs:sequence>
+                        <xs:element name="client" type="client-type" minOccurs="1" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                    <xs:attribute name="try-count" type="xs:int" default="0"/>
+                </xs:extension>
+            </xs:complexContent>
+        </xs:complexType>
+    </xs:element>
+
+
+    <xs:element name="client" type="client-type">
         <xs:annotation>
             <xs:documentation>
                 Configure the hazelcast client
@@ -1925,34 +1951,35 @@
                 </tool:annotation>
             </xs:appinfo>
         </xs:annotation>
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="hazelcast-bean">
-                    <xs:choice minOccurs="0" maxOccurs="unbounded">
-                        <xs:element name="spring-aware" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="group" type="group" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="instance-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="labels" type="labels" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="network" type="network-client" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="security" type="client-security" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="listeners" type="listeners" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="serialization" type="serialization" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="proxy-factories" type="proxy-factories" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="load-balancer" type="load-balancer" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="near-cache" type="near-cache-client" minOccurs="0" maxOccurs="unbounded"/>
-                        <xs:element name="query-caches" type="query-caches-client" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="connection-strategy" type="connection-strategy" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="user-code-deployment" type="user-code-deployment-client" minOccurs="0" maxOccurs="1"/>
-                        <xs:element name="flake-id-generator" type="client-flake-id-generator" minOccurs="0" maxOccurs="unbounded"/>
-                        <xs:element name="reliable-topic" type="client-reliable-topic" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:choice>
-                    <xs:attribute name="executor-pool-size" type="xs:int" use="optional"/>
-                    <xs:attribute name="credentials-ref" type="xs:string" use="optional"/>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
     </xs:element>
+
+    <xs:complexType name="client-type">
+        <xs:complexContent>
+            <xs:extension base="hazelcast-bean">
+                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element name="spring-aware" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="group" type="group" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="instance-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="labels" type="labels" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="network" type="network-client" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="security" type="client-security" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="listeners" type="listeners" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="serialization" type="serialization" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="proxy-factories" type="proxy-factories" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="load-balancer" type="load-balancer" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="near-cache" type="near-cache-client" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="query-caches" type="query-caches-client" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="connection-strategy" type="connection-strategy" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="user-code-deployment" type="user-code-deployment-client" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="flake-id-generator" type="client-flake-id-generator" minOccurs="0" maxOccurs="unbounded"/>
+                    <xs:element name="reliable-topic" type="client-reliable-topic" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:choice>
+                <xs:attribute name="executor-pool-size" type="xs:int" use="optional"/>
+                <xs:attribute name="credentials-ref" type="xs:string" use="optional"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
 
     <xs:element name="map" type="hazelcast-type">
         <xs:annotation>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestSpringClientFailoverContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestSpringClientFailoverContext.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring;
+
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.config.ClientFailoverConfig;
+import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(CustomSpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = {"node-client-applicationContext-failover-hazelcast.xml"})
+@Category(QuickTest.class)
+public class TestSpringClientFailoverContext {
+
+    @Resource
+    private ApplicationContext applicationContext;
+
+    @After
+    public void teardown() {
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    @Test
+    public void testBlueGreenClient() {
+        HazelcastClientProxy blueGreenClient = applicationContext.getBean("blueGreenClient", HazelcastClientProxy.class);
+        ClientFailoverConfig failoverConfig = blueGreenClient.client.getFailoverConfig();
+        List<ClientConfig> clientConfigs = failoverConfig.getClientConfigs();
+        assertEquals(2, clientConfigs.size());
+        assertEquals("spring-group", clientConfigs.get(0).getGroupConfig().getName());
+        assertEquals("alternativeClusterName", clientConfigs.get(1).getGroupConfig().getName());
+        assertEquals(5, failoverConfig.getTryCount());
+        blueGreenClient.shutdown();
+    }
+}

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:p="http://www.springframework.org/schema/p"
+       xmlns:hz="http://www.hazelcast.com/schema/spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.hazelcast.com/schema/spring
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
+
+    <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
+          p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
+        <property name="locations">
+            <list>
+                <value>classpath:/hazelcast-default.properties</value>
+            </list>
+        </property>
+    </bean>
+
+    <hz:hazelcast id="instance">
+        <hz:config>
+            <hz:group
+                    name="${cluster.group.name}"
+                    password="${cluster.group.password}"/>
+            <hz:properties>
+                <hz:property name="hazelcast.merge.first.run.delay.seconds">5</hz:property>
+                <hz:property name="hazelcast.merge.next.run.delay.seconds">5</hz:property>
+            </hz:properties>
+            <hz:network port="${cluster.port}" port-auto-increment="true">
+                <hz:join>
+                    <hz:multicast enabled="false"
+                                  multicast-group="224.2.2.3"
+                                  multicast-port="54327"/>
+                    <hz:tcp-ip enabled="true">
+                        <hz:members>${cluster.members}</hz:members>
+                    </hz:tcp-ip>
+                </hz:join>
+                <hz:interfaces enabled="false">
+                    <hz:interface>10.10.1.*</hz:interface>
+                </hz:interfaces>
+            </hz:network>
+        </hz:config>
+    </hz:hazelcast>
+
+    <hz:client-failover id="blueGreenClient" try-count="5" lazy-init="true">
+        <hz:client>
+            <hz:group name="${cluster.group.name}" password="${cluster.group.password}"/>
+            <hz:network>
+                <hz:member>127.0.0.1:5701</hz:member>
+            </hz:network>
+
+            <hz:connection-strategy async-start="true"></hz:connection-strategy>
+        </hz:client>
+
+        <hz:client>
+            <hz:group name="alternativeClusterName" password="${cluster.group.password}"/>
+            <hz:network>
+                <hz:member>127.0.0.1:5702</hz:member>
+            </hz:network>
+
+            <hz:connection-strategy async-start="true"></hz:connection-strategy>
+        </hz:client>
+    </hz:client-failover>
+
+</beans>

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
@@ -147,4 +147,19 @@ public interface ClientEngine extends Consumer<ClientMessage> {
     Map<String, String> getClientStatistics();
 
     String getOwnerUuid(String clientUuid);
+
+    /**
+     * @param client to check if allowed through current ClientSelector
+     * @return true if allowed, false otherwise
+     */
+    boolean isClientAllowed(Client client);
+
+    /**
+     * Only Clients that can pass through filter are allowed to connect to cluster.
+     * Only one selector can be active at a time. Applying new one will override old selector.
+     *
+     * @param selector to select a client or group of clients to act upon
+     */
+    void applySelector(ClientSelector selector);
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientImpl.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.client.impl.clientside;
+package com.hazelcast.client.impl;
 
 import com.hazelcast.core.Client;
 import com.hazelcast.core.ClientType;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientSelector.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl;
+
+import com.hazelcast.core.Client;
+
+public interface ClientSelector {
+
+    boolean select(Client client);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientSelectors.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientSelectors.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl;
+
+import com.hazelcast.core.Client;
+import com.hazelcast.util.AddressUtil;
+
+import java.util.Set;
+
+public final class ClientSelectors {
+
+    private ClientSelectors() {
+
+    }
+
+    public static ClientSelector any() {
+        return new ClientSelector() {
+            @Override
+            public boolean select(Client client) {
+                return true;
+            }
+
+            @Override
+            public String toString() {
+                return "ClientSelector{any}";
+            }
+        };
+    }
+
+    public static ClientSelector none() {
+        return new ClientSelector() {
+            @Override
+            public boolean select(Client client) {
+                return false;
+            }
+
+            @Override
+            public String toString() {
+                return "ClientSelector{none}";
+            }
+        };
+    }
+
+    /**
+     * Regular regex rules are applied. see String.matches
+     *
+     * @param nameMask of the clients that will be selected
+     * @return client selector according to name
+     */
+    public static ClientSelector nameSelector(final String nameMask) {
+        return new ClientSelector() {
+            @Override
+            public boolean select(Client client) {
+                String name = client.getName();
+                if (name == null) {
+                    return false;
+                }
+                return name.matches(nameMask);
+            }
+
+            @Override
+            public String toString() {
+                return "ClientSelector{nameMask:" + nameMask + " }";
+            }
+        };
+    }
+
+    /**
+     * Works with AddressUtil.mathInterface
+     *
+     * @param ipMask ip mask for the selector
+     * @return client selector according to IP
+     */
+    public static ClientSelector ipSelector(final String ipMask) {
+        return new ClientSelector() {
+            @Override
+            public boolean select(Client client) {
+                return AddressUtil.matchInterface(client.getSocketAddress().getHostName(), ipMask);
+            }
+
+            @Override
+            public String toString() {
+                return "ClientSelector{ipMask:" + ipMask + " }";
+            }
+        };
+    }
+
+    public static ClientSelector or(final ClientSelector... selectors) {
+        return new ClientSelector() {
+            @Override
+            public boolean select(Client client) {
+                for (ClientSelector selector : selectors) {
+                    if (selector.select(client)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public String toString() {
+                StringBuilder builder = new StringBuilder();
+                builder.append("ClientSelector{or:");
+                for (ClientSelector selector : selectors) {
+                    builder.append(selector).append(", ");
+                }
+                builder.append("}");
+                return builder.toString();
+            }
+        };
+    }
+
+    /**
+     * Regular regex rules are applied. see String.matches
+     *
+     * @param labelMask of the clients that will be selected
+     * @return client selector according to label
+     */
+    public static ClientSelector labelSelector(final String labelMask) {
+        return new ClientSelector() {
+            @Override
+            public boolean select(Client client) {
+                Set<String> labels = client.getLabels();
+                for (String label : labels) {
+                    if (label.matches(labelMask)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public String toString() {
+                return "ClientSelector{labelMask:" + labelMask + " }";
+            }
+        };
+    }
+
+    public static ClientSelector inverse(final ClientSelector clientSelector) {
+        return new ClientSelector() {
+            @Override
+            public boolean select(Client client) {
+                return !clientSelector.select(client);
+            }
+
+            @Override
+            public String toString() {
+                return "ClientSelector{inverse:" + clientSelector + " }";
+            }
+        };
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
@@ -127,6 +127,16 @@ public class NoOpClientEngine implements ClientEngine {
     }
 
     @Override
+    public boolean isClientAllowed(Client client) {
+        return true;
+    }
+
+    @Override
+    public void applySelector(ClientSelector selector) {
+
+    }
+
+    @Override
     public void accept(ClientMessage clientMessage) {
 
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/AuthenticationStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/AuthenticationStatus.java
@@ -23,7 +23,8 @@ public enum AuthenticationStatus {
 
     AUTHENTICATED(0),
     CREDENTIALS_FAILED(1),
-    SERIALIZATION_VERSION_MISMATCH(2);
+    SERIALIZATION_VERSION_MISMATCH(2),
+    NOT_ALLOWED_IN_CLUSTER(3);
 
     private final byte id;
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/DefaultMessageTaskFactoryProvider.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol;
 import com.hazelcast.client.impl.protocol.task.AddPartitionListenerMessageTask;
 import com.hazelcast.client.impl.protocol.task.CreateProxiesMessageTask;
 import com.hazelcast.client.impl.protocol.task.DeployClassesMessageTask;
+import com.hazelcast.client.impl.protocol.task.IsFailoverSupportedMessageTask;
 import com.hazelcast.client.impl.protocol.task.MessageTask;
 import com.hazelcast.client.impl.protocol.task.cache.CacheEventJournalReadTask;
 import com.hazelcast.client.impl.protocol.task.cache.CacheEventJournalSubscribeTask;
@@ -1786,6 +1787,11 @@ public class DefaultMessageTaskFactoryProvider implements MessageTaskFactoryProv
         factories[com.hazelcast.client.impl.protocol.codec.ClientCreateProxiesCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
             public MessageTask create(ClientMessage clientMessage, Connection connection) {
                 return new CreateProxiesMessageTask(clientMessage, node, connection);
+            }
+        };
+        factories[com.hazelcast.client.impl.protocol.codec.ClientIsFailoverSupportedCodec.RequestParameters.TYPE.id()] = new MessageTaskFactory() {
+            public MessageTask create(ClientMessage clientMessage, Connection connection) {
+                return new IsFailoverSupportedMessageTask(clientMessage, node, connection);
             }
         };
 //endregion

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -98,21 +98,21 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
     @Override
     public final void run() {
         try {
-            doRun();
+            if (requiresAuthentication() && !endpoint.isAuthenticated()) {
+                handleAuthenticationFailure();
+            } else {
+                initializeAndProcessMessage();
+            }
         } catch (Throwable e) {
             handleProcessingFailure(e);
         }
     }
 
-    protected void doRun() throws Throwable {
-        if (!endpoint.isAuthenticated()) {
-            handleAuthenticationFailure();
-        } else {
-            initializeAndProcessMessage();
-        }
+    protected boolean requiresAuthentication() {
+        return true;
     }
 
-    void initializeAndProcessMessage() throws Throwable {
+    private void initializeAndProcessMessage() throws Throwable {
         if (!node.getNodeExtension().isStartCompleted()) {
             throw new HazelcastInstanceNotActiveException("Hazelcast instance is not ready yet!");
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationCustomCredentialsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationCustomCredentialsMessageTask.java
@@ -49,6 +49,7 @@ public class AuthenticationCustomCredentialsMessageTask
     }
 
     @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
     protected ClientAuthenticationCustomCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
         ClientAuthenticationCustomCodec.RequestParameters parameters = ClientAuthenticationCustomCodec
                 .decodeRequest(clientMessage);
@@ -69,7 +70,11 @@ public class AuthenticationCustomCredentialsMessageTask
 
         if (parameters.labelsExist) {
             labels = Collections.unmodifiableSet(new HashSet<String>(parameters.labels));
+        } else {
+            labels = Collections.emptySet();
         }
+        partitionCount = parameters.partitionCountExist ? parameters.partitionCount : null;
+        clusterId = parameters.clusterIdExist ? parameters.clusterId : null;
         return parameters;
     }
 
@@ -80,10 +85,10 @@ public class AuthenticationCustomCredentialsMessageTask
 
     @Override
     protected ClientMessage encodeAuth(byte status, Address thisAddress, String uuid, String ownerUuid, byte version,
-                                       List<Member> cleanedUpMembers) {
+                                       List<Member> cleanedUpMembers, int partitionCount, String clusterId) {
         return ClientAuthenticationCustomCodec
                 .encodeResponse(status, thisAddress, uuid, ownerUuid, version, getMemberBuildInfo().getVersion(),
-                        cleanedUpMembers);
+                        cleanedUpMembers, partitionCount, clusterId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationMessageTask.java
@@ -39,6 +39,7 @@ public class AuthenticationMessageTask extends AuthenticationBaseMessageTask<Cli
     }
 
     @Override
+    @SuppressWarnings("checkstyle:npathcomplexity")
     protected ClientAuthenticationCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
         final ClientAuthenticationCodec.RequestParameters parameters = ClientAuthenticationCodec.decodeRequest(clientMessage);
         final String uuid = parameters.uuid;
@@ -58,7 +59,11 @@ public class AuthenticationMessageTask extends AuthenticationBaseMessageTask<Cli
 
         if (parameters.labelsExist) {
             labels = Collections.unmodifiableSet(new HashSet<String>(parameters.labels));
+        } else {
+            labels = Collections.emptySet();
         }
+        partitionCount = parameters.partitionCountExist ? parameters.partitionCount : null;
+        clusterId = parameters.clusterIdExist ? parameters.clusterId : null;
         return parameters;
     }
 
@@ -69,10 +74,10 @@ public class AuthenticationMessageTask extends AuthenticationBaseMessageTask<Cli
 
     @Override
     protected ClientMessage encodeAuth(byte status, Address thisAddress, String uuid, String ownerUuid, byte version,
-                                       List<Member> cleanedUpMembers) {
+                                       List<Member> cleanedUpMembers, int partitionCount, String clusterId) {
         return ClientAuthenticationCodec
                 .encodeResponse(status, thisAddress, uuid, ownerUuid, version, getMemberBuildInfo().getVersion(),
-                        cleanedUpMembers);
+                        cleanedUpMembers, partitionCount, clusterId);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/IsFailoverSupportedMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/IsFailoverSupportedMessageTask.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task;
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.codec.ClientIsFailoverSupportedCodec;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Connection;
+
+import java.security.Permission;
+
+public class IsFailoverSupportedMessageTask
+        extends AbstractCallableMessageTask<ClientIsFailoverSupportedCodec.RequestParameters> {
+
+    public IsFailoverSupportedMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
+        super(clientMessage, node, connection);
+    }
+
+    @Override
+    protected ClientIsFailoverSupportedCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
+        return ClientIsFailoverSupportedCodec.decodeRequest(clientMessage);
+    }
+
+    @Override
+    protected ClientMessage encodeResponse(Object response) {
+        return ClientIsFailoverSupportedCodec.encodeResponse((Boolean) response);
+    }
+
+    @Override
+    protected Object call() throws Exception {
+        return nodeEngine.getNode().getNodeExtension().isClientFailoverSupported();
+    }
+
+    @Override
+    protected boolean requiresAuthentication() {
+        return false;
+    }
+
+    @Override
+    public String getServiceName() {
+        return null;
+    }
+
+    @Override
+    public Permission getRequiredPermission() {
+        return null;
+    }
+
+    @Override
+    public String getDistributedObjectName() {
+        return null;
+    }
+
+    @Override
+    public String getMethodName() {
+        return null;
+    }
+
+    @Override
+    public Object[] getParameters() {
+        return null;
+    }
+
+}
+

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigBuilder.java
@@ -59,7 +59,8 @@ public abstract class AbstractXmlConfigBuilder extends AbstractXmlConfigHelper {
     protected enum ConfigType {
         SERVER("hazelcast"),
         CLIENT("hazelcast-client"),
-        JET("hazelcast-jet");
+        JET("hazelcast-jet"),
+        CLIENT_FAILOVER("hazelcast-client-failover");
 
         final String name;
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ListenerConfig.java
@@ -151,27 +151,6 @@ public class ListenerConfig implements IdentifiedDataSerializable {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        ListenerConfig that = (ListenerConfig) o;
-        if (className != null ? !className.equals(that.className) : that.className != null) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return className != null ? className.hashCode() : 0;
-    }
-
-    @Override
     public int getFactoryId() {
         return ConfigDataSerializerHook.F_ID;
     }
@@ -193,5 +172,32 @@ public class ListenerConfig implements IdentifiedDataSerializable {
         implementation = in.readObject();
     }
 
+    @Override
+    @SuppressWarnings({"checkstyle:npathcomplexity"})
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
+        ListenerConfig that = (ListenerConfig) o;
+
+        if (className != null ? !className.equals(that.className) : that.className != null) {
+            return false;
+        }
+        if (implementation != null ? !implementation.equals(that.implementation) : that.implementation != null) {
+            return false;
+        }
+        return readOnly != null ? readOnly.equals(that.readOnly) : that.readOnly == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = className != null ? className.hashCode() : 0;
+        result = 31 * result + (implementation != null ? implementation.hashCode() : 0);
+        result = 31 * result + (readOnly != null ? readOnly.hashCode() : 0);
+        return result;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/LegacyMatchingPointConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/LegacyMatchingPointConfigPatternMatcher.java
@@ -75,4 +75,17 @@ public class LegacyMatchingPointConfigPatternMatcher implements ConfigPatternMat
 
         return firstPart.length() + secondPart.length();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/LegacyWildcardConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/LegacyWildcardConfigPatternMatcher.java
@@ -63,4 +63,17 @@ public class LegacyWildcardConfigPatternMatcher implements ConfigPatternMatcher 
         int indexSecondPart = itemName.indexOf(secondPart, index + 1);
         return (indexSecondPart != -1);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/MatchingPointConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/MatchingPointConfigPatternMatcher.java
@@ -76,4 +76,18 @@ public class MatchingPointConfigPatternMatcher implements ConfigPatternMatcher {
 
         return firstPart.length() + secondPart.length();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/RegexConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/RegexConfigPatternMatcher.java
@@ -51,4 +51,23 @@ public class RegexConfigPatternMatcher implements ConfigPatternMatcher {
         }
         return candidate;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RegexConfigPatternMatcher that = (RegexConfigPatternMatcher) o;
+
+        return flags == that.flags;
+    }
+
+    @Override
+    public int hashCode() {
+        return flags;
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/matcher/WildcardConfigPatternMatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/matcher/WildcardConfigPatternMatcher.java
@@ -66,4 +66,17 @@ public class WildcardConfigPatternMatcher implements ConfigPatternMatcher {
 
         return true;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o != null && getClass() == o.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/LifecycleEvent.java
@@ -84,7 +84,12 @@ public final class LifecycleEvent {
         /**
          * Fired when a client is disconnected from the member.
          */
-        CLIENT_DISCONNECTED
+        CLIENT_DISCONNECTED,
+
+        /**
+         * Fired when a client is connected to a new cluster.
+         */
+        CLIENT_CHANGED_CLUSTER
     }
 
     final LifecycleState state;

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -21,7 +21,6 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.internal.networking.ChannelErrorHandler;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.internal.networking.Networking;
 import com.hazelcast.internal.networking.ServerSocketRegistry;
 import com.hazelcast.internal.networking.nio.NioNetworking;
@@ -144,7 +143,7 @@ public class DefaultNodeContext implements NodeContext {
     @Override
     public NetworkingService createNetworkingService(Node node, ServerSocketRegistry registry) {
         NodeIOService ioService = new NodeIOService(node, node.nodeEngine);
-        Networking networking = createNetworking(node, ioService);
+        Networking networking = createNetworking(node);
         Config config = node.getConfig();
 
         return new TcpIpNetworkingService(config,
@@ -153,12 +152,11 @@ public class DefaultNodeContext implements NodeContext {
                 node.loggingService,
                 node.nodeEngine.getMetricsRegistry(),
                 networking,
-
+                node.getNodeExtension().createChannelInitializerProvider(ioService),
                 node.getProperties());
     }
 
-    private Networking createNetworking(Node node, NodeIOService ioService) {
-        ChannelInitializerProvider initializerProvider = node.getNodeExtension().createChannelInitializerProvider(ioService);
+    private Networking createNetworking(Node node) {
 
         LoggingServiceImpl loggingService = node.loggingService;
 
@@ -175,7 +173,6 @@ public class DefaultNodeContext implements NodeContext {
                         .errorHandler(errorHandler)
                         .inputThreadCount(props.getInteger(IO_INPUT_THREAD_COUNT))
                         .outputThreadCount(props.getInteger(IO_OUTPUT_THREAD_COUNT))
-                        .balancerIntervalSeconds(props.getInteger(IO_BALANCER_INTERVAL_SECONDS))
-                        .channelInitializerProvider(initializerProvider));
+                        .balancerIntervalSeconds(props.getInteger(IO_BALANCER_INTERVAL_SECONDS)));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -490,6 +490,11 @@ public class DefaultNodeExtension implements NodeExtension {
         // NOP
     }
 
+    @Override
+    public boolean isClientFailoverSupported() {
+        return false;
+    }
+
     protected void createAndSetPhoneHome() {
         this.phoneHome = new PhoneHome(node);
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/NodeExtension.java
@@ -326,4 +326,9 @@ public interface NodeExtension {
      * method creates and schedules a new auto upgrade task.
      */
     void scheduleClusterVersionAutoUpgrade();
+
+    /**
+     * @return true if client failover feature is supported
+     */
+    boolean isClientFailoverSupported();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Networking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Networking.java
@@ -46,14 +46,17 @@ public interface Networking {
      * In the future we need to think about passing the socket channel because
      * it binds Networking to tcp and this is not desirable.
      *
-     * @param endpointQualifier the endpoint qualifier for this server socket
-     * @param socketChannel the socketChannel to register
-     * @param clientMode    if the channel is made in clientMode or server mode
+     * @param endpointQualifier          the endpoint qualifier for this server socket
+     * @param channelInitializerProvider the class used for initializing the Channel after creation
+     * @param socketChannel              the socketChannel to register
+     * @param clientMode                 if the channel is made in clientMode or server mode
      * @return the created Channel
      * @throws IOException when something failed while registering the
      *                     socketChannel
      */
-    Channel register(EndpointQualifier endpointQualifier, SocketChannel socketChannel, boolean clientMode) throws IOException;
+    Channel register(EndpointQualifier endpointQualifier, ChannelInitializerProvider channelInitializerProvider,
+                     SocketChannel socketChannel,
+                     boolean clientMode) throws IOException;
 
     /**
      * Starts Networking.

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -88,7 +88,6 @@ public final class NioNetworking implements Networking {
     private final String threadNamePrefix;
     private final ChannelErrorHandler errorHandler;
     private final int balancerIntervalSeconds;
-    private final ChannelInitializerProvider channelInitializerProvider;
     private final int inputThreadCount;
     private final int outputThreadCount;
     private final Set<NioChannel> channels = newSetFromMap(new ConcurrentHashMap<NioChannel, Boolean>());
@@ -110,7 +109,6 @@ public final class NioNetworking implements Networking {
         this.logger = loggingService.getLogger(NioNetworking.class);
         this.errorHandler = ctx.errorHandler;
         this.balancerIntervalSeconds = ctx.balancerIntervalSeconds;
-        this.channelInitializerProvider = ctx.channelInitializerProvider;
         this.selectorMode = ctx.selectorMode;
         this.selectorWorkaroundTest = ctx.selectorWorkaroundTest;
         this.idleStrategy = ctx.idleStrategy;
@@ -221,8 +219,8 @@ public final class NioNetworking implements Networking {
     }
 
     @Override
-    public Channel register(EndpointQualifier endpointQualifier, SocketChannel socketChannel, boolean clientMode)
-            throws IOException {
+    public Channel register(EndpointQualifier endpointQualifier, ChannelInitializerProvider channelInitializerProvider,
+                            SocketChannel socketChannel, boolean clientMode) throws IOException {
         ChannelInitializer initializer = channelInitializerProvider.provide(endpointQualifier);
         NioChannel channel = new NioChannel(socketChannel, clientMode, initializer, metricsRegistry, closeListenerExecutor);
 
@@ -333,7 +331,6 @@ public final class NioNetworking implements Networking {
         // In Hazelcast 3.8, selector mode must be set via HazelcastProperties
         private SelectorMode selectorMode = SelectorMode.getConfiguredValue();
         private boolean selectorWorkaroundTest = Boolean.getBoolean("hazelcast.io.selector.workaround.test");
-        private ChannelInitializerProvider channelInitializerProvider;
 
         public Context() {
             String selectorModeString = SelectorMode.getConfiguredString();
@@ -384,11 +381,6 @@ public final class NioNetworking implements Networking {
 
         public Context balancerIntervalSeconds(int balancerIntervalSeconds) {
             this.balancerIntervalSeconds = balancerIntervalSeconds;
-            return this;
-        }
-
-        public Context channelInitializerProvider(ChannelInitializerProvider channelInitializerProvider) {
-            this.channelInitializerProvider = channelInitializerProvider;
             return this;
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpUnifiedEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpUnifiedEndpointManager.java
@@ -16,10 +16,11 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.NetworkingService;
@@ -36,10 +37,12 @@ import static com.hazelcast.nio.ConnectionType.REST_CLIENT;
 class TcpIpUnifiedEndpointManager
         extends TcpIpEndpointManager {
 
-    TcpIpUnifiedEndpointManager(NetworkingService root, EndpointQualifier qualifier, IOService ioService,
-                                LoggingService loggingService, MetricsRegistry metricsRegistry,
+    TcpIpUnifiedEndpointManager(NetworkingService root, EndpointQualifier qualifier,
+                                ChannelInitializerProvider channelInitializerProvider,
+                                IOService ioService, LoggingService loggingService, MetricsRegistry metricsRegistry,
                                 HazelcastProperties properties) {
-        super(root, qualifier, ioService, loggingService, metricsRegistry, properties, ProtocolType.valuesAsSet());
+        super(root, qualifier, channelInitializerProvider, ioService, loggingService,
+                metricsRegistry, properties, ProtocolType.valuesAsSet());
     }
 
     Set<TcpIpConnection> getTextConnections() {

--- a/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedDataSerializableFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedDataSerializableFactory.java
@@ -20,6 +20,8 @@
 
 package com.hazelcast.client.test;
 
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.MapInterceptor;
@@ -48,7 +50,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
         }
 
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         public int getId() {
@@ -78,7 +80,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
         }
 
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         public int getClassId() {
@@ -106,7 +108,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
         }
 
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         public int getId() {
@@ -127,7 +129,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
 
         @Override
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         @Override
@@ -168,7 +170,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
 
         @Override
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         @Override
@@ -212,7 +214,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
     class KeyMultiplierWithNullableResult extends KeyMultiplier {
         @Override
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         @Override
@@ -234,7 +236,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
 
         @Override
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         @Override
@@ -263,7 +265,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
 
         @Override
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         @Override
@@ -368,7 +370,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
 
         @Override
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         @Override
@@ -424,7 +426,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
 
         @Override
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         @Override
@@ -448,7 +450,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
     class BaseDataSerializable implements IdentifiedDataSerializable {
         @Override
         public int getFactoryId() {
-            return 666;
+            return FACTORY_ID;
         }
 
         @Override
@@ -481,6 +483,56 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
         }
     }
 
+    public static class CallableSignalsRunAndSleep implements Callable, IdentifiedDataSerializable, HazelcastInstanceAware {
+
+        private transient HazelcastInstance hazelcastInstance;
+        private String startSignalLatchName;
+
+        public CallableSignalsRunAndSleep() {
+
+        }
+
+        public CallableSignalsRunAndSleep(String startSignalLatchName) {
+            this.startSignalLatchName = startSignalLatchName;
+        }
+
+        @Override
+        public Object call() {
+            hazelcastInstance.getCountDownLatch("callableStartedLatch").countDown();
+            try {
+                Thread.sleep(Long.MAX_VALUE);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return null;
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.hazelcastInstance = hazelcastInstance;
+        }
+
+        @Override
+        public int getFactoryId() {
+            return FACTORY_ID;
+        }
+
+        @Override
+        public int getId() {
+            return 13;
+        }
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            out.writeUTF(startSignalLatchName);
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+            startSignalLatchName = in.readUTF();
+        }
+    }
+
     @Override
     public IdentifiedDataSerializable create(int typeId) {
         switch (typeId) {
@@ -508,8 +560,18 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
                 return new Derived1DataSerializable();
             case 12:
                 return new Derived2DataSerializable();
+            case 13:
+                return new CallableSignalsRunAndSleep();
             default:
                 return null;
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        return o != null && getClass() == o.getClass();
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_NioNetworkingFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectNow_NioNetworkingFactory.java
@@ -16,15 +16,11 @@
 
 package com.hazelcast.internal.networking.nio;
 
-import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.networking.ChannelInitializer;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.nio.tcp.NetworkingFactory;
 import com.hazelcast.nio.tcp.MockIOService;
+import com.hazelcast.nio.tcp.NetworkingFactory;
 import com.hazelcast.nio.tcp.TcpIpConnectionChannelErrorHandler;
-import com.hazelcast.nio.tcp.UnifiedChannelInitializer;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import static com.hazelcast.spi.properties.GroupProperty.IO_BALANCER_INTERVAL_SECONDS;
@@ -48,12 +44,6 @@ public class SelectNow_NioNetworkingFactory implements NetworkingFactory {
                         .inputThreadCount(properties.getInteger(IO_INPUT_THREAD_COUNT))
                         .outputThreadCount(properties.getInteger(IO_OUTPUT_THREAD_COUNT))
                         .balancerIntervalSeconds(properties.getInteger(IO_BALANCER_INTERVAL_SECONDS))
-                        .channelInitializerProvider(new ChannelInitializerProvider() {
-                            @Override
-                            public ChannelInitializer provide(EndpointQualifier qualifier) {
-                                return new UnifiedChannelInitializer(ioService);
-                            }
-                        })
                         .selectorMode(SelectorMode.SELECT_NOW));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_NioNetworkingFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/SelectWithSelectorFix_NioNetworkingFactory.java
@@ -16,15 +16,11 @@
 
 package com.hazelcast.internal.networking.nio;
 
-import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.networking.ChannelInitializer;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.MockIOService;
 import com.hazelcast.nio.tcp.NetworkingFactory;
 import com.hazelcast.nio.tcp.TcpIpConnectionChannelErrorHandler;
-import com.hazelcast.nio.tcp.UnifiedChannelInitializer;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import static com.hazelcast.spi.properties.GroupProperty.IO_BALANCER_INTERVAL_SECONDS;
@@ -48,12 +44,6 @@ public class SelectWithSelectorFix_NioNetworkingFactory implements NetworkingFac
                         .inputThreadCount(properties.getInteger(IO_INPUT_THREAD_COUNT))
                         .outputThreadCount(properties.getInteger(IO_OUTPUT_THREAD_COUNT))
                         .balancerIntervalSeconds(properties.getInteger(IO_BALANCER_INTERVAL_SECONDS))
-                        .channelInitializerProvider(new ChannelInitializerProvider() {
-                            @Override
-                            public ChannelInitializer provide(EndpointQualifier qualifier) {
-                                return new UnifiedChannelInitializer(ioService);
-                            }
-                        })
                         .selectorMode(SelectorMode.SELECT_WITH_FIX)
                         .selectorWorkaroundTest(true));
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_NioNetworkingFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/Select_NioNetworkingFactory.java
@@ -16,15 +16,11 @@
 
 package com.hazelcast.internal.networking.nio;
 
-import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.metrics.MetricsRegistry;
-import com.hazelcast.internal.networking.ChannelInitializer;
-import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.nio.tcp.MockIOService;
 import com.hazelcast.nio.tcp.NetworkingFactory;
 import com.hazelcast.nio.tcp.TcpIpConnectionChannelErrorHandler;
-import com.hazelcast.nio.tcp.UnifiedChannelInitializer;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
 import static com.hazelcast.spi.properties.GroupProperty.IO_BALANCER_INTERVAL_SECONDS;
@@ -48,12 +44,6 @@ public class Select_NioNetworkingFactory implements NetworkingFactory {
                         .inputThreadCount(properties.getInteger(IO_INPUT_THREAD_COUNT))
                         .outputThreadCount(properties.getInteger(IO_OUTPUT_THREAD_COUNT))
                         .balancerIntervalSeconds(properties.getInteger(IO_BALANCER_INTERVAL_SECONDS))
-                        .channelInitializerProvider(new ChannelInitializerProvider() {
-                            @Override
-                            public ChannelInitializer provide(EndpointQualifier qualifier) {
-                                return new UnifiedChannelInitializer(ioService);
-                            }
-                        })
                         .selectorMode(SelectorMode.SELECT));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/TcpIpConnection_AbstractTest.java
@@ -17,8 +17,11 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.impl.MetricsRegistryImpl;
+import com.hazelcast.internal.networking.ChannelInitializer;
+import com.hazelcast.internal.networking.ChannelInitializerProvider;
 import com.hazelcast.internal.networking.ServerSocketRegistry;
 import com.hazelcast.internal.networking.nio.Select_NioNetworkingFactory;
 import com.hazelcast.internal.serialization.InternalSerializationService;
@@ -131,12 +134,19 @@ public abstract class TcpIpConnection_AbstractTest extends HazelcastTestSupport 
 
         ServerSocketRegistry registry = new ServerSocketRegistry(singletonMap(MEMBER, ioService.serverSocketChannel), true);
 
+        final MockIOService finalIoService = ioService;
         return new TcpIpNetworkingService(null,
                 ioService,
                 registry,
                 ioService.loggingService,
                 metricsRegistry,
-                networkingFactory.create(ioService, metricsRegistry));
+                networkingFactory.create(ioService, metricsRegistry),
+                new ChannelInitializerProvider() {
+                    @Override
+                    public ChannelInitializer provide(EndpointQualifier qualifier) {
+                        return new UnifiedChannelInitializer(finalIoService);
+                    }
+                });
     }
 
     // ====================== support ========================================

--- a/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/compatibility/SamplingNodeExtension.java
@@ -264,4 +264,9 @@ public class SamplingNodeExtension implements NodeExtension {
     public void scheduleClusterVersionAutoUpgrade() {
         nodeExtension.scheduleClusterVersionAutoUpgrade();
     }
+
+    @Override
+    public boolean isClientFailoverSupported() {
+        return false;
+    }
 }


### PR DESCRIPTION
Clients will be able to switch between alternative clusters when
the connected cluster is down or the client is blacklisted from
connected cluster on demand.

Clients will get alternative configurations:
1. Via hazelcast-client-failover.xml
```
<hazelcast-client-failover>
    <try-count>4</try-count>
    <clients>
        <client>hazelcast-client-c1.xml</client>
        <client>hazelcast-client-c2.xml</client>
    </clients>
</hazelcast-client-failover>
```

2. Via configuration
```
ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
clientFailoverConfig.addClientConfig(clientConfig).addClientConfig(clientConfig2);
HazelcastClient.newHazelcastFailoverClient(clientFailoverConfig);
```

3. Spring configuration
```
<beans>
    <hz:client-failover id="blueGreenClient" try-count="5">
        <hz:client>
            <hz:group name="${cluster.group.name}"/>
            <hz:network>
                <hz:member>127.0.0.1:5700</hz:member>
                <hz:member>127.0.0.1:5701</hz:member>
            </hz:network>
        </hz:client>

        <hz:client>
            <hz:group name="alternativeClusterName"/>
            <hz:network>
                <hz:member>127.0.0.1:5702</hz:member>
                <hz:member>127.0.0.1:5703</hz:member>
            </hz:network>
        </hz:client>

    </hz:cluster-switch-aware-client>
</beans>
```

Some notes on behavior
- different SSL configurations between clusters supported
- different socket interceptor configurations between clusters supported
- Each cluster can use different join mechanism. For example, one AWS, 
one cloud.
- group names don't have to be unique between clusters.
- near cache support: they are cleared when the cluster is switched. 
- query cache support: they are cleared and recreated on the new cluster.
- listeners continue to work on new clusters.
- Data is not migrated from the old cluster to the new cluster.
- CLIENT_CHANGED_CLUSTER event to lifecycle 
- Added test to make sure every new config on ClientConfig is considered.
The test will fail on addition and developer should handle it explicitly.
The developer should decide if it must be the same across clusters, or can it
be different.
- Added partition count check when switching clusters. Client does not support
switch between clusters with different partition count. The check is to
prevent inconsistent behavior and skip the clusters.
- inetAddressCache is introduced to control when the address resolution
will take effect to provide more consistent behavior. We will clear 
inetAddressCache when there is a cluster switch
- implemented ClientSelectors API to be used by management center service