### PR TITLE
Require java 8 as minimum version for building & running Hazelcast

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -71,6 +71,9 @@
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
                 <version>${maven.animal.sniffer.plugin.version}</version>
                 <configuration>
+                    <annotations>
+                        <annotation>com.hazelcast.internal.RequiresJdk8</annotation>
+                    </annotations>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
                         <artifactId>java16</artifactId>

--- a/hazelcast/src/main/java/com/hazelcast/internal/PlatformSpecific.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/PlatformSpecific.java
@@ -18,6 +18,45 @@ package com.hazelcast.internal;
 
 /**
  * Utility class to construct instances depending on the runtime platform.
+ * Steps to introduce Java 6 / 8 alternative implementations:
+ * <ol>
+ *     <li>Define and use an interface in Hazelcast codebase</li>
+ *     <li>Implement the interface for Java 6</li>
+ *     <li>Implement the interface for Java 8+. Annotate this implementation with
+ *     {@link RequiresJdk8}: animal-sniffer will not scan the annotated class or methods
+ *     for Java 6 API compatibility, so use this annotation at the smallest possible scope
+ *     </li>
+ *     <li>Add a {@code createXYZ} public static method in {@code PlatformSpecific} utility
+ *     class</li>
+ *     <li>Use {@code PlatformSpecific.createXYZ} whenever you need a new instance</li>
+ * </ol>
+ *
+ * The implementation of a constructor utility method would look something like this example:
+ * <pre>
+ * {@code
+ * public static <S> MethodProbe createLongMethodProbe(Method method, Probe probe, int type) {
+ *   if (JavaVersion.isAtLeast(JAVA_1_8)) {
+ *     return new LongMethodProbeJdk8<S>(method, probe, type);
+ *   } else {
+ *     return new MethodProbe.LongMethodProbe<S>(method, probe, type);
+ *   }
+ * }
+ * }
+ * </pre>
+ *
+ * This should be tested in two separate tests, to ensure the proper instance is created
+ * depending on Java runtime version, like this:
+ * <pre>
+ *     {@code
+ *     @Test
+ *     public void testJdk8Probe() {
+ *       // ensure this test only runs on JDK 8+
+ *       assumeJdk8OrNewer();
+ *       MethodProbe jdk8Probe = PlatformSpecific.createLongMethodProbe(...);
+ *       assertTrue(jdk8Probe instanceof LongMethodProbeJdk8.class);
+ *     }
+ *     }
+ * </pre>
  */
 public final class PlatformSpecific {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/PlatformSpecific.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/PlatformSpecific.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal;
+
+/**
+ * Utility class to construct instances depending on the runtime platform.
+ */
+public final class PlatformSpecific {
+
+    private PlatformSpecific() {
+
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/RequiresJdk8.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/RequiresJdk8.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates classes and methods which depend on JDK 8 API methods for compilation.
+ * Use at the most limited scope possible, as annotated elements are excluded from
+ * animal-sniffer JDK 6 API checks, therefore could risk leaking usage of newer APIs
+ * to code meant to run on JDK 6 or 7.
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface RequiresJdk8 {
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
@@ -229,8 +229,10 @@ public class PartitionServiceProxy implements PartitionService {
         @Override
         public int compareTo(Object o) {
             PartitionProxy partition = (PartitionProxy) o;
-            Integer id = partitionId;
-            return (id.compareTo(partition.getPartitionId()));
+            int otherPartitionId = partition.partitionId;
+            return (partitionId < otherPartitionId)
+                    ? -1
+                    : ((partitionId == otherPartitionId) ? 0 : 1);
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlTest.java
@@ -510,7 +510,7 @@ public class YamlTest {
         assertTrue(root instanceof YamlSequence);
 
         YamlSequence rootSeq = asSequence(root);
-        assertEquals(42, rootSeq.childAsScalarValue(0));
+        assertEquals(42, ((Integer) rootSeq.childAsScalarValue(0)).intValue());
 
         YamlMapping map = rootSeq.childAsMapping(1);
         assertEquals(YamlNode.UNNAMED_NODE, map.nodeName());

--- a/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
@@ -208,12 +208,18 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
 
     @Test
     public void scheduleOnMembers_callable_quorum() throws Exception {
-        wait(exec(0).scheduleOnMembers(callable(), asList(member(0)), 10, TimeUnit.MILLISECONDS));
+        Map<Member, IScheduledFuture<?>> futures = (Map<Member, IScheduledFuture<?>>) exec(0)
+                .scheduleOnMembers(callable(), asList(member(0)),
+                10, TimeUnit.MILLISECONDS);
+        wait(futures);
     }
 
     @Test(expected = QuorumException.class)
     public void scheduleOnMembers_callable_noQuorum() throws Exception {
-        wait(exec(3).scheduleOnMembers(callable(), asList(member(3)), 10, TimeUnit.MILLISECONDS));
+        Map<Member, IScheduledFuture<?>> futures = (Map<Member, IScheduledFuture<?>>) exec(3)
+                .scheduleOnMembers(callable(),
+                asList(member(3)), 10, TimeUnit.MILLISECONDS);
+        wait(futures);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/test/AnswerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/test/AnswerTest.java
@@ -217,7 +217,8 @@ public class AnswerTest extends HazelcastTestSupport {
         Data data = serializationService.toData(original);
         assertNotNull("data should not be null", data);
         assertFalse("data should be no proxy class", isProxyClass(data.getClass()));
-        assertEquals("toObject() should return original value", original, serializationService.toObject(data));
+        assertEquals("toObject() should return original value", original,
+                ((Integer) serializationService.toObject(data)).intValue());
 
         SerializationService localSerializationService = new DefaultSerializationServiceBuilder().build();
         Data localData = localSerializationService.toData(original);

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <client.protocol.version>1.8.0-1</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <jdk.version>1.6</jdk.version>
+        <jdk.version>6</jdk.version>
         <target.dir>target</target.dir>
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
@@ -1086,20 +1086,9 @@
             <activation>
                 <jdk>[1.8,)</jdk>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${maven.compiler.plugin.version}</version>
-                        <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                            <encoding>${project.build.sourceEncoding}</encoding>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
+            <properties>
+                <jdk.version>8</jdk.version>
+            </properties>
         </profile>
 
         <profile>
@@ -1107,7 +1096,8 @@
             Profile for execution of test suite only on JDKs prior to 1.8.
             Not suitable for building Hazelcast.
             Sample usage:
-            1. Build JDK 6 artifacts using JDK8:
+            1. Build JDK 6 artifacts using JDK8
+               (notice the "-" after -P option that deactivates profile jdk-8):
                $ mvn -P-jdk-8 -DskipTests -T1C clean install
 
             2. Switch to JDK 6 or 7 and execute the test suite:

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <maven.jacoco.plugin.version>0.8.2</maven.jacoco.plugin.version>
         <maven.failsafe.plugin.version>2.22.0</maven.failsafe.plugin.version>
         <maven.cobertura.plugin.version>2.6</maven.cobertura.plugin.version>
+        <maven.enforcer.plugin.version>3.0.0-M2</maven.enforcer.plugin.version>
 
         <log4j.version>1.2.17</log4j.version>
 
@@ -310,6 +311,26 @@
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven.enforcer.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-tools</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <!-- JDK 1.8+ is required for compilation. -->
+                                    <version>[1.8.0,)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -1058,6 +1079,64 @@
             <modules>
                 <module>modulepath-tests</module>
             </modules>
+        </profile>
+
+        <profile>
+            <id>jdk-8</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${maven.compiler.plugin.version}</version>
+                        <configuration>
+                            <source>1.8</source>
+                            <target>1.8</target>
+                            <encoding>${project.build.sourceEncoding}</encoding>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <!--
+            Profile for execution of test suite only on JDKs prior to 1.8.
+            Not suitable for building Hazelcast.
+            Sample usage:
+            1. Build JDK 6 artifacts using JDK8:
+               $ mvn -P-jdk-8 -DskipTests -T1C clean install
+
+            2. Switch to JDK 6 or 7 and execute the test suite:
+               $ mvn -Pjdk-pre-8 -T1C test
+            -->
+            <id>jdk-pre-8</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>${maven.enforcer.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>enforce-tools</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireJavaVersion>
+                                            <version>[1.6.0,1.8.0)</version>
+                                        </requireJavaVersion>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
A JDK 6 binary can be still built by explicitly disabling the JDK 8 profile, even though it is required to execute the build with JDK 8:
```
$ mvn -P-jdk-8 -DskipTests -T1C clean install
```

Minor changes in test code are included to facilitate type inference when building with JDK 8 for 1.6 or 1.8 target.