### PR TITLE
Redo "ConfigLocators to extend common parent"

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigLocator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigLocator.java
@@ -16,26 +16,14 @@
 
 package com.hazelcast.client.config;
 
-import com.hazelcast.config.Config;
+import com.hazelcast.config.AbstractConfigLocator;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.net.URL;
 
 /**
  * A support class for the {@link XmlClientConfigBuilder} to locate the client
  * xml configuration.
  */
-public class XmlClientConfigLocator {
-    private static final ILogger LOGGER = Logger.getLogger(XmlClientConfigLocator.class);
-
-    private InputStream in;
-
+public class XmlClientConfigLocator extends AbstractConfigLocator {
     /**
      * Constructs a XmlClientConfigBuilder.
      *
@@ -43,118 +31,21 @@ public class XmlClientConfigLocator {
      */
     public XmlClientConfigLocator() {
         try {
-            if (loadFromSystemProperty()) {
+            if (loadFromSystemProperty("hazelcast.client.config")) {
                 return;
             }
 
-            if (loadFromWorkingDirectory()) {
+            if (loadFromWorkingDirectory("hazelcast-client.xml")) {
                 return;
             }
 
-            if (loadClientHazelcastXmlFromClasspath()) {
+            if (loadHazelcastConfigFromClasspath("hazelcast-client.xml")) {
                 return;
             }
 
-            loadDefaultConfigurationFromClasspath();
+            loadDefaultConfigurationFromClasspath("hazelcast-client-default.xml");
         } catch (final RuntimeException e) {
             throw new HazelcastException("Failed to load ClientConfig", e);
         }
     }
-
-    public InputStream getIn() {
-        return in;
-    }
-
-    private void loadDefaultConfigurationFromClasspath() {
-        LOGGER.info("Loading 'hazelcast-client-default.xml' from classpath.");
-
-        in = Config.class.getClassLoader().getResourceAsStream("hazelcast-client-default.xml");
-        if (in == null) {
-            throw new HazelcastException("Could not load 'hazelcast-client-default.xml' from classpath");
-        }
-    }
-
-    private boolean loadClientHazelcastXmlFromClasspath() {
-        URL url = Config.class.getClassLoader().getResource("hazelcast-client.xml");
-        if (url == null) {
-            LOGGER.finest("Could not find 'hazelcast-client.xml' in classpath.");
-            return false;
-        }
-
-        LOGGER.info("Loading 'hazelcast-client.xml' from classpath.");
-
-        in = Config.class.getClassLoader().getResourceAsStream("hazelcast-client.xml");
-        if (in == null) {
-            throw new HazelcastException("Could not load 'hazelcast-client.xml' from classpath");
-        }
-        return true;
-    }
-
-    private boolean loadFromWorkingDirectory() {
-        File file = new File("hazelcast-client.xml");
-        if (!file.exists()) {
-            LOGGER.finest("Could not find 'hazelcast-client.xml' in working directory.");
-            return false;
-        }
-
-        LOGGER.info("Loading 'hazelcast-client.xml' from working directory.");
-        try {
-            in = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
-            throw new HazelcastException("Failed to open file: " + file.getAbsolutePath(), e);
-        }
-        return true;
-    }
-
-    private boolean loadFromSystemProperty() {
-        String configSystemProperty = System.getProperty("hazelcast.client.config");
-
-        if (configSystemProperty == null) {
-            LOGGER.finest("Could not 'hazelcast.client.config' System property");
-            return false;
-        }
-
-        LOGGER.info("Loading configuration " + configSystemProperty + " from System property 'hazelcast.client.config'");
-
-        if (configSystemProperty.startsWith("classpath:")) {
-            loadSystemPropertyClassPathResource(configSystemProperty);
-        } else {
-            loadSystemPropertyFileResource(configSystemProperty);
-        }
-        return true;
-    }
-
-    private void loadSystemPropertyFileResource(String configSystemProperty) {
-        //it is a file.
-        File configurationFile = new File(configSystemProperty);
-        LOGGER.info("Using configuration file at " + configurationFile.getAbsolutePath());
-
-        if (!configurationFile.exists()) {
-            String msg = "Config file at '" + configurationFile.getAbsolutePath() + "' doesn't exist.";
-            throw new HazelcastException(msg);
-        }
-
-        try {
-            in = new FileInputStream(configurationFile);
-        } catch (FileNotFoundException e) {
-            throw new HazelcastException("Failed to open file: " + configurationFile.getAbsolutePath(), e);
-        }
-    }
-
-    private void loadSystemPropertyClassPathResource(String configSystemProperty) {
-        //it is a explicit configured classpath resource.
-        String resource = configSystemProperty.substring("classpath:".length());
-
-        LOGGER.info("Using classpath resource at " + resource);
-
-        if (resource.isEmpty()) {
-            throw new HazelcastException("classpath resource can't be empty");
-        }
-
-        in = Config.class.getClassLoader().getResourceAsStream(resource);
-        if (in == null) {
-            throw new HazelcastException("Could not load classpath resource: " + resource);
-        }
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigLocator.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Abstract base class for config locators
+ *
+ * @see XmlConfigLocator
+ * @see YamlConfigLocator
+ */
+public abstract class AbstractConfigLocator {
+    private static final ILogger LOGGER = Logger.getLogger(AbstractConfigLocator.class);
+    private InputStream in;
+    private File configurationFile;
+    private URL configurationUrl;
+
+    public InputStream getIn() {
+        return in;
+    }
+
+    public File getConfigurationFile() {
+        return configurationFile;
+    }
+
+    public URL getConfigurationUrl() {
+        return configurationUrl;
+    }
+
+    protected void loadDefaultConfigurationFromClasspath(String defaultConfigFile) {
+        LOGGER.info("Loading '" + defaultConfigFile + "' from classpath.");
+
+        configurationUrl = Config.class.getClassLoader().getResource(defaultConfigFile);
+
+        if (configurationUrl == null) {
+            throw new HazelcastException("Could not find '" + defaultConfigFile + "' in the classpath!"
+                    + "This may be due to a wrong-packaged or corrupted jar file.");
+        }
+
+        in = Config.class.getClassLoader().getResourceAsStream(defaultConfigFile);
+        if (in == null) {
+            throw new HazelcastException("Could not load '" + defaultConfigFile + "' from classpath");
+        }
+    }
+
+    protected boolean loadHazelcastConfigFromClasspath(String configFileName) {
+        URL url = Config.class.getClassLoader().getResource(configFileName);
+        if (url == null) {
+            LOGGER.finest("Could not find '" + configFileName + "' in classpath.");
+            return false;
+        }
+
+        LOGGER.info("Loading '" + configFileName + "' from classpath.");
+
+        configurationUrl = url;
+        in = Config.class.getClassLoader().getResourceAsStream(configFileName);
+        if (in == null) {
+            throw new HazelcastException("Could not load '" + configFileName + "' from classpath");
+        }
+        return true;
+    }
+
+    protected boolean loadFromWorkingDirectory(String configFilePath) {
+        File file = new File(configFilePath);
+        if (!file.exists()) {
+            LOGGER.finest("Could not find '" + configFilePath + "' in working directory.");
+            return false;
+        }
+
+        LOGGER.info("Loading '" + configFilePath + "' from working directory.");
+
+        configurationFile = file;
+        try {
+            in = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            throw new HazelcastException("Failed to open file: " + file.getAbsolutePath(), e);
+        }
+        return true;
+    }
+
+    protected boolean loadFromSystemProperty(String propertyKey) {
+        String configSystemProperty = System.getProperty(propertyKey);
+
+        if (configSystemProperty == null) {
+            LOGGER.finest("Could not 'hazelcast.config' System property");
+            return false;
+        }
+
+        LOGGER.info("Loading configuration " + configSystemProperty + " from System property 'hazelcast.config'");
+
+        if (configSystemProperty.startsWith("classpath:")) {
+            loadSystemPropertyClassPathResource(configSystemProperty);
+        } else {
+            loadSystemPropertyFileResource(configSystemProperty);
+        }
+        return true;
+    }
+
+    private void loadSystemPropertyFileResource(String configSystemProperty) {
+        // it's a file
+        configurationFile = new File(configSystemProperty);
+        LOGGER.info("Using configuration file at " + configurationFile.getAbsolutePath());
+
+        if (!configurationFile.exists()) {
+            String msg = "Config file at '" + configurationFile.getAbsolutePath() + "' doesn't exist.";
+            throw new HazelcastException(msg);
+        }
+
+        try {
+            in = new FileInputStream(configurationFile);
+        } catch (FileNotFoundException e) {
+            throw new HazelcastException("Failed to open file: " + configurationFile.getAbsolutePath(), e);
+        }
+
+        try {
+            configurationUrl = configurationFile.toURI().toURL();
+        } catch (MalformedURLException e) {
+            throw new HazelcastException("Failed to create URL from the file: " + configurationFile.getAbsolutePath(), e);
+        }
+    }
+
+    private void loadSystemPropertyClassPathResource(String configSystemProperty) {
+        // it's an explicit configured classpath resource
+        String resource = configSystemProperty.substring("classpath:".length());
+
+        LOGGER.info("Using classpath resource at " + resource);
+
+        if (resource.isEmpty()) {
+            throw new HazelcastException("classpath resource can't be empty");
+        }
+
+        in = Config.class.getClassLoader().getResourceAsStream(resource);
+        if (in == null) {
+            throw new HazelcastException("Could not load classpath resource: " + resource);
+        }
+        configurationUrl = Config.class.getResource(resource);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigLocator.java
@@ -17,18 +17,9 @@
 package com.hazelcast.config;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
 
 /**
- * Support class for the {@link com.hazelcast.config.XmlConfigBuilder} that locates the XML configuration:
+ * Support class for the {@link XmlConfigBuilder} that locates the XML configuration:
  * <ol>
  * <li>system property</li>
  * <li>working directory</li>
@@ -36,13 +27,7 @@ import java.net.URL;
  * <li>default</li>
  * </ol>
  */
-public class XmlConfigLocator {
-
-    private static final ILogger LOGGER = Logger.getLogger(XmlConfigLocator.class);
-
-    private InputStream in;
-    private File configurationFile;
-    private URL configurationUrl;
+public class XmlConfigLocator extends AbstractConfigLocator {
 
     /**
      * Constructs a XmlConfigLocator that tries to find a usable XML configuration file.
@@ -51,142 +36,21 @@ public class XmlConfigLocator {
      */
     public XmlConfigLocator() {
         try {
-            if (loadFromSystemProperty()) {
+            if (loadFromSystemProperty("hazelcast.config")) {
                 return;
             }
 
-            if (loadFromWorkingDirectory()) {
+            if (loadFromWorkingDirectory("hazelcast.xml")) {
                 return;
             }
 
-            if (loadHazelcastXmlFromClasspath()) {
+            if (loadHazelcastConfigFromClasspath("hazelcast.xml")) {
                 return;
             }
 
-            loadDefaultConfigurationFromClasspath();
+            loadDefaultConfigurationFromClasspath("hazelcast-default.xml");
         } catch (RuntimeException e) {
             throw new HazelcastException(e);
         }
-    }
-
-    public InputStream getIn() {
-        return in;
-    }
-
-    public File getConfigurationFile() {
-        return configurationFile;
-    }
-
-    public URL getConfigurationUrl() {
-        return configurationUrl;
-    }
-
-    private void loadDefaultConfigurationFromClasspath() {
-        LOGGER.info("Loading 'hazelcast-default.xml' from classpath.");
-
-        configurationUrl = Config.class.getClassLoader().getResource("hazelcast-default.xml");
-
-        if (configurationUrl == null) {
-            throw new HazelcastException("Could not find 'hazelcast-default.xml' in the classpath!"
-                    + "This may be due to a wrong-packaged or corrupted jar file.");
-        }
-
-        in = Config.class.getClassLoader().getResourceAsStream("hazelcast-default.xml");
-        if (in == null) {
-            throw new HazelcastException("Could not load 'hazelcast-default.xml' from classpath");
-        }
-    }
-
-    private boolean loadHazelcastXmlFromClasspath() {
-        URL url = Config.class.getClassLoader().getResource("hazelcast.xml");
-        if (url == null) {
-            LOGGER.finest("Could not find 'hazelcast.xml' in classpath.");
-            return false;
-        }
-
-        LOGGER.info("Loading 'hazelcast.xml' from classpath.");
-
-        configurationUrl = url;
-        in = Config.class.getClassLoader().getResourceAsStream("hazelcast.xml");
-        if (in == null) {
-            throw new HazelcastException("Could not load 'hazelcast.xml' from classpath");
-        }
-        return true;
-    }
-
-    private boolean loadFromWorkingDirectory() {
-        File file = new File("hazelcast.xml");
-        if (!file.exists()) {
-            LOGGER.finest("Could not find 'hazelcast.xml' in working directory.");
-            return false;
-        }
-
-        LOGGER.info("Loading 'hazelcast.xml' from working directory.");
-
-        configurationFile = file;
-        try {
-            in = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
-            throw new HazelcastException("Failed to open file: " + file.getAbsolutePath(), e);
-        }
-        return true;
-    }
-
-    private boolean loadFromSystemProperty() {
-        String configSystemProperty = System.getProperty("hazelcast.config");
-
-        if (configSystemProperty == null) {
-            LOGGER.finest("Could not 'hazelcast.config' System property");
-            return false;
-        }
-
-        LOGGER.info("Loading configuration " + configSystemProperty + " from System property 'hazelcast.config'");
-
-        if (configSystemProperty.startsWith("classpath:")) {
-            loadSystemPropertyClassPathResource(configSystemProperty);
-        } else {
-            loadSystemPropertyFileResource(configSystemProperty);
-        }
-        return true;
-    }
-
-    private void loadSystemPropertyFileResource(String configSystemProperty) {
-        // it's a file
-        configurationFile = new File(configSystemProperty);
-        LOGGER.info("Using configuration file at " + configurationFile.getAbsolutePath());
-
-        if (!configurationFile.exists()) {
-            String msg = "Config file at '" + configurationFile.getAbsolutePath() + "' doesn't exist.";
-            throw new HazelcastException(msg);
-        }
-
-        try {
-            in = new FileInputStream(configurationFile);
-        } catch (FileNotFoundException e) {
-            throw new HazelcastException("Failed to open file: " + configurationFile.getAbsolutePath(), e);
-        }
-
-        try {
-            configurationUrl = configurationFile.toURI().toURL();
-        } catch (MalformedURLException e) {
-            throw new HazelcastException("Failed to create URL from the file: " + configurationFile.getAbsolutePath(), e);
-        }
-    }
-
-    private void loadSystemPropertyClassPathResource(String configSystemProperty) {
-        // it's an explicit configured classpath resource
-        String resource = configSystemProperty.substring("classpath:".length());
-
-        LOGGER.info("Using classpath resource at " + resource);
-
-        if (resource.isEmpty()) {
-            throw new HazelcastException("classpath resource can't be empty");
-        }
-
-        in = Config.class.getClassLoader().getResourceAsStream(resource);
-        if (in == null) {
-            throw new HazelcastException("Could not load classpath resource: " + resource);
-        }
-        configurationUrl = Config.class.getResource(resource);
     }
 }


### PR DESCRIPTION
`XmlConfigLocator` and `XmlClientConfigLocator` to extend new `AbstractConfigLocator` with shared logic that can be used as a parent class for YAML counterparts as well.

This change is identical to the PR #14263, which got reverted temporarily on master due to jdk6 compilation problems caused by other YAML related commit. 

Couldn't send the PR from the original branch, since the original PR was merged with a merge commit, and that merge commit was reverted -> github thinks the commit is on master.