### PR TITLE
Refactor XMLConfigBuilderTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -25,14 +25,14 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * Abstract class defining the common test cases for XML and YAML
- * based configuration tests
+ * based configuration tests.
  * <p/>
  * All common test cases should be defined in this class to guarantee
  * compilation error if either YAML or XML configuration misses to cover
  * a common case.
  * <p/>
  * For specific test cases, see {@link XmlOnlyConfigBuilderTest} and
- * {@link YamlOnlyConfigBuilderTest}
+ * {@link YamlOnlyConfigBuilderTest}.
  *
  * @see XMLConfigBuilderTest
  * @see YamlConfigBuilderTest
@@ -219,7 +219,7 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testWanReplicationConfig();
 
     @Test
-    public abstract void default_value_of_persist_wan_replicated_data_is_false();
+    public abstract void testDefaultOfPersistWanReplicatedDataIsFalse();
 
     @Test
     public abstract void testWanReplicationSyncConfig();
@@ -400,11 +400,11 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     @Test
     public abstract void testAllPermissionsCovered();
 
-    // TODO what is this really testing?
-    // The thrown Exception has nothing to do with the eviction config,
-    // it blames NATIVE in-memory-format in OS build...
     @Test(expected = InvalidConfigurationException.class)
     public abstract void testCacheConfig_withInvalidEvictionConfig_failsFast();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testCacheConfig_withNativeInMemoryFormat_failsFastInOSS();
 
     @Test(expected = InvalidConfigurationException.class)
     public abstract void testMemberAddressProvider_classNameIsMandatory();
@@ -433,7 +433,7 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     @Test(expected = InvalidConfigurationException.class)
     public abstract void testUnknownRestApiEndpointGroup();
 
-    protected void assertAwsConfig(AwsConfig aws) {
+    protected static void assertAwsConfig(AwsConfig aws) {
         assertEquals("sample-access-key", aws.getProperties().get("access-key"));
         assertEquals("sample-secret-key", aws.getProperties().get("secret-key"));
         assertEquals("sample-role", aws.getProperties().get("iam-role"));

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -1,0 +1,456 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastTestSupport;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Abstract class defining the common test cases for XML and YAML
+ * based configuration tests
+ * <p/>
+ * All common test cases should be defined in this class to guarantee
+ * compilation error if either YAML or XML configuration misses to cover
+ * a common case.
+ * <p/>
+ * For specific test cases, see {@link XmlOnlyConfigBuilderTest} and
+ * {@link YamlOnlyConfigBuilderTest}
+ *
+ * @see XMLConfigBuilderTest
+ * @see YamlConfigBuilderTest
+ */
+public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
+    @Test
+    public abstract void testConfigurationURL() throws Exception;
+
+    @Test
+    public abstract void testConfigurationWithFileName() throws Exception;
+
+    @Test(expected = IllegalArgumentException.class)
+    public abstract void testConfiguration_withNullInputStream();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testInvalidRootElement();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testJoinValidation();
+
+    @Test
+    public abstract void testSecurityInterceptorConfig();
+
+    @Test
+    public abstract void readAwsConfig();
+
+    @Test
+    public abstract void readGcpConfig();
+
+    @Test
+    public abstract void readAzureConfig();
+
+    @Test
+    public abstract void readKubernetesConfig();
+
+    @Test
+    public abstract void readEurekaConfig();
+
+    @Test
+    public abstract void readDiscoveryConfig();
+
+    @Test
+    public abstract void testSSLConfig();
+
+    @Test
+    public abstract void testSymmetricEncryptionConfig();
+
+    @Test
+    public abstract void readPortCount();
+
+    @Test
+    public abstract void readPortAutoIncrement();
+
+    @Test
+    public abstract void networkReuseAddress();
+
+    @Test
+    public abstract void readSemaphoreConfig();
+
+    @Test
+    public abstract void readQueueConfig();
+
+    @Test
+    public abstract void readListConfig();
+
+    @Test
+    public abstract void readSetConfig();
+
+    @Test
+    public abstract void readLockConfig();
+
+    @Test
+    public abstract void readReliableTopic();
+
+    @Test
+    public abstract void readRingbuffer();
+
+    @Test
+    public abstract void readAtomicLong();
+
+    @Test
+    public abstract void readAtomicReference();
+
+    @Test
+    public abstract void readCountDownLatch();
+
+    @Test
+    public abstract void testCaseInsensitivityOfSettings();
+
+    @Test
+    public abstract void testManagementCenterConfig();
+
+    @Test
+    public abstract void testManagementCenterConfigComplex();
+
+    @Test
+    public abstract void testNullManagementCenterConfig();
+
+    @Test
+    public abstract void testEmptyManagementCenterConfig();
+
+    @Test
+    public abstract void testNotEnabledManagementCenterConfig();
+
+    @Test
+    public abstract void testNotEnabledWithURLManagementCenterConfig();
+
+    @Test
+    public abstract void testManagementCenterConfigComplexDisabledMutualAuth();
+
+    @Test
+    public abstract void testMapStoreInitialModeLazy();
+
+    @Test
+    public abstract void testMapConfig_minEvictionCheckMillis();
+
+    @Test
+    public abstract void testMapConfig_minEvictionCheckMillis_defaultValue();
+
+    @Test
+    public abstract void testMapConfig_preprocessingPolicy();
+
+    @Test
+    public abstract void testMapConfig_preprocessingPolicy_defaultValue();
+
+    @Test
+    public abstract void testMapConfig_evictions();
+
+    @Test
+    public abstract void testMapConfig_optimizeQueries();
+
+    @Test
+    public abstract void testMapConfig_cacheValueConfig_defaultValue();
+
+    @Test
+    public abstract void testMapConfig_cacheValueConfig_never();
+
+    @Test
+    public abstract void testMapConfig_cacheValueConfig_always();
+
+    @Test
+    public abstract void testMapConfig_cacheValueConfig_indexOnly();
+
+    @Test
+    public abstract void testMapStoreInitialModeEager();
+
+    @Test
+    public abstract void testMapStoreWriteBatchSize();
+
+    @Test
+    public abstract void testMapStoreConfig_writeCoalescing_whenDefault();
+
+    @Test
+    public abstract void testMapStoreConfig_writeCoalescing_whenSetFalse();
+
+    @Test
+    public abstract void testMapStoreConfig_writeCoalescing_whenSetTrue();
+
+    @Test
+    public abstract void testNearCacheInMemoryFormat();
+
+    @Test
+    public abstract void testNearCacheInMemoryFormatNative_withKeysByReference();
+
+    @Test
+    public abstract void testNearCacheEvictionPolicy();
+
+    @Test
+    public abstract void testPartitionGroupZoneAware();
+
+    @Test
+    public abstract void testPartitionGroupSPI();
+
+    @Test
+    public abstract void testPartitionGroupMemberGroups();
+
+    @Test
+    public abstract void testNearCacheFullConfig();
+
+    @Test
+    public abstract void testMapWanReplicationRef();
+
+    @Test
+    public abstract void testWanReplicationConfig();
+
+    @Test
+    public abstract void default_value_of_persist_wan_replicated_data_is_false();
+
+    @Test
+    public abstract void testWanReplicationSyncConfig();
+
+    @Test
+    public abstract void testMapEventJournalConfig();
+
+    @Test
+    public abstract void testMapMerkleTreeConfig();
+
+    @Test
+    public abstract void testCacheEventJournalConfig();
+
+    @Test
+    public abstract void testFlakeIdGeneratorConfig();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testParseExceptionIsNotSwallowed();
+
+    @Test
+    public abstract void setMapStoreConfigImplementationTest();
+
+    @Test
+    public abstract void testMapPartitionLostListenerConfig();
+
+    @Test
+    public abstract void testMapPartitionLostListenerConfigReadOnly();
+
+    @Test
+    public abstract void testCachePartitionLostListenerConfig();
+
+    @Test
+    public abstract void testCachePartitionLostListenerConfigReadOnly();
+
+    protected abstract Config buildConfig(String xml);
+
+    @Test
+    public abstract void readMulticastConfig();
+
+    @Test
+    public abstract void testWanConfig();
+
+    @Test
+    public abstract void testQuorumConfig();
+
+    @Test
+    public abstract void testQuorumListenerConfig();
+
+    @Test(expected = ConfigurationException.class)
+    public abstract void testQuorumConfig_whenClassNameAndRecentlyActiveQuorumDefined_exceptionIsThrown();
+
+    @Test(expected = ConfigurationException.class)
+    public abstract void testQuorumConfig_whenClassNameAndProbabilisticQuorumDefined_exceptionIsThrown();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testQuorumConfig_whenBothBuiltinQuorumsDefined_exceptionIsThrown();
+
+    @Test
+    public abstract void testQuorumConfig_whenRecentlyActiveQuorum_withDefaultValues();
+
+    @Test
+    public abstract void testQuorumConfig_whenRecentlyActiveQuorum_withCustomValues();
+
+    @Test
+    public abstract void testQuorumConfig_whenProbabilisticQuorum_withDefaultValues();
+
+    @Test
+    public abstract void testQuorumConfig_whenProbabilisticQuorum_withCustomValues();
+
+    @Test
+    public abstract void testCacheConfig();
+
+    @Test
+    public abstract void testExecutorConfig();
+
+    @Test
+    public abstract void testDurableExecutorConfig();
+
+    @Test
+    public abstract void testScheduledExecutorConfig();
+
+    @Test
+    public abstract void testCardinalityEstimatorConfig();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testCardinalityEstimatorConfigWithInvalidMergePolicy();
+
+    @Test
+    public abstract void testPNCounterConfig();
+
+    @Test
+    public abstract void testMultiMapConfig();
+
+    @Test
+    public abstract void testReplicatedMapConfig();
+
+    @Test
+    public abstract void testListConfig();
+
+    @Test
+    public abstract void testSetConfig();
+
+    @Test
+    public abstract void testMapConfig();
+
+    @Test
+    public abstract void testIndexesConfig();
+
+    @Test
+    public abstract void testAttributeConfig();
+
+    @Test(expected = IllegalArgumentException.class)
+    public abstract void testAttributeConfig_noName_emptyTag();
+
+    @Test(expected = IllegalArgumentException.class)
+    public abstract void testAttributeConfig_noName_singleTag();
+
+    @Test(expected = IllegalArgumentException.class)
+    public abstract void testAttributeConfig_noExtractor();
+
+    @Test(expected = IllegalArgumentException.class)
+    public abstract void testAttributeConfig_emptyExtractor();
+
+    @Test
+    public abstract void testQueryCacheFullConfig();
+
+    @Test
+    public abstract void testMapQueryCachePredicate();
+
+    @Test
+    public abstract void testLiteMemberConfig();
+
+    @Test
+    public abstract void testNonLiteMemberConfig();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testNonLiteMemberConfigWithoutEnabledField();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testInvalidLiteMemberConfig();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testDuplicateLiteMemberConfig();
+
+    @Test
+    public abstract void testMapNativeMaxSizePolicy();
+
+    @Test
+    public abstract void testInstanceName();
+
+    @Test
+    public abstract void testUserCodeDeployment();
+
+    @Test
+    public abstract void testCRDTReplicationConfig();
+
+    @Test
+    public abstract void testGlobalSerializer();
+
+    @Test
+    public abstract void testJavaSerializationFilter();
+
+    @Test
+    public abstract void testHotRestart();
+
+    @Test
+    public abstract void testMapEvictionPolicyClassName();
+
+    @Test
+    public abstract void testMapEvictionPolicyIsSelected_whenEvictionPolicySet();
+
+    @Test
+    public abstract void testCachePermission();
+
+    @Test
+    public abstract void testConfigPermission();
+
+    @Test
+    public abstract void testAllPermissionsCovered();
+
+    // TODO what is this really testing?
+    // The thrown Exception has nothing to do with the eviction config,
+    // it blames NATIVE in-memory-format in OS build...
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testCacheConfig_withInvalidEvictionConfig_failsFast();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testMemberAddressProvider_classNameIsMandatory();
+
+    @Test
+    public abstract void testMemberAddressProviderEnabled();
+
+    @Test
+    public abstract void testMemberAddressProviderEnabled_withProperties();
+
+    @Test
+    public abstract void testFailureDetector_withProperties();
+
+    @Test
+    public abstract void testHandleMemberAttributes();
+
+    @Test
+    public abstract void testMemcacheProtocolEnabled();
+
+    @Test
+    public abstract void testRestApiDefaults();
+
+    @Test
+    public abstract void testRestApiEndpointGroups();
+
+    @Test(expected = InvalidConfigurationException.class)
+    public abstract void testUnknownRestApiEndpointGroup();
+
+    protected void assertAwsConfig(AwsConfig aws) {
+        assertEquals("sample-access-key", aws.getProperties().get("access-key"));
+        assertEquals("sample-secret-key", aws.getProperties().get("secret-key"));
+        assertEquals("sample-role", aws.getProperties().get("iam-role"));
+        assertEquals("sample-region", aws.getProperties().get("region"));
+        assertEquals("sample-header", aws.getProperties().get("host-header"));
+        assertEquals("sample-group", aws.getProperties().get("security-group-name"));
+        assertEquals("sample-tag-key", aws.getProperties().get("tag-key"));
+        assertEquals("sample-tag-value", aws.getProperties().get("tag-value"));
+        assertEquals("10", aws.getProperties().get("connection-timeout-seconds"));
+    }
+
+    protected static void assertPermissionConfig(PermissionConfig expected, Config config) {
+        Iterator<PermissionConfig> permConfigs = config.getSecurityConfig().getClientPermissionConfigs().iterator();
+        PermissionConfig configured = permConfigs.next();
+        assertEquals(expected.getType(), configured.getType());
+        assertEquals(expected.getPrincipal(), configured.getPrincipal());
+        assertEquals(expected.getName(), configured.getName());
+        assertEquals(expected.getActions(), configured.getActions());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -65,7 +65,7 @@ import static org.junit.Assert.fail;
 
 /**
  * XML specific implementation of the tests that should be maintained in
- * both XML and YAML configuration builder tests
+ * both XML and YAML configuration builder tests.
  * <p/>
  *
  * NOTE: This test class must not define test cases, it is meant only to
@@ -1430,7 +1430,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
-    public void default_value_of_persist_wan_replicated_data_is_false() {
+    public void testDefaultOfPersistWanReplicatedDataIsFalse() {
         String configName  = "test";
         String xml = HAZELCAST_START_TAG
                 + "  <wan-replication name=\"" + configName + "\">\n"
@@ -2883,12 +2883,21 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 permTypes.isEmpty());
     }
 
-    // TODO what is this really testing?
-    // The thrown Exception has nothing to do with the eviction config,
-    // it blames NATIVE in-memory-format in the OS build...
     @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testCacheConfig_withInvalidEvictionConfig_failsFast() {
+        String xml = HAZELCAST_START_TAG
+                + "    <cache name=\"cache\">"
+                + "        <eviction size=\"10000000\" max-size-policy=\"ENTRY_COUNT\" eviction-policy=\"INVALID\"/>"
+                + "    </cache>"
+                + HAZELCAST_END_TAG;
+
+        buildConfig(xml);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testCacheConfig_withNativeInMemoryFormat_failsFastInOSS() {
         String xml = HAZELCAST_START_TAG
                 + "    <cache name=\"cache\">"
                 + "        <eviction size=\"10000000\" max-size-policy=\"ENTRY_COUNT\" eviction-policy=\"LFU\"/>"

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -16,31 +16,24 @@
 
 package com.hazelcast.config;
 
+import com.google.common.collect.ImmutableSet;
+import com.hazelcast.config.LoginModuleConfig.LoginModuleUsage;
 import com.hazelcast.config.PermissionConfig.PermissionType;
 import com.hazelcast.config.helpers.DummyMapStore;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.quorum.impl.ProbabilisticQuorumFunction;
 import com.hazelcast.quorum.impl.RecentlyActiveQuorumFunction;
 import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
-import org.xml.sax.SAXException;
 
-import javax.xml.XMLConstants;
-import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-import javax.xml.validation.Validator;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
@@ -49,6 +42,7 @@ import java.io.Writer;
 import java.net.URL;
 import java.text.MessageFormat;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -61,7 +55,6 @@ import static com.hazelcast.config.EvictionPolicy.LRU;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CACHE;
 import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
 import static com.hazelcast.config.WANQueueFullBehavior.DISCARD_AFTER_MUTATION;
-import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -70,10 +63,25 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * XML specific implementation of the tests that should be maintained in
+ * both XML and YAML configuration builder tests
+ * <p/>
+ *
+ * NOTE: This test class must not define test cases, it is meant only to
+ * implement test cases defined in {@link AbstractConfigBuilderTest}.
+ * <p/>
+ *
+ * NOTE2: Test cases specific to XML should be added to {@link XmlOnlyConfigBuilderTest}
+ *
+ * @see AbstractConfigBuilderTest
+ * @see YamlConfigBuilderTest
+ * @see XmlOnlyConfigBuilderTest
+ */
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 @SuppressWarnings({"WeakerAccess", "deprecation"})
-public class XMLConfigBuilderTest extends HazelcastTestSupport {
+public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
     static final String HAZELCAST_START_TAG = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n";
     static final String HAZELCAST_END_TAG = "</hazelcast>\n";
@@ -87,14 +95,14 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
             + "<action>remove</action>"
             + "</actions>";
 
-    @Test
+    @Override
     public void testConfigurationURL() throws Exception {
         URL configURL = getClass().getClassLoader().getResource("hazelcast-default.xml");
         Config config = new XmlConfigBuilder(configURL).build();
         assertEquals(configURL, config.getConfigurationUrl());
     }
 
-    @Test
+    @Override
     public void testConfigurationWithFileName() throws Exception {
         assumeThatNotZingJDK6(); // https://github.com/hazelcast/hazelcast/issues/9044
 
@@ -116,11 +124,13 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(path, config.getConfigurationFile().getAbsolutePath());
     }
 
+    @Override
     @Test(expected = IllegalArgumentException.class)
     public void testConfiguration_withNullInputStream() {
         new XmlConfigBuilder((InputStream) null);
     }
 
+    @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testInvalidRootElement() {
         String xml = "<hazelcast-client>"
@@ -132,6 +142,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
+    @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testJoinValidation() {
         String xml = HAZELCAST_START_TAG
@@ -145,7 +156,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
-    @Test
+    @Override
     public void testSecurityInterceptorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<security enabled=\"true\">"
@@ -154,6 +165,40 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "    <interceptor class-name=\"bar\"/>"
                 + "  </security-interceptors>"
                 + "  <client-block-unmapped-actions>false</client-block-unmapped-actions>"
+                + "  <member-credentials-factory class-name=\"MyCredentialsFactory\">\n"
+                + "    <properties>\n"
+                + "      <property name=\"property\">value</property>\n"
+                + "    </properties>\n"
+                + "  </member-credentials-factory>\n"
+                + "  <member-login-modules>\n"
+                + "    <login-module class-name=\"MyRequiredLoginModule\" usage=\"REQUIRED\">\n"
+                + "      <properties>\n"
+                + "        <property name=\"login-property\">login-value</property>\n"
+                + "      </properties>\n"
+                + "    </login-module>\n"
+                + "    <login-module class-name=\"MyRequiredLoginModule2\" usage=\"SUFFICIENT\">\n"
+                + "      <properties>\n"
+                + "        <property name=\"login-property2\">login-value2</property>\n"
+                + "      </properties>\n"
+                + "    </login-module>\n"
+                + "  </member-login-modules>\n"
+                + "  <client-login-modules>\n"
+                + "    <login-module class-name=\"MyOptionalLoginModule\" usage=\"OPTIONAL\">\n"
+                + "      <properties>\n"
+                + "        <property name=\"client-property\">client-value</property>\n"
+                + "      </properties>\n"
+                + "    </login-module>\n"
+                + "    <login-module class-name=\"MyRequiredLoginModule\" usage=\"REQUIRED\">\n"
+                + "      <properties>\n"
+                + "        <property name=\"client-property2\">client-value2</property>\n"
+                + "      </properties>\n"
+                + "    </login-module>\n"
+                + "  </client-login-modules>\n"
+                + "  <client-permission-policy class-name=\"MyPermissionPolicy\">\n"
+                + "    <properties>\n"
+                + "      <property name=\"permission-property\">permission-value</property>\n"
+                + "    </properties>\n"
+                + "  </client-permission-policy>"
                 + "</security>"
                 + HAZELCAST_END_TAG;
 
@@ -165,9 +210,55 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("foo", interceptorConfigs.get(0).className);
         assertEquals("bar", interceptorConfigs.get(1).className);
         assertFalse(securityConfig.getClientBlockUnmappedActions());
+
+        // member-credentials-factory
+        CredentialsFactoryConfig memberCredentialsConfig = securityConfig.getMemberCredentialsConfig();
+        assertEquals("MyCredentialsFactory", memberCredentialsConfig.getClassName());
+        assertEquals(1, memberCredentialsConfig.getProperties().size());
+        assertEquals("value", memberCredentialsConfig.getProperties().getProperty("property"));
+
+        // member-login-modules
+        List<LoginModuleConfig> memberLoginModuleConfigs = securityConfig.getMemberLoginModuleConfigs();
+        assertEquals(2, memberLoginModuleConfigs.size());
+        Iterator<LoginModuleConfig> memberLoginIterator = memberLoginModuleConfigs.iterator();
+
+        LoginModuleConfig memberLoginModuleCfg1 = memberLoginIterator.next();
+        assertEquals("MyRequiredLoginModule", memberLoginModuleCfg1.getClassName());
+        assertEquals(LoginModuleUsage.REQUIRED, memberLoginModuleCfg1.getUsage());
+        assertEquals(1, memberLoginModuleCfg1.getProperties().size());
+        assertEquals("login-value", memberLoginModuleCfg1.getProperties().getProperty("login-property"));
+
+        LoginModuleConfig memberLoginModuleCfg2 = memberLoginIterator.next();
+        assertEquals("MyRequiredLoginModule2", memberLoginModuleCfg2.getClassName());
+        assertEquals(LoginModuleUsage.SUFFICIENT, memberLoginModuleCfg2.getUsage());
+        assertEquals(1, memberLoginModuleCfg2.getProperties().size());
+        assertEquals("login-value2", memberLoginModuleCfg2.getProperties().getProperty("login-property2"));
+
+        // client-login-modules
+        List<LoginModuleConfig> clientLoginModuleConfigs = securityConfig.getClientLoginModuleConfigs();
+        assertEquals(2, clientLoginModuleConfigs.size());
+        Iterator<LoginModuleConfig> clientLoginIterator = clientLoginModuleConfigs.iterator();
+
+        LoginModuleConfig clientLoginModuleCfg1 = clientLoginIterator.next();
+        assertEquals("MyOptionalLoginModule", clientLoginModuleCfg1.getClassName());
+        assertEquals(LoginModuleUsage.OPTIONAL, clientLoginModuleCfg1.getUsage());
+        assertEquals(1, clientLoginModuleCfg1.getProperties().size());
+        assertEquals("client-value", clientLoginModuleCfg1.getProperties().getProperty("client-property"));
+
+        LoginModuleConfig clientLoginModuleCfg2 = clientLoginIterator.next();
+        assertEquals("MyRequiredLoginModule", clientLoginModuleCfg2.getClassName());
+        assertEquals(LoginModuleUsage.REQUIRED, clientLoginModuleCfg2.getUsage());
+        assertEquals(1, clientLoginModuleCfg2.getProperties().size());
+        assertEquals("client-value2", clientLoginModuleCfg2.getProperties().getProperty("client-property2"));
+
+        // client-permission-policy
+        PermissionPolicyConfig permissionPolicyConfig = securityConfig.getClientPolicyConfig();
+        assertEquals("MyPermissionPolicy", permissionPolicyConfig.getClassName());
+        assertEquals(1, permissionPolicyConfig.getProperties().size());
+        assertEquals("permission-value", permissionPolicyConfig.getProperties().getProperty("permission-property"));
     }
 
-    @Test
+    @Override
     public void readAwsConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <group>\n"
@@ -208,7 +299,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertAwsConfig(awsConfig);
     }
 
-    @Test
+    @Override
     public void readGcpConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -216,6 +307,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "            <multicast enabled=\"false\"/>\n"
                 + "            <tcp-ip enabled=\"false\"/>\n"
                 + "            <gcp enabled=\"true\">\n"
+                + "                <use-public-ip>true</use-public-ip>\n"
                 + "                <zones>us-east1-b</zones>\n"
                 + "            </gcp>\n"
                 + "        </join>\n"
@@ -227,11 +319,11 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         GcpConfig gcpConfig = config.getNetworkConfig().getJoin().getGcpConfig();
 
         assertTrue(gcpConfig.isEnabled());
-        assertFalse(gcpConfig.isUsePublicIp());
+        assertTrue(gcpConfig.isUsePublicIp());
         assertEquals("us-east1-b", gcpConfig.getProperty("zones"));
     }
 
-    @Test
+    @Override
     public void readAzureConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -240,6 +332,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "            <tcp-ip enabled=\"false\"/>\n"
                 + "            <azure enabled=\"true\">\n"
                 + "                <client-id>123456789!</client-id>\n"
+                + "                <use-public-ip>true</use-public-ip>\n"
                 + "            </azure>\n"
                 + "        </join>\n"
                 + "    </network>"
@@ -250,10 +343,11 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         AzureConfig azureConfig = config.getNetworkConfig().getJoin().getAzureConfig();
 
         assertTrue(azureConfig.isEnabled());
+        assertTrue(azureConfig.isUsePublicIp());
         assertEquals("123456789!", azureConfig.getProperty("client-id"));
     }
 
-    @Test
+    @Override
     public void readKubernetesConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -261,6 +355,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "            <multicast enabled=\"false\"/>\n"
                 + "            <tcp-ip enabled=\"false\"/>\n"
                 + "            <kubernetes enabled=\"true\">\n"
+                + "                <use-public-ip>true</use-public-ip>\n"
                 + "                <namespace>hazelcast</namespace>\n"
                 + "            </kubernetes>\n"
                 + "        </join>\n"
@@ -272,10 +367,11 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         KubernetesConfig kubernetesConfig = config.getNetworkConfig().getJoin().getKubernetesConfig();
 
         assertTrue(kubernetesConfig.isEnabled());
+        assertTrue(kubernetesConfig.isUsePublicIp());
         assertEquals("hazelcast", kubernetesConfig.getProperty("namespace"));
     }
 
-    @Test
+    @Override
     public void readEurekaConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -283,6 +379,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "            <multicast enabled=\"false\"/>\n"
                 + "            <tcp-ip enabled=\"false\"/>\n"
                 + "            <eureka enabled=\"true\">\n"
+                + "                <use-public-ip>true</use-public-ip>\n"
                 + "                <namespace>hazelcast</namespace>\n"
                 + "            </eureka>\n"
                 + "        </join>\n"
@@ -294,10 +391,11 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         EurekaConfig eurekaConfig = config.getNetworkConfig().getJoin().getEurekaConfig();
 
         assertTrue(eurekaConfig.isEnabled());
+        assertTrue(eurekaConfig.isUsePublicIp());
         assertEquals("hazelcast", eurekaConfig.getProperty("namespace"));
     }
 
-    @Test
+    @Override
     public void readDiscoveryConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <group>\n"
@@ -337,7 +435,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertDiscoveryConfig(discoveryConfig);
     }
 
-    @Test
+    @Override
     public void testSSLConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -360,14 +458,14 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("TLS", sslConfig.getProperties().get("protocol"));
     }
 
-    @Test
+    @Override
     public void testSymmetricEncryptionConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
                 + "      <symmetric-encryption enabled=\"true\">\n"
                 + "        <algorithm>AES</algorithm>\n"
-                + "        <salt>thesalt</salt>\n"
-                + "        <password>thepass</password>\n"
+                + "        <salt>some-salt</salt>\n"
+                + "        <password>some-pass</password>\n"
                 + "        <iteration-count>7531</iteration-count>\n"
                 + "      </symmetric-encryption>"
                 + "    </network>\n"
@@ -377,20 +475,21 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         SymmetricEncryptionConfig symmetricEncryptionConfig = config.getNetworkConfig().getSymmetricEncryptionConfig();
         assertTrue(symmetricEncryptionConfig.isEnabled());
         assertEquals("AES", symmetricEncryptionConfig.getAlgorithm());
-        assertEquals("thesalt", symmetricEncryptionConfig.getSalt());
-        assertEquals("thepass", symmetricEncryptionConfig.getPassword());
+        assertEquals("some-salt", symmetricEncryptionConfig.getSalt());
+        assertEquals("some-pass", symmetricEncryptionConfig.getPassword());
         assertEquals(7531, symmetricEncryptionConfig.getIterationCount());
     }
 
-    @Test
+    @Override
     public void readPortCount() {
         // check when it is explicitly set
         Config config = buildConfig(HAZELCAST_START_TAG
                 + "    <network>\n"
-                + "        <port port-count=\"200\">5701</port>\n"
+                + "        <port port-count=\"200\">5702</port>\n"
                 + "    </network>\n"
                 + HAZELCAST_END_TAG);
         assertEquals(200, config.getNetworkConfig().getPortCount());
+        assertEquals(5702, config.getNetworkConfig().getPort());
 
         // check if the default is passed in correctly
         config = buildConfig(HAZELCAST_START_TAG
@@ -401,7 +500,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(100, config.getNetworkConfig().getPortCount());
     }
 
-    @Test
+    @Override
     public void readPortAutoIncrement() {
         // explicitly set
         Config config = buildConfig(HAZELCAST_START_TAG
@@ -420,7 +519,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(config.getNetworkConfig().isPortAutoIncrement());
     }
 
-    @Test
+    @Override
     public void networkReuseAddress() {
         Config config = buildConfig(HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -430,7 +529,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(config.getNetworkConfig().isReuseAddress());
     }
 
-    @Test
+    @Override
     public void readSemaphoreConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <semaphore name=\"default\">\n"
@@ -449,19 +548,19 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("customQuorumRule", customConfig.getQuorumName());
     }
 
-    @Test
+    @Override
     public void readQueueConfig() {
         String xml = HAZELCAST_START_TAG
                 + "      <queue name=\"custom\">"
-                + "        <statistics-enabled>true</statistics-enabled>"
+                + "        <statistics-enabled>false</statistics-enabled>"
                 + "        <max-size>100</max-size>"
-                + "        <backup-count>1</backup-count>"
-                + "        <async-backup-count>0</async-backup-count>"
-                + "        <empty-queue-ttl>-1</empty-queue-ttl>"
+                + "        <backup-count>2</backup-count>"
+                + "        <async-backup-count>1</async-backup-count>"
+                + "        <empty-queue-ttl>1</empty-queue-ttl>"
                 + "        <item-listeners>"
-                + "            <item-listener>com.hazelcast.examples.ItemListener</item-listener>"
+                + "            <item-listener include-value=\"false\">com.hazelcast.examples.ItemListener</item-listener>"
                 + "        </item-listeners>"
-                + "        <queue-store>"
+                + "        <queue-store enabled=\"false\">"
                 + "            <class-name>com.hazelcast.QueueStoreImpl</class-name>"
                 + "            <properties>"
                 + "                <property name=\"binary\">false</property>"
@@ -476,23 +575,24 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
 
         Config config = buildConfig(xml);
         QueueConfig queueConfig = config.getQueueConfig("custom");
-        assertTrue(queueConfig.isStatisticsEnabled());
+        assertFalse(queueConfig.isStatisticsEnabled());
         assertEquals(100, queueConfig.getMaxSize());
-        assertEquals(1, queueConfig.getBackupCount());
-        assertEquals(0, queueConfig.getAsyncBackupCount());
-        assertEquals(-1, queueConfig.getEmptyQueueTtl());
+        assertEquals(2, queueConfig.getBackupCount());
+        assertEquals(1, queueConfig.getAsyncBackupCount());
+        assertEquals(1, queueConfig.getEmptyQueueTtl());
 
         MergePolicyConfig mergePolicyConfig = queueConfig.getMergePolicyConfig();
         assertEquals("CustomMergePolicy", mergePolicyConfig.getPolicy());
         assertEquals(23, mergePolicyConfig.getBatchSize());
 
-        assertTrue(queueConfig.getItemListenerConfigs().size() == 1);
+        assertEquals(1, queueConfig.getItemListenerConfigs().size());
         ItemListenerConfig listenerConfig = queueConfig.getItemListenerConfigs().iterator().next();
         assertEquals("com.hazelcast.examples.ItemListener", listenerConfig.getClassName());
+        assertFalse(listenerConfig.isIncludeValue());
 
         QueueStoreConfig storeConfig = queueConfig.getQueueStoreConfig();
         assertNotNull(storeConfig);
-        assertTrue(storeConfig.isEnabled());
+        assertFalse(storeConfig.isEnabled());
         assertEquals("com.hazelcast.QueueStoreImpl", storeConfig.getClassName());
 
         Properties storeConfigProperties = storeConfig.getProperties();
@@ -504,16 +604,16 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("customQuorumRule", queueConfig.getQuorumName());
     }
 
-    @Test
+    @Override
     public void readListConfig() {
         String xml = HAZELCAST_START_TAG
                 + "      <list name=\"myList\">"
-                + "        <statistics-enabled>true</statistics-enabled>"
+                + "        <statistics-enabled>false</statistics-enabled>"
                 + "        <max-size>100</max-size>"
-                + "        <backup-count>1</backup-count>"
-                + "        <async-backup-count>0</async-backup-count>"
+                + "        <backup-count>2</backup-count>"
+                + "        <async-backup-count>1</async-backup-count>"
                 + "        <item-listeners>"
-                + "            <item-listener>com.hazelcast.examples.ItemListener</item-listener>"
+                + "            <item-listener include-value=\"false\">com.hazelcast.examples.ItemListener</item-listener>"
                 + "        </item-listeners>"
                 + "        <merge-policy batch-size=\"4223\">PassThroughMergePolicy</merge-policy>"
                 + "    </list>"
@@ -522,28 +622,29 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         ListConfig listConfig = config.getListConfig("myList");
 
         assertEquals("myList", listConfig.getName());
-        assertTrue(listConfig.isStatisticsEnabled());
+        assertFalse(listConfig.isStatisticsEnabled());
         assertEquals(100, listConfig.getMaxSize());
-        assertEquals(1, listConfig.getBackupCount());
-        assertEquals(0, listConfig.getAsyncBackupCount());
-        assertTrue(listConfig.getItemListenerConfigs().size() == 1);
+        assertEquals(2, listConfig.getBackupCount());
+        assertEquals(1, listConfig.getAsyncBackupCount());
+        assertEquals(1, listConfig.getItemListenerConfigs().size());
 
         ItemListenerConfig listenerConfig = listConfig.getItemListenerConfigs().iterator().next();
         assertEquals("com.hazelcast.examples.ItemListener", listenerConfig.getClassName());
+        assertFalse(listenerConfig.isIncludeValue());
 
         MergePolicyConfig mergePolicyConfig = listConfig.getMergePolicyConfig();
         assertEquals("PassThroughMergePolicy", mergePolicyConfig.getPolicy());
         assertEquals(4223, mergePolicyConfig.getBatchSize());
     }
 
-    @Test
+    @Override
     public void readSetConfig() {
         String xml = HAZELCAST_START_TAG
                 + "      <set name=\"mySet\">"
-                + "        <statistics-enabled>true</statistics-enabled>"
+                + "        <statistics-enabled>false</statistics-enabled>"
                 + "        <max-size>100</max-size>"
-                + "        <backup-count>1</backup-count>"
-                + "        <async-backup-count>0</async-backup-count>"
+                + "        <backup-count>2</backup-count>"
+                + "        <async-backup-count>1</async-backup-count>"
                 + "        <item-listeners>"
                 + "            <item-listener>com.hazelcast.examples.ItemListener</item-listener>"
                 + "        </item-listeners>"
@@ -554,11 +655,11 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         SetConfig setConfig = config.getSetConfig("mySet");
 
         assertEquals("mySet", setConfig.getName());
-        assertTrue(setConfig.isStatisticsEnabled());
+        assertFalse(setConfig.isStatisticsEnabled());
         assertEquals(100, setConfig.getMaxSize());
-        assertEquals(1, setConfig.getBackupCount());
-        assertEquals(0, setConfig.getAsyncBackupCount());
-        assertTrue(setConfig.getItemListenerConfigs().size() == 1);
+        assertEquals(2, setConfig.getBackupCount());
+        assertEquals(1, setConfig.getAsyncBackupCount());
+        assertEquals(1, setConfig.getItemListenerConfigs().size());
 
         ItemListenerConfig listenerConfig = setConfig.getItemListenerConfigs().iterator().next();
         assertEquals("com.hazelcast.examples.ItemListener", listenerConfig.getClassName());
@@ -568,7 +669,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(4223, mergePolicyConfig.getBatchSize());
     }
 
-    @Test
+    @Override
     public void readLockConfig() {
         String xml = HAZELCAST_START_TAG
                 + "  <lock name=\"default\">"
@@ -586,7 +687,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("customQuorumRule", customConfig.getQuorumName());
     }
 
-    @Test
+    @Override
     public void readReliableTopic() {
         String xml = HAZELCAST_START_TAG
                 + "    <reliable-topic name=\"custom\">"
@@ -614,7 +715,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertNull(listenerConfig.getImplementation());
     }
 
-    @Test
+    @Override
     public void readRingbuffer() {
         String xml = HAZELCAST_START_TAG
                 + "    <ringbuffer name=\"custom\">"
@@ -623,7 +724,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "        <async-backup-count>1</async-backup-count>"
                 + "        <time-to-live-seconds>9</time-to-live-seconds>"
                 + "        <in-memory-format>OBJECT</in-memory-format>"
-                + "        <ringbuffer-store>"
+                + "        <ringbuffer-store enabled=\"false\">"
                 + "            <class-name>com.hazelcast.RingbufferStoreImpl</class-name>"
                 + "            <properties>"
                 + "                <property name=\"store-path\">.//tmp//bufferstore</property>"
@@ -643,6 +744,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(InMemoryFormat.OBJECT, ringbufferConfig.getInMemoryFormat());
 
         RingbufferStoreConfig ringbufferStoreConfig = ringbufferConfig.getRingbufferStoreConfig();
+        assertFalse(ringbufferStoreConfig.isEnabled());
         assertEquals("com.hazelcast.RingbufferStoreImpl", ringbufferStoreConfig.getClassName());
         Properties ringbufferStoreProperties = ringbufferStoreConfig.getProperties();
         assertEquals(".//tmp//bufferstore", ringbufferStoreProperties.get("store-path"));
@@ -653,7 +755,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(2342, mergePolicyConfig.getBatchSize());
     }
 
-    @Test
+    @Override
     public void readAtomicLong() {
         String xml = HAZELCAST_START_TAG
                 + "    <atomic-long name=\"custom\">"
@@ -671,7 +773,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(23, mergePolicyConfig.getBatchSize());
     }
 
-    @Test
+    @Override
     public void readAtomicReference() {
         String xml = HAZELCAST_START_TAG
                 + "    <atomic-reference name=\"custom\">"
@@ -689,7 +791,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(23, mergePolicyConfig.getBatchSize());
     }
 
-    @Test
+    @Override
     public void readCountDownLatch() {
         String xml = HAZELCAST_START_TAG
                 + "    <count-down-latch name=\"custom\">"
@@ -702,38 +804,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("customQuorumRule", countDownLatchConfig.getQuorumName());
     }
 
-    @Test
-    public void testConfig2Xml2DefaultConfig() {
-        testConfig2Xml2Config("hazelcast-default.xml");
-    }
-
-    @Test
-    public void testConfig2Xml2FullConfig() {
-        testConfig2Xml2Config("hazelcast-fullconfig.xml");
-    }
-
-    private static void testConfig2Xml2Config(String fileName) {
-        String pass = "password";
-        Config config = new ClasspathXmlConfig(fileName);
-        config.getGroupConfig().setPassword(pass);
-
-        String xml = new ConfigXmlGenerator(true, false).generate(config);
-        Config config2 = new InMemoryXmlConfig(xml);
-
-        assertTrue(ConfigCompatibilityChecker.isCompatible(config, config2));
-    }
-
-    @Test
-    public void testXSDDefaultXML() throws Exception {
-        testXSDConfigXML("hazelcast-default.xml");
-    }
-
-    @Test
-    public void testFullConfigXML() throws Exception {
-        testXSDConfigXML("hazelcast-fullconfig.xml");
-    }
-
-    @Test
+    @Override
     public void testCaseInsensitivityOfSettings() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"testCaseInsensitivity\">"
@@ -761,7 +832,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(2342, mergePolicyConfig.getBatchSize());
     }
 
-    @Test
+    @Override
     public void testManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center enabled=\"true\" scripting-enabled='false'>"
@@ -777,7 +848,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("someUrl", manCenterCfg.getUrl());
     }
 
-    @Test
+    @Override
     public void testManagementCenterConfigComplex() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center enabled=\"true\">"
@@ -801,7 +872,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("/tmp/foo_truststore", manCenterCfg.getMutualAuthConfig().getProperty("trustStore"));
     }
 
-    @Test
+    @Override
     public void testNullManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center>"
@@ -815,7 +886,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertNull(manCenterCfg.getUrl());
     }
 
-    @Test
+    @Override
     public void testEmptyManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG + HAZELCAST_END_TAG;
 
@@ -826,7 +897,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertNull(manCenterCfg.getUrl());
     }
 
-    @Test
+    @Override
     public void testNotEnabledManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center enabled=\"false\">"
@@ -839,7 +910,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertNull(manCenterCfg.getUrl());
     }
 
-    @Test
+    @Override
     public void testNotEnabledWithURLManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center enabled=\"false\">"
@@ -854,7 +925,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("http://localhost:8080/mancenter", manCenterCfg.getUrl());
     }
 
-    @Test
+    @Override
     public void testManagementCenterConfigComplexDisabledMutualAuth() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center enabled=\"true\">"
@@ -872,7 +943,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertFalse(manCenterCfg.getMutualAuthConfig().isEnabled());
     }
 
-    @Test
+    @Override
     public void testMapStoreInitialModeLazy() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -887,7 +958,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(MapStoreConfig.InitialLoadMode.LAZY, mapStoreConfig.getInitialLoadMode());
     }
 
-    @Test
+    @Override
     public void testMapConfig_minEvictionCheckMillis() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -901,7 +972,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(123456789L, mapConfig.getMinEvictionCheckMillis());
     }
 
-    @Test
+    @Override
     public void testMapConfig_minEvictionCheckMillis_defaultValue() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -914,7 +985,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(MapConfig.DEFAULT_MIN_EVICTION_CHECK_MILLIS, mapConfig.getMinEvictionCheckMillis());
     }
 
-    @Test
+    @Override
     public void testMapConfig_preprocessingPolicy() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -928,7 +999,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(PreprocessingPolicy.CREATION_TIME, mapConfig.getPreprocessingPolicy());
     }
 
-    @Test
+    @Override
     public void testMapConfig_preprocessingPolicy_defaultValue() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -941,7 +1012,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(PreprocessingPolicy.OFF, mapConfig.getPreprocessingPolicy());
     }
 
-    @Test
+    @Override
     public void testMapConfig_evictions() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"lruMap\">"
@@ -967,7 +1038,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(EvictionPolicy.RANDOM, config.getMapConfig("randomMap").getEvictionPolicy());
     }
 
-    @Test
+    @Override
     public void testMapConfig_optimizeQueries() {
         String xml1 = HAZELCAST_START_TAG
                 + "<map name=\"mymap1\">"
@@ -991,7 +1062,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(CacheDeserializedValues.INDEX_ONLY, mapConfig2.getCacheDeserializedValues());
     }
 
-    @Test
+    @Override
     public void testMapConfig_cacheValueConfig_defaultValue() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1004,7 +1075,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(CacheDeserializedValues.INDEX_ONLY, mapConfig.getCacheDeserializedValues());
     }
 
-    @Test
+    @Override
     public void testMapConfig_cacheValueConfig_never() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1018,7 +1089,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(CacheDeserializedValues.NEVER, mapConfig.getCacheDeserializedValues());
     }
 
-    @Test
+    @Override
     public void testMapConfig_cacheValueConfig_always() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1032,7 +1103,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(CacheDeserializedValues.ALWAYS, mapConfig.getCacheDeserializedValues());
     }
 
-    @Test
+    @Override
     public void testMapConfig_cacheValueConfig_indexOnly() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1046,7 +1117,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(CacheDeserializedValues.INDEX_ONLY, mapConfig.getCacheDeserializedValues());
     }
 
-    @Test
+    @Override
     public void testMapStoreInitialModeEager() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1061,7 +1132,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(MapStoreConfig.InitialLoadMode.EAGER, mapStoreConfig.getInitialLoadMode());
     }
 
-    @Test
+    @Override
     public void testMapStoreWriteBatchSize() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1077,21 +1148,21 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(23, mapStoreConfig.getWriteBatchSize());
     }
 
-    @Test
+    @Override
     public void testMapStoreConfig_writeCoalescing_whenDefault() {
         MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(MapStoreConfig.DEFAULT_WRITE_COALESCING, true);
 
         assertTrue(mapStoreConfig.isWriteCoalescing());
     }
 
-    @Test
+    @Override
     public void testMapStoreConfig_writeCoalescing_whenSetFalse() {
         MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(false, false);
 
         assertFalse(mapStoreConfig.isWriteCoalescing());
     }
 
-    @Test
+    @Override
     public void testMapStoreConfig_writeCoalescing_whenSetTrue() {
         MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(true, false);
 
@@ -1114,7 +1185,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + HAZELCAST_END_TAG;
     }
 
-    @Test
+    @Override
     public void testNearCacheInMemoryFormat() {
         String mapName = "testMapNearCacheInMemoryFormat";
         String xml = HAZELCAST_START_TAG
@@ -1132,7 +1203,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(InMemoryFormat.OBJECT, ncConfig.getInMemoryFormat());
     }
 
-    @Test
+    @Override
     public void testNearCacheInMemoryFormatNative_withKeysByReference() {
         String mapName = "testMapNearCacheInMemoryFormatNative";
         String xml = HAZELCAST_START_TAG
@@ -1152,7 +1223,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(ncConfig.isSerializeKeys());
     }
 
-    @Test
+    @Override
     public void testNearCacheEvictionPolicy() {
         String xml = HAZELCAST_START_TAG
                 + "  <map name=\"lfuNearCache\">"
@@ -1188,27 +1259,60 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         return config.getMapConfig(mapName).getNearCacheConfig().getEvictionConfig().getEvictionPolicy();
     }
 
-    @Test
+    @Override
     public void testPartitionGroupZoneAware() {
         String xml = HAZELCAST_START_TAG
                 + "<partition-group enabled=\"true\" group-type=\"ZONE_AWARE\" />"
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
-        assertEquals(config.getPartitionGroupConfig().getGroupType(), PartitionGroupConfig.MemberGroupType.ZONE_AWARE);
+        PartitionGroupConfig partitionGroupConfig = config.getPartitionGroupConfig();
+        assertTrue(partitionGroupConfig.isEnabled());
+        assertEquals(PartitionGroupConfig.MemberGroupType.ZONE_AWARE, partitionGroupConfig.getGroupType());
     }
 
-    @Test
+    @Override
     public void testPartitionGroupSPI() {
         String xml = HAZELCAST_START_TAG
                 + "<partition-group enabled=\"true\" group-type=\"SPI\" />"
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
-        assertEquals(config.getPartitionGroupConfig().getGroupType(), PartitionGroupConfig.MemberGroupType.SPI);
+        assertEquals(PartitionGroupConfig.MemberGroupType.SPI, config.getPartitionGroupConfig().getGroupType());
     }
 
-    @Test
+    @Override
+    public void testPartitionGroupMemberGroups() {
+        String xml = HAZELCAST_START_TAG
+                + "<partition-group enabled=\"true\" group-type=\"SPI\">"
+                + "  <member-group>"
+                + "    <interface>10.10.1.1</interface>"
+                + "    <interface>10.10.1.2</interface>"
+                + "  </member-group>"
+                + "  <member-group>"
+                + "    <interface>10.10.1.3</interface>"
+                + "    <interface>10.10.1.4</interface>"
+                + "  </member-group>"
+                + "</partition-group>"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        Collection<MemberGroupConfig> memberGroupConfigs = config.getPartitionGroupConfig().getMemberGroupConfigs();
+        assertEquals(2, memberGroupConfigs.size());
+        Iterator<MemberGroupConfig> iterator = memberGroupConfigs.iterator();
+
+        MemberGroupConfig memberGroupConfig1 = iterator.next();
+        assertEquals(2, memberGroupConfig1.getInterfaces().size());
+        assertTrue(memberGroupConfig1.getInterfaces().contains("10.10.1.1"));
+        assertTrue(memberGroupConfig1.getInterfaces().contains("10.10.1.2"));
+
+        MemberGroupConfig memberGroupConfig2 = iterator.next();
+        assertEquals(2, memberGroupConfig2.getInterfaces().size());
+        assertTrue(memberGroupConfig2.getInterfaces().contains("10.10.1.3"));
+        assertTrue(memberGroupConfig2.getInterfaces().contains("10.10.1.4"));
+    }
+
+    @Override
     public void testNearCacheFullConfig() {
         String mapName = "testNearCacheFullConfig";
         String xml = HAZELCAST_START_TAG
@@ -1244,7 +1348,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("test", nearCacheConfig.getName());
     }
 
-    @Test
+    @Override
     public void testMapWanReplicationRef() {
         String mapName = "testMapWanReplicationRef";
         String refName = "test";
@@ -1271,7 +1375,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("com.example.SampleFilter", wanRef.getFilters().get(0));
     }
 
-    @Test
+    @Override
     public void testWanReplicationConfig() {
         String configName  = "test";
         String xml = HAZELCAST_START_TAG
@@ -1325,7 +1429,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("propValue1", properties.get("propName1"));
     }
 
-    @Test
+    @Override
     public void default_value_of_persist_wan_replicated_data_is_false() {
         String configName  = "test";
         String xml = HAZELCAST_START_TAG
@@ -1341,8 +1445,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertFalse(consumerConfig.isPersistWanReplicatedData());
     }
 
-
-    @Test
+    @Override
     public void testWanReplicationSyncConfig() {
         String configName  = "test";
         String xml = HAZELCAST_START_TAG
@@ -1369,11 +1472,11 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                                                                            .getConsistencyCheckStrategy());
     }
 
-    @Test
+    @Override
     public void testMapEventJournalConfig() {
         String journalName = "mapName";
         String xml = HAZELCAST_START_TAG
-                + "<event-journal enabled=\"true\">\n"
+                + "<event-journal enabled=\"false\">\n"
                 + "    <mapName>" + journalName + "</mapName>\n"
                 + "    <capacity>120</capacity>\n"
                 + "    <time-to-live-seconds>20</time-to-live-seconds>\n"
@@ -1383,12 +1486,12 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         Config config = buildConfig(xml);
         EventJournalConfig journalConfig = config.getMapEventJournalConfig(journalName);
 
-        assertTrue(journalConfig.isEnabled());
+        assertFalse(journalConfig.isEnabled());
         assertEquals(120, journalConfig.getCapacity());
         assertEquals(20, journalConfig.getTimeToLiveSeconds());
     }
 
-    @Test
+    @Override
     public void testMapMerkleTreeConfig() {
         String mapName = "mapName";
         String xml = HAZELCAST_START_TAG
@@ -1405,7 +1508,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(20, treeConfig.getDepth());
     }
 
-    @Test
+    @Override
     public void testCacheEventJournalConfig() {
         String journalName = "cacheName";
         String xml = HAZELCAST_START_TAG
@@ -1424,7 +1527,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(20, journalConfig.getTimeToLiveSeconds());
     }
 
-    @Test
+    @Override
     public void testFlakeIdGeneratorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<flake-id-generator name='gen'>"
@@ -1445,6 +1548,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertFalse(fConfig.isStatisticsEnabled());
     }
 
+    @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testParseExceptionIsNotSwallowed() {
         String invalidXml = HAZELCAST_START_TAG + "</hazelcast";
@@ -1454,7 +1558,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         fail();
     }
 
-    @Test
+    @Override
     public void setMapStoreConfigImplementationTest() {
         String mapName = "mapStoreImpObjTest";
         String xml = HAZELCAST_START_TAG
@@ -1480,7 +1584,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(o instanceof DummyMapStore);
     }
 
-    @Test
+    @Override
     public void testMapPartitionLostListenerConfig() {
         String mapName = "map1";
         String listenerName = "DummyMapPartitionLostListenerImpl";
@@ -1491,7 +1595,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertMapPartitionLostListener(listenerName, mapConfig);
     }
 
-    @Test
+    @Override
     public void testMapPartitionLostListenerConfigReadOnly() {
         String mapName = "map1";
         String listenerName = "DummyMapPartitionLostListenerImpl";
@@ -1517,7 +1621,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + HAZELCAST_END_TAG;
     }
 
-    @Test
+    @Override
     public void testCachePartitionLostListenerConfig() {
         String cacheName = "cache1";
         String listenerName = "DummyCachePartitionLostListenerImpl";
@@ -1528,7 +1632,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertCachePartitionLostListener(listenerName, cacheConfig);
     }
 
-    @Test
+    @Override
     public void testCachePartitionLostListenerConfigReadOnly() {
         String cacheName = "cache1";
         String listenerName = "DummyCachePartitionLostListenerImpl";
@@ -1554,30 +1658,14 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + HAZELCAST_END_TAG;
     }
 
-    private void testXSDConfigXML(String xmlFileName) throws Exception {
-        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-        URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-config-"
-                + Versions.CURRENT_CLUSTER_VERSION + ".xsd");
-        assertNotNull(schemaResource);
-
-        InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream(xmlFileName);
-        Schema schema = factory.newSchema(schemaResource);
-        Source source = new StreamSource(xmlResource);
-        Validator validator = schema.newValidator();
-        try {
-            validator.validate(source);
-        } catch (SAXException ex) {
-            fail(xmlFileName + " is not valid because: " + ex.toString());
-        }
-    }
-
-    private Config buildConfig(String xml) {
+    @Override
+    protected Config buildConfig(String xml) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
         XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
         return configBuilder.build();
     }
 
-    @Test
+    @Override
     public void readMulticastConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <group>\n"
@@ -1587,34 +1675,34 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "    <network>\n"
                 + "        <port auto-increment=\"true\">5701</port>\n"
                 + "        <join>\n"
-                + "            <multicast enabled=\"true\" loopbackModeEnabled=\"true\">\n"
-                + "                <multicast-group>224.2.2.3</multicast-group>\n"
-                + "                <multicast-port>54327</multicast-port>\n"
+                + "            <multicast enabled=\"false\" loopbackModeEnabled=\"true\">\n"
+                + "                <multicast-group>224.2.2.4</multicast-group>\n"
+                + "                <multicast-port>65438</multicast-port>\n"
+                + "                <multicast-timeout-seconds>4</multicast-timeout-seconds>\n"
+                + "                <multicast-time-to-live>42</multicast-time-to-live>\n"
+                + "                <trusted-interfaces>\n"
+                + "                  <interface>127.0.0.1</interface>\n"
+                + "                  <interface>0.0.0.0</interface>\n"
+                + "                </trusted-interfaces>\n"
                 + "            </multicast>\n"
-                + "            <tcp-ip enabled=\"false\">\n"
-                + "                <interface>127.0.0.1</interface>\n"
-                + "            </tcp-ip>\n"
-                + "            <aws enabled=\"false\" connection-timeout-seconds=\"10\" >\n"
-                + "                <access-key>access</access-key>\n"
-                + "                <secret-key>secret</secret-key>\n"
-                + "            </aws>\n"
                 + "        </join>\n"
-                + "        <interfaces enabled=\"false\">\n"
-                + "            <interface>10.10.1.*</interface>\n"
-                + "        </interfaces>\n"
                 + "    </network>\n"
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
         MulticastConfig multicastConfig = config.getNetworkConfig().getJoin().getMulticastConfig();
 
-        assertTrue(multicastConfig.isEnabled());
+        assertFalse(multicastConfig.isEnabled());
         assertTrue(multicastConfig.isLoopbackModeEnabled());
-        assertEquals("224.2.2.3", multicastConfig.getMulticastGroup());
-        assertEquals(54327, multicastConfig.getMulticastPort());
+        assertEquals("224.2.2.4", multicastConfig.getMulticastGroup());
+        assertEquals(65438, multicastConfig.getMulticastPort());
+        assertEquals(4, multicastConfig.getMulticastTimeoutSeconds());
+        assertEquals(42, multicastConfig.getMulticastTimeToLive());
+        assertEquals(2, multicastConfig.getTrustedInterfaces().size());
+        assertTrue(multicastConfig.getTrustedInterfaces().containsAll(ImmutableSet.of("127.0.0.1", "0.0.0.0")));
     }
 
-    @Test
+    @Override
     public void testWanConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <wan-replication name=\"my-wan-cluster\">\n"
@@ -1658,7 +1746,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "         <properties>\n"
                 + "            <property name=\"custom.prop.consumer\">prop.consumer</property>\n"
                 + "         </properties>\n"
-                + "      <persist-wan-replicated-data>false</persist-wan-replicated-data>\n"
+                + "      <persist-wan-replicated-data>true</persist-wan-replicated-data>\n"
                 + "      </wan-consumer>\n"
                 + "   </wan-replication>"
                 + HAZELCAST_END_TAG;
@@ -1698,7 +1786,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("com.hazelcast.wan.custom.WanConsumer", consumerConfig.getClassName());
         Map<String, Comparable> consProperties = consumerConfig.getProperties();
         assertEquals("prop.consumer", consProperties.get("custom.prop.consumer"));
-        assertFalse(consumerConfig.isPersistWanReplicatedData());
+        assertTrue(consumerConfig.isPersistWanReplicatedData());
     }
 
     private void assertDiscoveryConfig(DiscoveryConfig c) {
@@ -1714,19 +1802,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("true", props.get("key-boolean"));
     }
 
-    private void assertAwsConfig(AwsConfig aws) {
-        assertEquals("sample-access-key", aws.getProperties().get("access-key"));
-        assertEquals("sample-secret-key", aws.getProperties().get("secret-key"));
-        assertEquals("sample-role", aws.getProperties().get("iam-role"));
-        assertEquals("sample-region", aws.getProperties().get("region"));
-        assertEquals("sample-header", aws.getProperties().get("host-header"));
-        assertEquals("sample-group", aws.getProperties().get("security-group-name"));
-        assertEquals("sample-tag-key", aws.getProperties().get("tag-key"));
-        assertEquals("sample-tag-value", aws.getProperties().get("tag-value"));
-        assertEquals("10", aws.getProperties().get("connection-timeout-seconds"));
-    }
-
-    @Test
+    @Override
     public void testQuorumConfig() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1746,7 +1822,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(quorumConfig.getListenerConfigs().isEmpty());
     }
 
-    @Test
+    @Override
     public void testQuorumListenerConfig() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1768,6 +1844,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("com.hazelcast.SomeQuorumFunction", quorumConfig.getQuorumFunctionClassName());
     }
 
+    @Override
     @Test(expected = ConfigurationException.class)
     public void testQuorumConfig_whenClassNameAndRecentlyActiveQuorumDefined_exceptionIsThrown() {
         String xml = HAZELCAST_START_TAG
@@ -1781,6 +1858,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
+    @Override
     @Test(expected = ConfigurationException.class)
     public void testQuorumConfig_whenClassNameAndProbabilisticQuorumDefined_exceptionIsThrown() {
         String xml = HAZELCAST_START_TAG
@@ -1794,6 +1872,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
+    @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testQuorumConfig_whenBothBuiltinQuorumsDefined_exceptionIsThrown() {
         String xml = HAZELCAST_START_TAG
@@ -1807,7 +1886,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
-    @Test
+    @Override
     public void testQuorumConfig_whenRecentlyActiveQuorum_withDefaultValues() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1825,7 +1904,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 quorumFunction.getHeartbeatToleranceMillis());
     }
 
-    @Test
+    @Override
     public void testQuorumConfig_whenRecentlyActiveQuorum_withCustomValues() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1843,7 +1922,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(13000, quorumFunction.getHeartbeatToleranceMillis());
     }
 
-    @Test
+    @Override
     public void testQuorumConfig_whenProbabilisticQuorum_withDefaultValues() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1866,7 +1945,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(ProbabilisticQuorumConfigBuilder.DEFAULT_SAMPLE_SIZE, quorumFunction.getMaxSampleSize());
     }
 
-    @Test
+    @Override
     public void testQuorumConfig_whenProbabilisticQuorum_withCustomValues() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1888,7 +1967,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(42, quorumFunction.getMaxSampleSize());
     }
 
-    @Test
+    @Override
     public void testCacheConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <cache name=\"foobar\">\n"
@@ -1956,7 +2035,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("com.example.cache.MyEntryEventFilterFactory", cacheConfig.getCacheEntryListeners().get(0).getCacheEntryEventFilterFactory());
     }
 
-    @Test
+    @Override
     public void testExecutorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <executor-service name=\"foobar\">\n"
@@ -1977,7 +2056,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(0, executorConfig.getQueueCapacity());
     }
 
-    @Test
+    @Override
     public void testDurableExecutorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <durable-executor-service name=\"foobar\">\n"
@@ -1998,7 +2077,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("customQuorumRule", durableExecutorConfig.getQuorumName());
     }
 
-    @Test
+    @Override
     public void testScheduledExecutorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <scheduled-executor-service name=\"foobar\">\n"
@@ -2022,7 +2101,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("PutIfAbsent", scheduledExecutorConfig.getMergePolicyConfig().getPolicy());
     }
 
-    @Test
+    @Override
     public void testCardinalityEstimatorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <cardinality-estimator name=\"foobar\">\n"
@@ -2044,6 +2123,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("customQuorumRule", cardinalityEstimatorConfig.getQuorumName());
     }
 
+    @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testCardinalityEstimatorConfigWithInvalidMergePolicy() {
         String xml = HAZELCAST_START_TAG
@@ -2059,7 +2139,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         fail();
     }
 
-    @Test
+    @Override
     public void testPNCounterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <pn-counter name=\"pn-counter-1\">\n"
@@ -2078,7 +2158,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertFalse(pnCounterConfig.isStatisticsEnabled());
     }
 
-    @Test
+    @Override
     public void testMultiMapConfig() {
         String xml = HAZELCAST_START_TAG
                 + "  <multimap name=\"myMultiMap\">"
@@ -2114,7 +2194,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(23, mergePolicyConfig.getBatchSize());
     }
 
-    @Test
+    @Override
     public void testReplicatedMapConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <replicatedmap name=\"foobar\">\n"
@@ -2140,7 +2220,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(2342, mergePolicyConfig.getBatchSize());
     }
 
-    @Test
+    @Override
     public void testListConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <list name=\"foobar\">\n"
@@ -2172,7 +2252,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("SplitBrainMergePolicy", mergePolicyConfig.getPolicy());
     }
 
-    @Test
+    @Override
     public void testSetConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <set name=\"foobar\">\n"
@@ -2204,7 +2284,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("SplitBrainMergePolicy", mergePolicyConfig.getPolicy());
     }
 
-    @Test
+    @Override
     public void testMapConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <map name=\"foobar\">\n"
@@ -2333,7 +2413,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("com.example.SampleFilter".toLowerCase(), wanReplicationRef.getFilters().get(0).toLowerCase());
     }
 
-    @Test
+    @Override
     public void testIndexesConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <map name=\"people\">\n"
@@ -2357,7 +2437,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(expectedOrdered, indexConfig.isOrdered());
     }
 
-    @Test
+    @Override
     public void testAttributeConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <map name=\"people\">\n"
@@ -2376,6 +2456,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertAttributeEqual("weight", "com.car.WeightExtractor", mapConfig.getMapAttributeConfigs().get(1));
     }
 
+    @Override
     @Test(expected = IllegalArgumentException.class)
     public void testAttributeConfig_noName_emptyTag() {
         String xml = HAZELCAST_START_TAG
@@ -2393,6 +2474,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(expectedExtractor, attributeConfig.getExtractor());
     }
 
+    @Override
     @Test(expected = IllegalArgumentException.class)
     public void testAttributeConfig_noName_singleTag() {
         String xml = HAZELCAST_START_TAG
@@ -2405,30 +2487,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testAttributeConfig_noName_noExtractor() {
-        String xml = HAZELCAST_START_TAG
-                + "   <map name=\"people\">\n"
-                + "       <attributes>\n"
-                + "           <attribute></attribute>\n"
-                + "       </attributes>"
-                + "   </map>"
-                + HAZELCAST_END_TAG;
-        buildConfig(xml);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testAttributeConfig_noName_noExtractor_singleTag() {
-        String xml = HAZELCAST_START_TAG
-                + "   <map name=\"people\">\n"
-                + "       <attributes>\n"
-                + "           <attribute/>\n"
-                + "       </attributes>"
-                + "   </map>"
-                + HAZELCAST_END_TAG;
-        buildConfig(xml);
-    }
-
+    @Override
     @Test(expected = IllegalArgumentException.class)
     public void testAttributeConfig_noExtractor() {
         String xml = HAZELCAST_START_TAG
@@ -2441,6 +2500,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
+    @Override
     @Test(expected = IllegalArgumentException.class)
     public void testAttributeConfig_emptyExtractor() {
         String xml = HAZELCAST_START_TAG
@@ -2453,7 +2513,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
-    @Test
+    @Override
     public void testQueryCacheFullConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"test\">"
@@ -2503,54 +2563,72 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(133, queryCacheConfig.getEvictionConfig().getSize());
     }
 
-    @Test
+    @Override
+    public void testMapQueryCachePredicate() {
+        String xml = HAZELCAST_START_TAG
+                + "  <map name=\"test\">\n"
+                + "    <query-caches>\n"
+                + "      <query-cache name=\"cache-class-name\">\n"
+                + "        <predicate type=\"class-name\">com.hazelcast.examples.SimplePredicate</predicate>\n"
+                + "      </query-cache>\n"
+                + "      <query-cache name=\"cache-sql\">\n"
+                + "        <predicate type=\"sql\">%age=40</predicate>\n"
+                + "      </query-cache>\n"
+                + "    </query-caches>\n"
+                + "  </map>\n"
+                + HAZELCAST_END_TAG;
+
+        Config config = buildConfig(xml);
+        QueryCacheConfig queryCacheClassNameConfig = config.getMapConfig("test").getQueryCacheConfigs().get(0);
+        assertEquals("com.hazelcast.examples.SimplePredicate", queryCacheClassNameConfig.getPredicateConfig().getClassName());
+
+        QueryCacheConfig queryCacheSqlConfig = config.getMapConfig("test").getQueryCacheConfigs().get(1);
+        assertEquals("%age=40", queryCacheSqlConfig.getPredicateConfig().getSql());
+    }
+
+    @Override
     public void testLiteMemberConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <lite-member enabled=\"true\"/>\n"
                 + HAZELCAST_END_TAG;
 
-        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
-        XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
-        Config config = configBuilder.build();
+        Config config = buildConfig(xml);
 
         assertTrue(config.isLiteMember());
     }
 
-    @Test
+    @Override
     public void testNonLiteMemberConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <lite-member enabled=\"false\"/>\n"
                 + HAZELCAST_END_TAG;
 
-        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
-        XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
-        Config config = configBuilder.build();
+        Config config = buildConfig(xml);
 
         assertFalse(config.isLiteMember());
     }
 
+    @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testNonLiteMemberConfigWithoutEnabledField() {
         String xml = HAZELCAST_START_TAG
                 + "    <lite-member/>\n"
                 + HAZELCAST_END_TAG;
 
-        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
-        XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
-        configBuilder.build();
+        buildConfig(xml);
     }
 
+    @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testInvalidLiteMemberConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <lite-member enabled=\"dummytext\"/>\n"
                 + HAZELCAST_END_TAG;
 
-        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
-        XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
-        configBuilder.build();
+        buildConfig(xml);
     }
 
+    @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testDuplicateLiteMemberConfig() {
         String xml = HAZELCAST_START_TAG
@@ -2558,9 +2636,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "    <lite-member enabled=\"true\"/>\n"
                 + HAZELCAST_END_TAG;
 
-        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
-        XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
-        configBuilder.build();
+        buildConfig(xml);
         fail();
     }
 
@@ -2571,7 +2647,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         }
     }
 
-    @Test
+    @Override
     public void testMapNativeMaxSizePolicy() {
         String xmlFormat = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -2594,18 +2670,18 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         }
     }
 
-    @Test
+    @Override
     public void testInstanceName() {
         String name = randomName();
         String xml = HAZELCAST_START_TAG
                 + "<instance-name>" + name + "</instance-name>\n"
                 + HAZELCAST_END_TAG;
 
-        Config config = new InMemoryXmlConfig(xml);
+        Config config = buildConfig(xml);
         assertEquals(name, config.getInstanceName());
     }
 
-    @Test
+    @Override
     public void testUserCodeDeployment() {
         String xml = HAZELCAST_START_TAG
                 + "<user-code-deployment enabled=\"true\">"
@@ -2626,7 +2702,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("HAS_ATTRIBUTE:foo", dcConfig.getProviderFilter());
     }
 
-    @Test
+    @Override
     public void testCRDTReplicationConfig() {
         final String xml = HAZELCAST_START_TAG
                 + "<crdt-replication>\n"
@@ -2640,7 +2716,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(2000, replicationConfig.getReplicationPeriodMillis());
     }
 
-    @Test
+    @Override
     public void testGlobalSerializer() {
         String name = randomName();
         String val = "true";
@@ -2658,7 +2734,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(globalSerializerConfig.isOverrideJavaSerialization());
     }
 
-    @Test
+    @Override
     public void testJavaSerializationFilter() {
         String xml = HAZELCAST_START_TAG
                 + "  <serialization>\n"
@@ -2696,7 +2772,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(blackList.getClasses().contains("com.acme.app.BeanComparator"));
     }
 
-    @Test
+    @Override
     public void testHotRestart() {
         String dir = "/mnt/hot-restart-root/";
         String backupDir = "/mnt/hot-restart-backup/";
@@ -2729,37 +2805,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertFalse(hotRestartPersistenceConfig.isAutoRemoveStaleData());
     }
 
-    @Test(expected = InvalidConfigurationException.class)
-    public void testMissingNamespace() {
-        String xml = "<hazelcast/>";
-        buildConfig(xml);
-    }
-
-    @Test(expected = InvalidConfigurationException.class)
-    public void testInvalidNamespace() {
-        String xml = "<hazelcast xmlns=\"http://foo.bar\"/>";
-        buildConfig(xml);
-    }
-
-    @Test
-    public void testValidNamespace() {
-        String xml = HAZELCAST_START_TAG + HAZELCAST_END_TAG;
-        buildConfig(xml);
-    }
-
-    @Test(expected = InvalidConfigurationException.class)
-    public void testHazelcastTagAppearsTwice() {
-        String xml = HAZELCAST_START_TAG + "<hazelcast/>" + HAZELCAST_END_TAG;
-        buildConfig(xml);
-    }
-
-    @Test(expected = InvalidConfigurationException.class)
-    public void testHazelcastInstanceNameEmpty() {
-        String xml = HAZELCAST_START_TAG + "<instance-name></instance-name>" + HAZELCAST_END_TAG;
-        buildConfig(xml);
-    }
-
-    @Test
+    @Override
     public void testMapEvictionPolicyClassName() {
         String mapEvictionPolicyClassName = "com.hazelcast.map.eviction.LRUEvictionPolicy";
         String xml = HAZELCAST_START_TAG
@@ -2773,7 +2819,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(mapEvictionPolicyClassName, mapConfig.getMapEvictionPolicy().getClass().getName());
     }
 
-    @Test
+    @Override
     public void testMapEvictionPolicyIsSelected_whenEvictionPolicySet() {
         String mapEvictionPolicyClassName = "com.hazelcast.map.eviction.LRUEvictionPolicy";
         String xml = HAZELCAST_START_TAG
@@ -2788,7 +2834,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(mapEvictionPolicyClassName, mapConfig.getMapEvictionPolicy().getClass().getName());
     }
 
-    @Test
+    @Override
     public void testCachePermission() {
         String xml = HAZELCAST_START_TAG + SECURITY_START_TAG
                 + "  <client-permissions>"
@@ -2804,7 +2850,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertPermissionConfig(expected, config);
     }
 
-    @Test
+    @Override
     public void testConfigPermission() {
         String xml = HAZELCAST_START_TAG + SECURITY_START_TAG
                 + "  <client-permissions>"
@@ -2820,7 +2866,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertPermissionConfig(expected, config);
     }
 
-    @Test
+    @Override
     public void testAllPermissionsCovered() {
         InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream("hazelcast-fullconfig.xml");
         Config config = null;
@@ -2837,6 +2883,10 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 permTypes.isEmpty());
     }
 
+    // TODO what is this really testing?
+    // The thrown Exception has nothing to do with the eviction config,
+    // it blames NATIVE in-memory-format in the OS build...
+    @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testCacheConfig_withInvalidEvictionConfig_failsFast() {
         String xml = HAZELCAST_START_TAG
@@ -2849,6 +2899,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
+    @Override
     @Test(expected = InvalidConfigurationException.class)
     public void testMemberAddressProvider_classNameIsMandatory() {
         String xml = HAZELCAST_START_TAG
@@ -2861,7 +2912,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         buildConfig(xml);
     }
 
-    @Test
+    @Override
     public void testMemberAddressProviderEnabled() {
         String xml = HAZELCAST_START_TAG
                 + "<network> "
@@ -2878,7 +2929,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("foo.bar.Clazz", memberAddressProviderConfig.getClassName());
     }
 
-    @Test
+    @Override
     public void testMemberAddressProviderEnabled_withProperties() {
         String xml = HAZELCAST_START_TAG
                 + "<network> "
@@ -2899,7 +2950,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("propValue1", properties.get("propName1"));
     }
 
-    @Test
+    @Override
     public void testFailureDetector_withProperties() {
         String xml = HAZELCAST_START_TAG
                 + "<network>"
@@ -2929,7 +2980,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals(4200, icmpFailureDetectorConfig.getIntervalMilliseconds());
     }
 
-    @Test
+    @Override
     public void testHandleMemberAttributes() {
         String xml = HAZELCAST_START_TAG
                 + "<member-attributes>\n"
@@ -2943,7 +2994,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertEquals("ID", memberAttributeConfig.getStringAttribute("IDENTIFIER"));
     }
 
-    @Test
+    @Override
     public void testMemcacheProtocolEnabled() {
         String xml = HAZELCAST_START_TAG
                 + "<memcache-protocol enabled='true'/>\n"
@@ -2954,7 +3005,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         assertTrue(memcacheProtocolConfig.isEnabled());
     }
 
-    @Test
+    @Override
     public void testRestApiDefaults() {
         String xml = HAZELCAST_START_TAG
                 + "<rest-api enabled='false'/>\n"
@@ -2969,7 +3020,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
         }
     }
 
-    @Test
+    @Override
     public void testRestApiEndpointGroups() {
         String xml = HAZELCAST_START_TAG
                 + "<rest-api enabled='true'>\n"
@@ -2987,7 +3038,7 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 restApiConfig.isGroupEnabled(RestEndpointGroup.CLUSTER_WRITE));
     }
 
-    @Test(expected = InvalidConfigurationException.class)
+    @Override
     public void testUnknownRestApiEndpointGroup() {
         String xml = HAZELCAST_START_TAG
                 + "<rest-api enabled='true'>\n"
@@ -2995,41 +3046,5 @@ public class XMLConfigBuilderTest extends HazelcastTestSupport {
                 + "</rest-api>\n"
                 + HAZELCAST_END_TAG;
         buildConfig(xml);
-    }
-
-    @Test
-    public void testXsdVersion() {
-        String origVersionOverride = System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
-        assertXsdVersion("0.0", "0.0");
-        assertXsdVersion("3.9", "3.9");
-        assertXsdVersion("3.9-SNAPSHOT", "3.9");
-        assertXsdVersion("3.9.1-SNAPSHOT", "3.9");
-        assertXsdVersion("3.10", "3.10");
-        assertXsdVersion("3.10-SNAPSHOT", "3.10");
-        assertXsdVersion("3.10.1-SNAPSHOT", "3.10");
-        assertXsdVersion("99.99.99", "99.99");
-        assertXsdVersion("99.99.99-SNAPSHOT", "99.99");
-        assertXsdVersion("99.99.99-Beta", "99.99");
-        assertXsdVersion("99.99.99-Beta-SNAPSHOT", "99.99");
-        if (origVersionOverride != null) {
-            System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, origVersionOverride);
-        } else {
-            System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
-        }
-    }
-
-    private void assertXsdVersion(String buildVersion, String expectedXsdVersion) {
-        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, buildVersion);
-        assertEquals("Unexpected release version retrieved for build version " + buildVersion, expectedXsdVersion,
-                new XmlConfigBuilder().getReleaseVersion());
-    }
-
-    private static void assertPermissionConfig(PermissionConfig expected, Config config) {
-        Iterator<PermissionConfig> permConfigs = config.getSecurityConfig().getClientPermissionConfigs().iterator();
-        PermissionConfig configured = permConfigs.next();
-        assertEquals(expected.getType(), configured.getType());
-        assertEquals(expected.getPrincipal(), configured.getPrincipal());
-        assertEquals(expected.getName(), configured.getName());
-        assertEquals(expected.getActions(), configured.getActions());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlOnlyConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlOnlyConfigBuilderTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test cases specific only to XML based configuration. The cases not
+ * XML specific should be added to {@link XMLConfigBuilderTest}.
+ * <p/>
+ * This test class is expected to contain only <strong>extra</strong> test
+ * cases over the ones defined in {@link XMLConfigBuilderTest} in order
+ * to cover XML specific cases where XML configuration derives from the
+ * YAML configuration to allow usage of XML-native constructs.
+ *
+ * @see XMLConfigBuilderTest
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class XmlOnlyConfigBuilderTest {
+
+    private static final String HAZELCAST_START_TAG = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n";
+    private static final String HAZELCAST_END_TAG = "</hazelcast>\n";
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testMissingNamespace() {
+        String xml = "<hazelcast/>";
+        buildConfig(xml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testInvalidNamespace() {
+        String xml = "<hazelcast xmlns=\"http://foo.bar\"/>";
+        buildConfig(xml);
+    }
+
+    @Test
+    public void testValidNamespace() {
+        String xml = HAZELCAST_START_TAG + HAZELCAST_END_TAG;
+        buildConfig(xml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testHazelcastTagAppearsTwice() {
+        String xml = HAZELCAST_START_TAG + "<hazelcast/>" + HAZELCAST_END_TAG;
+        buildConfig(xml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testHazelcastInstanceNameEmpty() {
+        String xml = HAZELCAST_START_TAG + "<instance-name></instance-name>" + HAZELCAST_END_TAG;
+        buildConfig(xml);
+    }
+
+    @Test
+    public void testXsdVersion() {
+        String origVersionOverride = System.getProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
+        assertXsdVersion("0.0", "0.0");
+        assertXsdVersion("3.9", "3.9");
+        assertXsdVersion("3.9-SNAPSHOT", "3.9");
+        assertXsdVersion("3.9.1-SNAPSHOT", "3.9");
+        assertXsdVersion("3.10", "3.10");
+        assertXsdVersion("3.10-SNAPSHOT", "3.10");
+        assertXsdVersion("3.10.1-SNAPSHOT", "3.10");
+        assertXsdVersion("99.99.99", "99.99");
+        assertXsdVersion("99.99.99-SNAPSHOT", "99.99");
+        assertXsdVersion("99.99.99-Beta", "99.99");
+        assertXsdVersion("99.99.99-Beta-SNAPSHOT", "99.99");
+        if (origVersionOverride != null) {
+            System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, origVersionOverride);
+        } else {
+            System.clearProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION);
+        }
+    }
+
+    @Test
+    public void testConfig2Xml2DefaultConfig() {
+        testConfig2Xml2Config("hazelcast-default.xml");
+    }
+
+    @Test
+    public void testConfig2Xml2FullConfig() {
+        testConfig2Xml2Config("hazelcast-fullconfig.xml");
+    }
+
+    @Test
+    public void testXSDDefaultXML() throws Exception {
+        testXSDConfigXML("hazelcast-default.xml");
+    }
+
+    @Test
+    public void testFullConfig() throws Exception {
+        testXSDConfigXML("hazelcast-fullconfig.xml");
+    }
+
+    // No YAML identical to the XML can be written
+    @Test(expected = IllegalArgumentException.class)
+    public void testAttributeConfig_noName_noExtractor() {
+        String xml = HAZELCAST_START_TAG
+                + "   <map name=\"people\">\n"
+                + "       <attributes>\n"
+                + "           <attribute></attribute>\n"
+                + "       </attributes>"
+                + "   </map>"
+                + HAZELCAST_END_TAG;
+        buildConfig(xml);
+    }
+
+    // No YAML identical to the XML can be written
+    @Test(expected = IllegalArgumentException.class)
+    public void testAttributeConfig_noName_noExtractor_singleTag() {
+        String xml = HAZELCAST_START_TAG
+                + "   <map name=\"people\">\n"
+                + "       <attributes>\n"
+                + "           <attribute/>\n"
+                + "       </attributes>"
+                + "   </map>"
+                + HAZELCAST_END_TAG;
+        buildConfig(xml);
+    }
+
+    private void assertXsdVersion(String buildVersion, String expectedXsdVersion) {
+        System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, buildVersion);
+        assertEquals("Unexpected release version retrieved for build version " + buildVersion, expectedXsdVersion,
+                new XmlConfigBuilder().getReleaseVersion());
+    }
+
+    private static void testConfig2Xml2Config(String fileName) {
+        String pass = "password";
+        Config config = new ClasspathXmlConfig(fileName);
+        config.getGroupConfig().setPassword(pass);
+
+        String xml = new ConfigXmlGenerator(true, false).generate(config);
+        Config config2 = new InMemoryXmlConfig(xml);
+
+        assertTrue(ConfigCompatibilityChecker.isCompatible(config, config2));
+    }
+
+    private Config buildConfig(String xml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
+        XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
+        return configBuilder.build();
+    }
+
+    private void testXSDConfigXML(String xmlFileName) throws Exception {
+        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-config-"
+                + Versions.CURRENT_CLUSTER_VERSION + ".xsd");
+        assertNotNull(schemaResource);
+
+        InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream(xmlFileName);
+        Schema schema = factory.newSchema(schemaResource);
+        Source source = new StreamSource(xmlResource);
+        Validator validator = schema.newValidator();
+        try {
+            validator.validate(source);
+        } catch (SAXException ex) {
+            fail(xmlFileName + " is not valid because: " + ex.toString());
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlOnlyConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlOnlyConfigBuilderTest.java
@@ -37,7 +37,6 @@ import java.net.URL;
 
 import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -130,7 +129,6 @@ public class XmlOnlyConfigBuilderTest {
         testXSDConfigXML("hazelcast-fullconfig.xml");
     }
 
-    // No YAML identical to the XML can be written
     @Test(expected = IllegalArgumentException.class)
     public void testAttributeConfig_noName_noExtractor() {
         String xml = HAZELCAST_START_TAG
@@ -143,7 +141,6 @@ public class XmlOnlyConfigBuilderTest {
         buildConfig(xml);
     }
 
-    // No YAML identical to the XML can be written
     @Test(expected = IllegalArgumentException.class)
     public void testAttributeConfig_noName_noExtractor_singleTag() {
         String xml = HAZELCAST_START_TAG
@@ -156,7 +153,7 @@ public class XmlOnlyConfigBuilderTest {
         buildConfig(xml);
     }
 
-    private void assertXsdVersion(String buildVersion, String expectedXsdVersion) {
+    private static void assertXsdVersion(String buildVersion, String expectedXsdVersion) {
         System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, buildVersion);
         assertEquals("Unexpected release version retrieved for build version " + buildVersion, expectedXsdVersion,
                 new XmlConfigBuilder().getReleaseVersion());
@@ -173,22 +170,21 @@ public class XmlOnlyConfigBuilderTest {
         assertTrue(ConfigCompatibilityChecker.isCompatible(config, config2));
     }
 
-    private Config buildConfig(String xml) {
+    private static Config buildConfig(String xml) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
         XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
         return configBuilder.build();
     }
 
-    private void testXSDConfigXML(String xmlFileName) throws Exception {
+    private static void testXSDConfigXML(String xmlFileName) throws Exception {
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         URL schemaResource = XMLConfigBuilderTest.class.getClassLoader().getResource("hazelcast-config-"
                 + Versions.CURRENT_CLUSTER_VERSION + ".xsd");
-        assertNotNull(schemaResource);
-
         InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream(xmlFileName);
         Schema schema = factory.newSchema(schemaResource);
         Source source = new StreamSource(xmlResource);
         Validator validator = schema.newValidator();
+
         try {
             validator.validate(source);
         } catch (SAXException ex) {


### PR DESCRIPTION
This is a test only change.

Test cases common in XML and YAML are extracted to `AbstractConfigBuilderTest`, which is extended by `XMLConfigBuilderTest` and will be extended by `YamlConfigBuilderTest`.

Test cases specific to XML (such as XSD tests) are now implemented in `XmlOnlyConfigBuilderTest`.

Notes for reviewers:
- Test cases/code removed from `XMLConfigBuilderTest` are moved to either `AbstractConfigBuilderTest` or `XmlOnlyConfigBuilderTest`.
- Test cases added to `XMLConfigBuilderTest` were previously uncovered 
- Test cases modified (`true -> false` changes etc) were previously assigning on default values
- Assertions of the common test cases are kept together with the test case implementations. This is a trade-off between test case readability and the _guaranteed_ coherence of the XML/YAML implementations, in favor of readability. Thoughts are welcome on this aspect.