### PR TITLE
Speed-Up Partition Migrations

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -198,6 +198,8 @@
 
     <!-- Partition -->
     <suppress checks="Javadoc(Method|Type|Variable)" files="com[\\/]hazelcast[\\/]partition[\\/]"/>
+    <suppress checks="FileLength" files="com[\\/]hazelcast[\\/]internal[\\/]partition[\\/]impl[\\/]InternalPartitionServiceImpl"/>
+    <suppress checks="FileLength" files="com[\\/]hazelcast[\\/]internal[\\/]partition[\\/]impl[\\/]MigrationManager"/>
 
     <!-- Multimap -->
     <suppress checks="Javadoc(Method|Type)" files="com[\\/]hazelcast[\\/]multimap[\\/]"/>

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationPlanner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationPlanner.java
@@ -23,18 +23,20 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static com.hazelcast.internal.partition.impl.InternalPartitionImpl.getReplicaIndex;
+import static java.lang.String.format;
 
 /**
  * Decides type and order of migrations that will move the state from current replica ownerships
  * to the targeted replica ownerships. Migrations are planned in such a way that the current replica state
  * will be moved to the targeted replica state one migration at a time.
  * {@link MigrationDecisionCallback} implementation passed to the
- * {@link MigrationPlanner#planMigrations(PartitionReplica[], PartitionReplica[], MigrationDecisionCallback)}
+ * {@link MigrationPlanner#planMigrations(int, PartitionReplica[], PartitionReplica[], MigrationDecisionCallback)}
  * is notified with the planned migrations.
  * Planned migrations have a key property that they never decrease the available replica count of a partition.
  */
@@ -49,7 +51,8 @@ class MigrationPlanner {
 
     private final ILogger logger;
     private final PartitionReplica[] state = new PartitionReplica[InternalPartition.MAX_REPLICA_COUNT];
-    private final Set<PartitionReplica> verificationSet = new HashSet<PartitionReplica>();
+    private final Set<PartitionReplica> verificationSet = ASSERTION_ENABLED
+            ? new HashSet<PartitionReplica>() : Collections.<PartitionReplica>emptySet();
 
     MigrationPlanner() {
         logger = Logger.getLogger(getClass());
@@ -61,30 +64,39 @@ class MigrationPlanner {
 
     // the CheckStyle warnings are suppressed intentionally, because the algorithm is followed easier within fewer methods
     @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:cyclomaticcomplexity", "checkstyle:methodlength"})
-    void planMigrations(PartitionReplica[] oldReplicas, PartitionReplica[] newReplicas, MigrationDecisionCallback callback) {
+    void planMigrations(int partitionId, PartitionReplica[] oldReplicas, PartitionReplica[] newReplicas,
+            MigrationDecisionCallback callback) {
         assert oldReplicas.length == newReplicas.length : "Replica addresses with different lengths! Old: "
                 + Arrays.toString(oldReplicas) + ", New: " + Arrays.toString(newReplicas);
 
-        log("Initial state: %s", Arrays.toString(oldReplicas));
-        log("Final state: %s", Arrays.toString(newReplicas));
+        if (logger.isFinestEnabled()) {
+            logger.finest(format("partitionId=%d, Initial state: %s", partitionId, Arrays.toString(oldReplicas)));
+            logger.finest(format("partitionId=%d, Final state: %s", partitionId, Arrays.toString(newReplicas)));
+        }
 
         initState(oldReplicas);
-        assertNoDuplicate(oldReplicas, newReplicas);
+        assertNoDuplicate(partitionId, oldReplicas, newReplicas);
 
         // fix cyclic partition replica movements
         if (fixCycle(oldReplicas, newReplicas)) {
-            log("Final state (after cycle fix): %s", Arrays.toString(newReplicas));
+            if (logger.isFinestEnabled()) {
+                logger.finest(format("partitionId=%d, Final state (after cycle fix): %s", partitionId,
+                        Arrays.toString(newReplicas)));
+            }
         }
 
         int currentIndex = 0;
         while (currentIndex < oldReplicas.length) {
-            log("Current index: %d, state: %s", currentIndex, Arrays.toString(state));
-            assertNoDuplicate(oldReplicas, newReplicas);
+            if (logger.isFinestEnabled()) {
+                logger.finest(format("partitionId=%d, Current index: %d, state: %s", partitionId, currentIndex,
+                        Arrays.toString(state)));
+            }
+            assertNoDuplicate(partitionId, oldReplicas, newReplicas);
 
             if (newReplicas[currentIndex] == null) {
                 if (state[currentIndex] != null) {
                     // replica owner is removed and no one will own this replica
-                    log("New address is null at index: %d", currentIndex);
+                    trace("partitionId=%d, New address is null at index: %d", partitionId, currentIndex);
                     callback.migrate(state[currentIndex], currentIndex, -1, null, -1, -1);
                     state[currentIndex] = null;
                 }
@@ -96,7 +108,7 @@ class MigrationPlanner {
                 int i = getReplicaIndex(state, newReplicas[currentIndex]);
                 if (i == -1) {
                     // fresh replica copy is needed, so COPY replica to newReplicas[currentIndex] from partition owner
-                    log("COPY %s to index: %d", newReplicas[currentIndex], currentIndex);
+                    trace("partitionId=%d, COPY %s to index: %d", partitionId, newReplicas[currentIndex], currentIndex);
                     callback.migrate(null, -1, -1, newReplicas[currentIndex], -1, currentIndex);
                     state[currentIndex] = newReplicas[currentIndex];
                     currentIndex++;
@@ -105,16 +117,17 @@ class MigrationPlanner {
 
                 if (i > currentIndex) {
                     // SHIFT UP replica from i to currentIndex, copy data from partition owner
-                    log("SHIFT UP-2 %s from old addresses index: %d to index: %d", state[i], i, currentIndex);
+                    trace("partitionId=%d, SHIFT UP-2 %s from old addresses index: %d to index: %d", partitionId,
+                            state[i], i, currentIndex);
                     callback.migrate(null, -1, -1, state[i], i, currentIndex);
                     state[currentIndex] = state[i];
                     state[i] = null;
                     continue;
                 }
 
-                throw new AssertionError(
-                        "Migration decision algorithm failed during SHIFT UP! INITIAL: " + Arrays.toString(oldReplicas)
-                                + ", CURRENT: " + Arrays.toString(state) + ", FINAL: " + Arrays.toString(newReplicas));
+                throw new AssertionError("partitionId=" + partitionId
+                        + "Migration decision algorithm failed during SHIFT UP! INITIAL: " + Arrays.toString(oldReplicas)
+                        + ", CURRENT: " + Arrays.toString(state) + ", FINAL: " + Arrays.toString(newReplicas));
             }
 
             if (newReplicas[currentIndex].equals(state[currentIndex])) {
@@ -126,7 +139,7 @@ class MigrationPlanner {
             if (getReplicaIndex(newReplicas, state[currentIndex]) == -1
                     && getReplicaIndex(state, newReplicas[currentIndex]) == -1) {
                 // MOVE partition replica from its old owner to new owner
-                log("MOVE %s to index: %d", newReplicas[currentIndex], currentIndex);
+                trace("partitionId=%d, MOVE %s to index: %d", partitionId, newReplicas[currentIndex], currentIndex);
                 callback.migrate(state[currentIndex], currentIndex, -1, newReplicas[currentIndex], -1, currentIndex);
                 state[currentIndex] = newReplicas[currentIndex];
                 currentIndex++;
@@ -135,18 +148,19 @@ class MigrationPlanner {
 
             if (getReplicaIndex(state, newReplicas[currentIndex]) == -1) {
                 int newIndex = getReplicaIndex(newReplicas, state[currentIndex]);
-                assert newIndex > currentIndex : "Migration decision algorithm failed during SHIFT DOWN! INITIAL: "
+                assert newIndex > currentIndex : "partitionId=" + partitionId
+                        + ", Migration decision algorithm failed during SHIFT DOWN! INITIAL: "
                         + Arrays.toString(oldReplicas) + ", CURRENT: " + Arrays.toString(state)
                         + ", FINAL: " + Arrays.toString(newReplicas);
 
                 if (state[newIndex] == null) {
                     // it is a SHIFT DOWN
-                    log("SHIFT DOWN %s to index: %d, COPY %s to index: %d", state[currentIndex], newIndex,
-                            newReplicas[currentIndex], currentIndex);
+                    trace("partitionId=%d, SHIFT DOWN %s to index: %d, COPY %s to index: %d", partitionId, state[currentIndex],
+                            newIndex, newReplicas[currentIndex], currentIndex);
                     callback.migrate(state[currentIndex], currentIndex, newIndex, newReplicas[currentIndex], -1, currentIndex);
                     state[newIndex] = state[currentIndex];
                 } else {
-                    log("MOVE-3 %s to index: %d", newReplicas[currentIndex], currentIndex);
+                    trace("partitionId=%d, MOVE-3 %s to index: %d", partitionId, newReplicas[currentIndex], currentIndex);
                     callback.migrate(state[currentIndex], currentIndex, -1, newReplicas[currentIndex], -1, currentIndex);
                 }
 
@@ -155,61 +169,63 @@ class MigrationPlanner {
                 continue;
             }
 
-            planMigrations(oldReplicas, newReplicas, callback, currentIndex);
+            planMigrations(partitionId, oldReplicas, newReplicas, callback, currentIndex);
         }
 
         assert Arrays.equals(state, newReplicas)
-                : "Migration decisions failed! INITIAL: " + Arrays.toString(oldReplicas)
+                : "partitionId=" + partitionId + ", Migration decisions failed! INITIAL: " + Arrays.toString(oldReplicas)
                 + " CURRENT: " + Arrays.toString(state) + ", FINAL: " + Arrays.toString(newReplicas);
     }
 
-    private void planMigrations(PartitionReplica[] oldMembers, PartitionReplica[] newMembers, MigrationDecisionCallback callback,
-                                int currentIndex) {
+    private void planMigrations(int partitionId, PartitionReplica[] oldMembers, PartitionReplica[] newReplicas,
+            MigrationDecisionCallback callback, int currentIndex) {
         while (true) {
-            int targetIndex = getReplicaIndex(state, newMembers[currentIndex]);
-            assert targetIndex != -1 : "Migration algorithm failed during SHIFT UP! " + newMembers[currentIndex]
-                    + " is not present in " + Arrays.toString(state) + ". INITIAL: " + Arrays.toString(oldMembers)
-                    + ", FINAL: " + Arrays.toString(newMembers);
+            int targetIndex = getReplicaIndex(state, newReplicas[currentIndex]);
+            assert targetIndex != -1 : "partitionId=" + partitionId + ", Migration algorithm failed during SHIFT UP! "
+                    + newReplicas[currentIndex] + " is not present in " + Arrays.toString(state)
+                    + ". INITIAL: " + Arrays.toString(oldMembers) + ", FINAL: " + Arrays.toString(newReplicas);
 
-            if (newMembers[targetIndex] == null) {
+            if (newReplicas[targetIndex] == null) {
                 if (state[currentIndex] == null) {
-                    log("SHIFT UP %s from old addresses index: %d to index: %d", state[targetIndex], targetIndex, currentIndex);
+                    trace("partitionId=%d, SHIFT UP %s from old addresses index: %d to index: %d", partitionId,
+                            state[targetIndex], targetIndex, currentIndex);
                     callback.migrate(state[currentIndex], currentIndex, -1, state[targetIndex], targetIndex, currentIndex);
                     state[currentIndex] = state[targetIndex];
                 } else {
-                    int newIndex = getReplicaIndex(newMembers, state[currentIndex]);
+                    int newIndex = getReplicaIndex(newReplicas, state[currentIndex]);
                     if (newIndex == -1) {
-                        log("SHIFT UP %s from old addresses index: %d to index: %d with source: %s",
-                                state[targetIndex], targetIndex, currentIndex, state[currentIndex]);
+                        trace("partitionId=%d, SHIFT UP %s from old addresses index: %d to index: %d with source: %s",
+                                partitionId, state[targetIndex], targetIndex, currentIndex, state[currentIndex]);
                         callback.migrate(state[currentIndex], currentIndex, -1, state[targetIndex], targetIndex, currentIndex);
                         state[currentIndex] = state[targetIndex];
                     } else if (state[newIndex] == null) {
                         // SHIFT UP + SHIFT DOWN
-                        log("SHIFT UP %s from old addresses index: %d to index: %d AND SHIFT DOWN %s to index: %d",
-                                state[targetIndex], targetIndex, currentIndex, state[currentIndex], newIndex);
+                        trace("partitionId=%d, SHIFT UP %s from old addresses index: %d to index: %d "
+                                        + "and SHIFT DOWN %s to index: %d",
+                                partitionId, state[targetIndex], targetIndex, currentIndex, state[currentIndex], newIndex);
                         callback.migrate(state[currentIndex], currentIndex, newIndex, state[targetIndex], targetIndex,
                                 currentIndex);
                         state[newIndex] = state[currentIndex];
                         state[currentIndex] = state[targetIndex];
                     } else {
                         // only SHIFT UP because source will come back with another move migration
-                        log("SHIFT UP %s from old addresses index: %d to index: %d with source: %s will get "
-                                        + "another MOVE migration to index: %d", state[targetIndex], targetIndex, currentIndex,
-                                state[currentIndex], newIndex);
+                        trace("partitionId=%d, SHIFT UP %s from old addresses index: %d to index: %d with source: %s will get "
+                                        + "another MOVE migration to index: %d", partitionId, state[targetIndex],
+                                targetIndex, currentIndex, state[currentIndex], newIndex);
                         callback.migrate(state[currentIndex], currentIndex, -1, state[targetIndex], targetIndex, currentIndex);
                         state[currentIndex] = state[targetIndex];
                     }
                 }
                 state[targetIndex] = null;
                 break;
-            } else if (getReplicaIndex(state, newMembers[targetIndex]) == -1) {
+            } else if (getReplicaIndex(state, newReplicas[targetIndex]) == -1) {
                 // MOVE partition replica from its old owner to new owner
-                log("MOVE-2 %s  to index: %d", newMembers[targetIndex], targetIndex);
-                callback.migrate(state[targetIndex], targetIndex, -1, newMembers[targetIndex], -1, targetIndex);
-                state[targetIndex] = newMembers[targetIndex];
+                trace("partitionId=%d, MOVE-2 %s  to index: %d", partitionId, newReplicas[targetIndex], targetIndex);
+                callback.migrate(state[targetIndex], targetIndex, -1, newReplicas[targetIndex], -1, targetIndex);
+                state[targetIndex] = newReplicas[targetIndex];
                 break;
             } else {
-                // newMembers[targetIndex] is also present in old partition replicas
+                // newReplicas[targetIndex] is also present in old partition replicas
                 currentIndex = targetIndex;
             }
         }
@@ -232,21 +248,25 @@ class MigrationPlanner {
             prioritize(migrations, i);
         }
 
-        if (ASSERTION_ENABLED) {
-            log("Migration order after prioritization: ");
+        if (logger.isFinestEnabled()) {
+            StringBuilder s = new StringBuilder("Migration order after prioritization: [");
+            int ix = 0;
             for (MigrationInfo migration : migrations) {
-                log(migration.toString());
+                s.append("\n\t").append(ix++).append("- ").append(migration).append(",");
             }
+            s.deleteCharAt(s.length() - 1);
+            s.append("]");
+            logger.finest(s.toString());
         }
     }
 
     private void prioritize(List<MigrationInfo> migrations, int i) {
         MigrationInfo migration = migrations.get(i);
 
-        log("Trying to prioritize migration: %s", migration);
+        trace("Trying to prioritize migration: %s", migration);
 
         if (migration.getSourceCurrentReplicaIndex() != -1) {
-            log("Skipping non-copy migration: %s", migration);
+            trace("Skipping non-copy migration: %s", migration);
             return;
         }
 
@@ -254,25 +274,25 @@ class MigrationPlanner {
         for (; k >= 0; k--) {
             MigrationInfo other = migrations.get(k);
             if (other.getSourceCurrentReplicaIndex() == -1) {
-                log("Cannot prioritize against a copy / shift up. other: %s", other);
+                trace("Cannot prioritize against a copy / shift up. other: %s", other);
                 break;
             }
 
             if (migration.getDestination().equals(other.getSource())
                     || migration.getDestination().equals(other.getDestination())) {
-                log("Cannot prioritize against a conflicting migration. other: %s", other);
+                trace("Cannot prioritize against a conflicting migration. other: %s", other);
                 break;
             }
 
             if (other.getSourceNewReplicaIndex() != -1
                     && other.getSourceNewReplicaIndex() < migration.getDestinationNewReplicaIndex()) {
-                log("Cannot prioritize against a hotter shift down. other: %s", other);
+                trace("Cannot prioritize against a hotter shift down. other: %s", other);
                 break;
             }
         }
 
         if ((k + 1) != i) {
-            log("Prioritizing migration to: %d", (k + 1));
+            trace("Prioritizing migration %s to: %d", migration, (k + 1));
             migrations.remove(i);
             migrations.add(k + 1, migration);
         }
@@ -283,7 +303,7 @@ class MigrationPlanner {
         System.arraycopy(oldAddresses, 0, state, 0, oldAddresses.length);
     }
 
-    private void assertNoDuplicate(PartitionReplica[] oldReplicas, PartitionReplica[] newReplicas) {
+    private void assertNoDuplicate(int partitionId, PartitionReplica[] oldReplicas, PartitionReplica[] newReplicas) {
         if (!ASSERTION_ENABLED) {
             return;
         }
@@ -294,9 +314,9 @@ class MigrationPlanner {
                     continue;
                 }
                 assert verificationSet.add(replica)
-                        : "Migration decision algorithm failed! DUPLICATE REPLICA ADDRESSES! INITIAL: " + Arrays
-                        .toString(oldReplicas) + ", CURRENT: " + Arrays.toString(state) + ", FINAL: " + Arrays
-                        .toString(newReplicas);
+                        : "partitionId=" + partitionId + ", Migration decision algorithm failed! DUPLICATE REPLICA ADDRESSES!"
+                        + " INITIAL: " + Arrays.toString(oldReplicas) + ", CURRENT: " + Arrays.toString(state)
+                        + ", FINAL: " + Arrays.toString(newReplicas);
             }
         } finally {
             verificationSet.clear();
@@ -379,9 +399,9 @@ class MigrationPlanner {
         }
     }
 
-    private void log(String log, Object... args) {
+    private void trace(String log, Object... args) {
         if (logger.isFinestEnabled()) {
-            logger.finest(String.format(log, args));
+            logger.finest(format(log, args));
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationStats.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.impl;
+
+import com.hazelcast.internal.metrics.Probe;
+import com.hazelcast.util.Clock;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Collection of stats for partition migration tasks.
+ */
+public class MigrationStats {
+
+    @Probe
+    private final AtomicLong lastRepartitionTime = new AtomicLong();
+
+    @Probe
+    private final AtomicLong completedMigrations = new AtomicLong();
+
+    @Probe
+    private final AtomicLong totalCompletedMigrations = new AtomicLong();
+
+    @Probe
+    private final AtomicLong elapsedMigrationOperationTime = new AtomicLong();
+
+    @Probe
+    private final AtomicLong elapsedDestinationCommitTime = new AtomicLong();
+
+    @Probe
+    private final AtomicLong elapsedMigrationTime = new AtomicLong();
+
+    @Probe
+    private final AtomicLong totalElapsedMigrationOperationTime = new AtomicLong();
+
+    @Probe
+    private final AtomicLong totalElapsedDestinationCommitTime = new AtomicLong();
+
+    @Probe
+    private final AtomicLong totalElapsedMigrationTime = new AtomicLong();
+
+    /**
+     * Marks start of new repartitioning.
+     * Resets stats from previous repartitioning round.
+     */
+    void markNewRepartition() {
+        lastRepartitionTime.set(Clock.currentTimeMillis());
+        elapsedMigrationOperationTime.set(0);
+        elapsedDestinationCommitTime.set(0);
+        elapsedMigrationTime.set(0);
+        completedMigrations.set(0);
+    }
+
+    void incrementCompletedMigrations() {
+        completedMigrations.incrementAndGet();
+        totalCompletedMigrations.incrementAndGet();
+    }
+
+    void recordMigrationOperationTime(long time) {
+        elapsedMigrationOperationTime.addAndGet(time);
+        totalElapsedMigrationOperationTime.addAndGet(time);
+    }
+
+    void recordDestinationCommitTime(long time) {
+        elapsedDestinationCommitTime.addAndGet(time);
+        totalElapsedDestinationCommitTime.addAndGet(time);
+    }
+
+    void recordMigrationTaskTime(long time) {
+        elapsedMigrationTime.addAndGet(time);
+        totalElapsedMigrationTime.addAndGet(time);
+    }
+
+    /**
+     * Returns the last repartition time.
+     */
+    public Date getLastRepartitionTime() {
+        return new Date(lastRepartitionTime.get());
+    }
+
+    /**
+     * Returns the number of completed migrations on the latest repartitioning round.
+     */
+    public long getCompletedMigrations() {
+        return completedMigrations.get();
+    }
+
+    /**
+     * Returns the total number of completed migrations since the beginning.
+     */
+    public long getTotalCompletedMigrations() {
+        return totalCompletedMigrations.get();
+    }
+
+    /**
+     * Returns the total elapsed time of migration & replication operations' executions
+     * from source to destination endpoints, in milliseconds, on the latest repartitioning round.
+     */
+    public long getElapsedMigrationOperationTime() {
+        return TimeUnit.NANOSECONDS.toMillis(elapsedMigrationOperationTime.get());
+    }
+
+    /**
+     * Returns the total elapsed time of commit operations' executions to the destination endpoint,
+     * in milliseconds, on the latest repartitioning round.
+     */
+    public long getElapsedDestinationCommitTime() {
+        return TimeUnit.NANOSECONDS.toMillis(elapsedDestinationCommitTime.get());
+    }
+
+    /**
+     * Returns the total elapsed time from start of migration tasks to their completion,
+     * in milliseconds, on the latest repartitioning round.
+     */
+    public long getElapsedMigrationTime() {
+        return TimeUnit.NANOSECONDS.toMillis(elapsedMigrationTime.get());
+    }
+
+    /**
+     * Returns the total elapsed time of migration & replication operations' executions
+     * from source to destination endpoints, in milliseconds, since the beginning.
+     */
+    public long getTotalElapsedMigrationOperationTime() {
+        return TimeUnit.NANOSECONDS.toMillis(totalElapsedMigrationOperationTime.get());
+    }
+
+    /**
+     * Returns the total elapsed time of commit operations' executions to the destination endpoint,
+     * in milliseconds, since the beginning.
+     */
+    public long getTotalElapsedDestinationCommitTime() {
+        return TimeUnit.NANOSECONDS.toMillis(totalElapsedDestinationCommitTime.get());
+    }
+
+    /**
+     * Returns the total elapsed time from start of migration tasks to their completion,
+     * in milliseconds, since the beginning.
+     */
+    public long getTotalElapsedMigrationTime() {
+        return TimeUnit.NANOSECONDS.toMillis(totalElapsedMigrationTime.get());
+    }
+
+    public String formatToString(boolean detailed) {
+        StringBuilder s = new StringBuilder();
+        s.append("lastRepartitionTime=").append(getLastRepartitionTime())
+                .append(", completedMigrations=").append(getCompletedMigrations())
+                .append(", totalCompletedMigrations=").append(getTotalCompletedMigrations());
+
+        if (detailed) {
+            s.append(", elapsedMigrationOperationTime=").append(getElapsedMigrationOperationTime()).append("ms")
+                    .append(", totalElapsedMigrationOperationTime=").append(getTotalElapsedMigrationOperationTime()).append("ms")
+                    .append(", elapsedDestinationCommitTime=").append(getElapsedDestinationCommitTime()).append("ms")
+                    .append(", totalElapsedDestinationCommitTime=").append(getTotalElapsedDestinationCommitTime()).append("ms");
+        }
+
+        s.append(", elapsedMigrationTime=").append(getElapsedMigrationTime()).append("ms")
+                .append(", totalElapsedMigrationTime=").append(getTotalElapsedMigrationTime()).append("ms");
+        return s.toString();
+    }
+
+    @Override
+    public String toString() {
+        return "MigrationStats{" + formatToString(true) + "}";
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationThread.java
@@ -103,7 +103,8 @@ class MigrationThread extends Thread implements Runnable {
         boolean hasNoTasks = !queue.hasMigrationTasks();
         if (hasNoTasks) {
             if (migrating) {
-                logger.info("All migration tasks have been completed, queues are empty.");
+                logger.info("All migration tasks have been completed. ("
+                        + migrationManager.getStats().formatToString(logger.isFineEnabled()) + ")");
             }
             Thread.sleep(sleepTime);
         } else if (!migrationManager.areMigrationTasksAllowed()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionDataSerializerHook.java
@@ -31,7 +31,9 @@ import com.hazelcast.internal.partition.operation.PartitionReplicaSyncRequest;
 import com.hazelcast.internal.partition.operation.PartitionReplicaSyncResponse;
 import com.hazelcast.internal.partition.operation.PartitionReplicaSyncRetryResponse;
 import com.hazelcast.internal.partition.operation.PartitionStateOperation;
+import com.hazelcast.internal.partition.operation.PartitionStateVersionCheckOperation;
 import com.hazelcast.internal.partition.operation.PromotionCommitOperation;
+import com.hazelcast.internal.partition.operation.PublishCompletedMigrationsOperation;
 import com.hazelcast.internal.partition.operation.SafeStateCheckOperation;
 import com.hazelcast.internal.partition.operation.ShutdownRequestOperation;
 import com.hazelcast.internal.partition.operation.ShutdownResponseOperation;
@@ -69,8 +71,10 @@ public final class PartitionDataSerializerHook implements DataSerializerHook {
     public static final int MIGRATION_REQUEST = 19;
     public static final int NON_FRAGMENTED_SERVICE_NAMESPACE = 20;
     public static final int PARTITION_REPLICA = 21;
+    public static final int PUBLISH_COMPLETED_MIGRATIONS = 22;
+    public static final int PARTITION_STATE_VERSION_CHECK_OP = 23;
 
-    private static final int LEN = PARTITION_REPLICA + 1;
+    private static final int LEN = PARTITION_STATE_VERSION_CHECK_OP + 1;
 
     @Override
     public int getFactoryId() {
@@ -177,6 +181,18 @@ public final class PartitionDataSerializerHook implements DataSerializerHook {
         constructors[PARTITION_REPLICA] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
             public IdentifiedDataSerializable createNew(Integer arg) {
                 return new PartitionReplica();
+            }
+        };
+        constructors[PUBLISH_COMPLETED_MIGRATIONS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PublishCompletedMigrationsOperation();
+            }
+        };
+        constructors[PARTITION_STATE_VERSION_CHECK_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
+            @Override
+            public IdentifiedDataSerializable createNew(Integer arg) {
+                return new PartitionStateVersionCheckOperation();
             }
         };
         return new ArrayDataSerializableFactory(constructors);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.partition.impl;
 
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.logging.ILogger;
 
@@ -47,11 +48,15 @@ class PublishPartitionRuntimeStateTask implements Runnable {
             }
 
             if (migrationManager.hasOnGoingMigration()) {
-                logger.info("Remaining migration tasks in queue => " + partitionService.getMigrationQueueSize());
-            }
-
-            if (node.getState() == NodeState.ACTIVE) {
-                partitionService.publishPartitionRuntimeState();
+                logger.info("Remaining migration tasks in queue => " + partitionService.getMigrationQueueSize()
+                    + ". (" + migrationManager.getStats().formatToString(logger.isFineEnabled()) + ")");
+            } else if (node.getState() == NodeState.ACTIVE) {
+                if (node.getClusterService().getClusterVersion().isGreaterOrEqual(Versions.V3_12)) {
+                    partitionService.checkClusterPartitionRuntimeStates();
+                } else {
+                    // RU_COMPAT_3_11
+                    partitionService.publishPartitionRuntimeState();
+                }
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationCommitOperation.java
@@ -18,8 +18,10 @@ package com.hazelcast.internal.partition.operation;
 
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
+import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.partition.PartitionRuntimeState;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
@@ -38,17 +40,29 @@ import java.io.IOException;
  */
 public class MigrationCommitOperation extends AbstractPartitionOperation implements MigrationCycleOperation, Versioned {
 
+    // RU_COMPAT_3_11
     private PartitionRuntimeState partitionState;
+
+    private MigrationInfo migration;
+
+    private int newPartitionStateVersion;
 
     private String expectedMemberUuid;
 
-    private boolean success;
+    private transient boolean success;
 
     public MigrationCommitOperation() {
     }
 
+    // RU_COMPAT_3_11
     public MigrationCommitOperation(PartitionRuntimeState partitionState, String expectedMemberUuid) {
         this.partitionState = partitionState;
+        this.expectedMemberUuid = expectedMemberUuid;
+    }
+
+    public MigrationCommitOperation(MigrationInfo migration, int newPartitionStateVersion, String expectedMemberUuid) {
+        this.migration = migration;
+        this.newPartitionStateVersion = newPartitionStateVersion;
         this.expectedMemberUuid = expectedMemberUuid;
     }
 
@@ -62,9 +76,15 @@ public class MigrationCommitOperation extends AbstractPartitionOperation impleme
                     + "and not the expected target.");
         }
 
-        partitionState.setMaster(getCallerAddress());
-        InternalPartitionServiceImpl partitionService = getService();
-        success = partitionService.processPartitionRuntimeState(partitionState);
+        InternalPartitionServiceImpl service = getService();
+
+        if (nodeEngine.getClusterService().getClusterVersion().isGreaterOrEqual(Versions.V3_12)) {
+            success = service.commitMigrationOnDestination(migration, newPartitionStateVersion, getCallerAddress());
+        } else {
+            // RU_COMPAT_3_11
+            partitionState.setMaster(getCallerAddress());
+            success = service.processPartitionRuntimeState(partitionState);
+        }
     }
 
     @Override
@@ -90,15 +110,29 @@ public class MigrationCommitOperation extends AbstractPartitionOperation impleme
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         expectedMemberUuid = in.readUTF();
-        partitionState = new PartitionRuntimeState();
-        partitionState.readData(in);
+
+        if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+            migration = in.readObject();
+            newPartitionStateVersion = in.readInt();
+        } else {
+            // RU_COMPAT_3_11
+            partitionState = new PartitionRuntimeState();
+            partitionState.readData(in);
+        }
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(expectedMemberUuid);
-        partitionState.writeData(out);
+
+        if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
+            out.writeObject(migration);
+            out.writeInt(newPartitionStateVersion);
+        } else {
+            // RU_COMPAT_3_11
+            partitionState.writeData(out);
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -39,6 +39,7 @@ import com.hazelcast.spi.partition.MigrationEndpoint;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
@@ -67,9 +68,9 @@ public class MigrationOperation extends BaseMigrationOperation implements Target
     public MigrationOperation() {
     }
 
-    public MigrationOperation(MigrationInfo migrationInfo, int partitionStateVersion,
-                       ReplicaFragmentMigrationState fragmentMigrationState, boolean firstFragment, boolean lastFragment) {
-        super(migrationInfo, partitionStateVersion);
+    public MigrationOperation(MigrationInfo migrationInfo, List<MigrationInfo> completedMigrations, int partitionStateVersion,
+            ReplicaFragmentMigrationState fragmentMigrationState, boolean firstFragment, boolean lastFragment) {
+        super(migrationInfo, completedMigrations, partitionStateVersion);
         this.fragmentMigrationState = fragmentMigrationState;
         this.firstFragment = firstFragment;
         this.lastFragment = lastFragment;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PublishCompletedMigrationsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PublishCompletedMigrationsOperation.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.partition.operation;
+
+import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.internal.partition.MigrationCycleOperation;
+import com.hazelcast.internal.partition.MigrationInfo;
+import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
+import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.ExceptionAction;
+import com.hazelcast.spi.exception.TargetNotMemberException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Sent by master member to other cluster members to publish completed migrations
+ * and the new partition state version.
+ *
+ * @since 3.12
+ */
+public class PublishCompletedMigrationsOperation extends AbstractPartitionOperation implements MigrationCycleOperation {
+
+    private Collection<MigrationInfo> completedMigrations;
+
+    private int newPartitionStateVersion;
+
+    private transient boolean success;
+
+    public PublishCompletedMigrationsOperation() {
+    }
+
+    public PublishCompletedMigrationsOperation(Collection<MigrationInfo> completedMigrations,
+            int newPartitionStateVersion) {
+        this.completedMigrations = completedMigrations;
+        this.newPartitionStateVersion = newPartitionStateVersion;
+    }
+
+    @Override
+    public void run() {
+        InternalPartitionServiceImpl service = getService();
+        success = service.applyCompletedMigrations(completedMigrations, newPartitionStateVersion, getCallerAddress());
+    }
+
+    @Override
+    public Object getResponse() {
+        return success;
+    }
+
+    @Override
+    public String getServiceName() {
+        return InternalPartitionService.SERVICE_NAME;
+    }
+
+    @Override
+    public ExceptionAction onInvocationException(Throwable throwable) {
+        if (throwable instanceof MemberLeftException
+                || throwable instanceof TargetNotMemberException) {
+            return ExceptionAction.THROW_EXCEPTION;
+        }
+        return super.onInvocationException(throwable);
+    }
+
+    @Override
+    protected void readInternal(ObjectDataInput in) throws IOException {
+        super.readInternal(in);
+        int len = in.readInt();
+        completedMigrations = new ArrayList<MigrationInfo>(len);
+        for (int i = 0; i < len; i++) {
+            MigrationInfo migrationInfo = new MigrationInfo();
+            migrationInfo.readData(in);
+            completedMigrations.add(migrationInfo);
+        }
+        newPartitionStateVersion = in.readInt();
+    }
+
+    @Override
+    protected void writeInternal(ObjectDataOutput out) throws IOException {
+        super.writeInternal(out);
+        int len = completedMigrations.size();
+        out.writeInt(len);
+        for (MigrationInfo migrationInfo : completedMigrations) {
+            migrationInfo.writeData(out);
+        }
+        out.writeInt(newPartitionStateVersion);
+    }
+
+    @Override
+    public int getId() {
+        return PartitionDataSerializerHook.PUBLISH_COMPLETED_MIGRATIONS;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractGracefulShutdownCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractGracefulShutdownCorrectnessTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractGracefulShutdownCorrectnessTest extends PartitionC
             shutdownNodes(shutdownNodeCount);
             size -= shutdownNodeCount;
 
-            assertSizeAndData();
+            assertSizeAndDataEventually();
         }
     }
 
@@ -106,7 +106,7 @@ public abstract class AbstractGracefulShutdownCorrectnessTest extends PartitionC
             addresses = shutdownNodes(shutdownNodeCount);
             size -= shutdownNodeCount;
 
-            assertSizeAndData();
+            assertSizeAndDataEventually();
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractPartitionAssignmentsCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractPartitionAssignmentsCorrectnessTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.partition;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -28,7 +29,6 @@ import java.util.Collection;
 import java.util.Collections;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractPartitionAssignmentsCorrectnessTest extends PartitionCorrectnessTestSupport {
 
@@ -97,12 +97,14 @@ public abstract class AbstractPartitionAssignmentsCorrectnessTest extends Partit
             Node node = getNode(hz);
             InternalPartitionService partitionService = node.getPartitionService();
             InternalPartition[] partitions = partitionService.getInternalPartitions();
+            ClusterServiceImpl clusterService = node.getClusterService();
+            Address thisAddress = node.getThisAddress();
 
             for (InternalPartition partition : partitions) {
                 for (int i = 0; i < replicaCount; i++) {
                     Address replicaAddress = partition.getReplicaAddress(i);
-                    assertNotNull("Replica " + i + " is not found in " + partition, replicaAddress);
-                    assertTrue("Not member: " + replicaAddress, node.getClusterService().getMember(replicaAddress) != null);
+                    assertNotNull("On " + thisAddress + ", Replica " + i + " is not found in " + partition, replicaAddress);
+                    assertNotNull("On " + thisAddress + ", Not member: " + replicaAddress, clusterService.getMember(replicaAddress));
                 }
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownCorrectnessTest.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.internal.partition;
 
+import com.hazelcast.test.ChangeLoggingRule;
 import com.hazelcast.test.HazelcastParametersRunnerFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -30,6 +32,9 @@ import java.util.Collection;
 @Parameterized.UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class GracefulShutdownCorrectnessTest extends AbstractGracefulShutdownCorrectnessTest {
+
+    @ClassRule
+    public static ChangeLoggingRule changeLoggingRule = new ChangeLoggingRule("log4j2-debug.xml");
 
     @Parameterized.Parameters(name = "backups:{0},nodes:{1},shutdown:{2}")
     public static Collection<Object[]> parameters() {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/GracefulShutdownTest.java
@@ -42,6 +42,8 @@ import java.util.concurrent.Future;
 
 import static com.hazelcast.instance.TestUtil.terminateInstance;
 import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
+import static com.hazelcast.internal.partition.AbstractPartitionAssignmentsCorrectnessTest.assertPartitionAssignments;
+import static com.hazelcast.internal.partition.AbstractPartitionAssignmentsCorrectnessTest.assertPartitionAssignmentsEventually;
 import static com.hazelcast.internal.partition.InternalPartition.MAX_REPLICA_COUNT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -108,7 +110,7 @@ public class GracefulShutdownTest extends HazelcastTestSupport {
 
         warmUpPartitions(hz1, hz2, hz3);
         hz2.shutdown();
-        assertPartitionAssignments();
+        assertPartitionAssignmentsEventually(factory);
     }
 
     @Test
@@ -126,7 +128,7 @@ public class GracefulShutdownTest extends HazelcastTestSupport {
 
         hz2.shutdown();
 
-        assertPartitionAssignments();
+        assertPartitionAssignmentsEventually(factory);
     }
 
     @Test
@@ -138,7 +140,7 @@ public class GracefulShutdownTest extends HazelcastTestSupport {
         warmUpPartitions(hz1, hz2, hz3);
         hz2.shutdown();
 
-        assertPartitionAssignments();
+        assertPartitionAssignments(factory);
     }
 
     @Test
@@ -160,7 +162,7 @@ public class GracefulShutdownTest extends HazelcastTestSupport {
         warmUpPartitions(hz1, hz2, hz3);
         hz1.shutdown();
 
-        assertPartitionAssignments();
+        assertPartitionAssignmentsEventually(factory);
     }
 
     @Test
@@ -176,7 +178,7 @@ public class GracefulShutdownTest extends HazelcastTestSupport {
 
         hz1.shutdown();
 
-        assertPartitionAssignments();
+        assertPartitionAssignmentsEventually(factory);
     }
 
     @Test
@@ -188,7 +190,7 @@ public class GracefulShutdownTest extends HazelcastTestSupport {
         warmUpPartitions(hz1, hz2, hz3);
         hz1.shutdown();
 
-        assertPartitionAssignments();
+        assertPartitionAssignments(factory);
     }
 
     @Test
@@ -263,7 +265,7 @@ public class GracefulShutdownTest extends HazelcastTestSupport {
         assertOpenEventually(latch);
 
         if (initializePartitions) {
-            assertPartitionAssignments();
+            assertPartitionAssignmentsEventually(factory);
         }
     }
 
@@ -295,7 +297,7 @@ public class GracefulShutdownTest extends HazelcastTestSupport {
         }
 
         assertOpenEventually(latch);
-        assertPartitionAssignments();
+        assertPartitionAssignmentsEventually(factory);
     }
 
     @Test
@@ -349,7 +351,7 @@ public class GracefulShutdownTest extends HazelcastTestSupport {
         terminateInstance(instances[terminateIndex]);
 
         assertOpenEventually(latch);
-        assertPartitionAssignments();
+        assertPartitionAssignmentsEventually(factory);
     }
 
     @Test
@@ -477,10 +479,6 @@ public class GracefulShutdownTest extends HazelcastTestSupport {
 
         f1.get();
         f2.get();
-    }
-
-    private void assertPartitionAssignments() {
-        PartitionAssignmentsCorrectnessTest.assertPartitionAssignments(factory);
     }
 
     private static void assertPartitionTableEquals(InternalPartition[] partitions1, InternalPartition[] partitions2) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MasterSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MasterSplitTest.java
@@ -65,7 +65,7 @@ public class MasterSplitTest extends HazelcastTestSupport {
 
         int partitionStateVersion = getPartitionService(member1).getPartitionStateVersion();
 
-        Operation op = new MigrationRequestOperation(migration, partitionStateVersion, true);
+        Operation op = new MigrationRequestOperation(migration, Collections.<MigrationInfo>emptyList(), partitionStateVersion, true);
 
         InvocationBuilder invocationBuilder = getOperationServiceImpl(member1)
                 .createInvocationBuilder(SERVICE_NAME, op, getAddress(member2))
@@ -101,7 +101,7 @@ public class MasterSplitTest extends HazelcastTestSupport {
 
         ReplicaFragmentMigrationState migrationState
                 = new ReplicaFragmentMigrationState(Collections.<ServiceNamespace, long[]>emptyMap(), Collections.<Operation>emptySet());
-        Operation op = new MigrationOperation(migration, partitionStateVersion, migrationState, true, true);
+        Operation op = new MigrationOperation(migration, Collections.<MigrationInfo>emptyList(), partitionStateVersion, migrationState, true, true);
 
         InvocationBuilder invocationBuilder = getOperationServiceImpl(member1)
                 .createInvocationBuilder(SERVICE_NAME, op, getAddress(member2))

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/MigrationInvocationsSafetyTest.java
@@ -456,7 +456,7 @@ public class MigrationInvocationsSafetyTest extends PartitionCorrectnessTestSupp
         TestMigrationAwareService service = getNodeEngineImpl(hz).getService(TestMigrationAwareService.SERVICE_NAME);
         List<PartitionMigrationEvent> events = service.getBeforeEvents();
         Set<PartitionMigrationEvent> uniqueEvents = new HashSet<PartitionMigrationEvent>(events);
-        assertEquals(uniqueEvents.size(), events.size());
+        assertEquals("Node: " + getAddress(hz) + ", Events: " + events, uniqueEvents.size(), events.size());
     }
 
     private static InternalPartitionServiceImpl getPartitionServiceImpl(HazelcastInstance hz) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
@@ -255,8 +255,7 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
     }
 
     private <N> void assertPartitionVersionsAndBackupValues(int actualBackupCount, TestAbstractMigrationAwareService<N> service,
-                                                            Node node, InternalPartition[] partitions, N name,
-                                                            boolean allowDirty) throws InterruptedException {
+                                                            Node node, InternalPartition[] partitions, N name, boolean allowDirty) {
         Address thisAddress = node.getThisAddress();
         ServiceNamespace namespace = service.getNamespace(name);
 
@@ -267,7 +266,7 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
 
                 for (int replica = 1; replica <= actualBackupCount; replica++) {
                     Address address = partition.getReplicaAddress(replica);
-                    assertNotNull("Replica: " + replica + " is not found in " + partition, address);
+                    assertNotNull("On " + thisAddress + ", Replica: " + replica + " is not found in " + partition, address);
 
                     HazelcastInstance backupInstance = factory.getInstance(address);
                     assertNotNull("Instance for " + address + " is not found! -> " + partition, backupInstance);

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationPlannerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationPlannerTest.java
@@ -50,7 +50,7 @@ public class MigrationPlannerTest {
 
     @Test
     public void test_MOVE() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -59,7 +59,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5705), "5705"),
@@ -69,14 +69,14 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5701), "5701"), 0, -1, new PartitionReplica(new Address("localhost", 5704), "5704"), -1, 0);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5703), "5703"), 2, -1, new PartitionReplica(new Address("localhost", 5705), "5705"), -1, 2);
     }
 
     @Test
     public void test_COPY() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 null,
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -85,7 +85,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -95,13 +95,13 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(null, -1, -1, new PartitionReplica(new Address("localhost", 5704), "5704"), -1, 1);
     }
 
     @Test
     public void test_SHIFT_DOWN_withNullKeepReplicaIndex() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 null,
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -110,7 +110,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -120,13 +120,13 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5701), "5701"), 0, 1, new PartitionReplica(new Address("localhost", 5704), "5704"), -1, 0);
     }
 
     @Test
     public void test_SHIFT_DOWN_withNullNonNullKeepReplicaIndex() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -135,7 +135,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -145,14 +145,14 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5701), "5701"), 0, -1, new PartitionReplica(new Address("localhost", 5704), "5704"), -1, 0);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5702), "5702"), 1, -1, new PartitionReplica(new Address("localhost", 5701), "5701"), -1, 1);
     }
 
     @Test
     public void test_SHIFT_DOWN_performedBy_MOVE() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -161,7 +161,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {new PartitionReplica(new Address("localhost", 5704), "5704"),
+        final PartitionReplica[] newReplicas = {new PartitionReplica(new Address("localhost", 5704), "5704"),
                                                  new PartitionReplica(new Address("localhost", 5701), "5701"),
                                                  new PartitionReplica(new Address("localhost", 5702), "5702"),
                                                  null,
@@ -170,7 +170,7 @@ public class MigrationPlannerTest {
                                                  null,
                                                  };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5701), "5701"), 0, -1, new PartitionReplica(new Address("localhost", 5704), "5704"), -1, 0);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5702), "5702"), 1, -1, new PartitionReplica(new Address("localhost", 5701), "5701"), -1, 1);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5703), "5703"), 2, -1, new PartitionReplica(new Address("localhost", 5702), "5702"), -1, 2);
@@ -178,7 +178,7 @@ public class MigrationPlannerTest {
 
     @Test
     public void test_SHIFT_UP() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 null,
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -187,7 +187,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
@@ -197,7 +197,7 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
 
         verify(callback).migrate(null, -1, -1, new PartitionReplica(new Address("localhost", 5703), "5703"), 2, 1);
         verify(callback).migrate(null, -1, -1, new PartitionReplica(new Address("localhost", 5704), "5704"), 3, 2);
@@ -205,7 +205,7 @@ public class MigrationPlannerTest {
 
     @Test
     public void test_SHIFT_UPS_performedBy_MOVE() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -214,7 +214,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
@@ -224,7 +224,7 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
 
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5704), "5704"), 3, -1, new PartitionReplica(new Address("localhost", 5705), "5705"), -1, 3);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5703), "5703"), 2, -1, new PartitionReplica(new Address("localhost", 5704), "5704"), -1, 2);
@@ -233,7 +233,7 @@ public class MigrationPlannerTest {
 
     @Test
     public void test_SHIFT_DOWN_performedAfterKnownNewReplicaOwnerKickedOutOfReplicas() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -242,7 +242,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
                 new PartitionReplica(new Address("localhost", 5705), "5705"),
@@ -252,7 +252,7 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5701), "5701"), 0, 5, new PartitionReplica(new Address("localhost", 5704), "5704"), -1, 0);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5705), "5705"), 3, -1, new PartitionReplica(new Address("localhost", 5706), "5706"), -1, 3);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5703), "5703"), 2, -1, new PartitionReplica(new Address("localhost", 5705), "5705"), -1, 2);
@@ -261,7 +261,7 @@ public class MigrationPlannerTest {
 
     @Test
     public void test_SHIFT_DOWN_performedBeforeNonConflicting_SHIFT_UP() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -270,7 +270,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
                 new PartitionReplica(new Address("localhost", 5705), "5705"),
@@ -280,7 +280,7 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5701), "5701"), 0, 4, new PartitionReplica(new Address("localhost", 5704), "5704"), -1, 0);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5705), "5705"), 3, -1, new PartitionReplica(new Address("localhost", 5706), "5706"), -1, 3);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5703), "5703"), 2, -1, new PartitionReplica(new Address("localhost", 5705), "5705"), -1, 2);
@@ -288,7 +288,7 @@ public class MigrationPlannerTest {
 
     @Test
     public void test_MOVE_toNull() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -297,7 +297,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -307,13 +307,13 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5705), "5705"), 3, -1, null, -1, -1);
     }
 
     @Test
     public void test_SHIFT_UP_toReplicaIndexWithExistingOwner() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -322,7 +322,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -332,14 +332,14 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5702), "5702"), 1, -1, new PartitionReplica(new Address("localhost", 5704), "5704"), 3, 1);
     }
 
     @Test
     public void test_MOVE_performedAfter_SHIFT_UP_toReplicaIndexWithExistingOwnerKicksItOutOfCluster()
             throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -348,7 +348,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -358,14 +358,14 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5702), "5702"), 1, -1, new PartitionReplica(new Address("localhost", 5704), "5704"), 3, 1);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5701), "5701"), 0, -1, new PartitionReplica(new Address("localhost", 5702), "5702"), -1, 0);
     }
 
     @Test
     public void test_SHIFT_UP_multipleTimes() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 null,
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -374,7 +374,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
                 new PartitionReplica(new Address("localhost", 5704), "5704"),
@@ -384,14 +384,14 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(null, -1, -1, new PartitionReplica(new Address("localhost", 5703), "5703"), 2, 1);
         verify(callback).migrate(null, -1, -1, new PartitionReplica(new Address("localhost", 5704), "5704"), 3, 2);
     }
 
     @Test
     public void test_SHIFT_UP_nonNullSource_isNoLongerReplica() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 null,
@@ -400,7 +400,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 null,
                 null,
@@ -410,13 +410,13 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5701), "5701"), 0, -1, new PartitionReplica(new Address("localhost", 5702), "5702"), 1, 0);
     }
 
     @Test
     public void test_SHIFT_UP_nonNullSource_willGetAnotherMOVE() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 new PartitionReplica(new Address("localhost", 5702), "5702"),
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -425,7 +425,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 null,
@@ -435,14 +435,14 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5701), "5701"), 0, -1, new PartitionReplica(new Address("localhost", 5703), "5703"), 2, 0);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5702), "5702"), 1, -1, new PartitionReplica(new Address("localhost", 5701), "5701"), -1, 1);
     }
 
     @Test
     public void test_SHIFT_UP_SHIFT_DOWN_atomicTogether() throws UnknownHostException {
-        final PartitionReplica[] oldAddresses = {
+        final PartitionReplica[] oldReplicas = {
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 null,
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
@@ -451,7 +451,7 @@ public class MigrationPlannerTest {
                 null,
                 null,
         };
-        final PartitionReplica[] newAddresses = {
+        final PartitionReplica[] newReplicas = {
                 new PartitionReplica(new Address("localhost", 5703), "5703"),
                 new PartitionReplica(new Address("localhost", 5701), "5701"),
                 null,
@@ -461,7 +461,7 @@ public class MigrationPlannerTest {
                 null,
         };
 
-        migrationPlanner.planMigrations(oldAddresses, newAddresses, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
         verify(callback).migrate(new PartitionReplica(new Address("localhost", 5701), "5701"), 0, 1, new PartitionReplica(new Address("localhost", 5703), "5703"), 2, 0);
     }
 
@@ -573,20 +573,20 @@ public class MigrationPlannerTest {
     }
 
     private void testRandom(int initialLen) throws UnknownHostException {
-        PartitionReplica[] oldMembers = new PartitionReplica[InternalPartition.MAX_REPLICA_COUNT];
+        PartitionReplica[] oldReplicas = new PartitionReplica[InternalPartition.MAX_REPLICA_COUNT];
         for (int i = 0; i < initialLen; i++) {
-            oldMembers[i] = new PartitionReplica(newAddress(5000 + i), UuidUtil.newUnsecureUuidString());
+            oldReplicas[i] = new PartitionReplica(newAddress(5000 + i), UuidUtil.newUnsecureUuidString());
         }
 
-        PartitionReplica[] newMembers = Arrays.copyOf(oldMembers, oldMembers.length);
-        int newLen = (int) (Math.random() * (oldMembers.length - initialLen + 1));
+        PartitionReplica[] newReplicas = Arrays.copyOf(oldReplicas, oldReplicas.length);
+        int newLen = (int) (Math.random() * (oldReplicas.length - initialLen + 1));
         for (int i = 0; i < newLen; i++) {
-            newMembers[i + initialLen] = new PartitionReplica(newAddress(6000 + i), UuidUtil.newUnsecureUuidString());
+            newReplicas[i + initialLen] = new PartitionReplica(newAddress(6000 + i), UuidUtil.newUnsecureUuidString());
         }
 
-        shuffle(newMembers, initialLen + newLen);
+        shuffle(newReplicas, initialLen + newLen);
 
-        migrationPlanner.planMigrations(oldMembers, newMembers, callback);
+        migrationPlanner.planMigrations(0, oldReplicas, newReplicas, callback);
     }
 
     private void shuffle(PartitionReplica[] array, int len) {


### PR DESCRIPTION
When partition count becomes higher, cost of publishing
the new partition state increases dramatically.
And if partition count is high but average data size
in partitions is low, then committing migration
and publishing new partition state dominate most of the
total migration time.

To fix that, instead of sending the whole partition table
after each migration, only the latest completed migrations are
sent. Members receiving completed migrations list, apply those
to their partition state and generate the new partition table
theirselves.

Additionally, there's no need to send completed migrations
to all cluster members after each migration. Instead, completed migrations
are sent to source and destination members of the migration
inside migration operations. Remaining members receive
completed migrations in batches asynchronously.

There's a minor change in periodic partition table publishing task too.
Instead of publishing partition table periodically to all members,
master asks whether their partition table is stale when compared to
master's version. If one responds as its partition table is stale,
master sends partition table to that specific member only.