### PR TITLE
Introduced XEN optimized clock

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientClusterServiceImpl.java
@@ -139,7 +139,7 @@ public class ClientClusterServiceImpl implements ClientClusterService {
 
     @Override
     public long getClusterTime() {
-        return Clock.currentTimeMillis();
+        return Clock.approximateTimeMillis();
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientInvocation.java
@@ -34,6 +34,7 @@ import com.hazelcast.spi.exception.RetryableException;
 import com.hazelcast.spi.exception.TargetDisconnectedException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.sequence.CallIdSequence;
+import com.hazelcast.util.Clock;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -92,7 +93,7 @@ public class ClientInvocation implements Runnable {
         this.partitionId = partitionId;
         this.address = address;
         this.connection = connection;
-        this.startTimeMillis = System.currentTimeMillis();
+        this.startTimeMillis = Clock.approximateTimeMillis();
         this.retryPauseMillis = invocationService.getInvocationRetryPauseMillis();
         this.logger = invocationService.invocationLogger;
         this.callIdSequence = invocationService.getCallIdSequence();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterClock.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/ClusterClock.java
@@ -16,14 +16,26 @@
 
 package com.hazelcast.internal.cluster;
 
+import com.hazelcast.util.Clock;
+
 public interface ClusterClock {
 
     /**
      * Returns the cluster-time in milliseconds.
      * The cluster-time measures elapsed time since the cluster was created. Comparable to the {@link System#nanoTime()}.
+     *
      * @return the cluster-time (elapsed milliseconds since the cluster was created).
      */
     long getClusterTime();
+
+    /**
+     * Returns the approximate cluster-time in milliseconds.
+     *
+     * For more information see {@link Clock#approximateTimeMillis()}.
+     *
+     * @return the cluster-time (elapsed milliseconds since the cluster was created).
+     */
+    long getApproximateClusterTime();
 
     /**
      * Returns the cluster  up-time in milliseconds.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterClockImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterClockImpl.java
@@ -44,6 +44,11 @@ public class ClusterClockImpl implements ClusterClock {
         return Clock.currentTimeMillis() + clusterTimeDiff;
     }
 
+    @Override
+    public long getApproximateClusterTime() {
+        return Clock.approximateTimeMillis() + clusterTimeDiff;
+    }
+
     /**
      * Calculate and set the cluster clock diff.
      *

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
@@ -33,6 +33,7 @@ import java.nio.channels.Selector;
 import java.util.Arrays;
 
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.util.Clock.approximateTimeMillis;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.collection.ArrayUtils.append;
 import static com.hazelcast.util.collection.ArrayUtils.replaceFirst;
@@ -108,7 +109,7 @@ public final class NioInboundPipeline extends NioPipeline implements InboundPipe
         processCount.inc();
         // we are going to set the timestamp even if the channel is going to fail reading. In that case
         // the connection is going to be closed anyway.
-        lastReadTime = currentTimeMillis();
+        lastReadTime = approximateTimeMillis();
 
         int readBytes = socketChannel.read(receiveBuffer);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioOutboundPipeline.java
@@ -39,6 +39,7 @@ import static com.hazelcast.internal.metrics.ProbeLevel.DEBUG;
 import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
 import static com.hazelcast.internal.networking.HandlerStatus.DIRTY;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.util.Clock.approximateTimeMillis;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.collection.ArrayUtils.append;
 import static com.hazelcast.util.collection.ArrayUtils.replaceFirst;
@@ -269,7 +270,7 @@ public final class NioOutboundPipeline
     }
 
     private void flushToSocket() throws IOException {
-        lastWriteTime = currentTimeMillis();
+        lastWriteTime = approximateTimeMillis();
         int written = socketChannel.write(sendBuffer);
         bytesWritten.inc(written);
         //System.out.println(channel+" bytes written:"+written);

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -39,6 +39,7 @@ import static com.hazelcast.internal.metrics.ProbeLevel.INFO;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT_NOW;
 import static com.hazelcast.internal.networking.nio.SelectorOptimizer.newSelector;
 import static com.hazelcast.internal.util.counters.SwCounter.newSwCounter;
+import static com.hazelcast.util.Clock.approximateTimeMillis;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static java.lang.Math.max;
 import static java.lang.System.currentTimeMillis;
@@ -346,7 +347,7 @@ public class NioThread extends Thread implements OperationHostileThread {
     }
 
     private void processSelectionKeys() {
-        lastSelectTimeMs = currentTimeMillis();
+        lastSelectTimeMs = approximateTimeMillis();
         Iterator<SelectionKey> it = selector.selectedKeys().iterator();
         while (it.hasNext()) {
             SelectionKey sk = it.next();

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/Invocation.java
@@ -78,6 +78,7 @@ import static com.hazelcast.spi.impl.operationservice.impl.InvocationConstant.VO
 import static com.hazelcast.spi.impl.operationutil.Operations.isJoinOperation;
 import static com.hazelcast.spi.impl.operationutil.Operations.isMigrationOperation;
 import static com.hazelcast.spi.impl.operationutil.Operations.isWanReplicationOperation;
+import static com.hazelcast.util.Clock.approximateTimeMillis;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.StringUtil.timeToString;
 import static java.lang.Boolean.FALSE;
@@ -119,7 +120,7 @@ public abstract class Invocation<T> implements OperationResponseHandler {
      * This field is used to determine how long an invocation has actually been running.
      */
     @SuppressWarnings("checkstyle:visibilitymodifier")
-    public final long firstInvocationTimeMillis = Clock.currentTimeMillis();
+    public final long firstInvocationTimeMillis = approximateTimeMillis();
 
     /**
      * Contains the pending response from the primary. It is pending because it could be that backups need to complete.
@@ -376,7 +377,7 @@ public abstract class Invocation<T> implements OperationResponseHandler {
             // so the invocation has backups and since not all backups have completed, we need to wait
             // (it could be that backups arrive earlier than the response)
 
-            this.pendingResponseReceivedMillis = Clock.currentTimeMillis();
+            this.pendingResponseReceivedMillis = approximateTimeMillis();
 
             this.backupsAcksExpected = expectedBackups;
 
@@ -500,7 +501,7 @@ public abstract class Invocation<T> implements OperationResponseHandler {
 
         // a call is always allowed to execute as long as its own call timeout
         long deadlineMillis = op.getInvocationTime() + callTimeoutMillis;
-        if (deadlineMillis > context.clusterClock.getClusterTime()) {
+        if (deadlineMillis > context.clusterClock.getApproximateClusterTime()) {
             return NO_TIMEOUT__CALL_TIMEOUT_NOT_EXPIRED;
         }
 
@@ -608,7 +609,7 @@ public abstract class Invocation<T> implements OperationResponseHandler {
 
         invokeCount++;
 
-        setInvocationTime(op, context.clusterClock.getClusterTime());
+        setInvocationTime(op, context.clusterClock.getApproximateClusterTime());
 
         // We'll initialize the invocation before registering it. Invocation monitor iterates over
         // registered invocations and it must observe completely initialized invocations.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -370,7 +370,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
         }
 
         ClusterClock clusterClock = nodeEngine.getClusterService().getClusterClock();
-        long now = clusterClock.getClusterTime();
+        long now = clusterClock.getApproximateClusterTime();
         if (expireTime < now) {
             return true;
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/operations/Backup.java
@@ -141,7 +141,7 @@ public final class Backup extends Operation implements BackupOperation, AllowedD
             backupOp.setReplicaIndex(getReplicaIndex());
             backupOp.setCallerUuid(getCallerUuid());
             OperationAccessor.setCallerAddress(backupOp, getCallerAddress());
-            OperationAccessor.setInvocationTime(backupOp, Clock.currentTimeMillis());
+            OperationAccessor.setInvocationTime(backupOp, Clock.approximateTimeMillis());
             backupOp.setOperationResponseHandler(createEmptyResponseHandler());
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/util/JumpingSystemClock.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/JumpingSystemClock.java
@@ -37,6 +37,11 @@ class JumpingSystemClock extends Clock.ClockImpl {
     }
 
     @Override
+    protected long approximateTimeMillis() {
+        return currentTimeMillis();
+    }
+
+    @Override
     protected long currentTimeMillis() {
         long now = System.currentTimeMillis();
         if (now >= jumpAfter) {


### PR DESCRIPTION
Using the System.currentTimeMillis on EC2 can be expensive. This PR
introduces XEN optimized clock that is used when the xen clock on
Linux is detected and uses an approximate time instead of the actual
time.