### PR TITLE
Remove andThenInternal from ClientDelegatingFuture

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/cache/impl/AbstractClientInternalCacheProxy.java
@@ -411,7 +411,7 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
         if (callback == null) {
             return;
         }
-        delegatingFuture.andThenInternal(callback, true);
+        delegatingFuture.andThen(callback);
     }
 
     private ClientInvocationFuture putInternal(Data keyData, Data valueData, Data expiryPolicyData, boolean isGet,
@@ -475,7 +475,7 @@ abstract class AbstractClientInternalCacheProxy<K, V> extends AbstractClientCach
 
         CallbackAwareClientDelegatingFuture<V> future = new CallbackAwareClientDelegatingFuture<V>(invocationFuture,
                 getSerializationService(), PUT_RESPONSE_DECODER, callback);
-        future.andThenInternal(callback, true);
+        future.andThen(callback);
 
         return future;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/util/ClientDelegatingFuture.java
@@ -80,28 +80,14 @@ public class ClientDelegatingFuture<V> implements InternalCompletableFuture<V> {
         this(clientInvocationFuture, serializationService, clientMessageDecoder, null, deserializeResponse);
     }
 
-    /**
-     * Uses internal executor to execute callbacks instead of {@link #userExecutor}.
-     * This method is intended to use by hazelcast internals.
-     *
-     * @param callback              callback to execute
-     * @param shouldDeserializeData when {@code true} execution result is converted to object format
-     *                              before passing to {@link ExecutionCallback#onResponse},
-     *                              otherwise execution result will be in {@link com.hazelcast.nio.serialization.Data} format
-     * @param <T>                   type of the execution result which is passed to {@link ExecutionCallback#onResponse}
-     */
-    public <T> void andThenInternal(ExecutionCallback<T> callback, boolean shouldDeserializeData) {
-        future.andThen(new DelegatingExecutionCallback<T>(callback, shouldDeserializeData));
-    }
-
     @Override
     public void andThen(ExecutionCallback<V> callback) {
-        future.andThen(new DelegatingExecutionCallback<V>(callback, true), userExecutor);
+        future.andThen(new DelegatingExecutionCallback<V>(callback, deserializeResponse), userExecutor);
     }
 
     @Override
     public void andThen(ExecutionCallback<V> callback, Executor executor) {
-        future.andThen(new DelegatingExecutionCallback<V>(callback, true), executor);
+        future.andThen(new DelegatingExecutionCallback<V>(callback, deserializeResponse), executor);
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientMaxAllowedInvocationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientMaxAllowedInvocationTest.java
@@ -120,7 +120,7 @@ public class ClientMaxAllowedInvocationTest extends ClientTestSupport {
         testMaxAllowed(new RegisterCallback() {
             @Override
             public void call(ClientDelegatingFuture future, ExecutionCallback callback) {
-                future.andThenInternal(callback, false);
+                future.andThen(callback);
             }
         });
     }
@@ -177,7 +177,7 @@ public class ClientMaxAllowedInvocationTest extends ClientTestSupport {
         testMaxAllowed_withWaitingCallbacks(new RegisterCallback() {
             @Override
             public void call(ClientDelegatingFuture future, ExecutionCallback callback) {
-                future.andThenInternal(callback, false);
+                future.andThen(callback);
             }
         });
     }


### PR DESCRIPTION
and make `deserializeResponse` usage consistent in `ClientDelegatingFuture` class.