### PR TITLE
Introduced dynamic response processing for client.

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
@@ -43,4 +43,6 @@ public interface ClientInvocationService {
     boolean isRedoOperation();
 
     Consumer<ClientMessage> getResponseHandler();
+
+    long concurrentInvocations();
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AbstractClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AbstractClientInvocationService.java
@@ -80,11 +80,17 @@ public abstract class AbstractClientInvocationService implements ClientInvocatio
         HazelcastProperties properties = client.getProperties();
         int maxAllowedConcurrentInvocations = properties.getInteger(MAX_CONCURRENT_INVOCATIONS);
         long backofftimeoutMs = properties.getLong(BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS);
-        boolean isBackPressureEnabled = maxAllowedConcurrentInvocations != Integer.MAX_VALUE;
-        callIdSequence = CallIdFactory
-                .newCallIdSequence(isBackPressureEnabled, maxAllowedConcurrentInvocations, backofftimeoutMs);
+        // clients needs to have a call id generator capable of determining how many
+        // pending calls there are. So backpressure needs to be on
+        this.callIdSequence = CallIdFactory
+                .newCallIdSequence(true, maxAllowedConcurrentInvocations, backofftimeoutMs);
 
         client.getMetricsRegistry().scanAndRegister(this, "invocations");
+    }
+
+    @Override
+    public long concurrentInvocations() {
+        return callIdSequence.concurrentInvocations();
     }
 
     private long initInvocationRetryPauseMillis() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
@@ -183,6 +183,18 @@ public final class ClientProperty {
     public static final HazelcastProperty RESPONSE_THREAD_COUNT
             = new HazelcastProperty("hazelcast.client.response.thread.count", 2);
 
+    /**
+     * Enabled dynamic switching between processing responses on the io threads
+     * and offloading the response threads.
+     *
+     * Under certain conditions (single threaded clients) processing on the io
+     * thread can increase performance because useless handover to the response
+     * thread is removed. Also the response thread isn't created until it is needed
+     * and especially for ephemeral clients reducing threads can lead to
+     * increased performance and reduced memory usage.
+     */
+    public static final HazelcastProperty RESPONSE_THREAD_DYNAMIC
+            = new HazelcastProperty("hazelcast.client.response.thread.dynamic", false);
 
     /**
      * Token to use when discovering cluster via hazelcast.cloud

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientResponseHandlerSupplierTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientResponseHandlerSupplierTest.java
@@ -19,8 +19,8 @@ package com.hazelcast.client.spi.impl;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.protocol.ClientMessage;
-import com.hazelcast.client.spi.impl.ClientResponseHandlerSupplier.AsyncMultiThreadedResponseHandler;
-import com.hazelcast.client.spi.impl.ClientResponseHandlerSupplier.AsyncSingleThreadedResponseHandler;
+import com.hazelcast.client.spi.impl.ClientResponseHandlerSupplier.AsyncResponseHandler;
+import com.hazelcast.client.spi.impl.ClientResponseHandlerSupplier.DynamicResponseHandler;
 import com.hazelcast.client.spi.impl.ClientResponseHandlerSupplier.SyncResponseHandler;
 import com.hazelcast.client.test.ClientTestSupport;
 import com.hazelcast.client.test.TestHazelcastFactory;
@@ -36,6 +36,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.client.spi.properties.ClientProperty.RESPONSE_THREAD_COUNT;
+import static com.hazelcast.client.spi.properties.ClientProperty.RESPONSE_THREAD_DYNAMIC;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -54,31 +55,44 @@ public class ClientResponseHandlerSupplierTest extends ClientTestSupport {
 
     @Test(expected = IllegalArgumentException.class)
     public void whenNegativeResponseThreads() {
-        getResponseHandler(-1);
+        getResponseHandler(-1, false);
     }
 
     @Test
     public void whenZeroResponseThreads() {
-        Consumer<ClientMessage> handler = getResponseHandler(0);
+        Consumer<ClientMessage> handler = getResponseHandler(0, false);
         assertInstanceOf(SyncResponseHandler.class, handler);
     }
 
     @Test
-    public void whenOneResponseThreads() {
-        Consumer<ClientMessage> handler = getResponseHandler(1);
-        assertInstanceOf(AsyncSingleThreadedResponseHandler.class, handler);
+    public void whenOneResponseThreads_andStatic() {
+        Consumer<ClientMessage> handler = getResponseHandler(1, false);
+        assertInstanceOf(AsyncResponseHandler.class, handler);
     }
 
     @Test
-    public void whenMultipleResponseThreads() {
-        Consumer<ClientMessage> handler = getResponseHandler(2);
-        assertInstanceOf(AsyncMultiThreadedResponseHandler.class, handler);
+    public void whenMultipleResponseThreads_andStatic() {
+        Consumer<ClientMessage> handler = getResponseHandler(2, false);
+        assertInstanceOf(AsyncResponseHandler.class, handler);
     }
 
-    private Consumer<ClientMessage> getResponseHandler(int threadCount) {
+    @Test
+    public void whenOneResponseThreads_andDynamic() {
+        Consumer<ClientMessage> handler = getResponseHandler(1, true);
+        assertInstanceOf(DynamicResponseHandler.class, handler);
+    }
+
+    @Test
+    public void whenMultipleResponseThreads_andDynamic() {
+        Consumer<ClientMessage> handler = getResponseHandler(2, true);
+        assertInstanceOf(DynamicResponseHandler.class, handler);
+    }
+
+    private Consumer<ClientMessage> getResponseHandler(int threadCount, boolean dynamic) {
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(
                 new ClientConfig()
-                        .setProperty(RESPONSE_THREAD_COUNT.getName(), "" + threadCount));
+                        .setProperty(RESPONSE_THREAD_COUNT.getName(), "" + threadCount)
+                        .setProperty(RESPONSE_THREAD_DYNAMIC.getName(), "" + dynamic));
         HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
         AbstractClientInvocationService invocationService = (AbstractClientInvocationService) clientInstanceImpl.getInvocationService();
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
@@ -28,8 +28,8 @@ import static com.hazelcast.util.Preconditions.checkPositive;
  * <p>
  * It is possible to temporarily create more concurrent invocations than the declared capacity due to:
  * <ul>
- *     <li>system operations</li>
- *     <li>the racy nature of checking if space is available and getting the next sequence. </li>
+ * <li>system operations</li>
+ * <li>the racy nature of checking if space is available and getting the next sequence. </li>
  * </ul>
  * The latter cause is not a problem since the capacity is exceeded temporarily and it isn't sustainable.
  * So perhaps there are a few threads that at the same time see that the there is space and do a next.
@@ -85,7 +85,11 @@ public abstract class AbstractCallIdSequence implements CallIdSequence {
     }
 
     protected boolean hasSpace() {
-        return longs.get(INDEX_HEAD) - longs.get(INDEX_TAIL) < maxConcurrentInvocations;
+        return concurrentInvocations() < maxConcurrentInvocations;
     }
 
+    @Override
+    public long concurrentInvocations() {
+        return longs.get(INDEX_HEAD) - longs.get(INDEX_TAIL);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequence.java
@@ -76,4 +76,10 @@ public interface CallIdSequence {
      */
     long getLastCallId();
 
+    /**
+     * Returns the number of concurrent invocations.
+     *
+     * @return the number of concurrent invocations. Returns -1 if not known.
+     */
+    long concurrentInvocations();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithoutBackpressure.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithoutBackpressure.java
@@ -49,4 +49,9 @@ public final class CallIdSequenceWithoutBackpressure implements CallIdSequence {
     public void complete() {
         //no-op
     }
+
+    @Override
+    public long concurrentInvocations() {
+        return -1;
+    }
 }


### PR DESCRIPTION
Normally a client will offload response processing to the response
threads, but this is not always the best approach.

If a client is mostly single threaded, having respone threads will only
make the client slower because you get a useless handover from io thread
to response thread to user thread. In these cases it is better to let
the io thread do the response processing directly.

This PR makes the response processing dynamic; if there are few
invocations in flight then process on the IO thread, otherwise offload
to response threads.

Another improvement of this PR is that the response threads are only
created when they are needed. This is important for the ephemeral client
because thread creation can cause significant delays in starting such
a client.

The dynamic behavor is now enabled by default, but there is a property
that can disable the behavior:
hazelcast.client.response.thread.dynamic=true/false
So if for whatever reason we always want to offload, we can revert to
the original behavior.