### PR TITLE
Reduced thread creation in MetricsRegistry

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -163,15 +163,16 @@ public interface MetricsRegistry {
      * Schedules a publisher to be executed at a fixed rate.
      *
      * Probably this method will be removed in the future, but we need a mechanism
-     * for complex gauges that require some
-     * calculation to provide their values.
+     * for complex gauges that require some calculation to provide their values.
      *
      * @param publisher the published task that needs to be executed
      * @param period    the time between executions
      * @param timeUnit  the time unit for period
+     * @param probeLevel the ProbeLevel publisher it publishing on. This is needed to prevent scheduling
+     *                   publishers if their probe level isn't sufficient.
      * @throws NullPointerException if publisher or timeUnit is null.
      */
-    void scheduleAtFixedRate(Runnable publisher, long period, TimeUnit timeUnit);
+    void scheduleAtFixedRate(Runnable publisher, long period, TimeUnit timeUnit, ProbeLevel probeLevel);
 
     /**
      * Renders the content of the MetricsRegistry.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -63,7 +63,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     final ILogger logger;
     private final ProbeLevel minimumLevel;
 
-    private final ScheduledExecutorService scheduledExecutorService;
+    private final ScheduledExecutorService scheduler;
     private final ConcurrentMap<String, ProbeInstance> probeInstances = new ConcurrentHashMap<String, ProbeInstance>();
 
     // use ConcurrentReferenceHashMap to allow unreferenced Class instances to be garbage collected
@@ -99,8 +99,7 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     public MetricsRegistryImpl(String name, ILogger logger, ProbeLevel minimumLevel) {
         this.logger = checkNotNull(logger, "logger can't be null");
         this.minimumLevel = checkNotNull(minimumLevel, "minimumLevel can't be null");
-
-        scheduledExecutorService = new ScheduledThreadPoolExecutor(2,
+        this.scheduler = new ScheduledThreadPoolExecutor(2,
                 new ThreadFactoryImpl(createThreadPoolName(name, "MetricsRegistry")));
 
         if (logger.isFinestEnabled()) {
@@ -335,13 +334,16 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     }
 
     @Override
-    public void scheduleAtFixedRate(final Runnable publisher, long period, TimeUnit timeUnit) {
-        scheduledExecutorService.scheduleAtFixedRate(publisher, 0, period, timeUnit);
+    public void scheduleAtFixedRate(Runnable publisher, long period, TimeUnit timeUnit, ProbeLevel probeLevel) {
+        if (!probeLevel.isEnabled(minimumLevel)) {
+            return;
+        }
+        scheduler.scheduleAtFixedRate(publisher, 0, period, timeUnit);
     }
 
     public void shutdown() {
         // we want to immediately terminate; we don't want to wait till pending tasks have completed.
-        scheduledExecutorService.shutdownNow();
+        scheduler.shutdownNow();
     }
 
     private static class SortedProbeInstances {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/GarbageCollectionMetricSet.java
@@ -26,6 +26,7 @@ import java.lang.management.ManagementFactory;
 import java.util.Collections;
 import java.util.Set;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.internal.metrics.ProbeLevel.MANDATORY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.SetUtil.createHashSet;
@@ -66,7 +67,7 @@ public final class GarbageCollectionMetricSet {
         checkNotNull(metricsRegistry, "metricsRegistry");
 
         GcStats stats = new GcStats();
-        metricsRegistry.scheduleAtFixedRate(stats, PUBLISH_FREQUENCY_SECONDS, SECONDS);
+        metricsRegistry.scheduleAtFixedRate(stats, PUBLISH_FREQUENCY_SECONDS, SECONDS, INFO);
         metricsRegistry.scanAndRegister(stats, "gc");
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/StatisticsAwareMetricsSet.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.util.StringUtil.lowerCaseFirstChar;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -60,7 +61,7 @@ public class StatisticsAwareMetricsSet {
     }
 
     public void register(MetricsRegistry metricsRegistry) {
-        metricsRegistry.scheduleAtFixedRate(new Task(metricsRegistry), SCAN_PERIOD_SECONDS, SECONDS);
+        metricsRegistry.scheduleAtFixedRate(new Task(metricsRegistry), SCAN_PERIOD_SECONDS, SECONDS, INFO);
     }
 
     // Periodic task that goes through all StatisticsAwareService asking for stats and registers and if it doesn't exist,

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -17,6 +17,7 @@
 package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.internal.metrics.MetricsRegistry;
+import com.hazelcast.internal.metrics.ProbeLevel;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelCloseListener;
 import com.hazelcast.internal.networking.ChannelErrorHandler;
@@ -183,7 +184,7 @@ public final class NioNetworking implements Networking {
         startIOBalancer();
 
         if (metricsRegistry.minimumLevel().isEnabled(DEBUG)) {
-            metricsRegistry.scheduleAtFixedRate(new PublishAllTask(), 1, SECONDS);
+            metricsRegistry.scheduleAtFixedRate(new PublishAllTask(), 1, SECONDS, ProbeLevel.INFO);
         }
     }
 


### PR DESCRIPTION
THe MetricsRegistry has a scheduler where publishers can register
their tasks to be executed periodically. The issue is when publishers
with a low probe level, schedule a task. This task is scheduled even
through their probes will ignored by the metrics registry.

This is especially an issue for ephemeral clients where thread creation
matters because before this PR they would always get 2 metricsregistry
scheduler threads and with this PR a client with mandatry probe level
(default) will not create any metrics registry scheduler threads.

The thread creation in the scheduler is lazy; so as long as no tasks
get scheduled, no threads get created.