### PR TITLE
Speed up client connecting to cluster

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/AddressProvider.java
@@ -16,9 +16,6 @@
 
 package com.hazelcast.client.connection;
 
-import com.hazelcast.nio.Address;
-
-import java.util.Collection;
 
 /**
  * Provides initial addresses for client to find and connect to a node
@@ -28,6 +25,6 @@ public interface AddressProvider {
     /**
      * @return The possible member addresses to connect to.
      */
-    Collection<Address> loadAddresses();
+    Addresses loadAddresses();
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/Addresses.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/Addresses.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.connection;
+
+import com.hazelcast.nio.Address;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * A collection of addresses. It is split in a group of primary
+ * addresses (so the ones that should be tried first) and a group
+ * of secondary addresses (addresses that should be tried when the
+ * primary group of addresses could not be connected to).
+ */
+public class Addresses {
+    private final List<Address> primary = new LinkedList<Address>();
+    private final List<Address> secondary = new LinkedList<Address>();
+
+    public Addresses() {
+    }
+
+    public Addresses(Collection<Address> primary) {
+        this.primary.addAll(primary);
+    }
+
+    public void addAll(Addresses addresses) {
+        primary.addAll(addresses.primary);
+        secondary.addAll(addresses.secondary);
+    }
+
+    public List<Address> primary() {
+        return primary;
+    }
+
+    public List<Address> secondary() {
+        return secondary;
+    }
+}

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/DefaultAddressProvider.java
@@ -18,21 +18,19 @@ package com.hazelcast.client.spi.impl;
 
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.client.connection.Addresses;
 import com.hazelcast.client.util.AddressHelper;
-import com.hazelcast.nio.Address;
 
-import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 
 /**
  * Default address provider of Hazelcast.
- *
+ * <p>
  * Loads addresses from the Hazelcast configuration.
  */
 public class DefaultAddressProvider implements AddressProvider {
 
-    private ClientNetworkConfig networkConfig;
+    private final ClientNetworkConfig networkConfig;
     private boolean noOtherAddressProviderExist;
 
     public DefaultAddressProvider(ClientNetworkConfig networkConfig, boolean noOtherAddressProviderExist) {
@@ -41,16 +39,18 @@ public class DefaultAddressProvider implements AddressProvider {
     }
 
     @Override
-    public Collection<Address> loadAddresses() {
-        final List<String> addresses = networkConfig.getAddresses();
-        if (addresses.isEmpty() && noOtherAddressProviderExist) {
-            addresses.add("127.0.0.1");
-        }
-        final List<Address> possibleAddresses = new LinkedList<Address>();
+    public Addresses loadAddresses() {
+        List<String> configuredAddresses = networkConfig.getAddresses();
 
-        for (String address : addresses) {
-            possibleAddresses.addAll(AddressHelper.getSocketAddresses(address));
+        if (configuredAddresses.isEmpty() && noOtherAddressProviderExist) {
+            configuredAddresses.add("127.0.0.1");
         }
-        return possibleAddresses;
+
+        Addresses addresses = new Addresses();
+        for (String address : configuredAddresses) {
+            addresses.addAll(AddressHelper.getSocketAddresses(address));
+        }
+
+        return addresses;
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/DiscoveryAddressProvider.java
@@ -17,14 +17,11 @@
 package com.hazelcast.client.spi.impl.discovery;
 
 import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.client.connection.Addresses;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.nio.Address;
 import com.hazelcast.spi.discovery.DiscoveryNode;
 import com.hazelcast.spi.discovery.integration.DiscoveryService;
-
-import java.util.ArrayList;
-import java.util.Collection;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
@@ -40,13 +37,13 @@ public class DiscoveryAddressProvider
     }
 
     @Override
-    public Collection<Address> loadAddresses() {
+    public Addresses loadAddresses() {
         Iterable<DiscoveryNode> discoveredNodes = checkNotNull(discoveryService.discoverNodes(),
                 "Discovered nodes cannot be null!");
 
-        Collection<Address> possibleMembers = new ArrayList<Address>();
+        Addresses possibleMembers = new Addresses();
         for (DiscoveryNode discoveryNode : discoveredNodes) {
-            possibleMembers.add(discoveryNode.getPrivateAddress());
+            possibleMembers.primary().add(discoveryNode.getPrivateAddress());
         }
         return possibleMembers;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/HazelcastCloudAddressProvider.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/discovery/HazelcastCloudAddressProvider.java
@@ -17,12 +17,9 @@
 package com.hazelcast.client.spi.impl.discovery;
 
 import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.client.connection.Addresses;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
-import com.hazelcast.nio.Address;
-
-import java.util.Collection;
-import java.util.Collections;
 
 public class HazelcastCloudAddressProvider implements AddressProvider {
 
@@ -39,14 +36,12 @@ public class HazelcastCloudAddressProvider implements AddressProvider {
     }
 
     @Override
-    public Collection<Address> loadAddresses() {
+    public Addresses loadAddresses() {
         try {
-            return cloudDiscovery.discoverNodes().keySet();
+            return new Addresses(cloudDiscovery.discoverNodes().keySet());
         } catch (Exception e) {
             logger.warning("Failed to load addresses from hazelcast.cloud : " + e.getMessage());
         }
-        return Collections.emptyList();
+        return new Addresses();
     }
-
-
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientConnectionTest.java
@@ -103,7 +103,9 @@ public class ClientConnectionTest extends HazelcastTestSupport {
         Address serverAddress = server.getCluster().getLocalMember().getAddress();
         ClientConfig config = new ClientConfig();
         config.setProperty(ClientProperty.SHUFFLE_MEMBER_LIST.getName(), "false");
-        config.getNetworkConfig().addAddress(illegalAddress).addAddress(serverAddress.getHost() + ":" + serverAddress.getPort());
+        config.getNetworkConfig()
+                .addAddress(illegalAddress)
+                .addAddress(serverAddress.getHost() + ":" + serverAddress.getPort());
         HazelcastInstance client = hazelcastFactory.newHazelcastClient(config);
 
         Collection<Client> connectedClients = server.getClientService().getConnectedClients();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithRealNetworkTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.config.ClientConnectionStrategyConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.connection.ClientConnectionManager;
+import com.hazelcast.client.connection.Addresses;
 import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
 import com.hazelcast.client.impl.clientside.ClientConnectionManagerFactory;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
@@ -37,7 +38,6 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
 import com.hazelcast.map.listener.EntryAddedListener;
-import com.hazelcast.nio.Address;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -47,7 +47,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -229,7 +228,7 @@ public class ClientRegressionWithRealNetworkTest extends ClientTestSupport {
         final CountDownLatch testFinished = new CountDownLatch(1);
         final AddressProvider addressProvider = new AddressProvider() {
             @Override
-            public Collection<Address> loadAddresses() {
+            public Addresses loadAddresses() {
                 if (waitFlag.get()) {
                     try {
                         testFinished.await();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientConnectionManagerTranslateTest.java
@@ -16,9 +16,11 @@
 
 package com.hazelcast.client.spi.impl;
 
+import com.google.common.collect.ImmutableList;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.connection.AddressTranslator;
+import com.hazelcast.client.connection.Addresses;
 import com.hazelcast.client.connection.nio.ClientConnectionManagerImpl;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.test.ClientTestSupport;
@@ -97,9 +99,9 @@ public class ClientConnectionManagerTranslateTest extends ClientTestSupport {
 
     private class TestAddressProvider implements AddressProvider {
         @Override
-        public Collection<Address> loadAddresses() {
+        public Addresses loadAddresses() {
             try {
-                return Collections.singletonList(new Address("127.0.0.1", 5701));
+                return new Addresses(ImmutableList.of(new Address("127.0.0.1", 5701)));
             } catch (UnknownHostException e) {
                 return null;
             }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/DefaultAddressProviderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/DefaultAddressProviderTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.spi.impl;
+
+import com.hazelcast.client.config.ClientNetworkConfig;
+import com.hazelcast.client.connection.Addresses;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class DefaultAddressProviderTest {
+
+    @Test
+    public void whenNoAddresses() throws UnknownHostException {
+        ClientNetworkConfig config = new ClientNetworkConfig();
+        DefaultAddressProvider provider = new DefaultAddressProvider(config, true);
+        Addresses addresses = provider.loadAddresses();
+
+        assertPrimary(addresses, new Address("127.0.0.1", 5701));
+        assertSecondary(addresses, new Address("127.0.0.1", 5702), new Address("127.0.0.1", 5703));
+    }
+
+    @Test
+    public void whenExplicitNoPortAddress() throws UnknownHostException {
+        ClientNetworkConfig config = new ClientNetworkConfig();
+        config.addAddress("10.0.0.1");
+        DefaultAddressProvider provider = new DefaultAddressProvider(config, true);
+        Addresses addresses = provider.loadAddresses();
+
+        assertPrimary(addresses, new Address("10.0.0.1", 5701));
+        assertSecondary(addresses, new Address("10.0.0.1", 5702), new Address("10.0.0.1", 5703));
+    }
+
+    @Test
+    public void whenExplicitPorts() throws UnknownHostException {
+        ClientNetworkConfig config = new ClientNetworkConfig();
+        config.addAddress("10.0.0.1:5703");
+        config.addAddress("10.0.0.1:5702");
+        DefaultAddressProvider provider = new DefaultAddressProvider(config, true);
+        Addresses addresses = provider.loadAddresses();
+
+        assertPrimary(addresses, new Address("10.0.0.1", 5703), new Address("10.0.0.1", 5702));
+        assertSecondaryEmpty(addresses);
+    }
+
+    @Test
+    public void whenMix() throws UnknownHostException {
+        ClientNetworkConfig config = new ClientNetworkConfig();
+        config.addAddress("10.0.0.1:5701");
+        config.addAddress("10.0.0.1:5702");
+        config.addAddress("10.0.0.2");
+        DefaultAddressProvider provider = new DefaultAddressProvider(config, true);
+        Addresses addresses = provider.loadAddresses();
+
+        assertPrimary(addresses, new Address("10.0.0.1", 5701),
+                new Address("10.0.0.1", 5702),
+                new Address("10.0.0.2", 5701));
+        assertSecondary(addresses, new Address("10.0.0.2", 5702), new Address("10.0.0.2", 5703));
+    }
+
+    @Test
+    public void whenBogusAddress() {
+        ClientNetworkConfig config = new ClientNetworkConfig();
+        config.addAddress(UUID.randomUUID().toString());
+        DefaultAddressProvider provider = new DefaultAddressProvider(config, true);
+        Addresses addresses = provider.loadAddresses();
+
+        assertPrimaryEmpty(addresses);
+        assertSecondaryEmpty(addresses);
+    }
+
+    public void assertPrimary(Addresses addresses, Address... expected) {
+        assertEquals(Arrays.asList(expected), addresses.primary());
+    }
+
+    public void assertSecondaryEmpty(Addresses addresses) {
+        assertTrue(addresses.secondary().isEmpty());
+    }
+
+    public void assertPrimaryEmpty(Addresses addresses) {
+        assertTrue(addresses.primary().isEmpty());
+    }
+
+    public void assertSecondary(Addresses addresses, Address... expected) {
+        assertEquals(Arrays.asList(expected), addresses.secondary());
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/HazelcastCloudProviderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/HazelcastCloudProviderTest.java
@@ -63,7 +63,7 @@ public class HazelcastCloudProviderTest {
 
     @Test
     public void testLoadAddresses() {
-        Collection<Address> addresses = provider.loadAddresses();
+        Collection<Address> addresses = provider.loadAddresses().primary();
 
         assertEquals(3, addresses.size());
         for (Address address : expectedAddresses.keySet()) {
@@ -76,7 +76,7 @@ public class HazelcastCloudProviderTest {
     public void testLoadAddresses_whenExceptionIsThrown() {
         when(hazelcastCloudDiscovery.discoverNodes()).thenThrow(new IllegalStateException("Expected exception"));
 
-        Collection<Address> addresses = provider.loadAddresses();
+        Collection<Address> addresses = provider.loadAddresses().primary();
 
         assertEquals("Expected that no addresses are loaded", 0, addresses.size());
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.config.ClientAwsConfig;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.client.connection.Addresses;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.client.spi.properties.ClientProperty;
@@ -33,7 +34,6 @@ import com.hazelcast.test.TestEnvironment;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
@@ -97,10 +97,10 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
 
         return new AddressProvider() {
             @Override
-            public Collection<Address> loadAddresses() {
-                Collection<Address> possibleAddresses = new ArrayList<Address>();
+            public Addresses loadAddresses() {
+                Addresses possibleAddresses = new Addresses();
                 for (Address address : getKnownAddresses()) {
-                    Collection<Address> addresses = AddressHelper.getPossibleSocketAddresses(address.getPort(),
+                    Addresses addresses = AddressHelper.getPossibleSocketAddresses(address.getPort(),
                             address.getHost(), 1);
                     possibleAddresses.addAll(addresses);
                 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnOwnerDisconnectedTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientTxnOwnerDisconnectedTest.java
@@ -22,17 +22,16 @@ import com.hazelcast.client.HazelcastClientFactory;
 import com.hazelcast.client.HazelcastClientManager;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.connection.AddressProvider;
+import com.hazelcast.client.connection.Addresses;
 import com.hazelcast.client.impl.clientside.ClientConnectionManagerFactory;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
 import com.hazelcast.client.spi.properties.ClientProperty;
 import com.hazelcast.client.test.ClientTestSupport;
-import com.hazelcast.client.util.AddressHelper;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.LifecycleListener;
-import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.transaction.HazelcastXAResource;
@@ -47,9 +46,10 @@ import org.junit.runner.RunWith;
 import javax.transaction.Transaction;
 import java.io.File;
 import java.io.FilenameFilter;
-import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.hazelcast.client.util.AddressHelper.getSocketAddresses;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -75,7 +75,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
         final CountDownLatch testFinished = new CountDownLatch(1);
         final AddressProvider addressProvider = new AddressProvider() {
             @Override
-            public Collection<Address> loadAddresses() {
+            public Addresses loadAddresses() {
                 if (waitFlag.get()) {
                     try {
                         testFinished.await();
@@ -83,7 +83,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
                         e.printStackTrace();
                     }
                 }
-                return AddressHelper.getSocketAddresses("127.0.0.1");
+                return getSocketAddresses("127.0.0.1");
             }
         };
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
@@ -133,7 +133,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
         final CountDownLatch testFinished = new CountDownLatch(1);
         final AddressProvider addressProvider = new AddressProvider() {
             @Override
-            public Collection<Address> loadAddresses() {
+            public Addresses loadAddresses() {
                 if (waitFlag.get()) {
                     try {
                         testFinished.await();
@@ -141,7 +141,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
                         e.printStackTrace();
                     }
                 }
-                return AddressHelper.getSocketAddresses("127.0.0.1");
+                return getSocketAddresses("127.0.0.1");
             }
         };
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
@@ -191,7 +191,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
         final CountDownLatch testFinished = new CountDownLatch(1);
         final AddressProvider addressProvider = new AddressProvider() {
             @Override
-            public Collection<Address> loadAddresses() {
+            public Addresses loadAddresses() {
                 if (waitFlag.get()) {
                     try {
                         testFinished.await();
@@ -199,7 +199,7 @@ public class ClientTxnOwnerDisconnectedTest extends ClientTestSupport {
                         e.printStackTrace();
                     }
                 }
-                return AddressHelper.getSocketAddresses("127.0.0.1");
+                return getSocketAddresses("127.0.0.1");
             }
         };
         clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);


### PR DESCRIPTION
If a client has not configured explicit ports for the members,
it is likely it will try 5702 and 5703 as well. Leading to increased
latency because connecting to a non existing server port takes
time.

Backport of https://github.com/hazelcast/hazelcast/pull/14249