### PR TITLE
Optimize AbstractPredicate attribute extraction

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/Extractable.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/Extractable.java
@@ -19,12 +19,8 @@ package com.hazelcast.query.impl;
 import com.hazelcast.query.QueryException;
 
 /**
- * Enables extracting attribute values and types and their type from an object, usually from an Entry
+ * Enables extracting attribute value from an object, usually from an Entry
  */
 public interface Extractable {
-
     Object getAttributeValue(String attributeName) throws QueryException;
-
-    AttributeType getAttributeType(String attributeName) throws QueryException;
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/BetweenPredicate.java
@@ -55,11 +55,12 @@ public class BetweenPredicate extends AbstractIndexAwarePredicate {
         if (attributeValue == null) {
             return false;
         }
-        Comparable fromConvertedValue = convert(entry, attributeValue, from);
-        Comparable toConvertedValue = convert(entry, attributeValue, to);
+        Comparable fromConvertedValue = convert(attributeValue, from);
+        Comparable toConvertedValue = convert(attributeValue, to);
         if (fromConvertedValue == null || toConvertedValue == null) {
             return false;
         }
+        attributeValue = (Comparable) convertEnumValue(attributeValue);
         return attributeValue.compareTo(fromConvertedValue) >= 0 && attributeValue.compareTo(toConvertedValue) <= 0;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -61,7 +61,8 @@ public class EqualPredicate extends AbstractIndexAwarePredicate implements Negat
         if (attributeValue == null) {
             return value == null || value == IndexImpl.NULL;
         }
-        value = convert(mapEntry, attributeValue, value);
+        value = convert(attributeValue, value);
+        attributeValue = (Comparable) convertEnumValue(attributeValue);
         return attributeValue.equals(value);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/GreaterLessPredicate.java
@@ -61,7 +61,8 @@ public final class GreaterLessPredicate extends AbstractIndexAwarePredicate impl
         if (attributeValue == null) {
             return false;
         }
-        Comparable givenValue = convert(mapEntry, attributeValue, value);
+        Comparable givenValue = convert(attributeValue, value);
+        attributeValue = (Comparable) convertEnumValue(attributeValue);
         int result = attributeValue.compareTo(givenValue);
         return equal && result == 0 || (less ? (result < 0) : (result > 0));
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/InPredicate.java
@@ -58,11 +58,12 @@ public class InPredicate extends AbstractIndexAwarePredicate {
         if (attributeValue == null) {
             return false;
         }
+        attributeValue = (Comparable) convertEnumValue(attributeValue);
         Set<Comparable> set = convertedInValues;
         if (set == null) {
             set = createHashSet(values.length);
             for (Comparable value : values) {
-                set.add(convert(entry, attributeValue, value));
+                set.add(convert(attributeValue, value));
             }
             convertedInValues = set;
         }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/AndResultSetTest.java
@@ -217,11 +217,6 @@ public class AndResultSetTest extends HazelcastTestSupport {
         }
 
         @Override
-        public AttributeType getAttributeType(String attributeName) {
-            return null;
-        }
-
-        @Override
         public Object getTargetObject(boolean key) {
             return null;
         }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/OrResultSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/OrResultSetTest.java
@@ -103,11 +103,6 @@ public class OrResultSetTest extends HazelcastTestSupport {
         }
 
         @Override
-        public AttributeType getAttributeType(String attributeName) {
-            return null;
-        }
-
-        @Override
         public Object getTargetObject(boolean key) {
             return null;
         }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
@@ -96,7 +96,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
         // THEN
         assertEquals(1, values.size());
         assertEquals("body1", values.toArray(new Body[0])[0].getName());
-        assertEquals(2 + 1, bodyExtractorExecutions);
+        assertEquals(2, bodyExtractorExecutions);
         assertEquals(0, limbExtractorExecutions);
     }
 
@@ -112,7 +112,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
         // THEN
         assertEquals(1, values.size());
         assertEquals("body1", values.toArray(new Body[0])[0].getName());
-        assertEquals(2 + 1, bodyExtractorExecutions);
+        assertEquals(2, bodyExtractorExecutions);
         assertEquals(0, limbExtractorExecutions);
     }
 
@@ -131,7 +131,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
         assertEquals(1, values.size());
         assertEquals("body2", values.toArray(new Body[0])[0].getName());
         assertEquals(0, bodyExtractorExecutions);
-        assertEquals(2 + 1, limbExtractorExecutions);
+        assertEquals(2, limbExtractorExecutions);
     }
 
     @Test
@@ -193,7 +193,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
         assertEquals(1, values.size());
         assertEquals("body2", values.toArray(new Body[0])[0].getName());
         assertEquals(0, bodyExtractorExecutions);
-        assertEquals(2 + 1, limbExtractorExecutions);
+        assertEquals(2, limbExtractorExecutions);
     }
 
     public static class BodyNameExtractor extends ValueExtractor<Body, Object> {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -30,14 +30,12 @@ import com.hazelcast.query.Predicates;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.SampleTestObjects.Employee;
 import com.hazelcast.query.SampleTestObjects.Value;
-import com.hazelcast.query.impl.AttributeType;
 import com.hazelcast.query.impl.Index;
 import com.hazelcast.query.impl.IndexImpl;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.query.impl.getters.Extractors;
-import com.hazelcast.query.impl.getters.ReflectionHelper;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
@@ -334,11 +332,6 @@ public class PredicatesTest extends HazelcastTestSupport {
         public Comparable getAttributeValue(String attributeName) throws QueryException {
             return (Comparable) getValue();
         }
-
-        @Override
-        public AttributeType getAttributeType(String attributeName) {
-            return ReflectionHelper.getAttributeType(getValue().getClass());
-        }
     }
 
     private final class NullDummyEntry extends QueryableEntry {
@@ -374,11 +367,6 @@ public class PredicatesTest extends HazelcastTestSupport {
         @Override
         public Comparable getAttributeValue(String attributeName) throws QueryException {
             return null;
-        }
-
-        @Override
-        public AttributeType getAttributeType(String attributeName) {
-            return AttributeType.INTEGER;
         }
 
         @Override


### PR DESCRIPTION
AbstractPredicate needs the type of extracted attribute so it can compare the extracted attribute with given predicate value(possibly a different type). It repeats extraction procedure just to determine type by looking at the value extracted which is already available at the end of the first extraction procedure.

The second extraction is removed.