### PR TITLE
Load member config from YAML

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -97,7 +97,10 @@
     <suppress checks="MethodCount|MethodLength|FileLength" files="com[\\/]hazelcast[\\/]config[\\/]MemberDomConfigProcessor"/>
     <suppress checks="CyclomaticComplexity|ClassFanOutComplexity|ClassDataAbstractionCoupling"
               files="com[\\/]hazelcast[\\/]config[\\/]MemberDomConfigProcessor"/>
-    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]config[\\/]yaml[\\/]NodeAdapter"/>
+    <suppress checks="CyclomaticComplexity|ClassFanOutComplexity|ClassDataAbstractionCoupling|MethodCount"
+              files="com[\\/]hazelcast[\\/]config[\\/]YamlMemberDomConfigProcessor"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]config[\\/]yaml[\\/]ScalarTextNodeAdapter"/>
+    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]config[\\/]yaml[\\/]ElementAdapter"/>
 
     <!-- Concurrent -->
     <suppress checks="Javadoc(Method|Type|Variable)" files="com[\\/]hazelcast[\\/]concurrent[\\/]"/>

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.client.config;
 
-import com.hazelcast.config.AbstractConfigBuilder;
+import com.hazelcast.config.AbstractXmlConfigBuilder;
 import com.hazelcast.config.ConfigLoader;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.logging.ILogger;
@@ -41,13 +41,11 @@ import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
  * Loads the {@link com.hazelcast.client.config.ClientConfig} using XML.
  */
 @SuppressWarnings("checkstyle:methodcount")
-public class XmlClientConfigBuilder extends AbstractConfigBuilder {
+public class XmlClientConfigBuilder extends AbstractXmlConfigBuilder {
 
     private static final ILogger LOGGER = Logger.getLogger(XmlClientConfigBuilder.class);
 
     private final InputStream in;
-
-    private Properties properties = System.getProperties();
 
     public XmlClientConfigBuilder(String resource) throws IOException {
         URL url = ConfigLoader.locateConfig(resource);
@@ -109,17 +107,13 @@ public class XmlClientConfigBuilder extends AbstractConfigBuilder {
         }
     }
 
-    @Override
-    protected Properties getProperties() {
-        return properties;
-    }
-
-    public void setProperties(Properties properties) {
-        this.properties = properties;
+    public XmlClientConfigBuilder setProperties(Properties properties) {
+        setPropertiesInternal(properties);
+        return this;
     }
 
     @Override
-    protected ConfigType getXmlType() {
+    protected ConfigType getConfigType() {
         return ConfigType.CLIENT;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -85,6 +85,7 @@ public class XmlClientConfigBuilder extends AbstractXmlConfigBuilder {
      */
     public XmlClientConfigBuilder() {
         XmlClientConfigLocator locator = new XmlClientConfigLocator();
+        locator.locateEveryWhere();
         this.in = locator.getIn();
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigBuilder.java
@@ -85,7 +85,7 @@ public class XmlClientConfigBuilder extends AbstractXmlConfigBuilder {
      */
     public XmlClientConfigBuilder() {
         XmlClientConfigLocator locator = new XmlClientConfigLocator();
-        locator.locateEveryWhere();
+        locator.locateEverywhere();
         this.in = locator.getIn();
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigLocator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigLocator.java
@@ -17,35 +17,31 @@
 package com.hazelcast.client.config;
 
 import com.hazelcast.config.AbstractConfigLocator;
-import com.hazelcast.core.HazelcastException;
 
 /**
  * A support class for the {@link XmlClientConfigBuilder} to locate the client
  * xml configuration.
  */
 public class XmlClientConfigLocator extends AbstractConfigLocator {
-    /**
-     * Constructs a XmlClientConfigBuilder.
-     *
-     * @throws com.hazelcast.core.HazelcastException if the client XML config is not located.
-     */
-    public XmlClientConfigLocator() {
-        try {
-            if (loadFromSystemProperty("hazelcast.client.config")) {
-                return;
-            }
 
-            if (loadFromWorkingDirectory("hazelcast-client.xml")) {
-                return;
-            }
+    @Override
+    public boolean locateFromSystemProperty() {
+        return loadFromSystemProperty("hazelcast.client.config", "xml");
+    }
 
-            if (loadConfigurationFromClasspath("hazelcast-client.xml")) {
-                return;
-            }
+    @Override
+    protected boolean locateInWorkDir() {
+        return loadFromWorkingDirectory("hazelcast-client.xml");
+    }
 
-            loadDefaultConfigurationFromClasspath("hazelcast-client-default.xml");
-        } catch (final RuntimeException e) {
-            throw new HazelcastException("Failed to load ClientConfig", e);
-        }
+    @Override
+    protected boolean locateOnClasspath() {
+        return loadConfigurationFromClasspath("hazelcast-client.xml");
+    }
+
+    @Override
+    public boolean locateDefault() {
+        loadDefaultConfigurationFromClasspath("hazelcast-client-default.xml");
+        return true;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientConfigLocator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientConfigLocator.java
@@ -17,35 +17,31 @@
 package com.hazelcast.client.config;
 
 import com.hazelcast.config.AbstractConfigLocator;
-import com.hazelcast.core.HazelcastException;
 
 /**
  * A support class for the {@link YamlClientConfigBuilder} to locate the client
  * YAML configuration.
  */
 public class YamlClientConfigLocator extends AbstractConfigLocator {
-    /**
-     * Constructs a XmlClientConfigBuilder.
-     *
-     * @throws com.hazelcast.core.HazelcastException if the client YAML config is not located.
-     */
-    public YamlClientConfigLocator() {
-        try {
-            if (loadFromSystemProperty("hazelcast.client.config")) {
-                return;
-            }
 
-            if (loadFromWorkingDirectory("hazelcast-client.yaml")) {
-                return;
-            }
+    @Override
+    public boolean locateFromSystemProperty() {
+        return loadFromSystemProperty("hazelcast.client.config", "yaml", "yml");
+    }
 
-            if (loadConfigurationFromClasspath("hazelcast-client.yaml")) {
-                return;
-            }
+    @Override
+    protected boolean locateInWorkDir() {
+        return loadFromWorkingDirectory("hazelcast-client.yaml");
+    }
 
-            loadDefaultConfigurationFromClasspath("hazelcast-client.yaml");
-        } catch (final RuntimeException e) {
-            throw new HazelcastException("Failed to load ClientConfig", e);
-        }
+    @Override
+    protected boolean locateOnClasspath() {
+        return loadConfigurationFromClasspath("hazelcast-client.yaml");
+    }
+
+    @Override
+    public boolean locateDefault() {
+        loadDefaultConfigurationFromClasspath("hazelcast-client-default.yaml");
+        return true;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientConfigLocator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientConfigLocator.java
@@ -20,30 +20,30 @@ import com.hazelcast.config.AbstractConfigLocator;
 import com.hazelcast.core.HazelcastException;
 
 /**
- * A support class for the {@link XmlClientConfigBuilder} to locate the client
- * xml configuration.
+ * A support class for the {@link YamlClientConfigBuilder} to locate the client
+ * YAML configuration.
  */
-public class XmlClientConfigLocator extends AbstractConfigLocator {
+public class YamlClientConfigLocator extends AbstractConfigLocator {
     /**
      * Constructs a XmlClientConfigBuilder.
      *
-     * @throws com.hazelcast.core.HazelcastException if the client XML config is not located.
+     * @throws com.hazelcast.core.HazelcastException if the client YAML config is not located.
      */
-    public XmlClientConfigLocator() {
+    public YamlClientConfigLocator() {
         try {
             if (loadFromSystemProperty("hazelcast.client.config")) {
                 return;
             }
 
-            if (loadFromWorkingDirectory("hazelcast-client.xml")) {
+            if (loadFromWorkingDirectory("hazelcast-client.yaml")) {
                 return;
             }
 
-            if (loadConfigurationFromClasspath("hazelcast-client.xml")) {
+            if (loadConfigurationFromClasspath("hazelcast-client.yaml")) {
                 return;
             }
 
-            loadDefaultConfigurationFromClasspath("hazelcast-client-default.xml");
+            loadDefaultConfigurationFromClasspath("hazelcast-client.yaml");
         } catch (final RuntimeException e) {
             throw new HazelcastException("Failed to load ClientConfig", e);
         }

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.12.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.12.xsd
@@ -90,7 +90,7 @@
         <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true">
             <xs:annotation>
                 <xs:documentation>
-                    Specifies whether the the discovery stategy is enabled or not. Value can be true or false.
+                    Specifies whether the the discovery strategy is enabled or not. Value can be true or false.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -118,7 +118,7 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
 
     @Test(expected = HazelcastException.class)
     public void loadingThroughSystemProperty_nonExistingFile() throws IOException {
-        File file = File.createTempFile("foo", "bar");
+        File file = File.createTempFile("foo", ".xml");
         delete(file);
         System.setProperty("hazelcast.client.config", file.getAbsolutePath());
 
@@ -134,7 +134,7 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
                 + "    </group>\n"
                 + "</hazelcast-client>";
 
-        File file = File.createTempFile("foo", "bar");
+        File file = File.createTempFile("foo", ".xml");
         file.deleteOnExit();
         PrintWriter writer = new PrintWriter(file, "UTF-8");
         writer.println(xml);
@@ -149,7 +149,7 @@ public class XmlClientConfigBuilderTest extends HazelcastTestSupport {
 
     @Test(expected = HazelcastException.class)
     public void loadingThroughSystemProperty_nonExistingClasspathResource() throws IOException {
-        System.setProperty("hazelcast.client.config", "classpath:idontexist");
+        System.setProperty("hazelcast.client.config", "classpath:idontexist.xml");
         new XmlClientConfigBuilder();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigLocator.java
@@ -171,7 +171,7 @@ public abstract class AbstractConfigLocator {
             String configSystemProperty = System.getProperty(propertyKey);
 
             if (configSystemProperty == null) {
-                LOGGER.finest("Could not find 'hazelcast.config' System property");
+                LOGGER.finest("Could not find '" + propertyKey + "' System property");
                 return false;
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractConfigLocator.java
@@ -28,7 +28,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 /**
- * Abstract base class for config locators
+ * Abstract base class for config locators.
  *
  * @see XmlConfigLocator
  * @see YamlConfigLocator
@@ -56,7 +56,7 @@ public abstract class AbstractConfigLocator {
     }
 
     /**
-     * Locates the configuration file in a system property
+     * Locates the configuration file in a system property.
      *
      * @return true if the configuration file is found in the system property
      * @throws HazelcastException if there was a problem locating the
@@ -65,7 +65,7 @@ public abstract class AbstractConfigLocator {
     public abstract boolean locateFromSystemProperty();
 
     /**
-     * Locates the configuration file in the working directory
+     * Locates the configuration file in the working directory.
      *
      * @return true if the configuration file is found in the working directory
      * @throws HazelcastException if there was a problem locating the
@@ -74,7 +74,7 @@ public abstract class AbstractConfigLocator {
     protected abstract boolean locateInWorkDir();
 
     /**
-     * Locates the configuration file on the classpath
+     * Locates the configuration file on the classpath.
      *
      * @return true if the configuration file is found on the classpath
      * @throws HazelcastException if there was a problem locating the
@@ -83,7 +83,7 @@ public abstract class AbstractConfigLocator {
     protected abstract boolean locateOnClasspath();
 
     /**
-     * Locates the default configuration file
+     * Locates the default configuration file.
      *
      * @return true always, indicating the default configuration file is
      * found
@@ -92,7 +92,7 @@ public abstract class AbstractConfigLocator {
      */
     public abstract boolean locateDefault();
 
-    public boolean locateEveryWhere() {
+    public boolean locateEverywhere() {
         return locateFromSystemProperty()
                 || locateInWorkDir()
                 || locateOnClasspath()
@@ -105,18 +105,18 @@ public abstract class AbstractConfigLocator {
 
     protected void loadDefaultConfigurationFromClasspath(String defaultConfigFile) {
         try {
-            LOGGER.info("Loading '" + defaultConfigFile + "' from classpath.");
+            LOGGER.info(String.format("Loading '%s' from the classpath.", defaultConfigFile));
 
             configurationUrl = Config.class.getClassLoader().getResource(defaultConfigFile);
 
             if (configurationUrl == null) {
-                throw new HazelcastException("Could not find '" + defaultConfigFile + "' in the classpath!"
-                        + "This may be due to a wrong-packaged or corrupted jar file.");
+                throw new HazelcastException(String.format("Could not find '%s' in the classpath! This may be due to a "
+                        + "wrong-packaged or corrupted jar file.", defaultConfigFile));
             }
 
             in = Config.class.getClassLoader().getResourceAsStream(defaultConfigFile);
             if (in == null) {
-                throw new HazelcastException("Could not load '" + defaultConfigFile + "' from classpath");
+                throw new HazelcastException(String.format("Could not load '%s' from the classpath", defaultConfigFile));
             }
         } catch (RuntimeException e) {
             throw new HazelcastException(e);
@@ -127,16 +127,16 @@ public abstract class AbstractConfigLocator {
         try {
             URL url = Config.class.getClassLoader().getResource(configFileName);
             if (url == null) {
-                LOGGER.finest("Could not find '" + configFileName + "' in classpath.");
+                LOGGER.finest(String.format("Could not find '%s' in the classpath.", configFileName));
                 return false;
             }
 
-            LOGGER.info("Loading '" + configFileName + "' from classpath.");
+            LOGGER.info(String.format("Loading '%s' from the classpath.", configFileName));
 
             configurationUrl = url;
             in = Config.class.getClassLoader().getResourceAsStream(configFileName);
             if (in == null) {
-                throw new HazelcastException("Could not load '" + configFileName + "' from classpath");
+                throw new HazelcastException(String.format("Could not load '%s' from the classpath", configFileName));
             }
             return true;
         } catch (RuntimeException e) {
@@ -148,17 +148,17 @@ public abstract class AbstractConfigLocator {
         try {
             File file = new File(configFilePath);
             if (!file.exists()) {
-                LOGGER.finest("Could not find '" + configFilePath + "' in working directory.");
+                LOGGER.finest(String.format("Could not find '%s' in the working directory.", configFilePath));
                 return false;
             }
 
-            LOGGER.info("Loading '" + configFilePath + "' from working directory.");
+            LOGGER.info(String.format("Loading '%s' from the working directory.", configFilePath));
 
             configurationFile = file;
             try {
                 in = new FileInputStream(file);
             } catch (FileNotFoundException e) {
-                throw new HazelcastException("Failed to open file: " + file.getAbsolutePath(), e);
+                throw new HazelcastException(String.format("Failed to open file: %s", file.getAbsolutePath()), e);
             }
             return true;
         } catch (RuntimeException e) {
@@ -171,7 +171,7 @@ public abstract class AbstractConfigLocator {
             String configSystemProperty = System.getProperty(propertyKey);
 
             if (configSystemProperty == null) {
-                LOGGER.finest("Could not find '" + propertyKey + "' System property");
+                LOGGER.finest(String.format("Could not find '%s' System property", propertyKey));
                 return false;
             }
 
@@ -180,7 +180,7 @@ public abstract class AbstractConfigLocator {
                 return false;
             }
 
-            LOGGER.info("Loading configuration " + configSystemProperty + " from System property 'hazelcast.config'");
+            LOGGER.info(String.format("Loading configuration '%s' from System property '%s'", configSystemProperty, propertyKey));
 
             if (configSystemProperty.startsWith("classpath:")) {
                 loadSystemPropertyClassPathResource(configSystemProperty);
@@ -208,23 +208,24 @@ public abstract class AbstractConfigLocator {
     private void loadSystemPropertyFileResource(String configSystemProperty) {
         // it's a file
         configurationFile = new File(configSystemProperty);
-        LOGGER.info("Using configuration file at " + configurationFile.getAbsolutePath());
+        LOGGER.info(String.format("Using configuration file at %s", configurationFile.getAbsolutePath()));
 
         if (!configurationFile.exists()) {
-            String msg = "Config file at '" + configurationFile.getAbsolutePath() + "' doesn't exist.";
+            String msg = String.format("Config file at '%s' doesn't exist.", configurationFile.getAbsolutePath());
             throw new HazelcastException(msg);
         }
 
         try {
             in = new FileInputStream(configurationFile);
         } catch (FileNotFoundException e) {
-            throw new HazelcastException("Failed to open file: " + configurationFile.getAbsolutePath(), e);
+            throw new HazelcastException(String.format("Failed to open file: %s", configurationFile.getAbsolutePath()), e);
         }
 
         try {
             configurationUrl = configurationFile.toURI().toURL();
         } catch (MalformedURLException e) {
-            throw new HazelcastException("Failed to create URL from the file: " + configurationFile.getAbsolutePath(), e);
+            throw new HazelcastException(String.format("Failed to create URL from the file: %s", configurationFile
+                    .getAbsolutePath()), e);
         }
     }
 
@@ -232,7 +233,7 @@ public abstract class AbstractConfigLocator {
         // it's an explicit configured classpath resource
         String resource = configSystemProperty.substring("classpath:".length());
 
-        LOGGER.info("Using classpath resource at " + resource);
+        LOGGER.info(String.format("Using classpath resource at %s", resource));
 
         if (resource.isEmpty()) {
             throw new HazelcastException("classpath resource can't be empty");
@@ -240,7 +241,7 @@ public abstract class AbstractConfigLocator {
 
         in = Config.class.getClassLoader().getResourceAsStream(resource);
         if (in == null) {
-            throw new HazelcastException("Could not load classpath resource: " + resource);
+            throw new HazelcastException(String.format("Could not load classpath resource: %s", resource));
         }
         configurationUrl = Config.class.getResource(resource);
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractDomConfigProcessor.java
@@ -198,7 +198,7 @@ public abstract class AbstractDomConfigProcessor implements DomConfigProcessor {
         }
     }
 
-    private ClassFilter parseClassFilterList(Node node) {
+    protected ClassFilter parseClassFilterList(Node node) {
         ClassFilter list = new ClassFilter();
         for (Node child : childElements(node)) {
             final String name = cleanNodeName(child);

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigHelper.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.config.AbstractConfigBuilder.ConfigType;
+import com.hazelcast.config.AbstractXmlConfigBuilder.ConfigType;
 import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.logging.ILogger;
@@ -57,13 +57,13 @@ public abstract class AbstractXmlConfigHelper {
 
     final String xmlns = "http://www.hazelcast.com/schema/" + getNamespaceType();
 
-    private final String hazelcastSchemaLocation = getXmlType().name + "-config-" + getReleaseVersion() + ".xsd";
+    private final String hazelcastSchemaLocation = getConfigType().name + "-config-" + getReleaseVersion() + ".xsd";
 
     public String getNamespaceType() {
-        return getXmlType().name.equals("hazelcast") ? "config" : "client-config";
+        return getConfigType().name.equals("hazelcast") ? "config" : "client-config";
     }
 
-    protected ConfigType getXmlType() {
+    protected ConfigType getConfigType() {
         return ConfigType.SERVER;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ClasspathYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ClasspathYamlConfig.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * A {@link Config} which is initialized by loading a YAML configuration file from the classpath.
+ *
+ * @see FileSystemYamlConfig
+ */
+public class ClasspathYamlConfig extends Config {
+
+    private static final ILogger LOGGER = Logger.getLogger(ClasspathYamlConfig.class);
+
+    /**
+     * Creates a config which is loaded from a classpath resource using the
+     * Thread.currentThread contextClassLoader. The System.properties are used to resolve variables
+     * in the YAML.
+     *
+     * @param resource the resource, an YAML configuration file from the classpath
+     * @throws IllegalArgumentException              if the resource could not be found
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public ClasspathYamlConfig(String resource) {
+        this(resource, System.getProperties());
+    }
+
+    /**
+     * Creates a config which is loaded from a classpath resource using the
+     * Thread.currentThread contextClassLoader.
+     *
+     * @param resource   the resource, an YAML configuration file from the classpath
+     * @param properties the Properties to resolve variables in the YAML
+     * @throws IllegalArgumentException              if the resource could not be found or if properties is {@code null}
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public ClasspathYamlConfig(String resource, Properties properties) {
+        this(Thread.currentThread().getContextClassLoader(), resource, properties);
+    }
+
+    /**
+     * Creates a config which is loaded from a classpath resource. The System.properties are used to
+     * resolve variables in the YAML.
+     *
+     * @param classLoader the ClassLoader used to load the resource
+     * @param resource    the resource, an YAML configuration file from the classpath
+     * @throws IllegalArgumentException              if classLoader or resource is {@code null}, or if the resource is not found
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public ClasspathYamlConfig(ClassLoader classLoader, String resource) {
+        this(classLoader, resource, System.getProperties());
+    }
+
+    /**
+     * Creates a config which is loaded from a classpath resource.
+     *
+     * @param classLoader the ClassLoader used to load the resource
+     * @param resource    the resource, an YAML configuration file from the classpath
+     * @param properties  the properties used to resolve variables in the YAML
+     * @throws IllegalArgumentException              if classLoader or resource is {@code null}, or if the resource is not found
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public ClasspathYamlConfig(ClassLoader classLoader, String resource, Properties properties) {
+        if (classLoader == null) {
+            throw new IllegalArgumentException("classLoader can't be null");
+        }
+        if (resource == null) {
+            throw new IllegalArgumentException("resource can't be null");
+        }
+        if (properties == null) {
+            throw new IllegalArgumentException("properties can't be null");
+        }
+
+        LOGGER.info("Configuring Hazelcast from '" + resource + "'.");
+        InputStream in = classLoader.getResourceAsStream(resource);
+        if (in == null) {
+            throw new IllegalArgumentException("Specified resource '" + resource + "' could not be found!");
+        }
+        new YamlConfigBuilder(in).build(this);
+        //        new YamlConfigBuilder(in).setProperties(properties).build(this);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/ClasspathYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ClasspathYamlConfig.java
@@ -96,6 +96,5 @@ public class ClasspathYamlConfig extends Config {
             throw new IllegalArgumentException("Specified resource '" + resource + "' could not be found!");
         }
         new YamlConfigBuilder(in).build(this);
-        //        new YamlConfigBuilder(in).setProperties(properties).build(this);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/DomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DomConfigProcessor.java
@@ -23,7 +23,7 @@ import org.w3c.dom.Node;
  * and filling config object graph.
  *
  * @see MemberDomConfigProcessor
- * @see AbstractConfigBuilder
+ * @see AbstractXmlConfigBuilder
  */
 public interface DomConfigProcessor {
 

--- a/hazelcast/src/main/java/com/hazelcast/config/FileSystemYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FileSystemYamlConfig.java
@@ -27,61 +27,61 @@ import java.util.Properties;
 
 /**
  * A {@link Config} which includes functionality for loading itself from a
- * XML configuration file.
+ * YAML configuration file.
  */
-public class FileSystemXmlConfig extends Config {
+public class FileSystemYamlConfig extends Config {
 
-    private static final ILogger LOGGER = Logger.getLogger(FileSystemXmlConfig.class);
+    private static final ILogger LOGGER = Logger.getLogger(FileSystemYamlConfig.class);
 
     /**
-     * Creates a Config based on a Hazelcast xml file and uses the System.properties to resolve
-     * variables in the XML.
+     * Creates a Config based on a Hazelcast yaml file and uses the System.properties to resolve
+     * variables in the YAML.
      *
-     * @param configFilename the path of the Hazelcast xml configuration file
+     * @param configFilename the path of the Hazelcast yaml configuration file
      * @throws NullPointerException                  if configFilename is {@code null}
      * @throws FileNotFoundException                 fi the file is not found
-     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
      */
-    public FileSystemXmlConfig(String configFilename) throws FileNotFoundException {
+    public FileSystemYamlConfig(String configFilename) throws FileNotFoundException {
         this(configFilename, System.getProperties());
     }
 
     /**
-     * Creates a Config based on a Hazelcast XML file.
+     * Creates a Config based on a Hazelcast YAML file.
      *
-     * @param configFilename the path of the Hazelcast XML configuration file
-     * @param properties     the Properties to resolve variables in the XML
+     * @param configFilename the path of the Hazelcast YAML configuration file
+     * @param properties     the Properties to resolve variables in the YAML
      * @throws FileNotFoundException                 fi the file is not found
      * @throws NullPointerException                  if configFilename is {@code null}
      * @throws IllegalArgumentException              if properties is {@code null}
-     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
      */
-    public FileSystemXmlConfig(String configFilename, Properties properties) throws FileNotFoundException {
+    public FileSystemYamlConfig(String configFilename, Properties properties) throws FileNotFoundException {
         this(new File(configFilename), properties);
     }
 
     /**
-     * Creates a Config based on a Hazelcast xml file and uses the System.properties to resolve
-     * variables in the XML.
+     * Creates a Config based on a Hazelcast yaml file and uses the System.properties to resolve
+     * variables in the YAML.
      *
-     * @param configFile the path of the Hazelcast XML configuration file
+     * @param configFile the path of the Hazelcast YAML configuration file
      * @throws FileNotFoundException                 if the file doesn't exist
-     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
      */
-    public FileSystemXmlConfig(File configFile) throws FileNotFoundException {
+    public FileSystemYamlConfig(File configFile) throws FileNotFoundException {
         this(configFile, System.getProperties());
     }
 
     /**
-     * Creates a Config based on a Hazelcast XML file.
+     * Creates a Config based on a Hazelcast YAML file.
      *
-     * @param configFile the path of the Hazelcast xml configuration file
-     * @param properties the Properties to resolve variables in the XML
+     * @param configFile the path of the Hazelcast yaml configuration file
+     * @param properties the Properties to resolve variables in the YAML
      * @throws IllegalArgumentException              if configFile or properties is {@code null}
      * @throws FileNotFoundException                 if the file doesn't exist
-     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
      */
-    public FileSystemXmlConfig(File configFile, Properties properties) throws FileNotFoundException {
+    public FileSystemYamlConfig(File configFile, Properties properties) throws FileNotFoundException {
         if (configFile == null) {
             throw new IllegalArgumentException("configFile can't be null");
         }
@@ -91,6 +91,7 @@ public class FileSystemXmlConfig extends Config {
 
         LOGGER.info("Configuring Hazelcast from '" + configFile.getAbsolutePath() + "'.");
         InputStream in = new FileInputStream(configFile);
-        new XmlConfigBuilder(in).setProperties(properties).build(this);
+        new YamlConfigBuilder(in).build(this);
+        //                new YamlConfigBuilder(in).setProperties(properties).build(this);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/FileSystemYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FileSystemYamlConfig.java
@@ -92,6 +92,5 @@ public class FileSystemYamlConfig extends Config {
         LOGGER.info("Configuring Hazelcast from '" + configFile.getAbsolutePath() + "'.");
         InputStream in = new FileInputStream(configFile);
         new YamlConfigBuilder(in).build(this);
-        //                new YamlConfigBuilder(in).setProperties(properties).build(this);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryYamlConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Properties;
+
+import static com.hazelcast.util.StringUtil.stringToBytes;
+
+/**
+ * Creates a {@link Config} loaded from an in-memory Hazelcast YAML String.
+ */
+public class InMemoryYamlConfig extends Config {
+    private static final ILogger LOGGER = Logger.getLogger(InMemoryYamlConfig.class);
+
+    /**
+     * Creates a Config from the provided YAML string and uses the System.properties to resolve variables
+     * in the YAML.
+     *
+     * @param yaml the YAML content as a Hazelcast YAML String
+     * @throws IllegalArgumentException              if the YAML is null or empty
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public InMemoryYamlConfig(String yaml) {
+        this(yaml, System.getProperties());
+    }
+
+    /**
+     * Creates a Config from the provided YAML string and properties to resolve the variables in the YAML.
+     *
+     * @param yaml the YAML content as a Hazelcast YAML String
+     * @throws IllegalArgumentException              if the YAML is null or empty or if properties is null
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public InMemoryYamlConfig(String yaml, Properties properties) {
+        LOGGER.info("Configuring Hazelcast from 'in-memory YAML'.");
+        if (yaml == null || "".equals(yaml.trim())) {
+            throw new IllegalArgumentException("YAML configuration is null or empty! Please use a well-structured YAML.");
+        }
+        if (properties == null) {
+            throw new IllegalArgumentException("properties can't be null");
+        }
+
+        InputStream in = new ByteArrayInputStream(stringToBytes(yaml));
+        new YamlConfigBuilder(in).build(this);
+        //        new YamlConfigBuilder(in).setProperties(properties).build(this);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryYamlConfig.java
@@ -61,6 +61,5 @@ public class InMemoryYamlConfig extends Config {
 
         InputStream in = new ByteArrayInputStream(stringToBytes(yaml));
         new YamlConfigBuilder(in).build(this);
-        //        new YamlConfigBuilder(in).setProperties(properties).build(this);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -89,7 +89,29 @@ public class XmlConfigBuilder extends AbstractXmlConfigBuilder implements Config
      * Constructs a XmlConfigBuilder that tries to find a usable XML configuration file.
      */
     public XmlConfigBuilder() {
-        XmlConfigLocator locator = new XmlConfigLocator();
+        this((XmlConfigLocator) null);
+    }
+
+    /**
+     * Constructs a {@link XmlConfigBuilder} that loads the configuration
+     * with the provided {@link XmlConfigLocator}.
+     * <p/>
+     * If the provided {@link XmlConfigLocator} is {@code null}, a new
+     * instance is created and the config is located in every possible
+     * places. For these places, please see {@link XmlConfigLocator}.
+     * <p/>
+     * If the provided {@link XmlConfigLocator} is not {@code null}, it
+     * is expected that it already located the configuration XML to load
+     * from. No further attempt to locate the configuration XML is made
+     * if the configuration XML is not located already.
+     *
+     * @param locator the configured locator to use
+     */
+    public XmlConfigBuilder(XmlConfigLocator locator) {
+        if (locator == null) {
+            locator = new XmlConfigLocator();
+            locator.locateEveryWhere();
+        }
         this.in = locator.getIn();
         this.configurationFile = locator.getConfigurationFile();
         this.configurationUrl = locator.getConfigurationUrl();

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -40,13 +40,12 @@ import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 /**
  * A XML {@link ConfigBuilder} implementation.
  */
-public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBuilder {
+public class XmlConfigBuilder extends AbstractXmlConfigBuilder implements ConfigBuilder {
 
     private static final ILogger LOGGER = Logger.getLogger(XmlConfigBuilder.class);
 
     private final InputStream in;
 
-    private Properties properties = System.getProperties();
     private File configurationFile;
     private URL configurationUrl;
 
@@ -97,17 +96,6 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
     }
 
     /**
-     * Gets the current used properties. Can be null if no properties are set.
-     *
-     * @return the current used properties
-     * @see #setProperties(java.util.Properties)
-     */
-    @Override
-    public Properties getProperties() {
-        return properties;
-    }
-
-    /**
      * Sets the used properties. Can be null if no properties should be used.
      * <p>
      * Properties are used to resolve ${variable} occurrences in the XML file.
@@ -115,13 +103,13 @@ public class XmlConfigBuilder extends AbstractConfigBuilder implements ConfigBui
      * @param properties the new properties
      * @return the XmlConfigBuilder
      */
-    public XmlConfigBuilder setProperties(Properties properties) {
-        this.properties = properties;
+    protected XmlConfigBuilder setProperties(Properties properties) {
+        super.setPropertiesInternal(properties);
         return this;
     }
 
     @Override
-    protected ConfigType getXmlType() {
+    protected ConfigType getConfigType() {
         return ConfigType.SERVER;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -110,7 +110,7 @@ public class XmlConfigBuilder extends AbstractXmlConfigBuilder implements Config
     public XmlConfigBuilder(XmlConfigLocator locator) {
         if (locator == null) {
             locator = new XmlConfigLocator();
-            locator.locateEveryWhere();
+            locator.locateEverywhere();
         }
         this.in = locator.getIn();
         this.configurationFile = locator.getConfigurationFile();

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigLocator.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.core.HazelcastException;
-
 /**
  * Support class for the {@link XmlConfigBuilder} that locates the XML configuration:
  * <ol>
@@ -29,34 +27,24 @@ import com.hazelcast.core.HazelcastException;
  */
 public class XmlConfigLocator extends AbstractConfigLocator {
 
-    /**
-     * Constructs a XmlConfigLocator that tries to find a usable XML configuration file.
-     *
-     * @throws HazelcastException if there was a problem locating the config-file
-     */
-    public XmlConfigLocator() {
-        this(true);
+    @Override
+    public boolean locateFromSystemProperty() {
+        return loadFromSystemProperty("hazelcast.config", "xml");
     }
 
-    public XmlConfigLocator(boolean fallbackToDefault) {
-        try {
-            if (loadFromSystemProperty("hazelcast.config")) {
-                return;
-            }
+    @Override
+    protected boolean locateInWorkDir() {
+        return loadFromWorkingDirectory("hazelcast.xml");
+    }
 
-            if (loadFromWorkingDirectory("hazelcast.xml")) {
-                return;
-            }
+    @Override
+    protected boolean locateOnClasspath() {
+        return loadConfigurationFromClasspath("hazelcast.xml");
+    }
 
-            if (loadConfigurationFromClasspath("hazelcast.xml")) {
-                return;
-            }
-
-            if (fallbackToDefault) {
-                loadDefaultConfigurationFromClasspath("hazelcast-default.xml");
-            }
-        } catch (RuntimeException e) {
-            throw new HazelcastException(e);
-        }
+    @Override
+    public boolean locateDefault() {
+        loadDefaultConfigurationFromClasspath("hazelcast-default.xml");
+        return true;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.yaml.W3cDomUtil;
+import com.hazelcast.internal.yaml.YamlLoader;
+import com.hazelcast.internal.yaml.YamlMapping;
+import com.hazelcast.internal.yaml.YamlNode;
+import com.hazelcast.util.ExceptionUtil;
+import org.w3c.dom.Node;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
+/**
+ * A YAML {@link ConfigBuilder} implementation.
+ *
+ * This config builder is compatible with the YAML 1.2 specification and
+ * supports the JSON Scheme.
+ */
+public class YamlConfigBuilder implements ConfigBuilder {
+    private final InputStream in;
+
+    private File configurationFile;
+    private URL configurationUrl;
+
+    /**
+     * Constructs a YamlConfigBuilder that reads from the provided YAML file.
+     *
+     * @param yamlFileName the name of the YAML file that the YamlConfigBuilder reads from
+     * @throws FileNotFoundException if the file can't be found
+     */
+    public YamlConfigBuilder(String yamlFileName) throws FileNotFoundException {
+        this(new FileInputStream(yamlFileName));
+        this.configurationFile = new File(yamlFileName);
+    }
+
+    /**
+     * Constructs a YAMLConfigBuilder that reads from the given InputStream.
+     *
+     * @param inputStream the InputStream containing the YAML configuration
+     * @throws IllegalArgumentException if inputStream is {@code null}
+     */
+    public YamlConfigBuilder(InputStream inputStream) {
+        if (inputStream == null) {
+            throw new IllegalArgumentException("inputStream can't be null");
+        }
+        this.in = inputStream;
+    }
+
+    /**
+     * Constructs a YamlConfigBuilder that reads from the given URL.
+     *
+     * @param url the given url that the YamlConfigBuilder reads from
+     * @throws IOException if URL is invalid
+     */
+    public YamlConfigBuilder(URL url) throws IOException {
+        checkNotNull(url, "URL is null!");
+        this.in = url.openStream();
+        this.configurationUrl = url;
+    }
+
+    /**
+     * Constructs a YamlConfigBuilder that tries to find a usable YAML configuration file.
+     */
+    public YamlConfigBuilder() {
+        YamlConfigLocator locator = new YamlConfigLocator();
+        this.in = locator.getIn();
+        this.configurationFile = locator.getConfigurationFile();
+        this.configurationUrl = locator.getConfigurationUrl();
+    }
+
+    @Override
+    public Config build() {
+        return build(new Config());
+    }
+
+    Config build(Config config) {
+        config.setConfigurationFile(configurationFile);
+        config.setConfigurationUrl(configurationUrl);
+        try {
+            parseAndBuildConfig(config);
+        } catch (Exception e) {
+            throw ExceptionUtil.rethrow(e);
+        }
+        return config;
+    }
+
+    private void parseAndBuildConfig(Config config) throws Exception {
+        Node w3cRootNode;
+        YamlMapping yamlRootNode;
+        try {
+            yamlRootNode = ((YamlMapping) YamlLoader.load(in));
+        } catch (Exception ex) {
+            throw new InvalidConfigurationException("Invalid YAML configuration", ex);
+        }
+
+        YamlNode imdgRoot = yamlRootNode.childAsMapping(ConfigSections.HAZELCAST.name().toLowerCase());
+        if (imdgRoot == null) {
+            throw new InvalidConfigurationException("No mapping with hazelcast key is found in the provided configuration");
+        }
+
+        w3cRootNode = W3cDomUtil.asW3cNode(imdgRoot);
+
+        new YamlMemberDomConfigProcessor(true, config).buildConfig(w3cRootNode);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -84,7 +84,30 @@ public class YamlConfigBuilder implements ConfigBuilder {
      * Constructs a YamlConfigBuilder that tries to find a usable YAML configuration file.
      */
     public YamlConfigBuilder() {
-        YamlConfigLocator locator = new YamlConfigLocator();
+        this((YamlConfigLocator) null);
+    }
+
+    /**
+     * Constructs a {@link YamlConfigBuilder} that loads the configuration
+     * with the provided {@link YamlConfigLocator}.
+     * <p/>
+     * If the provided {@link YamlConfigLocator} is {@code null}, a new
+     * instance is created and the config is located in every possible
+     * places. For these places, please see {@link YamlConfigLocator}.
+     * <p/>
+     * If the provided {@link YamlConfigLocator} is not {@code null}, it
+     * is expected that it already located the configuration YAML to load
+     * from. No further attempt to locate the configuration YAML is made
+     * if the configuration YAML is not located already.
+     *
+     * @param locator the configured locator to use
+     */
+    public YamlConfigBuilder(YamlConfigLocator locator) {
+        if (locator == null) {
+            locator = new YamlConfigLocator();
+            locator.locateFromSystemProperty();
+        }
+
         this.in = locator.getIn();
         this.configurationFile = locator.getConfigurationFile();
         this.configurationUrl = locator.getConfigurationUrl();

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -21,7 +21,6 @@ import com.hazelcast.internal.yaml.YamlLoader;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
 import com.hazelcast.util.ExceptionUtil;
-import org.w3c.dom.Node;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -130,7 +129,6 @@ public class YamlConfigBuilder implements ConfigBuilder {
     }
 
     private void parseAndBuildConfig(Config config) throws Exception {
-        Node w3cRootNode;
         YamlMapping yamlRootNode;
         try {
             yamlRootNode = ((YamlMapping) YamlLoader.load(in));
@@ -143,9 +141,7 @@ public class YamlConfigBuilder implements ConfigBuilder {
             throw new InvalidConfigurationException("No mapping with hazelcast key is found in the provided configuration");
         }
 
-        w3cRootNode = W3cDomUtil.asW3cNode(imdgRoot);
-
-        new YamlMemberDomConfigProcessor(true, config).buildConfig(w3cRootNode);
+        new YamlMemberDomConfigProcessor(true, config).buildConfig(W3cDomUtil.asW3cNode(imdgRoot));
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigLocator.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.core.HazelcastException;
-
 /**
  * Support class for the {@link com.hazelcast.config.YamlConfigBuilder} that locates the YAML configuration:
  * <ol>
@@ -29,34 +27,24 @@ import com.hazelcast.core.HazelcastException;
  */
 public class YamlConfigLocator extends AbstractConfigLocator {
 
-    /**
-     * Constructs a YamlConfigLocator that tries to find a usable YAML configuration file.
-     *
-     * @throws HazelcastException if there was a problem locating the config-file
-     */
-    public YamlConfigLocator() {
-        this(true);
+    @Override
+    public boolean locateFromSystemProperty() {
+        return loadFromSystemProperty("hazelcast.config", "yaml", "yml");
     }
 
-    public YamlConfigLocator(boolean fallbackToDefault) {
-        try {
-            if (loadFromSystemProperty("hazelcast.config", "yaml", "yml")) {
-                return;
-            }
+    @Override
+    protected boolean locateInWorkDir() {
+        return loadFromWorkingDirectory("hazelcast.yaml");
+    }
 
-            if (loadFromWorkingDirectory("hazelcast.yaml")) {
-                return;
-            }
+    @Override
+    protected boolean locateOnClasspath() {
+        return loadConfigurationFromClasspath("hazelcast.yaml");
+    }
 
-            if (loadConfigurationFromClasspath("hazelcast.yaml")) {
-                return;
-            }
-
-            if (fallbackToDefault) {
-                loadDefaultConfigurationFromClasspath("hazelcast-default.yaml");
-            }
-        } catch (RuntimeException e) {
-            throw new HazelcastException(e);
-        }
+    @Override
+    public boolean locateDefault() {
+        loadDefaultConfigurationFromClasspath("hazelcast-default.yaml");
+        return true;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigLocator.java
@@ -19,7 +19,7 @@ package com.hazelcast.config;
 import com.hazelcast.core.HazelcastException;
 
 /**
- * Support class for the {@link XmlConfigBuilder} that locates the XML configuration:
+ * Support class for the {@link com.hazelcast.config.YamlConfigBuilder} that locates the YAML configuration:
  * <ol>
  * <li>system property</li>
  * <li>working directory</li>
@@ -27,33 +27,33 @@ import com.hazelcast.core.HazelcastException;
  * <li>default</li>
  * </ol>
  */
-public class XmlConfigLocator extends AbstractConfigLocator {
+public class YamlConfigLocator extends AbstractConfigLocator {
 
     /**
-     * Constructs a XmlConfigLocator that tries to find a usable XML configuration file.
+     * Constructs a YamlConfigLocator that tries to find a usable YAML configuration file.
      *
      * @throws HazelcastException if there was a problem locating the config-file
      */
-    public XmlConfigLocator() {
+    public YamlConfigLocator() {
         this(true);
     }
 
-    public XmlConfigLocator(boolean fallbackToDefault) {
+    public YamlConfigLocator(boolean fallbackToDefault) {
         try {
-            if (loadFromSystemProperty("hazelcast.config")) {
+            if (loadFromSystemProperty("hazelcast.config", "yaml", "yml")) {
                 return;
             }
 
-            if (loadFromWorkingDirectory("hazelcast.xml")) {
+            if (loadFromWorkingDirectory("hazelcast.yaml")) {
                 return;
             }
 
-            if (loadConfigurationFromClasspath("hazelcast.xml")) {
+            if (loadConfigurationFromClasspath("hazelcast.yaml")) {
                 return;
             }
 
             if (fallbackToDefault) {
-                loadDefaultConfigurationFromClasspath("hazelcast-default.xml");
+                loadDefaultConfigurationFromClasspath("hazelcast-default.yaml");
             }
         } catch (RuntimeException e) {
             throw new HazelcastException(e);

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
@@ -1,0 +1,866 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.yaml.ElementAdapter;
+import com.hazelcast.internal.yaml.YamlMapping;
+import com.hazelcast.internal.yaml.YamlNode;
+import com.hazelcast.internal.yaml.YamlScalar;
+import com.hazelcast.internal.yaml.YamlSequence;
+import com.hazelcast.util.function.Function;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.nio.ByteOrder;
+import java.util.Map;
+import java.util.Properties;
+
+import static com.hazelcast.config.DomConfigHelper.childElements;
+import static com.hazelcast.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.config.DomConfigHelper.getBooleanValue;
+import static com.hazelcast.config.DomConfigHelper.getIntegerValue;
+import static com.hazelcast.internal.yaml.YamlUtil.asMapping;
+import static com.hazelcast.internal.yaml.YamlUtil.asScalar;
+import static com.hazelcast.internal.yaml.YamlUtil.asSequence;
+import static com.hazelcast.util.StringUtil.lowerCaseInternal;
+import static com.hazelcast.util.StringUtil.upperCaseInternal;
+import static java.lang.Integer.parseInt;
+
+class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
+    YamlMemberDomConfigProcessor(boolean domLevel3, Config config) {
+        super(domLevel3, config);
+    }
+
+    @Override
+    protected void handleSecurityInterceptorsChild(SecurityConfig cfg, Node child) {
+        String className = child.getTextContent();
+        cfg.addSecurityInterceptorConfig(new SecurityInterceptorConfig(className));
+    }
+
+    protected void handleSecurityPermissions(Node node) {
+        for (Node child : childElements(node)) {
+            String nodeName = cleanNodeName(child);
+            PermissionConfig.PermissionType type;
+            if ("map".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.MAP;
+            } else if ("queue".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.QUEUE;
+            } else if ("multimap".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.MULTIMAP;
+            } else if ("topic".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.TOPIC;
+            } else if ("list".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.LIST;
+            } else if ("set".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.SET;
+            } else if ("lock".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.LOCK;
+            } else if ("atomic-long".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.ATOMIC_LONG;
+            } else if ("countdown-latch".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.COUNTDOWN_LATCH;
+            } else if ("semaphore".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.SEMAPHORE;
+            } else if ("id-generator".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.ID_GENERATOR;
+            } else if ("flake-id-generator".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.FLAKE_ID_GENERATOR;
+            } else if ("executor-service".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.EXECUTOR_SERVICE;
+            } else if ("transaction".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.TRANSACTION;
+            } else if ("all".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.ALL;
+            } else if ("durable-executor-service".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.DURABLE_EXECUTOR_SERVICE;
+            } else if ("cardinality-estimator".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.CARDINALITY_ESTIMATOR;
+            } else if ("scheduled-executor".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.SCHEDULED_EXECUTOR;
+            } else if ("pn-counter".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.PN_COUNTER;
+            } else if ("cache".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.CACHE;
+            } else if ("user-code-deployment".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.USER_CODE_DEPLOYMENT;
+            } else if ("config".equals(nodeName)) {
+                type = PermissionConfig.PermissionType.CONFIG;
+            } else {
+                continue;
+            }
+
+            if (PermissionConfig.PermissionType.CONFIG == type
+                    || PermissionConfig.PermissionType.ALL == type
+                    || PermissionConfig.PermissionType.TRANSACTION == type) {
+                handleSecurityPermission(child, type);
+            } else {
+                handleSecurityPermissionGroup(child, type);
+            }
+        }
+    }
+
+    private void handleSecurityPermissionGroup(Node node, PermissionConfig.PermissionType type) {
+        for (Node permissionNode : childElements(node)) {
+            handleSecurityPermission(permissionNode, type);
+        }
+    }
+
+    @Override
+    void handleSecurityPermissionActions(Node node, PermissionConfig permConfig) {
+        for (Node child : childElements(node)) {
+            permConfig.addAction(getTextContent(child).trim());
+        }
+    }
+
+    @Override
+    void handleSecurityPermissionEndpoints(Node node, PermissionConfig permConfig) {
+        for (Node child : childElements(node)) {
+            permConfig.addEndpoint(getTextContent(child).trim());
+        }
+    }
+
+    protected void handleLoginModules(Node node, boolean member, Config config) {
+        SecurityConfig cfg = config.getSecurityConfig();
+        for (Node child : childElements(node)) {
+            LoginModuleConfig lm = handleLoginModule(child);
+            if (member) {
+                cfg.addMemberLoginModuleConfig(lm);
+            } else {
+                cfg.addClientLoginModuleConfig(lm);
+            }
+        }
+    }
+
+    @Override
+    protected void handleTrustedInterfaces(MulticastConfig multicastConfig, Node n) {
+        YamlSequence yamlNode = asSequence(((ElementAdapter) n).getYamlNode());
+        for (YamlNode interfaceNode : yamlNode.children()) {
+            String trustedInterface = asScalar(interfaceNode).nodeValue();
+            multicastConfig.addTrustedInterface(trustedInterface);
+        }
+        super.handleTrustedInterfaces(multicastConfig, n);
+    }
+
+    @Override
+    protected void handleWanReplication(Node node) {
+        for (Node wanReplicationNode : childElements(node)) {
+            WanReplicationConfig wanReplicationConfig = new WanReplicationConfig();
+            wanReplicationConfig.setName(wanReplicationNode.getNodeName());
+            handleWanReplicationNode(wanReplicationNode, wanReplicationConfig);
+        }
+    }
+
+    @Override
+    protected void handleWanReplicationChild(WanReplicationConfig wanReplicationConfig, Node nodeTarget, String nodeName) {
+        if ("wan-publisher".equals(nodeName)) {
+            for (Node publisherNode : childElements(nodeTarget)) {
+                WanPublisherConfig publisherConfig = new WanPublisherConfig();
+                String groupNameOrPublisherId = publisherNode.getNodeName();
+                Node groupNameAttr = publisherNode.getAttributes().getNamedItem("group-name");
+
+                // the publisher's key may mean either the publisher-id or the
+                // group-name depending on whether the group-name is explicitly defined
+                String groupName = groupNameAttr != null ? groupNameAttr.getTextContent() : groupNameOrPublisherId;
+                String publisherId = groupNameAttr != null ? groupNameOrPublisherId : null;
+                publisherConfig.setPublisherId(publisherId);
+                publisherConfig.setGroupName(groupName);
+
+                handleWanPublisherNode(wanReplicationConfig, publisherNode, publisherConfig);
+            }
+        } else if ("wan-consumer".equals(nodeName)) {
+            handleWanConsumerNode(wanReplicationConfig, nodeTarget);
+        }
+    }
+
+    @Override
+    protected void handlePort(Node node, Config config) {
+        NetworkConfig networkConfig = config.getNetworkConfig();
+        NamedNodeMap attributes = node.getAttributes();
+        for (int a = 0; a < attributes.getLength(); a++) {
+            Node att = attributes.item(a);
+            String value = getTextContent(att).trim();
+
+            if ("port".equals(att.getNodeName())) {
+                int portCount = parseInt(value);
+                networkConfig.setPort(portCount);
+            } else if ("auto-increment".equals(att.getNodeName())) {
+                networkConfig.setPortAutoIncrement(getBooleanValue(value));
+            } else if ("port-count".equals(att.getNodeName())) {
+                int portCount = parseInt(value);
+                networkConfig.setPortCount(portCount);
+            }
+        }
+    }
+
+    @Override
+    protected void handleSemaphore(Node node) {
+        for (Node semaphoreNode : childElements(node)) {
+            SemaphoreConfig sConfig = new SemaphoreConfig();
+            sConfig.setName(semaphoreNode.getNodeName());
+            handleSemaphoreNode(semaphoreNode, sConfig);
+        }
+    }
+
+    @Override
+    protected void handleQueue(Node node) {
+        for (Node queueNode : childElements(node)) {
+            QueueConfig queueConfig = new QueueConfig();
+            queueConfig.setName(queueNode.getNodeName());
+            handleQueueNode(queueNode, queueConfig);
+        }
+    }
+
+    @Override
+    protected void handleList(Node node) {
+        for (Node listNode : childElements(node)) {
+            ListConfig listConfig = new ListConfig();
+            listConfig.setName(listNode.getNodeName());
+            handleListNode(listNode, listConfig);
+        }
+    }
+
+    @Override
+    protected void handleSet(Node node) {
+        for (Node setNode : childElements(node)) {
+            SetConfig setConfig = new SetConfig();
+            setConfig.setName(setNode.getNodeName());
+            handleSetNode(setNode, setConfig);
+        }
+    }
+
+    @Override
+    protected void handleLock(Node node) {
+        for (Node lockNode : childElements(node)) {
+            LockConfig lockConfig = new LockConfig();
+            lockConfig.setName(lockNode.getNodeName());
+            handleLockNode(lockNode, lockConfig);
+        }
+    }
+
+    @Override
+    protected void handleReliableTopic(Node node) {
+        for (Node topicNode : childElements(node)) {
+            ReliableTopicConfig topicConfig = new ReliableTopicConfig();
+            topicConfig.setName(topicNode.getNodeName());
+            handleReliableTopicNode(topicNode, topicConfig);
+        }
+    }
+
+    @Override
+    protected void handleTopic(Node node) {
+        for (Node topicNode : childElements(node)) {
+            TopicConfig topicConfig = new TopicConfig();
+            topicConfig.setName(topicNode.getNodeName());
+            handleTopicNode(topicNode, topicConfig);
+        }
+    }
+
+    @Override
+    protected void handleRingbuffer(Node node) {
+        for (Node rbNode : childElements(node)) {
+            RingbufferConfig ringBufferConfig = new RingbufferConfig();
+            ringBufferConfig.setName(rbNode.getNodeName());
+            handleRingBufferNode(rbNode, ringBufferConfig);
+        }
+    }
+
+    @Override
+    protected void handleAtomicLong(Node node) {
+        for (Node atomicLongNode : childElements(node)) {
+            AtomicLongConfig atomicLongConfig = new AtomicLongConfig();
+            atomicLongConfig.setName(atomicLongNode.getNodeName());
+            handleAtomicLongNode(atomicLongNode, atomicLongConfig);
+        }
+    }
+
+    @Override
+    protected void handleAtomicReference(Node node) {
+        for (Node atomicReferenceNode : childElements(node)) {
+            AtomicReferenceConfig atomicReferenceConfig = new AtomicReferenceConfig();
+            atomicReferenceConfig.setName(atomicReferenceNode.getNodeName());
+            handleAtomicReferenceNode(atomicReferenceNode, atomicReferenceConfig);
+        }
+    }
+
+    @Override
+    protected void handleCountDownLatchConfig(Node node) {
+        for (Node countDownLatchNode : childElements(node)) {
+            CountDownLatchConfig countDownLatchConfig = new CountDownLatchConfig();
+            countDownLatchConfig.setName(countDownLatchNode.getNodeName());
+            handleCountDownLatchNode(countDownLatchNode, countDownLatchConfig);
+        }
+    }
+
+    @Override
+    protected void handleMap(Node parentNode) {
+        for (Node mapNode : childElements(parentNode)) {
+            MapConfig mapConfig = new MapConfig();
+            mapConfig.setName(mapNode.getNodeName());
+            handleMapNode(mapNode, mapConfig);
+        }
+    }
+
+    @Override
+    protected void handleCache(Node parentNode) {
+        for (Node cacheNode : childElements(parentNode)) {
+            CacheSimpleConfig cacheConfig = new CacheSimpleConfig();
+            cacheConfig.setName(cacheNode.getNodeName());
+            handleCacheNode(cacheNode, cacheConfig);
+        }
+    }
+
+    @Override
+    protected void handleQuorum(Node node) {
+        for (Node quorumNode : childElements(node)) {
+            QuorumConfig quorumConfig = new QuorumConfig();
+            String quorumName = quorumNode.getNodeName();
+            quorumConfig.setName(quorumName);
+            handleQuorumNode(quorumNode, quorumConfig, quorumName);
+        }
+    }
+
+    @Override
+    protected void handleEventJournal(Node node) throws Exception {
+        for (Node typeNode : childElements(node)) {
+            String nodeName = typeNode.getNodeName().toLowerCase();
+            if ("map".equals(nodeName)) {
+                handleMapEventJournal(typeNode);
+            } else if ("cache".equals(nodeName)) {
+                handleCacheEventJournal(typeNode);
+            } else {
+                throw new ConfigurationException("Mapping name should either be 'map' or 'cache', but " + nodeName + " found");
+            }
+        }
+    }
+
+    private void handleMapEventJournal(Node mapNode) throws Exception {
+        for (Node journalNode : childElements(mapNode)) {
+            EventJournalConfig journalConfig = new EventJournalConfig();
+            journalConfig.setMapName(journalNode.getNodeName());
+            handleViaReflection(journalNode, config, journalConfig);
+        }
+    }
+
+    private void handleCacheEventJournal(Node cacheNode) throws Exception {
+        for (Node journalNode : childElements(cacheNode)) {
+            EventJournalConfig journalConfig = new EventJournalConfig();
+            journalConfig.setCacheName(journalNode.getNodeName());
+            handleViaReflection(journalNode, config, journalConfig);
+        }
+    }
+
+    @Override
+    protected void handleMerkleTree(Node node) throws Exception {
+        for (Node typeNode : childElements(node)) {
+            String nodeName = typeNode.getNodeName().toLowerCase();
+            if ("map".equals(nodeName)) {
+                handleMapMerkleTree(typeNode);
+            } else {
+                throw new ConfigurationException("Mapping name should be 'map', but " + nodeName + " found");
+            }
+        }
+    }
+
+    private void handleMapMerkleTree(Node mapNode) throws Exception {
+        for (Node journalNode : childElements(mapNode)) {
+            MerkleTreeConfig merkleTreeConfig = new MerkleTreeConfig();
+            merkleTreeConfig.setMapName(journalNode.getNodeName());
+            handleViaReflection(journalNode, config, merkleTreeConfig);
+        }
+    }
+
+    @Override
+    protected void handleFlakeIdGenerator(Node node) {
+        for (Node genNode : childElements(node)) {
+            FlakeIdGeneratorConfig genConfig = new FlakeIdGeneratorConfig();
+            genConfig.setName(genNode.getNodeName());
+            handleFlakeIdGeneratorNode(genNode, genConfig);
+        }
+    }
+
+    @Override
+    protected void handleExecutor(Node node) throws Exception {
+        for (Node executorNode : childElements(node)) {
+            ExecutorConfig executorConfig = new ExecutorConfig();
+            executorConfig.setName(executorNode.getNodeName());
+            handleViaReflection(executorNode, config, executorConfig);
+        }
+    }
+
+    @Override
+    protected void handleDurableExecutor(Node node) throws Exception {
+        for (Node executorNode : childElements(node)) {
+            DurableExecutorConfig executorConfig = new DurableExecutorConfig();
+            executorConfig.setName(executorNode.getNodeName());
+            handleViaReflection(executorNode, config, executorConfig);
+        }
+    }
+
+    @Override
+    protected void handleScheduledExecutor(Node node) {
+        for (Node executorNode : childElements(node)) {
+            ScheduledExecutorConfig executorConfig = new ScheduledExecutorConfig();
+            executorConfig.setName(executorNode.getNodeName());
+            handleScheduledExecutorNode(executorNode, executorConfig);
+        }
+    }
+
+    @Override
+    protected void handleCardinalityEstimator(Node node) {
+        for (Node estimatorNode : childElements(node)) {
+            CardinalityEstimatorConfig estimatorConfig = new CardinalityEstimatorConfig();
+            estimatorConfig.setName(estimatorNode.getNodeName());
+            handleCardinalityEstimatorNode(estimatorNode, estimatorConfig);
+        }
+    }
+
+    @Override
+    protected void handlePNCounter(Node node) throws Exception {
+        for (Node counterNode : childElements(node)) {
+            PNCounterConfig counterConfig = new PNCounterConfig();
+            counterConfig.setName(counterNode.getNodeName());
+            handleViaReflection(counterNode, config, counterConfig);
+        }
+    }
+
+    @Override
+    protected void handleMultiMap(Node node) {
+        for (Node multiMapNode : childElements(node)) {
+            MultiMapConfig multiMapConfig = new MultiMapConfig();
+            multiMapConfig.setName(multiMapNode.getNodeName());
+            handleMultiMapNode(multiMapNode, multiMapConfig);
+        }
+    }
+
+    @Override
+    protected void handleReplicatedMap(Node node) {
+        for (Node replicatedMapNode : childElements(node)) {
+            ReplicatedMapConfig replicatedMapConfig = new ReplicatedMapConfig();
+            replicatedMapConfig.setName(replicatedMapNode.getNodeName());
+            handleReplicatedMapNode(replicatedMapNode, replicatedMapConfig);
+        }
+    }
+
+    @Override
+    protected void mapWanReplicationRefHandle(Node n, MapConfig mapConfig) {
+        for (Node mapNode : childElements(n)) {
+            WanReplicationRef wanReplicationRef = new WanReplicationRef();
+            wanReplicationRef.setName(mapNode.getNodeName());
+            handleMapWanReplicationRefNode(mapNode, mapConfig, wanReplicationRef);
+        }
+    }
+
+    @Override
+    protected void handleWanFilters(Node wanChild, WanReplicationRef wanReplicationRef) {
+        for (Node filter : childElements(wanChild)) {
+            wanReplicationRef.addFilter(getTextContent(filter));
+        }
+    }
+
+    @Override
+    protected void handleMaxSizeConfig(MapConfig mapConfig, Node node, String value) {
+        MaxSizeConfig msc = mapConfig.getMaxSizeConfig();
+        NamedNodeMap attributes = node.getAttributes();
+        Node maxSizePolicy = attributes.getNamedItem("policy");
+        if (maxSizePolicy != null) {
+            msc.setMaxSizePolicy(MaxSizeConfig.MaxSizePolicy.valueOf(
+                    upperCaseInternal(getTextContent(maxSizePolicy))));
+        }
+        msc.setSize(getIntegerValue("max-size", attributes.getNamedItem("max-size").getNodeValue()));
+    }
+
+    @Override
+    protected void mapIndexesHandle(Node n, MapConfig mapConfig) {
+        for (Node indexNode : childElements(n)) {
+            NamedNodeMap attrs = indexNode.getAttributes();
+            boolean ordered = getBooleanValue(getTextContent(attrs.getNamedItem("ordered")));
+            String attribute = indexNode.getNodeName();
+            mapConfig.addMapIndexConfig(new MapIndexConfig(attribute, ordered));
+        }
+    }
+
+    @Override
+    protected void mapAttributesHandle(Node n, MapConfig mapConfig) {
+        for (Node extractorNode : childElements(n)) {
+            NamedNodeMap attrs = extractorNode.getAttributes();
+            String extractor = getTextContent(attrs.getNamedItem("extractor"));
+            String name = extractorNode.getNodeName();
+            mapConfig.addMapAttributeConfig(new MapAttributeConfig(name, extractor));
+        }
+    }
+
+    @Override
+    protected void mapQueryCacheHandler(Node n, MapConfig mapConfig) {
+        for (Node queryCacheNode : childElements(n)) {
+            String cacheName = queryCacheNode.getNodeName();
+            QueryCacheConfig queryCacheConfig = new QueryCacheConfig(cacheName);
+            handleMapQueryCacheNode(mapConfig, queryCacheNode, queryCacheConfig);
+        }
+    }
+
+    @Override
+    protected void queryCachePredicateHandler(Node childNode, QueryCacheConfig queryCacheConfig) {
+        NamedNodeMap predicateAttributes = childNode.getAttributes();
+        Node classNameNode = predicateAttributes.getNamedItem("class-name");
+        Node sqlNode = predicateAttributes.getNamedItem("sql");
+
+        if (classNameNode != null && sqlNode != null) {
+            throw new InvalidConfigurationException("Both class-name and sql is defined for the predicate of map "
+                    + childNode.getParentNode().getParentNode().getNodeName());
+        }
+
+        if (classNameNode == null && sqlNode == null) {
+            throw new InvalidConfigurationException("Either class-name and sql should be defined for the predicate of map "
+                    + childNode.getParentNode().getParentNode().getNodeName());
+        }
+
+        PredicateConfig predicateConfig = new PredicateConfig();
+        if (classNameNode != null) {
+            predicateConfig.setClassName(getTextContent(classNameNode));
+        } else if (sqlNode != null) {
+            predicateConfig.setSql(getTextContent(sqlNode));
+        }
+        queryCacheConfig.setPredicateConfig(predicateConfig);
+    }
+
+    @Override
+    protected void queryCacheIndexesHandle(Node n, QueryCacheConfig queryCacheConfig) {
+        for (Node indexNode : childElements(n)) {
+            NamedNodeMap attrs = indexNode.getAttributes();
+            boolean ordered = getBooleanValue(getTextContent(attrs.getNamedItem("ordered")));
+            String attribute = indexNode.getNodeName();
+            queryCacheConfig.addIndexConfig(new MapIndexConfig(attribute, ordered));
+        }
+    }
+
+    @Override
+    protected void handleMemberGroup(Node node, Config config) {
+        for (Node memberGroupNode : childElements(node)) {
+            MemberGroupConfig memberGroupConfig = new MemberGroupConfig();
+            for (Node interfacesNode : childElements(memberGroupNode)) {
+                memberGroupConfig.addInterface(interfacesNode.getNodeValue().trim());
+            }
+            config.getPartitionGroupConfig().addMemberGroupConfig(memberGroupConfig);
+        }
+    }
+
+    @Override
+    protected MergePolicyConfig createMergePolicyConfig(Node node) {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig();
+        String policyString = getTextContent(node.getAttributes().getNamedItem("class-name"));
+        mergePolicyConfig.setPolicy(policyString);
+        final String att = getAttribute(node, "batch-size");
+        if (att != null) {
+            mergePolicyConfig.setBatchSize(getIntegerValue("batch-size", att));
+        }
+        return mergePolicyConfig;
+    }
+
+    @Override
+    protected void mapPartitionLostListenerHandle(Node n, MapConfig mapConfig) {
+        for (Node listenerNode : childElements(n)) {
+            String listenerClass = listenerNode.getNodeValue();
+            mapConfig.addMapPartitionLostListenerConfig(new MapPartitionLostListenerConfig(listenerClass));
+        }
+    }
+
+    @Override
+    protected void cachePartitionLostListenerHandle(Node n, CacheSimpleConfig cacheConfig) {
+        for (Node listenerNode : childElements(n)) {
+            String listenerClass = listenerNode.getNodeValue();
+            cacheConfig.addCachePartitionLostListenerConfig(new CachePartitionLostListenerConfig(listenerClass));
+        }
+    }
+
+    @Override
+    protected void handleItemListeners(Node n, Function<ItemListenerConfig, Void> configAddFunction) {
+        for (Node listenerNode : childElements(n)) {
+            NamedNodeMap attrs = listenerNode.getAttributes();
+            boolean incValue = getBooleanValue(getTextContent(attrs.getNamedItem("include-value")));
+            String listenerClass = getTextContent(attrs.getNamedItem("class-name"));
+            configAddFunction.apply(new ItemListenerConfig(listenerClass, incValue));
+        }
+    }
+
+    @Override
+    protected void handleEntryListeners(Node n, Function<EntryListenerConfig, Void> configAddFunction) {
+        for (Node listenerNode : childElements(n)) {
+            NamedNodeMap attrs = listenerNode.getAttributes();
+            boolean incValue = getBooleanValue(getTextContent(attrs.getNamedItem("include-value")));
+            boolean local = getBooleanValue(getTextContent(attrs.getNamedItem("local")));
+            String listenerClass = getTextContent(attrs.getNamedItem("class-name"));
+            configAddFunction.apply(new EntryListenerConfig(listenerClass, local, incValue));
+        }
+    }
+
+    @Override
+    void handleMessageListeners(Node n, Function<ListenerConfig, Void> configAddFunction) {
+        for (Node listenerNode : childElements(n)) {
+            String listenerClass = listenerNode.getNodeValue().trim();
+            configAddFunction.apply(new ListenerConfig(listenerClass));
+        }
+    }
+
+    @Override
+    protected void handleQuorumListeners(QuorumConfig quorumConfig, Node n) {
+        for (Node listenerNode : childElements(n)) {
+            String listenerClass = listenerNode.getNodeValue().trim();
+            quorumConfig.addListenerConfig(new QuorumListenerConfig(listenerClass));
+        }
+    }
+
+    @Override
+    protected void handleServiceNodes(Node node, ServicesConfig servicesConfig) {
+        for (Node child : childElements(node)) {
+            String nodeName = cleanNodeName(child);
+            if (!"enable-defaults".equals(nodeName)) {
+                ServiceConfig serviceConfig = new ServiceConfig();
+                serviceConfig.setName(nodeName);
+                String enabledValue = getAttribute(child, "enabled");
+                boolean enabled = getBooleanValue(enabledValue);
+                serviceConfig.setEnabled(enabled);
+
+                for (Node n : childElements(child)) {
+                    handleServiceNode(n, serviceConfig);
+                }
+                servicesConfig.addServiceConfig(serviceConfig);
+            }
+        }
+    }
+
+    @Override
+    protected void fillProperties(Node node, Map<String, Comparable> properties) {
+        YamlMapping propertiesMapping = asMapping(((ElementAdapter) node).getYamlNode());
+        for (YamlNode propNode : propertiesMapping.children()) {
+            YamlScalar propScalar = asScalar(propNode);
+            String key = propScalar.nodeName();
+            String value = propScalar.nodeValue().toString();
+            properties.put(key, value);
+        }
+    }
+
+    @Override
+    protected void fillProperties(Node node, Properties properties) {
+        YamlMapping propertiesMapping = asMapping(((ElementAdapter) node).getYamlNode());
+        for (YamlNode propNode : propertiesMapping.children()) {
+            YamlScalar propScalar = asScalar(propNode);
+            String key = propScalar.nodeName();
+            String value = propScalar.nodeValue().toString();
+            properties.put(key, value);
+        }
+    }
+
+    @Override
+    protected void handleDiscoveryStrategiesChild(DiscoveryConfig discoveryConfig, Node child) {
+        String name = cleanNodeName(child);
+        if ("discovery-strategies".equals(name)) {
+            NodeList strategies = child.getChildNodes();
+            for (int i = 0; i < strategies.getLength(); i++) {
+                Node strategy = strategies.item(i);
+                handleDiscoveryStrategy(strategy, discoveryConfig);
+            }
+        } else if ("node-filter".equals(name)) {
+            handleDiscoveryNodeFilter(child, discoveryConfig);
+        }
+    }
+
+    protected SerializationConfig parseSerialization(final Node node) {
+        SerializationConfig serializationConfig = new SerializationConfig();
+        for (Node child : childElements(node)) {
+            final String name = cleanNodeName(child);
+            if ("portable-version".equals(name)) {
+                String value = getTextContent(child);
+                serializationConfig.setPortableVersion(getIntegerValue(name, value));
+            } else if ("check-class-def-errors".equals(name)) {
+                String value = getTextContent(child);
+                serializationConfig.setCheckClassDefErrors(getBooleanValue(value));
+            } else if ("use-native-byte-order".equals(name)) {
+                serializationConfig.setUseNativeByteOrder(getBooleanValue(getTextContent(child)));
+            } else if ("byte-order".equals(name)) {
+                String value = getTextContent(child);
+                ByteOrder byteOrder = null;
+                if (ByteOrder.BIG_ENDIAN.toString().equals(value)) {
+                    byteOrder = ByteOrder.BIG_ENDIAN;
+                } else if (ByteOrder.LITTLE_ENDIAN.toString().equals(value)) {
+                    byteOrder = ByteOrder.LITTLE_ENDIAN;
+                }
+                serializationConfig.setByteOrder(byteOrder != null ? byteOrder : ByteOrder.BIG_ENDIAN);
+            } else if ("enable-compression".equals(name)) {
+                serializationConfig.setEnableCompression(getBooleanValue(getTextContent(child)));
+            } else if ("enable-shared-object".equals(name)) {
+                serializationConfig.setEnableSharedObject(getBooleanValue(getTextContent(child)));
+            } else if ("allow-unsafe".equals(name)) {
+                serializationConfig.setAllowUnsafe(getBooleanValue(getTextContent(child)));
+            } else if ("data-serializable-factories".equals(name)) {
+                fillDataSerializableFactories(child, serializationConfig);
+            } else if ("portable-factories".equals(name)) {
+                fillPortableFactories(child, serializationConfig);
+            } else if ("serializers".equals(name)) {
+                fillSerializers(child, serializationConfig);
+            } else if ("global-serializer".equals(name)) {
+                fillGlobalSerializer(child, serializationConfig);
+            } else if ("java-serialization-filter".equals(name)) {
+                fillJavaSerializationFilter(child, serializationConfig);
+            }
+        }
+        return serializationConfig;
+    }
+
+    private void fillGlobalSerializer(Node child, SerializationConfig serializationConfig) {
+        GlobalSerializerConfig globalSerializerConfig = new GlobalSerializerConfig();
+        String attrClassName = getAttribute(child, "class-name");
+        String attrOverrideJavaSerialization = getAttribute(child, "override-java-serialization");
+        boolean overrideJavaSerialization =
+                attrOverrideJavaSerialization != null && getBooleanValue(attrOverrideJavaSerialization.trim());
+        globalSerializerConfig.setClassName(attrClassName);
+        globalSerializerConfig.setOverrideJavaSerialization(overrideJavaSerialization);
+        serializationConfig.setGlobalSerializerConfig(globalSerializerConfig);
+    }
+
+    @Override
+    protected void fillSerializers(Node node, SerializationConfig serializationConfig) {
+        for (Node child : childElements(node)) {
+            SerializerConfig serializerConfig = new SerializerConfig();
+            final String typeClassName = getAttribute(child, "type-class");
+            final String className = getAttribute(child, "class-name");
+            serializerConfig.setTypeClassName(typeClassName);
+            serializerConfig.setClassName(className);
+            serializationConfig.addSerializerConfig(serializerConfig);
+        }
+    }
+
+    @Override
+    protected void fillDataSerializableFactories(Node node, SerializationConfig serializationConfig) {
+        for (Node child : childElements(node)) {
+            NamedNodeMap attributes = child.getAttributes();
+            final Node factoryIdNode = attributes.getNamedItem("factory-id");
+            final Node classNameNode = attributes.getNamedItem("class-name");
+            if (factoryIdNode == null) {
+                throw new IllegalArgumentException(
+                        "'factory-id' attribute of 'data-serializable-factory' is required!");
+            }
+            if (classNameNode == null) {
+                throw new IllegalArgumentException(
+                        "'class-name' attribute of 'data-serializable-factory' is required!");
+            }
+            int factoryId = Integer.parseInt(getTextContent(factoryIdNode));
+            String className = getTextContent(classNameNode);
+            serializationConfig.addDataSerializableFactoryClass(factoryId, className);
+        }
+    }
+
+    @Override
+    protected void fillPortableFactories(Node node, SerializationConfig serializationConfig) {
+        for (Node child : childElements(node)) {
+            NamedNodeMap attributes = child.getAttributes();
+            final Node factoryIdNode = attributes.getNamedItem("factory-id");
+            final Node classNameNode = attributes.getNamedItem("class-name");
+            if (factoryIdNode == null) {
+                throw new IllegalArgumentException("'factory-id' attribute of 'portable-factory' is required!");
+            }
+            if (classNameNode == null) {
+                throw new IllegalArgumentException("'class-name' attribute of 'portable-factory' is required!");
+            }
+            int factoryId = Integer.parseInt(getTextContent(factoryIdNode));
+            String className = getTextContent(classNameNode);
+            serializationConfig.addPortableFactoryClass(factoryId, className);
+        }
+    }
+
+    protected ClassFilter parseClassFilterList(Node node) {
+        ClassFilter list = new ClassFilter();
+        for (Node typeNode : childElements(node)) {
+            final String name = cleanNodeName(typeNode);
+            if ("class".equals(name)) {
+                for (Node classNode : childElements(typeNode)) {
+                    list.addClasses(getTextContent(classNode));
+                }
+            } else if ("package".equals(name)) {
+                for (Node packageNode : childElements(typeNode)) {
+                    list.addPackages(getTextContent(packageNode));
+                }
+            } else if ("prefix".equals(name)) {
+                for (Node prefixNode : childElements(typeNode)) {
+                    list.addPrefixes(getTextContent(prefixNode));
+                }
+            }
+        }
+        return list;
+    }
+
+    @Override
+    protected void handleMemberAttributes(Node node) {
+        for (Node n : childElements(node)) {
+            String attributeValue = getTextContent(n.getAttributes().getNamedItem("value"));
+            String attributeName = n.getNodeName();
+            handleMemberAttributesNode(n, attributeName, attributeValue);
+        }
+    }
+
+    @Override
+    protected void handleOutboundPorts(Node child) {
+        NetworkConfig networkConfig = config.getNetworkConfig();
+        for (Node n : childElements(child)) {
+            String value = getTextContent(n);
+            networkConfig.addOutboundPortDefinition(value);
+        }
+    }
+
+    @Override
+    protected void handleInterfacesList(Node node, InterfacesConfig interfaces) {
+        for (Node interfacesNode : childElements(node)) {
+            if ("interfaces".equals(lowerCaseInternal(cleanNodeName(interfacesNode)))) {
+                for (Node interfaceNode : childElements(interfacesNode)) {
+                    String value = getTextContent(interfaceNode).trim();
+                    interfaces.addInterface(value);
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void handleListeners(Node node) {
+        for (Node child : childElements(node)) {
+            String listenerClass = getTextContent(child);
+            config.addListenerConfig(new ListenerConfig(listenerClass));
+        }
+    }
+
+    @Override
+    protected void handleMemberList(Node node) {
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        TcpIpConfig tcpIpConfig = join.getTcpIpConfig();
+        for (Node n : childElements(node)) {
+            String value = getTextContent(n).trim();
+            tcpIpConfig.addMember(value);
+        }
+    }
+
+    @Override
+    protected void handleRestApiEndpointGroups(Node node) {
+        for (Node child : childElements(node)) {
+            String nodeName = cleanNodeName(child);
+            if ("endpoint-groups".equals(nodeName)) {
+                for (Node groupNode : childElements(child)) {
+                    String groupName = groupNode.getNodeName();
+                    handleEndpointGroup(groupNode, groupName);
+                }
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/ElementAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/ElementAdapter.java
@@ -35,9 +35,9 @@ import static com.hazelcast.config.yaml.EmptyNamedNodeMap.emptyNamedNodeMap;
 import static com.hazelcast.config.yaml.EmptyNodeList.emptyNodeList;
 
 /**
- * Class adapting {@link YamlNode}s to {@link Element}
+ * Class adapting {@link YamlNode}s to {@link Element}.
  * <p/>
- * Used for processing YAML configuration
+ * Used for processing YAML configuration.
  */
 public class ElementAdapter implements Element {
     private final YamlNode yamlNode;

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/EmptyNamedNodeMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/EmptyNamedNodeMap.java
@@ -23,7 +23,7 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
 /**
- * Empty {@link NamedNodeMap} implementation. Used by {@link NodeAdapter#getAttributes()}
+ * Empty {@link NamedNodeMap} implementation. Used by {@link ElementAdapter#getAttributes()}
  * when wrapping {@link YamlNode}s other than {@link YamlMapping}.
  */
 final class EmptyNamedNodeMap implements NamedNodeMap {

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/NodeListScalarAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/NodeListScalarAdapter.java
@@ -16,37 +16,24 @@
 
 package com.hazelcast.config.yaml;
 
-import com.hazelcast.internal.yaml.YamlNode;
+import com.hazelcast.internal.yaml.YamlScalar;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-/**
- * Empty {@link NodeList} implementation. Used by {@link ElementAdapter#getChildNodes()}
- * when wrapping {@link YamlNode}s with no children.
- */
-final class EmptyNodeList implements NodeList {
-    private static final NodeList INSTANCE = new EmptyNodeList();
+class NodeListScalarAdapter implements NodeList {
+    private final YamlScalar scalar;
 
-    private EmptyNodeList() {
+    NodeListScalarAdapter(YamlScalar scalar) {
+        this.scalar = scalar;
     }
 
     @Override
     public Node item(int index) {
-        return null;
+        return new ScalarTextNodeAdapter(scalar);
     }
 
     @Override
     public int getLength() {
-        return 0;
-    }
-
-    /**
-     * Returns the singleton instance of this class
-     *
-     * @return an empty {@link NodeList}
-     * @see #INSTANCE
-     */
-    static NodeList emptyNodeList() {
-        return INSTANCE;
+        return 1;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/ScalarTextNodeAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/ScalarTextNodeAdapter.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.internal.yaml.YamlScalar;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.UserDataHandler;
+
+import static com.hazelcast.config.yaml.EmptyNodeList.emptyNodeList;
+
+class ScalarTextNodeAdapter implements Node {
+    private final YamlScalar scalar;
+
+    ScalarTextNodeAdapter(YamlScalar scalar) {
+        this.scalar = scalar;
+    }
+
+    @Override
+    public String getNodeName() {
+        return scalar.nodeName();
+    }
+
+    @Override
+    public String getNodeValue() throws DOMException {
+        return scalar.nodeValue().toString();
+    }
+
+    @Override
+    public void setNodeValue(String nodeValue) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public short getNodeType() {
+        return Node.TEXT_NODE;
+    }
+
+    @Override
+    public Node getParentNode() {
+        return W3cDomUtil.asW3cNode(scalar.parent());
+    }
+
+    @Override
+    public NodeList getChildNodes() {
+        return emptyNodeList();
+    }
+
+    @Override
+    public Node getFirstChild() {
+        return null;
+    }
+
+    @Override
+    public Node getLastChild() {
+        return null;
+    }
+
+    @Override
+    public Node getPreviousSibling() {
+        return null;
+    }
+
+    @Override
+    public Node getNextSibling() {
+        return null;
+    }
+
+    @Override
+    public NamedNodeMap getAttributes() {
+        return null;
+    }
+
+    @Override
+    public Document getOwnerDocument() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node insertBefore(Node newChild, Node refChild) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node replaceChild(Node newChild, Node oldChild) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node removeChild(Node oldChild) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Node appendChild(Node newChild) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean hasChildNodes() {
+        return false;
+    }
+
+    @Override
+    public Node cloneNode(boolean deep) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void normalize() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSupported(String feature, String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getNamespaceURI() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPrefix() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setPrefix(String prefix) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalName() {
+        return getNodeName();
+    }
+
+    @Override
+    public boolean hasAttributes() {
+        return false;
+    }
+
+    @Override
+    public String getBaseURI() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public short compareDocumentPosition(Node other) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getTextContent() throws DOMException {
+        return getNodeValue();
+    }
+
+    @Override
+    public void setTextContent(String textContent) throws DOMException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSameNode(Node other) {
+        return false;
+    }
+
+    @Override
+    public String lookupPrefix(String namespaceURI) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isDefaultNamespace(String namespaceURI) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String lookupNamespaceURI(String prefix) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isEqualNode(Node arg) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getFeature(String feature, String version) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object setUserData(String key, Object data, UserDataHandler handler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getUserData(String key) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/SingletonNodeList.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/SingletonNodeList.java
@@ -16,38 +16,27 @@
 
 package com.hazelcast.config.yaml;
 
-import com.hazelcast.internal.yaml.YamlNode;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import static com.hazelcast.config.yaml.EmptyNodeList.emptyNodeList;
+class SingletonNodeList implements NodeList {
 
-/**
- * Utility methods for YAML to W3C adaptors
- */
-public final class W3cDomUtil {
-    private W3cDomUtil() {
+    private final Node singletonItem;
+
+    SingletonNodeList(Node singletonItem) {
+        this.singletonItem = singletonItem;
     }
 
-    /**
-     * Returns an adapted W3C {@link Node} view of the provided {@link YamlNode}
-     *
-     * @param yamlNode The YAML node to adapt
-     * @return the adapted W3C Node or {@code null} if the provided YAML node is {@code null}
-     */
-    public static Node asW3cNode(YamlNode yamlNode) {
-        if (yamlNode == null) {
+    @Override
+    public Node item(int index) {
+        if (index != 0) {
             return null;
         }
-
-        return new ElementAdapter(yamlNode);
+        return singletonItem;
     }
 
-    static NodeList asNodeList(Node node) {
-        if (node == null) {
-            return emptyNodeList();
-        }
-
-        return new SingletonNodeList(node);
+    @Override
+    public int getLength() {
+        return 1;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlOrderedMappingImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlOrderedMappingImpl.java
@@ -94,7 +94,7 @@ final class YamlOrderedMappingImpl implements YamlOrderedMapping {
         return randomAccessChildren.get(index);
     }
 
-    static YamlOrderedMappingImpl asOrderedMapping(YamlMapping yamlMapping) {
+    public static YamlOrderedMappingImpl asOrderedMapping(YamlMapping yamlMapping) {
         return new YamlOrderedMappingImpl(yamlMapping);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -18,6 +18,8 @@ package com.hazelcast.instance;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.config.YamlConfigBuilder;
+import com.hazelcast.config.YamlConfigLocator;
 import com.hazelcast.core.DuplicateInstanceNameException;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.Member;
@@ -59,6 +61,7 @@ public final class HazelcastInstanceFactory {
 
     private static final AtomicInteger FACTORY_ID_GEN = new AtomicInteger();
     private static final ConcurrentMap<String, InstanceFuture> INSTANCE_MAP = new ConcurrentHashMap<String, InstanceFuture>(5);
+    private static final boolean DONT_USE_DEFAULT = false;
 
     static {
         ModularJavaUtils.checkJavaInternalAccess(Logger.getLogger(HazelcastInstanceFactory.class));
@@ -125,7 +128,13 @@ public final class HazelcastInstanceFactory {
      */
     public static HazelcastInstance newHazelcastInstance(Config config) {
         if (config == null) {
-            config = new XmlConfigBuilder().build();
+            // try load config from any provided YAML config except for the default config
+            YamlConfigLocator yamlConfigLocator = new YamlConfigLocator(DONT_USE_DEFAULT);
+            if (yamlConfigLocator.isConfigPresent()) {
+                config = new YamlConfigBuilder().build();
+            } else {
+                config = new XmlConfigBuilder().build();
+            }
         }
 
         return newHazelcastInstance(

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -62,7 +62,6 @@ public final class HazelcastInstanceFactory {
 
     private static final AtomicInteger FACTORY_ID_GEN = new AtomicInteger();
     private static final ConcurrentMap<String, InstanceFuture> INSTANCE_MAP = new ConcurrentHashMap<String, InstanceFuture>(5);
-    private static final boolean DONT_USE_DEFAULT = false;
 
     static {
         ModularJavaUtils.checkJavaInternalAccess(Logger.getLogger(HazelcastInstanceFactory.class));

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/ReflectiveYamlDocumentLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/ReflectiveYamlDocumentLoader.java
@@ -38,9 +38,16 @@ class ReflectiveYamlDocumentLoader implements YamlDocumentLoader {
     private final Method loadFromString;
 
     ReflectiveYamlDocumentLoader() {
+        final Class<?> loadSettingsBuilderClass;
         try {
             // instantiate LoadSettingsBuilder
-            Class<?> loadSettingsBuilderClass = Class.forName("org.snakeyaml.engine.v1.api.LoadSettingsBuilder");
+            loadSettingsBuilderClass = Class.forName("org.snakeyaml.engine.v1.api.LoadSettingsBuilder");
+        } catch (Exception ex) {
+            throw new YamlException("The SnakeYAML-Engine library couldn't be found on the classpath. Please include the "
+                    + "library on the classpath to be able to work with YAML documents.");
+        }
+
+        try {
             Constructor<?> loadSettingsBuilderConstructor = loadSettingsBuilderClass.getConstructor();
             Object loadSettingsBuilder = loadSettingsBuilderConstructor.newInstance();
             Method buildLoadSettingsMethod = loadSettingsBuilderClass.getMethod("build");

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlDomBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlDomBuilder.java
@@ -45,7 +45,8 @@ public final class YamlDomBuilder {
             rootNode = ((Map) document).get(rootName);
 
             if (rootNode == null) {
-                throw new YamlException("The required " + rootName + " root node couldn't be found in the document root");
+                throw new YamlException("The required " + rootName
+                        + " root node couldn't be found in the document root");
             }
         } else {
             rootNode = document;

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlScalarImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlScalarImpl.java
@@ -48,7 +48,7 @@ class YamlScalarImpl extends AbstractYamlNode implements YamlScalar {
     public String toString() {
         return "YamlScalarImpl{"
                 + "nodeName=" + nodeName()
-                + "value=" + value
+                + ", value=" + value
                 + '}';
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.internal.yaml;
 
-final class YamlUtil {
+public final class YamlUtil {
     private YamlUtil() {
     }
 
-    static YamlMapping asMapping(YamlNode node) {
+    public static YamlMapping asMapping(YamlNode node) {
         if (node != null && !(node instanceof YamlMapping)) {
             String nodeName = node.nodeName();
             throw new YamlException("Child " + nodeName + " is not a mapping, it's actual type is " + node.getClass());
@@ -29,7 +29,7 @@ final class YamlUtil {
         return (YamlMapping) node;
     }
 
-    static YamlSequence asSequence(YamlNode node) {
+    public static YamlSequence asSequence(YamlNode node) {
         if (node != null && !(node instanceof YamlSequence)) {
             String nodeName = node.nodeName();
             throw new YamlException("Child " + nodeName + " is not a sequence, it's actual type is " + node.getClass());
@@ -38,7 +38,7 @@ final class YamlUtil {
         return (YamlSequence) node;
     }
 
-    static YamlScalar asScalar(YamlNode node) {
+    public static YamlScalar asScalar(YamlNode node) {
         if (node != null && !(node instanceof YamlScalar)) {
             String nodeName = node.nodeName();
             throw new YamlException("Child " + nodeName + " is not a scalar, it's actual type is " + node.getClass());

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
@@ -16,32 +16,64 @@
 
 package com.hazelcast.internal.yaml;
 
+/**
+ * Utility class for working with YAML nodes.
+ */
 public final class YamlUtil {
     private YamlUtil() {
     }
 
+    /**
+     * Takes a generic {@link YamlNode} instance and returns it casted to
+     * {@link YamlMapping} if the type of the node is a descendant of
+     * {@link YamlMapping}.
+     *
+     * @param node The generic node to cast
+     * @return the casted mapping
+     * @throws YamlException if the provided node is not a mapping
+     */
     public static YamlMapping asMapping(YamlNode node) {
         if (node != null && !(node instanceof YamlMapping)) {
             String nodeName = node.nodeName();
-            throw new YamlException("Child " + nodeName + " is not a mapping, it's actual type is " + node.getClass());
+            throw new YamlException(String.format("Child %s is not a mapping, it's actual type is %s",
+                    nodeName, node.getClass()));
         }
 
         return (YamlMapping) node;
     }
 
+    /**
+     * Takes a generic {@link YamlNode} instance and returns it casted to
+     * {@link YamlSequence} if the type of the node is a descendant of
+     * {@link YamlSequence}.
+     *
+     * @param node The generic node to cast
+     * @return the casted sequence
+     * @throws YamlException if the provided node is not a sequence
+     */
     public static YamlSequence asSequence(YamlNode node) {
         if (node != null && !(node instanceof YamlSequence)) {
             String nodeName = node.nodeName();
-            throw new YamlException("Child " + nodeName + " is not a sequence, it's actual type is " + node.getClass());
+            throw new YamlException(String.format("Child %s is not a sequence, it's actual type is %s",
+                    nodeName, node.getClass()));
         }
 
         return (YamlSequence) node;
     }
 
+    /**
+     * Takes a generic {@link YamlNode} instance and returns it casted to
+     * {@link YamlScalar} if the type of the node is a descendant of
+     * {@link YamlScalar}.
+     *
+     * @param node The generic node to cast
+     * @return the casted scalar
+     * @throws YamlException if the provided node is not a scalar
+     */
     public static YamlScalar asScalar(YamlNode node) {
         if (node != null && !(node instanceof YamlScalar)) {
             String nodeName = node.nodeName();
-            throw new YamlException("Child " + nodeName + " is not a scalar, it's actual type is " + node.getClass());
+            throw new YamlException(String.format("Child %s is not a scalar, it's actual type is %s", nodeName, node.getClass()));
         }
 
         return (YamlScalar) node;

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -1,0 +1,359 @@
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The default Hazelcast configuration.
+#
+# This YAML file is used when no hazelcast.yaml is present.
+#
+# To learn how to configure Hazelcast, please see the Reference Manual
+# at https://hazelcast.org/documentation/
+hazelcast:
+  group:
+    name: dev
+    password: dev-pass
+  management-center:
+    enabled: false
+    url: http://localhost:8080/hazelcast-mancenter
+  network:
+    port:
+      auto-increment: true
+      port-count: 100
+      port: 5701
+    outbound-ports:
+      - 0
+    join:
+      multicast:
+        enabled: true
+        multicast-group: 224.2.2.3
+        multicast-port: 54327
+      tcp-ip:
+        enabled: false
+        interface: 127.0.0.1
+        member-list:
+          - 127.0.0.1
+      aws:
+        enabled: false
+        access-key: my-access-key
+        secret-key: my-secret-key
+        # optional, default is us-east-1
+        region: us-west-1
+        # optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property
+        host-header: ec2.amazonaws.com
+        # optional, only instances belonging to this group will be discovered, default will try all running instances
+        security-group-name: hazelcast-sg
+        tag-key: type
+        tag-value: hz-nodes
+      gcp:
+        enabled: false
+        zones: us-east1-b,us-east1-c
+      azure:
+        enabled: false
+        client-id: CLIENT_ID
+        client-secret: CLIENT_SECRET
+        tenant-id: TENANT_ID
+        subscription-id: SUB_ID
+        cluster-id: HZLCAST001
+        group-name: GROUP-NAME
+      kubernetes:
+        enabled: false
+        namespace: MY-KUBERNETES-NAMESPACE
+        service-name: MY-SERVICE-NAME
+        service-label-name: MY-SERVICE-LABEL-NAME
+        service-label-value: MY-SERVICE-LABEL-VALUE
+      eureka:
+        enabled: false
+        self-registration: true
+        namespace: hazelcast
+    interfaces:
+      enabled: false
+      interfaces:
+        - 10.10.1.*
+    ssl:
+      enabled: false
+    socket-interceptor:
+      enabled: false
+    symmetric-encryption:
+      enabled: false
+      #   encryption algorithm such as
+      #   DES/ECB/PKCS5Padding,
+      #   PBEWithMD5AndDES,
+      #   AES/CBC/PKCS5Padding,
+      #   Blowfish,
+      #   DESede
+      algorithm: PBEWithMD5AndDES
+      # salt value to use when generating the secret key
+      salt: thesalt
+      # pass phrase to use when generating the secret key
+      password: thepass
+      # iteration count to use when generating the secret key
+      iteration-count: 19
+    failure-detector:
+      icmp:
+        enabled: false
+
+  partition-group:
+    enabled: false
+
+  executor-service:
+    default:
+      pool-size: 16
+      # Queue capacity. 0 means Integer.MAX_VALUE.
+      queue-capacity: 0
+
+  security:
+    client-block-unmapped-actions: true
+
+  queue:
+    default:
+      # Maximum size of the queue. When a JVM's local queue size reaches the maximum,
+      # all put/offer operations will get blocked until the queue size
+      # of the JVM goes down below the maximum.
+      # Any integer between 0 and Integer.MAX_VALUE. 0 means
+      # Integer.MAX_VALUE. Default is 0.
+      max-size: 0
+
+      # Number of backups. If 1 is set as the backup-count for example,
+      # then all entries of the map will be copied to another JVM for
+      # fail-safety. 0 means no backup.
+      backup-count: 1
+      
+      # Number of async backups. 0 means no backup.
+      async-backup-count: 0
+
+      empty-queue-ttl: -1
+
+      merge-policy:
+        batch-size: 100
+        class-name: com.hazelcast.spi.merge.PutIfAbsentMergePolicy
+  map:
+    default:
+      # Data type that will be used for storing recordMap.
+      # Possible values:
+      # BINARY (default): keys and values will be stored as binary data
+      # OBJECT : values will be stored in their object forms
+      # NATIVE : values will be stored in non-heap region of JVM
+      in-memory-format: BINARY
+
+      # Number of backups. If 1 is set as the backup-count for example,
+      # then all entries of the map will be copied to another JVM for
+      # fail-safety. 0 means no backup.
+      backup-count: 1
+
+      # Number of async backups. 0 means no backup.
+      async-backup-count: 0
+
+      # Maximum number of seconds for each entry to stay in the map. Entries that are
+      # older than <time-to-live-seconds> and not updated for <time-to-live-seconds>
+      # will get automatically evicted from the map.
+      # Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0
+      time-to-live-seconds: 0
+
+      # Maximum number of seconds for each entry to stay idle in the map. Entries that are
+      # idle(not touched) for more than <max-idle-seconds> will get
+      # automatically evicted from the map. Entry is touched if get, put or containsKey is called.
+      # Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+      max-idle-seconds: 0
+
+      # Valid values are:
+      # NONE (no eviction),
+      # LRU (Least Recently Used),
+      # LFU (Least Frequently Used).
+      # NONE is the default.
+      eviction-policy: NONE
+
+      # Maximum size of the map. When max size is reached,
+      # map is evicted based on the policy defined.
+      # Any integer between 0 and Integer.MAX_VALUE. 0 means
+      # Integer.MAX_VALUE. Default is 0.
+      max-size:
+        policy: PER_NODE
+        max-size: 0
+
+        # `eviction-percentage` property is deprecated and will be ignored when it is set.
+        #
+        # As of version 3.7, eviction mechanism changed.
+        # It uses a probabilistic algorithm based on sampling. Please see documentation for further details
+        eviction-percentage: 25
+
+        # `min-eviction-check-millis` property is deprecated  and will be ignored when it is set.
+        #
+        # As of version 3.7, eviction mechanism changed.
+        # It uses a probabilistic algorithm based on sampling. Please see documentation for further details
+        min-eviction-check-millis: 100
+
+        # While recovering from split-brain (network partitioning),
+        # map entries in the small cluster will merge into the bigger cluster
+        # based on the policy set here. When an entry merge into the
+        # cluster, there might an existing entry with the same key already.
+        # Values of these entries might be different for that same key.
+        # Which value should be set for the key? Conflict is resolved by
+        # the policy set here. Default policy is PutIfAbsentMapMergePolicy
+        #
+        # There are built-in merge policies such as
+        # com.hazelcast.map.merge.PassThroughMergePolicy; entry will be overwritten if merging entry exists for the key.
+        # com.hazelcast.map.merge.PutIfAbsentMapMergePolicy ; entry will be added if the merging entry doesn't exist in the cluster.
+        # com.hazelcast.map.merge.HigherHitsMapMergePolicy ; entry with the higher hits wins.
+        # com.hazelcast.map.merge.LatestUpdateMapMergePolicy ; entry with the latest update wins.
+        merge-policy:
+          batch-size: 100
+          class-name: com.hazelcast.spi.merge.PutIfAbsentMergePolicy
+
+        # Control caching of de-serialized values. Caching makes query evaluation faster, but it cost memory.
+        # Possible Values:
+        #              NEVER: Never cache deserialized object
+        #              INDEX-ONLY: Caches values only when they are inserted into an index.
+        #              ALWAYS: Always cache deserialized values.
+        cache-deserialized-values: INDEX-ONLY
+
+  # Configuration for an event journal. The event journal keeps events related
+  # to a specific partition and data structure. For instance, it could keep
+  # map add, update, remove, merge events along with the key, old value, new value and so on.
+  event-journal:
+    map:
+      mapName:
+        enabled: false
+        capacity: 10000
+        time-to-live-seconds: 0
+
+    cache:
+      cacheName:
+        enabled: false
+        capacity: 10000
+        time-to-live-seconds: 0
+
+  # Configuration for a merkle tree.
+  # The merkle tree is a data structure used for efficient comparison of the
+  # difference in the contents of large data structures. The precision of
+  # such a comparison mechanism is defined by the depth of the merkle tree.
+  merkle-tree:
+    map:
+      mapName:
+        enabled: false
+        depth: 10
+
+  multimap:
+    default:
+      backup-count: 1
+      value-collection-type: SET
+      merge-policy:
+        batch-size: 100
+        class-name: com.hazelcast.spi.merge.PutIfAbsentMergePolicy
+
+  replicatedmap:
+    default:
+      in-memory-format: OBJECT
+      async-fillup: true
+      statistics-enabled: true
+      merge-policy:
+        batch-size: 100
+        class-name: com.hazelcast.spi.merge.PutIfAbsentMergePolicy
+
+  list:
+    default:
+      backup-count: 1
+      merge-policy:
+        batch-size: 100
+        class-name: com.hazelcast.spi.merge.PutIfAbsentMergePolicy
+
+  set:
+    default:
+      backup-count: 1
+      merge-policy:
+        batch-size: 100
+        class-name: com.hazelcast.spi.merge.PutIfAbsentMergePolicy
+
+  jobtracker:
+    default:
+      max-thread-size: 0
+      # Queue size 0 means number of partitions * 2
+      queue-size: 0
+      retry-count: 0
+      chunk-size: 1000
+      communicate-stats: true
+      topology-changed-strategy: CANCEL_RUNNING_OPERATION
+
+  semaphore:
+    default:
+      initial-permits: 0
+      backup-count: 1
+      async-backup-count: 0
+
+  reliable-topic:
+    default:
+      read-batch-size: 10
+      topic-overload-policy: BLOCK
+      statistics-enabled: true
+
+  ringbuffer:
+    default:
+      capacity: 10000
+      backup-count: 1
+      async-backup-count: 0
+      time-to-live-seconds: 0
+      in-memory-format: BINARY
+      merge-policy:
+        batch-size: 100
+        class-name: com.hazelcast.spi.merge.PutIfAbsentMergePolicy
+
+  flake-id-generator:
+    default:
+      prefetch-count: 100
+      prefetch-validity-millis: 600000
+      id-offset: 0
+      node-id-offset: 0
+      statistics-enabled: true
+
+  atomic-long:
+    default:
+      merge-policy:
+        batch-size: 100
+        class-name: com.hazelcast.spi.merge.PutIfAbsentMergePolicy
+
+  atomic-reference:
+    default:
+      merge-policy:
+        batch-size: 100
+        class-name: com.hazelcast.spi.merge.PutIfAbsentMergePolicy
+
+  count-down-latch:
+    default: {}
+
+  serialization:
+    portable-version: 0
+
+  services:
+    enable-defaults: true
+
+  cardinality-estimator:
+    default:
+      backup-count: 1
+      async-backup-count: 0
+      merge-policy:
+        batch-size: 100
+        class-name: HyperLogLogMergePolicy
+
+  scheduled-executor-service:
+    default:
+      capacity: 100
+      durability: 1
+      pool-size: 16
+
+  crdt-replication:
+    replication-period-millis: 1000
+    max-concurrent-replication-targets: 1
+
+  pn-counter:
+    default:
+      replica-count: 2147483647
+      statistics-enabled: true

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -401,9 +401,6 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testAllPermissionsCovered();
 
     @Test(expected = InvalidConfigurationException.class)
-    public abstract void testCacheConfig_withInvalidEvictionConfig_failsFast();
-
-    @Test(expected = InvalidConfigurationException.class)
     public abstract void testCacheConfig_withNativeInMemoryFormat_failsFastInOSS();
 
     @Test(expected = InvalidConfigurationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/config/MyServiceConfig.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MyServiceConfig.java
@@ -25,4 +25,6 @@ class MyServiceConfig {
     String stringProp;
     int intProp;
     boolean boolProp;
+    String nestedStringProp;
+    String nestedAttribute;
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/MyServiceConfigParser.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MyServiceConfigParser.java
@@ -39,6 +39,15 @@ public class MyServiceConfigParser extends AbstractXmlConfigHelper implements Se
                         config.intProp = Integer.parseInt(value);
                     } else if ("bool-prop".equals(name)) {
                         config.boolProp = Boolean.parseBoolean(getTextContent(node));
+                    } else if ("complex-prop".equals(name)) {
+                        Node attribute = node.getAttributes().getNamedItem("an-attribute");
+                        config.nestedAttribute = attribute.getTextContent();
+                        for (Node nestedNode : childElements(node)) {
+                            final String nestedNodeName = cleanNodeName(nestedNode);
+                            if ("nested-prop".equals(nestedNodeName)) {
+                                config.nestedStringProp = getTextContent(nestedNode);
+                            }
+                        }
                     }
                 }
             }

--- a/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
@@ -44,13 +44,27 @@ public class ServiceConfigTest extends HazelcastTestSupport {
         ServiceConfig serviceConfig = config.getServicesConfig().getServiceConfig("my-service");
         assertEquals("com.hazelcast.examples.MyService", serviceConfig.getClassName());
 
+        assertParsedServiceConfig(serviceConfig);
+    }
+
+    @Test
+    public void testYaml() {
+        Config config = new ClasspathYamlConfig("com/hazelcast/config/hazelcast-service.yaml");
+        ServiceConfig serviceConfig = config.getServicesConfig().getServiceConfig("my-service");
+        assertEquals("com.hazelcast.examples.MyService", serviceConfig.getClassName());
+
+        assertParsedServiceConfig(serviceConfig);
+    }
+
+    private void assertParsedServiceConfig(ServiceConfig serviceConfig) {
         MyServiceConfig configObject = (MyServiceConfig) serviceConfig.getConfigObject();
         assertNotNull(configObject);
         assertEquals("prop1", configObject.stringProp);
         assertEquals(123, configObject.intProp);
         assertTrue(configObject.boolProp);
+        assertEquals("nested-prop-value", configObject.nestedStringProp);
+        assertEquals("attr-value", configObject.nestedAttribute);
     }
-
 
     @Test
     public void testService() {

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1668,12 +1668,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     @Override
     public void readMulticastConfig() {
         String xml = HAZELCAST_START_TAG
-                + "   <group>\n"
-                + "        <name>dev</name>\n"
-                + "        <password>dev-pass</password>\n"
-                + "    </group>\n"
                 + "    <network>\n"
-                + "        <port auto-increment=\"true\">5701</port>\n"
                 + "        <join>\n"
                 + "            <multicast enabled=\"false\" loopbackModeEnabled=\"true\">\n"
                 + "                <multicast-group>224.2.2.4</multicast-group>\n"

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -96,6 +96,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
             + "</actions>";
 
     @Override
+    @Test
     public void testConfigurationURL() throws Exception {
         URL configURL = getClass().getClassLoader().getResource("hazelcast-default.xml");
         Config config = new XmlConfigBuilder(configURL).build();
@@ -103,6 +104,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testConfigurationWithFileName() throws Exception {
         assumeThatNotZingJDK6(); // https://github.com/hazelcast/hazelcast/issues/9044
 
@@ -157,6 +159,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testSecurityInterceptorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<security enabled=\"true\">"
@@ -259,6 +262,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readAwsConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <group>\n"
@@ -300,6 +304,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readGcpConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -324,6 +329,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readAzureConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -348,6 +354,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readKubernetesConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -372,6 +379,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readEurekaConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -396,6 +404,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readDiscoveryConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <group>\n"
@@ -436,6 +445,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testSSLConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -459,6 +469,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testSymmetricEncryptionConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -481,6 +492,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readPortCount() {
         // check when it is explicitly set
         Config config = buildConfig(HAZELCAST_START_TAG
@@ -501,6 +513,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readPortAutoIncrement() {
         // explicitly set
         Config config = buildConfig(HAZELCAST_START_TAG
@@ -520,6 +533,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void networkReuseAddress() {
         Config config = buildConfig(HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -530,6 +544,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readSemaphoreConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <semaphore name=\"default\">\n"
@@ -549,6 +564,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readQueueConfig() {
         String xml = HAZELCAST_START_TAG
                 + "      <queue name=\"custom\">"
@@ -605,6 +621,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readListConfig() {
         String xml = HAZELCAST_START_TAG
                 + "      <list name=\"myList\">"
@@ -638,6 +655,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readSetConfig() {
         String xml = HAZELCAST_START_TAG
                 + "      <set name=\"mySet\">"
@@ -670,6 +688,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readLockConfig() {
         String xml = HAZELCAST_START_TAG
                 + "  <lock name=\"default\">"
@@ -688,6 +707,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readReliableTopic() {
         String xml = HAZELCAST_START_TAG
                 + "    <reliable-topic name=\"custom\">"
@@ -716,6 +736,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readRingbuffer() {
         String xml = HAZELCAST_START_TAG
                 + "    <ringbuffer name=\"custom\">"
@@ -756,6 +777,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readAtomicLong() {
         String xml = HAZELCAST_START_TAG
                 + "    <atomic-long name=\"custom\">"
@@ -774,6 +796,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readAtomicReference() {
         String xml = HAZELCAST_START_TAG
                 + "    <atomic-reference name=\"custom\">"
@@ -792,6 +815,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readCountDownLatch() {
         String xml = HAZELCAST_START_TAG
                 + "    <count-down-latch name=\"custom\">"
@@ -805,6 +829,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCaseInsensitivityOfSettings() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"testCaseInsensitivity\">"
@@ -833,6 +858,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center enabled=\"true\" scripting-enabled='false'>"
@@ -849,6 +875,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testManagementCenterConfigComplex() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center enabled=\"true\">"
@@ -873,6 +900,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNullManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center>"
@@ -887,6 +915,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testEmptyManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG + HAZELCAST_END_TAG;
 
@@ -898,6 +927,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNotEnabledManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center enabled=\"false\">"
@@ -911,6 +941,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNotEnabledWithURLManagementCenterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center enabled=\"false\">"
@@ -926,6 +957,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testManagementCenterConfigComplexDisabledMutualAuth() {
         String xml = HAZELCAST_START_TAG
                 + "<management-center enabled=\"true\">"
@@ -944,6 +976,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreInitialModeLazy() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -959,6 +992,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_minEvictionCheckMillis() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -973,6 +1007,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_minEvictionCheckMillis_defaultValue() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -986,6 +1021,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_preprocessingPolicy() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1000,6 +1036,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_preprocessingPolicy_defaultValue() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1013,6 +1050,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_evictions() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"lruMap\">"
@@ -1039,6 +1077,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_optimizeQueries() {
         String xml1 = HAZELCAST_START_TAG
                 + "<map name=\"mymap1\">"
@@ -1063,6 +1102,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_cacheValueConfig_defaultValue() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1076,6 +1116,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_cacheValueConfig_never() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1090,6 +1131,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_cacheValueConfig_always() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1104,6 +1146,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_cacheValueConfig_indexOnly() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1118,6 +1161,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreInitialModeEager() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1133,6 +1177,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreWriteBatchSize() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -1149,6 +1194,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreConfig_writeCoalescing_whenDefault() {
         MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(MapStoreConfig.DEFAULT_WRITE_COALESCING, true);
 
@@ -1156,6 +1202,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreConfig_writeCoalescing_whenSetFalse() {
         MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(false, false);
 
@@ -1163,6 +1210,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreConfig_writeCoalescing_whenSetTrue() {
         MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(true, false);
 
@@ -1186,6 +1234,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNearCacheInMemoryFormat() {
         String mapName = "testMapNearCacheInMemoryFormat";
         String xml = HAZELCAST_START_TAG
@@ -1204,6 +1253,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNearCacheInMemoryFormatNative_withKeysByReference() {
         String mapName = "testMapNearCacheInMemoryFormatNative";
         String xml = HAZELCAST_START_TAG
@@ -1224,6 +1274,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNearCacheEvictionPolicy() {
         String xml = HAZELCAST_START_TAG
                 + "  <map name=\"lfuNearCache\">"
@@ -1260,6 +1311,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testPartitionGroupZoneAware() {
         String xml = HAZELCAST_START_TAG
                 + "<partition-group enabled=\"true\" group-type=\"ZONE_AWARE\" />"
@@ -1272,6 +1324,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testPartitionGroupSPI() {
         String xml = HAZELCAST_START_TAG
                 + "<partition-group enabled=\"true\" group-type=\"SPI\" />"
@@ -1282,6 +1335,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testPartitionGroupMemberGroups() {
         String xml = HAZELCAST_START_TAG
                 + "<partition-group enabled=\"true\" group-type=\"SPI\">"
@@ -1313,6 +1367,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNearCacheFullConfig() {
         String mapName = "testNearCacheFullConfig";
         String xml = HAZELCAST_START_TAG
@@ -1349,6 +1404,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapWanReplicationRef() {
         String mapName = "testMapWanReplicationRef";
         String refName = "test";
@@ -1376,6 +1432,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testWanReplicationConfig() {
         String configName  = "test";
         String xml = HAZELCAST_START_TAG
@@ -1430,6 +1487,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testDefaultOfPersistWanReplicatedDataIsFalse() {
         String configName  = "test";
         String xml = HAZELCAST_START_TAG
@@ -1446,6 +1504,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testWanReplicationSyncConfig() {
         String configName  = "test";
         String xml = HAZELCAST_START_TAG
@@ -1473,6 +1532,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapEventJournalConfig() {
         String journalName = "mapName";
         String xml = HAZELCAST_START_TAG
@@ -1492,6 +1552,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapMerkleTreeConfig() {
         String mapName = "mapName";
         String xml = HAZELCAST_START_TAG
@@ -1509,6 +1570,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCacheEventJournalConfig() {
         String journalName = "cacheName";
         String xml = HAZELCAST_START_TAG
@@ -1528,6 +1590,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testFlakeIdGeneratorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<flake-id-generator name='gen'>"
@@ -1559,6 +1622,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void setMapStoreConfigImplementationTest() {
         String mapName = "mapStoreImpObjTest";
         String xml = HAZELCAST_START_TAG
@@ -1585,6 +1649,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapPartitionLostListenerConfig() {
         String mapName = "map1";
         String listenerName = "DummyMapPartitionLostListenerImpl";
@@ -1596,6 +1661,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapPartitionLostListenerConfigReadOnly() {
         String mapName = "map1";
         String listenerName = "DummyMapPartitionLostListenerImpl";
@@ -1622,6 +1688,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCachePartitionLostListenerConfig() {
         String cacheName = "cache1";
         String listenerName = "DummyCachePartitionLostListenerImpl";
@@ -1633,6 +1700,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCachePartitionLostListenerConfigReadOnly() {
         String cacheName = "cache1";
         String listenerName = "DummyCachePartitionLostListenerImpl";
@@ -1666,6 +1734,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readMulticastConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <network>\n"
@@ -1698,6 +1767,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testWanConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <wan-replication name=\"my-wan-cluster\">\n"
@@ -1798,6 +1868,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumConfig() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1818,6 +1889,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumListenerConfig() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1882,6 +1954,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumConfig_whenRecentlyActiveQuorum_withDefaultValues() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1900,6 +1973,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumConfig_whenRecentlyActiveQuorum_withCustomValues() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1918,6 +1992,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumConfig_whenProbabilisticQuorum_withDefaultValues() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1941,6 +2016,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumConfig_whenProbabilisticQuorum_withCustomValues() {
         String xml = HAZELCAST_START_TAG
                 + "      <quorum enabled=\"true\" name=\"myQuorum\">\n"
@@ -1963,6 +2039,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCacheConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <cache name=\"foobar\">\n"
@@ -2031,6 +2108,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testExecutorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <executor-service name=\"foobar\">\n"
@@ -2052,6 +2130,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testDurableExecutorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <durable-executor-service name=\"foobar\">\n"
@@ -2073,6 +2152,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testScheduledExecutorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <scheduled-executor-service name=\"foobar\">\n"
@@ -2097,6 +2177,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCardinalityEstimatorConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <cardinality-estimator name=\"foobar\">\n"
@@ -2135,6 +2216,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testPNCounterConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <pn-counter name=\"pn-counter-1\">\n"
@@ -2154,6 +2236,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMultiMapConfig() {
         String xml = HAZELCAST_START_TAG
                 + "  <multimap name=\"myMultiMap\">"
@@ -2190,6 +2273,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testReplicatedMapConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <replicatedmap name=\"foobar\">\n"
@@ -2216,6 +2300,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testListConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <list name=\"foobar\">\n"
@@ -2248,6 +2333,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testSetConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <set name=\"foobar\">\n"
@@ -2280,6 +2366,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <map name=\"foobar\">\n"
@@ -2409,6 +2496,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testIndexesConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <map name=\"people\">\n"
@@ -2433,6 +2521,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testAttributeConfig() {
         String xml = HAZELCAST_START_TAG
                 + "   <map name=\"people\">\n"
@@ -2509,6 +2598,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQueryCacheFullConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"test\">"
@@ -2559,6 +2649,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapQueryCachePredicate() {
         String xml = HAZELCAST_START_TAG
                 + "  <map name=\"test\">\n"
@@ -2582,6 +2673,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testLiteMemberConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <lite-member enabled=\"true\"/>\n"
@@ -2593,6 +2685,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNonLiteMemberConfig() {
         String xml = HAZELCAST_START_TAG
                 + "    <lite-member enabled=\"false\"/>\n"
@@ -2643,6 +2736,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapNativeMaxSizePolicy() {
         String xmlFormat = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
@@ -2666,6 +2760,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testInstanceName() {
         String name = randomName();
         String xml = HAZELCAST_START_TAG
@@ -2677,6 +2772,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testUserCodeDeployment() {
         String xml = HAZELCAST_START_TAG
                 + "<user-code-deployment enabled=\"true\">"
@@ -2698,6 +2794,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCRDTReplicationConfig() {
         final String xml = HAZELCAST_START_TAG
                 + "<crdt-replication>\n"
@@ -2712,6 +2809,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testGlobalSerializer() {
         String name = randomName();
         String val = "true";
@@ -2730,6 +2828,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testJavaSerializationFilter() {
         String xml = HAZELCAST_START_TAG
                 + "  <serialization>\n"
@@ -2768,6 +2867,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testHotRestart() {
         String dir = "/mnt/hot-restart-root/";
         String backupDir = "/mnt/hot-restart-backup/";
@@ -2801,6 +2901,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapEvictionPolicyClassName() {
         String mapEvictionPolicyClassName = "com.hazelcast.map.eviction.LRUEvictionPolicy";
         String xml = HAZELCAST_START_TAG
@@ -2815,6 +2916,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapEvictionPolicyIsSelected_whenEvictionPolicySet() {
         String mapEvictionPolicyClassName = "com.hazelcast.map.eviction.LRUEvictionPolicy";
         String xml = HAZELCAST_START_TAG
@@ -2830,6 +2932,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCachePermission() {
         String xml = HAZELCAST_START_TAG + SECURITY_START_TAG
                 + "  <client-permissions>"
@@ -2846,6 +2949,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testConfigPermission() {
         String xml = HAZELCAST_START_TAG + SECURITY_START_TAG
                 + "  <client-permissions>"
@@ -2862,6 +2966,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testAllPermissionsCovered() {
         InputStream xmlResource = XMLConfigBuilderTest.class.getClassLoader().getResourceAsStream("hazelcast-fullconfig.xml");
         Config config = null;
@@ -2876,18 +2981,6 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         }
         assertTrue("All permission types should be listed in hazelcast-fullconfig.xml. Not found ones: " + permTypes,
                 permTypes.isEmpty());
-    }
-
-    @Override
-    @Test(expected = InvalidConfigurationException.class)
-    public void testCacheConfig_withInvalidEvictionConfig_failsFast() {
-        String xml = HAZELCAST_START_TAG
-                + "    <cache name=\"cache\">"
-                + "        <eviction size=\"10000000\" max-size-policy=\"ENTRY_COUNT\" eviction-policy=\"INVALID\"/>"
-                + "    </cache>"
-                + HAZELCAST_END_TAG;
-
-        buildConfig(xml);
     }
 
     @Override
@@ -2917,6 +3010,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMemberAddressProviderEnabled() {
         String xml = HAZELCAST_START_TAG
                 + "<network> "
@@ -2934,6 +3028,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMemberAddressProviderEnabled_withProperties() {
         String xml = HAZELCAST_START_TAG
                 + "<network> "
@@ -2955,6 +3050,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testFailureDetector_withProperties() {
         String xml = HAZELCAST_START_TAG
                 + "<network>"
@@ -2985,6 +3081,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testHandleMemberAttributes() {
         String xml = HAZELCAST_START_TAG
                 + "<member-attributes>\n"
@@ -2999,6 +3096,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMemcacheProtocolEnabled() {
         String xml = HAZELCAST_START_TAG
                 + "<memcache-protocol enabled='true'/>\n"
@@ -3010,6 +3108,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testRestApiDefaults() {
         String xml = HAZELCAST_START_TAG
                 + "<rest-api enabled='false'/>\n"
@@ -3025,6 +3124,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testRestApiEndpointGroups() {
         String xml = HAZELCAST_START_TAG
                 + "<rest-api enabled='true'>\n"
@@ -3043,6 +3143,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test(expected = InvalidConfigurationException.class)
     public void testUnknownRestApiEndpointGroup() {
         String xml = HAZELCAST_START_TAG
                 + "<rest-api enabled='true'>\n"

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigWithSystemPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigWithSystemPropertyTest.java
@@ -34,7 +34,6 @@ import static com.hazelcast.config.XMLConfigBuilderTest.HAZELCAST_END_TAG;
 import static com.hazelcast.config.XMLConfigBuilderTest.HAZELCAST_START_TAG;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * These tests manipulate system properties, therefore they must be run in serial mode.
@@ -54,7 +53,6 @@ public class XMLConfigWithSystemPropertyTest {
     @Test
     public void testConfigurationWithFile() throws Exception {
         URL url = getClass().getClassLoader().getResource("hazelcast-default.xml");
-        assertNotNull(url);
         String decodedURL = URLDecoder.decode(url.getFile(), "UTF-8");
         System.setProperty("hazelcast.config", decodedURL);
         Config config = new XmlConfigBuilder().build();

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlOnlyConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlOnlyConfigBuilderTest.java
@@ -153,6 +153,17 @@ public class XmlOnlyConfigBuilderTest {
         buildConfig(xml);
     }
 
+    @Test(expected = InvalidConfigurationException.class)
+    public void testCacheConfig_withInvalidEvictionConfig_failsFast() {
+        String xml = HAZELCAST_START_TAG
+                + "    <cache name=\"cache\">"
+                + "        <eviction size=\"10000000\" max-size-policy=\"ENTRY_COUNT\" eviction-policy=\"INVALID\"/>"
+                + "    </cache>"
+                + HAZELCAST_END_TAG;
+
+        buildConfig(xml);
+    }
+
     private static void assertXsdVersion(String buildVersion, String expectedXsdVersion) {
         System.setProperty(HAZELCAST_INTERNAL_OVERRIDE_VERSION, buildVersion);
         assertEquals("Unexpected release version retrieved for build version " + buildVersion, expectedXsdVersion,

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class XmlYamlConfigBuilderEqualsTest {
+    @Test
+    public void testFullConfig() {
+        Config xmlConfig = new ClasspathXmlConfig("hazelcast-fullconfig.xml");
+        Config yamlConfig = new ClasspathYamlConfig("hazelcast-fullconfig.yaml");
+
+        sortClientPermissionConfigs(xmlConfig);
+        sortClientPermissionConfigs(yamlConfig);
+
+        String xmlConfigFromXml = new ConfigXmlGenerator(true).generate(xmlConfig);
+        String xmlConfigFromYaml = new ConfigXmlGenerator(true).generate(yamlConfig);
+
+        assertEquals(xmlConfigFromXml, xmlConfigFromYaml);
+
+    }
+
+    @Test
+    public void testDefaultConfig() {
+        Config xmlConfig = new ClasspathXmlConfig("hazelcast-default.xml");
+        Config yamlConfig = new ClasspathYamlConfig("hazelcast-default.yaml");
+
+        sortClientPermissionConfigs(xmlConfig);
+        sortClientPermissionConfigs(yamlConfig);
+
+        String xmlConfigFromXml = new ConfigXmlGenerator(true).generate(xmlConfig);
+        String xmlConfigFromYaml = new ConfigXmlGenerator(true).generate(yamlConfig);
+
+        assertEquals(xmlConfigFromXml, xmlConfigFromYaml);
+
+    }
+
+    private void sortClientPermissionConfigs(Config config) {
+        SecurityConfig securityConfig = config.getSecurityConfig();
+        Set<PermissionConfig> unsorted = securityConfig.getClientPermissionConfigs();
+        Set<PermissionConfig> sorted = new TreeSet<PermissionConfig>(new PermissionConfigComparator());
+        sorted.addAll(unsorted);
+        securityConfig.setClientPermissionConfigs(sorted);
+
+    }
+
+    private static class PermissionConfigComparator implements Comparator<PermissionConfig> {
+        @Override
+        public int compare(PermissionConfig o1, PermissionConfig o2) {
+            if (o1 == o2) {
+                return 0;
+            }
+
+            if (o1 == null) {
+                return -1;
+            }
+
+            if (o2 == null) {
+                return 1;
+            }
+
+            return o1.getType().name().compareTo(o2.getType().name());
+        }
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -1,0 +1,3169 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.google.common.collect.ImmutableSet;
+import com.hazelcast.config.helpers.DummyMapStore;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.quorum.QuorumType;
+import com.hazelcast.quorum.impl.ProbabilisticQuorumFunction;
+import com.hazelcast.quorum.impl.RecentlyActiveQuorumFunction;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.topic.TopicOverloadPolicy;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.net.URL;
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.ENTRY_COUNT;
+import static com.hazelcast.config.EvictionPolicy.LRU;
+import static com.hazelcast.config.PermissionConfig.PermissionType.CACHE;
+import static com.hazelcast.config.PermissionConfig.PermissionType.CONFIG;
+import static com.hazelcast.config.WANQueueFullBehavior.DISCARD_AFTER_MUTATION;
+import static java.io.File.createTempFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * YAML specific implementation of the tests that should be maintained in
+ * both XML and YAML configuration builder tests
+ * <p/>
+ *
+ * NOTE: This test class must not define test cases, it is meant only to
+ * implement test cases defined in {@link AbstractConfigBuilderTest}.
+ * <p/>
+ *
+ * NOTE2: Test cases specific to YAML should be added to {@link YamlOnlyConfigBuilderTest}
+ *
+ * @see AbstractConfigBuilderTest
+ * @see XMLConfigBuilderTest
+ * @see YamlOnlyConfigBuilderTest
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
+
+    @Override
+    public void testConfigurationURL() throws Exception {
+        URL configURL = getClass().getClassLoader().getResource("hazelcast-default.yaml");
+        Config config = new YamlConfigBuilder(configURL).build();
+        assertEquals(configURL, config.getConfigurationUrl());
+    }
+
+    @Override
+    public void testConfigurationWithFileName() throws Exception {
+        assumeThatNotZingJDK6(); // https://github.com/hazelcast/hazelcast/issues/9044
+
+        File file = createTempFile("foo", "bar");
+        file.deleteOnExit();
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  group:\n"
+                + "    name: foobar\n"
+                + "    password: dev-pass";
+        Writer writer = new PrintWriter(file, "UTF-8");
+        writer.write(yaml);
+        writer.close();
+
+        String path = file.getAbsolutePath();
+        Config config = new YamlConfigBuilder(path).build();
+        assertEquals(path, config.getConfigurationFile().getAbsolutePath());
+    }
+
+    @Override
+    @Test(expected = IllegalArgumentException.class)
+    public void testConfiguration_withNullInputStream() {
+        new YamlConfigBuilder((InputStream) null);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testInvalidRootElement() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  group:\n"
+                + "    name: dev\n"
+                + "    password: clusterpass";
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testJoinValidation() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: true\n"
+                + "      tcp-ip:\n"
+                + "        enabled: true\n";
+        buildConfig(yaml);
+    }
+
+    @Override
+    public void testSecurityInterceptorConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  security:\n"
+                + "    enabled: true\n"
+                + "    security-interceptors:\n"
+                + "      - foo\n"
+                + "      - bar\n"
+                + "    client-block-unmapped-actions: false\n"
+                + "    member-credentials-factory:\n"
+                + "      class-name: MyCredentialsFactory\n"
+                + "      properties:\n"
+                + "        property: value\n"
+                + "    member-login-modules:\n"
+                + "      - class-name: MyRequiredLoginModule\n"
+                + "        usage: REQUIRED\n"
+                + "        properties:\n"
+                + "          login-property: login-value\n"
+                + "      - class-name: MyRequiredLoginModule2\n"
+                + "        usage: SUFFICIENT\n"
+                + "        properties:\n"
+                + "          login-property2: login-value2\n"
+                + "    client-login-modules:\n"
+                + "      - class-name: MyOptionalLoginModule\n"
+                + "        usage: OPTIONAL\n"
+                + "        properties:\n"
+                + "          client-property: client-value\n"
+                + "      - class-name: MyRequiredLoginModule\n"
+                + "        usage: REQUIRED\n"
+                + "        properties:\n"
+                + "          client-property2: client-value2\n"
+                + "    client-permission-policy:\n"
+                + "      class-name: MyPermissionPolicy\n"
+                + "      properties:\n"
+                + "        permission-property: permission-value\n";
+
+        Config config = buildConfig(yaml);
+        SecurityConfig securityConfig = config.getSecurityConfig();
+        List<SecurityInterceptorConfig> interceptorConfigs = securityConfig.getSecurityInterceptorConfigs();
+
+        assertEquals(2, interceptorConfigs.size());
+        assertEquals("foo", interceptorConfigs.get(0).className);
+        assertEquals("bar", interceptorConfigs.get(1).className);
+        assertFalse(securityConfig.getClientBlockUnmappedActions());
+
+        // member-credentials-factory
+        CredentialsFactoryConfig memberCredentialsConfig = securityConfig.getMemberCredentialsConfig();
+        assertEquals("MyCredentialsFactory", memberCredentialsConfig.getClassName());
+        assertEquals(1, memberCredentialsConfig.getProperties().size());
+        assertEquals("value", memberCredentialsConfig.getProperties().getProperty("property"));
+
+        // member-login-modules
+        List<LoginModuleConfig> memberLoginModuleConfigs = securityConfig.getMemberLoginModuleConfigs();
+        assertEquals(2, memberLoginModuleConfigs.size());
+        Iterator<LoginModuleConfig> memberLoginIterator = memberLoginModuleConfigs.iterator();
+
+        LoginModuleConfig memberLoginModuleCfg1 = memberLoginIterator.next();
+        assertEquals("MyRequiredLoginModule", memberLoginModuleCfg1.getClassName());
+        assertEquals(LoginModuleConfig.LoginModuleUsage.REQUIRED, memberLoginModuleCfg1.getUsage());
+        assertEquals(1, memberLoginModuleCfg1.getProperties().size());
+        assertEquals("login-value", memberLoginModuleCfg1.getProperties().getProperty("login-property"));
+
+        LoginModuleConfig memberLoginModuleCfg2 = memberLoginIterator.next();
+        assertEquals("MyRequiredLoginModule2", memberLoginModuleCfg2.getClassName());
+        assertEquals(LoginModuleConfig.LoginModuleUsage.SUFFICIENT, memberLoginModuleCfg2.getUsage());
+        assertEquals(1, memberLoginModuleCfg2.getProperties().size());
+        assertEquals("login-value2", memberLoginModuleCfg2.getProperties().getProperty("login-property2"));
+
+        // client-login-modules
+        List<LoginModuleConfig> clientLoginModuleConfigs = securityConfig.getClientLoginModuleConfigs();
+        assertEquals(2, clientLoginModuleConfigs.size());
+        Iterator<LoginModuleConfig> clientLoginIterator = clientLoginModuleConfigs.iterator();
+
+        LoginModuleConfig clientLoginModuleCfg1 = clientLoginIterator.next();
+        assertEquals("MyOptionalLoginModule", clientLoginModuleCfg1.getClassName());
+        assertEquals(LoginModuleConfig.LoginModuleUsage.OPTIONAL, clientLoginModuleCfg1.getUsage());
+        assertEquals(1, clientLoginModuleCfg1.getProperties().size());
+        assertEquals("client-value", clientLoginModuleCfg1.getProperties().getProperty("client-property"));
+
+        LoginModuleConfig clientLoginModuleCfg2 = clientLoginIterator.next();
+        assertEquals("MyRequiredLoginModule", clientLoginModuleCfg2.getClassName());
+        assertEquals(LoginModuleConfig.LoginModuleUsage.REQUIRED, clientLoginModuleCfg2.getUsage());
+        assertEquals(1, clientLoginModuleCfg2.getProperties().size());
+        assertEquals("client-value2", clientLoginModuleCfg2.getProperties().getProperty("client-property2"));
+
+        // client-permission-policy
+        PermissionPolicyConfig permissionPolicyConfig = securityConfig.getClientPolicyConfig();
+        assertEquals("MyPermissionPolicy", permissionPolicyConfig.getClassName());
+        assertEquals(1, permissionPolicyConfig.getProperties().size());
+        assertEquals("permission-value", permissionPolicyConfig.getProperties().getProperty("permission-property"));
+    }
+
+    @Override
+    public void readAwsConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    port:\n"
+                + "      auto-increment: true\n"
+                + "      port: 5701\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: false\n"
+                + "      aws:\n"
+                + "        enabled: true\n"
+                + "        use-public-ip: true\n"
+                + "        connection-timeout-seconds: 10\n"
+                + "        access-key: sample-access-key\n"
+                + "        secret-key: sample-secret-key\n"
+                + "        iam-role: sample-role\n"
+                + "        region: sample-region\n"
+                + "        host-header: sample-header\n"
+                + "        security-group-name: sample-group\n"
+                + "        tag-key: sample-tag-key\n"
+                + "        tag-value: sample-tag-value\n";
+
+        Config config = buildConfig(yaml);
+
+        AwsConfig awsConfig = config.getNetworkConfig().getJoin().getAwsConfig();
+        assertTrue(awsConfig.isEnabled());
+        assertTrue(awsConfig.isUsePublicIp());
+        assertAwsConfig(awsConfig);
+    }
+
+    @Override
+    public void readGcpConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: false\n"
+                + "      gcp:\n"
+                + "        enabled: true\n"
+                + "        use-public-ip: true\n"
+                + "        zones: us-east1-b\n";
+
+        Config config = buildConfig(yaml);
+
+        GcpConfig gcpConfig = config.getNetworkConfig().getJoin().getGcpConfig();
+
+        assertTrue(gcpConfig.isEnabled());
+        assertTrue(gcpConfig.isUsePublicIp());
+        assertEquals("us-east1-b", gcpConfig.getProperty("zones"));
+    }
+
+    @Override
+    public void readAzureConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: false\n"
+                + "      azure:\n"
+                + "        enabled: true\n"
+                + "        use-public-ip: true\n"
+                + "        client-id: 123456789!\n";
+
+        Config config = buildConfig(yaml);
+
+        AzureConfig azureConfig = config.getNetworkConfig().getJoin().getAzureConfig();
+
+        assertTrue(azureConfig.isEnabled());
+        assertTrue(azureConfig.isUsePublicIp());
+        assertEquals("123456789!", azureConfig.getProperty("client-id"));
+    }
+
+    @Override
+    public void readKubernetesConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: false\n"
+                + "      kubernetes:\n"
+                + "        enabled: true\n"
+                + "        use-public-ip: true\n"
+                + "        namespace: hazelcast\n";
+
+        Config config = buildConfig(yaml);
+
+        KubernetesConfig kubernetesConfig = config.getNetworkConfig().getJoin().getKubernetesConfig();
+
+        assertTrue(kubernetesConfig.isEnabled());
+        assertTrue(kubernetesConfig.isUsePublicIp());
+        assertEquals("hazelcast", kubernetesConfig.getProperty("namespace"));
+    }
+
+    @Override
+    public void readEurekaConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: false\n"
+                + "      eureka:\n"
+                + "        enabled: true\n"
+                + "        use-public-ip: true\n"
+                + "        namespace: hazelcast\n";
+
+        Config config = buildConfig(yaml);
+
+        EurekaConfig eurekaConfig = config.getNetworkConfig().getJoin().getEurekaConfig();
+
+        assertTrue(eurekaConfig.isEnabled());
+        assertTrue(eurekaConfig.isUsePublicIp());
+        assertEquals("hazelcast", eurekaConfig.getProperty("namespace"));
+    }
+
+    @Override
+    public void readDiscoveryConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: false\n"
+                + "      discovery-strategies:\n"
+                + "        node-filter:\n"
+                + "          class: DummyFilterClass\n"
+                + "        discovery-strategies:\n"
+                + "          - class: DummyDiscoveryStrategy1\n"
+                + "            enabled: true\n"
+                + "            properties:\n"
+                + "              key-string: foo\n"
+                + "              key-int: 123\n"
+                + "              key-boolean: true\n"
+                + "          - class: DummyDiscoveryStrategy2\n"
+                + "            enabled: true\n"
+                + "            properties:\n"
+                + "              key-string: foobar\n"
+                + "              key-int: 321\n"
+                + "              key-boolean: false\n";
+
+        Config config = buildConfig(yaml);
+        DiscoveryConfig discoveryConfig = config.getNetworkConfig().getJoin().getDiscoveryConfig();
+        assertTrue(discoveryConfig.isEnabled());
+        assertDiscoveryConfig(discoveryConfig);
+    }
+
+    @Override
+    public void testSSLConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    ssl:\n"
+                + "      enabled: true\r\n"
+                + "      factory-class-name: com.hazelcast.nio.ssl.BasicSSLContextFactory\r\n"
+                + "      properties:\r\n"
+                + "        protocol: TLS\r\n";
+
+        Config config = buildConfig(yaml);
+        SSLConfig sslConfig = config.getNetworkConfig().getSSLConfig();
+        assertTrue(sslConfig.isEnabled());
+        assertEquals("com.hazelcast.nio.ssl.BasicSSLContextFactory", sslConfig.getFactoryClassName());
+        assertEquals(1, sslConfig.getProperties().size());
+        assertEquals("TLS", sslConfig.getProperties().get("protocol"));
+    }
+
+    @Override
+    public void testSymmetricEncryptionConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    symmetric-encryption:\n"
+                + "      enabled: true\n"
+                + "      algorithm: AES\n"
+                + "      salt: some-salt\n"
+                + "      password: some-pass\n"
+                + "      iteration-count: 7531\n";
+
+        Config config = buildConfig(yaml);
+        SymmetricEncryptionConfig symmetricEncryptionConfig = config.getNetworkConfig().getSymmetricEncryptionConfig();
+        assertTrue(symmetricEncryptionConfig.isEnabled());
+        assertEquals("AES", symmetricEncryptionConfig.getAlgorithm());
+        assertEquals("some-salt", symmetricEncryptionConfig.getSalt());
+        assertEquals("some-pass", symmetricEncryptionConfig.getPassword());
+        assertEquals(7531, symmetricEncryptionConfig.getIterationCount());
+    }
+
+    @Override
+    public void readPortCount() {
+        // check when it is explicitly set
+        Config config = buildConfig(""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    port:\n"
+                + "      port-count: 200\n"
+                + "      port: 5702\n");
+
+        assertEquals(200, config.getNetworkConfig().getPortCount());
+        assertEquals(5702, config.getNetworkConfig().getPort());
+
+        // check if the default is passed in correctly
+        config = buildConfig(""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    port: 5701\n");
+        assertEquals(100, config.getNetworkConfig().getPortCount());
+    }
+
+    @Override
+    public void readPortAutoIncrement() {
+        // explicitly set
+        Config config = buildConfig(""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    port:\n"
+                + "      auto-increment: false\n"
+                + "      port: 5701\n");
+        assertFalse(config.getNetworkConfig().isPortAutoIncrement());
+
+        // check if the default is picked up correctly
+        config = buildConfig(""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    port: 5701\n");
+        assertTrue(config.getNetworkConfig().isPortAutoIncrement());
+    }
+
+    @Override
+    public void networkReuseAddress() {
+        Config config = buildConfig(""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    reuse-address: true\n");
+        assertTrue(config.getNetworkConfig().isReuseAddress());
+    }
+
+    @Override
+    public void readSemaphoreConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  semaphore:\n"
+                + "    default:\n"
+                + "      initial-permits: 1\n"
+                + "    custom:\n"
+                + "      initial-permits: 10\n"
+                + "      quorum-ref: customQuorumRule";
+
+        Config config = buildConfig(yaml);
+        SemaphoreConfig defaultConfig = config.getSemaphoreConfig("default");
+        SemaphoreConfig customConfig = config.getSemaphoreConfig("custom");
+        assertEquals(1, defaultConfig.getInitialPermits());
+        assertEquals(10, customConfig.getInitialPermits());
+        assertEquals("customQuorumRule", customConfig.getQuorumName());
+    }
+
+    @Override
+    public void readQueueConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  queue:\n"
+                + "    custom:\n"
+                + "      statistics-enabled: false\n"
+                + "      max-size: 100\n"
+                + "      backup-count: 2\n"
+                + "      async-backup-count: 1\n"
+                + "      empty-queue-ttl: 1\n"
+                + "      item-listeners:\n"
+                + "        - class-name: com.hazelcast.examples.ItemListener\n"
+                + "          include-value: false\n"
+                + "        - class-name: com.hazelcast.examples.ItemListener2\n"
+                + "          include-value: true\n"
+                + "      queue-store:\n"
+                + "        enabled: false\n"
+                + "        class-name: com.hazelcast.QueueStoreImpl\n"
+                + "        properties:\n"
+                + "          binary: false\n"
+                + "          memory-limit: 1000\n"
+                + "          bulk-load: 500\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "      merge-policy:\n"
+                + "        batch-size: 23\n"
+                + "        class-name: CustomMergePolicy\n"
+                + "    default:\n"
+                + "      max-size: 42\n";
+
+        Config config = buildConfig(yaml);
+        QueueConfig customQueueConfig = config.getQueueConfig("custom");
+        assertFalse(customQueueConfig.isStatisticsEnabled());
+        assertEquals(100, customQueueConfig.getMaxSize());
+        assertEquals(2, customQueueConfig.getBackupCount());
+        assertEquals(1, customQueueConfig.getAsyncBackupCount());
+        assertEquals(1, customQueueConfig.getEmptyQueueTtl());
+
+        MergePolicyConfig mergePolicyConfig = customQueueConfig.getMergePolicyConfig();
+        assertEquals("CustomMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(23, mergePolicyConfig.getBatchSize());
+
+        assertEquals(2, customQueueConfig.getItemListenerConfigs().size());
+        Iterator<ItemListenerConfig> itemListenerIterator = customQueueConfig.getItemListenerConfigs().iterator();
+        ItemListenerConfig listenerConfig1 = itemListenerIterator.next();
+        assertEquals("com.hazelcast.examples.ItemListener", listenerConfig1.getClassName());
+        assertFalse(listenerConfig1.isIncludeValue());
+        ItemListenerConfig listenerConfig2 = itemListenerIterator.next();
+        assertEquals("com.hazelcast.examples.ItemListener2", listenerConfig2.getClassName());
+        assertTrue(listenerConfig2.isIncludeValue());
+
+        QueueStoreConfig storeConfig = customQueueConfig.getQueueStoreConfig();
+        assertNotNull(storeConfig);
+        assertFalse(storeConfig.isEnabled());
+        assertEquals("com.hazelcast.QueueStoreImpl", storeConfig.getClassName());
+
+        Properties storeConfigProperties = storeConfig.getProperties();
+        assertEquals(3, storeConfigProperties.size());
+        assertEquals("500", storeConfigProperties.getProperty("bulk-load"));
+        assertEquals("1000", storeConfigProperties.getProperty("memory-limit"));
+        assertEquals("false", storeConfigProperties.getProperty("binary"));
+
+        assertEquals("customQuorumRule", customQueueConfig.getQuorumName());
+
+        QueueConfig defaultQueueConfig = config.getQueueConfig("default");
+        assertEquals(42, defaultQueueConfig.getMaxSize());
+    }
+
+    @Override
+    public void readListConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  list:\n"
+                + "    myList:\n"
+                + "      statistics-enabled: false\n"
+                + "      max-size: 100\n"
+                + "      backup-count: 2\n"
+                + "      async-backup-count: 1\n"
+                + "      item-listeners:\n"
+                + "        - class-name: com.hazelcast.examples.ItemListener\n"
+                + "          include-value: false\n"
+                + "        - class-name: com.hazelcast.examples.ItemListener2\n"
+                + "          include-value: true\n"
+                + "      merge-policy:\n"
+                + "        class-name: PassThroughMergePolicy\n"
+                + "        batch-size: 4223\n"
+                + "    default:\n"
+                + "      max-size: 42\n";
+
+        Config config = buildConfig(yaml);
+        ListConfig myListConfig = config.getListConfig("myList");
+
+        assertEquals("myList", myListConfig.getName());
+        assertFalse(myListConfig.isStatisticsEnabled());
+        assertEquals(100, myListConfig.getMaxSize());
+        assertEquals(2, myListConfig.getBackupCount());
+        assertEquals(1, myListConfig.getAsyncBackupCount());
+
+        assertEquals(2, myListConfig.getItemListenerConfigs().size());
+        Iterator<ItemListenerConfig> itemListenerIterator = myListConfig.getItemListenerConfigs().iterator();
+        ItemListenerConfig listenerConfig1 = itemListenerIterator.next();
+        assertEquals("com.hazelcast.examples.ItemListener", listenerConfig1.getClassName());
+        assertFalse(listenerConfig1.isIncludeValue());
+        ItemListenerConfig listenerConfig2 = itemListenerIterator.next();
+        assertEquals("com.hazelcast.examples.ItemListener2", listenerConfig2.getClassName());
+        assertTrue(listenerConfig2.isIncludeValue());
+
+        MergePolicyConfig mergePolicyConfig = myListConfig.getMergePolicyConfig();
+        assertEquals("PassThroughMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(4223, mergePolicyConfig.getBatchSize());
+
+        ListConfig defaultListConfig = config.getListConfig("default");
+        assertEquals(42, defaultListConfig.getMaxSize());
+    }
+
+    @Override
+    public void readSetConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  set:\n"
+                + "    mySet:\n"
+                + "      statistics-enabled: false\n"
+                + "      max-size: 100\n"
+                + "      backup-count: 2\n"
+                + "      async-backup-count: 1\n"
+                + "      item-listeners:\n"
+                + "        - class-name: com.hazelcast.examples.ItemListener\n"
+                + "          include-value: false\n"
+                + "        - class-name: com.hazelcast.examples.ItemListener2\n"
+                + "          include-value: true\n"
+                + "      merge-policy:\n"
+                + "        class-name: PassThroughMergePolicy\n"
+                + "        batch-size: 4223\n"
+                + "    default:\n"
+                + "      max-size: 42\n";
+
+        Config config = buildConfig(yaml);
+        SetConfig setConfig = config.getSetConfig("mySet");
+
+        assertEquals("mySet", setConfig.getName());
+        assertFalse(setConfig.isStatisticsEnabled());
+        assertEquals(100, setConfig.getMaxSize());
+        assertEquals(2, setConfig.getBackupCount());
+        assertEquals(1, setConfig.getAsyncBackupCount());
+
+        assertEquals(2, setConfig.getItemListenerConfigs().size());
+        Iterator<ItemListenerConfig> itemListenerIterator = setConfig.getItemListenerConfigs().iterator();
+        ItemListenerConfig listenerConfig1 = itemListenerIterator.next();
+        assertEquals("com.hazelcast.examples.ItemListener", listenerConfig1.getClassName());
+        assertFalse(listenerConfig1.isIncludeValue());
+        ItemListenerConfig listenerConfig2 = itemListenerIterator.next();
+        assertEquals("com.hazelcast.examples.ItemListener2", listenerConfig2.getClassName());
+        assertTrue(listenerConfig2.isIncludeValue());
+
+        MergePolicyConfig mergePolicyConfig = setConfig.getMergePolicyConfig();
+        assertEquals("PassThroughMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(4223, mergePolicyConfig.getBatchSize());
+
+        SetConfig defaultSetConfig = config.getSetConfig("default");
+        assertEquals(42, defaultSetConfig.getMaxSize());
+    }
+
+    @Override
+    public void readLockConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  lock:\n"
+                + "    default:\n"
+                + "      quorum-ref: quorumRuleWithThreeNodes\n"
+                + "    custom:\n"
+                + "      quorum-ref: customQuorumRule\n";
+
+        Config config = buildConfig(yaml);
+        LockConfig defaultConfig = config.getLockConfig("default");
+        LockConfig customConfig = config.getLockConfig("custom");
+        assertEquals("quorumRuleWithThreeNodes", defaultConfig.getQuorumName());
+        assertEquals("customQuorumRule", customConfig.getQuorumName());
+    }
+
+    @Override
+    public void readReliableTopic() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  reliable-topic:\n"
+                + "    custom:\n"
+                + "      read-batch-size: 35\n"
+                + "      statistics-enabled: false\n"
+                + "      topic-overload-policy: DISCARD_OLDEST\n"
+                + "      message-listeners:\n"
+                + "        - MessageListenerImpl\n"
+                + "        - MessageListenerImpl2\n"
+                + "    default:\n"
+                + "      read-batch-size: 42\n";
+
+        Config config = buildConfig(yaml);
+
+        ReliableTopicConfig topicConfig = config.getReliableTopicConfig("custom");
+
+        assertEquals(35, topicConfig.getReadBatchSize());
+        assertFalse(topicConfig.isStatisticsEnabled());
+        assertEquals(TopicOverloadPolicy.DISCARD_OLDEST, topicConfig.getTopicOverloadPolicy());
+
+        // checking listener configuration
+        assertEquals(2, topicConfig.getMessageListenerConfigs().size());
+        ListenerConfig listenerConfig1 = topicConfig.getMessageListenerConfigs().get(0);
+        assertEquals("MessageListenerImpl", listenerConfig1.getClassName());
+        assertNull(listenerConfig1.getImplementation());
+        ListenerConfig listenerConfig2 = topicConfig.getMessageListenerConfigs().get(1);
+        assertEquals("MessageListenerImpl2", listenerConfig2.getClassName());
+        assertNull(listenerConfig2.getImplementation());
+
+        ReliableTopicConfig defaultReliableTopicConfig = config.getReliableTopicConfig("default");
+        assertEquals(42, defaultReliableTopicConfig.getReadBatchSize());
+    }
+
+    @Override
+    public void readRingbuffer() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  ringbuffer:\n"
+                + "    custom:\n"
+                + "      capacity: 10\n"
+                + "      backup-count: 2\n"
+                + "      async-backup-count: 1\n"
+                + "      time-to-live-seconds: 9\n"
+                + "      in-memory-format: OBJECT\n"
+                + "      ringbuffer-store:\n"
+                + "        enabled: false\n"
+                + "        class-name: com.hazelcast.RingbufferStoreImpl\n"
+                + "        properties:\n"
+                + "          store-path: .//tmp//bufferstore\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "      merge-policy:\n"
+                + "        class-name: CustomMergePolicy\n"
+                + "        batch-size: 2342\n"
+                + "    default:\n"
+                + "      capacity: 42\n";
+
+        Config config = buildConfig(yaml);
+        RingbufferConfig ringbufferConfig = config.getRingbufferConfig("custom");
+
+        assertEquals(10, ringbufferConfig.getCapacity());
+        assertEquals(2, ringbufferConfig.getBackupCount());
+        assertEquals(1, ringbufferConfig.getAsyncBackupCount());
+        assertEquals(9, ringbufferConfig.getTimeToLiveSeconds());
+        assertEquals(InMemoryFormat.OBJECT, ringbufferConfig.getInMemoryFormat());
+
+        RingbufferStoreConfig ringbufferStoreConfig = ringbufferConfig.getRingbufferStoreConfig();
+        assertFalse(ringbufferStoreConfig.isEnabled());
+        assertEquals("com.hazelcast.RingbufferStoreImpl", ringbufferStoreConfig.getClassName());
+        Properties ringbufferStoreProperties = ringbufferStoreConfig.getProperties();
+        assertEquals(".//tmp//bufferstore", ringbufferStoreProperties.get("store-path"));
+        assertEquals("customQuorumRule", ringbufferConfig.getQuorumName());
+
+        MergePolicyConfig mergePolicyConfig = ringbufferConfig.getMergePolicyConfig();
+        assertEquals("CustomMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(2342, mergePolicyConfig.getBatchSize());
+
+        RingbufferConfig defaultRingBufferConfig = config.getRingbufferConfig("default");
+        assertEquals(42, defaultRingBufferConfig.getCapacity());
+    }
+
+    @Override
+    public void readAtomicLong() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  atomic-long:\n"
+                + "    custom:\n"
+                + "      merge-policy:\n"
+                + "        class-name: CustomMergePolicy\n"
+                + "        batch-size: 23\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "    default:\n"
+                + "      quorum-ref: customQuorumRule2\n";
+
+        Config config = buildConfig(yaml);
+        AtomicLongConfig atomicLongConfig = config.getAtomicLongConfig("custom");
+        assertEquals("custom", atomicLongConfig.getName());
+        assertEquals("customQuorumRule", atomicLongConfig.getQuorumName());
+
+        MergePolicyConfig mergePolicyConfig = atomicLongConfig.getMergePolicyConfig();
+        assertEquals("CustomMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(23, mergePolicyConfig.getBatchSize());
+
+        AtomicLongConfig defaultAtomicLongConfig = config.getAtomicLongConfig("default");
+        assertEquals("customQuorumRule2", defaultAtomicLongConfig.getQuorumName());
+    }
+
+    @Override
+    public void readAtomicReference() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  atomic-reference:\n"
+                + "    custom:\n"
+                + "      merge-policy:\n"
+                + "        class-name: CustomMergePolicy\n"
+                + "        batch-size: 23\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "    default:\n"
+                + "      quorum-ref: customQuorumRule2\n";
+
+        Config config = buildConfig(yaml);
+        AtomicReferenceConfig atomicReferenceConfig = config.getAtomicReferenceConfig("custom");
+        assertEquals("custom", atomicReferenceConfig.getName());
+        assertEquals("customQuorumRule", atomicReferenceConfig.getQuorumName());
+
+        MergePolicyConfig mergePolicyConfig = atomicReferenceConfig.getMergePolicyConfig();
+        assertEquals("CustomMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(23, mergePolicyConfig.getBatchSize());
+
+        AtomicReferenceConfig defaultAtomicReferenceConfig = config.getAtomicReferenceConfig("default");
+        assertEquals("customQuorumRule2", defaultAtomicReferenceConfig.getQuorumName());
+    }
+
+    @Override
+    public void readCountDownLatch() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  count-down-latch:\n"
+                + "    custom:\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "    default:\n"
+                + "      quorum-ref: customQuorumRule2\n";
+
+        Config config = buildConfig(yaml);
+        CountDownLatchConfig countDownLatchConfig = config.getCountDownLatchConfig("custom");
+        assertEquals("custom", countDownLatchConfig.getName());
+        assertEquals("customQuorumRule", countDownLatchConfig.getQuorumName());
+
+        CountDownLatchConfig defaultCountDownLatchConfig = config.getCountDownLatchConfig("default");
+        assertEquals("customQuorumRule2", defaultCountDownLatchConfig.getQuorumName());
+    }
+
+    @Override
+    public void testCaseInsensitivityOfSettings() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    testCaseInsensitivity:\n"
+                + "      in-memory-format: BINARY\n"
+                + "      backup-count: 1\n"
+                + "      async-backup-count: 0\n"
+                + "      time-to-live-seconds: 0\n"
+                + "      max-idle-seconds: 0\n"
+                + "      eviction-policy: NONE\n"
+                + "      max-size:\n"
+                + "        policy: per_partition\n"
+                + "        max-size: 0\n"
+                + "      eviction-percentage: 25\n"
+                + "      merge-policy:\n"
+                + "        class-name: CustomMergePolicy\n"
+                + "        batch-size: 2342\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("testCaseInsensitivity");
+
+        assertEquals(InMemoryFormat.BINARY, mapConfig.getInMemoryFormat());
+        assertEquals(EvictionPolicy.NONE, mapConfig.getEvictionPolicy());
+        assertEquals(MaxSizeConfig.MaxSizePolicy.PER_PARTITION, mapConfig.getMaxSizeConfig().getMaxSizePolicy());
+
+        MergePolicyConfig mergePolicyConfig = mapConfig.getMergePolicyConfig();
+        assertEquals("CustomMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(2342, mergePolicyConfig.getBatchSize());
+    }
+
+    @Override
+    public void testManagementCenterConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  management-center:\n"
+                + "    enabled: true\n"
+                + "    scripting-enabled: false\n"
+                + "    url: someUrl\n";
+
+        Config config = buildConfig(yaml);
+        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+
+        assertTrue(manCenterCfg.isEnabled());
+        assertFalse(manCenterCfg.isScriptingEnabled());
+        assertEquals("someUrl", manCenterCfg.getUrl());
+    }
+
+    @Override
+    public void testManagementCenterConfigComplex() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  management-center:\n"
+                + "    enabled: true\n"
+                + "    url: wowUrl\n"
+                + "    mutual-auth:\n"
+                + "      enabled: true\n"
+                + "      properties:\n"
+                + "        keyStore: /tmp/foo_keystore\n"
+                + "        trustStore: /tmp/foo_truststore\n";
+
+        Config config = buildConfig(yaml);
+        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+
+        assertTrue(manCenterCfg.isEnabled());
+        assertEquals("wowUrl", manCenterCfg.getUrl());
+        assertTrue(manCenterCfg.getMutualAuthConfig().isEnabled());
+        assertEquals("/tmp/foo_keystore", manCenterCfg.getMutualAuthConfig().getProperty("keyStore"));
+        assertEquals("/tmp/foo_truststore", manCenterCfg.getMutualAuthConfig().getProperty("trustStore"));
+    }
+
+    @Override
+    public void testNullManagementCenterConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  management-center: {}";
+
+        Config config = buildConfig(yaml);
+        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+
+        assertFalse(manCenterCfg.isEnabled());
+        assertNull(manCenterCfg.getUrl());
+    }
+
+    @Override
+    public void testEmptyManagementCenterConfig() {
+        String yaml = "hazelcast: {}";
+
+        Config config = buildConfig(yaml);
+        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+
+        assertFalse(manCenterCfg.isEnabled());
+        assertNull(manCenterCfg.getUrl());
+    }
+
+    @Override
+    public void testNotEnabledManagementCenterConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  management-center:\n"
+                + "    enabled: false\n";
+
+        Config config = buildConfig(yaml);
+        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+        assertFalse(manCenterCfg.isEnabled());
+        assertNull(manCenterCfg.getUrl());
+    }
+
+    @Override
+    public void testNotEnabledWithURLManagementCenterConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  management-center:\n"
+                + "    enabled: false\n"
+                + "    url: http://localhost:8080/mancenter\n";
+
+        Config config = buildConfig(yaml);
+        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+
+        assertFalse(manCenterCfg.isEnabled());
+        assertEquals("http://localhost:8080/mancenter", manCenterCfg.getUrl());
+    }
+
+    @Override
+    public void testManagementCenterConfigComplexDisabledMutualAuth() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  management-center:\n"
+                + "    enabled: true\n"
+                + "    url: wowUrl\n"
+                + "    mutual-auth:\n"
+                + "      enabled: false\n";
+
+        Config config = buildConfig(yaml);
+        ManagementCenterConfig manCenterCfg = config.getManagementCenterConfig();
+
+        assertTrue(manCenterCfg.isEnabled());
+        assertEquals("wowUrl", manCenterCfg.getUrl());
+        assertFalse(manCenterCfg.getMutualAuthConfig().isEnabled());
+    }
+
+    @Override
+    public void testMapStoreInitialModeLazy() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      map-store:\n"
+                + "        enabled: true\n"
+                + "        initial-mode: LAZY\n";
+
+        Config config = buildConfig(yaml);
+        MapStoreConfig mapStoreConfig = config.getMapConfig("mymap").getMapStoreConfig();
+
+        assertTrue(mapStoreConfig.isEnabled());
+        assertEquals(MapStoreConfig.InitialLoadMode.LAZY, mapStoreConfig.getInitialLoadMode());
+    }
+
+    @Override
+    public void testMapConfig_minEvictionCheckMillis() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      min-eviction-check-millis: 123456789\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("mymap");
+
+        assertEquals(123456789L, mapConfig.getMinEvictionCheckMillis());
+    }
+
+    @Override
+    public void testMapConfig_minEvictionCheckMillis_defaultValue() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap: {}\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("mymap");
+
+        assertEquals(MapConfig.DEFAULT_MIN_EVICTION_CHECK_MILLIS, mapConfig.getMinEvictionCheckMillis());
+    }
+
+    @Override
+    public void testMapConfig_preprocessingPolicy() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      preprocessing-policy: CREATION_TIME";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("mymap");
+
+        assertEquals(PreprocessingPolicy.CREATION_TIME, mapConfig.getPreprocessingPolicy());
+    }
+
+    @Override
+    public void testMapConfig_preprocessingPolicy_defaultValue() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap: {}";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("mymap");
+
+        assertEquals(PreprocessingPolicy.OFF, mapConfig.getPreprocessingPolicy());
+    }
+
+    @Override
+    public void testMapConfig_evictions() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    lruMap:\n"
+                + "      eviction-policy: LRU\n"
+                + ""
+                + "    lfuMap:\n"
+                + "      eviction-policy: LFU\n"
+                + ""
+                + "    noneMap:\n"
+                + "      eviction-policy: NONE\n"
+                + ""
+                + "    randomMap:\n"
+                + "      eviction-policy: RANDOM\n";
+
+        Config config = buildConfig(yaml);
+
+        assertEquals(EvictionPolicy.LRU, config.getMapConfig("lruMap").getEvictionPolicy());
+        assertEquals(EvictionPolicy.LFU, config.getMapConfig("lfuMap").getEvictionPolicy());
+        assertEquals(EvictionPolicy.NONE, config.getMapConfig("noneMap").getEvictionPolicy());
+        assertEquals(EvictionPolicy.RANDOM, config.getMapConfig("randomMap").getEvictionPolicy());
+    }
+
+    @Override
+    public void testMapConfig_optimizeQueries() {
+        String yaml1 = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap1:\n"
+                + "      optimize-queries: true\n";
+
+        Config config1 = buildConfig(yaml1);
+        MapConfig mapConfig1 = config1.getMapConfig("mymap1");
+        assertEquals(CacheDeserializedValues.ALWAYS, mapConfig1.getCacheDeserializedValues());
+
+        String yaml2 = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap2:\n"
+                + "      optimize-queries: false\n";
+
+        Config config2 = buildConfig(yaml2);
+        MapConfig mapConfig2 = config2.getMapConfig("mymap2");
+
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, mapConfig2.getCacheDeserializedValues());
+    }
+
+    @Override
+    public void testMapConfig_cacheValueConfig_defaultValue() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap: {}\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("mymap");
+
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, mapConfig.getCacheDeserializedValues());
+    }
+
+    @Override
+    public void testMapConfig_cacheValueConfig_never() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      cache-deserialized-values: NEVER\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("mymap");
+
+        assertEquals(CacheDeserializedValues.NEVER, mapConfig.getCacheDeserializedValues());
+    }
+
+    @Override
+    public void testMapConfig_cacheValueConfig_always() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      cache-deserialized-values: ALWAYS\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("mymap");
+
+        assertEquals(CacheDeserializedValues.ALWAYS, mapConfig.getCacheDeserializedValues());
+    }
+
+    @Override
+    public void testMapConfig_cacheValueConfig_indexOnly() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      cache-deserialized-values: INDEX-ONLY\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("mymap");
+
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, mapConfig.getCacheDeserializedValues());
+    }
+
+    @Override
+    public void testMapStoreInitialModeEager() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      map-store:\n"
+                + "        enabled: true\n"
+                + "        initial-mode: EAGER\n";
+
+        Config config = buildConfig(yaml);
+        MapStoreConfig mapStoreConfig = config.getMapConfig("mymap").getMapStoreConfig();
+
+        assertTrue(mapStoreConfig.isEnabled());
+        assertEquals(MapStoreConfig.InitialLoadMode.EAGER, mapStoreConfig.getInitialLoadMode());
+    }
+
+    @Override
+    public void testMapStoreWriteBatchSize() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      map-store:\n"
+                + "        write-batch-size: 23\n";
+
+        Config config = buildConfig(yaml);
+        MapStoreConfig mapStoreConfig = config.getMapConfig("mymap").getMapStoreConfig();
+
+        assertEquals(23, mapStoreConfig.getWriteBatchSize());
+    }
+
+    @Override
+    public void testMapStoreConfig_writeCoalescing_whenDefault() {
+        MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(MapStoreConfig.DEFAULT_WRITE_COALESCING, true);
+
+        assertTrue(mapStoreConfig.isWriteCoalescing());
+    }
+
+    @Override
+    public void testMapStoreConfig_writeCoalescing_whenSetFalse() {
+        MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(false, false);
+
+        assertFalse(mapStoreConfig.isWriteCoalescing());
+    }
+
+    @Override
+    public void testMapStoreConfig_writeCoalescing_whenSetTrue() {
+        MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(true, false);
+
+        assertTrue(mapStoreConfig.isWriteCoalescing());
+    }
+
+    private MapStoreConfig getWriteCoalescingMapStoreConfig(boolean writeCoalescing, boolean useDefault) {
+        String yaml = getWriteCoalescingConfigYaml(writeCoalescing, useDefault);
+        Config config = buildConfig(yaml);
+        return config.getMapConfig("mymap").getMapStoreConfig();
+    }
+
+    private String getWriteCoalescingConfigYaml(boolean value, boolean useDefault) {
+        return ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      map-store:"
+                + (useDefault ? "{}" : "\n        write-coalescing: " + String.valueOf(value) + "\n");
+    }
+
+    @Override
+    public void testNearCacheInMemoryFormat() {
+        String mapName = "testMapNearCacheInMemoryFormat";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    " + mapName + ":\n"
+                + "      near-cache:\n"
+                + "        in-memory-format: OBJECT\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig(mapName);
+        NearCacheConfig ncConfig = mapConfig.getNearCacheConfig();
+
+        assertEquals(InMemoryFormat.OBJECT, ncConfig.getInMemoryFormat());
+    }
+
+    @Override
+    public void testNearCacheInMemoryFormatNative_withKeysByReference() {
+        String mapName = "testMapNearCacheInMemoryFormatNative";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    " + mapName + ":\n"
+                + "      near-cache:\n"
+                + "        in-memory-format: NATIVE\n"
+                + "        serialize-keys: false\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig(mapName);
+        NearCacheConfig ncConfig = mapConfig.getNearCacheConfig();
+
+        assertEquals(InMemoryFormat.NATIVE, ncConfig.getInMemoryFormat());
+        assertTrue(ncConfig.isSerializeKeys());
+    }
+
+    @Override
+    public void testNearCacheEvictionPolicy() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    lfuNearCache:\n"
+                + "      near-cache:\n"
+                + "        eviction:\n"
+                + "          eviction-policy: LFU\n"
+                + ""
+                + "    lruNearCache:\n"
+                + "      near-cache:\n"
+                + "        eviction:\n"
+                + "          eviction-policy: LRU\n"
+                + ""
+                + "    noneNearCache:\n"
+                + "      near-cache:\n"
+                + "        eviction:\n"
+                + "          eviction-policy: NONE\n"
+                + "    randomNearCache:\n"
+                + "      near-cache:\n"
+                + "        eviction:\n"
+                + "          eviction-policy: RANDOM\n";
+
+        Config config = buildConfig(yaml);
+        assertEquals(EvictionPolicy.LFU, getNearCacheEvictionPolicy("lfuNearCache", config));
+        assertEquals(EvictionPolicy.LRU, getNearCacheEvictionPolicy("lruNearCache", config));
+        assertEquals(EvictionPolicy.NONE, getNearCacheEvictionPolicy("noneNearCache", config));
+        assertEquals(EvictionPolicy.RANDOM, getNearCacheEvictionPolicy("randomNearCache", config));
+    }
+
+    private EvictionPolicy getNearCacheEvictionPolicy(String mapName, Config config) {
+        return config.getMapConfig(mapName).getNearCacheConfig().getEvictionConfig().getEvictionPolicy();
+    }
+
+    @Override
+    public void testPartitionGroupZoneAware() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  partition-group:\n"
+                + "    enabled: true\n"
+                + "    group-type: ZONE_AWARE\n";
+
+        Config config = buildConfig(yaml);
+        PartitionGroupConfig partitionGroupConfig = config.getPartitionGroupConfig();
+        assertTrue(partitionGroupConfig.isEnabled());
+        assertEquals(PartitionGroupConfig.MemberGroupType.ZONE_AWARE, partitionGroupConfig.getGroupType());
+    }
+
+    @Override
+    public void testPartitionGroupSPI() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  partition-group:\n"
+                + "    enabled: true\n"
+                + "    group-type: SPI\n";
+
+        Config config = buildConfig(yaml);
+        assertEquals(PartitionGroupConfig.MemberGroupType.SPI, config.getPartitionGroupConfig().getGroupType());
+    }
+
+    @Override
+    public void testPartitionGroupMemberGroups() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  partition-group:\n"
+                + "    enabled: true\n"
+                + "    group-type: SPI\n"
+                + "    member-group:\n"
+                + "      -\n"
+                + "        - 10.10.1.1\n"
+                + "        - 10.10.1.2\n"
+                + "      -\n"
+                + "        - 10.10.1.3\n"
+                + "        - 10.10.1.4\n";
+
+        Config config = buildConfig(yaml);
+        Collection<MemberGroupConfig> memberGroupConfigs = config.getPartitionGroupConfig().getMemberGroupConfigs();
+        assertEquals(2, memberGroupConfigs.size());
+        Iterator<MemberGroupConfig> iterator = memberGroupConfigs.iterator();
+
+        MemberGroupConfig memberGroupConfig1 = iterator.next();
+        assertEquals(2, memberGroupConfig1.getInterfaces().size());
+        assertTrue(memberGroupConfig1.getInterfaces().contains("10.10.1.1"));
+        assertTrue(memberGroupConfig1.getInterfaces().contains("10.10.1.2"));
+
+        MemberGroupConfig memberGroupConfig2 = iterator.next();
+        assertEquals(2, memberGroupConfig2.getInterfaces().size());
+        assertTrue(memberGroupConfig2.getInterfaces().contains("10.10.1.3"));
+        assertTrue(memberGroupConfig2.getInterfaces().contains("10.10.1.4"));
+    }
+
+    @Override
+    public void testNearCacheFullConfig() {
+        String mapName = "testNearCacheFullConfig";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    " + mapName + ":\n"
+                + "      near-cache:\n"
+                + "        name: test\n"
+                + "        in-memory-format: OBJECT\n"
+                + "        serialize-keys: false\n"
+                + "        max-size: 1234\n"
+                + "        time-to-live-seconds: 77\n"
+                + "        max-idle-seconds: 92\n"
+                + "        eviction-policy: LFU\n"
+                + "        invalidate-on-change: false\n"
+                + "        cache-local-entries: false\n"
+                + "        eviction:\n"
+                + "          eviction-policy: LRU\n"
+                + "          max-size-policy: ENTRY_COUNT\n"
+                + "          size: 3333";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig(mapName);
+        NearCacheConfig nearCacheConfig = mapConfig.getNearCacheConfig();
+
+        assertEquals(InMemoryFormat.OBJECT, nearCacheConfig.getInMemoryFormat());
+        assertEquals(1234, nearCacheConfig.getMaxSize());
+        assertEquals(77, nearCacheConfig.getTimeToLiveSeconds());
+        assertEquals(92, nearCacheConfig.getMaxIdleSeconds());
+        assertEquals("LFU", nearCacheConfig.getEvictionPolicy());
+        assertFalse(nearCacheConfig.isInvalidateOnChange());
+        assertFalse(nearCacheConfig.isCacheLocalEntries());
+        assertEquals(LRU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
+        assertEquals(ENTRY_COUNT, nearCacheConfig.getEvictionConfig().getMaximumSizePolicy());
+        assertEquals(3333, nearCacheConfig.getEvictionConfig().getSize());
+        assertEquals("test", nearCacheConfig.getName());
+    }
+
+    @Override
+    public void testMapWanReplicationRef() {
+        String mapName = "testMapWanReplicationRef";
+        String refName = "test";
+        String mergePolicy = "TestMergePolicy";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    " + mapName + ":\n"
+                + "      wan-replication-ref:\n"
+                + "        test:\n"
+                + "          merge-policy: TestMergePolicy\n"
+                + "          filters:\n"
+                + "            - com.example.SampleFilter\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig(mapName);
+        WanReplicationRef wanRef = mapConfig.getWanReplicationRef();
+
+        assertEquals(refName, wanRef.getName());
+        assertEquals(mergePolicy, wanRef.getMergePolicy());
+        assertTrue(wanRef.isRepublishingEnabled());
+        assertEquals(1, wanRef.getFilters().size());
+        assertEquals("com.example.SampleFilter", wanRef.getFilters().get(0));
+    }
+
+    @Override
+    public void testWanReplicationConfig() {
+        String configName = "test";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  wan-replication:\n"
+                + "    " + configName + ":\n"
+                + "      wan-publisher:\n"
+                + "        publisherId:\n"
+                + "          group-name: nyc\n"
+                + "          class-name: PublisherClassName\n"
+                + "          queue-capacity: 15000\n"
+                + "          queue-full-behavior: DISCARD_AFTER_MUTATION\n"
+                + "          initial-publisher-state: STOPPED\n"
+                + "          properties:\n"
+                + "            propName1: propValue1\n"
+                + "      wan-consumer:\n"
+                + "        class-name: ConsumerClassName\n"
+                + "        properties:\n"
+                + "          propName1: propValue1\n";
+
+        Config config = buildConfig(yaml);
+        WanReplicationConfig wanReplicationConfig = config.getWanReplicationConfig(configName);
+
+        assertEquals(configName, wanReplicationConfig.getName());
+
+        WanConsumerConfig consumerConfig = wanReplicationConfig.getWanConsumerConfig();
+        assertNotNull(consumerConfig);
+        assertEquals("ConsumerClassName", consumerConfig.getClassName());
+
+        Map<String, Comparable> properties = consumerConfig.getProperties();
+        assertNotNull(properties);
+        assertEquals(1, properties.size());
+        assertEquals("propValue1", properties.get("propName1"));
+
+        List<WanPublisherConfig> publishers = wanReplicationConfig.getWanPublisherConfigs();
+        assertNotNull(publishers);
+        assertEquals(1, publishers.size());
+        WanPublisherConfig publisherConfig = publishers.get(0);
+        assertEquals("PublisherClassName", publisherConfig.getClassName());
+        assertEquals("nyc", publisherConfig.getGroupName());
+        assertEquals("publisherId", publisherConfig.getPublisherId());
+        assertEquals(15000, publisherConfig.getQueueCapacity());
+        assertEquals(DISCARD_AFTER_MUTATION, publisherConfig.getQueueFullBehavior());
+        assertEquals(WanPublisherState.STOPPED, publisherConfig.getInitialPublisherState());
+
+        properties = publisherConfig.getProperties();
+        assertNotNull(properties);
+        assertEquals(1, properties.size());
+        assertEquals("propValue1", properties.get("propName1"));
+    }
+
+    @Override
+    public void default_value_of_persist_wan_replicated_data_is_false() {
+        String configName = "test";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  wan-replication:\n"
+                + "    " + configName + ":\n"
+                + "      wan-consumer: {}\n";
+
+        Config config = buildConfig(yaml);
+        WanReplicationConfig wanReplicationConfig = config.getWanReplicationConfig(configName);
+        WanConsumerConfig consumerConfig = wanReplicationConfig.getWanConsumerConfig();
+        assertFalse(consumerConfig.isPersistWanReplicatedData());
+    }
+
+    @Override
+    public void testWanReplicationSyncConfig() {
+        String configName = "test";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  wan-replication:\n"
+                + "    " + configName + ":\n"
+                + "      wan-publisher:\n"
+                + "        nyc:\n"
+                + "          class-name: PublisherClassName\n"
+                + "          wan-sync:\n"
+                + "            consistency-check-strategy: MERKLE_TREES\n";
+
+        Config config = buildConfig(yaml);
+        WanReplicationConfig wanReplicationConfig = config.getWanReplicationConfig(configName);
+
+        assertEquals(configName, wanReplicationConfig.getName());
+
+        List<WanPublisherConfig> publishers = wanReplicationConfig.getWanPublisherConfigs();
+        assertNotNull(publishers);
+        assertEquals(1, publishers.size());
+        WanPublisherConfig publisherConfig = publishers.get(0);
+        assertEquals(ConsistencyCheckStrategy.MERKLE_TREES, publisherConfig.getWanSyncConfig()
+                                                                           .getConsistencyCheckStrategy());
+    }
+
+    @Override
+    public void testMapEventJournalConfig() {
+        String journalName = "mapName";
+        String journal2Name = "map2Name";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  event-journal:\n"
+                + "    map:\n"
+                + "      " + journalName + ":\n"
+                + "        enabled: false\n"
+                + "        capacity: 120\n"
+                + "        time-to-live-seconds: 20\n"
+                + "      " + journal2Name + ":\n"
+                + "        enabled: true\n";
+
+        Config config = buildConfig(yaml);
+        EventJournalConfig journalConfig = config.getMapEventJournalConfig(journalName);
+
+        assertFalse(journalConfig.isEnabled());
+        assertEquals(120, journalConfig.getCapacity());
+        assertEquals(20, journalConfig.getTimeToLiveSeconds());
+
+        EventJournalConfig journal2Config = config.getMapEventJournalConfig(journal2Name);
+        assertTrue(journal2Config.isEnabled());
+    }
+
+    @Override
+    public void testMapMerkleTreeConfig() {
+        String mapName = "mapName";
+        String map2Name = "map2Name";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  merkle-tree:\n"
+                + "    map:\n"
+                + "      " + mapName + ":\n"
+                + "        enabled: true\n"
+                + "        depth: 20\n"
+                + "      " + map2Name + ":\n"
+                + "        enabled: false\n"
+                + "        depth: 20\n";
+
+        Config config = buildConfig(yaml);
+        MerkleTreeConfig treeConfig = config.getMapMerkleTreeConfig(mapName);
+
+        assertTrue(treeConfig.isEnabled());
+        assertEquals(20, treeConfig.getDepth());
+
+        MerkleTreeConfig tree2Config = config.getMapMerkleTreeConfig(map2Name);
+        assertFalse(tree2Config.isEnabled());
+    }
+
+    @Override
+    public void testCacheEventJournalConfig() {
+        String journalName = "cacheName";
+        String journal2Name = "cache2Name";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  event-journal:\n"
+                + "    cache:\n"
+                + "      " + journalName + ":\n"
+                + "        enabled: true\n"
+                + "        capacity: 120\n"
+                + "        time-to-live-seconds: 20\n"
+                + "      " + journal2Name + ":\n"
+                + "        enabled: false\n";
+
+        Config config = buildConfig(yaml);
+        EventJournalConfig journalConfig = config.getCacheEventJournalConfig(journalName);
+
+        assertTrue(journalConfig.isEnabled());
+        assertEquals(120, journalConfig.getCapacity());
+        assertEquals(20, journalConfig.getTimeToLiveSeconds());
+
+        EventJournalConfig journal2Config = config.getCacheEventJournalConfig(journal2Name);
+        assertFalse(journal2Config.isEnabled());
+    }
+
+    @Override
+    public void testFlakeIdGeneratorConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  flake-id-generator:\n"
+                + "    gen:\n"
+                + "      prefetch-count: 3\n"
+                + "      prefetch-validity-millis: 10\n"
+                + "      id-offset: 20\n"
+                + "      node-id-offset: 30\n"
+                + "      statistics-enabled: false\n"
+                + "    gen2:\n"
+                + "      statistics-enabled: true";
+
+        Config config = buildConfig(yaml);
+        FlakeIdGeneratorConfig fConfig = config.findFlakeIdGeneratorConfig("gen");
+        assertEquals("gen", fConfig.getName());
+        assertEquals(3, fConfig.getPrefetchCount());
+        assertEquals(10L, fConfig.getPrefetchValidityMillis());
+        assertEquals(20L, fConfig.getIdOffset());
+        assertEquals(30L, fConfig.getNodeIdOffset());
+        assertFalse(fConfig.isStatisticsEnabled());
+
+        FlakeIdGeneratorConfig f2Config = config.findFlakeIdGeneratorConfig("gen2");
+        assertTrue(f2Config.isStatisticsEnabled());
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testParseExceptionIsNotSwallowed() {
+        String invalidYaml = "invalid-yaml";
+        buildConfig(invalidYaml);
+
+        // if we (for any reason) get through the parsing, then fail
+        fail();
+    }
+
+    @Override
+    public void setMapStoreConfigImplementationTest() {
+        String mapName = "mapStoreImpObjTest";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    " + mapName + ":\n"
+                + "      map-store:\n"
+                + "        enabled: true\n"
+                + "        class-name: com.hazelcast.config.helpers.DummyMapStore\n"
+                + "        write-delay-seconds: 5";
+
+        Config config = buildConfig(yaml);
+        HazelcastInstance hz = createHazelcastInstance(config);
+        IMap<String, String> map = hz.getMap(mapName);
+        // MapStore is not instantiated until the MapContainer is created lazily
+        map.put("sample", "data");
+
+        MapConfig mapConfig = hz.getConfig().getMapConfig(mapName);
+        MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();
+        Object o = mapStoreConfig.getImplementation();
+
+        assertNotNull(o);
+        assertTrue(o instanceof DummyMapStore);
+    }
+
+    @Override
+    public void testMapPartitionLostListenerConfig() {
+        String mapName = "map1";
+        String listenerName = "DummyMapPartitionLostListenerImpl";
+        String yaml = createMapPartitionLostListenerConfiguredYaml(mapName, listenerName);
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("map1");
+        assertMapPartitionLostListener(listenerName, mapConfig);
+    }
+
+    @Override
+    public void testMapPartitionLostListenerConfigReadOnly() {
+        String mapName = "map1";
+        String listenerName = "DummyMapPartitionLostListenerImpl";
+        String yaml = createMapPartitionLostListenerConfiguredYaml(mapName, listenerName);
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.findMapConfig("map1");
+        assertMapPartitionLostListener(listenerName, mapConfig);
+    }
+
+    private void assertMapPartitionLostListener(String listenerName, MapConfig mapConfig) {
+        assertFalse(mapConfig.getPartitionLostListenerConfigs().isEmpty());
+        assertEquals(listenerName, mapConfig.getPartitionLostListenerConfigs().get(0).getClassName());
+    }
+
+    private String createMapPartitionLostListenerConfiguredYaml(String mapName, String listenerName) {
+        return ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    " + mapName + ":\n"
+                + "      partition-lost-listeners:\n"
+                + "        - " + listenerName + "\n";
+    }
+
+    @Override
+    public void testCachePartitionLostListenerConfig() {
+        String cacheName = "cache1";
+        String listenerName = "DummyCachePartitionLostListenerImpl";
+        String yaml = createCachePartitionLostListenerConfiguredYaml(cacheName, listenerName);
+
+        Config config = buildConfig(yaml);
+        CacheSimpleConfig cacheConfig = config.getCacheConfig("cache1");
+        assertCachePartitionLostListener(listenerName, cacheConfig);
+    }
+
+    @Override
+    public void testCachePartitionLostListenerConfigReadOnly() {
+        String cacheName = "cache1";
+        String listenerName = "DummyCachePartitionLostListenerImpl";
+        String yaml = createCachePartitionLostListenerConfiguredYaml(cacheName, listenerName);
+
+        Config config = buildConfig(yaml);
+        CacheSimpleConfig cacheConfig = config.findCacheConfig("cache1");
+        assertCachePartitionLostListener(listenerName, cacheConfig);
+    }
+
+    private void assertCachePartitionLostListener(String listenerName, CacheSimpleConfig cacheConfig) {
+        assertFalse(cacheConfig.getPartitionLostListenerConfigs().isEmpty());
+        assertEquals(listenerName, cacheConfig.getPartitionLostListenerConfigs().get(0).getClassName());
+    }
+
+    private String createCachePartitionLostListenerConfiguredYaml(String cacheName, String listenerName) {
+        return ""
+                + "hazelcast:\n"
+                + "  cache:\n"
+                + "    " + cacheName + ":\n"
+                + "      partition-lost-listeners:\n"
+                + "        - " + listenerName + "\n";
+    }
+
+    @Override
+    public void readMulticastConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: false\n"
+                + "        loopbackModeEnabled: true\n"
+                + "        multicast-group: 224.2.2.4\n"
+                + "        multicast-port: 65438\n"
+                + "        multicast-timeout-seconds: 4\n"
+                + "        multicast-time-to-live: 42\n"
+                + "        trusted-interfaces:\n"
+                + "          - 127.0.0.1\n"
+                + "          - 0.0.0.0\n";
+
+        Config config = buildConfig(yaml);
+        MulticastConfig multicastConfig = config.getNetworkConfig().getJoin().getMulticastConfig();
+
+        assertFalse(multicastConfig.isEnabled());
+        assertTrue(multicastConfig.isLoopbackModeEnabled());
+        assertEquals("224.2.2.4", multicastConfig.getMulticastGroup());
+        assertEquals(65438, multicastConfig.getMulticastPort());
+        assertEquals(4, multicastConfig.getMulticastTimeoutSeconds());
+        assertEquals(42, multicastConfig.getMulticastTimeToLive());
+        assertEquals(2, multicastConfig.getTrustedInterfaces().size());
+        assertTrue(multicastConfig.getTrustedInterfaces().containsAll(ImmutableSet.of("127.0.0.1", "0.0.0.0")));
+    }
+
+    @Override
+    public void testWanConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  wan-replication:\n"
+                + "    my-wan-cluster:\n"
+                + "      wan-publisher:\n"
+                + "        istanbulPublisherId:\n"
+                + "          group-name: istanbul\n"
+                + "          class-name: com.hazelcast.wan.custom.WanPublisher\n"
+                + "          queue-full-behavior: THROW_EXCEPTION\n"
+                + "          queue-capacity: 21\n"
+                + "          aws:\n"
+                + "            enabled: false\n"
+                + "            connection-timeout-seconds: 10\n"
+                + "            access-key: sample-access-key\n"
+                + "            secret-key: sample-secret-key\n"
+                + "            iam-role: sample-role\n"
+                + "            region: sample-region\n"
+                + "            host-header: sample-header\n"
+                + "            security-group-name: sample-group\n"
+                + "            tag-key: sample-tag-key\n"
+                + "            tag-value: sample-tag-value\n"
+                + "          discovery-strategies:\n"
+                + "            node-filter:\n"
+                + "              class: DummyFilterClass\n"
+                + "            discovery-strategies:\n"
+                + "              - class: DummyDiscoveryStrategy1\n"
+                + "                enabled: true\n"
+                + "                properties:\n"
+                + "                  key-string: foo\n"
+                + "                  key-int: 123\n"
+                + "                  key-boolean: true\n"
+                + "              - class: DummyDiscoveryStrategy2\n"
+                + "                enabled: true\n"
+                + "                properties:\n"
+                + "                  key-string: foobar\n"
+                + "                  key-int: 321\n"
+                + "                  key-boolean: false\n"
+                + "          properties:\n"
+                + "            custom.prop.publisher: prop.publisher\n"
+                + "            discovery.period: 5\n"
+                + "            maxEndpoints: 2\n"
+                + "        ankara:\n"
+                + "          class-name: com.hazelcast.wan.custom.WanPublisher>\n"
+                + "          queue-full-behavior: THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE\n"
+                + "          initial-publisher-state: STOPPED\n"
+                + "      wan-consumer:\n"
+                + "        class-name: com.hazelcast.wan.custom.WanConsumer\n"
+                + "        properties:\n"
+                + "          custom.prop.consumer: prop.consumer\n"
+                + "        persist-wan-replicated-data: false\n";
+
+        Config config = buildConfig(yaml);
+        WanReplicationConfig wanConfig = config.getWanReplicationConfig("my-wan-cluster");
+        assertNotNull(wanConfig);
+
+        List<WanPublisherConfig> publisherConfigs = wanConfig.getWanPublisherConfigs();
+        assertEquals(2, publisherConfigs.size());
+        WanPublisherConfig publisherConfig1 = publisherConfigs.get(0);
+        assertEquals("istanbul", publisherConfig1.getGroupName());
+        assertEquals("istanbulPublisherId", publisherConfig1.getPublisherId());
+        assertEquals("com.hazelcast.wan.custom.WanPublisher", publisherConfig1.getClassName());
+        assertEquals(WANQueueFullBehavior.THROW_EXCEPTION, publisherConfig1.getQueueFullBehavior());
+        assertEquals(WanPublisherState.REPLICATING, publisherConfig1.getInitialPublisherState());
+        assertEquals(21, publisherConfig1.getQueueCapacity());
+        Map<String, Comparable> pubProperties = publisherConfig1.getProperties();
+        assertEquals("prop.publisher", pubProperties.get("custom.prop.publisher"));
+        assertEquals("5", pubProperties.get("discovery.period"));
+        assertEquals("2", pubProperties.get("maxEndpoints"));
+        assertFalse(publisherConfig1.getAwsConfig().isEnabled());
+        assertAwsConfig(publisherConfig1.getAwsConfig());
+        assertFalse(publisherConfig1.getGcpConfig().isEnabled());
+        assertFalse(publisherConfig1.getAzureConfig().isEnabled());
+        assertFalse(publisherConfig1.getKubernetesConfig().isEnabled());
+        assertFalse(publisherConfig1.getEurekaConfig().isEnabled());
+        assertDiscoveryConfig(publisherConfig1.getDiscoveryConfig());
+
+        WanPublisherConfig publisherConfig2 = publisherConfigs.get(1);
+        assertEquals("ankara", publisherConfig2.getGroupName());
+        assertNull(publisherConfig2.getPublisherId());
+        assertEquals(WANQueueFullBehavior.THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE, publisherConfig2.getQueueFullBehavior());
+        assertEquals(WanPublisherState.STOPPED, publisherConfig2.getInitialPublisherState());
+
+        WanConsumerConfig consumerConfig = wanConfig.getWanConsumerConfig();
+        assertEquals("com.hazelcast.wan.custom.WanConsumer", consumerConfig.getClassName());
+        Map<String, Comparable> consProperties = consumerConfig.getProperties();
+        assertEquals("prop.consumer", consProperties.get("custom.prop.consumer"));
+        assertFalse(consumerConfig.isPersistWanReplicatedData());
+    }
+
+    protected Config buildConfig(String yaml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(yaml.getBytes());
+        YamlConfigBuilder configBuilder = new YamlConfigBuilder(bis);
+        return configBuilder.build();
+    }
+
+    private void assertDiscoveryConfig(DiscoveryConfig c) {
+        assertEquals("DummyFilterClass", c.getNodeFilterClass());
+        assertEquals(2, c.getDiscoveryStrategyConfigs().size());
+
+        Iterator<DiscoveryStrategyConfig> iterator = c.getDiscoveryStrategyConfigs().iterator();
+        DiscoveryStrategyConfig config = iterator.next();
+        assertEquals("DummyDiscoveryStrategy1", config.getClassName());
+
+        Map<String, Comparable> props = config.getProperties();
+        assertEquals("foo", props.get("key-string"));
+        assertEquals("123", props.get("key-int"));
+        assertEquals("true", props.get("key-boolean"));
+
+        DiscoveryStrategyConfig config2 = iterator.next();
+        assertEquals("DummyDiscoveryStrategy2", config2.getClassName());
+
+        Map<String, Comparable> props2 = config2.getProperties();
+        assertEquals("foobar", props2.get("key-string"));
+        assertEquals("321", props2.get("key-int"));
+        assertEquals("false", props2.get("key-boolean"));
+    }
+
+    @Override
+    public void testQuorumConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  quorum:\n"
+                + "    myQuorum:\n"
+                + "      enabled: true\n"
+                + "      quorum-size: 3\n"
+                + "      quorum-function-class-name: com.my.quorum.function\n"
+                + "      quorum-type: READ\n";
+
+        Config config = buildConfig(yaml);
+        QuorumConfig quorumConfig = config.getQuorumConfig("myQuorum");
+
+        assertTrue("quorum should be enabled", quorumConfig.isEnabled());
+        assertEquals(3, quorumConfig.getSize());
+        assertEquals(QuorumType.READ, quorumConfig.getType());
+        assertEquals("com.my.quorum.function", quorumConfig.getQuorumFunctionClassName());
+        assertTrue(quorumConfig.getListenerConfigs().isEmpty());
+    }
+
+    @Override
+    public void testQuorumListenerConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  quorum:\n"
+                + "    myQuorum:\n"
+                + "      enabled: true\n"
+                + "      quorum-size: 3\n"
+                + "      quorum-listeners:\n"
+                + "         - com.abc.my.quorum.listener\n"
+                + "         - com.abc.my.second.listener\n"
+                + "      quorum-function-class-name: com.hazelcast.SomeQuorumFunction\n";
+
+        Config config = buildConfig(yaml);
+        QuorumConfig quorumConfig = config.getQuorumConfig("myQuorum");
+
+        assertFalse(quorumConfig.getListenerConfigs().isEmpty());
+        assertEquals("com.abc.my.quorum.listener", quorumConfig.getListenerConfigs().get(0).getClassName());
+        assertEquals("com.abc.my.second.listener", quorumConfig.getListenerConfigs().get(1).getClassName());
+        assertEquals("com.hazelcast.SomeQuorumFunction", quorumConfig.getQuorumFunctionClassName());
+    }
+
+    @Override
+    @Test(expected = ConfigurationException.class)
+    public void testQuorumConfig_whenClassNameAndRecentlyActiveQuorumDefined_exceptionIsThrown() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  quorum:\n"
+                + "    myQuorum:\n"
+                + "      enabled: true\n"
+                + "      quorum-size: 3\n"
+                + "      quorum-function-class-name: com.hazelcast.SomeQuorumFunction\n"
+                + "      recently-active-quorum: {}";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = ConfigurationException.class)
+    public void testQuorumConfig_whenClassNameAndProbabilisticQuorumDefined_exceptionIsThrown() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  quorum:\n"
+                + "    myQuorum:\n"
+                + "      enabled: true\n"
+                + "      quorum-size: 3\n"
+                + "      quorum-function-class-name: com.hazelcast.SomeQuorumFunction\n"
+                + "      probabilistic-quorum: {}";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    @Ignore("Schema validation is supposed to fail, two quorum implementation is defined")
+    public void testQuorumConfig_whenBothBuiltinQuorumsDefined_exceptionIsThrown() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  quorum:\n"
+                + "    myQuorum:\n"
+                + "      enabled: true\n"
+                + "      quorum-size: 3\n"
+                + "      probabilistic-quorum: {}\n"
+                + "      recently-active-quorum: {}\n";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    public void testQuorumConfig_whenRecentlyActiveQuorum_withDefaultValues() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  quorum:\n"
+                + "    myQuorum:\n"
+                + "      enabled: true\n"
+                + "      quorum-size: 3\n"
+                + "      recently-active-quorum: {}";
+
+        Config config = buildConfig(yaml);
+        QuorumConfig quorumConfig = config.getQuorumConfig("myQuorum");
+        assertInstanceOf(RecentlyActiveQuorumFunction.class, quorumConfig.getQuorumFunctionImplementation());
+        RecentlyActiveQuorumFunction quorumFunction = (RecentlyActiveQuorumFunction) quorumConfig
+                .getQuorumFunctionImplementation();
+        assertEquals(RecentlyActiveQuorumConfigBuilder.DEFAULT_HEARTBEAT_TOLERANCE_MILLIS,
+                quorumFunction.getHeartbeatToleranceMillis());
+    }
+
+    @Override
+    public void testQuorumConfig_whenRecentlyActiveQuorum_withCustomValues() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  quorum:\n"
+                + "    myQuorum:\n"
+                + "      enabled: true\n"
+                + "      quorum-size: 3\n"
+                + "      recently-active-quorum:\n"
+                + "        heartbeat-tolerance-millis: 13000\n";
+
+        Config config = buildConfig(yaml);
+        QuorumConfig quorumConfig = config.getQuorumConfig("myQuorum");
+        assertEquals(3, quorumConfig.getSize());
+        assertInstanceOf(RecentlyActiveQuorumFunction.class, quorumConfig.getQuorumFunctionImplementation());
+        RecentlyActiveQuorumFunction quorumFunction = (RecentlyActiveQuorumFunction) quorumConfig
+                .getQuorumFunctionImplementation();
+        assertEquals(13000, quorumFunction.getHeartbeatToleranceMillis());
+    }
+
+    @Override
+    public void testQuorumConfig_whenProbabilisticQuorum_withDefaultValues() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  quorum:\n"
+                + "    myQuorum:\n"
+                + "      enabled: true\n"
+                + "      quorum-size: 3\n"
+                + "      probabilistic-quorum: {}";
+
+        Config config = buildConfig(yaml);
+        QuorumConfig quorumConfig = config.getQuorumConfig("myQuorum");
+        assertInstanceOf(ProbabilisticQuorumFunction.class, quorumConfig.getQuorumFunctionImplementation());
+        ProbabilisticQuorumFunction quorumFunction = (ProbabilisticQuorumFunction) quorumConfig.getQuorumFunctionImplementation();
+        assertEquals(ProbabilisticQuorumConfigBuilder.DEFAULT_HEARTBEAT_INTERVAL_MILLIS,
+                quorumFunction.getHeartbeatIntervalMillis());
+        assertEquals(ProbabilisticQuorumConfigBuilder.DEFAULT_HEARTBEAT_PAUSE_MILLIS,
+                quorumFunction.getAcceptableHeartbeatPauseMillis());
+        assertEquals(ProbabilisticQuorumConfigBuilder.DEFAULT_MIN_STD_DEVIATION,
+                quorumFunction.getMinStdDeviationMillis());
+        assertEquals(ProbabilisticQuorumConfigBuilder.DEFAULT_PHI_THRESHOLD, quorumFunction.getSuspicionThreshold(), 0.01);
+        assertEquals(ProbabilisticQuorumConfigBuilder.DEFAULT_SAMPLE_SIZE, quorumFunction.getMaxSampleSize());
+    }
+
+    @Override
+    public void testQuorumConfig_whenProbabilisticQuorum_withCustomValues() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  quorum:\n"
+                + "    myQuorum:\n"
+                + "      enabled: true\n"
+                + "      quorum-size: 3\n"
+                + "      probabilistic-quorum:\n"
+                + "        acceptable-heartbeat-pause-millis: 37400\n"
+                + "        suspicion-threshold: 3.14592\n"
+                + "        max-sample-size: 42\n"
+                + "        min-std-deviation-millis: 1234\n"
+                + "        heartbeat-interval-millis: 4321";
+
+        Config config = buildConfig(yaml);
+        QuorumConfig quorumConfig = config.getQuorumConfig("myQuorum");
+        assertInstanceOf(ProbabilisticQuorumFunction.class, quorumConfig.getQuorumFunctionImplementation());
+        ProbabilisticQuorumFunction quorumFunction = (ProbabilisticQuorumFunction) quorumConfig.getQuorumFunctionImplementation();
+        assertEquals(4321, quorumFunction.getHeartbeatIntervalMillis());
+        assertEquals(37400, quorumFunction.getAcceptableHeartbeatPauseMillis());
+        assertEquals(1234, quorumFunction.getMinStdDeviationMillis());
+        assertEquals(3.14592d, quorumFunction.getSuspicionThreshold(), 0.001d);
+        assertEquals(42, quorumFunction.getMaxSampleSize());
+    }
+
+    @Override
+    public void testCacheConfig() {
+        // TODO do we really need to keep the 'class-name' keys?
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  cache:\n"
+                + "    foobar:\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "      key-type:\n"
+                + "        class-name: java.lang.Object\n"
+                + "      value-type:\n"
+                + "        class-name: java.lang.Object\n"
+                + "      statistics-enabled: false\n"
+                + "      management-enabled: false\n"
+                + "      read-through: true\n"
+                + "      write-through: true\n"
+                + "      cache-loader-factory:\n"
+                + "        class-name: com.example.cache.MyCacheLoaderFactory\n"
+                + "      cache-writer-factory:\n"
+                + "        class-name: com.example.cache.MyCacheWriterFactory\n"
+                + "      expiry-policy-factory:\n"
+                + "        class-name: com.example.cache.MyExpirePolicyFactory\n"
+                + "      in-memory-format: BINARY\n"
+                + "      backup-count: 1\n"
+                + "      async-backup-count: 0\n"
+                + "      eviction:\n"
+                + "        size: 1000\n"
+                + "        max-size-policy: ENTRY_COUNT\n"
+                + "        eviction-policy: LFU\n"
+                + "      merge-policy: com.hazelcast.cache.merge.LatestAccessCacheMergePolicy\n"
+                + "      disable-per-entry-invalidation-events: true\n"
+                + "      hot-restart:\n"
+                + "        enabled: false\n"
+                + "        fsync: false\n"
+                + "      partition-lost-listeners:\n"
+                + "        - com.your-package.YourPartitionLostListener\n"
+                + "      cache-entry-listeners:\n"
+                + "        cache-entry-listener:\n"
+                + "          old-value-required: false\n"
+                + "          synchronous: false\n"
+                + "          cache-entry-listener-factory:\n"
+                + "            class-name: com.example.cache.MyEntryListenerFactory\n"
+                + "          cache-entry-event-filter-factory:\n"
+                + "            class-name: com.example.cache.MyEntryEventFilterFactory\n";
+
+        Config config = buildConfig(yaml);
+        CacheSimpleConfig cacheConfig = config.getCacheConfig("foobar");
+
+        assertFalse(config.getCacheConfigs().isEmpty());
+        assertEquals("customQuorumRule", cacheConfig.getQuorumName());
+        assertEquals("java.lang.Object", cacheConfig.getKeyType());
+        assertEquals("java.lang.Object", cacheConfig.getValueType());
+        assertFalse(cacheConfig.isStatisticsEnabled());
+        assertFalse(cacheConfig.isManagementEnabled());
+        assertTrue(cacheConfig.isReadThrough());
+        assertTrue(cacheConfig.isWriteThrough());
+        assertEquals("com.example.cache.MyCacheLoaderFactory", cacheConfig.getCacheLoaderFactory());
+        assertEquals("com.example.cache.MyCacheWriterFactory", cacheConfig.getCacheWriterFactory());
+        assertEquals("com.example.cache.MyExpirePolicyFactory", cacheConfig.getExpiryPolicyFactoryConfig().getClassName());
+        assertEquals(InMemoryFormat.BINARY, cacheConfig.getInMemoryFormat());
+        assertEquals(1, cacheConfig.getBackupCount());
+        assertEquals(0, cacheConfig.getAsyncBackupCount());
+        assertEquals(1000, cacheConfig.getEvictionConfig().getSize());
+        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, cacheConfig.getEvictionConfig().getMaximumSizePolicy());
+        assertEquals(EvictionPolicy.LFU, cacheConfig.getEvictionConfig().getEvictionPolicy());
+        assertEquals("com.hazelcast.cache.merge.LatestAccessCacheMergePolicy", cacheConfig.getMergePolicy());
+        assertTrue(cacheConfig.isDisablePerEntryInvalidationEvents());
+        assertFalse(cacheConfig.getHotRestartConfig().isEnabled());
+        assertFalse(cacheConfig.getHotRestartConfig().isFsync());
+        assertEquals(1, cacheConfig.getPartitionLostListenerConfigs().size());
+        assertEquals("com.your-package.YourPartitionLostListener",
+                cacheConfig.getPartitionLostListenerConfigs().get(0).getClassName());
+        assertEquals(1, cacheConfig.getCacheEntryListeners().size());
+        assertEquals("com.example.cache.MyEntryListenerFactory",
+                cacheConfig.getCacheEntryListeners().get(0).getCacheEntryListenerFactory());
+        assertEquals("com.example.cache.MyEntryEventFilterFactory",
+                cacheConfig.getCacheEntryListeners().get(0).getCacheEntryEventFilterFactory());
+    }
+
+    @Override
+    public void testExecutorConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  executor-service:\n"
+                + "    foobar:\n"
+                + "      pool-size: 2\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "      statistics-enabled: true\n"
+                + "      queue-capacity: 0\n";
+
+        Config config = buildConfig(yaml);
+        ExecutorConfig executorConfig = config.getExecutorConfig("foobar");
+
+        assertFalse(config.getExecutorConfigs().isEmpty());
+        assertEquals(2, executorConfig.getPoolSize());
+        assertEquals("customQuorumRule", executorConfig.getQuorumName());
+        assertTrue(executorConfig.isStatisticsEnabled());
+        assertEquals(0, executorConfig.getQueueCapacity());
+    }
+
+    @Override
+    public void testDurableExecutorConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  durable-executor-service:\n"
+                + "    foobar:\n"
+                + "      pool-size: 2\n"
+                + "      durability: 3\n"
+                + "      capacity: 4\n"
+                + "      quorum-ref: customQuorumRule\n";
+
+        Config config = buildConfig(yaml);
+        DurableExecutorConfig durableExecutorConfig = config.getDurableExecutorConfig("foobar");
+
+        assertFalse(config.getDurableExecutorConfigs().isEmpty());
+        assertEquals(2, durableExecutorConfig.getPoolSize());
+        assertEquals(3, durableExecutorConfig.getDurability());
+        assertEquals(4, durableExecutorConfig.getCapacity());
+        assertEquals("customQuorumRule", durableExecutorConfig.getQuorumName());
+    }
+
+    @Override
+    public void testScheduledExecutorConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  scheduled-executor-service:\n"
+                + "    foobar:\n"
+                + "      durability: 4\n"
+                + "      pool-size: 5\n"
+                + "      capacity: 2\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "      merge-policy:\n"
+                + "        batch-size: 99\n"
+                + "        class-name: PutIfAbsent";
+
+        Config config = buildConfig(yaml);
+        ScheduledExecutorConfig scheduledExecutorConfig = config.getScheduledExecutorConfig("foobar");
+
+        assertFalse(config.getScheduledExecutorConfigs().isEmpty());
+        assertEquals(4, scheduledExecutorConfig.getDurability());
+        assertEquals(5, scheduledExecutorConfig.getPoolSize());
+        assertEquals(2, scheduledExecutorConfig.getCapacity());
+        assertEquals("customQuorumRule", scheduledExecutorConfig.getQuorumName());
+        assertEquals(99, scheduledExecutorConfig.getMergePolicyConfig().getBatchSize());
+        assertEquals("PutIfAbsent", scheduledExecutorConfig.getMergePolicyConfig().getPolicy());
+    }
+
+    @Override
+    public void testCardinalityEstimatorConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  cardinality-estimator:\n"
+                + "    foobar:\n"
+                + "      backup-count: 2\n"
+                + "      async-backup-count: 3\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "      merge-policy:\n"
+                + "        class-name: com.hazelcast.spi.merge.HyperLogLogMergePolicy";
+
+        Config config = buildConfig(yaml);
+        CardinalityEstimatorConfig cardinalityEstimatorConfig = config.getCardinalityEstimatorConfig("foobar");
+
+        assertFalse(config.getCardinalityEstimatorConfigs().isEmpty());
+        assertEquals(2, cardinalityEstimatorConfig.getBackupCount());
+        assertEquals(3, cardinalityEstimatorConfig.getAsyncBackupCount());
+        assertEquals("com.hazelcast.spi.merge.HyperLogLogMergePolicy",
+                cardinalityEstimatorConfig.getMergePolicyConfig().getPolicy());
+        assertEquals("customQuorumRule", cardinalityEstimatorConfig.getQuorumName());
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testCardinalityEstimatorConfigWithInvalidMergePolicy() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  cardinality-estimator:\n"
+                + "    foobar:\n"
+                + "      backup-count: 2\n"
+                + "      async-backup-count: 3\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "      merge-policy:\n"
+                + "        class-name: CustomMergePolicy";
+
+        buildConfig(yaml);
+        fail();
+    }
+
+    @Override
+    public void testPNCounterConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  pn-counter:\n"
+                + "    pn-counter-1:\n"
+                + "      replica-count: 100\n"
+                + "      quorum-ref: quorumRuleWithThreeMembers\n"
+                + "      statistics-enabled: false\n";
+
+        Config config = buildConfig(yaml);
+        PNCounterConfig pnCounterConfig = config.getPNCounterConfig("pn-counter-1");
+
+        assertFalse(config.getPNCounterConfigs().isEmpty());
+        assertEquals(100, pnCounterConfig.getReplicaCount());
+        assertEquals("quorumRuleWithThreeMembers", pnCounterConfig.getQuorumName());
+        assertFalse(pnCounterConfig.isStatisticsEnabled());
+    }
+
+    @Override
+    public void testMultiMapConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  multimap:\n"
+                + "    myMultiMap:\n"
+                + "      backup-count: 2\n"
+                + "      async-backup-count: 3\n"
+                + "      binary: false\n"
+                + "      value-collection-type: SET\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "      entry-listeners:\n"
+                + "        - class-name: com.hazelcast.examples.EntryListener\n"
+                + "          include-value: true\n"
+                + "          local: true\n"
+                + "      merge-policy:\n"
+                + "        batch-size: 23\n"
+                + "        class-name: CustomMergePolicy";
+
+        Config config = buildConfig(yaml);
+        assertFalse(config.getMultiMapConfigs().isEmpty());
+
+        MultiMapConfig multiMapConfig = config.getMultiMapConfig("myMultiMap");
+        assertEquals(2, multiMapConfig.getBackupCount());
+        assertEquals(3, multiMapConfig.getAsyncBackupCount());
+        assertFalse(multiMapConfig.isBinary());
+        assertEquals(MultiMapConfig.ValueCollectionType.SET, multiMapConfig.getValueCollectionType());
+        assertEquals(1, multiMapConfig.getEntryListenerConfigs().size());
+        assertEquals("com.hazelcast.examples.EntryListener", multiMapConfig.getEntryListenerConfigs().get(0).getClassName());
+        assertTrue(multiMapConfig.getEntryListenerConfigs().get(0).isIncludeValue());
+        assertTrue(multiMapConfig.getEntryListenerConfigs().get(0).isLocal());
+
+        MergePolicyConfig mergePolicyConfig = multiMapConfig.getMergePolicyConfig();
+        assertEquals("CustomMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals("customQuorumRule", multiMapConfig.getQuorumName());
+        assertEquals(23, mergePolicyConfig.getBatchSize());
+    }
+
+    @Override
+    public void testReplicatedMapConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  replicatedmap:\n"
+                + "    foobar:\n"
+                + "      in-memory-format: BINARY\n"
+                + "      async-fillup: false\n"
+                + "      statistics-enabled: false\n"
+                + "      quorum-ref: CustomQuorumRule\n"
+                + "      merge-policy:\n"
+                + "        batch-size: 2342\n"
+                + "        class-name: CustomMergePolicy\n";
+
+        Config config = buildConfig(yaml);
+        ReplicatedMapConfig replicatedMapConfig = config.getReplicatedMapConfig("foobar");
+
+        assertFalse(config.getReplicatedMapConfigs().isEmpty());
+        assertEquals(InMemoryFormat.BINARY, replicatedMapConfig.getInMemoryFormat());
+        assertFalse(replicatedMapConfig.isAsyncFillup());
+        assertFalse(replicatedMapConfig.isStatisticsEnabled());
+        assertEquals("CustomQuorumRule", replicatedMapConfig.getQuorumName());
+
+        MergePolicyConfig mergePolicyConfig = replicatedMapConfig.getMergePolicyConfig();
+        assertEquals("CustomMergePolicy", mergePolicyConfig.getPolicy());
+        assertEquals(2342, mergePolicyConfig.getBatchSize());
+    }
+
+    @Override
+    public void testListConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  list:\n"
+                + "    foobar:\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "      statistics-enabled: false\n"
+                + "      max-size: 42\n"
+                + "      backup-count: 2\n"
+                + "      async-backup-count: 1\n"
+                + "      merge-policy:\n"
+                + "        batch-size: 100\n"
+                + "        class-name: SplitBrainMergePolicy\n"
+                + "      item-listeners:\n"
+                + "         - include-value: true\n"
+                + "           class-name: com.hazelcast.examples.ItemListener\n";
+
+        Config config = buildConfig(yaml);
+        ListConfig listConfig = config.getListConfig("foobar");
+
+        assertFalse(config.getListConfigs().isEmpty());
+        assertEquals("customQuorumRule", listConfig.getQuorumName());
+        assertEquals(42, listConfig.getMaxSize());
+        assertEquals(2, listConfig.getBackupCount());
+        assertEquals(1, listConfig.getAsyncBackupCount());
+        assertEquals(1, listConfig.getItemListenerConfigs().size());
+        assertEquals("com.hazelcast.examples.ItemListener", listConfig.getItemListenerConfigs().get(0).getClassName());
+
+        MergePolicyConfig mergePolicyConfig = listConfig.getMergePolicyConfig();
+        assertEquals(100, mergePolicyConfig.getBatchSize());
+        assertEquals("SplitBrainMergePolicy", mergePolicyConfig.getPolicy());
+    }
+
+    @Override
+    public void testSetConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  set:\n"
+                + "    foobar:\n"
+                + "     quorum-ref: customQuorumRule\n"
+                + "     backup-count: 2\n"
+                + "     async-backup-count: 1\n"
+                + "     max-size: 42\n"
+                + "     merge-policy:\n"
+                + "       batch-size: 42\n"
+                + "       class-name: SplitBrainMergePolicy\n"
+                + "     item-listeners:\n"
+                + "         - include-value: true\n"
+                + "           class-name: com.hazelcast.examples.ItemListener\n";
+
+        Config config = buildConfig(yaml);
+        SetConfig setConfig = config.getSetConfig("foobar");
+
+        assertFalse(config.getSetConfigs().isEmpty());
+        assertEquals("customQuorumRule", setConfig.getQuorumName());
+        assertEquals(2, setConfig.getBackupCount());
+        assertEquals(1, setConfig.getAsyncBackupCount());
+        assertEquals(42, setConfig.getMaxSize());
+        assertEquals(1, setConfig.getItemListenerConfigs().size());
+        assertTrue(setConfig.getItemListenerConfigs().get(0).isIncludeValue());
+        assertEquals("com.hazelcast.examples.ItemListener", setConfig.getItemListenerConfigs().get(0).getClassName());
+
+        MergePolicyConfig mergePolicyConfig = setConfig.getMergePolicyConfig();
+        assertEquals(42, mergePolicyConfig.getBatchSize());
+        assertEquals("SplitBrainMergePolicy", mergePolicyConfig.getPolicy());
+    }
+
+    @Override
+    public void testMapConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    foobar:\n"
+                + "      quorum-ref: customQuorumRule\n"
+                + "      in-memory-format: BINARY\n"
+                + "      statistics-enabled: true\n"
+                + "      optimize-queries: false\n"
+                + "      cache-deserialized-values: INDEX-ONLY\n"
+                + "      backup-count: 2\n"
+                + "      async-backup-count: 1\n"
+                + "      time-to-live-seconds: 42\n"
+                + "      max-idle-seconds: 42\n"
+                + "      eviction-policy: RANDOM\n"
+                + "      max-size:\n"
+                + "        policy: PER_NODE\n"
+                + "        max-size: 42\n"
+                + "      eviction-percentage: 25\n"
+                + "      min-eviction-check-millis: 256\n"
+                + "      read-backup-data: true\n"
+                + "      hot-restart:\n"
+                + "        enabled: false\n"
+                + "        fsync: false\n"
+                + "      map-store:\n"
+                + "        enabled: true \n"
+                + "        initial-mode: LAZY\n"
+                + "        class-name: com.hazelcast.examples.DummyStore\n"
+                + "        write-delay-seconds: 42\n"
+                + "        write-batch-size: 42\n"
+                + "        write-coalescing: true\n"
+                + "        properties:\n"
+                + "           jdbc_url: my.jdbc.com\n"
+                + "      near-cache:\n"
+                + "        max-size: 5000\n"
+                + "        time-to-live-seconds: 42\n"
+                + "        max-idle-seconds: 42\n"
+                + "        eviction-policy: LRU\n"
+                + "        invalidate-on-change: true\n"
+                + "        in-memory-format: BINARY\n"
+                + "        cache-local-entries: false\n"
+                + "        eviction:\n"
+                + "          size: 1000\n"
+                + "          max-size-policy: ENTRY_COUNT\n"
+                + "          eviction-policy: LFU\n"
+                + "      wan-replication-ref:\n"
+                + "        my-wan-cluster-batch:\n"
+                + "          merge-policy: com.hazelcast.map.merge.PassThroughMergePolicy\n"
+                + "          filters:\n"
+                + "            - com.example.SampleFilter\n"
+                + "          republishing-enabled: false\n"
+                + "      indexes:\n"
+                + "        age:\n"
+                + "          ordered: true\n"
+                + "      attributes:\n"
+                + "        currency:\n"
+                + "          extractor: com.bank.CurrencyExtractor\n"
+                + "      partition-lost-listeners:\n"
+                + "         - com.your-package.YourPartitionLostListener\n"
+                + "      entry-listeners:\n"
+                + "         - class-name: com.your-package.MyEntryListener\n"
+                + "           include-value: false\n"
+                + "           local: false\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("foobar");
+
+        assertFalse(config.getMapConfigs().isEmpty());
+        assertEquals("customQuorumRule", mapConfig.getQuorumName());
+        assertEquals(InMemoryFormat.BINARY, mapConfig.getInMemoryFormat());
+        assertTrue(mapConfig.isStatisticsEnabled());
+        assertFalse(mapConfig.isOptimizeQueries());
+        assertEquals(CacheDeserializedValues.INDEX_ONLY, mapConfig.getCacheDeserializedValues());
+        assertEquals(2, mapConfig.getBackupCount());
+        assertEquals(1, mapConfig.getAsyncBackupCount());
+        assertEquals(1, mapConfig.getAsyncBackupCount());
+        assertEquals(42, mapConfig.getTimeToLiveSeconds());
+        assertEquals(42, mapConfig.getMaxIdleSeconds());
+        assertEquals(EvictionPolicy.RANDOM, mapConfig.getEvictionPolicy());
+        assertEquals(MaxSizeConfig.MaxSizePolicy.PER_NODE, mapConfig.getMaxSizeConfig().getMaxSizePolicy());
+        assertEquals(42, mapConfig.getMaxSizeConfig().getSize());
+        assertEquals(25, mapConfig.getEvictionPercentage());
+        assertEquals(256, mapConfig.getMinEvictionCheckMillis());
+        assertTrue(mapConfig.isReadBackupData());
+        assertEquals(1, mapConfig.getMapIndexConfigs().size());
+        assertEquals("age", mapConfig.getMapIndexConfigs().get(0).getAttribute());
+        assertTrue(mapConfig.getMapIndexConfigs().get(0).isOrdered());
+        assertEquals(1, mapConfig.getMapAttributeConfigs().size());
+        assertEquals("com.bank.CurrencyExtractor", mapConfig.getMapAttributeConfigs().get(0).getExtractor());
+        assertEquals("currency", mapConfig.getMapAttributeConfigs().get(0).getName());
+        assertEquals(1, mapConfig.getPartitionLostListenerConfigs().size());
+        assertEquals("com.your-package.YourPartitionLostListener",
+                mapConfig.getPartitionLostListenerConfigs().get(0).getClassName());
+        assertEquals(1, mapConfig.getEntryListenerConfigs().size());
+        assertFalse(mapConfig.getEntryListenerConfigs().get(0).isIncludeValue());
+        assertFalse(mapConfig.getEntryListenerConfigs().get(0).isLocal());
+        assertEquals("com.your-package.MyEntryListener", mapConfig.getEntryListenerConfigs().get(0).getClassName());
+        assertFalse(mapConfig.getHotRestartConfig().isEnabled());
+        assertFalse(mapConfig.getHotRestartConfig().isFsync());
+
+        MapStoreConfig mapStoreConfig = mapConfig.getMapStoreConfig();
+        assertNotNull(mapStoreConfig);
+        assertTrue(mapStoreConfig.isEnabled());
+        assertEquals(MapStoreConfig.InitialLoadMode.LAZY, mapStoreConfig.getInitialLoadMode());
+        assertEquals(42, mapStoreConfig.getWriteDelaySeconds());
+        assertEquals(42, mapStoreConfig.getWriteBatchSize());
+        assertTrue(mapStoreConfig.isWriteCoalescing());
+        assertEquals("com.hazelcast.examples.DummyStore", mapStoreConfig.getClassName());
+        assertEquals(1, mapStoreConfig.getProperties().size());
+        assertEquals("my.jdbc.com", mapStoreConfig.getProperties().getProperty("jdbc_url"));
+
+        NearCacheConfig nearCacheConfig = mapConfig.getNearCacheConfig();
+        assertNotNull(nearCacheConfig);
+        assertEquals(5000, nearCacheConfig.getMaxSize());
+        assertEquals(42, nearCacheConfig.getMaxIdleSeconds());
+        assertEquals(42, nearCacheConfig.getTimeToLiveSeconds());
+        assertEquals(InMemoryFormat.BINARY, nearCacheConfig.getInMemoryFormat());
+        assertFalse(nearCacheConfig.isCacheLocalEntries());
+        assertTrue(nearCacheConfig.isInvalidateOnChange());
+        assertEquals(1000, nearCacheConfig.getEvictionConfig().getSize());
+        assertEquals(EvictionPolicy.LFU, nearCacheConfig.getEvictionConfig().getEvictionPolicy());
+        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, nearCacheConfig.getEvictionConfig().getMaximumSizePolicy());
+
+        WanReplicationRef wanReplicationRef = mapConfig.getWanReplicationRef();
+        assertNotNull(wanReplicationRef);
+        assertFalse(wanReplicationRef.isRepublishingEnabled());
+        assertEquals("com.hazelcast.map.merge.PassThroughMergePolicy", wanReplicationRef.getMergePolicy());
+        assertEquals(1, wanReplicationRef.getFilters().size());
+        assertEquals("com.example.SampleFilter".toLowerCase(), wanReplicationRef.getFilters().get(0).toLowerCase());
+    }
+
+    @Override
+    public void testIndexesConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    people:\n"
+                + "      indexes:\n"
+                + "        name:\n"
+                + "          ordered: false\n"
+                + "        age:\n"
+                + "          ordered: true\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("people");
+
+        assertFalse(mapConfig.getMapIndexConfigs().isEmpty());
+        assertIndexEqual("name", false, mapConfig.getMapIndexConfigs().get(0));
+        assertIndexEqual("age", true, mapConfig.getMapIndexConfigs().get(1));
+    }
+
+    @Override
+    public void testAttributeConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    people:\n"
+                + "      attributes:\n"
+                + "        power:\n"
+                + "          extractor: com.car.PowerExtractor\n"
+                + "        weight:\n"
+                + "          extractor: com.car.WeightExtractor\n";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("people");
+
+        assertFalse(mapConfig.getMapAttributeConfigs().isEmpty());
+        assertAttributeEqual("power", "com.car.PowerExtractor", mapConfig.getMapAttributeConfigs().get(0));
+        assertAttributeEqual("weight", "com.car.WeightExtractor", mapConfig.getMapAttributeConfigs().get(1));
+    }
+
+    @Override
+    @Test(expected = IllegalArgumentException.class)
+    public void testAttributeConfig_noName_emptyTag() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    people:\n"
+                + "      attributes:\n"
+                + "        - extractor: com.car.WeightExtractor\n";
+
+        buildConfig(yaml);
+    }
+
+    private static void assertAttributeEqual(String expectedName, String expectedExtractor, MapAttributeConfig attributeConfig) {
+        assertEquals(expectedName, attributeConfig.getName());
+        assertEquals(expectedExtractor, attributeConfig.getExtractor());
+    }
+
+    @Override
+    @Test(expected = IllegalArgumentException.class)
+    public void testAttributeConfig_noName_singleTag() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "   people:\n"
+                + "     attributes:\n"
+                + "       - extractor: com.car.WeightExtractor\n";
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = IllegalArgumentException.class)
+    public void testAttributeConfig_noExtractor() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    people:\n"
+                + "      attributes:\n"
+                + "        weight: {}\n";
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = IllegalArgumentException.class)
+    public void testAttributeConfig_emptyExtractor() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    people:\n"
+                + "      attributes:\n"
+                + "        weight:\n"
+                + "          extractor:\n";
+        buildConfig(yaml);
+    }
+
+    @Override
+    public void testQueryCacheFullConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    test:\n"
+                + "      query-caches:\n"
+                + "        cache-name:\n"
+                + "          entry-listeners:\n"
+                + "            - class-name: com.hazelcast.examples.EntryListener\n"
+                + "              include-value: true\n"
+                + "              local: false\n"
+                + "          include-value: true\n"
+                + "          batch-size: 1\n"
+                + "          buffer-size: 16\n"
+                + "          delay-seconds: 0\n"
+                + "          in-memory-format: BINARY\n"
+                + "          coalesce: false\n"
+                + "          populate: true\n"
+                + "          indexes:\n"
+                + "            name:\n"
+                + "              ordered: false\n"
+                + "          predicate:\n"
+                + "            class-name: com.hazelcast.examples.SimplePredicate\n"
+                + "          eviction:\n"
+                + "            eviction-policy: LRU\n"
+                + "            max-size-policy: ENTRY_COUNT\n"
+                + "            size: 133\n";
+
+        Config config = buildConfig(yaml);
+        QueryCacheConfig queryCacheConfig = config.getMapConfig("test").getQueryCacheConfigs().get(0);
+        EntryListenerConfig entryListenerConfig = queryCacheConfig.getEntryListenerConfigs().get(0);
+
+        assertEquals("cache-name", queryCacheConfig.getName());
+        assertTrue(entryListenerConfig.isIncludeValue());
+        assertFalse(entryListenerConfig.isLocal());
+        assertEquals("com.hazelcast.examples.EntryListener", entryListenerConfig.getClassName());
+        assertTrue(queryCacheConfig.isIncludeValue());
+        assertEquals(1, queryCacheConfig.getBatchSize());
+        assertEquals(16, queryCacheConfig.getBufferSize());
+        assertEquals(0, queryCacheConfig.getDelaySeconds());
+        assertEquals(InMemoryFormat.BINARY, queryCacheConfig.getInMemoryFormat());
+        assertFalse(queryCacheConfig.isCoalesce());
+        assertTrue(queryCacheConfig.isPopulate());
+        assertIndexesEqual(queryCacheConfig);
+        assertEquals("com.hazelcast.examples.SimplePredicate", queryCacheConfig.getPredicateConfig().getClassName());
+        assertEquals(LRU, queryCacheConfig.getEvictionConfig().getEvictionPolicy());
+        assertEquals(ENTRY_COUNT, queryCacheConfig.getEvictionConfig().getMaximumSizePolicy());
+        assertEquals(133, queryCacheConfig.getEvictionConfig().getSize());
+    }
+
+    private void assertIndexesEqual(QueryCacheConfig queryCacheConfig) {
+        for (MapIndexConfig mapIndexConfig : queryCacheConfig.getIndexConfigs()) {
+            assertEquals("name", mapIndexConfig.getAttribute());
+            assertFalse(mapIndexConfig.isOrdered());
+        }
+    }
+
+    @Override
+    public void testMapQueryCachePredicate() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    test:\n"
+                + "      query-caches:\n"
+                + "        cache-class-name:\n"
+                + "          predicate:\n"
+                + "            class-name: com.hazelcast.examples.SimplePredicate\n"
+                + "        cache-sql:\n"
+                + "          predicate:\n"
+                + "            sql: \"%age=40\"\n";
+
+        Config config = buildConfig(yaml);
+        QueryCacheConfig queryCacheClassNameConfig = config.getMapConfig("test").getQueryCacheConfigs().get(0);
+        assertEquals("com.hazelcast.examples.SimplePredicate", queryCacheClassNameConfig.getPredicateConfig().getClassName());
+
+        QueryCacheConfig queryCacheSqlConfig = config.getMapConfig("test").getQueryCacheConfigs().get(1);
+        assertEquals("%age=40", queryCacheSqlConfig.getPredicateConfig().getSql());
+    }
+
+    @Override
+    public void testLiteMemberConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  lite-member:\n"
+                + "    enabled: true\n";
+
+        Config config = buildConfig(yaml);
+
+        assertTrue(config.isLiteMember());
+    }
+
+    @Override
+    public void testNonLiteMemberConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  lite-member:\n"
+                + "    enabled: false\n";
+
+        Config config = buildConfig(yaml);
+
+        assertFalse(config.isLiteMember());
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    @Ignore("Schema validation is supposed to fail with missing mandatory field: enabled")
+    public void testNonLiteMemberConfigWithoutEnabledField() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  lite-member: {}\n";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    @Ignore("Schema validation is supposed to fail with invalid boolean in enabled")
+    public void testInvalidLiteMemberConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  lite-member:\n"
+                + "    enabled: dummytext\n";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testDuplicateLiteMemberConfig() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  lite-member:\n"
+                + "    enabled: true\n"
+                + "  lite-member:\n"
+                + "    enabled: true\n";
+
+        buildConfig(yaml);
+        fail();
+    }
+
+    private static void assertIndexEqual(String expectedAttribute, boolean expectedOrdered, MapIndexConfig indexConfig) {
+        assertEquals(expectedAttribute, indexConfig.getAttribute());
+        assertEquals(expectedOrdered, indexConfig.isOrdered());
+    }
+
+    @Override
+    public void testMapNativeMaxSizePolicy() {
+        String yamlFormat = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      in-memory-format: NATIVE\n"
+                + "      max-size:\n"
+                + "        policy: \"{0}\"\n"
+                + "        max-size: 9991\n";
+        MessageFormat messageFormat = new MessageFormat(yamlFormat);
+
+        MaxSizeConfig.MaxSizePolicy[] maxSizePolicies = MaxSizeConfig.MaxSizePolicy.values();
+        for (MaxSizeConfig.MaxSizePolicy maxSizePolicy : maxSizePolicies) {
+            Object[] objects = {maxSizePolicy.toString()};
+            String yaml = messageFormat.format(objects);
+            Config config = buildConfig(yaml);
+            MapConfig mapConfig = config.getMapConfig("mymap");
+            MaxSizeConfig maxSizeConfig = mapConfig.getMaxSizeConfig();
+
+            assertEquals(9991, maxSizeConfig.getSize());
+            assertEquals(maxSizePolicy, maxSizeConfig.getMaxSizePolicy());
+        }
+    }
+
+    @Override
+    public void testInstanceName() {
+        String name = randomName();
+        String yaml = ""
+                + "hazelcast:\n"
+                + " instance-name: " + name + "\n";
+
+        Config config = buildConfig(yaml);
+        assertEquals(name, config.getInstanceName());
+    }
+
+    @Override
+    public void testUserCodeDeployment() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  user-code-deployment:\n"
+                + "    enabled: true\n"
+                + "    class-cache-mode: OFF\n"
+                + "    provider-mode: LOCAL_CLASSES_ONLY\n"
+                + "    blacklist-prefixes: com.blacklisted,com.other.blacklisted\n"
+                + "    whitelist-prefixes: com.whitelisted,com.other.whitelisted\n"
+                + "    provider-filter: HAS_ATTRIBUTE:foo\n";
+
+        Config config = new InMemoryYamlConfig(yaml);
+        UserCodeDeploymentConfig dcConfig = config.getUserCodeDeploymentConfig();
+        assertTrue(dcConfig.isEnabled());
+        assertEquals(UserCodeDeploymentConfig.ClassCacheMode.OFF, dcConfig.getClassCacheMode());
+        assertEquals(UserCodeDeploymentConfig.ProviderMode.LOCAL_CLASSES_ONLY, dcConfig.getProviderMode());
+        assertEquals("com.blacklisted,com.other.blacklisted", dcConfig.getBlacklistedPrefixes());
+        assertEquals("com.whitelisted,com.other.whitelisted", dcConfig.getWhitelistedPrefixes());
+        assertEquals("HAS_ATTRIBUTE:foo", dcConfig.getProviderFilter());
+    }
+
+    @Override
+    public void testCRDTReplicationConfig() {
+        final String yaml = ""
+                + "hazelcast:\n"
+                + "  crdt-replication:\n"
+                + "    max-concurrent-replication-targets: 10\n"
+                + "    replication-period-millis: 2000\n";
+
+        final Config config = new InMemoryYamlConfig(yaml);
+        final CRDTReplicationConfig replicationConfig = config.getCRDTReplicationConfig();
+        assertEquals(10, replicationConfig.getMaxConcurrentReplicationTargets());
+        assertEquals(2000, replicationConfig.getReplicationPeriodMillis());
+    }
+
+    @Override
+    public void testGlobalSerializer() {
+        String name = randomName();
+        String val = "true";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  serialization:\n"
+                + "    global-serializer:\n"
+                + "      class-name: " + name + "\n"
+                + "      override-java-serialization: " + val + "\n";
+
+        Config config = new InMemoryYamlConfig(yaml);
+        GlobalSerializerConfig globalSerializerConfig = config.getSerializationConfig().getGlobalSerializerConfig();
+        assertEquals(name, globalSerializerConfig.getClassName());
+        assertTrue(globalSerializerConfig.isOverrideJavaSerialization());
+    }
+
+    @Override
+    public void testJavaSerializationFilter() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  serialization:\n"
+                + "    java-serialization-filter:\n"
+                + "      defaults-disabled: true\n"
+                + "      whitelist:\n"
+                + "        class:\n"
+                + "          - java.lang.String\n"
+                + "          - example.Foo\n"
+                + "        package:\n"
+                + "          - com.acme.app\n"
+                + "          - com.acme.app.subpkg\n"
+                + "        prefix:\n"
+                + "          - java\n"
+                + "          - com.hazelcast.\n"
+                + "          - \"[\"\n"
+                + "      blacklist:\n"
+                + "        class:\n"
+                + "          - com.acme.app.BeanComparator\n";
+
+        Config config = new InMemoryYamlConfig(yaml);
+        JavaSerializationFilterConfig javaSerializationFilterConfig
+                = config.getSerializationConfig().getJavaSerializationFilterConfig();
+        assertNotNull(javaSerializationFilterConfig);
+        ClassFilter blackList = javaSerializationFilterConfig.getBlacklist();
+        assertNotNull(blackList);
+        ClassFilter whiteList = javaSerializationFilterConfig.getWhitelist();
+        assertNotNull(whiteList);
+        assertTrue(whiteList.getClasses().contains("java.lang.String"));
+        assertTrue(whiteList.getClasses().contains("example.Foo"));
+        assertTrue(whiteList.getPackages().contains("com.acme.app"));
+        assertTrue(whiteList.getPackages().contains("com.acme.app.subpkg"));
+        assertTrue(whiteList.getPrefixes().contains("java"));
+        assertTrue(whiteList.getPrefixes().contains("["));
+        assertTrue(blackList.getClasses().contains("com.acme.app.BeanComparator"));
+    }
+
+    @Override
+    public void testHotRestart() {
+        String dir = "/mnt/hot-restart-root/";
+        String backupDir = "/mnt/hot-restart-backup/";
+        int parallelism = 3;
+        int validationTimeout = 13131;
+        int dataLoadTimeout = 45454;
+        HotRestartClusterDataRecoveryPolicy policy = HotRestartClusterDataRecoveryPolicy.PARTIAL_RECOVERY_MOST_RECENT;
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  hot-restart-persistence:\n"
+                + "    enabled: true\n"
+                + "    base-dir: " + dir + "\n"
+                + "    backup-dir: " + backupDir + "\n"
+                + "    parallelism: " + parallelism + "\n"
+                + "    validation-timeout-seconds: " + validationTimeout + "\n"
+                + "    data-load-timeout-seconds: " + dataLoadTimeout + "\n"
+                + "    cluster-data-recovery-policy: " + policy + "\n";
+
+        Config config = new InMemoryYamlConfig(yaml);
+        HotRestartPersistenceConfig hotRestartPersistenceConfig = config.getHotRestartPersistenceConfig();
+
+        assertTrue(hotRestartPersistenceConfig.isEnabled());
+        assertEquals(new File(dir).getAbsolutePath(), hotRestartPersistenceConfig.getBaseDir().getAbsolutePath());
+        assertEquals(new File(backupDir).getAbsolutePath(), hotRestartPersistenceConfig.getBackupDir().getAbsolutePath());
+        assertEquals(parallelism, hotRestartPersistenceConfig.getParallelism());
+        assertEquals(validationTimeout, hotRestartPersistenceConfig.getValidationTimeoutSeconds());
+        assertEquals(dataLoadTimeout, hotRestartPersistenceConfig.getDataLoadTimeoutSeconds());
+        assertEquals(policy, hotRestartPersistenceConfig.getClusterDataRecoveryPolicy());
+    }
+
+    @Override
+    public void testMapEvictionPolicyClassName() {
+        String mapEvictionPolicyClassName = "com.hazelcast.map.eviction.LRUEvictionPolicy";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    test:\n"
+                + "      map-eviction-policy-class-name: " + mapEvictionPolicyClassName;
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("test");
+
+        assertEquals(mapEvictionPolicyClassName, mapConfig.getMapEvictionPolicy().getClass().getName());
+    }
+
+    @Override
+    public void testMapEvictionPolicyIsSelected_whenEvictionPolicySet() {
+        String mapEvictionPolicyClassName = "com.hazelcast.map.eviction.LRUEvictionPolicy";
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    test:\n"
+                + "      map-eviction-policy-class-name: " + mapEvictionPolicyClassName + "\n"
+                + "      eviction-policy: LFU";
+
+        Config config = buildConfig(yaml);
+        MapConfig mapConfig = config.getMapConfig("test");
+
+        assertEquals(mapEvictionPolicyClassName, mapConfig.getMapEvictionPolicy().getClass().getName());
+    }
+
+    @Override
+    public void testCachePermission() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  security:\n"
+                + "    enabled: true\n"
+                + "    client-permissions:\n"
+                + "      cache:\n"
+                + "        - name: /hz/cachemanager1/cache1\n"
+                + "          principal: dev\n"
+                + "          actions:\n"
+                + "            - create\n"
+                + "            - destroy\n"
+                + "            - add\n"
+                + "            - remove\n";
+
+        Config config = buildConfig(yaml);
+        PermissionConfig expected = new PermissionConfig(CACHE, "/hz/cachemanager1/cache1", "dev");
+        expected.addAction("create").addAction("destroy").addAction("add").addAction("remove");
+        assertPermissionConfig(expected, config);
+    }
+
+    @Override
+    public void testConfigPermission() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  security:\n"
+                + "    enabled: true\n"
+                + "    client-permissions:\n"
+                + "      config:\n"
+                + "        principal: dev\n"
+                + "        endpoints:\n"
+                + "          - 127.0.0.1";
+
+        Config config = buildConfig(yaml);
+        PermissionConfig expected = new PermissionConfig(CONFIG, "*", "dev");
+        expected.getEndpoints().add("127.0.0.1");
+        assertPermissionConfig(expected, config);
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    public void testCacheConfig_withInvalidEvictionConfig_failsFast() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  cache:\n"
+                + "    cache:\n"
+                + "      eviction:\n"
+                + "        size: 10000000\n"
+                + "        max-size-policy: ENTRY_COUNT\n"
+                + "        eviction-policy: LFU\n"
+                + "      in-memory-format: NATIVE\n";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    public void testAllPermissionsCovered() {
+        InputStream yamlResource = YamlConfigBuilderTest.class.getClassLoader().getResourceAsStream("hazelcast-fullconfig.yaml");
+        Config config = null;
+        try {
+            config = new YamlConfigBuilder(yamlResource).build();
+        } finally {
+            IOUtil.closeResource(yamlResource);
+        }
+        Set<PermissionConfig.PermissionType> permTypes = new HashSet<PermissionConfig.PermissionType>(Arrays
+                .asList(PermissionConfig.PermissionType.values()));
+        for (PermissionConfig pc : config.getSecurityConfig().getClientPermissionConfigs()) {
+            permTypes.remove(pc.getType());
+        }
+        assertTrue("All permission types should be listed in hazelcast-fullconfig.yaml. Not found ones: " + permTypes,
+                permTypes.isEmpty());
+    }
+
+    @Override
+    @Test(expected = InvalidConfigurationException.class)
+    @Ignore("Schema validation is supposed to fail with missing mandatory field: class-name")
+    public void testMemberAddressProvider_classNameIsMandatory() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    member-address-provider:\n"
+                + "      enabled: true\n";
+
+        buildConfig(yaml);
+    }
+
+    @Override
+    public void testMemberAddressProviderEnabled() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    member-address-provider:\n"
+                + "      enabled: true\n"
+                + "      class-name: foo.bar.Clazz\n";
+
+        Config config = buildConfig(yaml);
+        MemberAddressProviderConfig memberAddressProviderConfig = config.getNetworkConfig().getMemberAddressProviderConfig();
+
+        assertTrue(memberAddressProviderConfig.isEnabled());
+        assertEquals("foo.bar.Clazz", memberAddressProviderConfig.getClassName());
+    }
+
+    @Override
+    public void testMemberAddressProviderEnabled_withProperties() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    member-address-provider:\n"
+                + "      enabled: true\n"
+                + "      class-name: foo.bar.Clazz\n"
+                + "      properties:\n"
+                + "        propName1: propValue1\n";
+
+        Config config = buildConfig(yaml);
+        MemberAddressProviderConfig memberAddressProviderConfig = config.getNetworkConfig().getMemberAddressProviderConfig();
+
+        Properties properties = memberAddressProviderConfig.getProperties();
+        assertEquals(1, properties.size());
+        assertEquals("propValue1", properties.get("propName1"));
+    }
+
+    @Override
+    public void testFailureDetector_withProperties() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    failure-detector:\n"
+                + "      icmp:\n"
+                + "        enabled: true\n"
+                + "        timeout-milliseconds: 42\n"
+                + "        fail-fast-on-startup: true\n"
+                + "        interval-milliseconds: 4200\n"
+                + "        max-attempts: 42\n"
+                + "        parallel-mode: true\n"
+                + "        ttl: 255\n";
+
+        Config config = buildConfig(yaml);
+        NetworkConfig networkConfig = config.getNetworkConfig();
+        IcmpFailureDetectorConfig icmpFailureDetectorConfig = networkConfig.getIcmpFailureDetectorConfig();
+        assertNotNull(icmpFailureDetectorConfig);
+
+        assertTrue(icmpFailureDetectorConfig.isEnabled());
+        assertTrue(icmpFailureDetectorConfig.isParallelMode());
+        assertTrue(icmpFailureDetectorConfig.isFailFastOnStartup());
+        assertEquals(42, icmpFailureDetectorConfig.getTimeoutMilliseconds());
+        assertEquals(42, icmpFailureDetectorConfig.getMaxAttempts());
+        assertEquals(4200, icmpFailureDetectorConfig.getIntervalMilliseconds());
+    }
+
+    @Override
+    public void testHandleMemberAttributes() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  member-attributes:\n"
+                + "    IDENTIFIER:\n"
+                + "      type: string\n"
+                + "      value: ID\n";
+
+        Config config = buildConfig(yaml);
+        MemberAttributeConfig memberAttributeConfig = config.getMemberAttributeConfig();
+        assertNotNull(memberAttributeConfig);
+        assertEquals("ID", memberAttributeConfig.getStringAttribute("IDENTIFIER"));
+    }
+
+    @Override
+    public void testMemcacheProtocolEnabled() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  memcache-protocol:\n"
+                + "    enabled: true\n";
+        Config config = buildConfig(yaml);
+        MemcacheProtocolConfig memcacheProtocolConfig = config.getMemcacheProtocolConfig();
+        assertNotNull(memcacheProtocolConfig);
+        assertTrue(memcacheProtocolConfig.isEnabled());
+    }
+
+    @Override
+    public void testRestApiDefaults() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  rest-api:\n"
+                + "    enabled: false";
+        Config config = buildConfig(yaml);
+        RestApiConfig restApiConfig = config.getRestApiConfig();
+        assertNotNull(restApiConfig);
+        assertFalse(restApiConfig.isEnabled());
+        for (RestEndpointGroup group : RestEndpointGroup.values()) {
+            assertEquals("Unexpected status of group " + group, group.isEnabledByDefault(),
+                    restApiConfig.isGroupEnabled(group));
+        }
+    }
+
+    @Override
+    public void testRestApiEndpointGroups() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  rest-api:\n"
+                + "    enabled: true\n"
+                + "    endpoint-groups:\n"
+                + "      HEALTH_CHECK:\n "
+                + "        enabled: true\n"
+                + "      DATA:\n"
+                + "        enabled: true\n"
+                + "      CLUSTER_READ:\n"
+                + "        enabled: false";
+        Config config = buildConfig(yaml);
+        RestApiConfig restApiConfig = config.getRestApiConfig();
+        assertTrue(restApiConfig.isEnabled());
+        assertTrue(restApiConfig.isGroupEnabled(RestEndpointGroup.HEALTH_CHECK));
+        assertFalse(restApiConfig.isGroupEnabled(RestEndpointGroup.CLUSTER_READ));
+        assertEquals(RestEndpointGroup.CLUSTER_WRITE.isEnabledByDefault(),
+                restApiConfig.isGroupEnabled(RestEndpointGroup.CLUSTER_WRITE));
+
+    }
+
+    @Override
+    public void testUnknownRestApiEndpointGroup() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  rest-api:\n"
+                + "    enabled: true\n"
+                + "    endpoint-groups:\n"
+                + "      TEST:\n"
+                + "        enabled: true";
+        buildConfig(yaml);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -82,6 +82,7 @@ import static org.junit.Assert.fail;
 public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
+    @Test
     public void testConfigurationURL() throws Exception {
         URL configURL = getClass().getClassLoader().getResource("hazelcast-default.yaml");
         Config config = new YamlConfigBuilder(configURL).build();
@@ -89,6 +90,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testConfigurationWithFileName() throws Exception {
         assumeThatNotZingJDK6(); // https://github.com/hazelcast/hazelcast/issues/9044
 
@@ -141,6 +143,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testSecurityInterceptorConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -234,6 +237,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readAwsConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -266,6 +270,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readGcpConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -288,6 +293,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readAzureConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -310,6 +316,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readKubernetesConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -332,6 +339,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readEurekaConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -354,6 +362,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readDiscoveryConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -385,6 +394,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testSSLConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -404,6 +414,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testSymmetricEncryptionConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -425,6 +436,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readPortCount() {
         // check when it is explicitly set
         Config config = buildConfig(""
@@ -446,6 +458,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readPortAutoIncrement() {
         // explicitly set
         Config config = buildConfig(""
@@ -465,6 +478,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void networkReuseAddress() {
         Config config = buildConfig(""
                 + "hazelcast:\n"
@@ -474,6 +488,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readSemaphoreConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -493,6 +508,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readQueueConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -561,6 +577,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readListConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -608,6 +625,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readSetConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -655,6 +673,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readLockConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -672,6 +691,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readReliableTopic() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -708,6 +728,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readRingbuffer() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -755,6 +776,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readAtomicLong() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -781,6 +803,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readAtomicReference() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -807,6 +830,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readCountDownLatch() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -826,6 +850,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCaseInsensitivityOfSettings() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -858,6 +883,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testManagementCenterConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -875,6 +901,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testManagementCenterConfigComplex() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -898,6 +925,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNullManagementCenterConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -911,6 +939,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testEmptyManagementCenterConfig() {
         String yaml = "hazelcast: {}";
 
@@ -922,6 +951,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNotEnabledManagementCenterConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -935,6 +965,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNotEnabledWithURLManagementCenterConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -950,6 +981,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testManagementCenterConfigComplexDisabledMutualAuth() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -968,6 +1000,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreInitialModeLazy() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -985,6 +1018,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_minEvictionCheckMillis() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -999,6 +1033,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_minEvictionCheckMillis_defaultValue() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1012,6 +1047,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_preprocessingPolicy() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1026,6 +1062,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_preprocessingPolicy_defaultValue() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1039,6 +1076,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_evictions() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1064,6 +1102,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_optimizeQueries() {
         String yaml1 = ""
                 + "hazelcast:\n"
@@ -1088,6 +1127,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_cacheValueConfig_defaultValue() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1101,6 +1141,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_cacheValueConfig_never() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1115,6 +1156,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_cacheValueConfig_always() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1129,6 +1171,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig_cacheValueConfig_indexOnly() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1143,6 +1186,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreInitialModeEager() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1160,6 +1204,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreWriteBatchSize() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1175,6 +1220,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreConfig_writeCoalescing_whenDefault() {
         MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(MapStoreConfig.DEFAULT_WRITE_COALESCING, true);
 
@@ -1182,6 +1228,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreConfig_writeCoalescing_whenSetFalse() {
         MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(false, false);
 
@@ -1189,6 +1236,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapStoreConfig_writeCoalescing_whenSetTrue() {
         MapStoreConfig mapStoreConfig = getWriteCoalescingMapStoreConfig(true, false);
 
@@ -1211,6 +1259,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNearCacheInMemoryFormat() {
         String mapName = "testMapNearCacheInMemoryFormat";
         String yaml = ""
@@ -1228,6 +1277,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNearCacheInMemoryFormatNative_withKeysByReference() {
         String mapName = "testMapNearCacheInMemoryFormatNative";
         String yaml = ""
@@ -1247,6 +1297,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNearCacheEvictionPolicy() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1282,6 +1333,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testPartitionGroupZoneAware() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1296,6 +1348,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testPartitionGroupSPI() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1308,6 +1361,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testPartitionGroupMemberGroups() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1339,6 +1393,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNearCacheFullConfig() {
         String mapName = "testNearCacheFullConfig";
         String yaml = ""
@@ -1378,6 +1433,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapWanReplicationRef() {
         String mapName = "testMapWanReplicationRef";
         String refName = "test";
@@ -1404,6 +1460,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testWanReplicationConfig() {
         String configName = "test";
         String yaml = ""
@@ -1456,7 +1513,8 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
-    public void default_value_of_persist_wan_replicated_data_is_false() {
+    @Test
+    public void testDefaultOfPersistWanReplicatedDataIsFalse() {
         String configName = "test";
         String yaml = ""
                 + "hazelcast:\n"
@@ -1471,6 +1529,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testWanReplicationSyncConfig() {
         String configName = "test";
         String yaml = ""
@@ -1497,6 +1556,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapEventJournalConfig() {
         String journalName = "mapName";
         String journal2Name = "map2Name";
@@ -1523,6 +1583,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapMerkleTreeConfig() {
         String mapName = "mapName";
         String map2Name = "map2Name";
@@ -1548,6 +1609,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCacheEventJournalConfig() {
         String journalName = "cacheName";
         String journal2Name = "cache2Name";
@@ -1574,6 +1636,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testFlakeIdGeneratorConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1611,6 +1674,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void setMapStoreConfigImplementationTest() {
         String mapName = "mapStoreImpObjTest";
         String yaml = ""
@@ -1637,6 +1701,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapPartitionLostListenerConfig() {
         String mapName = "map1";
         String listenerName = "DummyMapPartitionLostListenerImpl";
@@ -1648,6 +1713,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapPartitionLostListenerConfigReadOnly() {
         String mapName = "map1";
         String listenerName = "DummyMapPartitionLostListenerImpl";
@@ -1673,6 +1739,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCachePartitionLostListenerConfig() {
         String cacheName = "cache1";
         String listenerName = "DummyCachePartitionLostListenerImpl";
@@ -1684,6 +1751,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCachePartitionLostListenerConfigReadOnly() {
         String cacheName = "cache1";
         String listenerName = "DummyCachePartitionLostListenerImpl";
@@ -1709,6 +1777,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void readMulticastConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1739,6 +1808,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testWanConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1858,6 +1928,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1879,6 +1950,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumListenerConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1947,6 +2019,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumConfig_whenRecentlyActiveQuorum_withDefaultValues() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1966,6 +2039,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumConfig_whenRecentlyActiveQuorum_withCustomValues() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -1986,6 +2060,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumConfig_whenProbabilisticQuorum_withDefaultValues() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2010,6 +2085,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQuorumConfig_whenProbabilisticQuorum_withCustomValues() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2036,6 +2112,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCacheConfig() {
         // TODO do we really need to keep the 'class-name' keys?
         String yaml = ""
@@ -2115,6 +2192,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testExecutorConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2136,6 +2214,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testDurableExecutorConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2157,6 +2236,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testScheduledExecutorConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2183,6 +2263,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCardinalityEstimatorConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2223,6 +2304,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testPNCounterConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2242,6 +2324,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMultiMapConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2280,6 +2363,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testReplicatedMapConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2308,6 +2392,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testListConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2342,6 +2427,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testSetConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2376,6 +2462,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2508,6 +2595,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testIndexesConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2528,6 +2616,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testAttributeConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2603,6 +2692,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testQueryCacheFullConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2661,6 +2751,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapQueryCachePredicate() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2683,6 +2774,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testLiteMemberConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2695,6 +2787,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testNonLiteMemberConfig() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2749,6 +2842,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapNativeMaxSizePolicy() {
         String yamlFormat = ""
                 + "hazelcast:\n"
@@ -2774,6 +2868,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testInstanceName() {
         String name = randomName();
         String yaml = ""
@@ -2785,6 +2880,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testUserCodeDeployment() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2807,6 +2903,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCRDTReplicationConfig() {
         final String yaml = ""
                 + "hazelcast:\n"
@@ -2821,6 +2918,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testGlobalSerializer() {
         String name = randomName();
         String val = "true";
@@ -2838,6 +2936,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testJavaSerializationFilter() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2877,6 +2976,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testHotRestart() {
         String dir = "/mnt/hot-restart-root/";
         String backupDir = "/mnt/hot-restart-backup/";
@@ -2908,6 +3008,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapEvictionPolicyClassName() {
         String mapEvictionPolicyClassName = "com.hazelcast.map.eviction.LRUEvictionPolicy";
         String yaml = ""
@@ -2923,6 +3024,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMapEvictionPolicyIsSelected_whenEvictionPolicySet() {
         String mapEvictionPolicyClassName = "com.hazelcast.map.eviction.LRUEvictionPolicy";
         String yaml = ""
@@ -2939,6 +3041,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testCachePermission() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2961,6 +3064,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testConfigPermission() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -2980,7 +3084,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test(expected = InvalidConfigurationException.class)
-    public void testCacheConfig_withInvalidEvictionConfig_failsFast() {
+    public void testCacheConfig_withNativeInMemoryFormat_failsFastInOSS() {
         String yaml = ""
                 + "hazelcast:\n"
                 + "  cache:\n"
@@ -2995,6 +3099,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testAllPermissionsCovered() {
         InputStream yamlResource = YamlConfigBuilderTest.class.getClassLoader().getResourceAsStream("hazelcast-fullconfig.yaml");
         Config config = null;
@@ -3026,6 +3131,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMemberAddressProviderEnabled() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -3042,6 +3148,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMemberAddressProviderEnabled_withProperties() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -3061,6 +3168,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testFailureDetector_withProperties() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -3089,6 +3197,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testHandleMemberAttributes() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -3104,6 +3213,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testMemcacheProtocolEnabled() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -3116,6 +3226,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testRestApiDefaults() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -3132,6 +3243,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test
     public void testRestApiEndpointGroups() {
         String yaml = ""
                 + "hazelcast:\n"
@@ -3155,6 +3267,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    @Test(expected = InvalidConfigurationException.class)
     public void testUnknownRestApiEndpointGroup() {
         String yaml = ""
                 + "hazelcast:\n"

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigWithSystemPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigWithSystemPropertyTest.java
@@ -30,8 +30,6 @@ import java.io.PrintWriter;
 import java.net.URL;
 import java.net.URLDecoder;
 
-import static com.hazelcast.config.XMLConfigBuilderTest.HAZELCAST_END_TAG;
-import static com.hazelcast.config.XMLConfigBuilderTest.HAZELCAST_START_TAG;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -39,11 +37,11 @@ import static org.junit.Assert.assertNotNull;
 /**
  * These tests manipulate system properties, therefore they must be run in serial mode.
  *
- * @see YamlConfigWithSystemPropertyTest
+ * @see XMLConfigWithSystemPropertyTest
  */
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
-public class XMLConfigWithSystemPropertyTest {
+public class YamlConfigWithSystemPropertyTest {
 
     @Before
     @After
@@ -53,11 +51,11 @@ public class XMLConfigWithSystemPropertyTest {
 
     @Test
     public void testConfigurationWithFile() throws Exception {
-        URL url = getClass().getClassLoader().getResource("hazelcast-default.xml");
+        URL url = getClass().getClassLoader().getResource("hazelcast-default.yaml");
         assertNotNull(url);
         String decodedURL = URLDecoder.decode(url.getFile(), "UTF-8");
         System.setProperty("hazelcast.config", decodedURL);
-        Config config = new XmlConfigBuilder().build();
+        Config config = new YamlConfigBuilder().build();
         URL file = new URL("file:");
         URL encodedURL = new URL(file, decodedURL);
         assertEquals(encodedURL, config.getConfigurationUrl());
@@ -66,45 +64,44 @@ public class XMLConfigWithSystemPropertyTest {
     @Test(expected = HazelcastException.class)
     @SuppressWarnings("ResultOfMethodCallIgnored")
     public void loadingThroughSystemProperty_nonExistingFile() throws Exception {
-        File file = createTempFile("foo", ".xml");
+        File file = createTempFile("foo", ".yaml");
         file.delete();
         System.setProperty("hazelcast.config", file.getAbsolutePath());
-        new XmlConfigBuilder();
+        new YamlConfigBuilder();
     }
 
     @Test
     public void loadingThroughSystemProperty_existingFile() throws Exception {
-        String xml = HAZELCAST_START_TAG
-                + "    <group>\n"
-                + "        <name>foobar</name>\n"
-                + "        <password>dev-pass</password>\n"
-                + "    </group>"
-                + HAZELCAST_END_TAG;
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  group:\n"
+                + "    name: foobar\n"
+                + "    password: dev-pass";
 
-        File file = createTempFile("foo", ".xml");
+        File file = createTempFile("foo", ".yaml");
         file.deleteOnExit();
         PrintWriter writer = new PrintWriter(file, "UTF-8");
-        writer.println(xml);
+        writer.println(yaml);
         writer.close();
 
         System.setProperty("hazelcast.config", file.getAbsolutePath());
 
-        XmlConfigBuilder configBuilder = new XmlConfigBuilder();
+        YamlConfigBuilder configBuilder = new YamlConfigBuilder();
         Config config = configBuilder.build();
         assertEquals("foobar", config.getGroupConfig().getName());
     }
 
     @Test(expected = HazelcastException.class)
     public void loadingThroughSystemProperty_nonExistingClasspathResource() {
-        System.setProperty("hazelcast.config", "classpath:idontexist.xml");
-        new XmlConfigBuilder();
+        System.setProperty("hazelcast.config", "classpath:idontexist.yaml");
+        new YamlConfigBuilder();
     }
 
     @Test
     public void loadingThroughSystemProperty_existingClasspathResource() {
-        System.setProperty("hazelcast.config", "classpath:test-hazelcast.xml");
+        System.setProperty("hazelcast.config", "classpath:test-hazelcast.yaml");
 
-        XmlConfigBuilder configBuilder = new XmlConfigBuilder();
+        YamlConfigBuilder configBuilder = new YamlConfigBuilder();
         Config config = configBuilder.build();
         assertEquals("foobar", config.getGroupConfig().getName());
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigWithSystemPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigWithSystemPropertyTest.java
@@ -32,7 +32,6 @@ import java.net.URLDecoder;
 
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 /**
  * These tests manipulate system properties, therefore they must be run in serial mode.
@@ -52,7 +51,6 @@ public class YamlConfigWithSystemPropertyTest {
     @Test
     public void testConfigurationWithFile() throws Exception {
         URL url = getClass().getClassLoader().getResource("hazelcast-default.yaml");
-        assertNotNull(url);
         String decodedURL = URLDecoder.decode(url.getFile(), "UTF-8");
         System.setProperty("hazelcast.config", decodedURL);
         Config config = new YamlConfigBuilder().build();

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlOnlyConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlOnlyConfigBuilderTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+
+/**
+ * Test cases specific only to YAML based configuration. The cases not
+ * YAML specific should be added to {@link YamlConfigBuilderTest}.
+ * <p/>
+ * This test class is expected to contain only <strong>extra</strong> test
+ * cases over the ones defined in {@link YamlConfigBuilderTest} in order
+ * to cover YAML specific cases where YAML configuration derives from the
+ * XML configuration to allow usage of YAML-native constructs.
+ *
+ * @see YamlConfigBuilderTest
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class YamlOnlyConfigBuilderTest {
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testMapQueryCachePredicateBothClassNameAndSql() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    test:\n"
+                + "      query-caches:\n"
+                + "        cache-name:\n"
+                + "          predicate:\n"
+                + "            class-name: com.hazelcast.examples.SimplePredicate\n"
+                + "            sql: \"%age=40\"\n";
+
+        buildConfig(yaml);
+    }
+
+    @Test(expected = InvalidConfigurationException.class)
+    public void testMapQueryCachePredicateNeitherClassNameNorSql() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    test:\n"
+                + "      query-caches:\n"
+                + "        cache-name:\n"
+                + "          predicate: {}\n";
+
+        buildConfig(yaml);
+    }
+
+    private Config buildConfig(String yaml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(yaml.getBytes());
+        YamlConfigBuilder configBuilder = new YamlConfigBuilder(bis);
+        return configBuilder.build();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/yaml/W3cDomTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/yaml/W3cDomTest.java
@@ -25,6 +25,7 @@ import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -32,7 +33,6 @@ import org.w3c.dom.NodeList;
 import java.io.InputStream;
 
 import static com.hazelcast.config.yaml.EmptyNamedNodeMap.emptyNamedNodeMap;
-import static com.hazelcast.config.yaml.EmptyNodeList.emptyNodeList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -105,7 +105,9 @@ public class W3cDomTest extends HazelcastTestSupport {
         assertEquals(NOT_EXISTING, elItem1);
         assertEquals(42.42D, elItem2, 10E-2);
         assertFalse(elItem3);
-        assertSame(emptyNodeList(), elItem0AsNode.getChildNodes());
+        NodeList elItem0ChildNodes = elItem0AsNode.getChildNodes();
+        assertEquals(1, elItem0ChildNodes.getLength());
+        assertEquals("value1", elItem0ChildNodes.item(0).getNodeValue());
         assertEquals("value1", elItem0AsNode.getNodeValue());
 
         // root-map/embedded-map/embedded-list2
@@ -118,6 +120,18 @@ public class W3cDomTest extends HazelcastTestSupport {
         assertEquals("Hazelcast IMDG\n"
                 + "The Leading Open Source In-Memory Data Grid:\n"
                 + "Distributed Computing, Simplified.\n", multilineStr);
+
+        Element embeddedMapAsElement = (Element) embeddedMap;
+        String scalarStrAttr = embeddedMapAsElement.getAttribute("scalar-str");
+        assertEquals("h4z3lc4st", scalarStrAttr);
+        assertEquals("embedded-map", embeddedMapAsElement.getTagName());
+        assertTrue(embeddedMapAsElement.hasAttribute("scalar-str"));
+
+        assertEquals("", embeddedMapAsElement.getAttribute("non-existing"));
+
+        NodeList nodesByTagName = embeddedMapAsElement.getElementsByTagName("scalar-str");
+        assertEquals(1, nodesByTagName.getLength());
+        assertEquals("h4z3lc4st", nodesByTagName.item(0).getNodeValue());
 
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/yaml/YamlUtilTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+import org.junit.Test;
+
+public class YamlUtilTest {
+
+    @Test
+    public void asMappingReturnsIfMappingPassed() {
+        YamlNode genericNode = new YamlMappingImpl(null, "mapping");
+        YamlUtil.asMapping(genericNode);
+    }
+
+    @Test(expected = YamlException.class)
+    public void asMappingThrowsIfNonMappingPassed() {
+        YamlNode genericNode = new YamlSequenceImpl(null, "sequence");
+        YamlUtil.asMapping(genericNode);
+    }
+
+    @Test
+    public void asSequenceReturnsIfSequencePassed() {
+        YamlNode genericNode = new YamlSequenceImpl(null, "sequence");
+        YamlUtil.asSequence(genericNode);
+    }
+
+    @Test(expected = YamlException.class)
+    public void asSequenceThrowsIfNonSequencePassed() {
+        YamlNode genericNode = new YamlMappingImpl(null, "mapping");
+        YamlUtil.asSequence(genericNode);
+    }
+
+    @Test
+    public void asScalarReturnsIfScalarPassed() {
+        YamlNode genericNode = new YamlScalarImpl(null, "scalar", "value");
+        YamlUtil.asScalar(genericNode);
+    }
+
+    @Test(expected = YamlException.class)
+    public void asScalarThrowsIfNonScalarPassed() {
+        YamlNode genericNode = new YamlMappingImpl(null, "mapping");
+        YamlUtil.asScalar(genericNode);
+    }
+}

--- a/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-service.xml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-service.xml
@@ -51,6 +51,9 @@
                     <s:string-prop>prop1</s:string-prop>
                     <s:int-prop>123</s:int-prop>
                     <s:bool-prop>true</s:bool-prop>
+                    <s:complex-prop an-attribute="attr-value">
+                        <s:nested-prop>nested-prop-value</s:nested-prop>
+                    </s:complex-prop>
                 </s:my-service>
             </configuration>
         </service>

--- a/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-service.yaml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-service.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-service.yaml
+++ b/hazelcast/src/test/resources/com/hazelcast/config/hazelcast-service.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+hazelcast:
+  group:
+    name: dev
+    password: dev-pass
+  network:
+    port:
+      auto-increment: true
+      port: 5701
+  join:
+    multicast:
+      enabled: true
+      multicast-group: 224.2.2.3
+      multicast-port: 54327
+
+  services:
+    enable-defaults: false
+    my-service:
+      enabled: true
+      class-name: com.hazelcast.examples.MyService
+      properties:
+        prop1: prop1-value
+        prop2: prop2-value
+      configuration:
+        parser: com.hazelcast.config.MyServiceConfigParser
+        my-service:
+          string-prop: prop1
+          int-prop: 123
+          bool-prop: true
+          complex-prop:
+            an-attribute: attr-value
+            nested-prop: nested-prop-value
+            

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -36,7 +36,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
 
     <group>
         <name>dev</name>
@@ -300,6 +300,7 @@
         <durability>2</durability>
         <capacity>50</capacity>
         <quorum-ref>quorumRuleWithThreeMembers</quorum-ref>
+        <merge-policy batch-size="10">PutIfAbsentMergePolicy</merge-policy>
     </scheduled-executor-service>
     <cardinality-estimator name="dummy">
         <backup-count>1</backup-count>
@@ -703,7 +704,8 @@
             <portable-factory factory-id="1">com.hazelcast.examples.PortableFactory</portable-factory>
         </portable-factories>
         <serializers>
-            <global-serializer override-java-serialization="true">com.hazelcast.examples.GlobalSerializerFactory</global-serializer>
+            <global-serializer override-java-serialization="true">com.hazelcast.examples.GlobalSerializerFactory
+            </global-serializer>
             <serializer type-class="com.hazelcast.examples.DummyType"
                         class-name="com.hazelcast.examples.SerializerFactory"/>
         </serializers>
@@ -935,4 +937,37 @@
         <mapName>default</mapName>
         <depth>5</depth>
     </merkle-tree>
+
+    <hot-restart-persistence enabled="false">
+        <backup-dir>backup-dir</backup-dir>
+        <base-dir>base-dir</base-dir>
+        <cluster-data-recovery-policy>FULL_RECOVERY_ONLY</cluster-data-recovery-policy>
+        <data-load-timeout-seconds>42</data-load-timeout-seconds>
+        <parallelism>3</parallelism>
+        <validation-timeout-seconds>10</validation-timeout-seconds>
+    </hot-restart-persistence>
+
+    <event-journal>
+        <mapName>mapName</mapName>
+        <capacity>10</capacity>
+        <time-to-live-seconds>10</time-to-live-seconds>
+    </event-journal>
+
+    <event-journal>
+        <cacheName>cacheName</cacheName>
+        <capacity>100</capacity>
+        <time-to-live-seconds>100</time-to-live-seconds>
+    </event-journal>
+
+    <jobtracker name="jobTracker">
+        <chunk-size>100</chunk-size>
+        <queue-size>200</queue-size>
+        <retry-count>10</retry-count>
+        <max-thread-size>20</max-thread-size>
+        <communicate-stats>false</communicate-stats>
+        <topology-changed-strategy>DISCARD_AND_RESTART</topology-changed-strategy>
+    </jobtracker>
+
+    <lite-member enabled="true"/>
+
 </hazelcast>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.yaml
@@ -1,0 +1,982 @@
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A comprehensive example of Hazelcast configuration.
+#
+# Hazelcast resolves configuration using the following approach:
+#
+# 1. First is checks to see if the ’hazelcast.config’ system property is set. If it is, then the value is used as the path.
+#
+#    The config option can be set by adding the following to the java command: -Dhazelcast.config=path_to_the_hazelcast.yaml.
+#
+#    The value can be a normal file path, but can also be a classpath reference if it is prefixed with ’classpath:’.
+#
+# 2. Otherwise it checks if there is a ’hazelcast.yaml’ in the working directory.
+#
+# 3. After that it checks if there is a ’hazelcast.yaml’ in the root of the classpath.
+#
+# 4. If a configuration cannot be found, Hazelcast will use the default hazelcast configuration
+#    ’hazelcast-default.yaml’, which is included in the the Hazelcast jar
+
+hazelcast:
+  group:
+    name: dev
+    password: dev-pass
+  license-key: HAZELCAST_ENTERPRISE_LICENSE_KEY
+  instance-name: dummy
+
+  management-center:
+    enabled: true
+    update-interval: 5
+    scripting-enabled: false
+    url: http://mywebserver:8080
+    mutual-auth:
+      enabled: true
+      factory-class-name: com.hazelcast.examples.MySSLContextFactory
+      properties:
+        foo: bar
+
+  properties:
+    foo: bar
+
+  wan-replication:
+    my-wan-cluster:
+      wan-publisher:
+
+        tokyoPublisherId:
+          group-name: tokyo
+          class-name: com.hazelcast.enterprise.wan.replication.WanBatchReplication
+          queue-capacity: 1000
+          queue-full-behavior: THROW_EXCEPTION
+          initial-publisher-state: REPLICATING
+          wan-sync:
+            consistency-check-strategy: MERKLE_TREES
+          properties:
+            batch.size: 50
+            batch.max.delay.millis: 3000
+            response.timeout.millis: 5000
+            ack.type: ACK_ON_OPERATION_COMPLETE
+            endpoints: "10.3.5.1:5701, 10.3.5.2:5701"
+            snapshot.enabled: false
+            group.password: pass
+
+        istanbul:
+          class-name: com.hazelcast.wan.custom.WanPublisher
+          queue-full-behavior: DISCARD_AFTER_MUTATION
+          initial-publisher-state: STOPPED
+          queue-capacity: 10000
+          aws:
+            enabled: false
+            connection-timeout-seconds: 10
+            access-key: sample-access-key
+            secret-key: sample-secret-key
+            iam-role: sample-role
+            region: sample-region
+            host-header: sample-header
+            security-group-name: sample-group
+            tag-key: sample-tag-key
+            tag-value: sample-tag-value
+          gcp:
+            enabled: false
+            zones: us-east1-b,us-east1-c
+          azure:
+            enabled: false
+            client-id: CLIENT_ID
+            client-secret: CLIENT_SECRET
+            tenant-id: TENANT_ID
+            subscription-id: SUB_ID
+            cluster-id: HZLCAST001
+            group-name: GROUP-NAME
+          kubernetes:
+            enabled: false
+            namespace: MY-KUBERNETES-NAMESPACE
+            service-name: MY-SERVICE-NAME
+            service-label-name: MY-SERVICE-LABEL-NAME
+            service-label-value: MY-SERVICE-LABEL-VALUE
+          eureka:
+            enabled: false
+            self-registration: true
+            namespace: hazelcast
+          discovery-strategies:
+            node-filter:
+              class: DummyFilterClass
+            discovery-strategies:
+              - class: DummyDiscoveryStrategy1
+                enabled: true
+                properties:
+                  key-string: foo
+                  key-int: 123
+                  key-boolean: true
+          properties:
+            custom.prop.publisher: prop.publisher
+            discovery.period: 5
+            maxEndpoints: 2
+
+      wan-consumer:
+        class-name: com.hazelcast.wan.custom.WanConsumer
+        properties:
+          custom.prop.consumer: prop.consumer
+        persist-wan-replicated-data: true
+
+  network:
+    public-address: dummy
+    port:
+      auto-increment: true
+      port-count: 100
+      port: 5701
+    # If the address should be reused. See NetworkConfig.setReuseAddress for more information.
+    reuse-address: true
+    outbound-ports:
+      - 33000-35000
+      - 37000,37001,37002,37003
+      - 38000,38500-38600
+    join:
+      multicast:
+        enabled: true
+        loopbackModeEnabled: true
+        multicast-group: 1.2.3.4
+        multicast-port: 12345
+        multicast-timeout-seconds: 5
+        multicast-time-to-live: 10
+        trusted-interfaces:
+          - 10.10.1.*
+          - 10.10.2.*
+      tcp-ip:
+        enabled: false
+        connection-timeout-seconds: 123
+        required-member: dummy
+        member: dummy1,dummy2
+        interface: 127.0.0.10
+        members: dummy3,dummy4
+        member-list:
+          - dummy5
+          - dummy6
+      aws:
+        enabled: false
+        access-key: my-access-key
+        secret-key: my-secret-key
+        iam-role: dummy
+        # optional, default is us-east-1
+        region: us-west-1
+        # optional, default is ec2.amazonaws.com. If set, region shouldn't be set as it will override this property
+        host-header: ec2.amazonaws.com
+        # optional, only instances belonging to this group will be discovered, default will try all running instances
+        security-group-name: hazelcast-sg
+        tag-key: type
+        tag-value: hz-nodes
+        use-public-ip: true
+      gcp:
+        enabled: false
+        zones: us-east1-b,us-east1-c
+      azure:
+        enabled: false
+        client-id: CLIENT_ID
+        client-secret: CLIENT_SECRET
+        tenant-id: TENANT_ID
+        subscription-id: SUB_ID
+        cluster-id: HZLCAST001
+        group-name: GROUP-NAME
+      kubernetes:
+        enabled: false
+        namespace: MY-KUBERNETES-NAMESPACE
+        service-name: MY-SERVICE-NAME
+        service-label-name: MY-SERVICE-LABEL-NAME
+        service-label-value: MY-SERVICE-LABEL-VALUE
+      eureka:
+        enabled: false
+        self-registration: true
+        namespace: hazelcast
+#       <discovery-strategies>
+#            <node-filter class="DummyFilterClass"/>
+#            <discovery-strategy class="DummyClass" enabled="true">
+#                <properties>
+#                    <property name="foo">bar</property>
+#                </properties>
+#            </discovery-strategy>
+#        </discovery-strategies>-->
+    interfaces:
+      enabled: true
+      interfaces:
+        - 10.10.1.*
+    ssl:
+      enabled: true
+      factory-class-name: com.hazelcast.examples.MySSLContextFactory
+      properties:
+        foo: bar
+    socket-interceptor:
+      enabled: true
+      class-name: com.hazelcast.examples.MySocketInterceptor
+      properties:
+        foo: bar
+    symmetric-encryption:
+      enabled: false
+      #   encryption algorithm such as
+      #   DES/ECB/PKCS5Padding,
+      #   PBEWithMD5AndDES,
+      #   AES/CBC/PKCS5Padding,
+      #   Blowfish,
+      #   DESede
+      algorithm: PBEWithMD5AndDES
+      # salt value to use when generating the secret key
+      salt: thesalt
+      # pass phrase to use when generating the secret key
+      password: thepass
+      # iteration count to use when generating the secret key
+      iteration-count: 19
+    member-address-provider:
+      enabled: false
+      class-name: DummyMemberAddressProvider
+      properties:
+        foo: bar
+    failure-detector:
+      icmp:
+        enabled: false
+        timeout-milliseconds: 1000
+        fail-fast-on-startup: true
+        interval-milliseconds: 1000
+        max-attempts: 2
+        parallel-mode: true
+        ttl: 255
+
+  partition-group:
+    enabled: true
+    group-type: CUSTOM
+    member-group:
+      -
+        - 10.10.0.*
+        - 10.10.3.*
+        - 10.10.5.*
+      -
+        - 10.10.10.10-100
+        - 10.10.1.*
+        - 10.10.2.*
+
+  executor-service:
+    default:
+      statistics-enabled: false
+      pool-size: 16
+      queue-capacity: 1000
+      quorum-ref: quorumRuleWithThreeMembers
+
+  durable-executor-service:
+    dummy:
+      pool-size: 10
+      durability: 2
+      capacity: 10
+      quorum-ref: quorumRuleWithThreeMembers
+
+  scheduled-executor-service:
+    dummy:
+      pool-size: 10
+      durability: 2
+      capacity: 50
+      quorum-ref: quorumRuleWithThreeMembers
+      merge-policy:
+        batch-size: 10
+        class-name: PutIfAbsentMergePolicy
+
+  cardinality-estimator:
+    dummy:
+      backup-count: 1
+      async-backup-count: 0
+      quorum-ref: quorumRuleWithThreeNodes
+      merge-policy:
+        batch-size: 50
+        class-name: HyperLogLogMergePolicy
+
+  queue:
+    default:
+      statistics-enabled: false
+        # Maximum size of the queue. When a JVM's local queue size reaches the maximum,
+        # all put/offer operations will get blocked until the queue size
+        # of the JVM goes down below the maximum.
+        # Any integer between 0 and Integer.MAX_VALUE. 0 means
+        # Integer.MAX_VALUE. Default is 0.
+      max-size: 10
+
+      backup-count: 2
+      async-backup-count: 2
+      empty-queue-ttl: 12
+
+      item-listeners:
+         - include-value: true
+           class-name: com.hazelcast.examples.ItemListener
+      queue-store:
+         enabled: true
+         # class-name: DummyClass
+         factory-class-name: DummyFactoryClass
+         properties:
+           foo: bar
+
+      quorum-ref: quorumRuleWithThreeMembers
+      merge-policy:
+        batch-size: 100
+        class-name: PutIfAbsentMergePolicy
+
+  map:
+    default:
+      # Data type that will be used for storing recordMap.
+      # Possible values:
+      # BINARY (default): keys and values will be stored as binary data
+      # OBJECT : values will be stored in their object forms
+      # NATIVE : values will be stored in non-heap region of JVM
+      in-memory-format: OBJECT
+
+      # Whether statistical information (hits, creation time, last access time etc.) should be gathered and stored.
+      # You can disable if you do not plan to use eviction on your entries.
+      statistics-enabled: false
+
+      optimize-queries: true
+      cache-deserialized-values: ALWAYS
+
+      # Number of backups. If 1 is set as the backup-count for example,
+      # then all entries of the map will be copied to another JVM for
+      # fail-safety. 0 means no backup.
+      backup-count: 2
+
+      # Number of async backups. 0 means no backup.
+      async-backup-count: 2
+
+      # Maximum number of seconds for each item to live.
+      # Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+      time-to-live-seconds: 2
+
+      # Maximum number of seconds for each item to stay idle (untouched).
+      # Any integer between 0 and Integer.MAX_VALUE. 0 means infinite. Default is 0.
+      max-idle-seconds: 2
+
+      # Valid values are:
+      # NONE (no eviction),
+      # LRU (Least Recently Used),
+      # LFU (Least Frequently Used).
+      # NONE is the default.
+      eviction-policy: LRU
+
+      # Maximum size of the map. When max size is reached,
+      # map is evicted based on the policy defined.
+      # Any integer between 0 and Integer.MAX_VALUE. 0 means
+      # Integer.MAX_VALUE. Default is 0.
+      max-size:
+        policy: PER_NODE
+        max-size: 20
+
+      # `eviction-percentage` property is deprecated.
+      #
+      # As of version 3.7, eviction mechanism changed.
+      # It uses a probabilistic algorithm based on sampling. Please see documentation for further details
+      eviction-percentage: 25
+
+      # `min-eviction-check-millis` property is deprecated.
+      #
+      # As of version 3.7, eviction mechanism changed.
+      # It uses a probabilistic algorithm based on sampling. Please see documentation for further details
+      min-eviction-check-millis: 200
+
+      # While recovering from split-brain (network partitioning), data structure entries in the small cluster
+      # merge into the bigger cluster based on the policy set here. When an entry merges into the cluster,
+      # an entry with the same key (or value) might already exist in the cluster.
+      # The merge policy resolves these conflicts with different out-of-the-box or custom strategies.
+      # The out-of-the-box merge polices can be references by their simple class name.
+      # For custom merge policies you have to provide a fully qualified class name.
+      #
+      # The out-of-the-box policies are:
+      #  * DiscardMergePolicy: the entry from the smaller cluster will be discarded.
+      #  * HigherHitsMergePolicy: the entry with the higher number of hits wins.
+      #  * LatestAccessMergePolicy: the entry with the latest access wins.
+      #  * LatestUpdateMergePolicy: the entry with the latest update wins.
+      #  * PassThroughMergePolicy: the entry from the smaller cluster wins.
+      #  * PutIfAbsentMergePolicy: the entry from the smaller cluster wins if it doesn't exist in the cluster.
+      #  * The default policy is: PutIfAbsentMergePolicy
+      # Beware that `merge-policy` is not supported for NATIVE in-memory format.
+      merge-policy:
+        batch-size: 100
+        class-name: PutIfAbsentMergePolicy
+
+      read-backup-data: true
+
+      hot-restart:
+        fsync: true
+
+      # Used to store Map entries in a backing store. If configured entries will be loaded from this store on startup.
+      #
+      # On startup, may be loaded in two ways, controlled by the initial-mode attribute:
+      #     - LAZY. Asynchronously loads the entries. This is the default.
+      #     - EAGER. Synchronously loads the entries. Calls to getMap() are blocked while this happens.
+      map-store:
+        enabled: true
+        initial-mode: LAZY
+        class-name: com.hazelcast.examples.DummyStore
+        # factory-class-name: com.hazelcast.examples.DummyStoreFactory
+        write-delay-seconds: 0
+        write-batch-size: 1
+        write-coalescing: true
+        properties:
+          dummy.property: value
+
+      # Note that the Near Cache eviction configuration is different for NATIVE in-memory format.
+      # Proper eviction configuration example for NATIVE in-memory format :
+      #    `<eviction max-size-policy="USED_NATIVE_MEMORY_SIZE" eviction-policy="LFU" size="60"/>`
+      near-cache:
+        max-size: 10000
+        time-to-live-seconds: 0
+        max-idle-seconds: 0
+        eviction-policy: LFU
+        invalidate-on-change: true
+        cache-local-entries: false
+
+      wan-replication-ref:
+        my-wan-cluster:
+          merge-policy: hz.PASS_THROUGH
+          filters:
+            - com.example.WanTestFilter1
+            - com.example.WanTestFilter2
+          republishing-enabled: false
+
+      indexes:
+        name:
+          ordered: false
+        age:
+          ordered: true
+
+      attributes:
+        currency:
+          extractor: com.example.CurrencyExtractor
+        age:
+          extractor: com.example.AgeExtractor
+
+      entry-listeners:
+        - include-value: true
+          local: false
+          class-name: com.hazelcast.examples.EntryListener
+
+      partition-lost-listeners:
+        - com.hazelcast.examples.MapPartitionLostListener
+
+      query-caches:
+        query-cache-name:
+          predicate:
+            class-name: com.hazelcast.examples.ExamplePredicate
+          entry-listeners:
+            - include-value: true
+              local: false
+              class-name: com.hazelcast.examples.EntryListener
+          include-value: true
+          batch-size: 1
+          buffer-size: 16
+          delay-seconds: 0
+          in-memory-format: BINARY
+          coalesce: false
+          populate: true
+          eviction:
+            eviction-policy: LRU
+            max-size-policy: ENTRY_COUNT
+            size: 10000
+          indexes:
+            name:
+              ordered: false
+            age:
+              ordered: true
+
+  multimap:
+    default:
+      backup-count: 1
+      async-backup-count: 0
+      statistics-enabled: false
+      binary: false
+      value-collection-type: SET
+      entry-listeners:
+        - include-value: true
+          local: true
+          class-name: com.hazelcast.examples.EntryListener
+      quorum-ref: quorumRuleWithThreeMembers
+      merge-policy:
+        batch-size: 100
+        class-name: PutIfAbsentMergePolicy
+
+  replicatedmap:
+    dummy:
+      in-memory-format: BINARY
+      concurrency-level: 12
+      replication-delay-millis: 12
+      async-fillup: false
+      statistics-enabled: false
+      quorum-ref: quorumRuleWithThreeMembers
+      merge-policy:
+        batch-size: 100
+        class-name: PutIfAbsentMergePolicy
+      entry-listeners:
+        - include-value: false
+          local: true
+          class-name: DummyListener
+
+  list:
+    default:
+      statistics-enabled: false
+      max-size: 5
+      backup-count: 2
+      async-backup-count: 2
+      item-listeners:
+        - include-value: true
+          class-name: com.hazelcast.examples.ItemListener
+      quorum-ref: quorumRuleWithThreeMembers
+      merge-policy:
+        batch-size: 100
+        class-name: PutIfAbsentMergePolicy
+
+  set:
+    default:
+      statistics-enabled: false
+      max-size: 0
+      backup-count: 1
+      async-backup-count: 0
+      item-listeners:
+        - include-value: true
+          class-name: com.hazelcast.examples.ItemListener
+      quorum-ref: quorumRuleWithThreeMembers
+      merge-policy:
+        batch-size: 100
+        class-name: PutIfAbsentMergePolicy
+
+  topic:
+    default:
+      statistics-enabled: false
+      global-ordering-enabled: true
+      message-listeners:
+        - com.hazelcast.examples.MessageListener
+      multi-threading-enabled: false
+
+  reliable-topic:
+    default:
+      statistics-enabled: true
+      topic-overload-policy: ERROR
+      read-batch-size: 10
+      message-listeners:
+        - com.hazelcast.examples.MessageListener
+
+  semaphore:
+    default:
+      initial-permits: 10
+      backup-count: 1
+      async-backup-count: 0
+      quorum-ref: quorumRuleWithThreeMembers
+
+  lock:
+    default:
+      quorum-ref: quorumRuleWithThreeMembers
+
+  atomic-long:
+    default:
+      quorum-ref: quorumRuleWithThreeMembers
+      merge-policy:
+        batch-size: 100
+        class-name: PutIfAbsentMergePolicy
+
+  atomic-reference:
+    default:
+      quorum-ref: quorumRuleWithThreeMembers
+      merge-policy:
+        batch-size: 100
+        class-name: PutIfAbsentMergePolicy
+
+  count-down-latch:
+    default:
+      quorum-ref: quorumRuleWithThreeMembers
+
+  ringbuffer:
+    default:
+      capacity: 25311
+      backup-count: 2
+      async-backup-count: 1
+      time-to-live-seconds: 29
+      in-memory-format: OBJECT
+      quorum-ref: quorumRuleWithThreeMembers
+      merge-policy:
+        batch-size: 100
+        class-name: PutIfAbsentMergePolicy
+
+  cache:
+    default:
+      key-type:
+        class-name: java.lang.Object
+      value-type:
+        class-name: java.lang.String
+      statistics-enabled: false
+      management-enabled: false
+
+      read-through: true
+      write-through: true
+      cache-loader-factory:
+        class-name: com.example.cache.MyCacheLoaderFactory
+      cache-writer-factory:
+        class-name: com.example.cache.MyCacheWriterFactory
+      expiry-policy-factory:
+        class-name: com.example.cache.MyExpirePolicyFactory
+        timed-expiry-policy-factory:
+          expiry-policy-type: ETERNAL
+          duration-amount: 123
+          time-unit: MICROSECONDS
+
+      cache-entry-listeners:
+        cache-entry-listener:
+          old-value-required: true
+          synchronous: true
+          cache-entry-listener-factory:
+            class-name: com.example.cache.MyEntryListenerFactory
+          cache-entry-event-filter-factory:
+            class-name: com.example.cache.MyEntryEventFilterFactory
+      in-memory-format: OBJECT
+      backup-count: 2
+      async-backup-count: 2
+      eviction:
+        comparator-class-name: DummyClass
+        eviction-policy: LRU
+        max-size-policy: FREE_NATIVE_MEMORY_PERCENTAGE
+        size: 50
+      wan-replication-ref:
+        name: my-wan-cluster
+        merge-policy: hz.PASS_THROUGH
+        filters:
+          - com.example.WanTestFilter1
+          - com.example.WanTestFilter2
+      quorum-ref: DummyQuorum
+      merge-policy: DummyMergePolicy
+      partition-lost-listeners:
+        - DummyListener
+      hot-restart:
+        fsync: true
+
+  flake-id-generator:
+    default:
+      prefetch-count: 100
+      prefetch-validity-millis: 600000
+      id-offset: 0
+      node-id-offset: 0
+      statistics-enabled: false
+
+  listeners:
+    - com.hazelcast.examples.MembershipListener
+    - com.hazelcast.examples.InstanceListener
+    - com.hazelcast.examples.MigrationListener
+    - com.hazelcast.examples.PartitionLostListener
+
+  serialization:
+    portable-version: 0
+    use-native-byte-order: true
+    byte-order: LITTLE_ENDIAN
+    enable-compression: true
+    enable-shared-object: true
+    allow-unsafe: true
+    data-serializable-factories:
+      - factory-id: 1
+        class-name: com.hazelcast.examples.DataSerializableFactory
+    portable-factories:
+      - factory-id: 1
+        class-name: com.hazelcast.examples.PortableFactory
+    global-serializer:
+       override-java-serialization: true
+       class-name: com.hazelcast.examples.GlobalSerializerFactory
+    serializers:
+       - type-class: com.hazelcast.examples.DummyType
+         class-name: com.hazelcast.examples.SerializerFactory
+    check-class-def-errors: false
+    java-serialization-filter:
+      defaults-disabled: true
+      blacklist:
+        class:
+          - com.acme.app.BeanComparator
+      whitelist:
+        class:
+          - java.lang.String
+          - example.Foo
+        package:
+          - com.acme.app
+          - com.acme.app.subpkg
+        prefix:
+          - java
+          - "["
+          - com.
+
+  native-memory:
+    allocator-type: STANDARD
+    enabled: true
+    size:
+      unit: MEGABYTES
+      value: 256
+    min-block-size: 123
+    page-size: 123
+    metadata-space-percentage: 12.5
+
+  services:
+    enable-defaults: false
+    service:
+      enabled: true
+      name: custom-service
+      class-name: com.hazelcast.examples.MyService
+      properties:
+        prop1: prop1-value
+        prop2: prop2-value
+
+  security:
+    enabled: false
+    member-credentials-factory:
+      class-name: com.hazelcast.examples.MyCredentialsFactory
+      properties:
+        property: value
+    member-login-modules:
+      - class-name: com.hazelcast.examples.MyRequiredLoginModule
+        usage: REQUIRED
+        properties:
+          property: value
+    client-login-modules:
+      - class-name: com.hazelcast.examples.MyOptionalLoginModule
+        usage: OPTIONAL
+        properties:
+          property: value
+      - class-name: com.hazelcast.examples.MyRequiredLoginModule
+        usage: REQUIRED
+        properties:
+          property: value
+    client-permission-policy:
+      class-name: com.hazelcast.examples.MyPermissionPolicy
+      properties:
+        property: value
+    client-permissions:
+      all:
+        principal: admin
+        endpoints:
+          - 127.0.0.1
+      config:
+        principal: deployer
+      countdown-latch:
+        - name: "*"
+          actions:
+            - all
+      id-generator:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      set:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      cardinality-estimator:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      scheduled-executor:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      atomic-long:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      transaction:
+        principal: deployer
+      pn-counter:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      semaphore:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      user-code-deployment:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      durable-executor-service:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      map:
+        - name: custom
+          principal: dev
+          endpoints:
+            - 127.0.0.1
+          actions:
+            - create
+            - destroy
+            - put
+            - read
+      flake-id-generator:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      topic:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      multimap:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      cache:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      lock:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      queue:
+        - name: "*"
+          actions:
+            - all
+      list:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+      executor-service:
+        - name: "*"
+          principal: "*"
+          actions:
+            - all
+    client-block-unmapped-actions: true
+
+  member-attributes:
+    attribute.string:
+      value: hazelcast
+    attribute.int:
+      type: int
+      value: 123
+    attribute.long:
+      type: long
+      value: 456
+    attribute.short:
+      type: short
+      value: 789
+    attribute.byte:
+      type: byte
+      value: 111
+    attribute.boolean:
+      type: boolean
+      value: true
+    attribute.double:
+      type: double
+      value: 0.0d
+    attribute.float:
+      type: float
+      value: 1234.5678
+
+
+  crdt-replication:
+    replication-period-millis: 1000
+    max-concurrent-replication-targets: 1
+
+  pn-counter:
+    pn-counter-1:
+      replica-count: 100
+      quorum-ref: quorumRuleWithThreeMembers
+      statistics-enabled: false
+
+  quorum:
+    quorumRuleWithThreeMembers:
+      enabled: true
+      quorum-size: 3
+      quorum-type: READ_WRITE
+      
+    member-count-quorum:
+      enabled: true
+      quorum-type: READ_WRITE
+      quorum-size: 3
+      member-count-quorum: {}
+
+    probabilistic-quorum:
+      enabled: true
+      quorum-size: 3
+      quorum-type: READ_WRITE
+      probabilistic-quorum:
+        acceptable-heartbeat-pause-millis: 100
+        max-sample-size: 20
+        suspicion-threshold: 10
+
+    recently-active-quorum:
+      enabled: true
+      quorum-size: 4
+      quorum-type: READ_WRITE
+      recently-active-quorum:
+        heartbeat-tolerance-millis: 60000
+
+  merkle-tree:
+    map:
+      default:
+        enabled: true
+        depth: 5
+
+  hot-restart-persistence:
+    enabled: false
+    backup-dir: backup-dir
+    base-dir: base-dir
+    cluster-data-recovery-policy: FULL_RECOVERY_ONLY
+    data-load-timeout-seconds: 42
+    parallelism: 3
+    validation-timeout-seconds: 10
+
+  event-journal:
+    map:
+      mapName:
+        capacity: 10
+        time-to-live-seconds: 10
+
+    cache:
+      cacheName:
+        capacity: 100
+        time-to-live-seconds: 100
+
+  jobtracker:
+    jobTracker:
+      chunk-size: 100
+      queue-size: 200
+      retry-count: 10
+      max-thread-size: 20
+      communicate-stats: false
+      topology-changed-strategy: DISCARD_AND_RESTART
+
+  lite-member:
+    enabled: true
+
+  rest-api:
+    enabled: true
+    endpoint-groups:
+      CLUSTER_READ:
+        enabled: true
+      CLUSTER_WRITE:
+        enabled: true
+      DATA:
+        enabled: true
+      HEALTH_CHECK:
+        enabled: true
+      HOT_RESTART:
+        enabled: true
+      WAN:
+        enabled: true
+
+  memcache-protocol:
+    enabled: true

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/hazelcast-sample-service.xsd
+++ b/hazelcast/src/test/resources/hazelcast-sample-service.xsd
@@ -22,16 +22,28 @@
     <xs:element name="my-service">
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="string-prop" minOccurs="0" maxOccurs="1" />
+                <xs:element ref="string-prop" minOccurs="0" maxOccurs="1"/>
                 <xs:element ref="int-prop" minOccurs="0" maxOccurs="1" />
                 <xs:element ref="bool-prop" minOccurs="0" maxOccurs="1" />
+                <xs:element ref="complex-prop" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             <xs:attribute name="id" type="xs:string" use="optional" default="default"/>
         </xs:complexType>
     </xs:element>
 
-    <xs:element name="string-prop" type="xs:string" />
+    <xs:complexType name="complex-prop">
+        <xs:all>
+            <xs:element ref="nested-prop" minOccurs="0" maxOccurs="1"/>
+            <xs:element ref="string-prop" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="an-attribute" type="xs:string" default="default"/>
+    </xs:complexType>
+
+    <xs:element name="string-prop" type="xs:string"/>
     <xs:element name="int-prop" type="xs:int" />
-    <xs:element name="bool-prop" type="xs:boolean" />
+    <xs:element name="bool-prop" type="xs:boolean"/>
+    <xs:element name="nested-prop" type="xs:string"/>
+
+    <xs:element name="complex-prop" type="complex-prop"/>
 
 </xs:schema>

--- a/hazelcast/src/test/resources/test-hazelcast.yaml
+++ b/hazelcast/src/test/resources/test-hazelcast.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hazelcast/src/test/resources/test-hazelcast.yaml
+++ b/hazelcast/src/test/resources/test-hazelcast.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+hazelcast:
+  group:
+    name: foobar
+    password: dev-pass

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
                     <include>**/*.sh</include>
                     <include>**/*.properties</include>
                     <include>**/*.xml</include>
+                    <include>**/*.yaml</include>
                     <include>**/*.xsd</include>
                     <include>**/*.handlers</include>
                     <include>**/*.schemas</include>


### PR DESCRIPTION
Load member config from YAML similarly to XML either from:
- Classpath
- File system
- In-memory stream

The same config file location mechanism is in use as for XML (`YamlConfigLocator`).
If the HZ instance is built with no config, an attempt is made to read the config from any provided YAML configuration (with excluding default YAML configuration). If there is no YAML configuration provided, the configuration is loaded from XML as before, this time including the default XML as the last option.

Added yaml configs to the classpath:
- `hazelcast-default.yaml`
- `hazelcast-fullconfig.yaml` (test)
- `hazelcast-service.yaml` (test)

Along with the changes missing configuration is added to hazelcast-fullconfig.xml as well.

Notable tests:
- `YamlConfigBuilderTest` with cases identical to the ones in `XMLConfigBuilderTest` (schema validation cases are ignored for now)
- Equality test for the default YAML and XML configs provided on the classpath
- Equality test for the full YAML and XML configs provided on the (test) classpath

While this is a change focusing on member configuration, contains some changes in client config classes as well where it is needed to compile.

Depends on #14410 

The PR consists of many added lines, which is mostly done in the following files:
- `MemberDomConfigProcessor`: the class shared between XML and YAML configuration processor. The change is done because of the differences in the XML and YAML languages
- `YamlMemberDomConfigProcessor`: the class building the `Config` structure from the YAML files
- `YamlConfigBuilderTest`: test class with the same test cases as in `XMLConfigBuilderTest`
- `hazelcast-fullconfig.yaml`: the full YAML configuration for testing (see the notable tests section above)