### PR TITLE
Inject logger into address provider implementation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/AmbigiousInstantiationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/AmbigiousInstantiationException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.core.HazelcastException;
+
+/**
+ * Indicates there are multiple constructors matching given parameters.
+ *
+ */
+final class AmbigiousInstantiationException extends HazelcastException {
+    public AmbigiousInstantiationException(String message) {
+        super(message);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InstantiationUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InstantiationUtils.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+
+/**
+ * Convenience for class instantiation.
+ *
+ */
+public final class InstantiationUtils {
+    private InstantiationUtils() {
+
+    }
+
+    /**
+     * Create a new instance of a given class. It will search for a constructor matching passed parameters.
+     * If a matching constructor is not found then it returns null.
+     *
+     * Constructor is matching when it can be invoked with given parameters. The order of parameters is significant.
+     *
+     * When a class constructor contains a primitive argument then it's matching if and only if
+     * a parameter at the same position is not null.
+     *
+     * It throws {@link AmbigiousInstantiationException} when multiple matching constructors are found.
+     *
+     * @param clazz class to be instantiated
+     * @param params parameters to be passed to the constructor
+     * @param <T> class type to be instantiated
+     * @return a new instance of a given class
+     * @throws AmbigiousInstantiationException when multiple constructors matching the parameters
+     */
+    public static <T> T newInstanceOrNull(Class<? extends T> clazz, Object...params)  {
+        Class[] paramTypes = new Class[params.length];
+        for (int i = 0; i < params.length; i++) {
+            Object param = params[i];
+            paramTypes[i] = param == null ? null : param.getClass();
+        }
+        Constructor<T> constructor = selectMatchingConstructor(clazz, params, paramTypes);
+        if (constructor == null) {
+            return null;
+        }
+        try {
+            return constructor.newInstance(params);
+        } catch (IllegalAccessException e) {
+            return null;
+        } catch (InstantiationException e) {
+            return null;
+        } catch (InvocationTargetException e) {
+            return null;
+        }
+    }
+
+    private static <T> Constructor<T> selectMatchingConstructor(Class<? extends T> clazz, Object[] params,
+                                                                Class<?>[] paramTypes) {
+        Constructor<?>[] constructors = clazz.getConstructors();
+        Constructor<T> selectedConstructor = null;
+        for (Constructor<?> constructor : constructors) {
+            if (isParamsMatching(constructor, params, paramTypes)) {
+                if (selectedConstructor == null) {
+                    selectedConstructor = (Constructor<T>) constructor;
+                } else {
+                    throw new AmbigiousInstantiationException("Class " + clazz + " has multiple constructors matching "
+                            + "given parameter types: " + Arrays.toString(paramTypes));
+                }
+            }
+        }
+        return selectedConstructor;
+    }
+
+    private static boolean isParamsMatching(Constructor<?> constructor, Object[] params, Class[] paramTypes) {
+        Class<?>[] constructorParamTypes = constructor.getParameterTypes();
+        if (constructorParamTypes.length != paramTypes.length) {
+            return false;
+        }
+        for (int i = 0; i < constructorParamTypes.length; i++) {
+            Class<?> constructorParamType = constructorParamTypes[i];
+            if (constructorParamType.isPrimitive()) {
+                if (params[i] == null) {
+                    // passed argument was null, but the argument in constructor is primitive - it's not matching
+                    return false;
+                } else {
+                    constructorParamType = toBoxedType(constructorParamType);
+                }
+            }
+            Class paramType = paramTypes[i];
+            if (paramType != null && !constructorParamType.isAssignableFrom(paramType)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static Class<?> toBoxedType(Class<?> type) {
+        assert type.isPrimitive();
+        if (type == boolean.class) {
+            return Boolean.class;
+        } else if (type == byte.class) {
+            return Byte.class;
+        } else if (type == char.class) {
+            return Character.class;
+        } else if (type == double.class) {
+            return Double.class;
+        } else if (type == float.class) {
+            return Float.class;
+        } else if (type == int.class) {
+            return Integer.class;
+        } else if (type == long.class) {
+            return Long.class;
+        } else if (type == short.class) {
+            return Short.class;
+        } else {
+            // should never happen ;-)
+            throw new IllegalArgumentException("Unknown primitive type " + type.getName());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/InstantiationUtilsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/InstantiationUtilsTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class InstantiationUtilsTest extends HazelcastTestSupport {
+
+    @Test
+    public void newInstanceOrNull_createInstanceWithNoArguments() {
+        ClassWithNonArgConstructor instance = InstantiationUtils.newInstanceOrNull(ClassWithNonArgConstructor.class);
+        assertNotNull(instance);
+    }
+
+    @Test
+    public void newInstanceOrNull_createInstanceWithSingleArgument() {
+        ClassWithStringConstructor instance = InstantiationUtils.newInstanceOrNull(ClassWithStringConstructor.class,
+                "foo");
+        assertNotNull(instance);
+    }
+
+    @Test
+    public void newInstanceOrNull_createInstanceWithSubclass() {
+        ClassWithObjectConstructor instance = InstantiationUtils.newInstanceOrNull(ClassWithObjectConstructor.class,
+                "foo");
+        assertNotNull(instance);
+    }
+
+    @Test
+    public void newInstanceOrNull_noMatchingConstructorFound() {
+        ClassWithNonArgConstructor instance = InstantiationUtils.newInstanceOrNull(ClassWithNonArgConstructor.class,
+                "foo");
+        assertNull(instance);
+    }
+
+    @Test
+    public void newInstanceOrNull_nullIsMatchingAllTypes() {
+        ClassWithTwoArgConstructorConstructor instance = InstantiationUtils.newInstanceOrNull(
+                ClassWithTwoArgConstructorConstructor.class,
+                "foo", null);
+        assertNotNull(instance);
+    }
+
+    @Test
+    public void newInstanceOrNull_primitiveArgInConstructor() {
+        ClassWithPrimitiveArgConstructor instance = InstantiationUtils.newInstanceOrNull(
+                ClassWithPrimitiveArgConstructor.class,
+                true, (byte) 0, 'c', 42d, 42f, 42, (long) 43, (short) 42);
+        assertNotNull(instance);
+    }
+
+    @Test
+    public void newInstanceOrNull_primitiveArgInConstructorPassingNull() {
+        ClassWithTwoConstructorsIncludingPrimitives instance = InstantiationUtils.newInstanceOrNull(
+                ClassWithTwoConstructorsIncludingPrimitives.class,
+                42, null);
+        assertNotNull(instance);
+    }
+
+    @Test(expected = AmbigiousInstantiationException.class)
+    public void newInstanceOrNull_ambigiousConstructor() {
+        InstantiationUtils.newInstanceOrNull(ClassWithTwoConstructors.class, "foo");
+    }
+
+    public static class ClassWithNonArgConstructor {
+
+    }
+
+    public static class ClassWithStringConstructor {
+        public ClassWithStringConstructor(String ignored) {
+
+        }
+    }
+
+    public static class ClassWithObjectConstructor {
+        public ClassWithObjectConstructor(Object ignored) {
+
+        }
+    }
+
+    public static class ClassWithTwoArgConstructorConstructor {
+        public ClassWithTwoArgConstructorConstructor(String arg0, String arg1) {
+
+        }
+    }
+
+    public static class ClassWithTwoConstructorsIncludingPrimitives {
+        public ClassWithTwoConstructorsIncludingPrimitives(int arg0, int arg1) {
+
+        }
+
+        public ClassWithTwoConstructorsIncludingPrimitives(int arg0, Object arg1) {
+
+        }
+    }
+
+    public static class ClassWithPrimitiveArgConstructor {
+        public ClassWithPrimitiveArgConstructor(boolean arg0, byte arg1, char arg2, double arg3, float arg4, int arg5,
+                                                long arg6, short arg7) {
+
+        }
+    }
+
+    public static class ClassWithTwoConstructors {
+        public ClassWithTwoConstructors(String ignored) {
+
+        }
+
+        public ClassWithTwoConstructors(Object ignored) {
+
+        }
+    }
+
+
+}


### PR DESCRIPTION
Fixes #11996

It looks long, but it's mostly tests. 

The code inside `DefaultNodeContext` is probably simpler than it was before. Most of the complexity is inside `InstantiationUtils` and this can be reviewed in isolation. 