### PR TITLE
Made NioThread.selector timeout configurable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioThread.java
@@ -46,7 +46,8 @@ import static java.lang.System.currentTimeMillis;
 public class NioThread extends Thread implements OperationHostileThread {
 
     // WARNING: This value has significant effect on idle CPU usage!
-    private static final int SELECT_WAIT_TIME_MILLIS = 5000;
+    private static final int SELECT_WAIT_TIME_MILLIS
+            = Integer.getInteger("hazelcast.io.select.wait.time.millis", 5000);
     private static final int SELECT_FAILURE_PAUSE_MILLIS = 1000;
     // When we detect Selector.select returning prematurely
     // for more than SELECT_IDLE_COUNT_THRESHOLD then we rebuild the selector


### PR DESCRIPTION
expert setting. Doesn't need to be documented and part of Group/ClientProperties.