### PR TITLE
Add OnJoinPermissionOperation support to member security configuration.

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -75,6 +75,7 @@ import com.hazelcast.config.MulticastConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.config.OnJoinPermissionOperationName;
 import com.hazelcast.config.PNCounterConfig;
 import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.config.PartitioningStrategyConfig;
@@ -1912,6 +1913,14 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         private void handleSecurityPermissions(Node node, BeanDefinitionBuilder securityConfigBuilder) {
             Set<BeanDefinition> permissions = new ManagedSet<BeanDefinition>();
+            NamedNodeMap attributes = node.getAttributes();
+            Node onJoinOpAttribute = attributes.getNamedItem("on-join-operation");
+            if (onJoinOpAttribute != null) {
+                String onJoinOp = getTextContent(onJoinOpAttribute);
+                OnJoinPermissionOperationName onJoinPermissionOperation = OnJoinPermissionOperationName
+                        .valueOf(upperCaseInternal(onJoinOp));
+                securityConfigBuilder.addPropertyValue("onJoinPermissionOperation", onJoinPermissionOperation);
+            }
             for (Node child : childElements(node)) {
                 String nodeName = cleanNodeName(child);
                 PermissionType type = PermissionType.getType(nodeName);

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -3032,6 +3032,7 @@
                                     maxOccurs="unbounded"/>
                         <xs:element name="config-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
                     </xs:choice>
+                    <xs:attribute name="on-join-operation" type="permission-on-join-operation" use="optional" default="RECEIVE"/>
                 </xs:complexType>
             </xs:element>
             <xs:element name="security-interceptors" type="interceptors" minOccurs="0" maxOccurs="1"/>
@@ -3048,6 +3049,13 @@
         </xs:sequence>
         <xs:attribute name="enabled" type="xs:string" default="false"/>
     </xs:complexType>
+    <xs:simpleType name="permission-on-join-operation">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="RECEIVE"/>
+            <xs:enumeration value="SEND"/>
+            <xs:enumeration value="NONE"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="interceptors">
         <xs:sequence>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -67,6 +67,7 @@ import com.hazelcast.config.MultiMapConfig;
 import com.hazelcast.config.NativeMemoryConfig;
 import com.hazelcast.config.NearCacheConfig;
 import com.hazelcast.config.NetworkConfig;
+import com.hazelcast.config.OnJoinPermissionOperationName;
 import com.hazelcast.config.PNCounterConfig;
 import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.config.PermissionConfig;
@@ -84,6 +85,7 @@ import com.hazelcast.config.RingbufferConfig;
 import com.hazelcast.config.RingbufferStoreConfig;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.config.ScheduledExecutorConfig;
+import com.hazelcast.config.SecurityConfig;
 import com.hazelcast.config.SemaphoreConfig;
 import com.hazelcast.config.SerializationConfig;
 import com.hazelcast.config.SerializerConfig;
@@ -573,8 +575,10 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
 
     @Test
     public void testSecurity() {
-        final Set<PermissionConfig> clientPermissionConfigs = config.getSecurityConfig().getClientPermissionConfigs();
-        assertFalse(config.getSecurityConfig().getClientBlockUnmappedActions());
+        SecurityConfig securityConfig = config.getSecurityConfig();
+        assertEquals(OnJoinPermissionOperationName.SEND, securityConfig.getOnJoinPermissionOperation());
+        final Set<PermissionConfig> clientPermissionConfigs = securityConfig.getClientPermissionConfigs();
+        assertFalse(securityConfig.getClientBlockUnmappedActions());
         assertTrue(isNotEmpty(clientPermissionConfigs));
         assertEquals(22, clientPermissionConfigs.size());
         final PermissionConfig pnCounterPermission = new PermissionConfig(PermissionType.PN_COUNTER, "pnCounterPermission", "*")

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -637,7 +637,7 @@
                 <hz:size unit="MEGABYTES" value="256"/>
             </hz:native-memory>
             <hz:security>
-                <hz:client-permissions>
+                <hz:client-permissions on-join-operation="SEND">
                     <hz:pn-counter-permission name="pnCounterPermission">
                         <hz:actions>
                             <hz:action>create</hz:action>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -295,15 +295,16 @@ public class ConfigXmlGenerator {
             gen.close();
         }
 
-        appendSecurityPermissions(gen, "client-permissions", c.getClientPermissionConfigs());
+        appendSecurityPermissions(gen, "client-permissions", c.getClientPermissionConfigs(),
+                "on-join-operation", c.getOnJoinPermissionOperation());
         gen.close();
     }
 
-    private static void appendSecurityPermissions(XmlGenerator gen, String tag, Set<PermissionConfig> cpc) {
+    private static void appendSecurityPermissions(XmlGenerator gen, String tag, Set<PermissionConfig> cpc, Object... attributes) {
         final List<PermissionConfig.PermissionType> clusterPermTypes = asList(ALL, CONFIG, TRANSACTION);
 
         if (!cpc.isEmpty()) {
-            gen.open(tag);
+            gen.open(tag, attributes);
             for (PermissionConfig p : cpc) {
                 if (clusterPermTypes.contains(p.getType())) {
                     gen.open(p.getType().getNodeName(), "principal", p.getPrincipal());

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -2722,6 +2722,12 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
     }
 
     protected void handleSecurityPermissions(Node node) {
+        String onJoinOp = getAttribute(node, "on-join-operation");
+        if (onJoinOp != null) {
+            OnJoinPermissionOperationName onJoinPermissionOperation = OnJoinPermissionOperationName
+                    .valueOf(upperCaseInternal(onJoinOp));
+            config.getSecurityConfig().setOnJoinPermissionOperation(onJoinPermissionOperation);
+        }
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             PermissionConfig.PermissionType type;

--- a/hazelcast/src/main/java/com/hazelcast/config/OnJoinPermissionOperationName.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/OnJoinPermissionOperationName.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Enum of operation names for handling client permissions when the member is joining into the cluster.
+ *
+ * @see SecurityConfig
+ */
+public enum OnJoinPermissionOperationName {
+
+    /**
+     * Operation which replaces locally configured permissions by the ones received from cluster.
+     */
+    RECEIVE,
+    /**
+     * Operation which refreshes cluster permissions with locally specified ones.
+     */
+    SEND,
+    /**
+     * No-op - neither receives nor sends permissions.
+     */
+    NONE;
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/SecurityConfig.java
@@ -16,10 +16,13 @@
 
 package com.hazelcast.config;
 
+import static com.hazelcast.util.Preconditions.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 /**
  * Contains configuration for Security
  */
@@ -42,6 +45,8 @@ public class SecurityConfig {
     private Set<PermissionConfig> clientPermissionConfigs = new HashSet<PermissionConfig>();
 
     private boolean clientBlockUnmappedActions = DEFAULT_CLIENT_BLOCK_UNMAPPED_ACTIONS;
+
+    private OnJoinPermissionOperationName onJoinPermissionOperation = OnJoinPermissionOperationName.RECEIVE;
 
     public SecurityConfig addSecurityInterceptorConfig(SecurityInterceptorConfig interceptorConfig) {
         securityInterceptorConfigs.add(interceptorConfig);
@@ -125,6 +130,16 @@ public class SecurityConfig {
         return this;
     }
 
+    public OnJoinPermissionOperationName getOnJoinPermissionOperation() {
+        return onJoinPermissionOperation;
+    }
+
+    public SecurityConfig setOnJoinPermissionOperation(OnJoinPermissionOperationName onJoinPermissionOperation) {
+        this.onJoinPermissionOperation = checkNotNull(onJoinPermissionOperation,
+                "Existing " + OnJoinPermissionOperationName.class.getSimpleName() + " value has to be provided.");
+        return this;
+    }
+
     /**
      * @return a boolean flag indicating whether actions, submitted as tasks in an Executor from clients
      * and have no permission mappings, are blocked or allowed.
@@ -170,6 +185,7 @@ public class SecurityConfig {
                 + ", clientPolicyConfig=" + clientPolicyConfig
                 + ", clientPermissionConfigs=" + clientPermissionConfigs
                 + ", clientBlockUnmappedActions=" + clientBlockUnmappedActions
+                + ", onJoinPermissionOperation=" + onJoinPermissionOperation
                 + '}';
     }
 
@@ -216,6 +232,9 @@ public class SecurityConfig {
                 : that.clientPolicyConfig != null) {
             return false;
         }
+        if (onJoinPermissionOperation != that.onJoinPermissionOperation) {
+            return false;
+        }
         return clientPermissionConfigs != null
                 ? clientPermissionConfigs.equals(that.clientPermissionConfigs)
                 : that.clientPermissionConfigs == null;
@@ -232,6 +251,7 @@ public class SecurityConfig {
         result = 31 * result + (clientPolicyConfig != null ? clientPolicyConfig.hashCode() : 0);
         result = 31 * result + (clientPermissionConfigs != null ? clientPermissionConfigs.hashCode() : 0);
         result = 31 * result + (clientBlockUnmappedActions ? 1 : 0);
+        result = 31 * result + onJoinPermissionOperation.ordinal();
         return result;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
@@ -52,7 +52,14 @@ class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
         cfg.addSecurityInterceptorConfig(new SecurityInterceptorConfig(className));
     }
 
+    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:methodlength"})
     protected void handleSecurityPermissions(Node node) {
+        String onJoinOp = getAttribute(node, "on-join-operation");
+        if (onJoinOp != null) {
+            OnJoinPermissionOperationName onJoinPermissionOperation = OnJoinPermissionOperationName
+                    .valueOf(upperCaseInternal(onJoinOp));
+            config.getSecurityConfig().setOnJoinPermissionOperation(onJoinPermissionOperation);
+        }
         for (Node child : childElements(node)) {
             String nodeName = cleanNodeName(child);
             PermissionConfig.PermissionType type;

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicSecurityConfig.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.dynamicconfig;
 
 import com.hazelcast.config.CredentialsFactoryConfig;
 import com.hazelcast.config.LoginModuleConfig;
+import com.hazelcast.config.OnJoinPermissionOperationName;
 import com.hazelcast.config.PermissionConfig;
 import com.hazelcast.config.PermissionPolicyConfig;
 import com.hazelcast.config.SecurityConfig;
@@ -156,6 +157,16 @@ public class DynamicSecurityConfig extends SecurityConfig {
 
     @Override
     public SecurityConfig setMemberCredentialsConfig(CredentialsFactoryConfig credentialsFactoryConfig) {
+        throw new UnsupportedOperationException("Unsupported operation");
+    }
+
+    @Override
+    public OnJoinPermissionOperationName getOnJoinPermissionOperation() {
+        return staticSecurityConfig.getOnJoinPermissionOperation();
+    }
+
+    @Override
+    public SecurityConfig setOnJoinPermissionOperation(OnJoinPermissionOperationName onJoinPermissionOperation) {
         throw new UnsupportedOperationException("Unsupported operation");
     }
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -2790,6 +2790,7 @@
             <xs:element name="user-code-deployment-permission" type="instance-permission" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="config-permission" type="base-permission" minOccurs="0" maxOccurs="1"/>
         </xs:choice>
+        <xs:attribute name="on-join-operation" type="permission-on-join-operation" use="optional" default="RECEIVE"/>
     </xs:complexType>
     <xs:complexType name="base-permission">
         <xs:sequence>
@@ -4399,4 +4400,11 @@
             </xs:element>
         </xs:choice>
     </xs:complexType>
+    <xs:simpleType name="permission-on-join-operation">
+        <xs:restriction base="non-space-string">
+            <xs:enumeration value="RECEIVE"/>
+            <xs:enumeration value="SEND"/>
+            <xs:enumeration value="NONE"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2153,7 +2153,7 @@
                 <property name="property">value</property>
             </properties>
         </client-permission-policy>
-        <client-permissions>
+        <client-permissions on-join-operation="RECEIVE">
             <all-permissions principal="admin">
                 <endpoints>
                     <endpoint>127.0.0.1</endpoint>

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -392,6 +392,9 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testMapEvictionPolicyIsSelected_whenEvictionPolicySet();
 
     @Test
+    public abstract void testOnJoinPermissionOperation();
+
+    @Test
     public abstract void testCachePermission();
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -1377,6 +1377,7 @@ public class ConfigCompatibilityChecker {
         boolean check(SecurityConfig c1, SecurityConfig c2) {
             return c1 == c2 || !(c1 == null || c2 == null)
                     && nullSafeEqual(c1.isEnabled(), c2.isEnabled())
+                    && (c1.getOnJoinPermissionOperation() == c2.getOnJoinPermissionOperation())
                     && nullSafeEqual(c1.getClientBlockUnmappedActions(), c2.getClientBlockUnmappedActions())
                     && isCompatible(c1.getMemberCredentialsConfig(), c2.getMemberCredentialsConfig())
                     && isCompatible(c1.getSecurityInterceptorConfigs(), c2.getSecurityInterceptorConfigs())

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -298,6 +298,7 @@ public class ConfigXmlGeneratorTest {
 
         SecurityConfig expectedConfig = new SecurityConfig();
         expectedConfig.setEnabled(true)
+          .setOnJoinPermissionOperation(OnJoinPermissionOperationName.NONE)
           .setClientBlockUnmappedActions(false)
           .setClientLoginModuleConfigs(Arrays.asList(
                   new LoginModuleConfig()

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -67,6 +67,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -2951,6 +2952,18 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
+    public void testOnJoinPermissionOperation() {
+        for (OnJoinPermissionOperationName onJoinOp : OnJoinPermissionOperationName.values()) {
+            String xml = HAZELCAST_START_TAG + SECURITY_START_TAG
+                    + "  <client-permissions on-join-operation='" + onJoinOp.name() + "'/>"
+                    + SECURITY_END_TAG + HAZELCAST_END_TAG;
+            Config config = buildConfig(xml);
+            assertSame(onJoinOp, config.getSecurityConfig().getOnJoinPermissionOperation());
+        }
+    }
+
+    @Override
+    @Test
     public void testCachePermission() {
         String xml = HAZELCAST_START_TAG + SECURITY_START_TAG
                 + "  <client-permissions>"
@@ -2961,6 +2974,8 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + SECURITY_END_TAG + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
+        assertSame("Receive is expected to be default on-join-operation", OnJoinPermissionOperationName.RECEIVE,
+                config.getSecurityConfig().getOnJoinPermissionOperation());
         PermissionConfig expected = new PermissionConfig(CACHE, "/hz/cachemanager1/cache1", "dev");
         expected.addAction("create").addAction("destroy").addAction("add").addAction("remove");
         assertPermissionConfig(expected, config);

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -60,6 +60,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -3067,6 +3068,20 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         PermissionConfig expected = new PermissionConfig(CACHE, "/hz/cachemanager1/cache1", "dev");
         expected.addAction("create").addAction("destroy").addAction("add").addAction("remove");
         assertPermissionConfig(expected, config);
+    }
+
+    @Override
+    @Test
+    public void testOnJoinPermissionOperation() {
+        for (OnJoinPermissionOperationName onJoinOp : OnJoinPermissionOperationName.values()) {
+            String yaml = ""
+                    + "hazelcast:\n"
+                    + "  security:\n"
+                    + "    client-permissions:\n"
+                    + "      on-join-operation: " + onJoinOp.name();
+            Config config = buildConfig(yaml);
+            assertSame(onJoinOp, config.getSecurityConfig().getOnJoinPermissionOperation());
+        }
     }
 
     @Override

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -774,7 +774,7 @@
                 <property name="property">value</property>
             </properties>
         </client-permission-policy>
-        <client-permissions>
+        <client-permissions on-join-operation="SEND">
             <all-permissions principal="admin">
                 <endpoints>
                     <endpoint>127.0.0.1</endpoint>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.yaml
@@ -769,6 +769,7 @@ hazelcast:
       properties:
         property: value
     client-permissions:
+      on-join-operation: SEND
       all:
         principal: admin
         endpoints:


### PR DESCRIPTION
This PR is an OS part (configuration) of new Hazelcast Enterprise security feature. It adds possibility to decide how to handle differently configured security permissions on members joining to a Hazelcast cluster.

The feature allows to update dynamic client permissions without Hazelcast cluster restart need.

The original behavior doesn't distribute permissions from newly joined member without an explicit API calls. This implementation introduces a suppression mechanism which will allow to newly joining members keep their set of permissions and send it to existing members when necessary.

## Modes of handling permissions during member join to a cluster
* `RECEIVE` (default) - copies current behavior - applies permissions from the master node before join
* `SEND` - doesn't apply permissions from the master before join; If the security is enabled then it refreshes/replaces cluster wide permissions after the join is complete
* `NONE` - neither applies pre-join permissions, nor sends the local permissions to other members. 

## XML Configuration
```xml
<hazelcast>
  <security enabled="true">
    <client-permissions on-join-operation="SEND">
      <!-- ... -->
    </client-permissions>
  </security>
</hazelcast>
```

## Java configuration
```java
Config config = new Config();
config.getSecurityConfig()
    .setEnabled(true)
    .setOnJoinPermissionOperation(OnJoinPermissionOperationName.SEND);
```

## Usecases

### RECEIVE
The RECEIVE is a default behavior where a newly joining member receives and uses cluster-wide permissions received from the master.

### SEND
The SEND is suitable for scenarios where users need to replace cluster wide permissions without restarting the cluster. 
E.g. Start new member (possibly lite) with new permissions configuration in `hazelcast.xml` and `on-join-operation="SEND"`. Once the member is started these new permissions are applied across the cluster and the member can be shut down again (if necessary).

### NONE
The NONE is suitable for scenarios where users need to elevate privileges on a single member for limited time period. When NONE is used, then make sure an unisocket client is used (i.e. smart routing feature is disabled).

Sample:
```java
// temporary lite member
Config config = new Config().setLiteMember(true);
PermissionConfig allPermission = new PermissionConfig(PermissionType.ALL, "*", null);
config.getSecurityConfig()
  .setEnabled(true)
  .setOnJoinPermissionOperation(OnJoinPermissionOperationName.NONE)
  .addClientPermissionConfig(allPermission);
HazelcastInstance hzLite = Hazelcast.newHazelcastInstance(config);

// temporary unisocket client connecting only to the lite member
String memberAddr = ...;
ClientConfig clientConfig = new ClientConfig();
clientConfig.getNetworkConfig().setSmartRouting(false)
  .addAddress(memberAddr);
HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);

// do operations with escalated privileges:
client.getMap("protectedConfig").put("master.resolution", "1920");

// shutdown the client and lite member
client.shutdown();
hzLite.shutdown();
```
