### PR TITLE
Improve TransactionalMap JavaDoc - ACID guarantees

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/TransactionalMap.java
@@ -61,6 +61,9 @@ import java.util.concurrent.TimeUnit;
  *      tm.rollback();
  * }
  * </code></pre>
+ * <h2>ACID Guarantees</h2>
+ * It should be noted that in split-brain situations or during a node failure Hazelcast might not be able
+ * to always hold ACID guarantees.
  *
  * @param <K> type of the map key
  * @param <V> type of the map value


### PR DESCRIPTION
Simple 1:1 replacement for stale PR https://github.com/hazelcast/hazelcast/pull/11684 from @dbrimley.

This PR adds a warning/note to JavaDoc for split-brain behavior in transactions.