### PR TITLE
Do not produce thread dump when test expects an exception

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.internal.runners.statements.RunAfters;
 import org.junit.internal.runners.statements.RunBefores;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TestRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
@@ -187,14 +188,18 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
         List<FrameworkMethod> afters = getTestClass().getAnnotatedMethods(After.class);
         Statement nextStatement = statement;
         List<TestRule> testRules = getTestRules(target);
+        boolean expectsException = false;
         if (!testRules.isEmpty()) {
             for (TestRule rule : testRules) {
                 if (rule instanceof BounceMemberRule) {
                     nextStatement = ((BounceMemberRule) rule).stopBouncing(statement);
                 }
+                if (rule instanceof ExpectedException) {
+                    expectsException = true;
+                }
             }
         }
-        if (THREAD_DUMP_ON_FAILURE) {
+        if (THREAD_DUMP_ON_FAILURE && !expectsException) {
             return new ThreadDumpAwareRunAfters(method, nextStatement, afters, target);
         }
         if (afters.isEmpty()) {

--- a/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AbstractHazelcastClassRunner.java
@@ -22,6 +22,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.test.annotation.Repeat;
 import com.hazelcast.test.bounce.BounceMemberRule;
 import com.hazelcast.test.compatibility.CompatibilityTestUtils;
+import com.hazelcast.test.starter.ReflectionUtils;
 import org.junit.After;
 import org.junit.AssumptionViolatedException;
 import org.junit.Before;
@@ -29,6 +30,7 @@ import org.junit.Test;
 import org.junit.internal.runners.statements.RunAfters;
 import org.junit.internal.runners.statements.RunBefores;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.ExpectedExceptionMatcherBuilderAccessor;
 import org.junit.rules.TestRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
@@ -188,19 +190,19 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
         List<FrameworkMethod> afters = getTestClass().getAnnotatedMethods(After.class);
         Statement nextStatement = statement;
         List<TestRule> testRules = getTestRules(target);
-        boolean expectsException = false;
+        ExpectedException expectedException = null;
         if (!testRules.isEmpty()) {
             for (TestRule rule : testRules) {
                 if (rule instanceof BounceMemberRule) {
                     nextStatement = ((BounceMemberRule) rule).stopBouncing(statement);
                 }
                 if (rule instanceof ExpectedException) {
-                    expectsException = true;
+                    expectedException = (ExpectedException) rule;
                 }
             }
         }
-        if (THREAD_DUMP_ON_FAILURE && !expectsException) {
-            return new ThreadDumpAwareRunAfters(method, nextStatement, afters, target);
+        if (THREAD_DUMP_ON_FAILURE) {
+            return new ThreadDumpAwareRunAfters(method, nextStatement, afters, target, expectedException);
         }
         if (afters.isEmpty()) {
             return nextStatement;
@@ -374,12 +376,15 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
         private final Statement next;
         private final Object target;
         private final List<FrameworkMethod> afters;
+        private final ExpectedException expectedException;
 
-        ThreadDumpAwareRunAfters(FrameworkMethod method, Statement next, List<FrameworkMethod> afters, Object target) {
+        ThreadDumpAwareRunAfters(FrameworkMethod method, Statement next, List<FrameworkMethod> afters, Object target,
+                                 ExpectedException expectedException) {
             this.method = method;
             this.next = next;
             this.afters = afters;
             this.target = target;
+            this.expectedException = expectedException;
         }
 
         @Override
@@ -388,7 +393,7 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
             try {
                 next.evaluate();
             } catch (Throwable e) {
-                if (!isJUnitAssumeException(e)) {
+                if (!isJUnitAssumeException(e) && !expectsException()) {
                     System.err.println("THREAD DUMP FOR TEST FAILURE: \"" + e.getMessage()
                             + "\" at \"" + method.getName() + "\"\n");
                     try {
@@ -413,6 +418,14 @@ public abstract class AbstractHazelcastClassRunner extends AbstractParameterized
 
         private boolean isJUnitAssumeException(Throwable e) {
             return e instanceof AssumptionViolatedException;
+        }
+
+        private boolean expectsException() throws IllegalAccessException {
+            if (expectedException == null) {
+                return false;
+            }
+            Object exceptionMatcher = ReflectionUtils.getFieldValueReflectively(expectedException, "matcherBuilder");
+            return ExpectedExceptionMatcherBuilderAccessor.expectsThrowable(exceptionMatcher);
         }
     }
 

--- a/hazelcast/src/test/java/org/junit/rules/ExpectedExceptionMatcherBuilderAccessor.java
+++ b/hazelcast/src/test/java/org/junit/rules/ExpectedExceptionMatcherBuilderAccessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.junit.rules;
+
+public class ExpectedExceptionMatcherBuilderAccessor {
+
+    private ExpectedExceptionMatcherBuilderAccessor() {
+    }
+
+    public static boolean expectsThrowable(Object target) {
+        ExpectedExceptionMatcherBuilder matcherBuilder = (ExpectedExceptionMatcherBuilder) target;
+        return matcherBuilder.expectsThrowable();
+    }
+}


### PR DESCRIPTION
Avoid producing a thread dump (and dumping it to system err) when the test includes an ExpectedException rule