### PR TITLE
[BACKPORT] Add javax.management.* to @PowerMockIgnore

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/VersionedInCurrentVersionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/VersionedInCurrentVersionTest.java
@@ -66,7 +66,7 @@ import static org.mockito.Mockito.when;
  * in.getVersion.isUnknownOrLessThan(CURRENT).
  */
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore({"javax.net.ssl.*", "javax.security.*"})
+@PowerMockIgnore({"javax.net.ssl.*", "javax.security.*", "javax.management.*"})
 @PrepareForTest(Version.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class VersionedInCurrentVersionTest {


### PR DESCRIPTION
VersionedInCurrentVersion test references HazelcastTestSupport
which in turn statically initializes a logger instance. Adding this
to ignored classes will avoid having the powermock classloader attempt
to load MBeanServer and related classes during log4j initialization.

Backport of #14413 