### PR TITLE
YAML loader and YAML specific DOM builder

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/AbstractYamlNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/AbstractYamlNode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+abstract class AbstractYamlNode implements YamlNode {
+    private final YamlNode parent;
+    private final String nodeName;
+
+    AbstractYamlNode(YamlNode parent, String nodeName) {
+        this.parent = parent;
+        this.nodeName = nodeName;
+    }
+
+    @Override
+    public String nodeName() {
+        return nodeName != null ? nodeName : UNNAMED_NODE;
+    }
+
+    @Override
+    public YamlNode parent() {
+        return parent;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/ReflectiveYamlDocumentLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/ReflectiveYamlDocumentLoader.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * {@link YamlDocumentLoader} implementation loading YAML documents via
+ * the SnakeYaml Engine library. Since the used library is a Java8+
+ * library, this implementation uses reflection to make the source
+ * compiling with JDK6. The aim of having this class is to hide the
+ * reflective access from {@link YamlLoader} and is meant to be
+ * exclusively used by {@link YamlLoader}.
+ */
+class ReflectiveYamlDocumentLoader implements YamlDocumentLoader {
+    private final Object load;
+    private final Method loadFromInputStream;
+    private final Method loadFromReader;
+    private final Method loadFromString;
+
+    ReflectiveYamlDocumentLoader() {
+        try {
+            // instantiate LoadSettingsBuilder
+            Class<?> loadSettingsBuilderClass = Class.forName("org.snakeyaml.engine.v1.api.LoadSettingsBuilder");
+            Constructor<?> loadSettingsBuilderConstructor = loadSettingsBuilderClass.getConstructor();
+            Object loadSettingsBuilder = loadSettingsBuilderConstructor.newInstance();
+            Method buildLoadSettingsMethod = loadSettingsBuilderClass.getMethod("build");
+
+            // instantiate LoadSettings via the builder
+            Object loadSettings = buildLoadSettingsMethod.invoke(loadSettingsBuilder);
+
+            // instantiate Load
+            Class<?> loadSettingsClass = Class.forName("org.snakeyaml.engine.v1.api.LoadSettings");
+            Class<?> loadClass = Class.forName("org.snakeyaml.engine.v1.api.Load");
+            Constructor<?> constructor = loadClass.getConstructor(loadSettingsClass);
+            load = constructor.newInstance(loadSettings);
+
+            // getting the Method instances for each loadFrom Load methods
+            loadFromInputStream = loadClass.getMethod("loadFromInputStream", InputStream.class);
+            loadFromReader = loadClass.getMethod("loadFromReader", Reader.class);
+            loadFromString = loadClass.getMethod("loadFromString", String.class);
+        } catch (Exception e) {
+            throw new YamlException("An error occurred while creating the SnakeYaml Load class", e);
+        }
+    }
+
+    @Override
+    public Object loadFromInputStream(InputStream yamlStream) {
+        checkNotNull(yamlStream, "The provided InputStream to load the YAML from must not be null");
+        try {
+            return loadFromInputStream.invoke(load, yamlStream);
+        } catch (Exception e) {
+            throw new YamlException("Couldn't load YAML document from the provided InputStream", e);
+        }
+    }
+
+    @Override
+    public Object loadFromReader(Reader yamlReader) {
+        checkNotNull(yamlReader, "The provided Reader to load the YAML from must not be null");
+        try {
+            return loadFromReader.invoke(load, yamlReader);
+        } catch (Exception e) {
+            throw new YamlException("Couldn't load YAML document from the provided Reader", e);
+        }
+    }
+
+    @Override
+    public Object loadFromString(String yaml) {
+        checkNotNull(yaml, "The provided String to load the YAML from must not be null");
+        try {
+            return loadFromString.invoke(load, yaml);
+        } catch (Exception e) {
+            throw new YamlException("Couldn't load YAML document from the provided String", e);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlCollection.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+/**
+ * Common ancestor interface for {@link YamlMapping} and {@link YamlSequence} nodes
+ */
+public interface YamlCollection extends YamlNode {
+
+    /**
+     * Returns the children nodes
+     *
+     * @return the children nodes
+     */
+    Iterable<YamlNode> children();
+
+    /**
+     * Returns the number of the children that the collection has
+     *
+     * @return the number of the children
+     */
+    int childCount();
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlDocumentLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlDocumentLoader.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+import java.io.InputStream;
+import java.io.Reader;
+
+/**
+ * Interface for YAML document loader implementations
+ * <p/>
+ * This interface and its implementations are meant to hide the actual
+ * loading logic from the {@link YamlLoader}.
+ *
+ * @see ReflectiveYamlDocumentLoader
+ */
+interface YamlDocumentLoader {
+
+    /**
+     * Loads the YAML document from the provided {@link InputStream}
+     *
+     * @param yamlStream The input stream to load the YAML document from
+     * @return the root of the loaded YAML document
+     * @throws NullPointerException if the provided {@link InputStream} is null
+     */
+    Object loadFromInputStream(InputStream yamlStream);
+
+    /**
+     * Loads the YAML document from the provided {@link Reader}
+     *
+     * @param yamlReader The reader to load the YAML document from
+     * @return the root of the loaded YAML document
+     * @throws NullPointerException if the provided {@link Reader} is null
+     */
+    Object loadFromReader(Reader yamlReader);
+
+    /**
+     * Loads the YAML document from the provided {@link String}
+     *
+     * @param yaml The string to load the YAML document from
+     * @return the root of the loaded YAML document
+     * @throws NullPointerException if the provided {@link String} is null
+     */
+    Object loadFromString(String yaml);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlDomBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlDomBuilder.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds a DOM of {@link YamlNode} instances from the structure parsed
+ * by SnakeYaml.
+ *
+ * @see YamlMapping
+ * @see YamlSequence
+ * @see YamlScalar
+ */
+public final class YamlDomBuilder {
+    private YamlDomBuilder() {
+    }
+
+    static YamlNode build(Object document, String rootName) {
+        if (document == null) {
+            throw new YamlException("The provided document is null");
+        }
+
+        if (rootName != null && !(document instanceof Map)) {
+            throw new YamlException("The provided document is not a Map, and rootName is defined.");
+        }
+
+        final Object rootNode;
+        if (rootName != null) {
+            rootNode = ((Map) document).get(rootName);
+
+            if (rootNode == null) {
+                throw new YamlException("The required " + rootName + " root node couldn't be found in the document root");
+            }
+        } else {
+            rootNode = document;
+        }
+
+        return buildNode(null, rootName, rootNode);
+    }
+
+    public static YamlNode build(Object document) {
+        return build(document, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static YamlNode buildNode(YamlNode parent, String nodeName, Object sourceNode) {
+        if (sourceNode == null) {
+            return null;
+        }
+
+        if (sourceNode instanceof Map) {
+            YamlMappingImpl node = new YamlMappingImpl(parent, nodeName);
+            buildChildren(node, (Map<String, Object>) sourceNode);
+            return node;
+        } else if (sourceNode instanceof List) {
+            YamlSequenceImpl node = new YamlSequenceImpl(parent, nodeName);
+            buildChildren(node, (List<Object>) sourceNode);
+            return node;
+        } else if (isSupportedScalarType(sourceNode)) {
+            return buildScalar(parent, nodeName, sourceNode);
+        } else {
+            throw new YamlException("An unsupported scalar type is encountered: " + nodeName + " is an instance of "
+                    + sourceNode.getClass().getName() + ". The supported types are String, Integer, Double and Boolean.");
+        }
+    }
+
+    private static boolean isSupportedScalarType(Object sourceNode) {
+        return sourceNode instanceof String
+                || sourceNode instanceof Integer
+                || sourceNode instanceof Double
+                || sourceNode instanceof Boolean;
+    }
+
+    private static void buildChildren(YamlMappingImpl parentNode, Map<String, Object> mapNode) {
+        for (Map.Entry<String, Object> entry : mapNode.entrySet()) {
+            String childNodeName = entry.getKey();
+            Object childNodeValue = entry.getValue();
+            YamlNode child = buildNode(parentNode, childNodeName, childNodeValue);
+            parentNode.addChild(childNodeName, child);
+        }
+    }
+
+    private static void buildChildren(YamlSequenceImpl parentNode, List<Object> listNode) {
+        for (Object value : listNode) {
+            YamlNode child = buildNode(parentNode, null, value);
+            parentNode.addChild(child);
+        }
+    }
+
+    private static YamlNode buildScalar(YamlNode parent, String nodeName, Object value) {
+        return new YamlScalarImpl(parent, nodeName, value);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+import com.hazelcast.core.HazelcastException;
+
+public class YamlException extends HazelcastException {
+
+    public YamlException(final String message) {
+        super(message);
+    }
+
+    public YamlException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlLoader.java
@@ -16,9 +16,7 @@
 
 package com.hazelcast.internal.yaml;
 
-import org.snakeyaml.engine.v1.api.Load;
-import org.snakeyaml.engine.v1.api.LoadSettings;
-import org.snakeyaml.engine.v1.api.LoadSettingsBuilder;
+import com.hazelcast.internal.util.JavaVersion;
 
 import java.io.InputStream;
 import java.io.Reader;
@@ -50,7 +48,7 @@ public final class YamlLoader {
      */
     public static YamlNode load(InputStream inputStream, String rootName) {
         try {
-            Load load = getLoad();
+            YamlDocumentLoader load = getLoad();
             Object document = load.loadFromInputStream(inputStream);
 
             return buildDom(rootName, document);
@@ -68,7 +66,7 @@ public final class YamlLoader {
      */
     public static YamlNode load(InputStream inputStream) {
         try {
-            Load load = getLoad();
+            YamlDocumentLoader load = getLoad();
             Object document = load.loadFromInputStream(inputStream);
 
             return buildDom(document);
@@ -89,7 +87,7 @@ public final class YamlLoader {
      */
     public static YamlNode load(Reader reader, String rootName) {
         try {
-            Load load = getLoad();
+            YamlDocumentLoader load = getLoad();
             Object document = load.loadFromReader(reader);
 
             return buildDom(rootName, document);
@@ -107,7 +105,7 @@ public final class YamlLoader {
      */
     public static YamlNode load(Reader reader) {
         try {
-            Load load = getLoad();
+            YamlDocumentLoader load = getLoad();
             Object document = load.loadFromReader(reader);
 
             return buildDom(document);
@@ -128,7 +126,7 @@ public final class YamlLoader {
      */
     public static YamlNode load(String yaml, String rootName) {
         try {
-            Load load = getLoad();
+            YamlDocumentLoader load = getLoad();
             Object document = load.loadFromString(yaml);
 
             return buildDom(rootName, document);
@@ -146,8 +144,8 @@ public final class YamlLoader {
      */
     public static YamlNode load(String yaml) {
         try {
-            Load load = getLoad();
-            Object document = load.loadFromString(yaml);
+            YamlDocumentLoader loader = getLoad();
+            Object document = loader.loadFromString(yaml);
 
             return buildDom(document);
         } catch (Exception ex) {
@@ -155,9 +153,12 @@ public final class YamlLoader {
         }
     }
 
-    private static Load getLoad() {
-        LoadSettings loadSettings = new LoadSettingsBuilder().build();
-        return new Load(loadSettings);
+    private static YamlDocumentLoader getLoad() {
+        if (!JavaVersion.isAtLeast(JavaVersion.JAVA_1_8)) {
+            throw new UnsupportedOperationException("Processing YAML documents requires Java 8 or higher version");
+        }
+
+        return new ReflectiveYamlDocumentLoader();
     }
 
     private static YamlNode buildDom(String rootName, Object document) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlLoader.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+import org.snakeyaml.engine.v1.api.Load;
+import org.snakeyaml.engine.v1.api.LoadSettings;
+import org.snakeyaml.engine.v1.api.LoadSettingsBuilder;
+
+import java.io.InputStream;
+import java.io.Reader;
+
+/**
+ * YAML loader that can load, parse YAML documents and can build a tree
+ * of {@link YamlNode} instances.
+ * <p/>
+ * The possible sources of the YAML documents are:
+ * <ul>
+ * <li>{@link InputStream}</li>
+ * <li>{@link Reader}</li>
+ * <li>{@link String}</li>
+ * </ul>
+ */
+public final class YamlLoader {
+    private YamlLoader() {
+    }
+
+    /**
+     * Loads a YAML document from an {@link InputStream} and builds a
+     * {@link YamlNode} tree that is under the provided top-level
+     * {@code rootName} key. This loading mode requires the topmost level
+     * of the YAML document to be a mapping.
+     *
+     * @param inputStream The input stream to load the YAML from
+     * @param rootName    The name of the root's key
+     * @return the tree built from the YAML document
+     */
+    public static YamlNode load(InputStream inputStream, String rootName) {
+        try {
+            Load load = getLoad();
+            Object document = load.loadFromInputStream(inputStream);
+
+            return buildDom(rootName, document);
+        } catch (Exception ex) {
+            throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);
+        }
+    }
+
+    /**
+     * Loads a YAML document from an {@link InputStream} and builds a
+     * {@link YamlNode} tree.
+     *
+     * @param inputStream The input stream to load the YAML from
+     * @return the tree built from the YAML document
+     */
+    public static YamlNode load(InputStream inputStream) {
+        try {
+            Load load = getLoad();
+            Object document = load.loadFromInputStream(inputStream);
+
+            return buildDom(document);
+        } catch (Exception ex) {
+            throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);
+        }
+    }
+
+    /**
+     * Loads a YAML document from an {@link Reader} and builds a
+     * {@link YamlNode} tree that is under the provided top-level
+     * {@code rootName} key. This loading mode requires the topmost level
+     * of the YAML document to be a mapping.
+     *
+     * @param reader   The reader to load the YAML from
+     * @param rootName The name of the root's key
+     * @return the tree built from the YAML document
+     */
+    public static YamlNode load(Reader reader, String rootName) {
+        try {
+            Load load = getLoad();
+            Object document = load.loadFromReader(reader);
+
+            return buildDom(rootName, document);
+        } catch (Exception ex) {
+            throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);
+        }
+    }
+
+    /**
+     * Loads a YAML document from an {@link Reader} and builds a
+     * {@link YamlNode} tree.
+     *
+     * @param reader The reader to load the YAML from
+     * @return the tree built from the YAML document
+     */
+    public static YamlNode load(Reader reader) {
+        try {
+            Load load = getLoad();
+            Object document = load.loadFromReader(reader);
+
+            return buildDom(document);
+        } catch (Exception ex) {
+            throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);
+        }
+    }
+
+    /**
+     * Loads a YAML document from an {@link String} and builds a
+     * {@link YamlNode} tree that is under the provided top-level
+     * {@code rootName} key. This loading mode requires the topmost level
+     * of the YAML document to be a mapping.
+     *
+     * @param yaml     The string to load the YAML from
+     * @param rootName The name of the root's key
+     * @return the tree built from the YAML document
+     */
+    public static YamlNode load(String yaml, String rootName) {
+        try {
+            Load load = getLoad();
+            Object document = load.loadFromString(yaml);
+
+            return buildDom(rootName, document);
+        } catch (Exception ex) {
+            throw new YamlException("An error occurred while loading and parsing the YAML string", ex);
+        }
+    }
+
+    /**
+     * Loads a YAML document from an {@link String} and builds a
+     * {@link YamlNode} tree.
+     *
+     * @param yaml The string to load the YAML from
+     * @return the tree built from the YAML string
+     */
+    public static YamlNode load(String yaml) {
+        try {
+            Load load = getLoad();
+            Object document = load.loadFromString(yaml);
+
+            return buildDom(document);
+        } catch (Exception ex) {
+            throw new YamlException("An error occurred while loading and parsing the YAML string", ex);
+        }
+    }
+
+    private static Load getLoad() {
+        LoadSettings loadSettings = new LoadSettingsBuilder().build();
+        return new Load(loadSettings);
+    }
+
+    private static YamlNode buildDom(String rootName, Object document) {
+        return YamlDomBuilder.build(document, rootName);
+    }
+
+    private static YamlNode buildDom(Object document) {
+        return YamlDomBuilder.build(document);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlMapping.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlMapping.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+/**
+ * Interface for YAML mapping nodes
+ */
+public interface YamlMapping extends YamlCollection {
+
+    /**
+     * Gets a child node by its name
+     *
+     * @param name the name of the child node
+     * @return the child node with the given name if exists,
+     * {@code null} otherwise
+     */
+    YamlNode child(String name);
+
+    /**
+     * Gets a child mapping node by its name
+     *
+     * @param name the name of the child node
+     * @return the child mapping node with the given name if exists,
+     * {@code null} otherwise
+     */
+    YamlMapping childAsMapping(String name);
+
+    /**
+     * Gets a child sequence node by its name
+     *
+     * @param name the name of the child node
+     * @return the child sequence node with the given name if exists,
+     * {@code null} otherwise
+     */
+    YamlSequence childAsSequence(String name);
+
+    /**
+     * Gets a child scalar node by its name
+     *
+     * @param name the name of the child node
+     * @return the child scalar node with the given name if exists,
+     * {@code null} otherwise
+     */
+    YamlScalar childAsScalar(String name);
+
+    /**
+     * Gets a child scalar node's value by its name
+     * <p/>
+     * See {@link YamlScalar} for the possible types
+     * <p/>
+     * Please note that if the scalar's type is not the expected type T,
+     * a {@link ClassCastException} is thrown <strong>at the call site</strong>.
+     *
+     * @param name the name of the child node
+     * @return the child scalar node's value with the given name if exists,
+     * {@code null} otherwise
+     * @see YamlScalar
+     * @see #childAsScalarValue(String, Class)
+     */
+    <T> T childAsScalarValue(String name);
+
+    /**
+     * Gets a child scalar node's value by its name with type hinting
+     * <p/>
+     * See {@link YamlScalar} for the possible types
+     *
+     * @param name the name of the child node
+     * @param type the type that the scalar's value type to be validated
+     *             against
+     * @return the child scalar node's value with the given name
+     * @throws YamlException if the scalar's value is not a type of T
+     * @see YamlScalar
+     */
+    <T> T childAsScalarValue(String name, Class<T> type);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlMappingImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlMappingImpl.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static com.hazelcast.internal.yaml.YamlUtil.asMapping;
+import static com.hazelcast.internal.yaml.YamlUtil.asScalar;
+import static com.hazelcast.internal.yaml.YamlUtil.asSequence;
+
+class YamlMappingImpl extends AbstractYamlNode implements YamlMapping {
+    private Map<String, YamlNode> children = Collections.emptyMap();
+
+    YamlMappingImpl(YamlNode parent, String nodeName) {
+        super(parent, nodeName);
+    }
+
+    @Override
+    public YamlNode child(String name) {
+        return children.get(name);
+    }
+
+    @Override
+    public YamlMapping childAsMapping(String name) {
+        return asMapping(child(name));
+    }
+
+    @Override
+    public YamlSequence childAsSequence(String name) {
+        return asSequence(child(name));
+    }
+
+    @Override
+    public YamlScalar childAsScalar(String name) {
+        return asScalar(child(name));
+    }
+
+    @Override
+    public <T> T childAsScalarValue(String name) {
+        return childAsScalar(name).nodeValue();
+    }
+
+    @Override
+    public <T> T childAsScalarValue(String name, Class<T> type) {
+        return childAsScalar(name).nodeValue(type);
+    }
+
+    @Override
+    public Iterable<YamlNode> children() {
+        return children.values();
+    }
+
+    void addChild(String name, YamlNode node) {
+        getOrCreateChildren().put(name, node);
+    }
+
+    private Map<String, YamlNode> getOrCreateChildren() {
+        if (children == Collections.<String, YamlNode>emptyMap()) {
+            children = new LinkedHashMap<String, YamlNode>();
+        }
+
+        return children;
+    }
+
+    @Override
+    public int childCount() {
+        return children.size();
+    }
+
+    @Override
+    public String toString() {
+        return "YamlMappingImpl{"
+                + "nodeName=" + nodeName()
+                + ", children=" + children
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlNode.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+/**
+ * Generic YAML node interface
+ */
+public interface YamlNode {
+    String UNNAMED_NODE = "<unnamed>";
+
+    /**
+     * Returns the parent of the given node
+     *
+     * @return the parent node if exists, <code>null</code> otherwise
+     */
+    YamlNode parent();
+
+    /**
+     * Returns the name of the node
+     *
+     * @return the name of the node or {@link #UNNAMED_NODE} if not available
+     */
+    String nodeName();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlScalar.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlScalar.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+/**
+ * Interface for YAML scalar nodes
+ * <p/>
+ * The following types are supported:
+ * <ul>
+ * <li>String</li>
+ * <li>Integer</li>
+ * <li>Float</li>
+ * <li>Boolean</li>
+ * </ul>
+ */
+public interface YamlScalar extends YamlNode {
+    /**
+     * Checks if the value of this node is the given type
+     *
+     * @param type the {@link Class} instance of the type to check
+     * @param <T>  the type to check
+     * @return true if the value of the node is instance of the given type
+     */
+    <T> boolean isA(Class<T> type);
+
+    /**
+     * Gets the value of the node
+     * <p/>
+     * Please note that if the scalar's type is not the expected type T,
+     * a {@link ClassCastException} is thrown <strong>at the call site</strong>.
+     *
+     * @param <T> the expected type of the node
+     * @return the value of the node
+     */
+    <T> T nodeValue();
+
+    /**
+     * Gets the value of the node with validating its type against the
+     * provided type
+     *
+     * @param <T> the expected type of the node
+     * @return the value of the node
+     * @throws YamlException if the scalar's value is not a type of T
+     */
+    <T> T nodeValue(Class<T> type);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlScalarImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlScalarImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+class YamlScalarImpl extends AbstractYamlNode implements YamlScalar {
+    private final Object value;
+
+    YamlScalarImpl(YamlNode parent, String nodeName, Object value) {
+        super(parent, nodeName);
+        this.value = value;
+    }
+
+    @Override
+    public <T> boolean isA(Class<T> type) {
+        return value != null && value.getClass().isAssignableFrom(type);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T nodeValue() {
+        return (T) value;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T nodeValue(Class<T> type) {
+        if (!isA(type)) {
+            throw new YamlException("The scalar's type " + value.getClass() + " is not the expected " + type);
+        }
+        return (T) value;
+    }
+
+    @Override
+    public String toString() {
+        return "YamlScalarImpl{"
+                + "nodeName=" + nodeName()
+                + "value=" + value
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlSequence.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+/**
+ * Interface for YAML sequence nodes
+ */
+public interface YamlSequence extends YamlCollection {
+
+    /**
+     * Gets a child node by its index
+     *
+     * @param index the index of the child node
+     * @return the child node with the given index if exists,
+     * {@code null} otherwise
+     */
+    YamlNode child(int index);
+
+    /**
+     * Gets a child mapping node by its index
+     *
+     * @param index the index of the child node
+     * @return the child mapping node with the given index if exists,
+     * {@code null} otherwise
+     */
+    YamlMapping childAsMapping(int index);
+
+    /**
+     * Gets a child sequence node by its index
+     *
+     * @param index the index of the child node
+     * @return the child sequence node with the given index if exists,
+     * {@code null} otherwise
+     */
+    YamlSequence childAsSequence(int index);
+
+    /**
+     * Gets a child scalar node by its index
+     *
+     * @param index the index of the child node
+     * @return the child scalar node with the given index if exists,
+     * {@code null} otherwise
+     */
+    YamlScalar childAsScalar(int index);
+
+    /**
+     * Gets a child scalar node's value by its index
+     * <p/>
+     * See {@link YamlScalar} for the possible types
+     * <p/>
+     * Please note that if the scalar's type is not the expected type T,
+     * a {@link ClassCastException} is thrown <strong>at the call site</strong>.
+     *
+     * @param index the index of the child node
+     * @return the child scalar node's value with the given index if exists,
+     * {@code null} otherwise
+     * @see YamlScalar
+     */
+    <T> T childAsScalarValue(int index);
+
+    /**
+     * Gets a child scalar node's value by its name with type hinting
+     * <p/>
+     * See {@link YamlScalar} for the possible types
+     *
+     * @param index the index of the child node
+     * @param type  the type that the scalar's value type to be validated
+     *              against
+     * @return the child scalar node's value with the given name if exists,
+     * {@code null} otherwise
+     * @throws YamlException if the scalar's value is not a type of T
+     * @see YamlScalar
+     */
+    <T> T childAsScalarValue(int index, Class<T> type);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlSequenceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlSequenceImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.hazelcast.internal.yaml.YamlUtil.asMapping;
+import static com.hazelcast.internal.yaml.YamlUtil.asScalar;
+import static com.hazelcast.internal.yaml.YamlUtil.asSequence;
+
+class YamlSequenceImpl extends AbstractYamlNode implements YamlSequence {
+    private List<YamlNode> children = Collections.emptyList();
+
+    YamlSequenceImpl(YamlNode parent, String nodeName) {
+        super(parent, nodeName);
+    }
+
+    @Override
+    public YamlNode child(int index) {
+        if (index >= children.size()) {
+            return null;
+        }
+        return children.get(index);
+    }
+
+    @Override
+    public Iterable<YamlNode> children() {
+        return children;
+    }
+
+    @Override
+    public YamlMapping childAsMapping(int index) {
+        return asMapping(child(index));
+    }
+
+    @Override
+    public YamlSequence childAsSequence(int index) {
+        return asSequence(child(index));
+    }
+
+    @Override
+    public YamlScalar childAsScalar(int index) {
+        return asScalar(child(index));
+    }
+
+    @Override
+    public <T> T childAsScalarValue(int index) {
+        return childAsScalar(index).nodeValue();
+    }
+
+    @Override
+    public <T> T childAsScalarValue(int index, Class<T> type) {
+        return childAsScalar(index).nodeValue(type);
+    }
+
+    void addChild(YamlNode child) {
+        getOrCreateChildren().add(child);
+    }
+
+    private List<YamlNode> getOrCreateChildren() {
+        if (children == Collections.<YamlNode>emptyList()) {
+            children = new ArrayList<YamlNode>();
+        }
+
+        return children;
+    }
+
+    @Override
+    public int childCount() {
+        return children.size();
+    }
+
+    @Override
+    public String toString() {
+        return "YamlSequenceImpl{"
+                + "nodeName=" + nodeName()
+                + ", children=" + children
+                + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+final class YamlUtil {
+    private YamlUtil() {
+    }
+
+    static YamlMapping asMapping(YamlNode node) {
+        if (node != null && !(node instanceof YamlMapping)) {
+            String nodeName = node.nodeName();
+            throw new YamlException("Child " + nodeName + " is not a mapping, it's actual type is " + node.getClass());
+        }
+
+        return (YamlMapping) node;
+    }
+
+    static YamlSequence asSequence(YamlNode node) {
+        if (node != null && !(node instanceof YamlSequence)) {
+            String nodeName = node.nodeName();
+            throw new YamlException("Child " + nodeName + " is not a sequence, it's actual type is " + node.getClass());
+        }
+
+        return (YamlSequence) node;
+    }
+
+    static YamlScalar asScalar(YamlNode node) {
+        if (node != null && !(node instanceof YamlScalar)) {
+            String nodeName = node.nodeName();
+            throw new YamlException("Child " + nodeName + " is not a scalar, it's actual type is " + node.getClass());
+        }
+
+        return (YamlScalar) node;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains classes for loading, parsing YAML documents and building a
+ * YAML specific DOM of {@link com.hazelcast.internal.yaml.YamlNode} instances
+ * <p/>
+ * The YAML documents are loaded and parsed with the external SnakeYaml
+ * parser, which supports YAML 1.2 documents, and the JSON schema.
+ */
+package com.hazelcast.internal.yaml;

--- a/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlDomBuilderNegativeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlDomBuilderNegativeTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tests the error cases of the {@link YamlDomBuilder}
+ *
+ * The positive cases are tested in {@link YamlTest}
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class YamlDomBuilderNegativeTest {
+    private static final Object NOT_A_MAP = new Object();
+
+    @Test(expected = YamlException.class)
+    public void testBuildFromNullDocumentThrows() {
+        YamlDomBuilder.build(null);
+    }
+
+    @Test(expected = YamlException.class)
+    public void testBuildFromNullDocumentAndRootNameThrows() {
+        YamlDomBuilder.build(null, "root");
+    }
+
+    @Test(expected = YamlException.class)
+    public void testBuildFromNotMapDocumentThrows() {
+        YamlDomBuilder.build(NOT_A_MAP);
+    }
+
+    @Test(expected = YamlException.class)
+    public void testBuildFromNotMapDocumentAndRootNameThrows() {
+        YamlDomBuilder.build(NOT_A_MAP, "root");
+    }
+
+    @Test(expected = YamlException.class)
+    public void testBuildFromMapDocumentRootNameNotFoundThrows() {
+        Map<String, Object> documentMap = new HashMap<String, Object>();
+        documentMap.put("not-root", new Object());
+        YamlDomBuilder.build(documentMap, "root");
+    }
+
+    @Test(expected = YamlException.class)
+    public void testBuildFromMapDocumentInvalidScalarThrows() {
+        Map<String, Object> documentMap = new HashMap<String, Object>();
+        documentMap.put("root", new Object());
+        YamlDomBuilder.build(documentMap, "root");
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlTest.java
@@ -32,6 +32,8 @@ import java.io.InputStreamReader;
 
 import static com.hazelcast.internal.yaml.YamlUtil.asMapping;
 import static com.hazelcast.internal.yaml.YamlUtil.asSequence;
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK6;
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -47,8 +49,18 @@ public class YamlTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    @Test(expected = YamlException.class)
+    public void testLoadOnJdk6Throws() {
+        assumeThatJDK6();
+
+        YamlLoader.load("irrelevant");
+    }
+
+
     @Test
     public void testYamlFromInputStream() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         YamlNode root = YamlLoader.load(inputStream, "root-map");
         verify(root);
@@ -56,6 +68,8 @@ public class YamlTest {
 
     @Test
     public void testYamlFromInputStreamWithoutRootName() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         YamlNode root = YamlLoader.load(inputStream);
         verify(asMapping(root).childAsMapping("root-map"));
@@ -63,6 +77,8 @@ public class YamlTest {
 
     @Test
     public void testYamlExtendedTestFromInputStream() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map-extended.yaml");
         YamlNode root = YamlLoader.load(inputStream, "root-map");
         verify(root);
@@ -71,6 +87,8 @@ public class YamlTest {
 
     @Test
     public void testJsonFromInputStream() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.json");
         YamlNode root = YamlLoader.load(inputStream, "root-map");
         verify(root);
@@ -78,6 +96,8 @@ public class YamlTest {
 
     @Test
     public void testYamlFromReader() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
         YamlNode root = YamlLoader.load(reader, "root-map");
@@ -86,6 +106,8 @@ public class YamlTest {
 
     @Test
     public void testYamlFromReaderWithoutRootName() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
         YamlNode root = YamlLoader.load(reader);
@@ -94,6 +116,8 @@ public class YamlTest {
 
     @Test
     public void testYamlFromString() throws IOException {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
         String yamlString = CharStreams.toString(reader);
@@ -103,6 +127,8 @@ public class YamlTest {
 
     @Test
     public void testYamlFromStringWithoutRootMap() throws IOException {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
         String yamlString = CharStreams.toString(reader);
@@ -112,6 +138,8 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromInputStream() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         expectedException.expect(YamlException.class);
         YamlLoader.load(inputStream);
@@ -119,6 +147,8 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromInputStreamWithRootName() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         expectedException.expect(YamlException.class);
         YamlLoader.load(inputStream, "root-map");
@@ -126,6 +156,8 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromReader() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
         expectedException.expect(YamlException.class);
@@ -134,6 +166,8 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromReaderWithRootName() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
         expectedException.expect(YamlException.class);
@@ -142,6 +176,8 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromString() throws IOException {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
         String yamlString = CharStreams.toString(reader);
@@ -151,6 +187,8 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromStringWithRootName() throws IOException {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
         String yamlString = CharStreams.toString(reader);
@@ -160,26 +198,32 @@ public class YamlTest {
 
     @Test
     public void testInvalidScalarValueTypeMap() {
+        assumeThatJDK8();
+
         YamlMapping rootMap = getYamlRoot();
         YamlMapping embeddedMap = rootMap.childAsMapping("embedded-map");
 
         expectedException.expect(ClassCastException.class);
-        int notAnInt = embeddedMap.childAsScalarValue("scalar-str");
+        int notAnInt = (Integer) embeddedMap.childAsScalarValue("scalar-str");
     }
 
     @Test
     public void testInvalidScalarValueTypeSeq() {
+        assumeThatJDK8();
+
         YamlMapping rootMap = getYamlRoot();
         YamlSequence embeddedList = rootMap
                 .childAsMapping("embedded-map")
                 .childAsSequence("embedded-list");
 
         expectedException.expect(ClassCastException.class);
-        int notAnInt = embeddedList.childAsScalarValue(0);
+        int notAnInt = (Integer) embeddedList.childAsScalarValue(0);
     }
 
     @Test
     public void testInvalidScalarValueTypeHintedMap() {
+        assumeThatJDK8();
+
         YamlMapping rootMap = getYamlRoot();
         YamlMapping embeddedMap = rootMap.childAsMapping("embedded-map");
 
@@ -191,6 +235,8 @@ public class YamlTest {
 
     @Test
     public void testInvalidScalarValueTypeHintedSeq() {
+        assumeThatJDK8();
+
         YamlMapping rootMap = getYamlRoot();
         YamlSequence embeddedList = rootMap
                 .childAsMapping("embedded-map")
@@ -204,21 +250,29 @@ public class YamlTest {
 
     @Test
     public void testNotExistingMappingFromMap() {
+        assumeThatJDK8();
+
         assertNull(getYamlRoot().childAsMapping("not-existing"));
     }
 
     @Test
     public void testNotExistingSequenceFromMap() {
+        assumeThatJDK8();
+
         assertNull(getYamlRoot().childAsSequence("not-existing"));
     }
 
     @Test
     public void testNotExistingScalarFromMap() {
+        assumeThatJDK8();
+
         assertNull(getYamlRoot().childAsScalar("not-existing"));
     }
 
     @Test
     public void testNotExistingMappingFromSeq() {
+        assumeThatJDK8();
+
         YamlSequence seq = getYamlRoot()
                 .childAsMapping("embedded-map")
                 .childAsSequence("embedded-list");
@@ -227,6 +281,8 @@ public class YamlTest {
 
     @Test
     public void testNotExistingSequenceFromSeq() {
+        assumeThatJDK8();
+
         YamlSequence seq = getYamlRoot()
                 .childAsMapping("embedded-map")
                 .childAsSequence("embedded-list");
@@ -235,6 +291,8 @@ public class YamlTest {
 
     @Test
     public void testNotExistingScalarFromSeq() {
+        assumeThatJDK8();
+
         YamlSequence seq = getYamlRoot()
                 .childAsMapping("embedded-map")
                 .childAsSequence("embedded-list");
@@ -243,6 +301,8 @@ public class YamlTest {
 
     @Test
     public void testInvalidNodeTypeNotAMapping() {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         YamlNode root = YamlLoader.load(inputStream, "root-map");
 
@@ -255,6 +315,8 @@ public class YamlTest {
 
     @Test
     public void testInvalidNodeTypeNotASeq() {
+        assumeThatJDK8();
+
         YamlMapping rootMap = getYamlRoot();
 
         expectedException.expect(YamlException.class);
@@ -263,6 +325,8 @@ public class YamlTest {
 
     @Test
     public void testInvalidNodeTypeNotAScalar() {
+        assumeThatJDK8();
+
         YamlMapping rootMap = getYamlRoot();
 
         expectedException.expect(YamlException.class);
@@ -271,6 +335,8 @@ public class YamlTest {
 
     @Test
     public void testIterateChildrenMap() {
+        assumeThatJDK8();
+
         YamlMapping embeddedMap = getYamlRoot()
                 .childAsMapping("embedded-map");
 
@@ -285,6 +351,8 @@ public class YamlTest {
 
     @Test
     public void testIterateChildrenSeq() {
+        assumeThatJDK8();
+
         YamlSequence embeddedList = getYamlRoot()
                 .childAsMapping("embedded-map")
                 .childAsSequence("embedded-list");
@@ -300,28 +368,38 @@ public class YamlTest {
 
     @Test
     public void testParentOfRootIsNull() {
+        assumeThatJDK8();
+
         assertNull(getYamlRoot().parent());
     }
 
     @Test
     public void testParentOfEmbeddedMapIsRoot() {
+        assumeThatJDK8();
+
         YamlMapping root = getYamlRoot();
         assertSame(root, root.childAsMapping("embedded-map").parent());
     }
 
     @Test
     public void testParentOfScalarIntIsEmbeddedMap() {
+        assumeThatJDK8();
+
         YamlMapping embeddedMap = getYamlRoot().childAsMapping("embedded-map");
         assertSame(embeddedMap, embeddedMap.childAsScalar("scalar-int").parent());
     }
 
     @Test
     public void testNameOfMap() {
+        assumeThatJDK8();
+
         assertEquals("embedded-map", getYamlRoot().childAsMapping("embedded-map").nodeName());
     }
 
     @Test
     public void testNameOfSeq() {
+        assumeThatJDK8();
+
         assertEquals("embedded-list", getYamlRoot().childAsMapping("embedded-map")
                                                    .childAsSequence("embedded-list")
                                                    .nodeName());
@@ -329,6 +407,8 @@ public class YamlTest {
 
     @Test
     public void testNameOfNamedScalar() {
+        assumeThatJDK8();
+
         assertEquals("scalar-int", getYamlRoot().childAsMapping("embedded-map")
                                                 .childAsScalar("scalar-int")
                                                 .nodeName());
@@ -336,6 +416,8 @@ public class YamlTest {
 
     @Test
     public void testNameOfUnnamedScalar() {
+        assumeThatJDK8();
+
         assertSame(YamlNode.UNNAMED_NODE, getYamlRoot().childAsMapping("embedded-map")
                                                        .childAsSequence("embedded-list")
                                                        .childAsScalar(0)
@@ -349,20 +431,20 @@ public class YamlTest {
         YamlMapping rootMap = (YamlMapping) root;
         YamlMapping embeddedMap = rootMap.childAsMapping("embedded-map");
         String scalarString = embeddedMap.childAsScalarValue("scalar-str");
-        int scalarInt = embeddedMap.childAsScalarValue("scalar-int");
-        double scalarDouble = embeddedMap.childAsScalarValue("scalar-double");
-        boolean scalarBool = embeddedMap.childAsScalarValue("scalar-bool");
+        int scalarInt = (Integer) embeddedMap.childAsScalarValue("scalar-int");
+        double scalarDouble = (Double) embeddedMap.childAsScalarValue("scalar-double");
+        boolean scalarBool = (Boolean) embeddedMap.childAsScalarValue("scalar-bool");
 
         YamlSequence embeddedList = embeddedMap.childAsSequence("embedded-list");
         String elItem0 = embeddedList.childAsScalarValue(0);
         YamlScalar elItem0AsScalar = embeddedList.childAsScalar(0);
-        int elItem1 = embeddedList.childAsScalarValue(1);
-        double elItem2 = embeddedList.childAsScalarValue(2);
-        boolean elItem3 = embeddedList.childAsScalarValue(3);
+        int elItem1 = (Integer) embeddedList.childAsScalarValue(1);
+        double elItem2 = (Double) embeddedList.childAsScalarValue(2);
+        boolean elItem3 = (Boolean) embeddedList.childAsScalarValue(3);
 
         YamlSequence embeddedList2 = embeddedMap.childAsSequence("embedded-list2");
         String el2Item0 = embeddedList2.childAsScalarValue(0);
-        double el2Item1 = embeddedList2.childAsScalarValue(1);
+        double el2Item1 = (Double) embeddedList2.childAsScalarValue(1);
 
         assertEquals("embedded-map", embeddedMap.nodeName());
         assertEquals("embedded-list", embeddedList.nodeName());
@@ -418,6 +500,8 @@ public class YamlTest {
 
     @Test
     public void testYamlListInRoot() throws IOException {
+        assumeThatJDK8();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-seq.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
         String yamlString = CharStreams.toString(reader);

--- a/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+import com.google.common.io.CharStreams;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static com.hazelcast.internal.yaml.YamlUtil.asMapping;
+import static com.hazelcast.internal.yaml.YamlUtil.asSequence;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class YamlTest {
+    private static final int NOT_EXISTING = 42;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testYamlFromInputStream() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
+        YamlNode root = YamlLoader.load(inputStream, "root-map");
+        verify(root);
+    }
+
+    @Test
+    public void testYamlFromInputStreamWithoutRootName() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
+        YamlNode root = YamlLoader.load(inputStream);
+        verify(asMapping(root).childAsMapping("root-map"));
+    }
+
+    @Test
+    public void testYamlExtendedTestFromInputStream() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map-extended.yaml");
+        YamlNode root = YamlLoader.load(inputStream, "root-map");
+        verify(root);
+        verifyExtendedYaml(root);
+    }
+
+    @Test
+    public void testJsonFromInputStream() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.json");
+        YamlNode root = YamlLoader.load(inputStream, "root-map");
+        verify(root);
+    }
+
+    @Test
+    public void testYamlFromReader() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
+        InputStreamReader reader = new InputStreamReader(inputStream);
+        YamlNode root = YamlLoader.load(reader, "root-map");
+        verify(root);
+    }
+
+    @Test
+    public void testYamlFromReaderWithoutRootName() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
+        InputStreamReader reader = new InputStreamReader(inputStream);
+        YamlNode root = YamlLoader.load(reader);
+        verify(asMapping(root).childAsMapping("root-map"));
+    }
+
+    @Test
+    public void testYamlFromString() throws IOException {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
+        InputStreamReader reader = new InputStreamReader(inputStream);
+        String yamlString = CharStreams.toString(reader);
+        YamlNode root = YamlLoader.load(yamlString, "root-map");
+        verify(root);
+    }
+
+    @Test
+    public void testYamlFromStringWithoutRootMap() throws IOException {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
+        InputStreamReader reader = new InputStreamReader(inputStream);
+        String yamlString = CharStreams.toString(reader);
+        YamlNode root = YamlLoader.load(yamlString);
+        verify(asMapping(root).childAsMapping("root-map"));
+    }
+
+    @Test
+    public void testLoadingInvalidYamlFromInputStream() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
+        expectedException.expect(YamlException.class);
+        YamlLoader.load(inputStream);
+    }
+
+    @Test
+    public void testLoadingInvalidYamlFromInputStreamWithRootName() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
+        expectedException.expect(YamlException.class);
+        YamlLoader.load(inputStream, "root-map");
+    }
+
+    @Test
+    public void testLoadingInvalidYamlFromReader() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
+        InputStreamReader reader = new InputStreamReader(inputStream);
+        expectedException.expect(YamlException.class);
+        YamlLoader.load(reader);
+    }
+
+    @Test
+    public void testLoadingInvalidYamlFromReaderWithRootName() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
+        InputStreamReader reader = new InputStreamReader(inputStream);
+        expectedException.expect(YamlException.class);
+        YamlLoader.load(reader, "root-map");
+    }
+
+    @Test
+    public void testLoadingInvalidYamlFromString() throws IOException {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
+        InputStreamReader reader = new InputStreamReader(inputStream);
+        String yamlString = CharStreams.toString(reader);
+        expectedException.expect(YamlException.class);
+        YamlLoader.load(yamlString);
+    }
+
+    @Test
+    public void testLoadingInvalidYamlFromStringWithRootName() throws IOException {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
+        InputStreamReader reader = new InputStreamReader(inputStream);
+        String yamlString = CharStreams.toString(reader);
+        expectedException.expect(YamlException.class);
+        YamlLoader.load(yamlString, "root-map");
+    }
+
+    @Test
+    public void testInvalidScalarValueTypeMap() {
+        YamlMapping rootMap = getYamlRoot();
+        YamlMapping embeddedMap = rootMap.childAsMapping("embedded-map");
+
+        expectedException.expect(ClassCastException.class);
+        int notAnInt = embeddedMap.childAsScalarValue("scalar-str");
+    }
+
+    @Test
+    public void testInvalidScalarValueTypeSeq() {
+        YamlMapping rootMap = getYamlRoot();
+        YamlSequence embeddedList = rootMap
+                .childAsMapping("embedded-map")
+                .childAsSequence("embedded-list");
+
+        expectedException.expect(ClassCastException.class);
+        int notAnInt = embeddedList.childAsScalarValue(0);
+    }
+
+    @Test
+    public void testInvalidScalarValueTypeHintedMap() {
+        YamlMapping rootMap = getYamlRoot();
+        YamlMapping embeddedMap = rootMap.childAsMapping("embedded-map");
+
+        embeddedMap.childAsScalarValue("scalar-str", String.class);
+
+        expectedException.expect(YamlException.class);
+        embeddedMap.childAsScalarValue("scalar-str", Integer.class);
+    }
+
+    @Test
+    public void testInvalidScalarValueTypeHintedSeq() {
+        YamlMapping rootMap = getYamlRoot();
+        YamlSequence embeddedList = rootMap
+                .childAsMapping("embedded-map")
+                .childAsSequence("embedded-list");
+
+        embeddedList.childAsScalarValue(0, String.class);
+
+        expectedException.expect(YamlException.class);
+        embeddedList.childAsScalarValue(0, Integer.class);
+    }
+
+    @Test
+    public void testNotExistingMappingFromMap() {
+        assertNull(getYamlRoot().childAsMapping("not-existing"));
+    }
+
+    @Test
+    public void testNotExistingSequenceFromMap() {
+        assertNull(getYamlRoot().childAsSequence("not-existing"));
+    }
+
+    @Test
+    public void testNotExistingScalarFromMap() {
+        assertNull(getYamlRoot().childAsScalar("not-existing"));
+    }
+
+    @Test
+    public void testNotExistingMappingFromSeq() {
+        YamlSequence seq = getYamlRoot()
+                .childAsMapping("embedded-map")
+                .childAsSequence("embedded-list");
+        assertNull(seq.childAsMapping(NOT_EXISTING));
+    }
+
+    @Test
+    public void testNotExistingSequenceFromSeq() {
+        YamlSequence seq = getYamlRoot()
+                .childAsMapping("embedded-map")
+                .childAsSequence("embedded-list");
+        assertNull(seq.childAsSequence(NOT_EXISTING));
+    }
+
+    @Test
+    public void testNotExistingScalarFromSeq() {
+        YamlSequence seq = getYamlRoot()
+                .childAsMapping("embedded-map")
+                .childAsSequence("embedded-list");
+        assertNull(seq.childAsScalar(NOT_EXISTING));
+    }
+
+    @Test
+    public void testInvalidNodeTypeNotAMapping() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
+        YamlNode root = YamlLoader.load(inputStream, "root-map");
+
+        YamlMapping embeddedMap = ((YamlMapping) root)
+                .childAsMapping("embedded-map");
+
+        expectedException.expect(YamlException.class);
+        embeddedMap.childAsMapping("embedded-list");
+    }
+
+    @Test
+    public void testInvalidNodeTypeNotASeq() {
+        YamlMapping rootMap = getYamlRoot();
+
+        expectedException.expect(YamlException.class);
+        rootMap.childAsSequence("embedded-map");
+    }
+
+    @Test
+    public void testInvalidNodeTypeNotAScalar() {
+        YamlMapping rootMap = getYamlRoot();
+
+        expectedException.expect(YamlException.class);
+        rootMap.childAsScalar("embedded-map");
+    }
+
+    @Test
+    public void testIterateChildrenMap() {
+        YamlMapping embeddedMap = getYamlRoot()
+                .childAsMapping("embedded-map");
+
+        int childCount = 0;
+        for (YamlNode node : embeddedMap.children()) {
+            assertNotNull(node);
+            childCount++;
+        }
+
+        assertEquals(6, childCount);
+    }
+
+    @Test
+    public void testIterateChildrenSeq() {
+        YamlSequence embeddedList = getYamlRoot()
+                .childAsMapping("embedded-map")
+                .childAsSequence("embedded-list");
+
+        int childCount = 0;
+        for (YamlNode node : embeddedList.children()) {
+            assertNotNull(node);
+            childCount++;
+        }
+
+        assertEquals(4, childCount);
+    }
+
+    @Test
+    public void testParentOfRootIsNull() {
+        assertNull(getYamlRoot().parent());
+    }
+
+    @Test
+    public void testParentOfEmbeddedMapIsRoot() {
+        YamlMapping root = getYamlRoot();
+        assertSame(root, root.childAsMapping("embedded-map").parent());
+    }
+
+    @Test
+    public void testParentOfScalarIntIsEmbeddedMap() {
+        YamlMapping embeddedMap = getYamlRoot().childAsMapping("embedded-map");
+        assertSame(embeddedMap, embeddedMap.childAsScalar("scalar-int").parent());
+    }
+
+    @Test
+    public void testNameOfMap() {
+        assertEquals("embedded-map", getYamlRoot().childAsMapping("embedded-map").nodeName());
+    }
+
+    @Test
+    public void testNameOfSeq() {
+        assertEquals("embedded-list", getYamlRoot().childAsMapping("embedded-map")
+                                                   .childAsSequence("embedded-list")
+                                                   .nodeName());
+    }
+
+    @Test
+    public void testNameOfNamedScalar() {
+        assertEquals("scalar-int", getYamlRoot().childAsMapping("embedded-map")
+                                                .childAsScalar("scalar-int")
+                                                .nodeName());
+    }
+
+    @Test
+    public void testNameOfUnnamedScalar() {
+        assertSame(YamlNode.UNNAMED_NODE, getYamlRoot().childAsMapping("embedded-map")
+                                                       .childAsSequence("embedded-list")
+                                                       .childAsScalar(0)
+                                                       .nodeName());
+    }
+
+    private void verify(YamlNode root) {
+
+        assertTrue(root instanceof YamlMapping);
+
+        YamlMapping rootMap = (YamlMapping) root;
+        YamlMapping embeddedMap = rootMap.childAsMapping("embedded-map");
+        String scalarString = embeddedMap.childAsScalarValue("scalar-str");
+        int scalarInt = embeddedMap.childAsScalarValue("scalar-int");
+        double scalarDouble = embeddedMap.childAsScalarValue("scalar-double");
+        boolean scalarBool = embeddedMap.childAsScalarValue("scalar-bool");
+
+        YamlSequence embeddedList = embeddedMap.childAsSequence("embedded-list");
+        String elItem0 = embeddedList.childAsScalarValue(0);
+        YamlScalar elItem0AsScalar = embeddedList.childAsScalar(0);
+        int elItem1 = embeddedList.childAsScalarValue(1);
+        double elItem2 = embeddedList.childAsScalarValue(2);
+        boolean elItem3 = embeddedList.childAsScalarValue(3);
+
+        YamlSequence embeddedList2 = embeddedMap.childAsSequence("embedded-list2");
+        String el2Item0 = embeddedList2.childAsScalarValue(0);
+        double el2Item1 = embeddedList2.childAsScalarValue(1);
+
+        assertEquals("embedded-map", embeddedMap.nodeName());
+        assertEquals("embedded-list", embeddedList.nodeName());
+
+        // root-map/embedded-map/scalars
+        assertEquals(6, embeddedMap.childCount());
+        assertEquals("h4z3lc4st", scalarString);
+        assertEquals(123, scalarInt);
+        assertEquals(123.12312D, scalarDouble, 10E-5);
+        assertTrue(scalarBool);
+
+        // root-map/embedded-map/embedded-list
+        assertEquals("value1", elItem0);
+        assertTrue(elItem0AsScalar.isA(String.class));
+        assertEquals("value1", elItem0AsScalar.nodeValue());
+        assertEquals(NOT_EXISTING, elItem1);
+        assertEquals(42.42D, elItem2, 10E-2);
+        assertFalse(elItem3);
+
+        // root-map/embedded-map/embedded-list2
+        assertEquals(2, embeddedList2.childCount());
+        assertEquals("value2", el2Item0);
+        assertEquals(1D, el2Item1, 10E-1);
+    }
+
+    /*
+     * Verifies can't be tested in YAML and JSON together because JSON
+     * doesn't support everything that YAML does, like
+     * - Embedded mapping in sequences
+     * - Multiline strings
+     */
+    private void verifyExtendedYaml(YamlNode root) {
+        String keysValue = ((YamlMapping) root)
+                .childAsMapping("embedded-map")
+                .childAsSequence("embedded-list")
+                .childAsMapping(4)
+                .childAsScalarValue("key");
+        assertEquals("value", keysValue);
+
+        String multilineStr = ((YamlMapping) root).childAsScalarValue("multiline-str");
+        assertEquals("Hazelcast IMDG\n"
+                        + "The Leading Open Source In-Memory Data Grid:\n"
+                        + "Distributed Computing, Simplified.\n",
+                multilineStr);
+    }
+
+    private YamlMapping getYamlRoot() {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
+        YamlNode root = YamlLoader.load(inputStream, "root-map");
+
+        return (YamlMapping) root;
+    }
+
+    @Test
+    public void testYamlListInRoot() throws IOException {
+        InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-seq.yaml");
+        InputStreamReader reader = new InputStreamReader(inputStream);
+        String yamlString = CharStreams.toString(reader);
+        YamlNode root = YamlLoader.load(yamlString);
+
+        assertTrue(root instanceof YamlSequence);
+
+        YamlSequence rootSeq = asSequence(root);
+        assertEquals(42, rootSeq.childAsScalarValue(0));
+
+        YamlMapping map = rootSeq.childAsMapping(1);
+        assertEquals(YamlNode.UNNAMED_NODE, map.nodeName());
+        assertEquals("embedded-map", map.childAsMapping("embedded-map").nodeName());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1573,6 +1573,10 @@ public abstract class HazelcastTestSupport {
     // ########## test assumptions ##########
     // ######################################
 
+    public static void assumeThatJDK6() {
+        assumeTrue("Java 6 should be used", JAVA_VERSION.startsWith("1.6."));
+    }
+
     public static void assumeThatNoJDK6() {
         assumeFalse("Java 6 used", JAVA_VERSION.startsWith("1.6."));
     }

--- a/hazelcast/src/test/resources/yaml-test-invalid.yaml
+++ b/hazelcast/src/test/resources/yaml-test-invalid.yaml
@@ -1,0 +1,1 @@
+%invalid-yaml

--- a/hazelcast/src/test/resources/yaml-test-root-map-extended.yaml
+++ b/hazelcast/src/test/resources/yaml-test-root-map-extended.yaml
@@ -1,0 +1,21 @@
+# this test file has some 
+root-map:
+  embedded-map:
+    scalar-str: h4z3lc4st
+    scalar-int: 123
+    scalar-double: 123.12312
+    scalar-bool: true
+    embedded-list:
+      - value1
+      - 42
+      - 42.42
+      - false
+      - embedded-map-in-list:
+        key: value
+    embedded-list2:
+      - !!str value2
+      - !!float 1
+  multiline-str: |
+    Hazelcast IMDG
+    The Leading Open Source In-Memory Data Grid:
+    Distributed Computing, Simplified.

--- a/hazelcast/src/test/resources/yaml-test-root-map.json
+++ b/hazelcast/src/test/resources/yaml-test-root-map.json
@@ -1,0 +1,20 @@
+{
+  "root-map": {
+    "embedded-map": {
+      "scalar-str": "h4z3lc4st",
+      "scalar-int": 123,
+      "scalar-double": 123.12312,
+      "scalar-bool": true,
+      "embedded-list": [
+        "value1",
+        42,
+        42.42,
+        false
+      ],
+      "embedded-list2": [
+        "value2",
+        1.0
+      ]
+    }
+  }
+}

--- a/hazelcast/src/test/resources/yaml-test-root-map.yaml
+++ b/hazelcast/src/test/resources/yaml-test-root-map.yaml
@@ -1,0 +1,16 @@
+# contains structure that can be defined in a JSON config as well
+# see yaml-test-root-map.json
+root-map:
+  embedded-map:
+    scalar-str: h4z3lc4st
+    scalar-int: 123
+    scalar-double: 123.12312
+    scalar-bool: true
+    embedded-list:
+      - value1
+      - 42
+      - 42.42
+      - false
+    embedded-list2:
+      - !!str value2
+      - !!float 1

--- a/hazelcast/src/test/resources/yaml-test-root-seq.yaml
+++ b/hazelcast/src/test/resources/yaml-test-root-seq.yaml
@@ -1,0 +1,3 @@
+- 42
+- embedded-map:
+    key: value

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,8 @@
         <jsr107.api.version>1.1.0</jsr107.api.version>
         <jsr107.tck.version>1.1.0</jsr107.tck.version>
 
+        <snakeyaml.engine.version>1.0</snakeyaml.engine.version>
+
         <h2.version>1.3.160</h2.version>
         <atomikos.version>3.9.3</atomikos.version>
         <!-- Additional JVM system arguments -->
@@ -1153,6 +1155,13 @@
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
             <version>${jsr107.api.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
+            <version>${snakeyaml.engine.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
This PR is a JDK6 compatible version of the previously merged https://github.com/hazelcast/hazelcast/pull/14237

The first commit is identical to the #14237 PR's content that has already been reviewed.
The second commit is making it compiling with JDK6 and is meant to be reviewed in this PR.

Copied description from the original PR:

The YAML documents are loaded and parsed with the provided SnakeYaml-Engine parser.
In line with the YAML specification, the following YamlNode sub-types exist:
- YamlMapping
- YamlSequence
- YamlScalar

The scalars can be instances of the following types:
- String
- Integer
- Double
- Boolean

Changes since the original PR:
- The used Java8+ SnakeYaml-Engine provided lib is used via reflection so it compiles with JDK6 as well
- New version check to inform the user in an exception that Yaml can be used with Java8+ only.
- Updated tests with JDK version specific assumptions
