### PR TITLE
[BACKPORT] Ignore call timeout check for WAN operations (#14332)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -64,6 +64,7 @@ import static com.hazelcast.spi.InvocationBuilder.DEFAULT_CALL_TIMEOUT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_DESERIALIZE_RESULT;
 import static com.hazelcast.spi.InvocationBuilder.DEFAULT_REPLICA_INDEX;
 import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
+import static com.hazelcast.spi.impl.operationutil.Operations.isWanReplicationOperation;
 import static com.hazelcast.spi.properties.GroupProperty.FAIL_ON_INDETERMINATE_OPERATION_STATE;
 import static com.hazelcast.spi.properties.GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS;
 import static com.hazelcast.util.CollectionUtil.toIntegerList;
@@ -353,9 +354,10 @@ public final class OperationServiceImpl implements InternalOperationService, Met
 
     @Override
     public boolean isCallTimedOut(Operation op) {
-        // Join operations should not be checked for timeout because caller is not member of this cluster
-        // and can have a different clock.
-        if (isJoinOperation(op)) {
+        // Join and WAN replication operations should not be checked for timeout
+        // because caller is not member of this cluster and can have a different
+        // clock.
+        if (isJoinOperation(op) || isWanReplicationOperation(op)) {
             return false;
         }
 


### PR DESCRIPTION
Call timeout check is based on the cluster clock. In the case of WAN,
the difference between the cluster clocks of the source and target
cluster is included in the timeout and when the cluster clocks are too
far apart, the WAN operations might get rejected immediately, thus
causing WAN to fail indefinitely. We ignore the call timeout check for
WAN operations, similarly as we do for join operations.

Fixes: https://github.com/hazelcast/hazelcast/issues/13301
(cherry picked from commit 6a5bc11)
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2665