### PR TITLE
Fix small issues with FlakeIdGenerator

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientFlakeIdGeneratorConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientFlakeIdGeneratorConfig.java
@@ -70,7 +70,7 @@ public class ClientFlakeIdGeneratorConfig {
      * @see #setPrefetchCount(int)
      */
     public int getPrefetchCount() {
-        return Math.max(1, prefetchCount);
+        return prefetchCount;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FlakeIdGeneratorConfig.java
@@ -118,7 +118,7 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
      * @see #setPrefetchCount(int)
      */
     public int getPrefetchCount() {
-        return Math.max(1, prefetchCount);
+        return prefetchCount;
     }
 
     /**
@@ -156,11 +156,10 @@ public class FlakeIdGeneratorConfig implements IdentifiedDataSerializable {
      * This setting pertains only to {@link FlakeIdGenerator#newId newId} calls made on the member
      * that configured it.
      *
-     * @param prefetchValidityMs the desired ID validity or unlimited, if configured to 0.
+     * @param prefetchValidityMs the desired ID validity or unlimited, if &lt;=0
      * @return this instance for fluent API
      */
     public FlakeIdGeneratorConfig setPrefetchValidityMillis(long prefetchValidityMs) {
-        checkNotNegative(prefetchValidityMs, "prefetchValidityMs must be non negative");
         this.prefetchValidityMillis = prefetchValidityMs;
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastInstance.java
@@ -328,6 +328,11 @@ public interface HazelcastInstance {
 
     /**
      * Returns all {@link DistributedObject}'s such as; queue, map, set, list, topic, lock, multimap.
+     * <p>
+     * The results are returned on a best-effort basis. The result might miss
+     * just-created objects and contain just-deleted objects. An existing
+     * object can also be missing from the list occasionally. One cluster
+     * member is queried to obtain the list.
      *
      * @return the collection of instances created by Hazelcast.
      */

--- a/hazelcast/src/main/java/com/hazelcast/flakeidgen/FlakeIdGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/flakeidgen/FlakeIdGenerator.java
@@ -16,8 +16,8 @@
 
 package com.hazelcast.flakeidgen;
 
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.core.IdGenerator;
-import com.hazelcast.flakeidgen.impl.NodeIdOutOfRangeException;
 import com.hazelcast.internal.cluster.ClusterService;
 
 /**
@@ -64,7 +64,7 @@ public interface FlakeIdGenerator extends IdGenerator {
      *
      * @return new cluster-wide unique ID
      *
-     * @throws NodeIdOutOfRangeException if node ID for all members in the cluster is out of valid range.
+     * @throws HazelcastException if node ID for all members in the cluster is out of valid range.
      *      See "Node ID overflow" in {@link FlakeIdGenerator class documentation} for more details.
      * @throws UnsupportedOperationException if the cluster version is below 3.10
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/MemoryManagerBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/memory/impl/MemoryManagerBean.java
@@ -21,7 +21,7 @@ import com.hazelcast.internal.memory.MemoryAllocator;
 import com.hazelcast.internal.memory.MemoryManager;
 
 /**
- * Simp]e implementation of {@link MemoryManager} which aggregates the
+ * Simple implementation of {@link MemoryManager} which aggregates the
  * {@link MemoryAllocator} and {@link MemoryAccessor} supplied at construction time.
  */
 public class MemoryManagerBean implements MemoryManager {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/HsaHeapMemoryManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/HsaHeapMemoryManager.java
@@ -23,7 +23,7 @@ import com.hazelcast.internal.memory.MemoryManager;
 import static java.lang.System.arraycopy;
 
 /**
- * Memory manager backed by {@code long[][]}. Supports the minimum function needod for {@link LongSetHsa}:
+ * Memory manager backed by {@code long[][]}. Supports the minimum function needed for {@link LongSetHsa}:
  * <ul>
  *     <li>A maximum of two blocks can be allocated at any time.</li>
  *     <li>All addresses and sizes must be 8 byte-aligned.</li>

--- a/hazelcast/src/main/java/com/hazelcast/spi/exception/WrongTargetException.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/exception/WrongTargetException.java
@@ -20,7 +20,7 @@ import com.hazelcast.core.Member;
 
 /**
  * A {@link com.hazelcast.spi.exception.RetryableHazelcastException} indicating that an operation is executed on
- * the wrong machine.
+ * a wrong member.
  */
 public class WrongTargetException extends RetryableHazelcastException {
 


### PR DESCRIPTION
- fix javadoc that HazelcastException is thrown and not
NodeIdOutOfRangeException. Reason: NodeIdOutOfRangeException is in
`impl` package, we don't want users to catch it, it's internal. Also
there's no specific action the user code could take to fix the problem,
other than logging it and failing

- allov negative `prefetchValidityMillis` in client config to make it
equivalent to the member config

- remove redundant `Math.max`

Fixes #14397
