### PR TITLE
Minor cleanup in the ClientListenerService logic.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -540,14 +540,9 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
 
     @SuppressWarnings("checkstyle:illegaltype")
     private AbstractClientListenerService initListenerService() {
-        int eventQueueCapacity = properties.getInteger(ClientProperty.EVENT_QUEUE_CAPACITY);
-        int eventThreadCount = properties.getInteger(ClientProperty.EVENT_THREAD_COUNT);
-        final ClientNetworkConfig networkConfig = config.getNetworkConfig();
-        if (networkConfig.isSmartRouting()) {
-            return new SmartClientListenerService(this, eventThreadCount, eventQueueCapacity);
-        } else {
-            return new NonSmartClientListenerService(this, eventThreadCount, eventQueueCapacity);
-        }
+        return config.getNetworkConfig().isSmartRouting()
+                ? new SmartClientListenerService(this)
+                : new NonSmartClientListenerService(this);
     }
 
     private ClientExecutionServiceImpl initExecutionService() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/NonSmartClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/NonSmartClientListenerService.java
@@ -21,9 +21,8 @@ import com.hazelcast.nio.ConnectionListener;
 
 public class NonSmartClientListenerService extends AbstractClientListenerService implements ConnectionListener {
 
-    public NonSmartClientListenerService(HazelcastClientInstanceImpl client,
-                                         int eventThreadCount, int eventQueueCapacity) {
-        super(client, eventThreadCount, eventQueueCapacity);
+    public NonSmartClientListenerService(HazelcastClientInstanceImpl client) {
+        super(client);
     }
 
     boolean registersLocalOnly() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/SmartClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/SmartClientListenerService.java
@@ -32,9 +32,8 @@ import static com.hazelcast.util.StringUtil.timeToString;
 
 public class SmartClientListenerService extends AbstractClientListenerService  {
 
-    public SmartClientListenerService(HazelcastClientInstanceImpl client,
-                                      int eventThreadCount, int eventQueueCapacity) {
-        super(client, eventThreadCount, eventQueueCapacity);
+    public SmartClientListenerService(HazelcastClientInstanceImpl client) {
+        super(client);
     }
 
     @Override


### PR DESCRIPTION
The constructor of the ClientListenerService implementations is now self contained.
So it will pull out the appropriate settings out of the client properties instead of
expecting them to be passed from the outside.

This simplifies the constructors and the calling logic.