### PR TITLE
Adds Json preprocessing system 

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/json/JsonReducedValueParser.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/json/JsonReducedValueParser.java
@@ -1,0 +1,357 @@
+/*******************************************************************************
+ * Original work Copyright (c) 2013, 2016 EclipseSource.
+ * Modified work Copyright (c) 2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ ******************************************************************************/
+package com.hazelcast.internal.json;
+
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * A parser for a single JsonValue which is not an object or array.
+ * Underlying reader must be pointing to the beginning of a value.
+ */
+public class JsonReducedValueParser {
+
+    /**
+     * It is important that default buffer size is small. It takes a
+     * significant time to read and convert UTF8 text to Java string.
+     * This parser intends to parse only a single value from a json
+     * text. There is no need to fill the buffer with useless text.
+     */
+    private static final int DEFAULT_BUFFER_SIZE = 20;
+    private Reader reader;
+    private char[] buffer;
+    private int bufferOffset;
+    private int index;
+    private int fill;
+    private int line;
+    private int lineOffset;
+    private int current;
+    private StringBuilder captureBuffer;
+    private int captureStart;
+
+    public JsonReducedValueParser() {
+    }
+
+    /**
+     * Reads a single value from the given reader and parses it as
+     * JsonValue. The input must be pointing to the beginning of a
+     * JsonLiteral, not JsonArray or JsonObject.
+     *
+     * @param reader the reader to read the input from
+     * @throws IOException    if an I/O error occurs in the reader
+     * @throws ParseException if the input is not valid JSON
+     */
+    public JsonValue parse(Reader reader) throws IOException {
+        return parse(reader, DEFAULT_BUFFER_SIZE);
+    }
+
+    /**
+     * Reads a single value from the given reader and parses it as JsonValue.
+     * The input must be pointing to the beginning of a JsonLiteral,
+     * not JsonArray or JsonObject.
+     *
+     * @param reader     the reader to read the input from
+     * @param buffersize the size of the input buffer in chars
+     * @throws IOException    if an I/O error occurs in the reader
+     * @throws ParseException if the input is not valid JSON
+     */
+    public JsonValue parse(Reader reader, int buffersize) throws IOException {
+        if (reader == null) {
+            throw new NullPointerException("reader is null");
+        }
+        if (buffersize <= 0) {
+            throw new IllegalArgumentException("buffersize is zero or negative");
+        }
+        this.reader = reader;
+        buffer = new char[buffersize];
+        bufferOffset = 0;
+        index = 0;
+        fill = 0;
+        line = 1;
+        lineOffset = 0;
+        current = 0;
+        captureStart = -1;
+        read();
+        return readValue();
+    }
+
+    private JsonValue readValue() throws IOException {
+        switch (current) {
+            case 'n':
+                return readNull();
+            case 't':
+                return readTrue();
+            case 'f':
+                return readFalse();
+            case '"':
+                return readString();
+            case '-':
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                return readNumber();
+            default:
+                throw expected("value");
+        }
+    }
+
+    private JsonValue readNull() throws IOException {
+        read();
+        readRequiredChar('u');
+        readRequiredChar('l');
+        readRequiredChar('l');
+        return Json.NULL;
+    }
+
+    private JsonValue readTrue() throws IOException {
+        read();
+        readRequiredChar('r');
+        readRequiredChar('u');
+        readRequiredChar('e');
+        return Json.TRUE;
+    }
+
+    private JsonValue readFalse() throws IOException {
+        read();
+        readRequiredChar('a');
+        readRequiredChar('l');
+        readRequiredChar('s');
+        readRequiredChar('e');
+        return Json.FALSE;
+    }
+
+    private void readRequiredChar(char ch) throws IOException {
+        if (!readChar(ch)) {
+            throw expected("'" + ch + "'");
+        }
+    }
+
+    private JsonString readString() throws IOException {
+        return new JsonString(readStringInternal());
+    }
+
+    private String readStringInternal() throws IOException {
+        read();
+        startCapture();
+        while (current != '"') {
+            if (current == '\\') {
+                pauseCapture();
+                readEscape();
+                startCapture();
+            } else if (current < 0x20) {
+                throw expected("valid string character");
+            } else {
+                read();
+            }
+        }
+        String string = endCapture();
+        read();
+        return string;
+    }
+
+    private void readEscape() throws IOException {
+        read();
+        switch (current) {
+            case '"':
+            case '/':
+            case '\\':
+                captureBuffer.append((char) current);
+                break;
+            case 'b':
+                captureBuffer.append('\b');
+                break;
+            case 'f':
+                captureBuffer.append('\f');
+                break;
+            case 'n':
+                captureBuffer.append('\n');
+                break;
+            case 'r':
+                captureBuffer.append('\r');
+                break;
+            case 't':
+                captureBuffer.append('\t');
+                break;
+            case 'u':
+                char[] hexChars = new char[4];
+                for (int i = 0; i < 4; i++) {
+                    read();
+                    if (!isHexDigit()) {
+                        throw expected("hexadecimal digit");
+                    }
+                    hexChars[i] = (char) current;
+                }
+                captureBuffer.append((char) Integer.parseInt(new String(hexChars), 16));
+                break;
+            default:
+                throw expected("valid escape sequence");
+        }
+        read();
+    }
+
+    private JsonNumber readNumber() throws IOException {
+        startCapture();
+        readChar('-');
+        int firstDigit = current;
+        if (!readDigit()) {
+            throw expected("digit");
+        }
+        if (firstDigit != '0') {
+            while (readDigit()) {
+            }
+        }
+        readFraction();
+        readExponent();
+        return new JsonNumber(endCapture());
+    }
+
+    private boolean readFraction() throws IOException {
+        if (!readChar('.')) {
+            return false;
+        }
+        if (!readDigit()) {
+            throw expected("digit");
+        }
+        while (readDigit()) {
+        }
+        return true;
+    }
+
+    private boolean readExponent() throws IOException {
+        if (!readChar('e') && !readChar('E')) {
+            return false;
+        }
+        if (!readChar('+')) {
+            readChar('-');
+        }
+        if (!readDigit()) {
+            throw expected("digit");
+        }
+        while (readDigit()) {
+        }
+        return true;
+    }
+
+    private boolean readChar(char ch) throws IOException {
+        if (current != ch) {
+            return false;
+        }
+        read();
+        return true;
+    }
+
+    private boolean readDigit() throws IOException {
+        if (!isDigit()) {
+            return false;
+        }
+        read();
+        return true;
+    }
+
+    private void read() throws IOException {
+        if (index == fill) {
+            if (captureStart != -1) {
+                captureBuffer.append(buffer, captureStart, fill - captureStart);
+                captureStart = 0;
+            }
+            bufferOffset += fill;
+            fill = reader.read(buffer, 0, buffer.length);
+            index = 0;
+            if (fill == -1) {
+                current = -1;
+                index++;
+                return;
+            }
+        }
+        if (current == '\n') {
+            line++;
+            lineOffset = bufferOffset + index;
+        }
+        current = buffer[index++];
+    }
+
+    private void startCapture() {
+        if (captureBuffer == null) {
+            captureBuffer = new StringBuilder();
+        }
+        captureStart = index - 1;
+    }
+
+    private void pauseCapture() {
+        int end = current == -1 ? index : index - 1;
+        captureBuffer.append(buffer, captureStart, end - captureStart);
+        captureStart = -1;
+    }
+
+    private String endCapture() {
+        int start = captureStart;
+        int end = index - 1;
+        captureStart = -1;
+        if (captureBuffer.length() > 0) {
+            captureBuffer.append(buffer, start, end - start);
+            String captured = captureBuffer.toString();
+            captureBuffer.setLength(0);
+            return captured;
+        }
+        return new String(buffer, start, end - start);
+    }
+
+    Location getLocation() {
+        int offset = bufferOffset + index - 1;
+        int column = offset - lineOffset + 1;
+        return new Location(offset, line, column);
+    }
+
+    private ParseException expected(String expected) {
+        if (isEndOfText()) {
+            return error("Unexpected end of input");
+        }
+        return error("Expected " + expected);
+    }
+
+    private ParseException error(String message) {
+        return new ParseException(message, getLocation());
+    }
+
+    private boolean isDigit() {
+        return current >= '0' && current <= '9';
+    }
+
+    private boolean isHexDigit() {
+        return current >= '0' && current <= '9'
+                || current >= 'a' && current <= 'f'
+                || current >= 'A' && current <= 'F';
+    }
+
+    private boolean isEndOfText() {
+        return current == -1;
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/DataInputNavigableJsonAdapter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.hazelcast.internal.json.JsonReducedValueParser;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.nio.Bits;
+import com.hazelcast.nio.BufferObjectDataInput;
+import com.hazelcast.query.impl.getters.JsonPathCursor;
+
+import java.io.DataInput;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.charset.Charset;
+
+public class DataInputNavigableJsonAdapter extends NavigableJsonInputAdapter {
+
+    private final int initialOffset;
+    private BufferObjectDataInput input;
+
+    public DataInputNavigableJsonAdapter(BufferObjectDataInput input, int initialOffset) {
+        this.input = input;
+        this.input.position(initialOffset);
+        this.initialOffset = initialOffset;
+    }
+
+    @Override
+    public void position(int position) {
+        input.position(position + initialOffset);
+    }
+
+    @Override
+    public int position() {
+        return input.position() - initialOffset;
+    }
+
+    @Override
+    public void reset() {
+        input.position(initialOffset);
+    }
+
+    @Override
+    public boolean isAttributeName(JsonPathCursor cursor) {
+        try {
+            byte[] nameBytes = cursor.getCurrent().getBytes(Charset.forName("UTF8"));
+            if (!isQuote()) {
+                return false;
+            }
+            for (int i = 0; i < nameBytes.length; i++) {
+                if (nameBytes[i] != input.readByte()) {
+                    return false;
+                }
+            }
+            return isQuote();
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public JsonValue parseValue(JsonReducedValueParser parser, int offset) throws IOException {
+        input.position(offset + initialOffset);
+        return parser.parse(new UTF8Reader(input));
+    }
+
+    @Override
+    public JsonParser createParser(JsonFactory factory) throws IOException {
+        return factory.createParser(SerializationUtil.convertToInputStream(input, initialOffset));
+    }
+
+    private boolean isQuote() throws IOException {
+        return input.readByte() == '"';
+    }
+
+    private static class UTF8Reader extends Reader {
+
+        private final DataInput input;
+
+        UTF8Reader(DataInput input) {
+            this.input = input;
+        }
+
+        @Override
+        public int read(char[] cbuf, int off, int len) throws IOException {
+            if (off < 0 || (off + len) > cbuf.length) {
+                throw new IndexOutOfBoundsException();
+            }
+            int i = 0;
+            try {
+                for (i = 0; i < len; i++) {
+                    byte firstByte = input.readByte();
+                    char c = Bits.readUtf8Char(input, firstByte);
+                    cbuf[off + i] = c;
+                }
+            } catch (EOFException e) {
+                if (i == 0) {
+                    return -1;
+                }
+            }
+            return i;
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/NavigableJsonInputAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/NavigableJsonInputAdapter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.hazelcast.internal.json.JsonReducedValueParser;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.query.impl.getters.JsonPathCursor;
+
+import java.io.IOException;
+
+/**
+ * An adapter offering utility methods over a data input containing
+ * Json content.
+ */
+public abstract class NavigableJsonInputAdapter {
+
+    /**
+     * Sets the position of underlying data input.
+     * @param position
+     */
+    public abstract void position(int position);
+
+    /**
+     * Gives the current position of the cursor.
+     *
+     * @return the current read position of the cursor
+     */
+    public abstract int position();
+
+    /**
+     * Resets the read cursor.
+     */
+    public abstract void reset();
+
+    /**
+     * This method verifies that the underlying input currently points
+     * to an attribute name of a Json object. {@link JsonPathCursor#getCurrent()}
+     * method is called to retrieve the attribute name.
+     *
+     * The cursor is moved to the end of the attribute name, after
+     * quote character if successful. Otherwise cursor might be in
+     * any position further forward than where it was prior to this
+     * method.
+     *
+     * @param cursor
+     * @return {@code true} if the given attributeName matches the one
+     *          in underlying data input
+     */
+    public abstract boolean isAttributeName(JsonPathCursor cursor);
+
+    /**
+     * Tries to parse a single JsonValue from the input. The {@code offset}
+     * must be pointing to the beginning of a scalar Json value.
+     *
+     * @param parser
+     * @param offset
+     * @return either null or a scalar JsonValue.
+     * @throws IOException if offset is pointing to a non-scalar
+     *                      or invalid Json input
+     */
+    public abstract JsonValue parseValue(JsonReducedValueParser parser, int offset) throws IOException;
+
+    /**
+     * Creates a parser from given factory
+     *
+     * @param factory
+     * @return the parser
+     * @throws IOException
+     */
+    public abstract JsonParser createParser(JsonFactory factory) throws IOException;
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -30,6 +30,8 @@ import com.hazelcast.nio.serialization.Serializer;
 import com.hazelcast.nio.serialization.StreamSerializer;
 import com.hazelcast.nio.serialization.VersionedPortable;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInput;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -120,6 +122,14 @@ public final class SerializationUtil {
 
     public static ObjectDataInputStream createObjectDataInputStream(InputStream in, InternalSerializationService ss) {
         return new ObjectDataInputStream(in, ss);
+    }
+
+    public static InputStream convertToInputStream(DataInput in, int offset) {
+        if (!(in instanceof ByteArrayObjectDataInput)) {
+            throw new HazelcastSerializationException("Cannot convert " + in.getClass().getName() + " to input stream");
+        }
+        ByteArrayObjectDataInput byteArrayInput = (ByteArrayObjectDataInput) in;
+        return new ByteArrayInputStream(byteArrayInput.data, offset, byteArrayInput.size - offset);
     }
 
     @SerializableByConvention

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StringNavigableJsonAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StringNavigableJsonAdapter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.serialization.impl;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.hazelcast.internal.json.JsonReducedValueParser;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.query.impl.getters.JsonPathCursor;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+public class StringNavigableJsonAdapter extends NavigableJsonInputAdapter {
+
+    private final int initialOffset;
+    private String source;
+    private int pos;
+
+    public StringNavigableJsonAdapter(String source, int initialOffset) {
+        this.initialOffset = initialOffset;
+        this.source = source;
+        this.pos = initialOffset;
+    }
+
+    @Override
+    public void position(int position) {
+        this.pos = initialOffset + position;
+    }
+
+    @Override
+    public int position() {
+        return pos - initialOffset;
+    }
+
+    @Override
+    public void reset() {
+        pos = initialOffset;
+    }
+
+    @Override
+    public boolean isAttributeName(JsonPathCursor cursor) {
+        if (source.length() < pos + cursor.getCurrent().length() + 2) {
+            return false;
+        }
+        if (source.charAt(pos++) != '"') {
+            return false;
+        }
+        for (int i = 0; i < cursor.getCurrent().length() && pos < source.length(); i++) {
+            if (cursor.getCurrent().charAt(i) != source.charAt(pos++)) {
+                return false;
+            }
+        }
+        return source.charAt(pos++) == '"';
+    }
+
+    @SuppressFBWarnings("SR_NOT_CHECKED")
+    @Override
+    public JsonValue parseValue(JsonReducedValueParser parser, int offset) throws IOException {
+        StringReader reader = new StringReader(source);
+        if (reader.skip(initialOffset + offset) != initialOffset + offset) {
+            throw new IOException("There are not enough characters in this string");
+        }
+        return parser.parse(reader);
+    }
+
+    @Override
+    public JsonParser createParser(JsonFactory factory) throws IOException {
+        return factory.createParser(new StringReader(source));
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/json/internal/JsonPattern.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/internal/JsonPattern.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A JsonPattern is a structure that represents a logical path to a
+ * terminal value in a Json object. A logical path is a series of numbers
+ * that defines the location of a specific item within their parent.
+ * If an item is within an object, than the corresponding number is the
+ * order of that item within the object. If an item is within an array,
+ * then the corresponding number is the index of that item within the
+ * array.
+ *
+ * For example;
+ * A Json object is given:
+ * {
+ *     "attr1": 10,
+ *     "attr2": [
+ *          "aText",
+ *          "anotherText"
+ *     ]
+ * }
+ * The path "attr2[1]" represents "anotherText" JsonString. The logical
+ * position of this value is "1.1" because "attr2" is the second attribute
+ * and we are looking for the second item in the corresponding array.
+ */
+public class JsonPattern {
+
+    private final List<Integer> pattern;
+    private boolean containsAny;
+
+    /**
+     * Creates an empty JsonPattern.
+     */
+    public JsonPattern() {
+        this(new ArrayList<Integer>());
+    }
+
+    public JsonPattern(List<Integer> list) {
+        pattern = list;
+    }
+
+    /**
+     * Creates a deep copy of a JsonPattern
+     * @param other
+     */
+    public JsonPattern(JsonPattern other) {
+        this(new ArrayList<Integer>(other.pattern));
+    }
+
+    public int get(int index) {
+        return pattern.get(index);
+    }
+
+    public void add(int patternItem) {
+        pattern.add(patternItem);
+    }
+
+    /**
+     * Marks this pattern as having "any" keyword. It is upto the user
+     * how to use this information.
+     * See {@link #hasAny()}
+     */
+    public void addAny() {
+        containsAny = true;
+    }
+
+    public void add(JsonPattern other) {
+        pattern.addAll(other.pattern);
+    }
+
+    /**
+     * Checks if this pattern has "any" keyword.
+     *
+     * @return {@code true} if this pattern has "any"
+     */
+    public boolean hasAny() {
+        return containsAny;
+    }
+
+    /**
+     * Returns the depth of this pattern.
+     *
+     * @return the depth of this pattern
+     */
+    public int depth() {
+        return pattern.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JsonPattern pattern1 = (JsonPattern) o;
+
+        if (containsAny != pattern1.containsAny) {
+            return false;
+        }
+        return pattern != null ? pattern.equals(pattern1.pattern) : pattern1.pattern == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = pattern != null ? pattern.hashCode() : 0;
+        result = 31 * result + (containsAny ? 1 : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "JsonPattern{"
+                + "pattern=" + pattern
+                + ", containsAny=" + containsAny
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSchemaHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSchemaHelper.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.json.ReaderBasedJsonParser;
+import com.fasterxml.jackson.core.json.UTF8StreamJsonParser;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.internal.json.JsonReducedValueParser;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.json.ParseException;
+import com.hazelcast.internal.serialization.impl.NavigableJsonInputAdapter;
+import com.hazelcast.query.impl.getters.JsonPathCursor;
+
+import java.io.IOException;
+
+/**
+ * Responsible for creating and using {@link JsonSchemaNode}s.
+ */
+public final class JsonSchemaHelper {
+
+    private JsonSchemaHelper() {
+        // private constructor
+    }
+
+    /**
+     * Creates a {@link JsonPattern} for given query path. If the path
+     * matches a terminal value in the schema, then the schema is
+     * returned. Otherwise this method returns null. If given path
+     * has "any", pattern is created only upto that part. The rest is
+     * omitted.
+     *
+     * @param input         a buffer containing the queried object.
+     * @param schemaNode the description of the given object
+     * @param path          query path
+     * @return              a pattern object matching the path or null
+     *                      when path does not match a terminal value
+     * @throws IOException
+     */
+    @SuppressWarnings("checkstyle:npathcomplexity")
+    public static JsonPattern createPattern(NavigableJsonInputAdapter input, JsonSchemaNode schemaNode, JsonPathCursor path) {
+        if (schemaNode.isTerminal()) {
+            return null;
+        }
+        JsonPattern pattern = new JsonPattern();
+        while (path.getNext() != null) {
+            if (schemaNode.isTerminal()) {
+                return null;
+            }
+            int suggestedIndexInPath;
+            int numberOfChildren = ((JsonSchemaStructNode) schemaNode).getChildCount();
+            if (path.isArray()) {
+                if (path.isAny()) {
+                    pattern.addAny();
+                    return pattern;
+                }
+                suggestedIndexInPath = path.getArrayIndex();
+            } else {
+                for (suggestedIndexInPath = 0; suggestedIndexInPath < numberOfChildren; suggestedIndexInPath++) {
+                    JsonSchemaNameValue nameValue = ((JsonSchemaStructNode) schemaNode)
+                            .getChild(suggestedIndexInPath);
+                    int nameAddress = nameValue.getNameStart();
+                    if (nameAddress < 0) {
+                        return null;
+                    }
+                    input.position(nameAddress);
+                    if (input.isAttributeName(path)) {
+                        break;
+                    }
+                }
+            }
+            if (isValidIndex(suggestedIndexInPath, (JsonSchemaStructNode) schemaNode, path.isArray())) {
+                schemaNode = ((JsonSchemaStructNode) schemaNode).getChild(suggestedIndexInPath).getValue();
+                pattern.add(suggestedIndexInPath);
+            } else {
+                return null;
+            }
+        }
+        if (schemaNode.isTerminal()) {
+            return pattern;
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Extract the JsonValue that is stored in attributePath in input.
+     * This method validates expectedPattern using attributePath while
+     * extraction. If expectedPattern points to invalid or wrong attributes
+     * at any point, this method returns {@code null}
+     *
+     * NOTE: this method cannot handle patterns with "any" in it.
+     *
+     * @param input             a byte array containing the target object
+     * @param schemaNode        valid schema description to the target
+     *                          object. The behavior is undefined if
+     *                          description does not match the actual
+     *                          object
+     * @param expectedPattern   this cannot contain "any"
+     * @param attributePath     this cannot contain "any"
+     * @return                  JsonValue extracted or null
+     */
+    @SuppressWarnings("checkstyle:npathcomplexity")
+    public static JsonValue findValueWithPattern(NavigableJsonInputAdapter input,
+                                                 JsonSchemaNode schemaNode, JsonPattern expectedPattern,
+                                                 JsonPathCursor attributePath) throws IOException {
+        for (int i = 0; i < expectedPattern.depth(); i++) {
+            if (attributePath.getNext() == null) {
+                return null;
+            }
+            if (schemaNode.isTerminal()) {
+                return null;
+            }
+            int expectedOrderIndex = expectedPattern.get(i);
+            JsonSchemaStructNode structDescription = (JsonSchemaStructNode) schemaNode;
+            if (structDescription.getChildCount() <= expectedOrderIndex) {
+                return null;
+            }
+            JsonSchemaNameValue nameValue = structDescription.getChild(expectedOrderIndex);
+            if (structMatches(input, nameValue, expectedOrderIndex, attributePath)) {
+                schemaNode = nameValue.getValue();
+            } else {
+                return null;
+            }
+        }
+        if (schemaNode.isTerminal() && attributePath.getNext() == null) {
+            // at this point we are sure we found the value by pattern. So we have to be able to extract JsonValue.
+            // Otherwise, let the exceptions propagate
+            try {
+                JsonReducedValueParser valueParser = new JsonReducedValueParser();
+                int valuePos = ((JsonSchemaTerminalNode) schemaNode).getValueStartLocation();
+                return input.parseValue(valueParser, valuePos);
+            } catch (ParseException parseException) {
+                throw new HazelcastException(parseException);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates a description out of a JsonValue. The parser must be
+     * pointing to the start of the input.
+     *
+     * @param parser
+     * @return
+     * @throws IOException
+     */
+    public static JsonSchemaNode createSchema(JsonParser parser) throws IOException {
+        JsonSchemaNode dummy = new JsonSchemaStructNode(null);
+        JsonSchemaStructNode parent = (JsonSchemaStructNode) dummy;
+        JsonToken currentToken = parser.nextToken();
+        int nameLocation = -1;
+        if (currentToken == null) {
+            return null;
+        }
+        while (currentToken != null) {
+            if (currentToken.isStructStart()) {
+                JsonSchemaStructNode structNode = new JsonSchemaStructNode(parent);
+                JsonSchemaNameValue nameValue = new JsonSchemaNameValue(nameLocation, structNode);
+                parent.addChild(nameValue);
+                parent = structNode;
+                nameLocation = -1;
+            } else if (currentToken == JsonToken.FIELD_NAME) {
+                nameLocation = (int) getTokenLocation(parser);
+            } else if (currentToken.isStructEnd()) {
+                parent = parent.getParent();
+                nameLocation = -1;
+            } else {
+                JsonSchemaTerminalNode terminalNode = new JsonSchemaTerminalNode(parent);
+                terminalNode.setValueStartLocation((int) getTokenLocation(parser));
+                JsonSchemaNameValue nameValue = new JsonSchemaNameValue(nameLocation, terminalNode);
+                parent.addChild(nameValue);
+                nameLocation = -1;
+            }
+            currentToken = parser.nextToken();
+        }
+        JsonSchemaNameValue nameValue = ((JsonSchemaStructNode) dummy).getChild(0);
+        if (nameValue == null) {
+            return null;
+        }
+        dummy = nameValue.getValue();
+        dummy.setParent(null);
+        return dummy;
+    }
+
+    private static boolean isValidIndex(int suggestedIndex, JsonSchemaStructNode structNode, boolean isArrayPath) {
+        if (suggestedIndex >= structNode.getChildCount()) {
+            return false;
+        }
+        JsonSchemaNameValue nameValue = structNode.getChild(suggestedIndex);
+        return (nameValue.isArrayItem() && isArrayPath) || (nameValue.isObjectItem() && !isArrayPath);
+    }
+
+    private static long getTokenLocation(JsonParser parser) {
+        if (parser instanceof ReaderBasedJsonParser) {
+            return parser.getTokenLocation().getCharOffset();
+        } else if (parser instanceof UTF8StreamJsonParser) {
+            return parser.getTokenLocation().getByteOffset();
+        } else {
+            throw new HazelcastException("Provided parser does not support location: "
+                    + parser.getClass().getName());
+        }
+    }
+
+    private static boolean structMatches(NavigableJsonInputAdapter input,
+                                         JsonSchemaNameValue nameValue, int attributeIndex, JsonPathCursor currentPath) {
+        int currentNamePos = nameValue.getNameStart();
+        if (currentPath.isArray()) {
+            return currentNamePos == -1 && attributeIndex == currentPath.getArrayIndex();
+        } else {
+            if (currentNamePos == -1) {
+                return false;
+            }
+            input.position(currentNamePos);
+            return input.isAttributeName(currentPath);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSchemaNameValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSchemaNameValue.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+/**
+ * A node that describes either a name-value pair in a Json object or
+ * an item in a Json array. For arrays items, {@link #getNameStart()}
+ * always return -1 whereas for name-value pairs, it represents the
+ * location of name of the attribute for object attributes.
+ */
+public class JsonSchemaNameValue {
+
+    private final int nameStart;
+    private final JsonSchemaNode value;
+
+    public JsonSchemaNameValue(int nameStart, JsonSchemaNode value) {
+        this.nameStart = nameStart;
+        this.value = value;
+    }
+
+    /**
+     * Points to name of the object described in {@link #getValue()}.
+     * The returned integer represents the offset of the name according
+     * to the underlying data format. It could be byte offset for Data
+     * or char offset for String
+     *
+     * @return  the location of the name relative to the beginning of the object
+     *          -1 for array items
+     */
+    public int getNameStart() {
+        return nameStart;
+    }
+
+    /**
+     *
+     * @return true if this represents an array item
+     */
+    public boolean isArrayItem() {
+        return nameStart == -1;
+    }
+
+    /**
+     *
+     * @return true if this represents an object attribute
+     */
+    public boolean isObjectItem() {
+        return nameStart > 0;
+    }
+
+    /**
+     * Returns the description of the value stored in here
+     * @return
+     */
+    public JsonSchemaNode getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JsonSchemaNameValue that = (JsonSchemaNameValue) o;
+
+        if (nameStart != that.nameStart) {
+            return false;
+        }
+        return value != null ? value.equals(that.value) : that.value == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = nameStart;
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "JsonSchemaNameValue{"
+                + "nameStart=" + nameStart
+                + ", value=" + value
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSchemaNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSchemaNode.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+/**
+ * A node that describes either a JsonValue
+ */
+abstract class JsonSchemaNode {
+
+    private JsonSchemaStructNode parent;
+
+    /**
+     * Creates a schema node with given parent
+     * @param parent may be null for top element
+     */
+    public JsonSchemaNode(JsonSchemaStructNode parent) {
+        this.parent = parent;
+    }
+
+
+    /**
+     * Returns the parent.
+     *
+     * @return the parent
+     */
+    public JsonSchemaStructNode getParent() {
+        return parent;
+    }
+
+    /**
+     * Sets the parent of this node. May be null for top element.
+     *
+     * @param parent
+     */
+    public void setParent(JsonSchemaStructNode parent) {
+        this.parent = parent;
+    }
+
+    /**
+     * Returns whether this node represents a scalar value.
+     * @return false if this is an array or object, true otherwise
+     */
+    public boolean isTerminal() {
+        return false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSchemaStructNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSchemaStructNode.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A node that describes either a Json array or Json object.
+ */
+public class JsonSchemaStructNode extends JsonSchemaNode {
+
+    private final List<JsonSchemaNameValue> inners = new ArrayList<JsonSchemaNameValue>();
+
+    public JsonSchemaStructNode(JsonSchemaStructNode parent) {
+        super(parent);
+    }
+
+    /**
+     * Adds a child node to this Json node. It is added as the last item
+     * in order.
+     *
+     * @param description
+     */
+    public void addChild(JsonSchemaNameValue description) {
+        inners.add(description);
+    }
+
+    /**
+     * Returns a name-value pair for the ith child of this struct.
+     * For arrays, it is the simple order index. For attributes,
+     * the index is the definition order of the specific attribute
+     * within the object. See {@link JsonPattern}.
+     *
+     * @param i the order of the desired child
+     * @return a name value pair
+     */
+    public JsonSchemaNameValue getChild(int i) {
+        return inners.get(i);
+    }
+
+    /**
+     * The size of this object in terms of items or attributes it contains.
+     * @return the number of child nodes
+     */
+    public int getChildCount() {
+        return inners.size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        JsonSchemaStructNode that = (JsonSchemaStructNode) o;
+
+        return inners != null ? inners.equals(that.inners) : that.inners == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (inners != null ? inners.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "JsonSchemaStructNode{"
+                + "inners=" + inners
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSchemaTerminalNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/internal/JsonSchemaTerminalNode.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+/**
+ * Represents the description of a Json terminal value. These are null,
+ * true, false, number or string.
+ */
+public class JsonSchemaTerminalNode extends JsonSchemaNode {
+
+    private int valueStartLocation;
+
+    public JsonSchemaTerminalNode(JsonSchemaStructNode parent) {
+        super(parent);
+    }
+
+    /**
+     * Points to the location where this object starts in underlying
+     * input. The returned value is offset from the start of the
+     * object. The unit of the offset depends on the context.
+     *
+     * @return
+     */
+    public int getValueStartLocation() {
+        return valueStartLocation;
+    }
+
+    /**
+     * Sets the location of the value in the underlying input.
+     *
+     * @param valueStartLocation
+     */
+    public void setValueStartLocation(int valueStartLocation) {
+        this.valueStartLocation = valueStartLocation;
+    }
+
+    @Override
+    public boolean isTerminal() {
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        JsonSchemaTerminalNode that = (JsonSchemaTerminalNode) o;
+
+        return valueStartLocation == that.valueStartLocation;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + valueStartLocation;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "JsonSchemaTerminalNode{"
+                + "valueStartLocation=" + valueStartLocation
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/json/internal/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/internal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains JsonSchema related functionality
+ */
+package com.hazelcast.json.internal;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Extractors.java
@@ -43,6 +43,7 @@ public final class Extractors {
     private static final float EVICTION_PERCENTAGE = 0.2f;
 
     private volatile PortableGetter genericPortableGetter;
+    private volatile JsonDataGetter jsonDataGetter;
 
     /**
      * Maps the extractorAttributeName WITHOUT the arguments to a
@@ -131,14 +132,17 @@ public final class Extractors {
         } else {
             if (targetObject instanceof Data) {
                 if (((Data) targetObject).isPortable()) {
-                    //targetObject may be a Data whose object form is a json?
                     if (genericPortableGetter == null) {
                         // will be initialised a couple of times in the worst case
                         genericPortableGetter = new PortableGetter(ss);
                     }
                     return genericPortableGetter;
                 } else if (((Data) targetObject).isJson()) {
-                    return JsonDataGetter.INSTANCE;
+                    if (jsonDataGetter == null) {
+                        // will be initialised a couple of times in the worst case
+                        jsonDataGetter = new JsonDataGetter();
+                    }
+                    return jsonDataGetter;
                 } else {
                     throw new HazelcastSerializationException("No Data getter found for type " + ((Data) targetObject).getType());
                 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonPathCursor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonPathCursor.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+/**
+ * Represents a query path for Json querying. Parsing of a query path
+ * is lazy. This cursor splits parts of an attribute path by "."s and
+ * "["s.
+ */
+public class JsonPathCursor {
+
+    private String attributePath;
+    private String current;
+    private int currentArrayIndex = -1;
+    private boolean isArray;
+    private boolean isAny;
+    private int cursor;
+
+    /**
+     * Creates a new cursor from given attribute path.
+     * @param attributePath
+     */
+    public JsonPathCursor(String attributePath) {
+        this.attributePath = attributePath;
+        cursor = 0;
+    }
+
+    /**
+     * Returns the next attribute path part. The returned string is either
+     * the name of the next attribute or the string representation of an
+     * array index. {@code null} indicates the end of input.
+     *
+     * @return either {@code null} or the next part of the attribute path
+     */
+    public String getNext() {
+        next();
+        return current;
+    }
+
+    /**
+     * Returns the current attribute path part. The returned string is either
+     * the name of the current attribute or the string representation of an
+     * array index. {@code null} indicates the end of input.
+     *
+     * @return either {@code null} or the current part of the attribute path
+     */
+    public String getCurrent() {
+        return current;
+    }
+
+    /**
+     *
+     * @return true if the current item is an array
+     */
+    public boolean isArray() {
+        return isArray;
+    }
+
+    /**
+     *
+     * @return true if the current item is "any"
+     */
+    public boolean isAny() {
+        return isAny;
+    }
+
+    /**
+     * Returns array index if the current item is array and not "any".
+     * @return -1 if the current item is "any" or non-array.
+     */
+    public int getArrayIndex() {
+        return currentArrayIndex;
+    }
+
+    public void reset() {
+        current = null;
+        currentArrayIndex = -1;
+        isArray = false;
+        isAny = false;
+        cursor = 0;
+    }
+
+    private void next() {
+        currentArrayIndex = -1;
+        isAny = false;
+        isArray = false;
+        int nextCursor = iterate();
+        if (nextCursor == -1) {
+            return;
+        }
+        current = attributePath.substring(cursor, nextCursor);
+        cursor = nextCursor + 1;
+        if (isArray) {
+            if ("any".equals(current)) {
+                isAny = true;
+            } else {
+                try {
+                    currentArrayIndex = Integer.parseInt(current);
+                } catch (NumberFormatException e) {
+                    throw createIllegalArgumentException();
+                }
+            }
+        }
+    }
+
+    private int iterate() {
+        if (cursor < attributePath.length()) {
+            try {
+                while (attributePath.charAt(cursor) == '[' || attributePath.charAt(cursor) == '.') {
+                    cursor++;
+                }
+            } catch (IndexOutOfBoundsException e) {
+                throw createIllegalArgumentException();
+            }
+        } else {
+            current = null;
+            return -1;
+        }
+        for (int i = cursor; i < attributePath.length(); i++) {
+            switch (attributePath.charAt(i)) {
+                case '.':
+                case '[':
+                    return i;
+                case ']':
+                    isArray = true;
+                    return i;
+                default:
+                    // no-op
+            }
+        }
+        return attributePath.length();
+    }
+
+    private IllegalArgumentException createIllegalArgumentException() {
+        return new IllegalArgumentException("Malformed query path " + attributePath);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/json/RandomPrint.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/json/RandomPrint.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.json;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Random;
+
+/**
+ * Converts a JsonValue to a string. It adds whitespaces randomly. The
+ * resulting string is functionally equal to the version without any
+ * whitespace in it.
+ */
+public class RandomPrint extends WriterConfig {
+
+    public static final RandomPrint RANDOM_PRINT = new RandomPrint(5);
+
+    private final int atMostRandomWhitespace;
+
+    public RandomPrint(int atMostRandomWhitespace) {
+        this.atMostRandomWhitespace = atMostRandomWhitespace;
+    }
+
+    @Override
+    protected JsonWriter createWriter(Writer writer) {
+        return new RandomJsonPrinter(writer, atMostRandomWhitespace);
+    }
+
+    private static class RandomJsonPrinter extends JsonWriter {
+
+        private final int atMostWeirdWhitespaces;
+
+        private Random random = new Random();
+
+        private RandomJsonPrinter(Writer writer, int atMostWeirdWhitespaces) {
+            super(writer);
+            this.atMostWeirdWhitespaces = atMostWeirdWhitespaces;
+        }
+
+        @Override
+        protected void writeArrayOpen() throws IOException {
+            writeRandomWhitespace();
+            writer.write('[');
+        }
+
+        @Override
+        protected void writeArrayClose() throws IOException {
+            writeRandomWhitespace();
+            writer.write(']');
+        }
+
+        @Override
+        protected void writeArraySeparator() throws IOException {
+            writeRandomWhitespace();
+            writer.write(',');
+        }
+
+        @Override
+        protected void writeObjectOpen() throws IOException {
+            writeRandomWhitespace();
+            writer.write('{');
+        }
+
+        @Override
+        protected void writeObjectClose() throws IOException {
+            writeRandomWhitespace();
+            writer.write('}');
+        }
+
+        @Override
+        protected void writeMemberSeparator() throws IOException {
+            writeRandomWhitespace();
+            writer.write(':');
+        }
+
+        @Override
+        protected void writeObjectSeparator() throws IOException {
+            writeRandomWhitespace();
+            writer.write(',');
+        }
+
+        private void writeRandomWhitespace() throws IOException {
+            int numberOfWhitespace = random.nextInt(atMostWeirdWhitespaces);
+            for (int i = 0; i < numberOfWhitespace; i++) {
+                switch (random.nextInt(3)) {
+                    case 0:
+                        writer.write(' ');
+                        break;
+                    case 1:
+                        writer.write('\t');
+                        break;
+                    case 2:
+                        writer.write('\n');
+                        break;
+                    default:
+                        writer.write(' ');
+                }
+            }
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
@@ -25,10 +25,6 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.JsonValue;
-import com.hazelcast.nio.serialization.Portable;
-import com.hazelcast.nio.serialization.PortableFactory;
-import com.hazelcast.nio.serialization.PortableReader;
-import com.hazelcast.nio.serialization.PortableWriter;
 import com.hazelcast.query.Predicates;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -41,7 +37,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 
@@ -76,17 +71,6 @@ public class MapPredicateJsonTest extends HazelcastTestSupport {
     protected Config getConfig() {
         Config config = super.getConfig();
         config.getMapConfig("default").setInMemoryFormat(inMemoryFormat);
-        config.getSerializationConfig().addPortableFactory(1, new PortableFactory() {
-            @Override
-            public Portable create(int classId) {
-                if (classId == 1) {
-                    return new MyPortable();
-                } else if (classId == 2) {
-                    return new LittlePortable();
-                }
-                return null;
-            }
-        });
         return config;
     }
 
@@ -629,75 +613,5 @@ public class MapPredicateJsonTest extends HazelcastTestSupport {
         assertEquals(2, vals.size());
         assertTrue(vals.contains("one"));
         assertTrue(vals.contains("two"));
-    }
-
-    public static class MyPortable implements Portable {
-
-        private LittlePortable[] littlePortables;
-
-        public MyPortable() {
-
-        }
-
-        public MyPortable(LittlePortable[] littlePortables) {
-            this.littlePortables = littlePortables;
-        }
-
-        @Override
-        public int getFactoryId() {
-            return 1;
-        }
-
-        @Override
-        public int getClassId() {
-            return 1;
-        }
-
-        @Override
-        public void writePortable(PortableWriter writer) throws IOException {
-            writer.writePortableArray("littlePortables", this.littlePortables);
-        }
-
-        @Override
-        public void readPortable(PortableReader reader) throws IOException {
-            this.littlePortables = (LittlePortable[]) reader.readPortableArray("littlePortables");
-        }
-    }
-
-    public static class LittlePortable implements Portable {
-
-        private int real;
-        private int[] tempReals;
-
-        public LittlePortable() {
-
-        }
-
-        public LittlePortable(int real, int[] tempReals) {
-            this.real = real;
-            this.tempReals = tempReals;
-        }
-
-        @Override
-        public int getFactoryId() {
-            return 1;
-        }
-
-        @Override
-        public int getClassId() {
-            return 2;
-        }
-
-        @Override
-        public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeInt("real", this.real);
-            writer.writeIntArray("tempReals", this.tempReals);
-        }
-
-        @Override
-        public void readPortable(PortableReader reader) throws IOException {
-            this.real = reader.readInt("real");
-            this.tempReals = reader.readIntArray("tempReals");
-        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/AbstractJsonSchemaCreateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/AbstractJsonSchemaCreateTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.hazelcast.internal.json.Json;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public abstract class AbstractJsonSchemaCreateTest {
+
+    @Test
+    public void testOneFirstLevelAttribute() throws IOException {
+        String jsonString = Json.object().add("name", "aName").toString();
+        JsonParser parser = createParserFromString(jsonString);
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(parser);
+
+        validate(description, "0", 1, 8);
+    }
+
+    @Test
+    public void testTwoFirstLevelAttributes() throws IOException {
+        String jsonString = Json.object().add("name", "aName").add("age", 4).toString();
+        JsonParser parser = createParserFromString(jsonString);
+        JsonSchemaStructNode description = (JsonSchemaStructNode) JsonSchemaHelper.createSchema(parser);
+
+        validate(description, "0", 1, 8);
+        validate(description, "1", 16, 22);
+    }
+
+    @Test
+    public void testThreeFirstLevelAttributes() throws IOException {
+        String jsonString = Json.object()
+                .add("name", "aName")
+                .add("age", 4)
+                .add("location", "ankara")
+                .toString();
+
+        JsonParser parser = createParserFromString(jsonString);
+        JsonSchemaStructNode description = (JsonSchemaStructNode) JsonSchemaHelper.createSchema(parser);
+
+        validate(description, "0", 1, 8);
+        validate(description, "1", 16, 22);
+        validate(description, "2", 24, 35);
+    }
+
+    @Test
+    public void testOneFirstLevelTwoInnerAttributes() throws IOException {
+        String jsonString = Json.object()
+                .add("name", Json.object()
+                        .add("firstName", "fName")
+                        .add("surname", "sname")
+                )
+                .toString();
+
+        JsonParser parser = createParserFromString(jsonString);
+        JsonSchemaStructNode description = (JsonSchemaStructNode) JsonSchemaHelper.createSchema(parser);
+
+        validate(description, "0.0", 9, 21);
+        validate(description, "0.1", 29, 39);
+    }
+
+    @Test
+    public void testTwoFirstLevelOneInnerAttributesEach() throws IOException {
+        String jsonString = Json.object()
+                .add("name", Json.object()
+                        .add("firstName", "fName"))
+                .add("address", Json.object()
+                        .add("addressId", 4))
+                .toString();
+
+        JsonParser parser = createParserFromString(jsonString);
+        JsonSchemaStructNode description = (JsonSchemaStructNode) JsonSchemaHelper.createSchema(parser);
+
+        validate(description, "0.0", 9, 21);
+        validate(description, "1.0", 41, 53);
+    }
+
+    @Test
+    public void testFourNestedLevelsEachHavingAValue() throws IOException {
+        String jsonString = Json.object()
+                .add("firstObject", Json.object()
+                        .add("secondObject", Json.object()
+                                .add("thirdLevelTerminalString", "terminalvalue")
+                                .add("thirdObject", Json.object()
+                                        .add("fourthTerminalValue", true)))
+                        .add("secondLevelTerminalNumber", 43534324))
+                .add("firstLevelTerminalNumber", 53).toString();
+
+        JsonParser parser = createParserFromString(jsonString);
+        JsonSchemaStructNode description = (JsonSchemaStructNode) JsonSchemaHelper.createSchema(parser);
+
+        validate(description, "1", 157, 184);
+        validate(description, "0.1", 119, 147);
+        validate(description, "0.0.0", 32, 59);
+        validate(description, "0.0.1.0", 90, 112);
+    }
+
+
+    @Test
+    public void testFourNestedLevels() throws IOException {
+        String jsonString = Json.object()
+                .add("firstObject", Json.object()
+                        .add("secondObject", Json.object()
+                                .add("thirdObject", Json.object()
+                                        .add("fourthObject", true)))).toString();
+
+        JsonParser parser = createParserFromString(jsonString);
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(parser);
+
+        validate(description, "0.0.0.0", 47, 62);
+    }
+
+    @Test
+    public void testSimpleArray() throws IOException {
+        String jsonString = Json.array(1, 2, 3).toString();
+
+        JsonParser parser = createParserFromString(jsonString);
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(parser);
+
+        validate(description, "0", -1, 1);
+        validate(description, "1", -1, 3);
+        validate(description, "2", -1, 5);
+    }
+
+    protected void validate(JsonSchemaNode root, String attributePath, int expectedNameLoc, int expectedValueLoc) {
+        assertNotNull(root);
+        JsonSchemaNode schemaDescription = root;
+        String[] path = attributePath.split("\\.");
+        JsonSchemaNameValue nameValue;
+        int nameLoc = 1000;
+        for (String p : path) {
+            nameValue = ((JsonSchemaStructNode) schemaDescription).getChild(Integer.parseInt(p));
+            nameLoc = nameValue.getNameStart();
+            schemaDescription = nameValue.getValue();
+        }
+        assertEquals(String.format("\nExpected name location: %d\nActual name location: %d\n", expectedNameLoc, nameLoc), expectedNameLoc, nameLoc);
+        int actualValueLoc = ((JsonSchemaTerminalNode) schemaDescription).getValueStartLocation();
+        assertEquals(String.format("\nExpected value location: %d\nActual value location: %d\n", expectedValueLoc, actualValueLoc), expectedValueLoc, actualValueLoc);
+    }
+
+    protected abstract JsonParser createParserFromString(String jsonString) throws IOException;
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/AbstractJsonSchemaTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/AbstractJsonSchemaTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.core.HazelcastJsonValue;
+import com.hazelcast.internal.json.JsonArray;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.json.WriterConfig;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DataInputNavigableJsonAdapter;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.internal.serialization.impl.NavigableJsonInputAdapter;
+import com.hazelcast.internal.serialization.impl.StringNavigableJsonAdapter;
+import com.hazelcast.json.HazelcastJson;
+import com.hazelcast.query.impl.getters.JsonPathCursor;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.hazelcast.query.impl.getters.AbstractJsonGetter.getPath;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public abstract class AbstractJsonSchemaTest {
+
+    protected final int JSON_UTF8_START_OFFSET = 12; // 8 byte (header) + 4 byte (character count)
+
+    protected JsonFactory factory = new JsonFactory();
+
+    protected InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+
+    protected abstract InMemoryFormat getInMemoryFormay();
+
+    protected JsonParser createParserFromInput(NavigableJsonInputAdapter input) throws IOException {
+        return input.createParser(factory);
+    }
+
+    protected NavigableJsonInputAdapter toAdapter(HazelcastJsonValue jsonValue) {
+        if (getInMemoryFormay() == InMemoryFormat.OBJECT) {
+            return new StringNavigableJsonAdapter(jsonValue.toString(), 0);
+        } else {
+            return new DataInputNavigableJsonAdapter(serializationService.createObjectDataInput(serializationService.toData(jsonValue)), JSON_UTF8_START_OFFSET);
+        }
+    }
+
+    protected void testPaths(WriterConfig config) throws IOException {
+        for (JsonValue value : TestJsonValues.LIST) {
+            String jsonString = value.toString(config);
+            validateJson(jsonString, value);
+        }
+    }
+
+
+    protected void validateJson(String originalString, JsonValue jsonValue) throws IOException {
+        NavigableJsonInputAdapter input = toAdapter(HazelcastJson.fromString(originalString));
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(createParserFromInput(input));
+        if (jsonValue.isObject()) {
+            validateJsonObject(originalString, new JsonPattern(), jsonValue.asObject(), description, input, null);
+        } else if (jsonValue.isArray()) {
+            validateJsonArray(originalString, new JsonPattern(), jsonValue.asArray(), description, input, null);
+        } else {
+            // shoult not reach here
+            fail();
+        }
+    }
+
+    private void validateJsonObject(String originalString, JsonPattern patternPrefix, JsonObject jsonObject,
+                                    JsonSchemaNode description, NavigableJsonInputAdapter input,
+                                    String pathPrefix) throws IOException {
+        List<String> attributeNames = jsonObject.names();
+        for (int i = 0; i < attributeNames.size(); i++) {
+            String attributeName = attributeNames.get(i);
+            JsonValue attribute = jsonObject.get(attributeName);
+            JsonPattern copy =  new JsonPattern(patternPrefix);
+            copy.add(i);
+            String nextPath = attributeName;
+            if (pathPrefix != null) {
+                nextPath = pathPrefix + "." + attributeName;
+            }
+            if (attribute.isObject()) {
+                validateJsonObject(originalString, copy, attribute.asObject(), description, input, nextPath);
+            } else if (attribute.isArray()) {
+                validateJsonArray(originalString, copy, attribute.asArray(), description, input, nextPath);
+            } else {
+                validateJsonLiteral(attribute, originalString, copy, description, input, nextPath);
+            }
+        }
+    }
+
+    private void validateJsonArray(String originalString, JsonPattern patternPrefix, JsonArray jsonArray,
+                                   JsonSchemaNode description, NavigableJsonInputAdapter input, String pathPrefix)
+            throws IOException {
+        for (int i = 0; i < jsonArray.size(); i++) {
+            JsonValue item = jsonArray.get(i);
+            JsonPattern copy = new JsonPattern(patternPrefix);
+            copy.add(i);
+            String nextPath = "[" + i + "]";
+            if (pathPrefix != null) {
+                nextPath = pathPrefix + nextPath;
+            }
+            if (item.isObject()) {
+                validateJsonObject(originalString, copy, item.asObject(), description, input, nextPath);
+            } else if (item.isArray()) {
+                validateJsonArray(originalString, copy, item.asArray(), description, input, nextPath);
+            } else {
+                validateJsonLiteral(item, originalString, copy, description, input, nextPath);
+            }
+        }
+    }
+
+    protected void validateJsonLiteral(JsonValue expectedValue, String originalString,
+                                       JsonPattern expectedPattern,
+                                       JsonSchemaNode description,
+                                       NavigableJsonInputAdapter input,
+                                       String path) throws IOException {
+        JsonPathCursor pathArray = splitPath(path);
+        JsonPattern pattern = JsonSchemaHelper.createPattern(input, description, pathArray);
+        String failureString = String.format("Path ( %s ) failed on ( %s )", path, originalString);
+        assertEquals(failureString, expectedPattern, pattern);
+        pathArray.reset();
+        input.reset();
+        JsonValue foundValue = JsonSchemaHelper.findValueWithPattern(input, description, pattern, pathArray);
+        assertEquals(failureString, expectedValue, foundValue);
+    }
+
+    JsonPathCursor splitPath(String attributePath) {
+        return getPath(attributePath);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/DataInputJsonSchemaCreateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/DataInputJsonSchemaCreateTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.serialization.InternalSerializationService;
+import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
+import com.hazelcast.json.HazelcastJson;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static com.hazelcast.internal.serialization.impl.SerializationUtil.convertToInputStream;
+
+@Category({ParallelTest.class, QuickTest.class})
+@RunWith(HazelcastParallelClassRunner.class)
+public class DataInputJsonSchemaCreateTest extends AbstractJsonSchemaCreateTest {
+
+    private InternalSerializationService serializationService = new DefaultSerializationServiceBuilder().build();
+    private JsonFactory factory = new JsonFactory();
+
+    protected JsonParser createParserFromString(String jsonString) throws IOException {
+        return factory.createParser(convertToInputStream(serializationService.createObjectDataInput(serializationService.toBytes(HazelcastJson.fromString(jsonString))), 12));
+    }
+
+    @Test
+    public void testOneFirstLevelAttribute_withTwoByteCharacterInName() throws IOException {
+        String jsonString = Json.object().add("this-name-includes-two-byte-utf8-character-£",
+                "so the value should start at next byte location").toString();
+        JsonParser parser = createParserFromString(jsonString);
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(parser);
+
+        validate(description, "0", 1, 49);
+    }
+
+    @Test
+    public void testTwoFirstLevelAttributes_withTwoByteCharacterInValues() throws IOException {
+        String jsonString = Json.object()
+                .add("anAttribute", "this value has two byte character -£ ")
+                .add("secondAttribute", 4).toString();
+        JsonParser parser = createParserFromString(jsonString);
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(parser);
+
+        validate(description, "0", 1, 15);
+        validate(description, "1", 56, 74);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/JsonSchemaHelperMultiValueTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/JsonSchemaHelperMultiValueTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonArray;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.serialization.impl.NavigableJsonInputAdapter;
+import com.hazelcast.json.HazelcastJson;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class JsonSchemaHelperMultiValueTest extends AbstractJsonSchemaTest {
+
+    @Parameterized.Parameters(name = "InMemoryFormat: {0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY},
+                {InMemoryFormat.OBJECT}
+        });
+    }
+
+    @Parameterized.Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Override
+    protected InMemoryFormat getInMemoryFormay() {
+        return inMemoryFormat;
+    }
+
+    @Test
+    public void testAnyPattern() throws IOException {
+        JsonObject object = Json.object()
+                .add("array", Json.array()
+                        .add(1)
+                        .add(2)
+                        .add(3));
+
+        NavigableJsonInputAdapter input = toAdapter(HazelcastJson.fromString(object.toString()));
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(createParserFromInput(input));
+        JsonPattern pattern = JsonSchemaHelper.createPattern(input, description, splitPath("array[any]"));
+        assertEquals(1, pattern.depth());
+        assertEquals(0, pattern.get(0));
+        assertTrue(pattern.hasAny());
+    }
+
+    @Test
+    public void testAnyPattern_partsAfterAnyIsOmitted() throws IOException {
+        JsonObject object = Json.object()
+                .add("array", Json.array()
+                        .add(1)
+                        .add(2)
+                        .add(3));
+
+        NavigableJsonInputAdapter input = toAdapter(HazelcastJson.fromString(object.toString()));
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(createParserFromInput(input));
+        JsonPattern pattern = JsonSchemaHelper.createPattern(input, description, splitPath("array[any].a"));
+        assertEquals(1, pattern.depth());
+        assertEquals(0, pattern.get(0));
+        assertTrue(pattern.hasAny());
+    }
+
+    @Test
+    public void testAnyPattern_whenFirstItem() throws IOException {
+        JsonArray object = Json.array()
+                        .add(1)
+                        .add(2)
+                        .add(3);
+
+        NavigableJsonInputAdapter input = toAdapter(HazelcastJson.fromString(object.toString()));
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(createParserFromInput(input));
+        JsonPattern pattern = JsonSchemaHelper.createPattern(input, description, splitPath("[any]"));
+        assertEquals(0, pattern.depth());
+        assertTrue(pattern.hasAny());
+    }
+
+    @Test
+    public void testAnyPattern__whenFirstItem_partsAfterAnyIsOmitted() throws IOException {
+        JsonArray object = Json.array()
+                .add(1)
+                .add(2)
+                .add(3);
+
+        NavigableJsonInputAdapter input = toAdapter(HazelcastJson.fromString(object.toString()));
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(createParserFromInput(input));
+        JsonPattern pattern = JsonSchemaHelper.createPattern(input, description, splitPath("[any].abc.de"));
+        assertEquals(0, pattern.depth());
+        assertTrue(pattern.hasAny());
+    }
+
+    @Test
+    public void testAnyPattern_whenNotArrayOrObject_returnsNull() throws IOException {
+        JsonObject object = Json.object()
+                .add("scalarValue", 4);
+
+        NavigableJsonInputAdapter input = toAdapter(HazelcastJson.fromString(object.toString()));
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(createParserFromInput(input));
+        JsonPattern pattern = JsonSchemaHelper.createPattern(input, description, splitPath("scalarValue[any]"));
+        assertNull(pattern);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/JsonSchemaHelperNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/JsonSchemaHelperNullTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.serialization.impl.NavigableJsonInputAdapter;
+import com.hazelcast.json.HazelcastJson;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertNull;
+
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class JsonSchemaHelperNullTest extends AbstractJsonSchemaTest {
+
+    @Parameters(name = "InMemoryFormat: {0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY},
+                {InMemoryFormat.OBJECT}
+        });
+    }
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    private static final String SIMPLE_ARRAY = Json.array(1, 2, 3, 4).toString();
+    private static final String SIMPLE_OBJECT = Json.object()
+            .add("a", 1)
+            .add("b", 2)
+            .add("c", 3)
+            .toString();
+    private static final String NESTED_OBJECT = Json.object()
+            .add("a", 1)
+            .add("b", Json.object()
+                    .add("ba", 21)
+                    .add("bb", 22)
+                    .add("bc", 23))
+            .add("c", Json.array(31, 32, 33, 34))
+            .add("d", true)
+            .toString();
+
+    // tests on simple array
+    @Test
+    public void test_givenInvalidPath_shouldCreateNullPattern_pathAttribute() throws IOException {
+        test_givenInvalidPattern_createNullPattern(SIMPLE_ARRAY, "abc");
+    }
+
+    @Test
+    public void test_givenInvalidPath_shouldCreateNullPattern_whenArray_pathIndex() throws IOException {
+        test_givenInvalidPattern_createNullPattern(SIMPLE_ARRAY, "[4]");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenArray_queriedByWrongIndex() throws IOException {
+        test_givenWrongPattern_returnNull(SIMPLE_ARRAY, "[1]", "[2]");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenArray_queriedByAttribute() throws IOException {
+        test_givenWrongPattern_returnNull(SIMPLE_ARRAY, "[1]", "someAttribute");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenArray_queriedByExtraAttribute() throws IOException {
+        test_givenWrongPattern_returnNull(SIMPLE_ARRAY, "[1]", "[1].abc");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenArray_queriedByExtraIndex() throws IOException {
+        test_givenWrongPattern_returnNull(SIMPLE_ARRAY, "[1]", "[1][0]");
+    }
+
+    // tests on simple object
+
+    @Test
+    public void test_givenInvalidPath_shouldCreateNullPattern_whenObject_pathAttribute() throws IOException {
+        test_givenInvalidPattern_createNullPattern(SIMPLE_OBJECT, "abc");
+    }
+
+    @Test
+    public void test_givenInvalidPath_shouldCreateNullPattern_whenObject_pathExtraAttribute() throws IOException {
+        test_givenInvalidPattern_createNullPattern(SIMPLE_OBJECT, "b.abc");
+    }
+
+    @Test
+    public void test_givenInvalidPath_shouldCreateNullPattern_whenObject_pathIndex() throws IOException {
+        test_givenInvalidPattern_createNullPattern(SIMPLE_OBJECT, "[0]");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenObject_queriedByWrongAttribute() throws IOException {
+        test_givenWrongPattern_returnNull(SIMPLE_OBJECT, "a", "b");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenObject_queriedByIndex() throws IOException {
+        test_givenWrongPattern_returnNull(SIMPLE_OBJECT, "b", "[1]");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenObject_queriedByExtraAttribute() throws IOException {
+        test_givenWrongPattern_returnNull(SIMPLE_OBJECT, "b", "b.abc");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenObject_queriedByExtraIndex() throws IOException {
+        test_givenWrongPattern_returnNull(SIMPLE_OBJECT, "b", "b[0]");
+    }
+
+    // tests on nested object
+
+    @Test
+    public void testNestedObject_givenInvalidPath_shouldCreateNullPattern_whenObject_pathMissingAttribute() throws IOException {
+        test_givenInvalidPattern_createNullPattern(NESTED_OBJECT, "b");
+    }
+
+    @Test
+    public void testNestedObject_givenInvalidPath_shouldCreateNullPattern_whenObject_pathExtraAttribute() throws IOException {
+        test_givenInvalidPattern_createNullPattern(NESTED_OBJECT, "b.ba.a");
+    }
+
+    @Test
+    public void testNestedObject_givenInvalidPath_shouldCreateNullPattern_whenObject_pathInvalidAttribute() throws IOException {
+        test_givenInvalidPattern_createNullPattern(NESTED_OBJECT, "b.bd");
+    }
+
+    @Test
+    public void testNestedObject_givenInvalidPath_shouldCreateNullPattern_whenObject_pathIndex() throws IOException {
+        test_givenInvalidPattern_createNullPattern(NESTED_OBJECT, "b[0]");
+    }
+
+    @Test
+    public void testNestedObject_givenInvalidPath_shouldCreateNullPattern_whenArray_pathExtraIndex() throws IOException {
+        test_givenInvalidPattern_createNullPattern(NESTED_OBJECT, "c[1][1]");
+    }
+
+    @Test
+    public void testNestedObject_givenInvalidPath_shouldCreateNullPattern_whenArray_pathInvalidIndex() throws IOException {
+        test_givenInvalidPattern_createNullPattern(NESTED_OBJECT, "c[5]");
+    }
+
+    @Test
+    public void testNestedObject_givenInvalidPath_shouldCreateNullPattern_whenArray_pathExtraAttribute() throws IOException {
+        test_givenInvalidPattern_createNullPattern(NESTED_OBJECT, "c[0].abc");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenNestedObject_queriedByWrongAttribute() throws IOException {
+        test_givenWrongPattern_returnNull(NESTED_OBJECT, "b.bb", "b.bc");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenNestedObject_queriedByMissingAttribute() throws IOException {
+        test_givenWrongPattern_returnNull(NESTED_OBJECT, "b.bb", "b");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenNestedObject_queriedByIndex() throws IOException {
+        test_givenWrongPattern_returnNull(NESTED_OBJECT, "b.bb", "b[1]");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenNestedObject_queriedByExtraAttribute() throws IOException {
+        test_givenWrongPattern_returnNull(NESTED_OBJECT, "b.bb", "b.bb.abc");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenNestedObject_queriedByExtraIndex() throws IOException {
+        test_givenWrongPattern_returnNull(NESTED_OBJECT, "b.bb", "b.bb[0]");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenNestedArray_queriedByAttribute() throws IOException {
+        test_givenWrongPattern_returnNull(NESTED_OBJECT, "c[1]", "c.cb");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenNestedArray_queriedByMissingIndex() throws IOException {
+        test_givenWrongPattern_returnNull(NESTED_OBJECT, "c[1]", "c");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenNestedArray_queriedByWrongIndex() throws IOException {
+        test_givenWrongPattern_returnNull(NESTED_OBJECT, "c[1]", "c[0]");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenNestedArray_queriedByExtraAttribute() throws IOException {
+        test_givenWrongPattern_returnNull(NESTED_OBJECT, "c[1]", "c[1].abc");
+    }
+
+    @Test
+    public void test_givenWrongPattern_returnNull_whenNestedArray_queriedByExtraIndex() throws IOException {
+        test_givenWrongPattern_returnNull(NESTED_OBJECT, "c[1]", "c[1][0]");
+    }
+
+    @Override
+    protected InMemoryFormat getInMemoryFormay() {
+        return inMemoryFormat;
+    }
+
+    private void test_givenInvalidPattern_createNullPattern(String jsonString, String path) throws IOException {
+        NavigableJsonInputAdapter inputAdapter = toAdapter(HazelcastJson.fromString(jsonString));
+        JsonSchemaNode schemaNode = JsonSchemaHelper.createSchema(createParserFromInput(inputAdapter));
+        JsonPattern pattern = JsonSchemaHelper.createPattern(inputAdapter, schemaNode, splitPath(path));
+        assertNull(pattern);
+    }
+
+    private void test_givenWrongPattern_returnNull(String jsonString, String patternPath, String queryPath) throws IOException {
+        NavigableJsonInputAdapter input = toAdapter(HazelcastJson.fromString(jsonString));
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(createParserFromInput(input));
+        JsonPattern pattern = JsonSchemaHelper.createPattern(input, description, splitPath(patternPath));
+
+        JsonValue found = JsonSchemaHelper.findValueWithPattern(input, description, pattern, splitPath(queryPath));
+        assertNull(found);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/JsonSchemaHelperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/JsonSchemaHelperTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.json.PrettyPrint;
+import com.hazelcast.internal.json.RandomPrint;
+import com.hazelcast.internal.json.WriterConfig;
+import com.hazelcast.internal.serialization.impl.NavigableJsonInputAdapter;
+import com.hazelcast.json.HazelcastJson;
+import com.hazelcast.query.impl.getters.JsonPathCursor;
+import com.hazelcast.test.HazelcastParametersRunnerFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * This test automatically tests
+ * {@link JsonSchemaHelper#createPattern(NavigableJsonInputAdapter, JsonSchemaNode, JsonPathCursor)}
+ * and
+ * {@link JsonSchemaHelper#findValueWithPattern(NavigableJsonInputAdapter, JsonSchemaNode, JsonPattern, JsonPathCursor)}
+ * methods.
+ *
+ * It runs the mentioned methods on pre-determined {@code JsonValue}s.
+ * The tests use all valid attribute paths to extract {@code JsonValue}s
+ * and compare extracted values with the ones that are available from
+ * JsonValue tree.
+ *
+ * This suite include simple test cases along with automated test cases.
+ * These are just there to demonstrate what kind of testing is done and
+ * additional peace of mind. They are already covered by the automated
+ * tests.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class JsonSchemaHelperTest extends AbstractJsonSchemaTest {
+
+    @Parameters(name = "InMemoryFormat: {0}")
+    public static Collection<Object[]> parameters() {
+        return asList(new Object[][]{
+                {InMemoryFormat.BINARY},
+                {InMemoryFormat.OBJECT}
+        });
+    }
+
+    @Parameter
+    public InMemoryFormat inMemoryFormat;
+
+    @Test
+    public void testAllValidPaths_MinimalPrint() throws IOException {
+        testPaths(WriterConfig.MINIMAL);
+    }
+
+    @Test
+    public void testAllValidPaths_PrettyPrint() throws IOException {
+        testPaths(PrettyPrint.PRETTY_PRINT);
+    }
+
+    @Test
+    public void testAllValidPaths_RandomPrint() throws IOException {
+        testPaths(RandomPrint.RANDOM_PRINT);
+    }
+
+    @Test
+    public void testQuerySimpleNestedQuery() throws IOException {
+        JsonObject object = Json.object()
+                .add("inner", Json.object()
+                        .add("a", 3)
+                        .add("b", 5));
+
+        NavigableJsonInputAdapter input = toAdapter(HazelcastJson.fromString(object.toString()));
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(createParserFromInput(input));
+        JsonPattern pattern = JsonSchemaHelper.createPattern(input, description, splitPath("inner.b"));
+        assertEquals(new JsonPattern(asList(0, 1)), pattern);
+    }
+
+    @Test
+    public void testEmptyStringReturnsNullSchema() throws IOException {
+        NavigableJsonInputAdapter input = toAdapter(HazelcastJson.fromString(""));
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(createParserFromInput(input));
+        assertNull(description);
+    }
+
+    @Test
+    public void testOneLevelObject() throws IOException {
+        JsonObject object = Json.object()
+                .add("a", true)
+                .add("b", false)
+                .add("c", Json.NULL)
+                .add("d", 4)
+                .add("e", "asd");
+
+        NavigableJsonInputAdapter input = toAdapter(HazelcastJson.fromString(object.toString()));
+        JsonSchemaNode description = JsonSchemaHelper.createSchema(createParserFromInput(input));
+        JsonPattern pattern = JsonSchemaHelper.createPattern(input, description, splitPath("b"));
+        assertEquals(new JsonPattern(asList(1)), pattern);
+
+        JsonValue found = JsonSchemaHelper.findValueWithPattern(input, description, pattern, splitPath("b"));
+        assertEquals(Json.FALSE, found);
+    }
+
+    @Override
+    protected InMemoryFormat getInMemoryFormay() {
+        return inMemoryFormat;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/StringJsonSchemaCreateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/StringJsonSchemaCreateTest.java
@@ -14,30 +14,25 @@
  * limitations under the License.
  */
 
-package com.hazelcast.query.impl.getters;
+package com.hazelcast.json.internal;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
-import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import java.io.IOException;
 
-import static com.hazelcast.internal.serialization.impl.HeapData.HEAP_DATA_OVERHEAD;
-
-public final class JsonDataGetter extends AbstractJsonGetter {
-
-    private static final int UTF_CHARACTER_COUNT_FIELD_SIZE = 4;
+@Category({ParallelTest.class, QuickTest.class})
+@RunWith(HazelcastParallelClassRunner.class)
+public class StringJsonSchemaCreateTest extends AbstractJsonSchemaCreateTest {
 
     private JsonFactory factory = new JsonFactory();
 
-    public JsonDataGetter() {
-        super(null);
-    }
-
-    protected JsonParser createParser(Object obj) throws IOException {
-        Data data = (Data) obj;
-        return factory.createParser(data.toByteArray(),
-                HEAP_DATA_OVERHEAD + UTF_CHARACTER_COUNT_FIELD_SIZE,
-                data.dataSize() - UTF_CHARACTER_COUNT_FIELD_SIZE);
+    protected JsonParser createParserFromString(String jsonString) throws IOException {
+        return factory.createParser(jsonString);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/TestJsonValues.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/TestJsonValues.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.json.internal;
+
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestJsonValues {
+
+    public static final List<JsonValue> LIST = new ArrayList<JsonValue>();
+
+    static {
+        // arrays
+        LIST.add(Json.array(1, 2, 3, 4, 5));
+        LIST.add(Json.array()
+                .add(Json.object())
+                .add(1)
+                .add(2));
+        LIST.add(Json.array()
+                .add(Json.object().add("a", true))
+                .add(1)
+                .add(2));
+        LIST.add(Json.array()
+                .add(1)
+                .add(Json.object().add("a", true))
+                .add(2));
+        LIST.add(Json.array()
+                .add(1)
+                .add(2)
+                .add(Json.object().add("a", true)));
+        LIST.add(Json.array()
+                .add(Json.object()
+                        .add("a", true)
+                        .add("b", Json.NULL))
+                .add(1)
+                .add(2));
+        LIST.add(Json.array()
+                .add(Json.array(1, 2, 3, 4)
+                        .add(Json.array(1, 2, 3, 4)
+                                .add(Json.array(1, 2, 3, 4)
+                                        .add(Json.array(1, 2, 3, 4))))));
+        LIST.add(Json.array()
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103)));
+        LIST.add(Json.array()
+                .add(Json.array())
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103)));
+        LIST.add(Json.array()
+                .add(Json.array(101))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103)));
+        LIST.add(Json.array()
+                .add(Json.array(101, 102, 103))
+                .add(Json.array())
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103)));
+        LIST.add(Json.array()
+                .add(Json.TRUE)
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103))
+                .add(Json.array(101, 102, 103)));
+
+        // object
+        LIST.add(Json.object());
+        LIST.add(Json.object().add("a", 2));
+        LIST.add(Json.object().add("a", 2).add("b", 34));
+        LIST.add(Json.object()
+                .add("a", Json.object()
+                        .add("b", Json.object()
+                                .add("b", Json.object()
+                                        .add("b", Json.object()
+                                                .add("b", 34))))));
+        LIST.add(Json.object().add("arr", Json.array(1, 2, 3, 4, 5)));
+        LIST.add(Json.object()
+                .add("arr6", Json.array(1, 2, 3, 4, 5))
+                .add("arr5", Json.array(1, 2, 3, 4, 5))
+                .add("arr4", Json.array(1, 2, 3, 4, 5))
+                .add("arr3", Json.array(1, 2, 3, 4, 5))
+                .add("arr2", Json.array(1, 2, 3, 4, 5))
+                .add("arr1", Json.array(1, 2, 3, 4, 5)));
+        LIST.add(Json.object()
+                .add("arr6", Json.array(1, 5))
+                .add("arr5", Json.array(1, 2, 3, 4, 5))
+                .add("arr4", Json.array(1, 2, 3, 4, 5))
+                .add("arr3", Json.array(1, 2, 3, 4, 5))
+                .add("arr2", Json.array(1, 2, 3, 4, 5))
+                .add("arr1", Json.array(1, 2, 3, 4, 5)));
+        LIST.add(Json.object()
+                .add("arr6", Json.array())
+                .add("arr5", Json.array(1, 2, 3, 4, 5))
+                .add("arr4", Json.array(1, 2, 3, 4, 5))
+                .add("arr3", Json.array(1, 2, 3, 4, 5))
+                .add("arr2", Json.array(1, 2, 3, 4, 5))
+                .add("arr1", Json.array(1, 2, 3, 4, 5)));
+        LIST.add(Json.object()
+                .add("arr6", Json.array(1, 2, 3, 4, 5))
+                .add("arr5", Json.array(1, 5))
+                .add("arr4", Json.array(1, 2, 3, 4, 5))
+                .add("arr3", Json.array(1, 2, 3, 4, 5))
+                .add("arr2", Json.array(1, 2, 3, 4, 5))
+                .add("arr1", Json.array(1, 2, 3, 4, 5)));
+        LIST.add(Json.object()
+                .add("arr6", Json.array(34))
+                .add("arr5", Json.array(1, 2, 3, 4, 5))
+                .add("arr4", Json.array(1, 2, 3, 4, 5))
+                .add("arr3", Json.array())
+                .add("arr2", Json.array(1, 2, 3, 4, 5))
+                .add("arr1", Json.array(1, 2, 3, 4, 5)));
+        LIST.add(Json.object()
+                .add("firstObject", Json.object()
+                        .add("firstAttribute", Json.object()
+                                .add("extraAttr", "extraName"))
+                        .add("secondAttribute", 5))
+        );
+        LIST.add(Json.object()
+                .add("a1", true)
+                .add("a2", false)
+                .add("a3", "v3")
+                .add("a4", 4.5)
+                .add("a5", Json.NULL));
+        LIST.add(Json.object()
+                .add("a1", true)
+                .add("a2", false)
+                .add("arr", Json.array())
+                .add("a3", "v3")
+                .add("a4", 4.5)
+                .add("a5", Json.NULL));
+        LIST.add(Json.object()
+                .add("a1", true)
+                .add("a2", false)
+                .add("arr", Json.array()
+                        .add(true)
+                        .add(false)
+                        .add(Json.NULL)
+                        .add(12.4).add("asd"))
+                .add("a3", "v3")
+                .add("a4", 4.5)
+                .add("a5", Json.NULL));
+        LIST.add(Json.object()
+                .add("firstObject", 1)
+                .add("second", 2)
+                .add("third", Json.object()
+                        .add("inner", 5)));
+        LIST.add(Json.object()
+                .add("this-name-includes-two-byte-utf8-character-£", "this-value-includes-two-byte-utf8-character-£")
+                .add("this-name-includes-two-byte-utf8-character-£-2", 2)
+                .add("this-name-includes-two-byte-utf8-character-£-3", Json.object()
+                        .add("this-name-includes-two-byte-utf8-character-£-inner", 5)));
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/JsonPathCursorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/JsonPathCursorTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.query.impl.getters;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class JsonPathCursorTest {
+
+    @Test
+    public void testOneItemPath() {
+        JsonPathCursor cursor = new JsonPathCursor("abc");
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPathWithUnMatchedCloseBraceShouldThrowIllegalArgumentException() {
+        JsonPathCursor cursor = new JsonPathCursor("a]");
+        cursor.getNext();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPathWithNonNumberArrayIndexShouldThrowIllegalArgumentException() {
+        JsonPathCursor cursor = new JsonPathCursor("[a]");
+        cursor.getNext();
+    }
+
+    @Test
+    public void testOneItemArrayPath() {
+        JsonPathCursor cursor = new JsonPathCursor("[4]");
+        assertEquals("4", cursor.getNext());
+        assertEquals(4, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testTwoItemPath() {
+        JsonPathCursor cursor = new JsonPathCursor("abc.def");
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEquals("def", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testTwoArrayItemPath() {
+        JsonPathCursor cursor = new JsonPathCursor("[4][1]");
+        assertEquals("4", cursor.getNext());
+        assertEquals(4, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("1", cursor.getNext());
+        assertEquals(1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testTwoItemPath_whenTheSecondIsArray() {
+        JsonPathCursor cursor = new JsonPathCursor("abc[1]");
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEquals("1", cursor.getNext());
+        assertEquals(1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testTwoItemPath_whenTheFirstIsArray() {
+        JsonPathCursor cursor = new JsonPathCursor("[1].abc");
+        assertEquals("1", cursor.getNext());
+        assertEquals(1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testOneItemArrayPath_whenAny() {
+        JsonPathCursor cursor = new JsonPathCursor("[any]");
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testTwoItemArrayPath_whenAny() {
+        JsonPathCursor cursor = new JsonPathCursor("[any][any]");
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testTwoItemPath_whenFirstIsAny() {
+        JsonPathCursor cursor = new JsonPathCursor("[any].abc");
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testTwoItemPath_whenSecondIsAny() {
+        JsonPathCursor cursor = new JsonPathCursor("abc[any]");
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testThreeItemPath_whenAllNonArray() {
+        JsonPathCursor cursor = new JsonPathCursor("abc.def.ghi");
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEquals("def", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEquals("ghi", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testThreeItemPath_whenNonArray_array_any() {
+        JsonPathCursor cursor = new JsonPathCursor("abc[12][any]");
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEquals("12", cursor.getNext());
+        assertEquals(12, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testThreeItemPath_whenNonArray_any_array() {
+        JsonPathCursor cursor = new JsonPathCursor("abc[any][12]");
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("12", cursor.getNext());
+        assertEquals(12, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testThreeItemPath_whenArray_nonArray_any() {
+        JsonPathCursor cursor = new JsonPathCursor("[12].abc[any]");
+        assertEquals("12", cursor.getNext());
+        assertEquals(12, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testThreeItemPath_whenArray_any_nonArray() {
+        JsonPathCursor cursor = new JsonPathCursor("[12][any].abc");
+        assertEquals("12", cursor.getNext());
+        assertEquals(12, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testThreeItemPath_whenAny_nonArray_array() {
+        JsonPathCursor cursor = new JsonPathCursor("[any].abc[12]");
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEquals("12", cursor.getNext());
+        assertEquals(12, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    @Test
+    public void testThreeItemPath_whenAny_array_nonArray() {
+        JsonPathCursor cursor = new JsonPathCursor("[any][12].abc");
+        assertEquals("any", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertTrue(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("12", cursor.getNext());
+        assertEquals(12, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertTrue(cursor.isArray());
+        assertEquals("abc", cursor.getNext());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isAny());
+        assertFalse(cursor.isArray());
+        assertEnd(cursor);
+    }
+
+    private void assertEnd(JsonPathCursor cursor) {
+        assertNull(cursor.getNext());
+        assertNull(cursor.getNext());
+        assertNull(cursor.getCurrent());
+        assertEquals(-1, cursor.getArrayIndex());
+        assertFalse(cursor.isArray());
+        assertFalse(cursor.isAny());
+    }
+}


### PR DESCRIPTION
Json pre-processing system is a collection of utilities that makes it possible to create metadata about Json objects and query these objects faster by using the generated metadata. Metadata consists of the locations of points of interests within a JsonValue. JsonValue may be in either serialized or de-serialized form. Points of interests are:
- The offset of each scalar value from the beginning of the JsonValue
- The offset of each attribute name within the JsonValue

JsonPattern is a data structure representing logical location of a scalar value within a JsonValue. If we have a Json value A `{ "person": { "name": "abc", "age": 22 } }`. The logical location of "age" is "the second attribute of A's first attribute". We can do fast queries over Json objects by combining logical location with metadata explained above.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2670