### PR TITLE
Fix LockAdvancedTest.testCleanupOperationIgnoresQuorum

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -79,14 +79,19 @@ public class LockAdvancedTest extends HazelcastTestSupport {
         String lockName = "lock";
         HazelcastInstance i1 = instances[0];
         HazelcastInstance i2 = instances[1];
-        ILock l1 = i1.getLock(lockName);
+        final ILock l1 = i1.getLock(lockName);
         ILock l2 = i2.getLock(lockName);
         l2.lock();
         assertTrue(l1.isLocked());
         assertTrue(l2.isLocked());
 
         i2.shutdown();
-        assertFalse(l1.isLocked());
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertFalse(l1.isLocked());
+            }
+        });
     }
 
     private void testShutDownNodeWhenOtherWaitingOnLock(boolean localKey) throws InterruptedException {


### PR DESCRIPTION
The membership change event/lock cleanup mechanism is concurrent to the
shutdown mechanism of the shutting down member so we must assert that
the lock will be freed eventually.

Fixes: https://github.com/hazelcast/hazelcast/issues/14350