### PR TITLE
Fixing initial membership event when client start async

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -172,6 +172,11 @@ public class ClientClusterServiceImpl implements ClientClusterService {
         if (listener instanceof InitialMembershipListener) {
             Cluster cluster = client.getCluster();
             Collection<Member> memberCollection = members.get().values();
+            if (memberCollection.isEmpty()) {
+                //if members are empty,it means initial event did not arrive yet
+                //it will be redirected to listeners when it arrives see #handleInitialMembershipEvent
+                return;
+            }
             LinkedHashSet<Member> members = new LinkedHashSet<Member>(memberCollection);
             InitialMembershipEvent event = new InitialMembershipEvent(cluster, members);
             ((InitialMembershipListener) listener).init(event);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/MembershipListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/MembershipListenerTest.java
@@ -252,6 +252,25 @@ public class MembershipListenerTest extends HazelcastTestSupport {
     }
 
     @Test
+    public void initialMemberEvents_whenAddedAfterClientStartedAsync() throws InterruptedException {
+        hazelcastFactory.newHazelcastInstance();
+        hazelcastFactory.newHazelcastInstance();
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getConnectionStrategyConfig().setAsyncStart(true);
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(clientConfig);
+
+        final InitialMemberShipEventLogger listener = new InitialMemberShipEventLogger();
+        client.getCluster().addMembershipListener(listener);
+
+        EventObject eventObject = listener.events.poll(ASSERT_TRUE_EVENTUALLY_TIMEOUT, TimeUnit.SECONDS);
+        assertInstanceOf(InitialMembershipEvent.class, eventObject);
+        InitialMembershipEvent event = (InitialMembershipEvent) eventObject;
+        assertEquals(2, event.getMembers().size());
+        assertEquals(0, listener.events.size());
+    }
+
+    @Test
     public void initialMemberEvents_whenClusterRestarted() throws InterruptedException {
         HazelcastInstance instance1 = hazelcastFactory.newHazelcastInstance();
         HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance();


### PR DESCRIPTION
We were firing two events mistakenly when a client starts async.

The first event was empty. This pr adds a check for the first event.
If the member list is empty, it means that the initial membership
event did not arrive yet. We don't need to fire an event.

The actual event will come later and delivered to user-listener.

fixes #14364

(cherry picked from commit 83ebe2588386cb28e6c9219f611eb689c53f9368)