### PR TITLE
Replace and import support in YAML member config

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
@@ -16,11 +16,11 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.config.AbstractConfigImportVariableReplacementTest.IdentityReplacer;
+import com.hazelcast.config.AbstractConfigImportVariableReplacementTest.TestReplacer;
 import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.InvalidConfigurationException;
-import com.hazelcast.config.XmlConfigImportVariableReplacementTest.IdentityReplacer;
-import com.hazelcast.config.XmlConfigImportVariableReplacementTest.TestReplacer;
 import com.hazelcast.config.replacer.EncryptionReplacer;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractDomVariableReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractDomVariableReplacer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.w3c.dom.Node;
+
+import static java.lang.String.format;
+
+abstract class AbstractDomVariableReplacer implements DomVariableReplacer {
+    private static final ILogger LOGGER = Logger.getLogger(ConfigReplacerHelper.class);
+
+    protected static String replaceValue(Node node, ConfigReplacer replacer, boolean failFast, String value) {
+        StringBuilder sb = new StringBuilder(value);
+        String replacerPrefix = "$" + replacer.getPrefix() + "{";
+        int endIndex = -1;
+        int startIndex = sb.indexOf(replacerPrefix);
+        while (startIndex > -1) {
+            endIndex = sb.indexOf("}", startIndex);
+            if (endIndex == -1) {
+                LOGGER.warning("Bad variable syntax. Could not find a closing curly bracket '}' for prefix " + replacerPrefix
+                        + " on node: " + node.getLocalName());
+                break;
+            }
+
+            String variable = sb.substring(startIndex + replacerPrefix.length(), endIndex);
+            String variableReplacement = replacer.getReplacement(variable);
+            if (variableReplacement != null) {
+                sb.replace(startIndex, endIndex + 1, variableReplacement);
+                endIndex = startIndex + variableReplacement.length();
+            } else {
+                handleMissingVariable(sb.substring(startIndex, endIndex + 1), node.getLocalName(), failFast);
+            }
+            startIndex = sb.indexOf(replacerPrefix, endIndex);
+        }
+        return sb.toString();
+    }
+
+    void replaceVariableInNodeValue(Node node, ConfigReplacer replacer, boolean failFast) {
+        String value = node.getNodeValue();
+        if (value != null) {
+            String replacedValue = replaceValue(node, replacer, failFast, value);
+            node.setNodeValue(replacedValue);
+        }
+    }
+
+    private static void handleMissingVariable(String variable, String nodeName, boolean failFast) throws ConfigurationException {
+        String message = format("Could not find a replacement for '%s' on node '%s'", variable, nodeName);
+        if (failFast) {
+            throw new ConfigurationException(message);
+        }
+        LOGGER.warning(message);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigBuilder.java
@@ -123,7 +123,8 @@ public abstract class AbstractXmlConfigBuilder extends AbstractXmlConfigHelper {
             throw new InvalidConfigurationException("Failed to load resource: " + resource);
         }
         if (!currentlyImportedFiles.add(url.getPath())) {
-            throw new InvalidConfigurationException("Cyclic loading of resource '" + url.getPath() + "' detected!");
+            throw new InvalidConfigurationException("Resource '" + url.getPath() + "' is already loaded! This can be due to"
+                    + " duplicate or cyclic imports.");
         }
         Document doc = parse(url.openStream());
         Element importedRoot = doc.getDocumentElement();

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigBuilder.java
@@ -205,10 +205,7 @@ public abstract class AbstractXmlConfigBuilder extends AbstractXmlConfigHelper {
             }
         }
 
-        // Use all the replacers on the XML content
-        for (ConfigReplacer replacer : replacers) {
-            traverseChildrenAndReplaceVariables(root, replacer, failFast);
-        }
+        ConfigReplacerHelper.traverseChildrenAndReplaceVariables(root, replacers, failFast);
     }
 
     private ConfigReplacer createReplacer(Node node) throws Exception {
@@ -224,58 +221,4 @@ public abstract class AbstractXmlConfigBuilder extends AbstractXmlConfigHelper {
         replacer.init(properties);
         return replacer;
     }
-
-    private void traverseChildrenAndReplaceVariables(Node root, ConfigReplacer replacer, boolean failFast) {
-        NamedNodeMap attributes = root.getAttributes();
-        if (attributes != null) {
-            for (int k = 0; k < attributes.getLength(); k++) {
-                Node attribute = attributes.item(k);
-                replaceVariables(attribute, replacer, failFast);
-            }
-        }
-        if (root.getNodeValue() != null) {
-            replaceVariables(root, replacer, failFast);
-        }
-        final NodeList childNodes = root.getChildNodes();
-        for (int k = 0; k < childNodes.getLength(); k++) {
-            Node child = childNodes.item(k);
-            traverseChildrenAndReplaceVariables(child, replacer, failFast);
-        }
-    }
-
-    private void replaceVariables(Node node, ConfigReplacer replacer, boolean failFast) {
-        String value = node.getNodeValue();
-        StringBuilder sb = new StringBuilder(value);
-        String replacerPrefix = "$" + replacer.getPrefix() + "{";
-        int endIndex = -1;
-        int startIndex = sb.indexOf(replacerPrefix);
-        while (startIndex > -1) {
-            endIndex = sb.indexOf("}", startIndex);
-            if (endIndex == -1) {
-                LOGGER.warning("Bad variable syntax. Could not find a closing curly bracket '}' for prefix " + replacerPrefix
-                        + " on node: " + node.getLocalName());
-                break;
-            }
-
-            String variable = sb.substring(startIndex + replacerPrefix.length(), endIndex);
-            String variableReplacement = replacer.getReplacement(variable);
-            if (variableReplacement != null) {
-                sb.replace(startIndex, endIndex + 1, variableReplacement);
-                endIndex = startIndex + variableReplacement.length();
-            } else {
-                handleMissingVariable(sb.substring(startIndex, endIndex + 1), node.getLocalName(), failFast);
-            }
-            startIndex = sb.indexOf(replacerPrefix, endIndex);
-        }
-        node.setNodeValue(sb.toString());
-    }
-
-    private void handleMissingVariable(String variable, String nodeName, boolean failFast) throws ConfigurationException {
-        String message = format("Could not find a replacement for '%s' on node '%s'", variable, nodeName);
-        if (failFast) {
-            throw new ConfigurationException(message);
-        }
-        LOGGER.warning(message);
-    }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractXmlConfigBuilder.java
@@ -197,7 +197,7 @@ public abstract class AbstractXmlConfigBuilder extends AbstractXmlConfigHelper {
                 XPathConstants.NODE);
         if (node != null) {
             String failFastAttr = getAttribute(node, "fail-if-value-missing");
-            failFast = isNullOrEmpty(failFastAttr) ? true : Boolean.parseBoolean(failFastAttr);
+            failFast = isNullOrEmpty(failFastAttr) || Boolean.parseBoolean(failFastAttr);
             for (Node n : childElements(node)) {
                 String value = cleanNodeName(n);
                 if ("replacer".equals(value)) {
@@ -206,7 +206,7 @@ public abstract class AbstractXmlConfigBuilder extends AbstractXmlConfigHelper {
             }
         }
 
-        ConfigReplacerHelper.traverseChildrenAndReplaceVariables(root, replacers, failFast);
+        ConfigReplacerHelper.traverseChildrenAndReplaceVariables(root, replacers, failFast, new XmlDomVariableReplacer());
     }
 
     private ConfigReplacer createReplacer(Node node) throws Exception {

--- a/hazelcast/src/main/java/com/hazelcast/config/ClasspathYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ClasspathYamlConfig.java
@@ -95,6 +95,6 @@ public class ClasspathYamlConfig extends Config {
         if (in == null) {
             throw new IllegalArgumentException("Specified resource '" + resource + "' could not be found!");
         }
-        new YamlConfigBuilder(in).build(this);
+        new YamlConfigBuilder(in).setProperties(properties).build(this);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigReplacerHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigReplacerHelper.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import com.hazelcast.config.yaml.ElementAdapter;
+import com.hazelcast.internal.yaml.MutableYamlNode;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.util.List;
+
+import static java.lang.String.format;
+
+/**
+ * Helper class for replacing variables in the XML and YAML configuration DOMs
+ */
+final class ConfigReplacerHelper {
+
+    private static final ILogger LOGGER = Logger.getLogger(ConfigReplacerHelper.class);
+
+    private ConfigReplacerHelper() {
+    }
+
+    static void traverseChildrenAndReplaceVariables(Node root, List<ConfigReplacer> replacers, boolean failFast) {
+
+        // Use all the replacers on the content
+        for (ConfigReplacer replacer : replacers) {
+            traverseChildrenAndReplaceVariables(root, replacer, failFast);
+        }
+    }
+
+    private static void traverseChildrenAndReplaceVariables(Node root, ConfigReplacer replacer, boolean failFast) {
+        NamedNodeMap attributes = root.getAttributes();
+        if (attributes != null) {
+            for (int k = 0; k < attributes.getLength(); k++) {
+                Node attribute = attributes.item(k);
+                replaceVariables(attribute, replacer, failFast);
+            }
+        }
+        if (root.getNodeValue() != null) {
+            replaceVariables(root, replacer, failFast);
+        }
+        final NodeList childNodes = root.getChildNodes();
+        for (int k = 0; k < childNodes.getLength(); k++) {
+            Node child = childNodes.item(k);
+            if (child != null) {
+                traverseChildrenAndReplaceVariables(child, replacer, failFast);
+            }
+        }
+    }
+
+    private static void replaceVariables(Node node, ConfigReplacer replacer, boolean failFast) {
+        if (node == null) {
+            return;
+        }
+
+        String value = node.getNodeValue();
+        if (value != null) {
+            String replacedValue = replaceValue(node, replacer, failFast, value);
+            node.setNodeValue(replacedValue);
+        }
+
+        // if its an ElementAdapter, this is a YAML node, in which case
+        // we may need to replace variable in the name of the node as well
+        if (node instanceof ElementAdapter) {
+            MutableYamlNode yamlNode = (MutableYamlNode) ((ElementAdapter) node).getYamlNode();
+            String nodeName = yamlNode.nodeName();
+            if (nodeName != null) {
+                String replacedName = replaceValue(node, replacer, failFast, nodeName);
+                yamlNode.setNodeName(replacedName);
+            }
+        }
+    }
+
+    private static String replaceValue(Node node, ConfigReplacer replacer, boolean failFast, String value) {
+        StringBuilder sb = new StringBuilder(value);
+        String replacerPrefix = "$" + replacer.getPrefix() + "{";
+        int endIndex = -1;
+        int startIndex = sb.indexOf(replacerPrefix);
+        while (startIndex > -1) {
+            endIndex = sb.indexOf("}", startIndex);
+            if (endIndex == -1) {
+                LOGGER.warning("Bad variable syntax. Could not find a closing curly bracket '}' for prefix " + replacerPrefix
+                        + " on node: " + node.getLocalName());
+                break;
+            }
+
+            String variable = sb.substring(startIndex + replacerPrefix.length(), endIndex);
+            String variableReplacement = replacer.getReplacement(variable);
+            if (variableReplacement != null) {
+                sb.replace(startIndex, endIndex + 1, variableReplacement);
+                endIndex = startIndex + variableReplacement.length();
+            } else {
+                handleMissingVariable(sb.substring(startIndex, endIndex + 1), node.getLocalName(), failFast);
+            }
+            startIndex = sb.indexOf(replacerPrefix, endIndex);
+        }
+        return sb.toString();
+    }
+
+    private static void handleMissingVariable(String variable, String nodeName, boolean failFast) throws ConfigurationException {
+        String message = format("Could not find a replacement for '%s' on node '%s'", variable, nodeName);
+        if (failFast) {
+            throw new ConfigurationException(message);
+        }
+        LOGGER.warning(message);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigReplacerHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigReplacerHelper.java
@@ -61,17 +61,11 @@ final class ConfigReplacerHelper {
         final NodeList childNodes = root.getChildNodes();
         for (int k = 0; k < childNodes.getLength(); k++) {
             Node child = childNodes.item(k);
-            if (child != null) {
-                traverseChildrenAndReplaceVariables(child, replacer, failFast);
-            }
+            traverseChildrenAndReplaceVariables(child, replacer, failFast);
         }
     }
 
     private static void replaceVariables(Node node, ConfigReplacer replacer, boolean failFast) {
-        if (node == null) {
-            return;
-        }
-
         String value = node.getNodeValue();
         if (value != null) {
             String replacedValue = replaceValue(node, replacer, failFast, value);

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigReplacerHelper.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigReplacerHelper.java
@@ -17,104 +17,45 @@
 package com.hazelcast.config;
 
 import com.hazelcast.config.replacer.spi.ConfigReplacer;
-import com.hazelcast.config.yaml.ElementAdapter;
-import com.hazelcast.internal.yaml.MutableYamlNode;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import java.util.List;
 
-import static java.lang.String.format;
-
 /**
- * Helper class for replacing variables in the XML and YAML configuration DOMs
+ * Helper class for replacing variables in the configuration DOMs.
  */
 final class ConfigReplacerHelper {
-
-    private static final ILogger LOGGER = Logger.getLogger(ConfigReplacerHelper.class);
 
     private ConfigReplacerHelper() {
     }
 
-    static void traverseChildrenAndReplaceVariables(Node root, List<ConfigReplacer> replacers, boolean failFast) {
-
+    static void traverseChildrenAndReplaceVariables(Node root, List<ConfigReplacer> replacers, boolean failFast,
+                                                    DomVariableReplacer variableReplacer) {
         // Use all the replacers on the content
         for (ConfigReplacer replacer : replacers) {
-            traverseChildrenAndReplaceVariables(root, replacer, failFast);
+            traverseChildrenAndReplaceVariables(root, replacer, failFast, variableReplacer);
         }
     }
 
-    private static void traverseChildrenAndReplaceVariables(Node root, ConfigReplacer replacer, boolean failFast) {
+    private static void traverseChildrenAndReplaceVariables(Node root, ConfigReplacer replacer, boolean failFast,
+                                                            DomVariableReplacer variableReplacer) {
         NamedNodeMap attributes = root.getAttributes();
         if (attributes != null) {
             for (int k = 0; k < attributes.getLength(); k++) {
                 Node attribute = attributes.item(k);
-                replaceVariables(attribute, replacer, failFast);
+                variableReplacer.replaceVariables(attribute, replacer, failFast);
             }
         }
         if (root.getNodeValue() != null) {
-            replaceVariables(root, replacer, failFast);
+            variableReplacer.replaceVariables(root, replacer, failFast);
         }
         final NodeList childNodes = root.getChildNodes();
         for (int k = 0; k < childNodes.getLength(); k++) {
             Node child = childNodes.item(k);
-            traverseChildrenAndReplaceVariables(child, replacer, failFast);
+            traverseChildrenAndReplaceVariables(child, replacer, failFast, variableReplacer);
         }
     }
 
-    private static void replaceVariables(Node node, ConfigReplacer replacer, boolean failFast) {
-        String value = node.getNodeValue();
-        if (value != null) {
-            String replacedValue = replaceValue(node, replacer, failFast, value);
-            node.setNodeValue(replacedValue);
-        }
-
-        // if its an ElementAdapter, this is a YAML node, in which case
-        // we may need to replace variable in the name of the node as well
-        if (node instanceof ElementAdapter) {
-            MutableYamlNode yamlNode = (MutableYamlNode) ((ElementAdapter) node).getYamlNode();
-            String nodeName = yamlNode.nodeName();
-            if (nodeName != null) {
-                String replacedName = replaceValue(node, replacer, failFast, nodeName);
-                yamlNode.setNodeName(replacedName);
-            }
-        }
-    }
-
-    private static String replaceValue(Node node, ConfigReplacer replacer, boolean failFast, String value) {
-        StringBuilder sb = new StringBuilder(value);
-        String replacerPrefix = "$" + replacer.getPrefix() + "{";
-        int endIndex = -1;
-        int startIndex = sb.indexOf(replacerPrefix);
-        while (startIndex > -1) {
-            endIndex = sb.indexOf("}", startIndex);
-            if (endIndex == -1) {
-                LOGGER.warning("Bad variable syntax. Could not find a closing curly bracket '}' for prefix " + replacerPrefix
-                        + " on node: " + node.getLocalName());
-                break;
-            }
-
-            String variable = sb.substring(startIndex + replacerPrefix.length(), endIndex);
-            String variableReplacement = replacer.getReplacement(variable);
-            if (variableReplacement != null) {
-                sb.replace(startIndex, endIndex + 1, variableReplacement);
-                endIndex = startIndex + variableReplacement.length();
-            } else {
-                handleMissingVariable(sb.substring(startIndex, endIndex + 1), node.getLocalName(), failFast);
-            }
-            startIndex = sb.indexOf(replacerPrefix, endIndex);
-        }
-        return sb.toString();
-    }
-
-    private static void handleMissingVariable(String variable, String nodeName, boolean failFast) throws ConfigurationException {
-        String message = format("Could not find a replacement for '%s' on node '%s'", variable, nodeName);
-        if (failFast) {
-            throw new ConfigurationException(message);
-        }
-        LOGGER.warning(message);
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/DomVariableReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/DomVariableReplacer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import org.w3c.dom.Node;
+
+/**
+ * Interface for replacing variable in DOM {@link Node}s.
+ */
+interface DomVariableReplacer {
+
+    /**
+     * Replaces variables in the given {@link Node} with the provided
+     * {@link ConfigReplacer}.
+     *
+     * @param node     The node in which the variables to be replaced
+     * @param replacer The replacer to be used for replacing the variables
+     * @param failFast Indicating whether or not a {@link ConfigurationException}
+     *                 should be thrown if no replacement found for the
+     *                 variables in the node
+     *
+     * @throws ConfigurationException if no replacement is found for a variable and {@code failFast} is {@code }true
+     */
+    void replaceVariables(Node node, ConfigReplacer replacer, boolean failFast);
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/FileSystemYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/FileSystemYamlConfig.java
@@ -91,6 +91,6 @@ public class FileSystemYamlConfig extends Config {
 
         LOGGER.info("Configuring Hazelcast from '" + configFile.getAbsolutePath() + "'.");
         InputStream in = new FileInputStream(configFile);
-        new YamlConfigBuilder(in).build(this);
+        new YamlConfigBuilder(in).setProperties(properties).build(this);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryXmlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryXmlConfig.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Properties;
 
+import static com.hazelcast.util.StringUtil.isNullOrEmptyAfterTrim;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
 /**
@@ -53,7 +54,7 @@ public class InMemoryXmlConfig extends Config {
      */
     public InMemoryXmlConfig(String xml, Properties properties) {
         LOGGER.info("Configuring Hazelcast from 'in-memory xml'.");
-        if (xml == null || "".equals(xml.trim())) {
+        if (isNullOrEmptyAfterTrim(xml)) {
             throw new IllegalArgumentException("XML configuration is null or empty! Please use a well-structured xml.");
         }
         if (properties == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryYamlConfig.java
@@ -60,6 +60,6 @@ public class InMemoryYamlConfig extends Config {
         }
 
         InputStream in = new ByteArrayInputStream(stringToBytes(yaml));
-        new YamlConfigBuilder(in).build(this);
+        new YamlConfigBuilder(in).setProperties(properties).build(this);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/InMemoryYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/InMemoryYamlConfig.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.Properties;
 
+import static com.hazelcast.util.StringUtil.isNullOrEmptyAfterTrim;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
 /**
@@ -52,7 +53,7 @@ public class InMemoryYamlConfig extends Config {
      */
     public InMemoryYamlConfig(String yaml, Properties properties) {
         LOGGER.info("Configuring Hazelcast from 'in-memory YAML'.");
-        if (yaml == null || "".equals(yaml.trim())) {
+        if (isNullOrEmptyAfterTrim(yaml)) {
             throw new IllegalArgumentException("YAML configuration is null or empty! Please use a well-structured YAML.");
         }
         if (properties == null) {

--- a/hazelcast/src/main/java/com/hazelcast/config/UrlYamlConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/UrlYamlConfig.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Properties;
+
+/**
+ * A {@link Config} which is loaded using some url pointing to a Hazelcast YAML file.
+ */
+public class UrlYamlConfig extends Config {
+
+    private static final ILogger LOGGER = Logger.getLogger(UrlYamlConfig.class);
+
+    /**
+     * Creates new Config which is loaded from the given url and uses the System.properties to replace
+     * variables in the YAML.
+     *
+     * @param url the url pointing to the Hazelcast YAML file
+     * @throws MalformedURLException                 if the url is not correct
+     * @throws IOException                           if something fails while loading the resource
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public UrlYamlConfig(String url) throws IOException {
+        this(new URL(url));
+    }
+
+    /**
+     * Creates new Config which is loaded from the given url.
+     *
+     * @param url        the url pointing to the Hazelcast YAML file
+     * @param properties the properties for replacing variables
+     * @throws IllegalArgumentException              if properties is {@code null}
+     * @throws MalformedURLException                 if the url is not correct
+     * @throws IOException                           if something fails while loading the resource
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public UrlYamlConfig(String url, Properties properties) throws IOException {
+        this(new URL(url), properties);
+    }
+
+    /**
+     * Creates new Config which is loaded from the given url and uses the System.properties to replace
+     * variables in the YAML.
+     *
+     * @param url the URL pointing to the Hazelcast YAML file
+     * @throws IOException                           if something fails while loading the resource
+     * @throws IllegalArgumentException              if the url is {@code null}
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public UrlYamlConfig(URL url) throws IOException {
+        this(url, System.getProperties());
+    }
+
+    /**
+     * Creates new Config which is loaded from the given url.
+     *
+     * @param url        the URL pointing to the Hazelcast YAML file
+     * @param properties the properties for replacing variables
+     * @throws IOException                           if something fails while loading the resource
+     * @throws IllegalArgumentException              if the url or properties is {@code null}
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public UrlYamlConfig(URL url, Properties properties) throws IOException {
+        if (url == null) {
+            throw new IllegalArgumentException("url can't be null");
+        }
+        if (properties == null) {
+            throw new IllegalArgumentException("properties can't be null");
+        }
+
+        LOGGER.info("Configuring Hazelcast from '" + url.toString() + "'.");
+        InputStream in = url.openStream();
+        new YamlConfigBuilder(in).setProperties(properties).build(this);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlDomVariableReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlDomVariableReplacer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import org.w3c.dom.Node;
+
+class XmlDomVariableReplacer extends AbstractDomVariableReplacer {
+
+    @Override
+    public void replaceVariables(Node node, ConfigReplacer replacer, boolean failFast) {
+        replaceVariableInNodeValue(node, replacer, failFast);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -16,11 +16,18 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.config.yaml.W3cDomUtil;
+import com.hazelcast.config.replacer.PropertyReplacer;
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import com.hazelcast.config.yaml.ElementAdapter;
+import com.hazelcast.internal.yaml.MutableYamlMapping;
 import com.hazelcast.internal.yaml.YamlLoader;
 import com.hazelcast.internal.yaml.YamlMapping;
+import com.hazelcast.internal.yaml.YamlMappingImpl;
+import com.hazelcast.internal.yaml.YamlNameNodePair;
 import com.hazelcast.internal.yaml.YamlNode;
+import com.hazelcast.internal.yaml.YamlSequence;
 import com.hazelcast.util.ExceptionUtil;
+import org.w3c.dom.Node;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -28,21 +35,36 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
 
+import static com.hazelcast.config.DomConfigHelper.childElements;
+import static com.hazelcast.config.DomConfigHelper.cleanNodeName;
+import static com.hazelcast.config.DomConfigHelper.getAttribute;
+import static com.hazelcast.config.yaml.W3cDomUtil.asW3cNode;
+import static com.hazelcast.internal.yaml.YamlUtil.asMapping;
+import static com.hazelcast.internal.yaml.YamlUtil.asScalar;
 import static com.hazelcast.internal.yaml.YamlUtil.ensureRunningOnJava8OrHigher;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static com.hazelcast.util.StringUtil.isNullOrEmpty;
 
 /**
  * A YAML {@link ConfigBuilder} implementation.
- *
+ * <p/>
  * This config builder is compatible with the YAML 1.2 specification and
- * supports the JSON Scheme.
+ * supports the JSON Schema.
  */
 public class YamlConfigBuilder implements ConfigBuilder {
+
+    private final Set<String> currentlyImportedFiles = new HashSet<String>();
     private final InputStream in;
 
     private File configurationFile;
     private URL configurationUrl;
+    private Properties properties;
 
     /**
      * Constructs a YamlConfigBuilder that reads from the provided YAML file.
@@ -144,7 +166,139 @@ public class YamlConfigBuilder implements ConfigBuilder {
             throw new InvalidConfigurationException("No mapping with hazelcast key is found in the provided configuration");
         }
 
-        new YamlMemberDomConfigProcessor(true, config).buildConfig(W3cDomUtil.asW3cNode(imdgRoot));
+        Node w3cRootNode = asW3cNode(imdgRoot);
+        replaceVariables(w3cRootNode);
+        importDocuments(imdgRoot);
+
+        new YamlMemberDomConfigProcessor(true, config).buildConfig(w3cRootNode);
+    }
+
+    private void importDocuments(YamlNode imdgRoot) throws Exception {
+        YamlMapping rootAsMapping = asMapping(imdgRoot);
+        YamlSequence importSeq = rootAsMapping.childAsSequence(ConfigSections.IMPORT.name);
+        if (importSeq == null || importSeq.childCount() == 0) {
+            return;
+        }
+
+        for (YamlNode importNode : importSeq.children()) {
+            String resource = asScalar(importNode).nodeValue();
+            URL url = ConfigLoader.locateConfig(resource);
+            if (url == null) {
+                throw new InvalidConfigurationException("Failed to load resource: " + resource);
+            }
+            if (!currentlyImportedFiles.add(url.getPath())) {
+                throw new InvalidConfigurationException("Cyclic loading of resource '" + url.getPath() + "' detected!");
+            }
+
+            YamlNode rootLoaded;
+            try {
+                rootLoaded = YamlLoader.load(url.openStream());
+            } catch (Exception ex) {
+                throw new InvalidConfigurationException("Loading YAML document from resource " + url.getPath() + " failed", ex);
+            }
+            YamlNode imdgRootLoaded = asMapping(rootLoaded).child(ConfigSections.HAZELCAST.name().toLowerCase());
+
+            replaceVariables(asW3cNode(imdgRootLoaded));
+            importDocuments(imdgRootLoaded);
+
+            // we need to merge and not just substitute with the content of the imported document
+            // YAML documents define mappings where the name of the nodes should be unique
+            merge(imdgRootLoaded, imdgRoot);
+        }
+
+        ((MutableYamlMapping) rootAsMapping).removeChild(ConfigSections.IMPORT.name);
+    }
+
+    /**
+     * Merges the source YAML document into the target YAML document
+     * <p/>
+     * If a given source node is not found in the target, it will be attached
+     * If a given source node is found in the target, this method is invoked
+     * recursively with the given node
+     *
+     * @param source The source YAML document's root
+     * @param target The target YAML document's root
+     */
+    private void merge(YamlNode source, YamlNode target) {
+        if (source == null) {
+            return;
+        }
+
+        YamlMapping sourceAsMapping = asMapping(source);
+        YamlMapping targetAsMapping = asMapping(target);
+
+        for (YamlNode sourceChild : sourceAsMapping.children()) {
+            YamlNode targetChild = targetAsMapping.child(sourceChild.nodeName());
+            if (targetChild != null) {
+                merge(sourceChild, targetChild);
+            } else {
+                if (targetAsMapping instanceof MutableYamlMapping) {
+                    ((YamlMappingImpl) targetAsMapping).addChild(sourceChild.nodeName(), sourceChild);
+                }
+            }
+        }
+    }
+
+    private void replaceVariables(Node node) throws Exception {
+        // if no config-replacer is defined, use backward compatible default behavior for missing properties
+        boolean failFast = false;
+
+        List<ConfigReplacer> replacers = new ArrayList<ConfigReplacer>();
+
+        // Always use the Property replacer first.
+        PropertyReplacer propertyReplacer = new PropertyReplacer();
+        propertyReplacer.init(properties);
+        replacers.add(propertyReplacer);
+
+        // Add other replacers
+        Node replacersNode = node.getAttributes().getNamedItem(ConfigSections.CONFIG_REPLACERS.name);
+
+        if (replacersNode != null) {
+            String failFastAttr = getAttribute(replacersNode, "fail-if-value-missing", true);
+            failFast = isNullOrEmpty(failFastAttr) ? true : Boolean.parseBoolean(failFastAttr);
+            for (Node n : childElements(replacersNode)) {
+                String nodeName = cleanNodeName(n);
+                if ("replacers".equals(nodeName)) {
+                    for (Node replacerNode : childElements(n)) {
+                        replacers.add(createReplacer(replacerNode));
+                    }
+                }
+            }
+        }
+
+        ConfigReplacerHelper.traverseChildrenAndReplaceVariables(node, replacers, failFast);
+    }
+
+    private ConfigReplacer createReplacer(Node node) throws Exception {
+        String replacerClass = getAttribute(node, "class-name", true);
+        Properties properties = new Properties();
+        for (Node n : childElements(node)) {
+            String value = cleanNodeName(n);
+            if ("properties".equals(value)) {
+                fillReplacerProperties(n, properties);
+            }
+        }
+        ConfigReplacer replacer = (ConfigReplacer) Class.forName(replacerClass).newInstance();
+        replacer.init(properties);
+        return replacer;
+    }
+
+    public void setProperties(Properties properties) {
+        this.properties = properties;
+    }
+
+    private void fillReplacerProperties(Node node, Properties properties) {
+        YamlMapping propertiesMapping = asMapping(((ElementAdapter) node).getYamlNode());
+        for (YamlNameNodePair childNodePair : propertiesMapping.childrenPairs()) {
+            String childName = childNodePair.nodeName();
+            YamlNode child = childNodePair.childNode();
+            if (child != null) {
+                Object nodeValue = asScalar(child).nodeValue();
+                properties.put(childName, nodeValue != null ? nodeValue.toString() : "");
+            } else {
+                properties.put(childName, "");
+            }
+        }
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -283,8 +283,9 @@ public class YamlConfigBuilder implements ConfigBuilder {
         return replacer;
     }
 
-    public void setProperties(Properties properties) {
+    public YamlConfigBuilder setProperties(Properties properties) {
         this.properties = properties;
+        return this;
     }
 
     private void fillReplacerProperties(Node node, Properties properties) {

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlDomVariableReplacer.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlDomVariableReplacer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import com.hazelcast.config.yaml.ElementAdapter;
+import com.hazelcast.internal.yaml.MutableYamlNode;
+import org.w3c.dom.Node;
+
+import static com.hazelcast.config.yaml.W3cDomUtil.getWrappedMutableYamlNode;
+
+class YamlDomVariableReplacer extends AbstractDomVariableReplacer {
+
+    @Override
+    public void replaceVariables(Node node, ConfigReplacer replacer, boolean failFast) {
+        replaceVariableInNodeValue(node, replacer, failFast);
+        replaceVariableInNodeName(node, replacer, failFast);
+    }
+
+    private void replaceVariableInNodeName(Node node, ConfigReplacer replacer, boolean failFast) {
+        if (node instanceof ElementAdapter) {
+            MutableYamlNode yamlNode = getWrappedMutableYamlNode(node);
+            String nodeName = yamlNode.nodeName();
+            if (nodeName != null) {
+                String replacedName = replaceValue(node, replacer, failFast, nodeName);
+                yamlNode.setNodeName(replacedName);
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.config;
 
-import com.hazelcast.config.yaml.ElementAdapter;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
 import com.hazelcast.internal.yaml.YamlScalar;
@@ -34,9 +33,9 @@ import static com.hazelcast.config.DomConfigHelper.childElements;
 import static com.hazelcast.config.DomConfigHelper.cleanNodeName;
 import static com.hazelcast.config.DomConfigHelper.getBooleanValue;
 import static com.hazelcast.config.DomConfigHelper.getIntegerValue;
-import static com.hazelcast.internal.yaml.YamlUtil.asMapping;
+import static com.hazelcast.config.yaml.W3cDomUtil.getWrappedYamlMapping;
+import static com.hazelcast.config.yaml.W3cDomUtil.getWrappedYamlSequence;
 import static com.hazelcast.internal.yaml.YamlUtil.asScalar;
-import static com.hazelcast.internal.yaml.YamlUtil.asSequence;
 import static com.hazelcast.util.StringUtil.lowerCaseInternal;
 import static com.hazelcast.util.StringUtil.upperCaseInternal;
 import static java.lang.Integer.parseInt;
@@ -148,7 +147,7 @@ class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
 
     @Override
     protected void handleTrustedInterfaces(MulticastConfig multicastConfig, Node n) {
-        YamlSequence yamlNode = asSequence(((ElementAdapter) n).getYamlNode());
+        YamlSequence yamlNode = getWrappedYamlSequence(n);
         for (YamlNode interfaceNode : yamlNode.children()) {
             String trustedInterface = asScalar(interfaceNode).nodeValue();
             multicastConfig.addTrustedInterface(trustedInterface);
@@ -645,7 +644,7 @@ class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
 
     @Override
     protected void fillProperties(Node node, Map<String, Comparable> properties) {
-        YamlMapping propertiesMapping = asMapping(((ElementAdapter) node).getYamlNode());
+        YamlMapping propertiesMapping = getWrappedYamlMapping(node);
         for (YamlNode propNode : propertiesMapping.children()) {
             YamlScalar propScalar = asScalar(propNode);
             String key = propScalar.nodeName();
@@ -656,7 +655,7 @@ class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
 
     @Override
     protected void fillProperties(Node node, Properties properties) {
-        YamlMapping propertiesMapping = asMapping(((ElementAdapter) node).getYamlNode());
+        YamlMapping propertiesMapping = getWrappedYamlMapping(node);
         for (YamlNode propNode : propertiesMapping.children()) {
             YamlScalar propScalar = asScalar(propNode);
             String key = propScalar.nodeName();

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/ElementAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/ElementAdapter.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config.yaml;
 
+import com.hazelcast.internal.yaml.MutableYamlScalar;
 import com.hazelcast.internal.yaml.YamlCollection;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
@@ -58,14 +59,19 @@ public class ElementAdapter implements Element {
     @Override
     public String getNodeValue() throws DOMException {
         if (yamlNode instanceof YamlScalar) {
-            return ((YamlScalar) yamlNode).nodeValue().toString();
+            Object nodeValue = ((YamlScalar) yamlNode).nodeValue();
+            return nodeValue != null ? nodeValue.toString() : null;
         }
         return null;
     }
 
     @Override
     public void setNodeValue(String nodeValue) throws DOMException {
-        throw new UnsupportedOperationException();
+        if (yamlNode instanceof MutableYamlScalar) {
+            ((MutableYamlScalar) yamlNode).setValue(nodeValue);
+        } else {
+            throw new UnsupportedOperationException();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/ScalarTextNodeAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/ScalarTextNodeAdapter.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config.yaml;
 
+import com.hazelcast.internal.yaml.MutableYamlScalar;
 import com.hazelcast.internal.yaml.YamlScalar;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -27,7 +28,7 @@ import org.w3c.dom.UserDataHandler;
 import static com.hazelcast.config.yaml.EmptyNodeList.emptyNodeList;
 
 class ScalarTextNodeAdapter implements Node {
-    private final YamlScalar scalar;
+    private YamlScalar scalar;
 
     ScalarTextNodeAdapter(YamlScalar scalar) {
         this.scalar = scalar;
@@ -40,12 +41,17 @@ class ScalarTextNodeAdapter implements Node {
 
     @Override
     public String getNodeValue() throws DOMException {
-        return scalar.nodeValue().toString();
+        Object nodeValue = scalar.nodeValue();
+        return nodeValue != null ? nodeValue.toString() : null;
     }
 
     @Override
     public void setNodeValue(String nodeValue) throws DOMException {
-        throw new UnsupportedOperationException();
+        if (scalar instanceof MutableYamlScalar) {
+            ((MutableYamlScalar) scalar).setValue(nodeValue);
+        } else {
+            throw new UnsupportedOperationException();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/W3cDomUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/W3cDomUtil.java
@@ -16,7 +16,12 @@
 
 package com.hazelcast.config.yaml;
 
+import com.hazelcast.internal.yaml.MutableYamlNode;
+import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
+import com.hazelcast.internal.yaml.YamlScalar;
+import com.hazelcast.internal.yaml.YamlSequence;
+import com.hazelcast.internal.yaml.YamlUtil;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -43,11 +48,90 @@ public final class W3cDomUtil {
         return new ElementAdapter(yamlNode);
     }
 
+    /**
+     * Returns the the wrapped {@link YamlMapping} instance of the
+     * provided {@link Node} if the {@code node} is an instance of
+     * {@link ElementAdapter} and the YAML node wrapped by the {@code node}
+     * is a {@link YamlMapping}.
+     *
+     * @param node The W3C node wrapping a YAML node
+     * @return the wrapped YAML node as mapping
+     * @throws IllegalArgumentException if the provided node is not an
+     *                                  instance of {@link ElementAdapter}
+     */
+    public static YamlMapping getWrappedYamlMapping(Node node) {
+        checkNodeIsElementAdapter(node);
+
+        return asYamlType(node, YamlMapping.class);
+    }
+
+    /**
+     * Returns the the wrapped {@link YamlSequence} instance of the
+     * provided {@link Node} if the {@code node} is an instance of
+     * {@link ElementAdapter} and the YAML node wrapped by the {@code node}
+     * is a {@link YamlSequence}.
+     *
+     * @param node The W3C node wrapping a YAML node
+     * @return the wrapped YAML node as sequence
+     * @throws IllegalArgumentException if the provided node is not an
+     *                                  instance of {@link ElementAdapter}
+     */
+    public static YamlSequence getWrappedYamlSequence(Node node) {
+        checkNodeIsElementAdapter(node);
+
+        return asYamlType(node, YamlSequence.class);
+    }
+
+    /**
+     * Returns the the wrapped {@link YamlScalar} instance of the
+     * provided {@link Node} if the {@code node} is an instance of
+     * {@link ElementAdapter} and the YAML node wrapped by the {@code node}
+     * is a {@link YamlScalar}.
+     *
+     * @param node The W3C node wrapping a YAML node
+     * @return the wrapped YAML node as scalar
+     * @throws IllegalArgumentException if the provided node is not an
+     *                                  instance of {@link ElementAdapter}
+     */
+    public static YamlScalar getWrappedYamlScalar(Node node) {
+        checkNodeIsElementAdapter(node);
+
+        return asYamlType(node, YamlScalar.class);
+    }
+
+    /**
+     * Returns the the wrapped {@link MutableYamlNode} instance of the
+     * provided {@link Node} if the {@code node} is an instance of
+     * {@link ElementAdapter} and the YAML node wrapped by the {@code node}
+     * is a {@link MutableYamlNode}.
+     *
+     * @param node The W3C node wrapping a YAML node
+     * @return the wrapped YAML node as a mutable YAML node
+     * @throws IllegalArgumentException if the provided node is not an
+     *                                  instance of {@link ElementAdapter}
+     */
+    public static MutableYamlNode getWrappedMutableYamlNode(Node node) {
+        checkNodeIsElementAdapter(node);
+
+        return asYamlType(node, MutableYamlNode.class);
+    }
+
     static NodeList asNodeList(Node node) {
         if (node == null) {
             return emptyNodeList();
         }
 
         return new SingletonNodeList(node);
+    }
+
+    private static <T extends YamlNode> T asYamlType(Node node, Class<T> type) {
+        return YamlUtil.asType(((ElementAdapter) node).getYamlNode(), type);
+    }
+
+    private static void checkNodeIsElementAdapter(Node node) {
+        if (!(node instanceof ElementAdapter)) {
+            throw new IllegalArgumentException(String.format("The provided node is not an instance of ElementAdapter, it is a %s",
+                    node.getClass().getName()));
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlOrderedMappingImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlOrderedMappingImpl.java
@@ -17,6 +17,7 @@
 package com.hazelcast.config.yaml;
 
 import com.hazelcast.internal.yaml.YamlMapping;
+import com.hazelcast.internal.yaml.YamlNameNodePair;
 import com.hazelcast.internal.yaml.YamlNode;
 import com.hazelcast.internal.yaml.YamlScalar;
 import com.hazelcast.internal.yaml.YamlSequence;
@@ -71,6 +72,11 @@ final class YamlOrderedMappingImpl implements YamlOrderedMapping {
     }
 
     @Override
+    public Iterable<YamlNameNodePair> childrenPairs() {
+        return wrappedMapping.childrenPairs();
+    }
+
+    @Override
     public int childCount() {
         return wrappedMapping.childCount();
     }
@@ -94,7 +100,7 @@ final class YamlOrderedMappingImpl implements YamlOrderedMapping {
         return randomAccessChildren.get(index);
     }
 
-    public static YamlOrderedMappingImpl asOrderedMapping(YamlMapping yamlMapping) {
+    static YamlOrderedMappingImpl asOrderedMapping(YamlMapping yamlMapping) {
         return new YamlOrderedMappingImpl(yamlMapping);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/MutableYamlMapping.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/MutableYamlMapping.java
@@ -16,27 +16,23 @@
 
 package com.hazelcast.internal.yaml;
 
-public abstract class AbstractYamlNode implements MutableYamlNode {
-    private final YamlNode parent;
-    private String nodeName;
+/**
+ * Mutable interface of {@link YamlMapping}
+ */
+public interface MutableYamlMapping extends YamlMapping, MutableYamlNode {
 
-    AbstractYamlNode(YamlNode parent, String nodeName) {
-        this.parent = parent;
-        this.nodeName = nodeName;
-    }
+    /**
+     * Adds a new child node to the mapping with the provided name
+     *
+     * @param name The name of the new child
+     * @param node The child node
+     */
+    void addChild(String name, YamlNode node);
 
-    @Override
-    public String nodeName() {
-        return nodeName != null ? nodeName : UNNAMED_NODE;
-    }
-
-    @Override
-    public void setNodeName(String nodeName) {
-        this.nodeName = nodeName;
-    }
-
-    @Override
-    public YamlNode parent() {
-        return parent;
-    }
+    /**
+     * Removes a child with the given name if exists
+     *
+     * @param name The name of the child to remove
+     */
+    void removeChild(String name);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/MutableYamlNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/MutableYamlNode.java
@@ -16,27 +16,14 @@
 
 package com.hazelcast.internal.yaml;
 
-public abstract class AbstractYamlNode implements MutableYamlNode {
-    private final YamlNode parent;
-    private String nodeName;
-
-    AbstractYamlNode(YamlNode parent, String nodeName) {
-        this.parent = parent;
-        this.nodeName = nodeName;
-    }
-
-    @Override
-    public String nodeName() {
-        return nodeName != null ? nodeName : UNNAMED_NODE;
-    }
-
-    @Override
-    public void setNodeName(String nodeName) {
-        this.nodeName = nodeName;
-    }
-
-    @Override
-    public YamlNode parent() {
-        return parent;
-    }
+/**
+ * Mutable interface for {@link YamlNode} instances.
+ */
+public interface MutableYamlNode extends YamlNode {
+    /**
+     * Sets the name of the node to the provided one
+     *
+     * @param nodeName The new name of the node
+     */
+    void setNodeName(String nodeName);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/MutableYamlScalar.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/MutableYamlScalar.java
@@ -16,27 +16,14 @@
 
 package com.hazelcast.internal.yaml;
 
-public abstract class AbstractYamlNode implements MutableYamlNode {
-    private final YamlNode parent;
-    private String nodeName;
-
-    AbstractYamlNode(YamlNode parent, String nodeName) {
-        this.parent = parent;
-        this.nodeName = nodeName;
-    }
-
-    @Override
-    public String nodeName() {
-        return nodeName != null ? nodeName : UNNAMED_NODE;
-    }
-
-    @Override
-    public void setNodeName(String nodeName) {
-        this.nodeName = nodeName;
-    }
-
-    @Override
-    public YamlNode parent() {
-        return parent;
-    }
+/**
+ * Mutable interface of {@link YamlScalar}
+ */
+public interface MutableYamlScalar extends YamlScalar {
+    /**
+     * Sets the value of the scalar node
+     *
+     * @param newValue The new value of the scalar node
+     */
+    void setValue(Object newValue);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlMapping.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlMapping.java
@@ -31,6 +31,21 @@ public interface YamlMapping extends YamlCollection {
     YamlNode child(String name);
 
     /**
+     * Returns the children as {@link YamlNameNodePair}s
+     * <p/>
+     * This method may have {@code null} values as the {@code childNode}
+     * in the returned pairs if the node's values is explicitly defined
+     * as {@code !!null} in the YAML document.
+     * <p/>
+     * The difference from the {@link #children()} children method is
+     * that {@link #children()} does not return {@code null} children
+     * nodes, while {@link #childrenPairs()} does.
+     *
+     * @return an {@link Iterable} pair of node names and node instances
+     */
+    Iterable<YamlNameNodePair> childrenPairs();
+
+    /**
      * Gets a child mapping node by its name
      *
      * @param name the name of the child node

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlMappingImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlMappingImpl.java
@@ -18,13 +18,15 @@ package com.hazelcast.internal.yaml;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import static com.hazelcast.internal.yaml.YamlUtil.asMapping;
 import static com.hazelcast.internal.yaml.YamlUtil.asScalar;
 import static com.hazelcast.internal.yaml.YamlUtil.asSequence;
 
-class YamlMappingImpl extends AbstractYamlNode implements YamlMapping {
+public class YamlMappingImpl extends AbstractYamlNode implements MutableYamlMapping {
     private Map<String, YamlNode> children = Collections.emptyMap();
 
     YamlMappingImpl(YamlNode parent, String nodeName) {
@@ -66,8 +68,23 @@ class YamlMappingImpl extends AbstractYamlNode implements YamlMapping {
         return children.values();
     }
 
-    void addChild(String name, YamlNode node) {
+    @Override
+    public Iterable<YamlNameNodePair> childrenPairs() {
+        List<YamlNameNodePair> pairs = new LinkedList<YamlNameNodePair>();
+        for (Map.Entry<String, YamlNode> child : children.entrySet()) {
+            pairs.add(new YamlNameNodePair(child.getKey(), child.getValue()));
+        }
+        return pairs;
+    }
+
+    @Override
+    public void addChild(String name, YamlNode node) {
         getOrCreateChildren().put(name, node);
+    }
+
+    @Override
+    public void removeChild(String name) {
+        children.remove(name);
     }
 
     private Map<String, YamlNode> getOrCreateChildren() {
@@ -90,4 +107,5 @@ class YamlMappingImpl extends AbstractYamlNode implements YamlMapping {
                 + ", children=" + children
                 + '}';
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlNameNodePair.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlNameNodePair.java
@@ -16,27 +16,37 @@
 
 package com.hazelcast.internal.yaml;
 
-public abstract class AbstractYamlNode implements MutableYamlNode {
-    private final YamlNode parent;
-    private String nodeName;
+/**
+ * A pair consists of a node's name and its representing {@link YamlNode}
+ * instance
+ *
+ * @see YamlMapping#childrenPairs()
+ */
+public class YamlNameNodePair {
+    private final String nodeName;
+    private final YamlNode childNode;
 
-    AbstractYamlNode(YamlNode parent, String nodeName) {
-        this.parent = parent;
+    YamlNameNodePair(String nodeName, YamlNode childNode) {
         this.nodeName = nodeName;
+        this.childNode = childNode;
     }
 
-    @Override
+    /**
+     * Returns the name of the node
+     *
+     * @return the name of the node
+     */
     public String nodeName() {
-        return nodeName != null ? nodeName : UNNAMED_NODE;
+        return nodeName;
     }
 
-    @Override
-    public void setNodeName(String nodeName) {
-        this.nodeName = nodeName;
-    }
-
-    @Override
-    public YamlNode parent() {
-        return parent;
+    /**
+     * The {@link YamlNode} instance
+     *
+     * @return the node instance if present or {@code null} if the node
+     * is explicitly defined as {@code !!null} in the YAML document
+     */
+    public YamlNode childNode() {
+        return childNode;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlScalarImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlScalarImpl.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.internal.yaml;
 
-class YamlScalarImpl extends AbstractYamlNode implements YamlScalar {
-    private final Object value;
+public class YamlScalarImpl extends AbstractYamlNode implements MutableYamlScalar {
+    private Object value;
 
-    YamlScalarImpl(YamlNode parent, String nodeName, Object value) {
+    public YamlScalarImpl(YamlNode parent, String nodeName, Object value) {
         super(parent, nodeName);
         this.value = value;
     }
@@ -42,6 +42,11 @@ class YamlScalarImpl extends AbstractYamlNode implements YamlScalar {
             throw new YamlException("The scalar's type " + value.getClass() + " is not the expected " + type);
         }
         return (T) value;
+    }
+
+    @Override
+    public void setValue(Object newValue) {
+        value = newValue;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
@@ -82,6 +82,24 @@ public final class YamlUtil {
     }
 
     /**
+     * Takes a generic {@link YamlNode} instance and returns it casted to
+     * the provided {@code type} if the node is an instance of that type.
+     *
+     * @param node The generic node to cast
+     * @return the casted node
+     * @throws YamlException if the provided node is not the expected type
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T asType(YamlNode node, Class<T> type) {
+        if (node != null && !type.isAssignableFrom(node.getClass())) {
+            String nodeName = node.nodeName();
+            throw new YamlException(String.format("Child %s is not a %s, it's actual type is %s", nodeName, type.getSimpleName(),
+                    node.getClass().getSimpleName()));
+        }
+        return (T) node;
+    }
+
+    /**
      * Checks if the runtime environment is Java8 or higher. If the
      * runtime is an older version the check throws
      * {@link UnsupportedOperationException}.

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigImportVariableReplacementTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.replacer.PropertyReplacer;
+import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.Properties;
+
+/**
+ * Abstract class defining common test cases for {@link XmlConfigImportVariableReplacementTest}
+ * and {@link YamlConfigImportVariableReplacementTest}
+ */
+public abstract class AbstractConfigImportVariableReplacementTest {
+    @Rule
+    public ExpectedException rule = ExpectedException.none();
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    protected static File createConfigFile(String filename, String suffix) throws Exception {
+        File file = File.createTempFile(filename, suffix);
+        file.setWritable(true);
+        file.deleteOnExit();
+        return file;
+    }
+
+    protected static void writeStringToStreamAndClose(FileOutputStream os, String string) throws Exception {
+        os.write(string.getBytes());
+        os.flush();
+        os.close();
+    }
+
+    @Test
+    public abstract void testHazelcastElementOnlyAppearsOnce();
+
+    @Test
+    public abstract void readVariables();
+
+    @Test
+    public abstract void testImportConfigFromResourceVariables() throws Exception;
+
+    @Test
+    public abstract void testImportedConfigVariableReplacement() throws Exception;
+
+    @Test
+    public abstract void testTwoResourceCyclicImportThrowsException() throws Exception;
+
+    @Test
+    public abstract void testThreeResourceCyclicImportThrowsException() throws Exception;
+
+    @Test
+    public abstract void testImportEmptyResourceContent() throws Exception;
+
+    @Test
+    public abstract void testImportEmptyResourceThrowsException();
+
+    @Test
+    public abstract void testImportNotExistingResourceThrowsException();
+
+    @Test
+    public abstract void testImportNetworkConfigFromFile() throws Exception;
+
+    @Test
+    public abstract void testImportMapConfigFromFile() throws Exception;
+
+    /**
+     * This test case verifies the behavior of the XML and YAML import
+     * implementations when the definition of one map is spanned over
+     * two configuration files. Note that there is a difference between
+     * the two implementations. XML uses the content for the given map
+     * from the main XML (where the import is), while YAML recursively
+     * merges the main and the imported file. See the assertions in the
+     * two test case implementations.
+     */
+    @Test
+    public abstract void testImportOverlappingMapConfigFromFile() throws Exception;
+
+    @Test
+    public abstract void testMapConfigFromMainAndImportedFile() throws Exception;
+
+    @Test
+    public abstract void testImportGroupConfigFromClassPath();
+
+    @Test
+    public abstract void testReplacers() throws Exception;
+
+    @Test(expected = ConfigurationException.class)
+    public abstract void testMissingReplacement() throws Exception;
+
+    @Test
+    public abstract void testBadVariableSyntaxIsIgnored() throws Exception;
+
+    @Test
+    public abstract void testReplacerProperties() throws Exception;
+
+    /**
+     * Given: No replacer is used in the configuration file<br>
+     * When: A property variable is used within the file<br>
+     * Then: The configuration parsing doesn't fail and the variable string remains unchanged (i.e. backward compatible
+     * behavior, as if {@code fail-if-value-missing} attribute is {@code false}).
+     */
+    @Test
+    public abstract void testNoConfigReplacersMissingProperties() throws Exception;
+
+    @Test
+    public abstract void testVariableReplacementAsSubstring();
+
+    @Test
+    public abstract void testImportWithVariableReplacementAsSubstring() throws Exception;
+
+    protected void expectInvalid() {
+        InvalidConfigurationTest.expectInvalid(rule);
+    }
+
+    public static class IdentityReplacer implements ConfigReplacer {
+        @Override
+        public String getPrefix() {
+            return "ID";
+        }
+
+        @Override
+        public String getReplacement(String maskedValue) {
+            return maskedValue;
+        }
+
+        @Override
+        public void init(Properties properties) {
+        }
+    }
+
+    public static class TestReplacer extends PropertyReplacer {
+        @Override
+        public String getPrefix() {
+            return "T";
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigImportVariableReplacementTest.java
@@ -129,6 +129,18 @@ public abstract class AbstractConfigImportVariableReplacementTest {
     @Test
     public abstract void testImportWithVariableReplacementAsSubstring() throws Exception;
 
+    @Test
+    public abstract void testReplaceVariablesWithFileSystemConfig() throws Exception;
+
+    @Test
+    public abstract void testReplaceVariablesWithInMemoryConfig();
+
+    @Test
+    public abstract void testReplaceVariablesWithClasspathConfig();
+
+    @Test
+    public abstract void testReplaceVariablesWithUrlConfig() throws Exception;
+
     protected void expectInvalid() {
         InvalidConfigurationTest.expectInvalid(rule);
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigImportVariableReplacementTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.config;
 
 import com.hazelcast.config.replacer.PropertyReplacer;
 import com.hazelcast.config.replacer.spi.ConfigReplacer;
+import com.hazelcast.core.HazelcastException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -77,6 +78,9 @@ public abstract class AbstractConfigImportVariableReplacementTest {
 
     @Test
     public abstract void testImportNotExistingResourceThrowsException();
+
+    @Test(expected = HazelcastException.class)
+    public abstract void testImportFromNonHazelcastConfigThrowsException() throws Exception;
 
     @Test
     public abstract void testImportNetworkConfigFromFile() throws Exception;

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
@@ -493,6 +493,70 @@ public class XmlConfigImportVariableReplacementTest extends AbstractConfigImport
         assertEquals(config.getProperty("prop2"), "value2");
     }
 
+    @Override
+    @Test
+    public void testReplaceVariablesWithFileSystemConfig() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String configXml = HAZELCAST_START_TAG
+                + "    <properties>\n"
+                + "        <property name=\"prop\">${variable}</property>\n"
+                + "    </properties>\n"
+                + HAZELCAST_END_TAG;
+        writeStringToStreamAndClose(os, configXml);
+
+        Properties properties = new Properties();
+        properties.put("variable", "foobar");
+        Config config = new FileSystemXmlConfig(file, properties);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
+    @Override
+    @Test
+    public void testReplaceVariablesWithInMemoryConfig() {
+        String configXml = HAZELCAST_START_TAG
+                + "    <properties>\n"
+                + "        <property name=\"prop\">${variable}</property>\n"
+                + "    </properties>\n"
+                + HAZELCAST_END_TAG;
+
+        Properties properties = new Properties();
+        properties.put("variable", "foobar");
+        Config config = new InMemoryXmlConfig(configXml, properties);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
+    @Override
+    @Test
+    public void testReplaceVariablesWithClasspathConfig() {
+        Properties properties = new Properties();
+        properties.put("variable", "foobar");
+        Config config = new ClasspathXmlConfig("test-hazelcast-variable.xml", properties);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
+    @Override
+    @Test
+    public void testReplaceVariablesWithUrlConfig() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String configXml = HAZELCAST_START_TAG
+                + "    <properties>\n"
+                + "        <property name=\"prop\">${variable}</property>\n"
+                + "    </properties>\n"
+                + HAZELCAST_END_TAG;
+        writeStringToStreamAndClose(os, configXml);
+
+        Properties properties = new Properties();
+        properties.put("variable", "foobar");
+        Config config = new UrlXmlConfig("file://" + file.getPath(), properties);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
     private static Config buildConfig(String xml, Properties properties) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
         XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlSchemaValidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlSchemaValidationTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+import java.util.Properties;
+
+import static com.hazelcast.config.XMLConfigBuilderTest.HAZELCAST_END_TAG;
+import static com.hazelcast.config.XMLConfigBuilderTest.HAZELCAST_START_TAG;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class XmlSchemaValidationTest {
+    @Rule
+    public ExpectedException rule = ExpectedException.none();
+
+    @Test
+    public void testXmlDeniesDuplicateGroupConfig() {
+        expectDuplicateElementError("group");
+        String groupConfig = "    <group>\n"
+                + "        <name>foobar</name>\n"
+                + "        <password>dev-pass</password>\n"
+                + "    </group>\n";
+        buildConfig(HAZELCAST_START_TAG + groupConfig + groupConfig + HAZELCAST_END_TAG, null);
+    }
+
+    @Test
+    public void testXmlDeniesDuplicateNetworkConfig() {
+        expectDuplicateElementError("network");
+        String networkConfig = "    <network>\n"
+                + "        <join>\n"
+                + "            <multicast enabled=\"false\"/>\n"
+                + "            <tcp-ip enabled=\"true\"/>\n"
+                + "        </join>\n"
+                + "    </network>\n";
+        buildConfig(HAZELCAST_START_TAG + networkConfig + networkConfig + HAZELCAST_END_TAG, null);
+    }
+
+    @Test
+    public void testXmlDeniesDuplicateLicenseKeyConfig() {
+        expectDuplicateElementError("license-key");
+        String licenseConfig = "    <license-key>foo</license-key>";
+        buildConfig(HAZELCAST_START_TAG + licenseConfig + licenseConfig + HAZELCAST_END_TAG, null);
+    }
+
+    @Test
+    public void testXmlDeniesDuplicatePropertiesConfig() {
+        expectDuplicateElementError("properties");
+        String propertiesConfig = "    <properties>\n"
+                + "        <property name='foo'>fooval</property>\n"
+                + "    </properties>\n";
+        buildConfig(HAZELCAST_START_TAG + propertiesConfig + propertiesConfig + HAZELCAST_END_TAG, null);
+    }
+
+    @Test
+    public void testXmlDeniesDuplicatePartitionGroupConfig() {
+        expectDuplicateElementError("partition-group");
+        String partitionConfig = "   <partition-group>\n"
+                + "      <member-group>\n"
+                + "          <interface>foo</interface>\n"
+                + "      </member-group>\n"
+                + "   </partition-group>\n";
+        buildConfig(HAZELCAST_START_TAG + partitionConfig + partitionConfig + HAZELCAST_END_TAG, null);
+    }
+
+    @Test
+    public void testXmlDeniesDuplicateListenersConfig() {
+        expectDuplicateElementError("listeners");
+        String listenersConfig = "   <listeners>"
+                + "        <listener>foo</listener>\n\n"
+                + "   </listeners>\n";
+        buildConfig(HAZELCAST_START_TAG + listenersConfig + listenersConfig + HAZELCAST_END_TAG, null);
+    }
+
+    @Test
+    public void testXmlDeniesDuplicateSerializationConfig() {
+        expectDuplicateElementError("serialization");
+        String serializationConfig = "       <serialization>\n"
+                + "        <portable-version>0</portable-version>\n"
+                + "        <data-serializable-factories>\n"
+                + "            <data-serializable-factory factory-id=\"1\">com.hazelcast.examples.DataSerializableFactory\n"
+                + "            </data-serializable-factory>\n"
+                + "        </data-serializable-factories>\n"
+                + "        <portable-factories>\n"
+                + "            <portable-factory factory-id=\"1\">com.hazelcast.examples.PortableFactory</portable-factory>\n"
+                + "        </portable-factories>\n"
+                + "        <serializers>\n"
+                + "            <global-serializer>com.hazelcast.examples.GlobalSerializerFactory</global-serializer>\n"
+                + "            <serializer type-class=\"com.hazelcast.examples.DummyType\"\n"
+                + "                class-name=\"com.hazelcast.examples.SerializerFactory\"/>\n"
+                + "        </serializers>\n"
+                + "        <check-class-def-errors>true</check-class-def-errors>\n"
+                + "    </serialization>\n";
+        buildConfig(HAZELCAST_START_TAG + serializationConfig + serializationConfig + HAZELCAST_END_TAG, null);
+    }
+
+    @Test
+    public void testXmlDeniesDuplicateServicesConfig() {
+        expectDuplicateElementError("services");
+        String servicesConfig = "   <services>       "
+                + "       <service enabled=\"true\">\n"
+                + "            <name>custom-service</name>\n"
+                + "            <class-name>com.hazelcast.examples.MyService</class-name>\n"
+                + "        </service>\n"
+                + "   </services>";
+        buildConfig(HAZELCAST_START_TAG + servicesConfig + servicesConfig + HAZELCAST_END_TAG, null);
+    }
+
+    @Test
+    public void testXmlDeniesDuplicateSecurityConfig() {
+        expectDuplicateElementError("security");
+        String securityConfig = "   <security/>\n";
+        buildConfig(HAZELCAST_START_TAG + securityConfig + securityConfig + HAZELCAST_END_TAG, null);
+    }
+
+    @Test
+    public void testXmlDeniesDuplicateMemberAttributesConfig() {
+        expectDuplicateElementError("member-attributes");
+        String memberAttConfig = "    <member-attributes>\n"
+                + "        <attribute name=\"attribute.float\" type=\"float\">1234.5678</attribute>\n"
+                + "    </member-attributes>\n";
+        buildConfig(HAZELCAST_START_TAG + memberAttConfig + memberAttConfig + HAZELCAST_END_TAG, null);
+    }
+
+    private void expectDuplicateElementError(String elName) {
+        InvalidConfigurationTest.expectInvalid(rule);
+    }
+
+    private static Config buildConfig(String xml, Properties properties) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
+        XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
+        configBuilder.setProperties(properties);
+        return configBuilder.build();
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlSchemaValidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlSchemaValidationTest.java
@@ -26,10 +26,10 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.io.ByteArrayInputStream;
-import java.util.Properties;
 
 import static com.hazelcast.config.XMLConfigBuilderTest.HAZELCAST_END_TAG;
 import static com.hazelcast.config.XMLConfigBuilderTest.HAZELCAST_START_TAG;
+import static org.hamcrest.Matchers.containsString;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -40,65 +40,71 @@ public class XmlSchemaValidationTest {
     @Test
     public void testXmlDeniesDuplicateGroupConfig() {
         expectDuplicateElementError("group");
-        String groupConfig = "    <group>\n"
+        String groupConfig = ""
+                + "    <group>\n"
                 + "        <name>foobar</name>\n"
                 + "        <password>dev-pass</password>\n"
                 + "    </group>\n";
-        buildConfig(HAZELCAST_START_TAG + groupConfig + groupConfig + HAZELCAST_END_TAG, null);
+        buildConfig(HAZELCAST_START_TAG + groupConfig + groupConfig + HAZELCAST_END_TAG);
     }
 
     @Test
     public void testXmlDeniesDuplicateNetworkConfig() {
         expectDuplicateElementError("network");
-        String networkConfig = "    <network>\n"
+        String networkConfig = ""
+                + "    <network>\n"
                 + "        <join>\n"
                 + "            <multicast enabled=\"false\"/>\n"
                 + "            <tcp-ip enabled=\"true\"/>\n"
                 + "        </join>\n"
                 + "    </network>\n";
-        buildConfig(HAZELCAST_START_TAG + networkConfig + networkConfig + HAZELCAST_END_TAG, null);
+        buildConfig(HAZELCAST_START_TAG + networkConfig + networkConfig + HAZELCAST_END_TAG);
     }
 
     @Test
     public void testXmlDeniesDuplicateLicenseKeyConfig() {
         expectDuplicateElementError("license-key");
         String licenseConfig = "    <license-key>foo</license-key>";
-        buildConfig(HAZELCAST_START_TAG + licenseConfig + licenseConfig + HAZELCAST_END_TAG, null);
+        buildConfig(HAZELCAST_START_TAG + licenseConfig + licenseConfig + HAZELCAST_END_TAG);
     }
 
     @Test
     public void testXmlDeniesDuplicatePropertiesConfig() {
         expectDuplicateElementError("properties");
-        String propertiesConfig = "    <properties>\n"
+        String propertiesConfig = ""
+                + "    <properties>\n"
                 + "        <property name='foo'>fooval</property>\n"
                 + "    </properties>\n";
-        buildConfig(HAZELCAST_START_TAG + propertiesConfig + propertiesConfig + HAZELCAST_END_TAG, null);
+        buildConfig(HAZELCAST_START_TAG + propertiesConfig + propertiesConfig + HAZELCAST_END_TAG);
     }
 
     @Test
     public void testXmlDeniesDuplicatePartitionGroupConfig() {
         expectDuplicateElementError("partition-group");
-        String partitionConfig = "   <partition-group>\n"
+        String partitionConfig = ""
+                + "   <partition-group>\n"
                 + "      <member-group>\n"
                 + "          <interface>foo</interface>\n"
                 + "      </member-group>\n"
                 + "   </partition-group>\n";
-        buildConfig(HAZELCAST_START_TAG + partitionConfig + partitionConfig + HAZELCAST_END_TAG, null);
+        buildConfig(HAZELCAST_START_TAG + partitionConfig + partitionConfig + HAZELCAST_END_TAG);
     }
 
     @Test
     public void testXmlDeniesDuplicateListenersConfig() {
         expectDuplicateElementError("listeners");
-        String listenersConfig = "   <listeners>"
+        String listenersConfig = ""
+                + "   <listeners>\n"
                 + "        <listener>foo</listener>\n\n"
                 + "   </listeners>\n";
-        buildConfig(HAZELCAST_START_TAG + listenersConfig + listenersConfig + HAZELCAST_END_TAG, null);
+        buildConfig(HAZELCAST_START_TAG + listenersConfig + listenersConfig + HAZELCAST_END_TAG);
     }
 
     @Test
     public void testXmlDeniesDuplicateSerializationConfig() {
         expectDuplicateElementError("serialization");
-        String serializationConfig = "       <serialization>\n"
+        String serializationConfig = ""
+                + "       <serialization>\n"
                 + "        <portable-version>0</portable-version>\n"
                 + "        <data-serializable-factories>\n"
                 + "            <data-serializable-factory factory-id=\"1\">com.hazelcast.examples.DataSerializableFactory\n"
@@ -114,45 +120,47 @@ public class XmlSchemaValidationTest {
                 + "        </serializers>\n"
                 + "        <check-class-def-errors>true</check-class-def-errors>\n"
                 + "    </serialization>\n";
-        buildConfig(HAZELCAST_START_TAG + serializationConfig + serializationConfig + HAZELCAST_END_TAG, null);
+        buildConfig(HAZELCAST_START_TAG + serializationConfig + serializationConfig + HAZELCAST_END_TAG);
     }
 
     @Test
     public void testXmlDeniesDuplicateServicesConfig() {
         expectDuplicateElementError("services");
-        String servicesConfig = "   <services>       "
+        String servicesConfig = ""
+                + "   <services>\n"
                 + "       <service enabled=\"true\">\n"
                 + "            <name>custom-service</name>\n"
                 + "            <class-name>com.hazelcast.examples.MyService</class-name>\n"
                 + "        </service>\n"
                 + "   </services>";
-        buildConfig(HAZELCAST_START_TAG + servicesConfig + servicesConfig + HAZELCAST_END_TAG, null);
+        buildConfig(HAZELCAST_START_TAG + servicesConfig + servicesConfig + HAZELCAST_END_TAG);
     }
 
     @Test
     public void testXmlDeniesDuplicateSecurityConfig() {
         expectDuplicateElementError("security");
         String securityConfig = "   <security/>\n";
-        buildConfig(HAZELCAST_START_TAG + securityConfig + securityConfig + HAZELCAST_END_TAG, null);
+        buildConfig(HAZELCAST_START_TAG + securityConfig + securityConfig + HAZELCAST_END_TAG);
     }
 
     @Test
     public void testXmlDeniesDuplicateMemberAttributesConfig() {
         expectDuplicateElementError("member-attributes");
-        String memberAttConfig = "    <member-attributes>\n"
+        String memberAttConfig = ""
+                + "    <member-attributes>\n"
                 + "        <attribute name=\"attribute.float\" type=\"float\">1234.5678</attribute>\n"
                 + "    </member-attributes>\n";
-        buildConfig(HAZELCAST_START_TAG + memberAttConfig + memberAttConfig + HAZELCAST_END_TAG, null);
+        buildConfig(HAZELCAST_START_TAG + memberAttConfig + memberAttConfig + HAZELCAST_END_TAG);
     }
 
     private void expectDuplicateElementError(String elName) {
+        rule.expectMessage(containsString(elName));
         InvalidConfigurationTest.expectInvalid(rule);
     }
 
-    private static Config buildConfig(String xml, Properties properties) {
+    private static Config buildConfig(String xml) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
         XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
-        configBuilder.setProperties(properties);
         return configBuilder.build();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -2693,7 +2693,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "    people:\n"
                 + "      attributes:\n"
                 + "        weight:\n"
-                + "          extractor:\n";
+                + "          extractor: \"\"\n";
         buildConfig(yaml);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
@@ -485,6 +485,67 @@ public class YamlConfigImportVariableReplacementTest extends AbstractConfigImpor
         assertEquals(config.getProperty("prop2"), "value2");
     }
 
+    @Override
+    @Test
+    public void testReplaceVariablesWithFileSystemConfig() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String configYaml = ""
+                + "hazelcast:\n"
+                + "  properties:\n"
+                + "    prop: ${variable}";
+        writeStringToStreamAndClose(os, configYaml);
+
+        Properties properties = new Properties();
+        properties.put("variable", "foobar");
+        Config config = new FileSystemYamlConfig(file, properties);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
+    @Override
+    @Test
+    public void testReplaceVariablesWithInMemoryConfig() {
+        String configYaml = ""
+                + "hazelcast:\n"
+                + "  properties:\n"
+                + "    prop: ${variable}";
+
+        Properties properties = new Properties();
+        properties.put("variable", "foobar");
+        Config config = new InMemoryYamlConfig(configYaml, properties);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
+    @Override
+    @Test
+    public void testReplaceVariablesWithClasspathConfig() {
+        Properties properties = new Properties();
+        properties.put("variable", "foobar");
+        Config config = new ClasspathYamlConfig("test-hazelcast-variable.yaml", properties);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
+    @Override
+    @Test
+    public void testReplaceVariablesWithUrlConfig() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String configYaml = ""
+                + "hazelcast:\n"
+                + "  properties:\n"
+                + "    prop: ${variable}";
+        writeStringToStreamAndClose(os, configYaml);
+
+        Properties properties = new Properties();
+        properties.put("variable", "foobar");
+        Config config = new UrlYamlConfig("file://" + file.getPath(), properties);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
     private static Config buildConfig(String yaml, Properties properties) {
         ByteArrayInputStream bis = new ByteArrayInputStream(yaml.getBytes());
         YamlConfigBuilder configBuilder = new YamlConfigBuilder(bis);

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
@@ -1,0 +1,501 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.replacer.EncryptionReplacer;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintWriter;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class YamlConfigImportVariableReplacementTest extends AbstractConfigImportVariableReplacementTest {
+
+    @Override
+    @Test
+    public void testHazelcastElementOnlyAppearsOnce() {
+        String yaml = ""
+                + "hazelcast:\n{}"
+                + "hazelcast:";
+        expectInvalid();
+        buildConfig(yaml, null);
+    }
+
+    @Override
+    @Test
+    public void readVariables() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  semaphore:\n"
+                + "    ${name}:\n"
+                + "      initial-permits: ${initial.permits}\n"
+                + "      backup-count: ${backupcount.part1}${backupcount.part2}\n";
+
+        Properties properties = new Properties();
+        properties.setProperty("name", "s");
+        properties.setProperty("initial.permits", "25");
+
+        properties.setProperty("backupcount.part1", "0");
+        properties.setProperty("backupcount.part2", "6");
+        Config config = buildConfig(yaml, properties);
+        SemaphoreConfig semaphoreConfig = config.getSemaphoreConfig("s");
+        assertEquals(25, semaphoreConfig.getInitialPermits());
+        assertEquals(6, semaphoreConfig.getBackupCount());
+        assertEquals(0, semaphoreConfig.getAsyncBackupCount());
+    }
+
+    @Override
+    @Test
+    public void testImportConfigFromResourceVariables() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String networkConfig = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: false\n"
+                + "      tcp-ip:\n"
+                + "        enabled: true\n";
+        writeStringToStreamAndClose(os, networkConfig);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - ${config.location}\n";
+        Config config = buildConfig(yaml, "config.location", file.getAbsolutePath());
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        assertFalse(join.getMulticastConfig().isEnabled());
+        assertTrue(join.getTcpIpConfig().isEnabled());
+    }
+
+    @Override
+    @Test
+    public void testImportedConfigVariableReplacement() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String networkConfig = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: false\n"
+                + "      tcp-ip:\n"
+                + "        enabled: ${tcp.ip.enabled}\n";
+        writeStringToStreamAndClose(os, networkConfig);
+
+        String xml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - ${config.location}";
+
+        Properties properties = new Properties();
+        properties.setProperty("config.location", file.getAbsolutePath());
+        properties.setProperty("tcp.ip.enabled", "true");
+        Config config = buildConfig(xml, properties);
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        assertFalse(join.getMulticastConfig().isEnabled());
+        assertTrue(join.getTcpIpConfig().isEnabled());
+    }
+
+    @Override
+    @Test
+    public void testTwoResourceCyclicImportThrowsException() throws Exception {
+        File config1 = createConfigFile("hz1", "yaml");
+        File config2 = createConfigFile("hz2", "yaml");
+        FileOutputStream os1 = new FileOutputStream(config1);
+        FileOutputStream os2 = new FileOutputStream(config2);
+        String config1Yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - file:///" + config2.getAbsolutePath();
+        String config2Yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - file:///" + config1.getAbsolutePath();
+        writeStringToStreamAndClose(os1, config1Yaml);
+        writeStringToStreamAndClose(os2, config2Yaml);
+        expectInvalid();
+        buildConfig(config1Yaml, null);
+    }
+
+    @Override
+    @Test
+    public void testThreeResourceCyclicImportThrowsException() throws Exception {
+        String template = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - file:///%s";
+        File config1 = createConfigFile("hz1", "xml");
+        File config2 = createConfigFile("hz2", "xml");
+        File config3 = createConfigFile("hz3", "xml");
+        String config1Yaml = String.format(template, config2.getAbsolutePath());
+        String config2Yaml = String.format(template, config3.getAbsolutePath());
+        String config3Yaml = String.format(template, config1.getAbsolutePath());
+        writeStringToStreamAndClose(new FileOutputStream(config1), config1Yaml);
+        writeStringToStreamAndClose(new FileOutputStream(config2), config2Yaml);
+        writeStringToStreamAndClose(new FileOutputStream(config3), config3Yaml);
+        expectInvalid();
+        buildConfig(config1Yaml, null);
+    }
+
+    @Override
+    @Test
+    public void testImportEmptyResourceContent() throws Exception {
+        File config1 = createConfigFile("hz1", "xml");
+        FileOutputStream os1 = new FileOutputStream(config1);
+        String config1Yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - file:///" + config1.getAbsolutePath();
+        writeStringToStreamAndClose(os1, "%invalid-yaml");
+        expectInvalid();
+        buildConfig(config1Yaml, null);
+    }
+
+    @Override
+    @Test
+    public void testImportEmptyResourceThrowsException() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - \"\"";
+        expectInvalid();
+        buildConfig(yaml, null);
+    }
+
+    @Override
+    @Test
+    public void testImportNotExistingResourceThrowsException() {
+        expectInvalid();
+        String xml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - notexisting.yaml";
+        buildConfig(xml, null);
+    }
+
+    @Override
+    @Test
+    public void testImportNetworkConfigFromFile() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String networkConfig = ""
+                + "hazelcast:\n"
+                + "  network:\n"
+                + "    join:\n"
+                + "      multicast:\n"
+                + "        enabled: false\n"
+                + "      tcp-ip:\n"
+                + "        enabled: true\n";
+        writeStringToStreamAndClose(os, networkConfig);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - file:///" + file.getAbsolutePath();
+
+        Config config = buildConfig(yaml, null);
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        assertFalse(join.getMulticastConfig().isEnabled());
+        assertTrue(join.getTcpIpConfig().isEnabled());
+    }
+
+    @Override
+    @Test
+    public void testImportMapConfigFromFile() throws Exception {
+        File file = createConfigFile("mymap", "config");
+        FileOutputStream os = new FileOutputStream(file);
+        String mapConfig = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      backup-count: 6\n"
+                + "      time-to-live-seconds: 10\n"
+                + "      map-store:\n"
+                + "        enabled: true\n"
+                + "        initial-mode: LAZY\n"
+                + "        class-name: com.hazelcast.examples.MyMapStore\n"
+                + "        write-delay-seconds: 10\n"
+                + "        write-batch-size: 100\n";
+        writeStringToStreamAndClose(os, mapConfig);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - file:///" + file.getAbsolutePath();
+
+        Config config = buildConfig(yaml, null);
+        MapConfig myMapConfig = config.getMapConfig("mymap");
+        assertEquals("mymap", myMapConfig.getName());
+        assertEquals(6, myMapConfig.getBackupCount());
+        assertEquals(10, myMapConfig.getTimeToLiveSeconds());
+        MapStoreConfig myMapStoreConfig = myMapConfig.getMapStoreConfig();
+        assertEquals(10, myMapStoreConfig.getWriteDelaySeconds());
+        assertEquals(100, myMapStoreConfig.getWriteBatchSize());
+        assertEquals("com.hazelcast.examples.MyMapStore", myMapStoreConfig.getClassName());
+    }
+
+    @Override
+    @Test
+    public void testImportOverlappingMapConfigFromFile() throws Exception {
+        File file = createConfigFile("mymap", "config");
+        FileOutputStream os = new FileOutputStream(file);
+        String mapConfig = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      backup-count: 6\n"
+                + "      map-store:\n"
+                + "        enabled: true\n"
+                + "        initial-mode: LAZY\n"
+                + "        class-name: com.hazelcast.examples.MyMapStore\n"
+                + "        write-delay-seconds: 10\n"
+                + "        write-batch-size: 100\n";
+        writeStringToStreamAndClose(os, mapConfig);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - file:///" + file.getAbsolutePath() + "\n"
+                + "  map:\n"
+                + "    mymap:\n"
+                + "      time-to-live-seconds: 10\n";
+
+        Config config = buildConfig(yaml, null);
+        MapConfig myMapConfig = config.getMapConfig("mymap");
+        assertEquals("mymap", myMapConfig.getName());
+        assertEquals(6, myMapConfig.getBackupCount());
+        assertEquals(10, myMapConfig.getTimeToLiveSeconds());
+        MapStoreConfig myMapStoreConfig = myMapConfig.getMapStoreConfig();
+        assertEquals(10, myMapStoreConfig.getWriteDelaySeconds());
+        assertEquals(100, myMapStoreConfig.getWriteBatchSize());
+        assertEquals("com.hazelcast.examples.MyMapStore", myMapStoreConfig.getClassName());
+    }
+
+    @Override
+    public void testMapConfigFromMainAndImportedFile() throws Exception {
+        File file = createConfigFile("importmap", "config");
+        FileOutputStream os = new FileOutputStream(file);
+        String mapConfig = ""
+                + "hazelcast:\n"
+                + "  map:\n"
+                + "    importedMap:\n"
+                + "      backup-count: 6\n"
+                + "      time-to-live-seconds: 10\n"
+                + "      map-store:\n"
+                + "        enabled: true\n"
+                + "        initial-mode: LAZY\n"
+                + "        class-name: com.hazelcast.examples.MyMapStore\n"
+                + "        write-delay-seconds: 10\n"
+                + "        write-batch-size: 100\n";
+        writeStringToStreamAndClose(os, mapConfig);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - file:///" + file.getAbsolutePath() + "\n"
+                + "  map:\n"
+                + "    mapInMain:\n"
+                + "      backup-count: 2\n"
+                + "      time-to-live-seconds: 5\n";
+
+        Config config = buildConfig(yaml, null);
+
+        MapConfig mapInMainMapConfig = config.getMapConfig("mapInMain");
+        assertEquals("mapInMain", mapInMainMapConfig.getName());
+        assertEquals(5, mapInMainMapConfig.getTimeToLiveSeconds());
+        assertEquals(2, mapInMainMapConfig.getBackupCount());
+
+        MapConfig importedMap = config.getMapConfig("importedMap");
+        assertEquals("importedMap", importedMap.getName());
+        assertEquals(10, importedMap.getTimeToLiveSeconds());
+        assertEquals(6, importedMap.getBackupCount());
+        MapStoreConfig myMapStoreConfig = importedMap.getMapStoreConfig();
+        assertEquals(10, myMapStoreConfig.getWriteDelaySeconds());
+        assertEquals(100, myMapStoreConfig.getWriteBatchSize());
+        assertEquals("com.hazelcast.examples.MyMapStore", myMapStoreConfig.getClassName());
+    }
+
+    @Override
+    @Test
+    public void testImportGroupConfigFromClassPath() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - classpath:test-hazelcast.yaml";
+        Config config = buildConfig(yaml, null);
+        GroupConfig groupConfig = config.getGroupConfig();
+        assertEquals("foobar", groupConfig.getName());
+        assertEquals("dev-pass", groupConfig.getPassword());
+    }
+
+    @Override
+    @Test
+    public void testReplacers() throws Exception {
+        File passwordFile = tempFolder.newFile(getClass().getSimpleName() + ".pwd");
+        PrintWriter out = new PrintWriter(passwordFile);
+        try {
+            out.print("This is a password");
+        } finally {
+            IOUtil.closeResource(out);
+        }
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  config-replacers:\n"
+                + "    replacers:\n"
+                + "      - class-name: " + EncryptionReplacer.class.getName() + "\n"
+                + "        properties:\n"
+                + "          passwordFile: " + passwordFile.getAbsolutePath() + "\n"
+                + "          passwordUserProperties: false\n"
+                + "          keyLengthBits: 64\n"
+                + "          saltLengthBytes: 8\n"
+                + "          cipherAlgorithm: DES\n"
+                + "          secretKeyFactoryAlgorithm: PBKDF2WithHmacSHA1\n"
+                + "          secretKeyAlgorithm: DES\n"
+                + "      - class-name: " + XmlConfigImportVariableReplacementTest.IdentityReplacer.class.getName() + "\n"
+                + "  group:\n"
+                + "    name: ${java.version} $ID{dev}\n"
+                + "    password: $ENC{7JX2r/8qVVw=:10000:Jk4IPtor5n/vCb+H8lYS6tPZOlCZMtZv}\n";
+        GroupConfig groupConfig = buildConfig(yaml, System.getProperties()).getGroupConfig();
+        assertEquals(System.getProperty("java.version") + " dev", groupConfig.getName());
+        assertEquals("My very secret secret", groupConfig.getPassword());
+    }
+
+    @Override
+    @Test(expected = ConfigurationException.class)
+    public void testMissingReplacement() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  config-replacers:\n"
+                + "    replacers:\n"
+                + "      - class-name: " + EncryptionReplacer.class.getName() + "\n"
+                + "  group:\n"
+                + "    name: $ENC{7JX2r/8qVVw=:10000:Jk4IPtor5n/vCb+H8lYS6tPZOlCZMtZv}";
+        buildConfig(yaml, System.getProperties());
+    }
+
+    @Override
+    @Test
+    public void testBadVariableSyntaxIsIgnored() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  group:\n"
+                + "    name: ${noSuchPropertyAvailable]";
+        GroupConfig groupConfig = buildConfig(yaml, System.getProperties()).getGroupConfig();
+        assertEquals("${noSuchPropertyAvailable]", groupConfig.getName());
+    }
+
+    @Override
+    @Test
+    public void testReplacerProperties() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  config-replacers:\n"
+                + "    fail-if-value-missing: false\n"
+                + "    replacers:\n"
+                + "      - class-name: " + XmlConfigImportVariableReplacementTest.TestReplacer.class.getName() + "\n"
+                + "        properties:\n"
+                + "          p1: a property\n"
+                + "          p2: !!null\n"
+                + "          p3: another property\n"
+                + "          p4: <test/>\n"
+                + "  group:\n"
+                + "    name: $T{p1} $T{p2} $T{p3} $T{p4} $T{p5}\n";
+        GroupConfig groupConfig = buildConfig(yaml, System.getProperties()).getGroupConfig();
+        assertEquals("a property  another property <test/> $T{p5}", groupConfig.getName());
+    }
+
+    /**
+     * Given: No replacer is used in the configuration file<br>
+     * When: A property variable is used within the file<br>
+     * Then: The configuration parsing doesn't fail and the variable string remains unchanged (i.e. backward compatible
+     * behavior, as if {@code fail-if-value-missing} attribute is {@code false}).
+     */
+    @Override
+    @Test
+    public void testNoConfigReplacersMissingProperties() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  group:\n"
+                + "    name: ${noSuchPropertyAvailable}";
+        GroupConfig groupConfig = buildConfig(yaml, System.getProperties()).getGroupConfig();
+        assertEquals("${noSuchPropertyAvailable}", groupConfig.getName());
+    }
+
+    @Override
+    @Test
+    public void testVariableReplacementAsSubstring() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  properties:\n"
+                + "    ${env}-with-suffix: local-with-suffix\n"
+                + "    with-prefix-${env}: with-prefix-local";
+
+        Config config = buildConfig(yaml, "env", "local");
+        assertEquals(config.getProperty("local-with-suffix"), "local-with-suffix");
+        assertEquals(config.getProperty("with-prefix-local"), "with-prefix-local");
+    }
+
+    @Override
+    @Test
+    public void testImportWithVariableReplacementAsSubstring() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String networkConfig = ""
+                + "hazelcast:\n"
+                + "  properties:\n"
+                + "    prop1: value1\n"
+                + "    prop2: value2\n";
+        writeStringToStreamAndClose(os, networkConfig);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - file:///" + "${file}";
+        Config config = buildConfig(yaml, "file", file.getAbsolutePath());
+        assertEquals(config.getProperty("prop1"), "value1");
+        assertEquals(config.getProperty("prop2"), "value2");
+    }
+
+    private static Config buildConfig(String yaml, Properties properties) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(yaml.getBytes());
+        YamlConfigBuilder configBuilder = new YamlConfigBuilder(bis);
+        configBuilder.setProperties(properties);
+        return configBuilder.build();
+    }
+
+    private static Config buildConfig(String xml, String key, String value) {
+        Properties properties = new Properties();
+        properties.setProperty(key, value);
+        return buildConfig(xml, properties);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -31,6 +32,7 @@ import java.io.FileOutputStream;
 import java.io.PrintWriter;
 import java.util.Properties;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -39,6 +41,11 @@ import static org.junit.Assert.assertTrue;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class YamlConfigImportVariableReplacementTest extends AbstractConfigImportVariableReplacementTest {
+
+    @Before
+    public void assumeRunningOnJdk8() {
+        assumeThatJDK8OrHigher();
+    }
 
     @Override
     @Test

--- a/hazelcast/src/test/resources/test-hazelcast-variable.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-variable.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
+
+    <properties>
+        <property name="prop">${variable}</property>
+    </properties>
+
+</hazelcast>

--- a/hazelcast/src/test/resources/test-hazelcast-variable.yaml
+++ b/hazelcast/src/test/resources/test-hazelcast-variable.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+hazelcast:
+  properties:
+    prop: ${variable}


### PR DESCRIPTION
Add support for importing external documents and replacing variables in YAML member configs.

Replacing is fully identical to the behavior of replacing in XML.

Importing has one difference. Importing XML documents replaces the import tag with the content of the imported XML document. In the case of YAML replacing is not enough, the two YAML documents need to be merged recursively in order to ensure we get a valid YAML document as the result. This is done at YAML DOM level, following this logic:
- if a given source node is not found in the target DOM, we attach the given node to the target
- if the node is found, we recursively continue the process with the given node

This results in a difference if the same datastructure config is spanned over two files. In the case of YAML, the result configuration is merged, taking the configuration values from both files. In the XML case, the configuration values taken from the main XML file - the one that imports the other XML. This can be seen in the two implementations of the `AbstractConfigImportVariableReplacementTest#testMapConfigFromMainAndImportedFile`. The YAML merging logic is implemented in `YamlConfigBuilder#merge`.

Depends on #14410, #14415 