### PR TITLE
Introduce filtering for text protocols - HTTP REST API and MEMCACHE

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -70,6 +70,7 @@ import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MemberAttributeConfig;
+import com.hazelcast.config.MemcacheProtocolConfig;
 import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.NativeMemoryConfig;
@@ -81,6 +82,7 @@ import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.RingbufferStoreConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
@@ -1224,6 +1226,26 @@ public class ClientDynamicClusterConfig extends Config {
 
     @Override
     public Config setPNCounterConfigs(Map<String, PNCounterConfig> pnCounterConfigs) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public RestApiConfig getRestApiConfig() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Config setRestApiConfig(RestApiConfig restApiConfig) {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public MemcacheProtocolConfig getMemcacheProtocolConfig() {
+        throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
+    }
+
+    @Override
+    public Config setMemcacheProtocolConfig(MemcacheProtocolConfig memcacheProtocolConfig) {
         throw new UnsupportedOperationException(UNSUPPORTED_ERROR_MESSAGE);
     }
 

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -28,7 +28,7 @@
         <xs:complexType>
             <xs:complexContent>
                 <xs:extension base="hazelcast-bean">
-                    <xs:sequence>
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
                         <xs:element name="spring-aware" type="xs:string" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="instance-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="group" type="group" minOccurs="0" maxOccurs="1"/>
@@ -37,6 +37,8 @@
                         <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="wan-replication" type="wan-replication" minOccurs="0" maxOccurs="unbounded"/>
                         <xs:element name="network" type="network" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="rest-api" type="rest-api" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="memcache-protocol" type="memcache-protocol" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="partition-group" type="partition-group" minOccurs="0" maxOccurs="1"/>
                         <xs:element name="executor-service" minOccurs="0" maxOccurs="unbounded">
                             <xs:complexType>
@@ -1752,7 +1754,7 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
-                    </xs:sequence>
+                    </xs:choice>
                 </xs:extension>
             </xs:complexContent>
         </xs:complexType>
@@ -2880,6 +2882,32 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
+
+    <xs:complexType name="memcache-protocol">
+        <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+    </xs:complexType>
+    <xs:complexType name="rest-api">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="endpoint-group" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="endpoint-group-name" use="required"/>
+                    <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+    </xs:complexType>
+    <xs:simpleType name="endpoint-group-name">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="CLUSTER_READ"/>
+            <xs:enumeration value="CLUSTER_WRITE"/>
+            <xs:enumeration value="HEALTH_CHECK"/>
+            <xs:enumeration value="HOT_RESTART"/>
+            <xs:enumeration value="WAN"/>
+            <xs:enumeration value="DATA"/>
+            <xs:enumeration value="MEMCACHE"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="partition-group">
         <xs:sequence>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -60,6 +60,7 @@ import com.hazelcast.config.MaxSizeConfig;
 import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.config.MemberAttributeConfig;
 import com.hazelcast.config.MemberGroupConfig;
+import com.hazelcast.config.MemcacheProtocolConfig;
 import com.hazelcast.config.MergePolicyConfig;
 import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.MultiMapConfig;
@@ -76,6 +77,8 @@ import com.hazelcast.config.QueueStoreConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.config.RestApiConfig;
+import com.hazelcast.config.RestEndpointGroup;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.RingbufferStoreConfig;
 import com.hazelcast.config.SSLConfig;
@@ -1417,5 +1420,22 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(2, whitelist.getPackages().size());
         assertTrue(whitelist.getPackages().contains("com.acme.app"));
         assertTrue(whitelist.getPackages().contains("com.acme.app.subpkg"));
+    }
+
+    @Test
+    public void testRestApiConfig() {
+        RestApiConfig restApiConfig = config.getRestApiConfig();
+        assertNotNull(restApiConfig);
+        assertFalse(restApiConfig.isEnabled());
+        for (RestEndpointGroup group : RestEndpointGroup.values()) {
+            assertTrue("Unexpected status of REST Endpoint group" + group, restApiConfig.isGroupEnabled(group));
+        }
+    }
+
+    @Test
+    public void testMemcacheProtocolConfig() {
+        MemcacheProtocolConfig memcacheProtocolConfig = config.getMemcacheProtocolConfig();
+        assertNotNull(memcacheProtocolConfig);
+        assertTrue(memcacheProtocolConfig.isEnabled());
     }
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -813,6 +813,17 @@
                 <hz:quorum-ref>my-quorum</hz:quorum-ref>
                 <hz:replica-count>100</hz:replica-count>
             </hz:pn-counter>
+
+            <hz:memcache-protocol enabled="true"/>
+
+            <hz:rest-api enabled="false">
+                <hz:endpoint-group name="CLUSTER_READ" enabled="true"/>
+                <hz:endpoint-group name="CLUSTER_WRITE" enabled="true"/>
+                <hz:endpoint-group name="HEALTH_CHECK" enabled="true"/>
+                <hz:endpoint-group name="HOT_RESTART" enabled="true"/>
+                <hz:endpoint-group name="WAN" enabled="true"/>
+                <hz:endpoint-group name="DATA" enabled="true"/>
+            </hz:rest-api>
         </hz:config>
     </hz:hazelcast>
 

--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -161,6 +161,10 @@ public class Config {
 
     private CRDTReplicationConfig crdtReplicationConfig = new CRDTReplicationConfig();
 
+    private MemcacheProtocolConfig memcacheProtocolConfig;
+
+    private RestApiConfig restApiConfig;
+
     private String licenseKey;
 
     private boolean liteMember;
@@ -3441,6 +3445,24 @@ public class Config {
         return this;
     }
 
+    public RestApiConfig getRestApiConfig() {
+        return restApiConfig;
+    }
+
+    public Config setRestApiConfig(RestApiConfig restApiConfig) {
+        this.restApiConfig = restApiConfig;
+        return this;
+    }
+
+    public MemcacheProtocolConfig getMemcacheProtocolConfig() {
+        return memcacheProtocolConfig;
+    }
+
+    public Config setMemcacheProtocolConfig(MemcacheProtocolConfig memcacheProtocolConfig) {
+        this.memcacheProtocolConfig = memcacheProtocolConfig;
+        return this;
+    }
+
     @Override
     public String toString() {
         return "Config{"
@@ -3467,6 +3489,8 @@ public class Config {
                 + ", securityConfig=" + securityConfig
                 + ", liteMember=" + liteMember
                 + ", crdtReplicationConfig=" + crdtReplicationConfig
+                + ", restApiConfig=" + restApiConfig
+                + ", memcacheProtocolConfig=" + memcacheProtocolConfig
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigSections.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigSections.java
@@ -67,7 +67,10 @@ enum ConfigSections {
     RELIABLE_ID_GENERATOR("reliable-id-generator", true),
     FLAKE_ID_GENERATOR("flake-id-generator", true),
     CRDT_REPLICATION("crdt-replication", false),
-    PN_COUNTER("pn-counter", true);
+    PN_COUNTER("pn-counter", true),
+    REST_API("rest-api", false),
+    MEMCACHE_PROTOCOL("memcache-protocol", false),
+    ;
 
     final String name;
     final boolean multipleOccurrence;

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -159,6 +159,8 @@ public class ConfigXmlGenerator {
         crdtReplicationXmlGenerator(gen, config);
         pnCounterXmlGenerator(gen, config);
         quorumXmlGenerator(gen, config);
+        restApiXmlGenerator(gen, config);
+        memcacheProtocolXmlGenerator(gen, config);
 
         xml.append("</hazelcast>");
 
@@ -1375,6 +1377,26 @@ public class ConfigXmlGenerator {
 
     private static void liteMemberXmlGenerator(XmlGenerator gen, Config config) {
         gen.node("lite-member", null, "enabled", config.isLiteMember());
+    }
+
+    private static void restApiXmlGenerator(XmlGenerator gen, Config config) {
+        RestApiConfig c = config.getRestApiConfig();
+        if (c == null) {
+            return;
+        }
+        gen.open("rest-api", "enabled", c.isEnabled());
+        for (RestEndpointGroup group : RestEndpointGroup.values()) {
+            gen.node("endpoint-group", null, "name", group.name(), "enabled", c.isGroupEnabled(group));
+        }
+        gen.close();
+    }
+
+    private static void memcacheProtocolXmlGenerator(XmlGenerator gen, Config config) {
+        MemcacheProtocolConfig c = config.getMemcacheProtocolConfig();
+        if (c == null) {
+            return;
+        }
+        gen.node("memcache-protocol", null, "enabled", c.isEnabled());
     }
 
     private String format(String input, int indent) {

--- a/hazelcast/src/main/java/com/hazelcast/config/MemcacheProtocolConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemcacheProtocolConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * This class allows to enable MEMCACHE text protocol support in Hazelcast.
+ */
+public class MemcacheProtocolConfig {
+
+    private boolean enabled;
+
+    /**
+     * Returns if MEMCACHE protocol support is enabled.
+     *
+     * @return {@code true} if enabled, {@code false} otherwise
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enables or disables the MEMCACHE protocol on the member.
+     */
+    public MemcacheProtocolConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "MemcacheProtocolConfig{enabled=" + enabled + "}";
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/RestApiConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RestApiConfig.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This class allows to control which parts of Hazelcast REST API will be enabled. There are 2 levels of control:
+ * <ul>
+ * <li>overall REST access (enabled by default);</li>
+ * <li>access to REST endpoint groups (see {@link RestEndpointGroup}).</li>
+ * </ul>
+ */
+public class RestApiConfig {
+
+    private boolean enabled;
+
+    private final Set<RestEndpointGroup> enabledGroups = Collections
+            .newSetFromMap(new ConcurrentHashMap<RestEndpointGroup, Boolean>());
+
+    public RestApiConfig() {
+        for (RestEndpointGroup eg : RestEndpointGroup.values()) {
+            if (eg.isEnabledByDefault()) {
+                enabledGroups.add(eg);
+            }
+        }
+    }
+
+    /**
+     * Enables all REST endpoint groups.
+     */
+    public RestApiConfig enableAllGroups() {
+        return enableGroups(RestEndpointGroup.values());
+    }
+
+    /**
+     * Enables provided REST endpoint groups. It doesn't replace already enabled groups.
+     */
+    public RestApiConfig enableGroups(RestEndpointGroup... endpointGroups) {
+        if (endpointGroups != null) {
+            enabledGroups.addAll(Arrays.asList(endpointGroups));
+        }
+        return this;
+    }
+
+    /**
+     * Disables all REST endpoint groups.
+     */
+    public RestApiConfig disableAllGroups() {
+        enabledGroups.clear();
+        return this;
+    }
+
+    /**
+     * Disables provided REST endpoint groups.
+     */
+    public RestApiConfig disableGroups(RestEndpointGroup... endpointGroups) {
+        if (endpointGroups != null) {
+            enabledGroups.removeAll(Arrays.asList(endpointGroups));
+        }
+        return this;
+    }
+
+    /**
+     * Checks if REST API access is enabled. This flag controls access to all REST resources on a Hazelcast member. Once the
+     * REST API is enabled you can control access to REST endpoints by enabling/disabling enpoint groups.
+     *
+     * @return {@code true} if enabled, {@code false} otherwise
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Return true if the REST API is enabled and at least one REST endpoint group is allowed.
+     */
+    public boolean isEnabledAndNotEmpty() {
+        return enabled && !enabledGroups.isEmpty();
+    }
+
+    /**
+     * Enables or disables the REST API on the member.
+     */
+    public RestApiConfig setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    /**
+     * Returns a not-{@code null} set of enabled REST endpoint groups.
+     */
+    public Set<RestEndpointGroup> getEnabledGroups() {
+        return new HashSet<RestEndpointGroup>(enabledGroups);
+    }
+
+    /**
+     * Checks if given REST endpoint group is enabled. It can return {@code true} even if the REST API itself is disabled.
+     */
+    public boolean isGroupEnabled(RestEndpointGroup group) {
+        return enabledGroups.contains(group);
+    }
+
+    public void setEnabledGroups(Collection<RestEndpointGroup> groups) {
+        enabledGroups.clear();
+        if (groups != null) {
+            enabledGroups.addAll(groups);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "RestApiConfig{enabled=" + enabled + ", enabledGroups=" + enabledGroups + "}";
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/RestApiConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RestApiConfig.java
@@ -19,9 +19,9 @@ package com.hazelcast.config;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This class allows to control which parts of Hazelcast REST API will be enabled. There are 2 levels of control:
@@ -34,8 +34,7 @@ public class RestApiConfig {
 
     private boolean enabled;
 
-    private final Set<RestEndpointGroup> enabledGroups = Collections
-            .newSetFromMap(new ConcurrentHashMap<RestEndpointGroup, Boolean>());
+    private final Set<RestEndpointGroup> enabledGroups = Collections.synchronizedSet(EnumSet.noneOf(RestEndpointGroup.class));
 
     public RestApiConfig() {
         for (RestEndpointGroup eg : RestEndpointGroup.values()) {

--- a/hazelcast/src/main/java/com/hazelcast/config/RestEndpointGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RestEndpointGroup.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Enum of REST endpoint groups. A REST group is predefined set of REST endpoints which can be enabled or disabled. Groups don't
+ * overlap - each Hazelcast REST endpoint belongs to exactly one group. Each group has a default value
+ * ({@link #isEnabledByDefault()}) which controls if it will be included by default in {@link RestApiConfig} configuration.
+ *
+ * @see RestApiConfig
+ */
+public enum RestEndpointGroup {
+
+    /**
+     * Group of operations for retrieving cluster state and its version.
+     */
+    CLUSTER_READ(true),
+    /**
+     * Operations which changes cluster or node state or their configurations.
+     */
+    CLUSTER_WRITE(false),
+    /**
+     * Group of endpoints for HTTP health checking.
+     */
+    HEALTH_CHECK(true),
+    /**
+     * Group of HTTP REST APIs related to Hot Restart feature.
+     */
+    HOT_RESTART(false),
+    /**
+     * Group of HTTP REST APIs related to WAN Replication feature.
+     */
+    WAN(false),
+    /**
+     * Group of HTTP REST APIs for data manipulation in the cluster (e.g. IMap and IQueue operations).
+     */
+    DATA(false);
+
+    private final boolean enabledByDefault;
+
+    private RestEndpointGroup(boolean enabledByDefault) {
+        this.enabledByDefault = enabledByDefault;
+    }
+
+    /**
+     * Returns if this group is enabled by default.
+     */
+    public boolean isEnabledByDefault() {
+        return enabledByDefault;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommandProcessor.java
@@ -60,6 +60,9 @@ public abstract class HttpCommandProcessor<T> extends AbstractTextCommandProcess
     public static final String LEGACY_URI_MANCENTER_WAN_CLEAR_QUEUES = "/hazelcast/rest/mancenter/clearWanQueues";
     public static final String LEGACY_URI_ADD_WAN_CONFIG = "/hazelcast/rest/wan/addWanConfig";
 
+    // License info
+    public static final String URI_LICENSE_INFO = "/hazelcast/rest/license";
+
     protected HttpCommandProcessor(TextCommandService textCommandService) {
         super(textCommandService);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -59,6 +59,8 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
                 handleHealthcheck(command, uri);
             } else if (uri.startsWith(URI_CLUSTER_VERSION_URL)) {
                 handleGetClusterVersion(command);
+            } else if (uri.startsWith(URI_LICENSE_INFO)) {
+                handleLicense(command);
             } else {
                 command.send404();
             }
@@ -191,5 +193,12 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         } else {
             command.setResponse(CONTENT_TYPE_BINARY, textCommandService.toByteArray(value));
         }
+    }
+
+    /**
+     * License info is mplemented in the Enterprise GET command processor. The OS version returns simple "404 Not Found".
+     */
+    protected void handleLicense(HttpGetCommand command) {
+        command.send404();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicConfigurationAwareConfig.java
@@ -42,6 +42,7 @@ import com.hazelcast.config.LockConfig;
 import com.hazelcast.config.ManagementCenterConfig;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MemberAttributeConfig;
+import com.hazelcast.config.MemcacheProtocolConfig;
 import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.NativeMemoryConfig;
@@ -52,6 +53,7 @@ import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QuorumConfig;
 import com.hazelcast.config.ReliableTopicConfig;
 import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
 import com.hazelcast.config.SecurityConfig;
@@ -171,6 +173,26 @@ public class DynamicConfigurationAwareConfig extends Config {
         this.isStaticFirst = !properties.getBoolean(SEARCH_DYNAMIC_CONFIG_FIRST);
         this.dynamicSecurityConfig = new DynamicSecurityConfig(staticConfig.getSecurityConfig(), null);
         this.configSearcher = initConfigSearcher();
+    }
+
+    @Override
+    public RestApiConfig getRestApiConfig() {
+        return staticConfig.getRestApiConfig();
+    }
+
+    @Override
+    public Config setRestApiConfig(RestApiConfig restApiConfig) {
+        return staticConfig.setRestApiConfig(restApiConfig);
+    }
+
+    @Override
+    public MemcacheProtocolConfig getMemcacheProtocolConfig() {
+        return staticConfig.getMemcacheProtocolConfig();
+    }
+
+    @Override
+    public Config setMemcacheProtocolConfig(MemcacheProtocolConfig memcacheProtocolConfig) {
+        return staticConfig.setMemcacheProtocolConfig(memcacheProtocolConfig);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOService.java
@@ -17,6 +17,8 @@
 package com.hazelcast.nio;
 
 import com.hazelcast.client.impl.ClientEngine;
+import com.hazelcast.config.MemcacheProtocolConfig;
+import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.internal.ascii.TextCommandService;
@@ -51,6 +53,15 @@ public interface IOService {
     void onFatalError(Exception e);
 
     SymmetricEncryptionConfig getSymmetricEncryptionConfig();
+
+    /**
+     * Returns initialized {@link RestApiConfig} for the node.
+     */
+    RestApiConfig getRestApiConfig();
+    /**
+     * Returns initialized {@link MemcacheProtocolConfig} for the node.
+     */
+    MemcacheProtocolConfig getMemcacheProtocolConfig();
 
     SSLConfig getSSLConfig();
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/AllowingTextProtocolFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/AllowingTextProtocolFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import com.hazelcast.nio.tcp.TcpIpConnection;
+
+/**
+ * This class is an all allowing implementation of {@link TextProtocolFilter}.
+ */
+public class AllowingTextProtocolFilter implements TextProtocolFilter {
+
+    public static final AllowingTextProtocolFilter INSTANCE = new AllowingTextProtocolFilter();
+
+    @Override
+    public void filterConnection(String commandLine, TcpIpConnection connection) {
+        // nothing to do here, allowing all
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/MemcacheTextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/MemcacheTextDecoder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ADD;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.APPEND;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.DECREMENT;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.INCREMENT;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.PREPEND;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.QUIT;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.REPLACE;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.SET;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.STATS;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.TOUCH;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.VERSION;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.hazelcast.internal.ascii.CommandParser;
+import com.hazelcast.internal.ascii.memcache.DeleteCommandParser;
+import com.hazelcast.internal.ascii.memcache.GetCommandParser;
+import com.hazelcast.internal.ascii.memcache.IncrementCommandParser;
+import com.hazelcast.internal.ascii.memcache.SetCommandParser;
+import com.hazelcast.internal.ascii.memcache.SimpleCommandParser;
+import com.hazelcast.internal.ascii.memcache.TouchCommandParser;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.spi.annotation.PrivateApi;
+
+@PrivateApi
+public class MemcacheTextDecoder extends TextDecoder {
+
+    public static final TextParsers TEXT_PARSERS;
+
+    static {
+        Map<String, CommandParser> parsers = new HashMap<String, CommandParser>();
+        parsers.put("get", new GetCommandParser());
+        parsers.put("gets", new GetCommandParser());
+        parsers.put("set", new SetCommandParser(SET));
+        parsers.put("add", new SetCommandParser(ADD));
+        parsers.put("replace", new SetCommandParser(REPLACE));
+        parsers.put("append", new SetCommandParser(APPEND));
+        parsers.put("prepend", new SetCommandParser(PREPEND));
+        parsers.put("touch", new TouchCommandParser(TOUCH));
+        parsers.put("incr", new IncrementCommandParser(INCREMENT));
+        parsers.put("decr", new IncrementCommandParser(DECREMENT));
+        parsers.put("delete", new DeleteCommandParser());
+        parsers.put("quit", new SimpleCommandParser(QUIT));
+        parsers.put("stats", new SimpleCommandParser(STATS));
+        parsers.put("version", new SimpleCommandParser(VERSION));
+        TEXT_PARSERS = new TextParsers(parsers);
+    }
+
+    public MemcacheTextDecoder(TcpIpConnection connection, TextEncoder encoder) {
+        super(connection, encoder, AllowingTextProtocolFilter.INSTANCE, TEXT_PARSERS);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/RestApiFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/RestApiFilter.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import java.util.StringTokenizer;
+
+import com.hazelcast.config.RestApiConfig;
+import com.hazelcast.config.RestEndpointGroup;
+import com.hazelcast.internal.ascii.rest.HttpCommandProcessor;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+
+/**
+ * This class is a policy enforcement point for HTTP REST API. It checks incoming command lines and validates if the command can
+ * be processed. If the command is unknown or not allowed the connection is closed.
+ */
+public class RestApiFilter implements TextProtocolFilter {
+
+    private final RestApiConfig restApiConfig;
+    private final TextParsers parsers;
+
+    RestApiFilter(RestApiConfig restApiConfig, TextParsers parsers) {
+        this.restApiConfig = restApiConfig;
+        this.parsers = parsers;
+    }
+
+    @Override
+    public void filterConnection(String commandLine, TcpIpConnection connection) {
+        RestEndpointGroup restEndpointGroup = getEndpointGroup(commandLine);
+        if (restEndpointGroup != null) {
+            if (!restApiConfig.isGroupEnabled(restEndpointGroup)) {
+                connection.close("REST endpoint group is not enabled - " + restEndpointGroup, null);
+            }
+        } else if (!commandLine.isEmpty()) {
+            connection.close("Unsupported command received on REST API handler.", null);
+        }
+    }
+
+    /**
+     * Parses given command line and return corresponding {@link RestEndpointGroup} instance, or {@code null} if no such is
+     * found.
+     */
+    private RestEndpointGroup getEndpointGroup(String commandLine) {
+        if (commandLine == null) {
+            return null;
+        }
+        StringTokenizer st = new StringTokenizer(commandLine);
+        String operation = nextToken(st);
+        // If the operation doesn't have a parser, then it's unknown.
+        if (parsers.getParser(operation) == null) {
+            return null;
+        }
+        // the operation is a HTTP method so the next token should be a resource path
+        String requestUri = nextToken(st);
+        return requestUri != null ? getHttpApiEndpointGroup(operation, requestUri) : null;
+    }
+
+    @SuppressWarnings({ "checkstyle:cyclomaticcomplexity", "checkstyle:npathcomplexity",
+            "checkstyle:booleanexpressioncomplexity" })
+    private RestEndpointGroup getHttpApiEndpointGroup(String operation, String requestUri) {
+        if (requestUri.startsWith(HttpCommandProcessor.URI_MAPS)
+                || requestUri.startsWith(HttpCommandProcessor.URI_QUEUES)) {
+            return RestEndpointGroup.DATA;
+        }
+        if (requestUri.startsWith(HttpCommandProcessor.URI_HEALTH_URL)) {
+            return RestEndpointGroup.HEALTH_CHECK;
+        }
+        if (requestUri.startsWith(HttpCommandProcessor.URI_MANCENTER_BASE_URL + "/wan/")
+                || requestUri.startsWith("/hazelcast/rest/wan/")
+                || requestUri.startsWith(HttpCommandProcessor.LEGACY_URI_MANCENTER_WAN_CLEAR_QUEUES)) {
+            return RestEndpointGroup.WAN;
+        }
+        if (requestUri.startsWith(HttpCommandProcessor.URI_FORCESTART_CLUSTER_URL)
+                || requestUri.startsWith(HttpCommandProcessor.URI_PARTIALSTART_CLUSTER_URL)
+                || requestUri.startsWith(HttpCommandProcessor.URI_HOT_RESTART_BACKUP_CLUSTER_URL)
+                || requestUri.startsWith(HttpCommandProcessor.URI_HOT_RESTART_BACKUP_INTERRUPT_CLUSTER_URL)) {
+            return RestEndpointGroup.HOT_RESTART;
+        }
+        if (requestUri.startsWith(HttpCommandProcessor.URI_CLUSTER)
+                || requestUri.startsWith(HttpCommandProcessor.URI_CLUSTER_STATE_URL)
+                || requestUri.startsWith(HttpCommandProcessor.URI_CLUSTER_NODES_URL)
+                || requestUri.startsWith(HttpCommandProcessor.URI_LICENSE_INFO)
+                || ("GET".equals(operation) && requestUri.startsWith(HttpCommandProcessor.URI_CLUSTER_VERSION_URL))) {
+            return RestEndpointGroup.CLUSTER_READ;
+        }
+        if (requestUri.startsWith("/hazelcast/")) {
+            return RestEndpointGroup.CLUSTER_WRITE;
+        }
+        return null;
+    }
+
+    private String nextToken(StringTokenizer st) {
+        return st.hasMoreTokens() ? st.nextToken() : null;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/RestApiTextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/RestApiTextDecoder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.hazelcast.internal.ascii.CommandParser;
+import com.hazelcast.internal.ascii.rest.HttpDeleteCommandParser;
+import com.hazelcast.internal.ascii.rest.HttpGetCommandParser;
+import com.hazelcast.internal.ascii.rest.HttpHeadCommandParser;
+import com.hazelcast.internal.ascii.rest.HttpPostCommandParser;
+import com.hazelcast.nio.IOService;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.spi.annotation.PrivateApi;
+
+@PrivateApi
+public class RestApiTextDecoder extends TextDecoder {
+
+    public static final TextParsers TEXT_PARSERS;
+
+    static {
+        Map<String, CommandParser> parsers = new HashMap<String, CommandParser>();
+        parsers.put("GET", new HttpGetCommandParser());
+        parsers.put("POST", new HttpPostCommandParser());
+        parsers.put("PUT", new HttpPostCommandParser());
+        parsers.put("DELETE", new HttpDeleteCommandParser());
+        parsers.put("HEAD", new HttpHeadCommandParser());
+        TEXT_PARSERS = new TextParsers(parsers);
+    }
+
+    public RestApiTextDecoder(TcpIpConnection connection, TextEncoder encoder) {
+        super(connection, encoder, createFilter(connection), TEXT_PARSERS);
+    }
+
+    private static RestApiFilter createFilter(TcpIpConnection connection) {
+        IOService ioService = connection.getConnectionManager().getIoService();
+        return new RestApiFilter(ioService.getRestApiConfig() , TEXT_PARSERS);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextParsers.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextParsers.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.hazelcast.internal.ascii.CommandParser;
+import com.hazelcast.nio.Protocols;
+import com.hazelcast.spi.annotation.PrivateApi;
+
+@PrivateApi
+public class TextParsers {
+
+    private final Map<String, CommandParser> parsers;
+    private final Set<String> commandPrefixes;
+
+    public TextParsers(Map<String, CommandParser> parsers) {
+        this.parsers = new HashMap<String, CommandParser>(parsers);
+        Set<String> prefixes = new HashSet<String>();
+        for (String command : parsers.keySet()) {
+            prefixes.add(command.substring(0, Protocols.PROTOCOL_LENGTH));
+        }
+        this.commandPrefixes = prefixes;
+    }
+
+    public CommandParser getParser(String command) {
+        return command != null ? parsers.get(command) : null;
+    }
+
+    public boolean isCommandPrefix(String prefix) {
+        return prefix != null ? commandPrefixes.contains(prefix) : false;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextProtocolFilter.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextProtocolFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import com.hazelcast.nio.tcp.TcpIpConnection;
+
+/**
+ * This interface is a text protocols policy enforcement point. It checks incoming command lines and validates if the command
+ * can be processed. If the command is unknown or not allowed the connection is closed.
+ */
+interface TextProtocolFilter {
+    void filterConnection(String commandLine, TcpIpConnection connection);
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -243,11 +243,24 @@ public final class GroupProperty {
     public static final HazelcastProperty CONNECT_ALL_WAIT_SECONDS
             = new HazelcastProperty("hazelcast.connect.all.wait.seconds", 120, SECONDS);
 
+    /**
+     * @deprecated Use {@link com.hazelcast.config.MemcacheProtocolConfig} instead.
+     */
+    @Deprecated
     public static final HazelcastProperty MEMCACHE_ENABLED
             = new HazelcastProperty("hazelcast.memcache.enabled", false);
+    /**
+     * @deprecated Use {@link com.hazelcast.config.RestEndpointGroup RestEndpointGroups} in
+     *             {@link com.hazelcast.config.RestApiConfig} instead.
+     */
+    @Deprecated
     public static final HazelcastProperty REST_ENABLED
             = new HazelcastProperty("hazelcast.rest.enabled", false);
-
+    /**
+     * @deprecated Enable or disable the {@link com.hazelcast.config.RestEndpointGroup#HEALTH_CHECK} group in
+     *             {@link com.hazelcast.config.RestApiConfig} instead.
+     */
+    @Deprecated
     public static final HazelcastProperty HTTP_HEALTHCHECK_ENABLED
             = new HazelcastProperty("hazelcast.http.healthcheck.enabled", false);
 
@@ -597,6 +610,11 @@ public final class GroupProperty {
 
     public static final HazelcastProperty MC_MAX_VISIBLE_SLOW_OPERATION_COUNT
             = new HazelcastProperty("hazelcast.mc.max.visible.slow.operations.count", 10);
+    /**
+     * @deprecated Enable or disable the {@link com.hazelcast.config.RestEndpointGroup#CLUSTER_WRITE} group in
+     *             {@link com.hazelcast.config.RestApiConfig} instead.
+     */
+    @Deprecated
     public static final HazelcastProperty MC_URL_CHANGE_ENABLED
             = new HazelcastProperty("hazelcast.mc.url.change.enabled", true);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/HazelcastProperties.java
@@ -137,6 +137,30 @@ public class HazelcastProperties {
     }
 
     /**
+     * Returns true if value for given key is provided (either as a HazelcastProperty or a System property). Default values are
+     * not taken into account.
+     *
+     * @param property the {@link HazelcastProperty} to check
+     * @return {@code true} if the value was explicitly provided
+     */
+    public boolean containsKey(HazelcastProperty property) {
+        if (property == null) {
+            return false;
+        }
+        return containsKey(property.getName())
+                || containsKey(property.getParent())
+                || containsKey(property.getDeprecatedName());
+    }
+
+    private boolean containsKey(String propertyName) {
+        if (propertyName == null) {
+            return false;
+        }
+        return properties.containsKey(propertyName)
+                || System.getProperty(propertyName) != null;
+    }
+
+    /**
      * Returns the configured boolean value of a {@link HazelcastProperty}.
      *
      * @param property the {@link HazelcastProperty} to get the value from

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -76,6 +76,8 @@
                 <xs:element name="flake-id-generator" type="flake-id-generator" minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="crdt-replication" type="crdt-replication" minOccurs="0" maxOccurs="1"/>
                 <xs:element name="pn-counter" type="pn-counter" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="rest-api" type="rest-api" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="memcache-protocol" type="memcache-protocol" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
@@ -4053,6 +4055,65 @@
         <xs:restriction base="non-space-string">
             <xs:enumeration value="NONE"/>
             <xs:enumeration value="MERKLE_TREES"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="memcache-protocol">
+        <xs:annotation>
+            <xs:documentation>
+                Allows to configure Memcache text protocol.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether the Memcache text protocol support is enabled. Default value is false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="rest-api">
+        <xs:annotation>
+            <xs:documentation>
+                Controls access to Hazelcast HTTP REST API.
+                The methods available through REST API are grouped to several REST endpoint groups.
+                There are 2 levels of configuration:
+                 - a global switch which enables/disables access to the REST API;
+                 - REST endpoint group level switch. It is used to check which groups are allowed once the global switch is enabled.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="endpoint-group" type="endpoint-group" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation>
+                        Enables or disables named REST enpoint group.
+                        If a group is not listed within the rest-api configuration, then it's 'enabledByDefault' flag is used
+                        to control the behavior of the group.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+        <xs:attribute name="enabled" type="xs:boolean" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Specifies whether the HTTP REST API is enabled. Default value is false.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="endpoint-group">
+        <xs:attribute name="name" type="endpoint-group-name" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="required"/>
+    </xs:complexType>
+    <xs:simpleType name="endpoint-group-name">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="CLUSTER_READ"/>
+            <xs:enumeration value="CLUSTER_WRITE"/>
+            <xs:enumeration value="HEALTH_CHECK"/>
+            <xs:enumeration value="HOT_RESTART"/>
+            <xs:enumeration value="WAN"/>
+            <xs:enumeration value="DATA"/>
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2425,4 +2425,41 @@
         <statistics-enabled>true</statistics-enabled>
     </pn-counter>
 
+    <!--
+    ===== HAZELCAST REST API CONFIGURATION =====
+
+    Configures Hazelcast HTTP REST API.
+    The <rest-api/> element has a global enabled switch, which controls the entrypoint to HTTP REST API. If it's disabled
+    then no text protocol is available.
+    Once the global switch is enabled there is an optional second level of control - REST endpoint groups. They are configured 
+    by element <endpoint-group/>. 
+    Groups and their defaults:
+    * CLUSTER_READ - enabled
+      Group of operations for retrieving cluster state and its version.
+    * CLUSTER_WRITE - disabled
+      Operations which changes cluster or node state or their configurations.
+    * HEALTH_CHECK - disabled
+      Group of endpoints for HTTP health checking.
+    * HOT_RESTART - disabled
+      Group of HTTP REST APIs related to Hot Restart feature.
+    * WAN - disabled
+      Group of HTTP REST APIs related to WAN Replication feature.
+    * DATA - disabled
+      Group of HTTP REST APIs for data manipulation in the cluster (e.g. IMap and IQueue operations).
+    -->
+    <rest-api enabled="false">
+        <endpoint-group name="CLUSTER_READ" enabled="true"/>
+        <endpoint-group name="CLUSTER_WRITE" enabled="false"/>
+        <endpoint-group name="HEALTH_CHECK" enabled="false"/>
+        <endpoint-group name="HOT_RESTART" enabled="false"/>
+        <endpoint-group name="WAN" enabled="false"/>
+        <endpoint-group name="DATA" enabled="false"/>
+    </rest-api>
+
+    <!--
+    ===== HAZELCAST MEMCACHE PROTOCOL CONFIGURATION =====
+
+    Allows to configure Memcache text protocol support in Hazelcast.
+    -->
+    <memcache-protocol enabled="false"/>
 </hazelcast>

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -129,6 +129,10 @@ public class ConfigCompatibilityChecker {
         checkCompatibleConfigs("quorum", c1, c2, c1.getQuorumConfigs(), c2.getQuorumConfigs(), new QuorumConfigChecker());
         checkCompatibleConfigs("security", c1, c2, singletonMap("", c1.getSecurityConfig()),
                 singletonMap("", c2.getSecurityConfig()), new SecurityConfigChecker());
+        checkCompatibleConfigs("rest-api", c1.getRestApiConfig(), c2.getRestApiConfig(),
+                new RestApiConfigChecker());
+        checkCompatibleConfigs("memcache-protocol", c1.getMemcacheProtocolConfig(), c2.getMemcacheProtocolConfig(),
+                new MemcacheProtocolConfigChecker());
 
         return true;
     }
@@ -1350,6 +1354,33 @@ public class ConfigCompatibilityChecker {
                     && nullSafeEqual(c1.getQuorumFunctionClassName(), c2.getQuorumFunctionClassName())
                     && nullSafeEqual(c1.getQuorumFunctionImplementation(), c2.getQuorumFunctionImplementation())
                     && nullSafeEqual(c1.getListenerConfigs(), c2.getListenerConfigs()));
+        }
+    }
+
+    static class RestApiConfigChecker extends ConfigChecker<RestApiConfig> {
+        @Override
+        boolean check(RestApiConfig c1, RestApiConfig c2) {
+            if (c1 == c2) {
+                return true;
+            }
+            if (c1 == null || c2 == null) {
+                return false;
+            }
+            return (c1.isEnabled() == c2.isEnabled())
+                    && nullSafeEqual(c1.getEnabledGroups(), c2.getEnabledGroups());
+        }
+    }
+
+    static class MemcacheProtocolConfigChecker extends ConfigChecker<MemcacheProtocolConfig> {
+        @Override
+        boolean check(MemcacheProtocolConfig c1, MemcacheProtocolConfig c2) {
+            if (c1 == c2) {
+                return true;
+            }
+            if (c1 == null || c2 == null) {
+                return false;
+            }
+            return (c1.isEnabled() == c2.isEnabled());
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -1357,6 +1357,50 @@ public class ConfigXmlGeneratorTest {
                 new ConfigCompatibilityChecker.QuorumConfigChecker().check(quorumConfig, generatedConfig));
     }
 
+    @Test
+    public void testMemcacheProtocolConfig() {
+        MemcacheProtocolConfig memcacheProtocolConfig = new MemcacheProtocolConfig().setEnabled(true);
+        Config config = new Config().setMemcacheProtocolConfig(memcacheProtocolConfig);
+        MemcacheProtocolConfig generatedConfig = getNewConfigViaXMLGenerator(config).getMemcacheProtocolConfig();
+        assertTrue(generatedConfig.toString() + " should be compatible with " + memcacheProtocolConfig.toString(),
+                new ConfigCompatibilityChecker.MemcacheProtocolConfigChecker().check(memcacheProtocolConfig, generatedConfig));
+    }
+
+    @Test
+    public void testEmptyRestApiConfig() {
+        RestApiConfig restApiConfig = new RestApiConfig();
+        Config config = new Config().setRestApiConfig(restApiConfig);
+        RestApiConfig generatedConfig = getNewConfigViaXMLGenerator(config).getRestApiConfig();
+        assertTrue(generatedConfig.toString() + " should be compatible with " + restApiConfig.toString(),
+                new ConfigCompatibilityChecker.RestApiConfigChecker().check(restApiConfig, generatedConfig));
+    }
+
+    @Test
+    public void testAllEnabledRestApiConfig() {
+        RestApiConfig restApiConfig = new RestApiConfig();
+        restApiConfig.setEnabled(true).enableAllGroups();
+        Config config = new Config().setRestApiConfig(restApiConfig);
+        RestApiConfig generatedConfig = getNewConfigViaXMLGenerator(config).getRestApiConfig();
+        assertTrue(generatedConfig.toString() + " should be compatible with " + restApiConfig.toString(),
+                new ConfigCompatibilityChecker.RestApiConfigChecker().check(restApiConfig, generatedConfig));
+    }
+
+    @Test
+    public void testExplicitlyAssignedGroupsRestApiConfig() {
+        RestApiConfig restApiConfig = new RestApiConfig();
+        restApiConfig.setEnabled(true);
+        restApiConfig.enableGroups(RestEndpointGroup.CLUSTER_READ,
+                RestEndpointGroup.HEALTH_CHECK,
+                RestEndpointGroup.HOT_RESTART,
+                RestEndpointGroup.WAN);
+        restApiConfig.disableGroups(RestEndpointGroup.CLUSTER_WRITE,
+                RestEndpointGroup.DATA);
+        Config config = new Config().setRestApiConfig(restApiConfig);
+        RestApiConfig generatedConfig = getNewConfigViaXMLGenerator(config).getRestApiConfig();
+        assertTrue(generatedConfig.toString() + " should be compatible with " + restApiConfig.toString(),
+                new ConfigCompatibilityChecker.RestApiConfigChecker().check(restApiConfig, generatedConfig));
+    }
+
     private DiscoveryConfig getDummyDiscoveryConfig() {
         DiscoveryStrategyConfig strategyConfig = new DiscoveryStrategyConfig("dummyClass");
         strategyConfig.addProperty("prop1", "val1");

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
@@ -55,8 +55,6 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
-// intentionally not in ParallelTest category,
-// test is starting standalone HazelcastInstances.
 public class MemcachedTest extends HazelcastTestSupport {
 
     private Config config = new Config();

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -18,12 +18,12 @@ package com.hazelcast.internal.ascii;
 
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.instance.BuildInfoProvider;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
@@ -40,6 +40,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
+import java.net.SocketException;
 import java.util.concurrent.CountDownLatch;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterStateEventually;
@@ -71,8 +72,8 @@ public class RestClusterTest {
 
     protected Config createConfigWithRestEnabled() {
         Config config = new Config();
-        config.setProperty(GroupProperty.REST_ENABLED.getName(), "true");
-        config.setProperty(GroupProperty.HTTP_HEALTHCHECK_ENABLED.getName(), "true");
+        RestApiConfig restApiConfig = new RestApiConfig().setEnabled(true).enableAllGroups();
+        config.setRestApiConfig(restApiConfig);
         return config;
     }
 
@@ -90,7 +91,7 @@ public class RestClusterTest {
         try {
             communicator.getClusterInfo();
             fail("Rest is disabled. Not expected to reach here!");
-        } catch (NoHttpResponseException ignored) {
+        } catch (SocketException ignored) {
         }
     }
 
@@ -297,7 +298,7 @@ public class RestClusterTest {
         assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, communicator.getClusterHealthResponseCode("/unknown-parameter"));
     }
 
-    @Test(expected = NoHttpResponseException.class)
+    @Test(expected = SocketException.class)
     public void fail_with_deactivatedHealthCheck() throws Exception {
         // Healthcheck REST URL is deactivated by default - no passed config on purpose
         HazelcastInstance instance = factory.newHazelcastInstance(null);

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.ascii;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.PermissionConfig;
+import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
@@ -26,7 +27,6 @@ import com.hazelcast.core.IQueue;
 import com.hazelcast.internal.management.dto.WanReplicationConfigDTO;
 import com.hazelcast.internal.management.request.UpdatePermissionConfigRequest;
 import com.hazelcast.nio.Address;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestAwareInstanceFactory;
@@ -77,10 +77,9 @@ public class RestTest {
 
     private Config setup() {
         Config config = new Config();
-        config.setProperty(GroupProperty.REST_ENABLED.getName(), "true");
-
+        RestApiConfig restApiConfig = new RestApiConfig().setEnabled(true).enableAllGroups();
+        config.setRestApiConfig(restApiConfig);
         instance = factory.newHazelcastInstance(config);
-
         communicator = new HTTPCommunicator(instance);
         return config;
     }
@@ -229,7 +228,7 @@ public class RestTest {
         permissionConfigs.add(new PermissionConfig(PermissionConfig.PermissionType.MAP, "test", "*"));
         UpdatePermissionConfigRequest request = new UpdatePermissionConfigRequest(permissionConfigs);
         String result = communicator.updatePermissions(config.getGroupConfig().getName(),
-                config.getGroupConfig().getPassword(), request.toJson().toString());
+                "", request.toJson().toString());
         assertEquals("{\"status\":\"forbidden\"}", result);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/NodeIOServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/NodeIOServiceTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.NetworkConfig;
 import com.hazelcast.instance.Node;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -49,11 +50,12 @@ public class NodeIOServiceTest extends HazelcastTestSupport {
     public void setUp() {
         Node mockNode = mock(Node.class);
         NodeEngineImpl mockNodeEngine = mock(NodeEngineImpl.class);
-        ioService = new NodeIOService(mockNode, mockNodeEngine);
-
         Config config = new Config();
+        HazelcastProperties properties = new HazelcastProperties(config);
         networkConfig = config.getNetworkConfig();
         when(mockNode.getConfig()).thenReturn(config);
+        when(mockNode.getProperties()).thenReturn(properties);
+        ioService = new NodeIOService(mockNode, mockNodeEngine);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/nio/ascii/AbstractTextProtocolsTestBase.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ascii/AbstractTextProtocolsTestBase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertThat;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import com.hazelcast.config.RestApiConfig;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.TestAwareInstanceFactory;
+
+/**
+ * Shared code for {@link RestApiConfig} and {@link TextProtocolFilter} testing.
+ */
+public abstract class AbstractTextProtocolsTestBase {
+
+    public static final String CRLF = "\r\n";
+
+    protected final TestAwareInstanceFactory factory = new TestAwareInstanceFactory();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @After
+    public void cleanup() {
+        factory.terminateAll();
+    }
+
+    protected AssertTask createResponseAssertTask(final String message, final TextProtocolClient client, final String expectedSubstring) {
+        return new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                assertThat(message, client.getReceivedString(), containsString(expectedSubstring));
+            }
+        };
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/ascii/HttpRestEndpointGroupsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ascii/HttpRestEndpointGroupsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
+
+import com.hazelcast.config.RestEndpointGroup;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelParametersRunnerFactory;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Tests if HTTP REST URLs are protected by the correct REST endpoint groups.
+ */
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(HazelcastParallelParametersRunnerFactory.class)
+@Category(QuickTest.class)
+public class HttpRestEndpointGroupsTest extends RestApiConfigTestBase {
+
+    @Parameter
+    public RestEndpointGroup restEndpointGroup;
+
+    @Parameters(name = "restEndpointGroup:{0}")
+    public static RestEndpointGroup[] parameters() {
+        return RestEndpointGroup.values();
+    }
+
+    @Test
+    public void testGroupEnabled() throws Exception {
+        HazelcastInstance hz = factory.newHazelcastInstance(createConfigWithEnabledGroups(restEndpointGroup));
+        for (TestUrl testUrl : TEST_URLS) {
+            if (restEndpointGroup == testUrl.restEndpointGroup) {
+                assertTextProtocolResponse(hz, testUrl);
+            }
+        }
+    }
+
+    @Test
+    public void testGroupDisabled() throws Exception {
+        HazelcastInstance hz = factory.newHazelcastInstance(createConfigWithDisabledGroups(restEndpointGroup));
+        for (TestUrl testUrl : TEST_URLS) {
+            if (restEndpointGroup == testUrl.restEndpointGroup) {
+                assertNoTextProtocolResponse(hz, testUrl);
+            }
+        }
+    }
+
+    @Test
+    public void testOthersWhenGroupEnabled() throws Exception {
+        HazelcastInstance hz = factory.newHazelcastInstance(createConfigWithEnabledGroups(restEndpointGroup));
+        for (TestUrl testUrl : TEST_URLS) {
+            if (restEndpointGroup != testUrl.restEndpointGroup) {
+                assertNoTextProtocolResponse(hz, testUrl);
+            }
+        }
+    }
+
+    @Test
+    public void testOthersWhenGroupDisabled() throws Exception {
+        HazelcastInstance hz = factory.newHazelcastInstance(createConfigWithDisabledGroups(restEndpointGroup));
+        for (TestUrl testUrl : TEST_URLS) {
+            if (restEndpointGroup != testUrl.restEndpointGroup) {
+                assertTextProtocolResponse(hz, testUrl);
+            }
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/ascii/MemcacheProtocolFilterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ascii/MemcacheProtocolFilterTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.getAddress;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MemcacheProtocolConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Tests enabling Memcache text protocol by {@link MemcacheProtocolConfig}.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class MemcacheProtocolFilterTest extends AbstractTextProtocolsTestBase {
+
+    /**
+     * <pre>
+     * Given: Memcache protocol is explicitly disabled
+     * When: version commad prefix (ver) is used by client
+     * Then: connection is terminated after reading the first 3 bytes (protocol header)
+     * </pre>
+     */
+    @Test
+    public void testRestApiDisabled() throws Exception {
+        Config config = new Config();
+        config.setMemcacheProtocolConfig(new MemcacheProtocolConfig().setEnabled(false));
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData("ver");
+            client.waitUntilClosed();
+            assertEquals(3, client.getSentBytesCount());
+            assertEquals(0, client.getReceivedBytes().length);
+            assertTrue(client.isConnectionClosed());
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * <pre>
+     * Given: Memcache protocol config is not provided (default is used)
+     * When: version commad prefix (ver) is used by client
+     * Then: connection is terminated after reading the first 3 bytes (protocol header)
+     * </pre>
+     */
+    @Test
+    public void testMemcacheDisabledByDefault() throws Exception {
+        HazelcastInstance hz = factory.newHazelcastInstance(null);
+        TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData("ver");
+            client.waitUntilClosed();
+            assertEquals(3, client.getSentBytesCount());
+            assertEquals(0, client.getReceivedBytes().length);
+            assertTrue(client.isConnectionClosed());
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * <pre>
+     * Given: Memcache protocol  is explicitly enabled
+     * When: HTTP GET command prefix is used by client
+     * Then: connection is terminated after reading the first 3 bytes (protocol header)
+     * </pre>
+     */
+    @Test
+    public void testRestApiWhenMemcacheEnabled() throws Exception {
+        Config config = new Config();
+        config.setMemcacheProtocolConfig(new MemcacheProtocolConfig().setEnabled(true));
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData("GET");
+            client.waitUntilClosed();
+            assertEquals(3, client.getSentBytesCount());
+            assertEquals(0, client.getReceivedBytes().length);
+            assertTrue(client.isConnectionClosed());
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * <pre>
+     * Given: Memcache protocol is explicitly enabled
+     * When: version command is used
+     * Then: correct response is provided
+     * </pre>
+     */
+    @Test
+    public void testVersionCommandWithMemcacheEnabled() throws Exception {
+        Config config = new Config();
+        config.setMemcacheProtocolConfig(new MemcacheProtocolConfig().setEnabled(true));
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData("version\n");
+            assertTrueEventually(createResponseAssertTask("Version expected", client, "VERSION Hazelcast"), 10);
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/ascii/RestApiConfigTestBase.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ascii/RestApiConfigTestBase.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.getAddress;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.RestApiConfig;
+import com.hazelcast.config.RestEndpointGroup;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.internal.cluster.Versions;
+
+import static com.hazelcast.config.RestEndpointGroup.CLUSTER_READ;
+import static com.hazelcast.config.RestEndpointGroup.CLUSTER_WRITE;
+import static com.hazelcast.config.RestEndpointGroup.DATA;
+import static com.hazelcast.config.RestEndpointGroup.HEALTH_CHECK;
+import static com.hazelcast.config.RestEndpointGroup.HOT_RESTART;
+import static com.hazelcast.config.RestEndpointGroup.WAN;
+
+/**
+ * Shared code for HTTP REST API and Memcache protocol testing.
+ */
+public abstract class RestApiConfigTestBase extends AbstractTextProtocolsTestBase {
+
+    public static final String POST = "POST";
+    public static final String GET = "GET";
+    public static final String DELETE = "DELETE";
+    public static final String CRLF = "\r\n";
+
+    protected static final TestUrl[] TEST_URLS = new TestUrl[]{
+            new TestUrl(CLUSTER_WRITE, POST, "/hazelcast/rest/mancenter/changeurl ", "HTTP/1.1 500"),
+            new TestUrl(CLUSTER_WRITE, POST, "/hazelcast/rest/mancenter/security/permissions", "forbidden"),
+            new TestUrl(CLUSTER_READ, GET, "/hazelcast/rest/cluster", "Members {size:1, ver:1} ["),
+            new TestUrl(CLUSTER_READ, POST, "/hazelcast/rest/management/cluster/state", "forbidden"),
+            new TestUrl(CLUSTER_WRITE, POST, "/hazelcast/rest/management/cluster/changeState", "HTTP/1.1 500"),
+            new TestUrl(CLUSTER_WRITE, POST, "/hazelcast/rest/management/cluster/version", "HTTP/1.1 500"),
+            new TestUrl(CLUSTER_READ, GET, "/hazelcast/rest/management/cluster/version", Versions.CURRENT_CLUSTER_VERSION.toString()),
+            new TestUrl(CLUSTER_WRITE, POST, "/hazelcast/rest/management/cluster/clusterShutdown", "forbidden"),
+            new TestUrl(CLUSTER_WRITE, POST, "/hazelcast/rest/management/cluster/memberShutdown", "forbidden"),
+            new TestUrl(CLUSTER_READ, POST, "/hazelcast/rest/management/cluster/nodes", "forbidden"),
+            new TestUrl(CLUSTER_READ, GET, "/hazelcast/rest/license", getLicenseInfoExpectedResponse()),
+            new TestUrl(HOT_RESTART, POST, "/hazelcast/rest/management/cluster/forceStart", "forbidden"),
+            new TestUrl(HOT_RESTART, POST, "/hazelcast/rest/management/cluster/partialStart", "forbidden"),
+            new TestUrl(HOT_RESTART, POST, "/hazelcast/rest/management/cluster/hotBackup", "forbidden"),
+            new TestUrl(HOT_RESTART, POST, "/hazelcast/rest/management/cluster/hotBackupInterrupt", "forbidden"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/mancenter/wan/sync/map", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/mancenter/wan/sync/allmaps", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/mancenter/wan/clearWanQueues", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/mancenter/wan/addWanConfig", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/mancenter/wan/pausePublisher", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/mancenter/wan/stopPublisher", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/mancenter/wan/resumePublisher", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/mancenter/wan/consistencyCheck/map", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/wan/sync/map", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/wan/sync/allmaps", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/mancenter/clearWanQueues", "HTTP/1.1 500"),
+            new TestUrl(WAN, POST, "/hazelcast/rest/wan/addWanConfig", "HTTP/1.1 500"),
+            new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/node-state", "ACTIVE"),
+            new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/cluster-state", "ACTIVE"),
+            new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/cluster-safe", "HTTP/1.1 200"),
+            new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/migration-queue-size", "HTTP/1.1 200"),
+            new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/cluster-size", "HTTP/1.1 200"),
+            new TestUrl(DATA, POST, "/hazelcast/rest/maps/", "HTTP/1.1 400"),
+            new TestUrl(DATA, GET, "/hazelcast/rest/maps/", "HTTP/1.1 400"),
+            new TestUrl(DATA, DELETE, "/hazelcast/rest/maps/", "HTTP/1.1 200"),
+            new TestUrl(DATA, POST, "/hazelcast/rest/queues/", "HTTP/1.1 400"),
+            new TestUrl(DATA, GET, "/hazelcast/rest/queues/", "HTTP/1.1 400"),
+            new TestUrl(DATA, DELETE, "/hazelcast/rest/queues/", "HTTP/1.1 400"),
+            new TestUrl(CLUSTER_WRITE, POST, "/hazelcast/1", "HTTP/1.1 404"),
+            new TestUrl(CLUSTER_WRITE, GET, "/hazelcast/1", "HTTP/1.1 404"),
+            new TestUrl(CLUSTER_WRITE, DELETE, "/hazelcast/1", "HTTP/1.1 404"),
+    };
+
+    /**
+     * Creates Hazelcast {@link Config} with enabled all but provided {@link RestEndpointGroup RestEndpointGroups}.
+     */
+    protected Config createConfigWithDisabledGroups(RestEndpointGroup... group) {
+        RestApiConfig restApiConfig = new RestApiConfig();
+        restApiConfig.setEnabled(true);
+        restApiConfig.enableAllGroups().disableGroups(group);
+        return new Config().setRestApiConfig(restApiConfig);
+    }
+
+    /**
+     * Creates Hazelcast {@link Config} with disabled all but provided {@link RestEndpointGroup RestEndpointGroups}.
+     */
+    protected Config createConfigWithEnabledGroups(RestEndpointGroup... group) {
+        RestApiConfig restApiConfig = new RestApiConfig();
+        restApiConfig.setEnabled(true);
+        restApiConfig.disableAllGroups().enableGroups(group);
+        return new Config().setRestApiConfig(restApiConfig);
+    }
+
+    protected static void assertEmptyString(String stringToCheck) {
+        if (stringToCheck != null && !stringToCheck.isEmpty()) {
+            fail("Empty string was expected, but got '" + stringToCheck + "'");
+        }
+    }
+
+    /**
+     * Asserts that a text protocol client call to given {@link TestUrl} returns an expected response.
+     */
+    protected void assertTextProtocolResponse(HazelcastInstance hz, TestUrl testUrl) throws UnknownHostException, IOException {
+        final TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData(testUrl.method + " " + testUrl.requestUri + " HTTP/1.0" + CRLF + CRLF);
+            assertTrueEventually(createResponseAssertTask(testUrl.toString(), client, testUrl.expectedSubstring), 10);
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * Asserts that a wrong text protocol method call using given {@link TestUrl} closes the connection without returning any
+     * response (e.g. a call to a disabled REST API).
+     */
+    protected void assertNoTextProtocolResponse(HazelcastInstance hz, TestUrl testUrl)
+            throws UnknownHostException, InterruptedException, IOException {
+        TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData(testUrl.method + " " + testUrl.requestUri + " HTTP/1.0" + CRLF);
+            client.waitUntilClosed();
+            assertTrue("Connection close was expected (from server side). " + testUrl, client.isConnectionClosed());
+            String receivedResponse = client.getReceivedString();
+            if (receivedResponse != null && !receivedResponse.isEmpty()) {
+                fail("Empty response was expected, but got '" + receivedResponse + "'. " + testUrl);
+            }
+        } finally {
+            client.close();
+        }
+    }
+
+    static class TestUrl {
+        final RestEndpointGroup restEndpointGroup;
+        final String method;
+        final String requestUri;
+        final String expectedSubstring;
+
+        public TestUrl(RestEndpointGroup restEndpointGroup, String httpMethod, String requestUri, String expectedSubstring) {
+            this.restEndpointGroup = restEndpointGroup;
+            this.method = httpMethod;
+            this.requestUri = requestUri;
+            this.expectedSubstring = expectedSubstring;
+        }
+
+        @Override
+        public String toString() {
+            return "TestUrl [restEndpointGroup=" + restEndpointGroup + ", method=" + method + ", requestUri=" + requestUri
+                    + ", expectedSubstring=" + expectedSubstring + "]";
+        }
+    }
+
+    private static String getLicenseInfoExpectedResponse() {
+        return BuildInfoProvider.getBuildInfo().isEnterprise() ? "HTTP/1.1 200" : "HTTP/1.1 404";
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/ascii/RestApiFilterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ascii/RestApiFilterTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import static com.hazelcast.test.HazelcastTestSupport.getAddress;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.RestApiConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+
+/**
+ * Tests enabling HTTP REST API by {@link RestApiConfig}.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class RestApiFilterTest extends RestApiConfigTestBase {
+
+    /**
+     * <pre>
+     * Given: RestApiConfig is explicitly disabled
+     * When: a HTTP GET method is used by client
+     * Then: connection is terminated after reading the first 3 bytes (protocol header)
+     * </pre>
+     */
+    @Test
+    public void testRestApiDisabled() throws Exception {
+        Config config = new Config();
+        config.setRestApiConfig(new RestApiConfig().setEnabled(false));
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData(GET);
+            client.waitUntilClosed();
+            assertEquals(3, client.getSentBytesCount());
+            assertEquals(0, client.getReceivedBytes().length);
+            assertTrue(client.isConnectionClosed());
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * <pre>
+     * Given: RestApiConfig is not provided (default is used)
+     * When: a HTTP GET method is used by client
+     * Then: connection is terminated after reading the first 3 bytes (protocol header)
+     * </pre>
+     */
+    @Test
+    public void testRestApiDisabledByDefault() throws Exception {
+        HazelcastInstance hz = factory.newHazelcastInstance(null);
+        TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData(GET);
+            client.waitUntilClosed();
+            assertEquals(3, client.getSentBytesCount());
+            assertEquals(0, client.getReceivedBytes().length);
+            assertTrue(client.isConnectionClosed());
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * <pre>
+     * Given: RestApiConfig is explicitly enabled
+     * When: a memcache command prefix is used by client
+     * Then: connection is terminated after reading the first 3 bytes (protocol header)
+     * </pre>
+     */
+    @Test
+    public void testMemcacheWhenRestApiEnabled() throws Exception {
+        Config config = new Config();
+        config.setRestApiConfig(new RestApiConfig().setEnabled(true));
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData("ver");
+            client.waitUntilClosed();
+            assertEquals(3, client.getSentBytesCount());
+            assertEquals(0, client.getReceivedBytes().length);
+            assertTrue(client.isConnectionClosed());
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * <pre>
+     * Given: RestApiConfig is explicitly enabled
+     * When: HTTP GET command is used to retrieve a non-Hazelcast resource
+     * Then: connection is terminated after reading the command line
+     * </pre>
+     */
+    @Test
+    public void testHttpGetForUnknownResource() throws Exception {
+        Config config = new Config();
+        config.setRestApiConfig(new RestApiConfig().setEnabled(true));
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData(GET);
+            client.waitUntilClosed(2000);
+            assertFalse(client.isConnectionClosed());
+            client.sendData(" /test/abc HTTP/1.0" + CRLF);
+            client.waitUntilClosed();
+            assertEquals(0, client.getReceivedBytes().length);
+            assertTrue(client.isConnectionClosed());
+        } finally {
+            client.close();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/ascii/TextProtocolClient.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ascii/TextProtocolClient.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import static com.hazelcast.util.StringUtil.stringToBytes;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import com.hazelcast.logging.Logger;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.util.StringUtil;
+
+/**
+ * Test client for verifying text protocols (HTTP REST API, Memcache, ...). Sample usage:
+ * <p>
+ * <code><pre>
+ * TextProtocolClient client = new TextProtocolClient(address, port);
+ * try {
+ *   client.sendData("GET /hazelcast/health/node-state HTTP/1.0\r\n\r\n");
+ *   Thread.sleep(1000L);
+ *   assertThat(client.getReceivedString(), containsString("ACTIVE"));
+ * } finally {
+ *   client.close();
+ * }
+ * </pre></code>
+ * <p>
+ * This class is not thread safe.
+ */
+public class TextProtocolClient implements Closeable {
+
+    /**
+     * Default timeout for waiting for connection close (from server side).
+     *
+     * @see #waitUntilClosed()
+     */
+    private static final long DEFAULT_TIMEOUT_MILLIS = 10 * 1000L;
+
+    private final InetAddress inetAddress;
+    private final int port;
+
+    private Socket socket = null;
+    private int sentBytesCount = 0;
+    private InputStreamConsumerThread isThread = null;
+    private Exception exception = null;
+    private OutputStream os = null;
+
+    /**
+     * Creates new client for given address and port. Client is not connected automatically.
+     */
+    public TextProtocolClient(InetAddress inetAddress, int port) {
+        this.inetAddress = inetAddress;
+        this.port = port;
+    }
+
+    /**
+     * Creates new client for given socket address. Client is not connected automatically.
+     */
+    public TextProtocolClient(InetSocketAddress inetSocketAdddress) {
+        this(inetSocketAdddress.getAddress(), inetSocketAdddress.getPort());
+    }
+
+    /**
+     * Returns true if the client was connected (and not closed after the connect).
+     */
+    public boolean isConnected() {
+        return socket != null;
+    }
+
+    /**
+     * Connects the client to a server and starts a new data consuming thread.
+     */
+    public void connect() {
+        try {
+            socket = new Socket(inetAddress, port);
+            isThread = new InputStreamConsumerThread(socket.getInputStream());
+            isThread.start();
+            os = socket.getOutputStream();
+        } catch (IOException ioe) {
+            throw new RuntimeException("Unable to connect to a server.", ioe);
+        }
+    }
+
+    /**
+     * Sends given String (as UTF-8) to the server.
+     *
+     * @see #sendData(byte[])
+     */
+    public boolean sendData(String requestDataStr) {
+        return sendData(stringToBytes(requestDataStr));
+    }
+
+    /**
+     * Sends given bytes to the server.
+     *
+     * @throws IllegalStateException if the client is not connected
+     */
+    public boolean sendData(byte[] requestData) {
+        if (!isConnected()) {
+            throw new IllegalStateException("Client is not connected. Call the connect() method first!");
+        }
+        try {
+            os.write(requestData);
+            os.flush();
+            sentBytesCount += requestData.length;
+        } catch (Exception e) {
+            exception = e;
+            return false;
+        }
+        return isThread.getException() != null;
+    }
+
+    /**
+     * Returns {@code true} if the client is not yet connected or the connection was already closed.
+     */
+    public boolean isConnectionClosed() {
+        return isThread != null && !isThread.isAlive();
+    }
+
+    /**
+     * Waits default timeout ({@value #DEFAULT_TIMEOUT_MILLIS} ms) for closed connection. If the timeout is reached, the
+     * program run continues without exception.
+     */
+    public void waitUntilClosed() throws InterruptedException {
+        waitUntilClosed(DEFAULT_TIMEOUT_MILLIS);
+    }
+
+    /**
+     * Waits given timeout (ms) for closed connection. If the timeout is reached, the
+     * program run continues without exception.
+     */
+    public void waitUntilClosed(long timeoutMillis) throws InterruptedException {
+        if (isThread != null) {
+            isThread.join(timeoutMillis);
+        }
+    }
+
+    public InetAddress getInetAddress() {
+        return inetAddress;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    /**
+     * Send bytes counter.
+     */
+    public int getSentBytesCount() {
+        return sentBytesCount;
+    }
+
+    /**
+     * Exceptions holder.
+     */
+    public Exception getException() {
+        return exception != null ? exception : (isThread != null ? isThread.getException() : null);
+    }
+
+    /**
+     * Returns all bytes received by this client from a server.
+     */
+    public byte[] getReceivedBytes() {
+        return isThread != null ? isThread.getReceivedBytes() : null;
+    }
+
+    /**
+     * Returns all bytes received by this client from a server as UTF-8 String.
+     */
+    public String getReceivedString() {
+        return StringUtil.bytesToString(getReceivedBytes());
+    }
+
+    /**
+     * Closes this client and releases resources.
+     */
+    @Override
+    public void close() throws IOException {
+        if (socket == null) {
+            return;
+        }
+        try {
+            socket.close();
+        } catch (IOException e) {
+            Logger.getLogger(TextProtocolClient.class).finest("close failed", e);
+        }
+        socket = null;
+        isThread = null;
+        os = null;
+        exception = null;
+        sentBytesCount = 0;
+    }
+
+    private static class InputStreamConsumerThread extends Thread {
+        private final InputStream is;
+        private final ByteArrayOutputStream os = new ByteArrayOutputStream();
+        private volatile IOException exception;
+
+        public InputStreamConsumerThread(InputStream is) {
+            this.is = is;
+        }
+
+        public void run() {
+            try {
+                IOUtil.drainTo(is, os);
+            } catch (IOException e) {
+                exception = e;
+            }
+        }
+
+        public byte[] getReceivedBytes() {
+            return os.toByteArray();
+        }
+
+        public IOException getException() {
+            return exception;
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/ascii/TextProtocolsConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ascii/TextProtocolsConfigTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.ascii;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ConfigurationException;
+import com.hazelcast.config.MemcacheProtocolConfig;
+import com.hazelcast.config.RestApiConfig;
+import com.hazelcast.config.RestEndpointGroup;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.config.RestEndpointGroup.DATA;
+import static com.hazelcast.config.RestEndpointGroup.HEALTH_CHECK;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.getAddress;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests enabling text protocols by {@link RestApiConfig}, {@link MemcacheProtocolConfig} and legacy system properties.
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+@SuppressWarnings("deprecation")
+public class TextProtocolsConfigTest extends RestApiConfigTestBase {
+
+    private static final TestUrl TEST_URL_HEALTH_CHECK =
+            new TestUrl(HEALTH_CHECK, GET, "/hazelcast/health/node-state", "ACTIVE");
+    private static final TestUrl TEST_URL_DATA = new TestUrl(DATA, GET, "/hazelcast/rest/maps/test/testKey", "testValue");
+
+    /**
+     * <pre>
+     * Given: -
+     * When: empty RestApiConfig object is created
+     * Then: it's disabled and the only enabled REST endpoint group is the CLUSTER_READ
+     * </pre>
+     */
+    @Test
+    public void testRestApiDefaults() throws Exception {
+        RestApiConfig restApiConfig = new RestApiConfig();
+        assertFalse("REST should be disabled by default", restApiConfig.isEnabled());
+        for (RestEndpointGroup endpointGroup : RestEndpointGroup.values()) {
+            if (isExpectedDefaultEnabled(endpointGroup)) {
+                assertTrue(
+                        "REST endpoint group should be enabled by default: " + endpointGroup,
+                        restApiConfig.isGroupEnabled(endpointGroup));
+            } else {
+                assertFalse(
+                        "REST endpoint group should be disabled by default: " + endpointGroup,
+                        restApiConfig.isGroupEnabled(endpointGroup));
+            }
+        }
+    }
+
+    /**
+     * <pre>
+     * Given: -
+     * When: empty RestApiConfig object is created
+     * Then: access to all REST endpoints is denied
+     * </pre>
+     */
+    @Test
+    public void testRestApiCallWithDefaults() throws Exception {
+        Config config = new Config();
+        config.setRestApiConfig(new RestApiConfig());
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        for (TestUrl testUrl : TEST_URLS) {
+            assertNoTextProtocolResponse(hz, testUrl);
+        }
+    }
+
+    /**
+     * <pre>
+     * Given: RestApiConfig is explicitly enabled
+     * When: REST endpoint is accessed
+     * Then: it is permitted/denied based on its default groups values
+     * </pre>
+     */
+    @Test
+    public void testEnabledRestApiCallWithGroupDefaults() throws Exception {
+        Config config = new Config();
+        config.setRestApiConfig(new RestApiConfig().setEnabled(true));
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        for (TestUrl testUrl : TEST_URLS) {
+            if (isExpectedDefaultEnabled(testUrl.restEndpointGroup)) {
+                assertTextProtocolResponse(hz, testUrl);
+            } else {
+                assertNoTextProtocolResponse(hz, testUrl);
+            }
+        }
+    }
+
+    /**
+     * <pre>
+     * Given: RestApiConfig is explicitly enabled and all groups are explicitly enabled
+     * When: REST endpoint is accessed
+     * Then: access is permitted
+     * </pre>
+     */
+    @Test
+    public void testRestApiCallEnabledGroupsEnabled() throws Exception {
+        Config config = new Config();
+        config.setRestApiConfig(new RestApiConfig().setEnabled(true).enableAllGroups());
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        for (TestUrl testUrl : TEST_URLS) {
+            assertTextProtocolResponse(hz, testUrl);
+        }
+    }
+
+    /**
+     * <pre>
+     * Given: RestApiConfig is explicitly disabled and all groups are explicitly enabled
+     * When: REST endpoint is accessed
+     * Then: access is denied
+     * </pre>
+     */
+    @Test
+    public void testRestApiCallDisabledGroupsEnabled() throws Exception {
+        Config config = new Config();
+        config.setRestApiConfig(new RestApiConfig().setEnabled(false).enableAllGroups());
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        for (TestUrl testUrl : TEST_URLS) {
+            assertNoTextProtocolResponse(hz, testUrl);
+        }
+    }
+
+    @Test
+    public void testRestConfigWithRestProperty() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.REST_ENABLED.getName(), "true");
+        createMemberWithRestConfigAndAssertConfigException(config);
+    }
+
+    @Test
+    public void testRestConfigWithHealthCheckProperty() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.HTTP_HEALTHCHECK_ENABLED.getName(), "true");
+        createMemberWithRestConfigAndAssertConfigException(config);
+    }
+
+    @Test
+    public void testRestConfigWithMemcacheProperty() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.MEMCACHE_ENABLED.getName(), "true");
+        config.setRestApiConfig(new RestApiConfig());
+        factory.newHazelcastInstance(config);
+    }
+
+    @Test
+    public void testMemcacheProtocolConfigWithMemcachePropertyEnabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.MEMCACHE_ENABLED.getName(), "true");
+        config.setMemcacheProtocolConfig(new MemcacheProtocolConfig());
+        expectedException.expect(ConfigurationException.class);
+        factory.newHazelcastInstance(config);
+    }
+
+    @Test
+    public void testRestConfigWithRestPropertyDisabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.REST_ENABLED.getName(), "false");
+        createMemberWithRestConfigAndAssertConfigException(config);
+    }
+
+    @Test
+    public void testRestConfigWithHealthCheckPropertyDisabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.HTTP_HEALTHCHECK_ENABLED.getName(), "false");
+        createMemberWithRestConfigAndAssertConfigException(config);
+    }
+
+    @Test
+    public void testRestConfigWithMemcachePropertyDisabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.MEMCACHE_ENABLED.getName(), "false");
+        config.setRestApiConfig(new RestApiConfig());
+        factory.newHazelcastInstance(config);
+    }
+
+    @Test
+    public void testMemcacheProtocolConfigWithMemcachePropertyDisabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.MEMCACHE_ENABLED.getName(), "false");
+        config.setMemcacheProtocolConfig(new MemcacheProtocolConfig());
+        expectedException.expect(ConfigurationException.class);
+        factory.newHazelcastInstance(config);
+    }
+
+    @Test
+    public void testMemcachePropertyEnabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.MEMCACHE_ENABLED.getName(), "true");
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        assertNoTextProtocolResponse(hz, TEST_URL_HEALTH_CHECK);
+        TextProtocolClient client = new TextProtocolClient(getAddress(hz).getInetSocketAddress());
+        try {
+            client.connect();
+            client.sendData("version\n");
+            assertTrueEventually(createResponseAssertTask("Version expected", client, "VERSION Hazelcast"), 10);
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    public void testMemcachePropertyDisabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.MEMCACHE_ENABLED.getName(), "false");
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        assertNoTextProtocolResponse(hz, TEST_URL_DATA);
+        assertNoTextProtocolResponse(hz, TEST_URL_HEALTH_CHECK);
+    }
+
+    @Test
+    public void testHealthCheckPropertyEnabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.HTTP_HEALTHCHECK_ENABLED.getName(), "true");
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        assertTextProtocolResponse(hz, TEST_URL_HEALTH_CHECK);
+        assertNoTextProtocolResponse(hz, TEST_URL_DATA);
+    }
+
+    @Test
+    public void testHealthCheckPropertyDisabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.HTTP_HEALTHCHECK_ENABLED.getName(), "false");
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        assertNoTextProtocolResponse(hz, TEST_URL_DATA);
+        assertNoTextProtocolResponse(hz, TEST_URL_HEALTH_CHECK);
+    }
+
+    @Test
+    public void testRestPropertyEnabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.REST_ENABLED.getName(), "true");
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        hz.getMap("test").put("testKey", "testValue");
+        assertTextProtocolResponse(hz, TEST_URL_DATA);
+        assertTextProtocolResponse(hz, TEST_URL_HEALTH_CHECK);
+    }
+
+    @Test
+    public void testRestPropertyDisabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.REST_ENABLED.getName(), "false");
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        hz.getMap("test").put("testKey", "testValue");
+        assertNoTextProtocolResponse(hz, TEST_URL_DATA);
+        assertNoTextProtocolResponse(hz, TEST_URL_HEALTH_CHECK);
+    }
+
+    @Test
+    public void testAllRestPropertiesEnabled() throws Exception {
+        Config config = new Config()
+                .setProperty(GroupProperty.REST_ENABLED.getName(), "true")
+                .setProperty(GroupProperty.HTTP_HEALTHCHECK_ENABLED.getName(), "true")
+                .setProperty(GroupProperty.MEMCACHE_ENABLED.getName(), "true")
+                ;
+        HazelcastInstance hz = factory.newHazelcastInstance(config);
+        hz.getMap("test").put("testKey", "testValue");
+        assertTextProtocolResponse(hz, TEST_URL_DATA);
+        assertTextProtocolResponse(hz, TEST_URL_HEALTH_CHECK);
+    }
+
+    private void createMemberWithRestConfigAndAssertConfigException(Config config) {
+        config.setRestApiConfig(new RestApiConfig());
+        expectedException.expect(ConfigurationException.class);
+        factory.newHazelcastInstance(config);
+    }
+
+    private boolean isExpectedDefaultEnabled(RestEndpointGroup endpointGroup) {
+        return endpointGroup == RestEndpointGroup.CLUSTER_READ || endpointGroup == RestEndpointGroup.HEALTH_CHECK;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -17,6 +17,8 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.client.impl.ClientEngine;
+import com.hazelcast.config.MemcacheProtocolConfig;
+import com.hazelcast.config.RestApiConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.SymmetricEncryptionConfig;
 import com.hazelcast.instance.BuildInfoProvider;
@@ -328,5 +330,15 @@ public class MockIOService implements IOService {
     @Override
     public OutboundHandler[] createMemberOutboundHandlers(TcpIpConnection connection) {
         return new OutboundHandler[]{new PacketEncoder()};
+    }
+
+    @Override
+    public RestApiConfig getRestApiConfig() {
+        return new RestApiConfig();
+    }
+
+    @Override
+    public MemcacheProtocolConfig getMemcacheProtocolConfig() {
+        return new MemcacheProtocolConfig();
     }
 }

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -262,6 +262,15 @@
             </icmp>
         </failure-detector>
     </network>
+    <rest-api enabled="true">
+        <endpoint-group name="CLUSTER_READ" enabled="true"/>
+        <endpoint-group name="CLUSTER_WRITE" enabled="true"/>
+        <endpoint-group name="HEALTH_CHECK" enabled="true"/>
+        <endpoint-group name="HOT_RESTART" enabled="true"/>
+        <endpoint-group name="WAN" enabled="true"/>
+        <endpoint-group name="DATA" enabled="true"/>
+    </rest-api>
+    <memcache-protocol enabled="true"/>
     <partition-group enabled="true" group-type="CUSTOM">
         <member-group>
             <interface>10.10.0.*</interface>


### PR DESCRIPTION
This PR replaces REST API and Memcache protocol configuration based on Hazelcast properties with finer grained configuration in the member config model.

## Background
Hazelcast 3.11 allows to control text protocols (HTTP REST API and MEMCACHE) by following Hazelcast `true`/`false` properties :
* `hazelcast.rest.enabled`
* `hazelcast.http.healthcheck.enabled`
* `hazelcast.mc.url.change.enabled`
* `hazelcast.memcache.enabled`

These properties doesn't cover all operations available over the text protocols and some operations were always enabled.

## New text protocols configuration
This PR introduces a new `<rest-api/>` and `<memcache-protocol/> elements and corresponding `RestApiConfig` / `MemcacheProtocolConfig` classes to control the enabled parts of text protocols.

The `RestApiConfig` has 2 layers of configuration - a global enabled switch, which controls the entrypoint to text protocols. If it's disabled then no text protocol is available.

Once the global switch is enabled there is an optional second level of control - the REST endpoint groups. They are configured by child element <endpoint-group/>. 
Groups and their defaults:
* `CLUSTER_READ` - enabled
  Group of operations for retrieving cluster state and its version.
* `CLUSTER_WRITE` - disabled
  Operations which changes cluster or node state or their configurations.
* `HEALTH_CHECK` - enabled
  Group of endpoints for HTTP health checking.
* `HOT_RESTART` - disabled
  Group of HTTP REST APIs related to Hot Restart feature.
* `WAN` - disabled
  Group of HTTP REST APIs related to WAN Replication feature.
* `DATA` - disabled
  Group of HTTP REST APIs for data manipulation in the cluster (e.g. IMap and IQueue operations).

### Example XML config

```xml
<hazelcast>
    <rest-api enabled="true">
        <endpoint-group name="DATA" enabled="true"/>
    </rest-api>
    <memcache-protocol enabled="true"/>
</hazelcast>
```
This configuration has the Memcache protocol and HTTP REST API with 3 groups enabled: CLUSTER_READ and HEALTH_CHECK (as they are not explicitly disabled) and DATA.

### Example Java config
```java
RestApiConfig restApiConfig = new RestApiConfig()
    .setEnabled(true)
    .disableAllGroups()
    .enableGroups(RestEndpointGroup.DATA);
Config config = new Config()
    .setRestApiConfig(restApiConfig)
    .setMemcacheProtocolConfig(new MemcacheProtocolConfig().setEnabled(true));
```
Enables only the DATA endpoints in REST API. As the `disableAllGroups()` is called no other group is enabled. Also enables the Memcache protocol.

## Backward compatibility
The legacy Hazelcast properties were deprecated and they can be used if the explicit config object is not provided in Hazelcast member configuration.
If both the properties and the  config object instance are used, then a configuration exception is thrown and the member doesn't start.
There is an exception to the rule -  the `hazelcast.mc.url.change.enabled` property can be used together with a `RestApiConfig`.