### PR TITLE
Remove password checks in REST API calls

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.12.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.12.xsd
@@ -402,7 +402,14 @@
     <xs:complexType name="cluster-group">
         <xs:all>
             <xs:element name="name" type="xs:string" minOccurs="0" maxOccurs="1" default="dev"/>
-            <xs:element name="password" type="xs:string" minOccurs="0" maxOccurs="1" default="dev-pass"/>
+            <xs:element name="password" type="xs:string" minOccurs="0" maxOccurs="1" default="dev-pass">
+                <xs:annotation>
+                    <xs:documentation>
+                        Password of the group to connect to.
+                        The password is only checked when security is enabled on Hazelcast members.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:all>
     </xs:complexType>
     <xs:complexType name="listeners">

--- a/hazelcast/src/main/java/com/hazelcast/config/GroupConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/GroupConfig.java
@@ -91,8 +91,8 @@ public final class GroupConfig {
      * Gets the password of the group.
      *
      * @return the password of the group
-     * @deprecated since 3.11, password check is removed.
-     * use {@link SecurityConfig()} ,  ClientSecurityConfig()  for authentication
+     * @deprecated since 3.11, password check is removed. Passwords are only checked in default LoginModule when Hazelcast
+     *             {@link SecurityConfig security} is enabled (Enterprise edition only).
      */
     @Deprecated
     public String getPassword() {
@@ -105,8 +105,8 @@ public final class GroupConfig {
      * @param password the password to set for the group
      * @return the updated GroupConfig
      * @throws IllegalArgumentException if password is {@code null}
-     * @deprecated since 3.11, password check is removed.
-     * use {@link SecurityConfig()} ,  ClientSecurityConfig()  for authentication
+     * @deprecated since 3.11, password check is removed. Passwords are only checked in default LoginModule when Hazelcast
+     *             {@link SecurityConfig security} is enabled (Enterprise edition only).
      */
     @Deprecated
     public GroupConfig setPassword(final String password) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -36,7 +36,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
     public static final String HEADER_CUSTOM_PREFIX = "Hazelcast-";
     public static final byte[] RES_200 = stringToBytes("HTTP/1.1 200 OK\r\n");
     public static final byte[] RES_400 = stringToBytes("HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n");
-    public static final byte[] RES_403 = stringToBytes("HTTP/1.1 403 Forbidden\r\n\r\n");
+    public static final byte[] RES_403 = stringToBytes("HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n");
     public static final byte[] RES_404 = stringToBytes("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n");
     public static final byte[] RES_100 = stringToBytes("HTTP/1.1 100 Continue\r\n\r\n");
     public static final byte[] RES_204 = stringToBytes("HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n");

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -206,13 +206,8 @@ public class ManagementCenterService {
         }
     }
 
-    public byte[] clusterWideUpdateManagementCenterUrl(String groupName, String groupPass, String newUrl) {
+    public byte[] clusterWideUpdateManagementCenterUrl(String newUrl) {
         try {
-            GroupConfig groupConfig = instance.getConfig().getGroupConfig();
-            if (!(groupConfig.getName().equals(groupName) && groupConfig.getPassword().equals(groupPass))) {
-                return HttpCommand.RES_403;
-            }
-
             final Collection<Member> memberList = instance.node.clusterService.getMembers();
             for (Member member : memberList) {
                 send(member.getAddress(), new UpdateManagementCenterUrlOperation(newUrl));

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -2860,6 +2860,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         Password of the group to be created.
+                        The password is only checked when security is enabled on the member.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -168,9 +168,9 @@ public class HTTPCommunicator {
         return doDelete(url).responseCode;
     }
 
-    public int shutdownCluster(String groupName, String groupPassword) throws IOException {
+    public ConnectionResponse shutdownCluster(String groupName, String groupPassword) throws IOException {
         String url = address + "management/cluster/clusterShutdown";
-        return doPost(url, groupName, groupPassword).responseCode;
+        return doPost(url, groupName, groupPassword);
     }
 
     public String shutdownMember(String groupName, String groupPassword) throws IOException {

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -18,21 +18,21 @@ package com.hazelcast.internal.ascii;
 
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
-import com.hazelcast.config.JoinConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.instance.BuildInfoProvider;
-import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
-import com.hazelcast.test.annotation.SlowTest;
+import com.hazelcast.test.TestAwareInstanceFactory;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.NoHttpResponseException;
+import org.hamcrest.CoreMatchers;
 import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,38 +42,49 @@ import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.util.concurrent.CountDownLatch;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterStateEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertContains;
+import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-@RunWith(HazelcastSerialClassRunner.class)
-@Category(SlowTest.class)
-public class RestClusterTest extends HazelcastTestSupport {
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class RestClusterTest {
 
-    private static final String STATUS_FORBIDDEN = "{\"status\":\"forbidden\"}";
+    protected static final String STATUS_FORBIDDEN = "{\"status\":\"forbidden\"}";
 
-    private Config config = new Config();
+    protected final TestAwareInstanceFactory factory = new TestAwareInstanceFactory();
 
-    @Before
-    public void setup() {
-        config.setProperty(GroupProperty.REST_ENABLED.getName(), "true");
-        config.setProperty(GroupProperty.HTTP_HEALTHCHECK_ENABLED.getName(), "true");
-
-        JoinConfig join = config.getNetworkConfig().getJoin();
-        join.getMulticastConfig().setEnabled(false);
-        join.getTcpIpConfig().setEnabled(true).clear().addMember("127.0.0.1");
+    @BeforeClass
+    public static void beforeClass() {
+        Hazelcast.shutdownAll();
     }
 
     @After
     public void tearDown() {
-        HazelcastInstanceFactory.terminateAll();
+        factory.terminateAll();
+    }
+
+    protected Config createConfigWithRestEnabled() {
+        Config config = new Config();
+        config.setProperty(GroupProperty.REST_ENABLED.getName(), "true");
+        config.setProperty(GroupProperty.HTTP_HEALTHCHECK_ENABLED.getName(), "true");
+        return config;
+    }
+
+    protected String getPassword() {
+        // Community version doesn't check the password.
+        return "";
     }
 
     @Test
     public void testDisabledRest() throws Exception {
         // REST should be disabled by default
-        Config config = new Config();
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(new Config());
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
 
         try {
@@ -85,11 +96,14 @@ public class RestClusterTest extends HazelcastTestSupport {
 
     @Test
     public void testClusterShutdown() throws Exception {
-        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
+        Config config = createConfigWithRestEnabled();
+        final HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance instance2 = factory.newHazelcastInstance(config);
         HTTPCommunicator communicator = new HTTPCommunicator(instance2);
 
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.shutdownCluster("dev", "dev-pass"));
+
+        String response = communicator.shutdownCluster(config.getGroupConfig().getName(), getPassword()).response;
+        assertThat(response, CoreMatchers.containsString("\"status\":\"success\""));
         assertTrueEventually(new AssertTask() {
             @Override
             public void run()
@@ -102,29 +116,32 @@ public class RestClusterTest extends HazelcastTestSupport {
 
     @Test
     public void testGetClusterState() throws Exception {
-        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
-
+        Config config = createConfigWithRestEnabled();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        HazelcastInstance instance2 = factory.newHazelcastInstance(config);
+        String groupName = config.getGroupConfig().getName();
         HTTPCommunicator communicator1 = new HTTPCommunicator(instance1);
         HTTPCommunicator communicator2 = new HTTPCommunicator(instance2);
 
         instance1.getCluster().changeClusterState(ClusterState.FROZEN);
         assertEquals("{\"status\":\"success\",\"state\":\"frozen\"}",
-                communicator1.getClusterState("dev", "dev-pass"));
+                communicator1.getClusterState(groupName, getPassword()));
 
         instance1.getCluster().changeClusterState(ClusterState.PASSIVE);
         assertEquals("{\"status\":\"success\",\"state\":\"passive\"}",
-                communicator2.getClusterState("dev", "dev-pass"));
+                communicator2.getClusterState(groupName, getPassword()));
     }
 
     @Test
     public void testChangeClusterState() throws Exception {
-        final HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
-        final HazelcastInstance instance2 = Hazelcast.newHazelcastInstance(config);
+        Config config = createConfigWithRestEnabled();
+        final HazelcastInstance instance1 = factory.newHazelcastInstance(config);
+        final HazelcastInstance instance2 = factory.newHazelcastInstance(config);
         HTTPCommunicator communicator = new HTTPCommunicator(instance1);
+        String groupName = config.getGroupConfig().getName();
 
-        assertEquals(STATUS_FORBIDDEN, communicator.changeClusterState("dev1", "dev-pass", "frozen").response);
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.changeClusterState("dev", "dev-pass", "frozen").responseCode);
+        assertEquals(STATUS_FORBIDDEN, communicator.changeClusterState(groupName + "1", getPassword(), "frozen").response);
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.changeClusterState(groupName, getPassword(), "frozen").responseCode);
 
         assertClusterStateEventually(ClusterState.FROZEN, instance1);
         assertClusterStateEventually(ClusterState.FROZEN, instance2);
@@ -132,7 +149,7 @@ public class RestClusterTest extends HazelcastTestSupport {
 
     @Test
     public void testGetClusterVersion() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        final HazelcastInstance instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
         final HTTPCommunicator communicator = new HTTPCommunicator(instance);
         final String expected = "{\"status\":\"success\","
                 + "\"version\":\"" + instance.getCluster().getClusterVersion().toString() + "\"}";
@@ -141,65 +158,77 @@ public class RestClusterTest extends HazelcastTestSupport {
 
     @Test
     public void testChangeClusterVersion() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        Config config = createConfigWithRestEnabled();
+        final HazelcastInstance instance = factory.newHazelcastInstance(config);
         final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.changeClusterVersion("dev", "dev-pass",
+        String groupName = config.getGroupConfig().getName();
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.changeClusterVersion(groupName, getPassword(),
                 instance.getCluster().getClusterVersion().toString()).responseCode);
-        assertEquals(STATUS_FORBIDDEN, communicator.changeClusterVersion("dev1", "dev-pass", "1.2.3").response);
+        assertEquals(STATUS_FORBIDDEN, communicator.changeClusterVersion(groupName + "1", getPassword(), "1.2.3").response);
     }
 
     @Test
     public void testHotBackup() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        Config config = createConfigWithRestEnabled();
+        final HazelcastInstance instance = factory.newHazelcastInstance(config);
         final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.hotBackup("dev", "dev-pass").responseCode);
-        assertEquals(STATUS_FORBIDDEN, communicator.hotBackup("dev1", "dev-pass").response);
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.hotBackupInterrupt("dev", "dev-pass").responseCode);
-        assertEquals(STATUS_FORBIDDEN, communicator.hotBackupInterrupt("dev1", "dev-pass").response);
+        String groupName = config.getGroupConfig().getName();
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.hotBackup(groupName, getPassword()).responseCode);
+        assertEquals(STATUS_FORBIDDEN, communicator.hotBackup(groupName + "1", getPassword()).response);
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.hotBackupInterrupt(groupName, getPassword()).responseCode);
+        assertEquals(STATUS_FORBIDDEN, communicator.hotBackupInterrupt(groupName + "1", getPassword()).response);
     }
 
     @Test
     public void testForceAndPartialStart() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        Config config = createConfigWithRestEnabled();
+        final HazelcastInstance instance = factory.newHazelcastInstance(config);
         final HTTPCommunicator communicator = new HTTPCommunicator(instance);
-
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.forceStart("dev", "dev-pass").responseCode);
-        assertEquals(STATUS_FORBIDDEN, communicator.forceStart("dev1", "dev-pass").response);
-        assertEquals(HttpURLConnection.HTTP_OK, communicator.partialStart("dev", "dev-pass").responseCode);
-        assertEquals(STATUS_FORBIDDEN, communicator.partialStart("dev1", "dev-pass").response);
+        String groupName = config.getGroupConfig().getName();
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.forceStart(groupName, getPassword()).responseCode);
+        assertEquals(STATUS_FORBIDDEN, communicator.forceStart(groupName + "1", getPassword()).response);
+        assertEquals(HttpURLConnection.HTTP_OK, communicator.partialStart(groupName, getPassword()).responseCode);
+        assertEquals(STATUS_FORBIDDEN, communicator.partialStart(groupName + "1", getPassword()).response);
     }
 
     @Test
     public void testManagementCenterUrlChange() throws IOException {
-        final HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        Config config = createConfigWithRestEnabled();
+        final HazelcastInstance instance = factory.newHazelcastInstance(config);
         final HTTPCommunicator communicator = new HTTPCommunicator(instance);
+        String groupName = config.getGroupConfig().getName();
         assertEquals(HttpURLConnection.HTTP_NO_CONTENT,
-                communicator.changeManagementCenterUrl("dev", "dev-pass", "http://bla").responseCode);
+                communicator.changeManagementCenterUrl(groupName, getPassword(), "http://bla").responseCode);
     }
 
     @Test
     public void testListNodes() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        Config config = createConfigWithRestEnabled();
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         HazelcastTestSupport.waitInstanceForSafeState(instance);
         String result = String.format("{\"status\":\"success\",\"response\":\"[%s]\n%s\n%s\"}",
                 instance.getCluster().getLocalMember().toString(),
                 BuildInfoProvider.getBuildInfo().getVersion(),
                 System.getProperty("java.version"));
-        assertEquals(result, communicator.listClusterNodes("dev", "dev-pass"));
+        String groupName = config.getGroupConfig().getName();
+        assertEquals(result, communicator.listClusterNodes(groupName, getPassword()));
     }
 
     @Test
     public void testListNodesWithWrongCredentials() throws Exception {
-        HazelcastInstance instance1 = Hazelcast.newHazelcastInstance(config);
+        Config config = createConfigWithRestEnabled();
+        HazelcastInstance instance1 = factory.newHazelcastInstance(config);
         HTTPCommunicator communicator = new HTTPCommunicator(instance1);
         HazelcastTestSupport.waitInstanceForSafeState(instance1);
-        assertEquals(STATUS_FORBIDDEN, communicator.listClusterNodes("dev1", "dev-pass"));
+        String groupName = config.getGroupConfig().getName();
+        assertEquals(STATUS_FORBIDDEN, communicator.listClusterNodes(groupName + "1", getPassword()));
     }
 
     @Test
     public void testShutdownNode() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        Config config = createConfigWithRestEnabled();
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
 
         final CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -211,9 +240,9 @@ public class RestClusterTest extends HazelcastTestSupport {
                 }
             }
         });
-
+        String groupName = config.getGroupConfig().getName();
         try {
-            assertEquals("{\"status\":\"success\"}", communicator.shutdownMember("dev", "dev-pass"));
+            assertEquals("{\"status\":\"success\"}", communicator.shutdownMember(groupName, getPassword()));
         } catch (ConnectException ignored) {
             // if node shuts down before response is received, `java.net.ConnectException: Connection refused` is expected
         } catch (NoHttpResponseException ignored) {
@@ -228,15 +257,16 @@ public class RestClusterTest extends HazelcastTestSupport {
 
     @Test
     public void testShutdownNodeWithWrongCredentials() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        Config config = createConfigWithRestEnabled();
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
-
-        assertEquals(STATUS_FORBIDDEN, communicator.shutdownMember("dev1", "dev-pass"));
+        String groupName = config.getGroupConfig().getName();
+        assertEquals(STATUS_FORBIDDEN, communicator.shutdownMember(groupName + "1", getPassword()));
     }
 
     @Test
     public void simpleHealthCheck() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         String result = communicator.getClusterHealth();
 
@@ -249,7 +279,7 @@ public class RestClusterTest extends HazelcastTestSupport {
 
     @Test
     public void healthCheckWithPathParameters() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
 
         assertEquals("ACTIVE", communicator.getClusterHealth("/node-state"));
@@ -261,7 +291,7 @@ public class RestClusterTest extends HazelcastTestSupport {
 
     @Test
     public void healthCheckWithUnknownPathParameter() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
 
         assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, communicator.getClusterHealthResponseCode("/unknown-parameter"));
@@ -270,36 +300,36 @@ public class RestClusterTest extends HazelcastTestSupport {
     @Test(expected = NoHttpResponseException.class)
     public void fail_with_deactivatedHealthCheck() throws Exception {
         // Healthcheck REST URL is deactivated by default - no passed config on purpose
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance();
+        HazelcastInstance instance = factory.newHazelcastInstance(null);
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         communicator.getClusterHealth();
     }
 
     @Test
     public void fail_on_healthcheck_url_with_garbage() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, communicator.getFailingClusterHealthWithTrailingGarbage());
     }
 
     @Test
     public void testHeadRequest_ClusterVersion() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         assertEquals(HttpURLConnection.HTTP_OK, communicator.headRequestToClusterVersionURI().responseCode);
     }
 
     @Test
     public void testHeadRequest_ClusterInfo() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         assertEquals(HttpURLConnection.HTTP_OK, communicator.headRequestToClusterInfoURI().responseCode);
     }
 
     @Test
     public void testHeadRequest_ClusterHealth() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
+        factory.newHazelcastInstance(createConfigWithRestEnabled());
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         HTTPCommunicator.ConnectionResponse response = communicator.headRequestToClusterHealthURI();
         assertEquals(HttpURLConnection.HTTP_OK, response.responseCode);
@@ -315,7 +345,7 @@ public class RestClusterTest extends HazelcastTestSupport {
 
     @Test
     public void testHeadRequest_GarbageClusterHealth() throws Exception {
-        HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfigWithRestEnabled());
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
         assertEquals(HttpURLConnection.HTTP_NOT_FOUND, communicator.headRequestToGarbageClusterHealthURI().responseCode);
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/UpdateManagementCenterUrlRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/UpdateManagementCenterUrlRequestTest.java
@@ -46,7 +46,7 @@ public class UpdateManagementCenterUrlRequestTest extends HazelcastTestSupport {
 
     @Test
     public void testExecuteScriptRequest() {
-        byte[] result = managementCenterService.clusterWideUpdateManagementCenterUrl("dev", "dev-pass", "invalid");
+        byte[] result = managementCenterService.clusterWideUpdateManagementCenterUrl("invalid");
         assertEquals(HttpCommand.RES_204, result);
     }
 }


### PR DESCRIPTION
This PR removes password checks in REST API calls - only group name checks remain.
If the Hazelcast Security is enabled (on Enterprise members) then JAAS authentication is used to verify the request against member login module stack.

The commit aligns the password checking behavior to other parts of Hazelcast (members & clients authentication).
