### PR TITLE
Change semantics and name of assumeThatJDK8

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/config/yaml/W3cDomTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/yaml/W3cDomTest.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.yaml.YamlLoader;
 import com.hazelcast.internal.yaml.YamlNode;
 import com.hazelcast.internal.yaml.YamlTest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,11 +48,13 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
-public class W3cDomTest {
+public class W3cDomTest extends HazelcastTestSupport {
     private static final int NOT_EXISTING = 42;
 
     @Test
-    public void testYamlExtendedTestFromInputStream() {
+    public void testW3cDomAdapter() {
+        assumeThatJDK8OrHigher();
+
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map-extended.yaml");
         YamlNode yamlRoot = YamlLoader.load(inputStream, "root-map");
         Node domRoot = W3cDomUtil.asW3cNode(yamlRoot);

--- a/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlTest.java
@@ -33,7 +33,7 @@ import java.io.InputStreamReader;
 import static com.hazelcast.internal.yaml.YamlUtil.asMapping;
 import static com.hazelcast.internal.yaml.YamlUtil.asSequence;
 import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK6;
-import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8;
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -59,7 +59,7 @@ public class YamlTest {
 
     @Test
     public void testYamlFromInputStream() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         YamlNode root = YamlLoader.load(inputStream, "root-map");
@@ -68,7 +68,7 @@ public class YamlTest {
 
     @Test
     public void testYamlFromInputStreamWithoutRootName() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         YamlNode root = YamlLoader.load(inputStream);
@@ -77,7 +77,7 @@ public class YamlTest {
 
     @Test
     public void testYamlExtendedTestFromInputStream() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map-extended.yaml");
         YamlNode root = YamlLoader.load(inputStream, "root-map");
@@ -87,7 +87,7 @@ public class YamlTest {
 
     @Test
     public void testJsonFromInputStream() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.json");
         YamlNode root = YamlLoader.load(inputStream, "root-map");
@@ -96,7 +96,7 @@ public class YamlTest {
 
     @Test
     public void testYamlFromReader() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
@@ -106,7 +106,7 @@ public class YamlTest {
 
     @Test
     public void testYamlFromReaderWithoutRootName() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
@@ -116,7 +116,7 @@ public class YamlTest {
 
     @Test
     public void testYamlFromString() throws IOException {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
@@ -127,7 +127,7 @@ public class YamlTest {
 
     @Test
     public void testYamlFromStringWithoutRootMap() throws IOException {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
@@ -138,7 +138,7 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromInputStream() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         expectedException.expect(YamlException.class);
@@ -147,7 +147,7 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromInputStreamWithRootName() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         expectedException.expect(YamlException.class);
@@ -156,7 +156,7 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromReader() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
@@ -166,7 +166,7 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromReaderWithRootName() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
@@ -176,7 +176,7 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromString() throws IOException {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
@@ -187,7 +187,7 @@ public class YamlTest {
 
     @Test
     public void testLoadingInvalidYamlFromStringWithRootName() throws IOException {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-invalid.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);
@@ -198,7 +198,7 @@ public class YamlTest {
 
     @Test
     public void testInvalidScalarValueTypeMap() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlMapping rootMap = getYamlRoot();
         YamlMapping embeddedMap = rootMap.childAsMapping("embedded-map");
@@ -209,7 +209,7 @@ public class YamlTest {
 
     @Test
     public void testInvalidScalarValueTypeSeq() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlMapping rootMap = getYamlRoot();
         YamlSequence embeddedList = rootMap
@@ -222,7 +222,7 @@ public class YamlTest {
 
     @Test
     public void testInvalidScalarValueTypeHintedMap() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlMapping rootMap = getYamlRoot();
         YamlMapping embeddedMap = rootMap.childAsMapping("embedded-map");
@@ -235,7 +235,7 @@ public class YamlTest {
 
     @Test
     public void testInvalidScalarValueTypeHintedSeq() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlMapping rootMap = getYamlRoot();
         YamlSequence embeddedList = rootMap
@@ -250,28 +250,28 @@ public class YamlTest {
 
     @Test
     public void testNotExistingMappingFromMap() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         assertNull(getYamlRoot().childAsMapping("not-existing"));
     }
 
     @Test
     public void testNotExistingSequenceFromMap() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         assertNull(getYamlRoot().childAsSequence("not-existing"));
     }
 
     @Test
     public void testNotExistingScalarFromMap() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         assertNull(getYamlRoot().childAsScalar("not-existing"));
     }
 
     @Test
     public void testNotExistingMappingFromSeq() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlSequence seq = getYamlRoot()
                 .childAsMapping("embedded-map")
@@ -281,7 +281,7 @@ public class YamlTest {
 
     @Test
     public void testNotExistingSequenceFromSeq() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlSequence seq = getYamlRoot()
                 .childAsMapping("embedded-map")
@@ -291,7 +291,7 @@ public class YamlTest {
 
     @Test
     public void testNotExistingScalarFromSeq() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlSequence seq = getYamlRoot()
                 .childAsMapping("embedded-map")
@@ -301,7 +301,7 @@ public class YamlTest {
 
     @Test
     public void testInvalidNodeTypeNotAMapping() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-map.yaml");
         YamlNode root = YamlLoader.load(inputStream, "root-map");
@@ -315,7 +315,7 @@ public class YamlTest {
 
     @Test
     public void testInvalidNodeTypeNotASeq() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlMapping rootMap = getYamlRoot();
 
@@ -325,7 +325,7 @@ public class YamlTest {
 
     @Test
     public void testInvalidNodeTypeNotAScalar() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlMapping rootMap = getYamlRoot();
 
@@ -335,7 +335,7 @@ public class YamlTest {
 
     @Test
     public void testIterateChildrenMap() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlMapping embeddedMap = getYamlRoot()
                 .childAsMapping("embedded-map");
@@ -351,7 +351,7 @@ public class YamlTest {
 
     @Test
     public void testIterateChildrenSeq() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlSequence embeddedList = getYamlRoot()
                 .childAsMapping("embedded-map")
@@ -368,14 +368,14 @@ public class YamlTest {
 
     @Test
     public void testParentOfRootIsNull() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         assertNull(getYamlRoot().parent());
     }
 
     @Test
     public void testParentOfEmbeddedMapIsRoot() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlMapping root = getYamlRoot();
         assertSame(root, root.childAsMapping("embedded-map").parent());
@@ -383,7 +383,7 @@ public class YamlTest {
 
     @Test
     public void testParentOfScalarIntIsEmbeddedMap() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         YamlMapping embeddedMap = getYamlRoot().childAsMapping("embedded-map");
         assertSame(embeddedMap, embeddedMap.childAsScalar("scalar-int").parent());
@@ -391,14 +391,14 @@ public class YamlTest {
 
     @Test
     public void testNameOfMap() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         assertEquals("embedded-map", getYamlRoot().childAsMapping("embedded-map").nodeName());
     }
 
     @Test
     public void testNameOfSeq() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         assertEquals("embedded-list", getYamlRoot().childAsMapping("embedded-map")
                                                    .childAsSequence("embedded-list")
@@ -407,7 +407,7 @@ public class YamlTest {
 
     @Test
     public void testNameOfNamedScalar() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         assertEquals("scalar-int", getYamlRoot().childAsMapping("embedded-map")
                                                 .childAsScalar("scalar-int")
@@ -416,7 +416,7 @@ public class YamlTest {
 
     @Test
     public void testNameOfUnnamedScalar() {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         assertSame(YamlNode.UNNAMED_NODE, getYamlRoot().childAsMapping("embedded-map")
                                                        .childAsSequence("embedded-list")
@@ -500,7 +500,7 @@ public class YamlTest {
 
     @Test
     public void testYamlListInRoot() throws IOException {
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InputStream inputStream = YamlTest.class.getClassLoader().getResourceAsStream("yaml-test-root-seq.yaml");
         InputStreamReader reader = new InputStreamReader(inputStream);

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -1585,8 +1585,9 @@ public abstract class HazelcastTestSupport {
         assumeFalse("Java 7 used", JAVA_VERSION.startsWith("1.7."));
     }
 
-    public static void assumeThatJDK8() {
-        assumeTrue("Java 8 should be used", JAVA_VERSION.startsWith("1.8."));
+    public static void assumeThatJDK8OrHigher() {
+        assumeFalse("Java 8+ should be used", JAVA_VERSION.startsWith("1.6."));
+        assumeFalse("Java 8+ should be used", JAVA_VERSION.startsWith("1.7."));
     }
 
     public static void assumeThatNotZingJDK6() {

--- a/hazelcast/src/test/java/com/hazelcast/util/AddressUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/AddressUtilTest.java
@@ -211,7 +211,7 @@ public class AddressUtilTest extends HazelcastTestSupport {
     @Test
     public void testFixScopeIdAndGetInetAddress_whenLinkLocalAddress() throws SocketException, UnknownHostException {
         // refer to https://github.com/hazelcast/hazelcast/pull/13069#issuecomment-388719847
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         Inet6Address inet6Address = PowerMockito.mock(Inet6Address.class);
         when(inet6Address.isLinkLocalAddress()).thenReturn(true);
@@ -223,7 +223,7 @@ public class AddressUtilTest extends HazelcastTestSupport {
     @Test
     public void testFixScopeIdAndGetInetAddress_whenLinkLocalAddress_withNoInterfaceBind() throws SocketException, UnknownHostException {
         // refer to https://github.com/hazelcast/hazelcast/pull/13069#issuecomment-388719847
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         Inet6Address inet6Address = PowerMockito.mock(Inet6Address.class);
         when(inet6Address.isLinkLocalAddress()).thenReturn(true);
@@ -236,7 +236,7 @@ public class AddressUtilTest extends HazelcastTestSupport {
     @Test
     public void testGetInetAddressFor() throws SocketException, UnknownHostException {
         // refer to https://github.com/hazelcast/hazelcast/pull/13069#issuecomment-388719847
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InetAddress expected = InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334");
         Inet6Address inet6Address = PowerMockito.mock(Inet6Address.class);
@@ -257,7 +257,7 @@ public class AddressUtilTest extends HazelcastTestSupport {
     @Test
     public void testGetPossibleInetAddressesFor_whenNotLocalAddress() {
         // refer to https://github.com/hazelcast/hazelcast/pull/13069#issuecomment-388719847
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         Inet6Address inet6Address = PowerMockito.mock(Inet6Address.class);
         when(inet6Address.isSiteLocalAddress()).thenReturn(false);
@@ -270,7 +270,7 @@ public class AddressUtilTest extends HazelcastTestSupport {
     @Test
     public void testGetPossibleInetAddressesFor_whenLocalAddress() throws SocketException, UnknownHostException {
         // refer to https://github.com/hazelcast/hazelcast/pull/13069#issuecomment-388719847
-        assumeThatJDK8();
+        assumeThatJDK8OrHigher();
 
         InetAddress expected = InetAddress.getByName("2001:db8:85a3:0:0:8a2e:370:7334");
         Inet6Address inet6Address = PowerMockito.mock(Inet6Address.class);


### PR DESCRIPTION
The primary intention of this change is to ignore `W3cDomTest` on JDK6.
Since we test our builds with JDK8+ versions as well, assumeThatJDK8 ignores the affected tests on JDK8+ builds, therefore changed the name and the semantics of the assumeThatJDK8 method. From now it ignores the affected tests on JDK6 and JDK7 only.

Fixes #14379