### PR TITLE
Improve & simplify TcpIpJoiner

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -584,7 +584,7 @@ public class ClusterJoinManager {
             return;
         }
 
-        if (clusterService.getMasterAddress() != null) {
+        if (clusterService.isJoined()) {
             if (!checkIfJoinRequestFromAnExistingMember(joinMessage, connection)) {
                 sendMasterAnswer(joinMessage.getAddress());
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -663,10 +663,8 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     // should be called under lock
     void setMasterAddress(Address master) {
         assert lock.isHeldByCurrentThread() : "Called without holding cluster service lock!";
-        if (master != null) {
-            if (logger.isFineEnabled()) {
-                logger.fine("Setting master address to " + master);
-            }
+        if (logger.isFineEnabled()) {
+            logger.fine("Setting master address to " + master);
         }
         masterAddress = master;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinMastershipClaimOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinMastershipClaimOp.java
@@ -40,7 +40,7 @@ public class JoinMastershipClaimOp extends AbstractJoinOperation {
             TcpIpJoiner tcpIpJoiner = (TcpIpJoiner) joiner;
             final Address endpoint = getCallerAddress();
             final Address masterAddress = clusterService.getMasterAddress();
-            approvedAsMaster = !tcpIpJoiner.isClaimingMaster() && !clusterService.isMaster()
+            approvedAsMaster = !tcpIpJoiner.isClaimingMastership() && !clusterService.isMaster()
                     && (masterAddress == null || masterAddress.equals(endpoint));
         } else {
             approvedAsMaster = false;


### PR DESCRIPTION
Improved TcpIpJoiner to use a simpler approach;
- try to connect defined members
- ask for master address
- try to join cluster if master found
- reset master address if cannot join for a period
- rinse & repeat

(This is the same approach used in MulticastJoiner and MockJoiner.)

Additionally, a member should answer a master discovery question
only when it has already joined to a cluster. Otherwise, it can
lead other joining members to a non-existing address and eventually
none of the members can join each other.

Fixes #14051