### PR TITLE
 Introduce query cache recreate method, a query cache can recreate its…

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEndToEndConstructor.java
@@ -41,10 +41,10 @@ public class ClientQueryCacheEndToEndConstructor extends AbstractQueryCacheEndTo
 
     @Override
     public void createPublisherAccumulator(AccumulatorInfo info) throws Exception {
-        ClientMessage request = createClientMessage(info);
+        ClientMessage publisherCreateMessage = newPublisherCreateMessage(info);
 
         InvokerWrapper invokerWrapper = context.getInvokerWrapper();
-        ClientMessage response = (ClientMessage) invokerWrapper.invoke(request);
+        ClientMessage response = (ClientMessage) invokerWrapper.invoke(publisherCreateMessage);
 
         prepopulate(queryCache, response, info.isIncludeValue());
 
@@ -54,7 +54,7 @@ public class ClientQueryCacheEndToEndConstructor extends AbstractQueryCacheEndTo
         }
     }
 
-    private ClientMessage createClientMessage(AccumulatorInfo info) {
+    private ClientMessage newPublisherCreateMessage(AccumulatorInfo info) {
         Data dataPredicate = context.getSerializationService().toData(info.getPredicate());
 
         if (info.isIncludeValue()) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientSubscriberContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientSubscriberContext.java
@@ -18,6 +18,8 @@ package com.hazelcast.client.impl.querycache.subscriber;
 
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
 import com.hazelcast.map.impl.querycache.subscriber.AbstractSubscriberContext;
+import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndConstructor;
+import com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContextSupport;
 
 /**
@@ -37,5 +39,10 @@ public class ClientSubscriberContext extends AbstractSubscriberContext {
     @Override
     public SubscriberContextSupport getSubscriberContextSupport() {
         return clientSubscriberContextSupport;
+    }
+
+    @Override
+    public QueryCacheEndToEndConstructor newEndToEndConstructor(QueryCacheRequest request) {
+        return new ClientQueryCacheEndToEndConstructor(request);
     }
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -88,7 +88,6 @@ import com.hazelcast.client.impl.protocol.codec.MapValuesCodec;
 import com.hazelcast.client.impl.protocol.codec.MapValuesWithPagingPredicateCodec;
 import com.hazelcast.client.impl.protocol.codec.MapValuesWithPredicateCodec;
 import com.hazelcast.client.impl.querycache.ClientQueryCacheContext;
-import com.hazelcast.client.impl.querycache.subscriber.ClientQueryCacheEndToEndConstructor;
 import com.hazelcast.client.map.impl.ClientMapPartitionIterator;
 import com.hazelcast.client.map.impl.ClientMapQueryPartitionIterator;
 import com.hazelcast.client.spi.ClientContext;
@@ -1642,7 +1641,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
         SubscriberContext subscriberContext = queryCacheContext.getSubscriberContext();
         QueryCacheEndToEndProvider queryCacheEndToEndProvider = subscriberContext.getEndToEndQueryCacheProvider();
         return queryCacheEndToEndProvider.getOrCreateQueryCache(request.getMapName(), request.getCacheName(),
-                new ClientQueryCacheEndToEndConstructor(request));
+                subscriberContext.newEndToEndConstructor(request));
     }
 
     @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheRecreationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheRecreationTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.map.impl.querycache;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.core.EntryAdapter;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.QueryCache;
+import com.hazelcast.map.impl.querycache.subscriber.InternalQueryCache;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientQueryCacheRecreationTest extends HazelcastTestSupport {
+
+    private final String mapName = "mapName";
+    private final String queryCacheName = "queryCacheName";
+    private final TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    private HazelcastInstance client;
+    private HazelcastInstance server;
+
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfig();
+    }
+
+    @Before
+    public void setUp() {
+        server = factory.newHazelcastInstance(getConfig());
+
+        QueryCacheConfig queryCacheConfig = new QueryCacheConfig(queryCacheName);
+
+        ClientConfig config = new ClientConfig();
+        config.addQueryCacheConfig(mapName, queryCacheConfig);
+        config.getConnectionStrategyConfig().getConnectionRetryConfig().setEnabled(true)
+                .setMaxBackoffMillis((int) TimeUnit.SECONDS.toMillis(5));
+
+        client = factory.newHazelcastClient(config);
+    }
+
+    @After
+    public void tearDown() {
+        factory.shutdownAll();
+    }
+
+    @Test
+    public void query_cache_recreates_itself_after_server_restart() {
+        IMap<Object, Object> map = client.getMap(mapName);
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+
+        final QueryCache<Object, Object> queryCache = map.getQueryCache(queryCacheName,
+                Predicates.alwaysTrue(), true);
+
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+
+        server.shutdown();
+        server = factory.newHazelcastInstance(getConfig());
+
+        for (int i = 100; i < 200; i++) {
+            map.put(i, i);
+        }
+
+        InternalQueryCache internalQueryCache = (InternalQueryCache) queryCache;
+        internalQueryCache.recreate();
+
+        for (int i = 200; i < 300; i++) {
+            map.put(i, i);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(200, queryCache.size());
+            }
+        });
+
+        Set<Object> keySet = queryCache.keySet();
+        for (int i = 0; i < 300; i++) {
+            if (i < 100) {
+                assertFalse(keySet.contains(i));
+            } else {
+                assertTrue(keySet.contains(i));
+            }
+        }
+    }
+
+    @Test
+    public void listeners_still_works_after_query_cache_recreation() {
+        IMap<Object, Object> map = client.getMap(mapName);
+        QueryCache<Object, Object> queryCache = map.getQueryCache(queryCacheName,
+                Predicates.alwaysTrue(), true);
+        final AtomicInteger entryAddedCounter = new AtomicInteger();
+        queryCache.addEntryListener(new EntryAdapter() {
+            @Override
+            public void entryAdded(EntryEvent event) {
+                entryAddedCounter.incrementAndGet();
+            }
+        }, new SqlPredicate("__key >= 10"), true);
+
+        // Restart server
+        server.shutdown();
+        server = factory.newHazelcastInstance(getConfig());
+
+        // Recreate query cache on same reference
+        // Recreation empties query cache.
+        ((InternalQueryCache) queryCache).recreate();
+
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+
+        AssertTask assertTask = new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(90, entryAddedCounter.get());
+            }
+        };
+
+        assertTrueEventually(assertTask);
+        assertTrueAllTheTime(assertTask, 3);
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheUpdateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheUpdateTest.java
@@ -43,8 +43,8 @@ import static org.junit.Assert.assertNotNull;
 @Category({QuickTest.class, ParallelTest.class})
 public class ClientQueryCacheUpdateTest extends HazelcastTestSupport {
 
-    private final String mapName = randomString();
-    private final String queryCacheName = randomString();
+    private final String mapName = "mapName";
+    private final String queryCacheName = "queryCacheName";
     private final TestHazelcastFactory factory = new TestHazelcastFactory();
 
     private HazelcastInstance client;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/subscriber/TestClientSubscriberContext.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/subscriber/TestClientSubscriberContext.java
@@ -113,5 +113,11 @@ public class TestClientSubscriberContext extends ClientSubscriberContext {
             }
             return super.isNextEvent(eventData);
         }
+
+        @Override
+        public void reset() {
+            lostSequenceNumber.clear();
+            super.reset();
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
@@ -73,7 +73,7 @@ public class MapPublisherCreateMessageTask
         for (MemberImpl member : members) {
             Predicate predicate = serializationService.toObject(parameters.predicate);
             AccumulatorInfo accumulatorInfo =
-                    AccumulatorInfo.createAccumulatorInfo(parameters.mapName, parameters.cacheName, predicate,
+                    AccumulatorInfo.toAccumulatorInfo(parameters.mapName, parameters.cacheName, predicate,
                             parameters.batchSize, parameters.bufferSize, parameters.delaySeconds,
                             false, parameters.populate, parameters.coalesce);
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateWithValueMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateWithValueMessageTask.java
@@ -74,7 +74,7 @@ public class MapPublisherCreateWithValueMessageTask
         for (MemberImpl member : members) {
             Predicate predicate = serializationService.toObject(parameters.predicate);
             AccumulatorInfo accumulatorInfo =
-                    AccumulatorInfo.createAccumulatorInfo(parameters.mapName, parameters.cacheName, predicate,
+                    AccumulatorInfo.toAccumulatorInfo(parameters.mapName, parameters.cacheName, predicate,
                             parameters.batchSize, parameters.bufferSize, parameters.delaySeconds,
                             true, parameters.populate, parameters.coalesce);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheEventPublisher.java
@@ -111,7 +111,7 @@ public class QueryCacheEventPublisher {
             Accumulator accumulator = accumulatorRegistry.getOrCreate(partitionId);
 
             QueryCacheEventData singleEventData = newQueryCacheEventDataBuilder(false).withPartitionId(partitionId)
-                                                                                      .withEventType(eventType.getType()).build();
+                    .withEventType(eventType.getType()).build();
 
             accumulator.accumulate(singleEventData);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -42,7 +42,6 @@ import com.hazelcast.map.impl.query.AggregationResult;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.Target;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
-import com.hazelcast.map.impl.querycache.subscriber.NodeQueryCacheEndToEndConstructor;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheEndToEndProvider;
 import com.hazelcast.map.impl.querycache.subscriber.QueryCacheRequest;
 import com.hazelcast.map.impl.querycache.subscriber.SubscriberContext;
@@ -1071,7 +1070,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
         SubscriberContext subscriberContext = queryCacheContext.getSubscriberContext();
         QueryCacheEndToEndProvider queryCacheEndToEndProvider = subscriberContext.getEndToEndQueryCacheProvider();
         return queryCacheEndToEndProvider.getOrCreateQueryCache(request.getMapName(), request.getCacheName(),
-                new NodeQueryCacheEndToEndConstructor(request));
+                subscriberContext.newEndToEndConstructor(request));
     }
 
     private static void checkNotPagingPredicate(Predicate predicate, String method) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AbstractAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AbstractAccumulator.java
@@ -58,4 +58,10 @@ abstract class AbstractAccumulator<E extends Sequenced> implements Accumulator<E
         return entry != null
                 && (now - entry.getCreationTime()) >= delayMillis;
     }
+
+    @Override
+    public void reset() {
+        buffer.reset();
+        partitionSequencer.reset();
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorHandler.java
@@ -31,7 +31,13 @@ public interface AccumulatorHandler<T> {
      * Handles element.
      *
      * @param element     the element to be processed.
-     * @param lastElement {@code true} if this is the last element got from the {@code Accumulator}, otherwise {@code false}.
+     * @param lastElement {@code true} if this is the last element
+     *                    got from the {@code Accumulator}, otherwise {@code false}.
      */
     void handle(T element, boolean lastElement);
+
+    /**
+     * Resets this handler to its initial state.
+     */
+    void reset();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorInfo.java
@@ -55,8 +55,10 @@ public class AccumulatorInfo implements Portable {
      */
     private volatile boolean publishable;
 
-    public static AccumulatorInfo createAccumulatorInfo(QueryCacheConfig config, String mapName, String cacheId,
-                                                        Predicate predicate) {
+    public static AccumulatorInfo toAccumulatorInfo(QueryCacheConfig config,
+                                                    String mapName,
+                                                    String cacheId,
+                                                    Predicate predicate) {
         checkNotNull(config, "config cannot be null");
 
         AccumulatorInfo info = new AccumulatorInfo();
@@ -74,9 +76,9 @@ public class AccumulatorInfo implements Portable {
     }
 
     @SuppressWarnings("checkstyle:parameternumber")
-    public static AccumulatorInfo createAccumulatorInfo(String mapName, String cacheId, Predicate predicate, int batchSize,
-                                                        int bufferSize, long delaySeconds, boolean includeValue, boolean populate,
-                                                        boolean coalesce) {
+    public static AccumulatorInfo toAccumulatorInfo(String mapName, String cacheId, Predicate predicate, int batchSize,
+                                                    int bufferSize, long delaySeconds, boolean includeValue, boolean populate,
+                                                    boolean coalesce) {
         AccumulatorInfo info = new AccumulatorInfo();
         info.mapName = mapName;
         info.cacheId = cacheId;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AccumulatorProcessor.java
@@ -18,7 +18,7 @@ package com.hazelcast.map.impl.querycache.accumulator;
 
 /**
  * Responsible for processing of an event of an {@link Accumulator}.
- * <p/>
+ *
  * Processing can vary according to the implementation.
  *
  * @param <T> type of element to process.

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/BasicAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/BasicAccumulator.java
@@ -40,8 +40,8 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  */
 public class BasicAccumulator<E extends Sequenced> extends AbstractAccumulator<E> {
 
-    protected final ILogger logger = Logger.getLogger(getClass());
     protected final AccumulatorHandler<E> handler;
+    protected final ILogger logger = Logger.getLogger(getClass());
 
     protected BasicAccumulator(QueryCacheContext context, AccumulatorInfo info) {
         super(context, info);
@@ -132,8 +132,7 @@ public class BasicAccumulator<E extends Sequenced> extends AbstractAccumulator<E
 
     @Override
     public void reset() {
-        buffer.reset();
-        partitionSequencer.reset();
+        handler.reset();
     }
 
     private E readNextExpiredOrNull(long now, long delay, TimeUnit unit) {
@@ -156,7 +155,7 @@ public class BasicAccumulator<E extends Sequenced> extends AbstractAccumulator<E
     }
 
     @SuppressWarnings("unchecked")
-    private AccumulatorHandler<E> createAccumulatorHandler(QueryCacheContext context, AccumulatorInfo info) {
+    protected AccumulatorHandler<E> createAccumulatorHandler(QueryCacheContext context, AccumulatorInfo info) {
         QueryCacheEventService queryCacheEventService = context.getQueryCacheEventService();
         AccumulatorProcessor<Sequenced> processor = createAccumulatorProcessor(info, queryCacheEventService);
         return (AccumulatorHandler<E>) new PublisherAccumulatorHandler(context, processor);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/DefaultSubscriberSequencerProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/DefaultSubscriberSequencerProvider.java
@@ -63,6 +63,13 @@ public class DefaultSubscriberSequencerProvider implements SubscriberSequencerPr
         sequence.reset();
     }
 
+    @Override
+    public void resetAll() {
+        for (PartitionSequencer partitionSequencer : partitionSequences.values()) {
+            partitionSequencer.reset();
+        }
+    }
+
     private PartitionSequencer getOrCreateSequence(int partitionId) {
         return getOrPutIfAbsent(partitionSequences, partitionId, PARTITION_SEQUENCER_CONSTRUCTOR);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/SubscriberSequencerProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/event/sequence/SubscriberSequencerProvider.java
@@ -29,7 +29,8 @@ public interface SubscriberSequencerProvider {
      * @param expect      the expected sequence.
      * @param update      the new sequence.
      * @param partitionId ID of the partition.
-     * @return {@code true} if Compare-and-Set operation is successful, otherwise returns {@code false}.
+     * @return {@code true} if Compare-and-Set operation
+     * is successful, otherwise returns {@code false}.
      */
     boolean compareAndSetSequence(long expect, long update, int partitionId);
 
@@ -47,4 +48,9 @@ public interface SubscriberSequencerProvider {
      * @param partitionId ID of the partition.
      */
     void reset(int partitionId);
+
+    /**
+     * Like {@link #reset(int)} but this method resets all partition sequences.
+     */
+    void resetAll();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/CoalescingPublisherAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/CoalescingPublisherAccumulator.java
@@ -61,6 +61,12 @@ class CoalescingPublisherAccumulator extends BasicAccumulator<QueryCacheEventDat
         poll(handler, info.getDelaySeconds(), SECONDS);
     }
 
+    @Override
+    public void reset() {
+        index.clear();
+        super.reset();
+    }
+
     private void setSequence(QueryCacheEventData eventData) {
         Data dataKey = eventData.getDataKey();
         Long sequence = index.get(dataKey);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PartitionAccumulatorRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PartitionAccumulatorRegistry.java
@@ -47,7 +47,8 @@ public class PartitionAccumulatorRegistry implements Registry<Integer, Accumulat
      */
     private volatile String uuid;
 
-    public PartitionAccumulatorRegistry(AccumulatorInfo info, ConstructorFunction<Integer, Accumulator> accumulatorConstructor) {
+    public PartitionAccumulatorRegistry(AccumulatorInfo info,
+                                        ConstructorFunction<Integer, Accumulator> accumulatorConstructor) {
         this.info = info;
         this.eventFilter = createEventFilter();
         this.accumulatorConstructor = accumulatorConstructor;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/publisher/PublisherAccumulatorHandler.java
@@ -26,6 +26,7 @@ import com.hazelcast.map.impl.querycache.event.sequence.Sequenced;
 import com.hazelcast.nio.Address;
 import com.hazelcast.spi.properties.GroupProperty;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,6 +47,7 @@ public class PublisherAccumulatorHandler implements AccumulatorHandler<Sequenced
 
     private final QueryCacheContext context;
     private final AccumulatorProcessor<Sequenced> processor;
+
     private Queue<QueryCacheEventData> eventCollection;
 
     public PublisherAccumulatorHandler(QueryCacheContext context, AccumulatorProcessor<Sequenced> processor) {
@@ -66,6 +68,15 @@ public class PublisherAccumulatorHandler implements AccumulatorHandler<Sequenced
         }
     }
 
+    @Override
+    public void reset() {
+        if (eventCollection == null) {
+            return;
+        }
+
+        eventCollection.clear();
+    }
+
     private void process() {
         Queue<QueryCacheEventData> eventCollection = this.eventCollection;
         if (eventCollection.isEmpty()) {
@@ -79,7 +90,7 @@ public class PublisherAccumulatorHandler implements AccumulatorHandler<Sequenced
         }
     }
 
-    private void sendInBatches(Queue<QueryCacheEventData> events) {
+    private void sendInBatches(@Nonnull Queue<QueryCacheEventData> events) {
         Map<Integer, List<QueryCacheEventData>> partitionToEventDataMap = createPartitionToEventDataMap(events);
         sendToSubscriber(partitionToEventDataMap);
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -63,7 +63,7 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
     /**
      * ID of registered listener on publisher side.
      */
-    protected String publisherListenerId;
+    protected volatile String publisherListenerId;
 
     public AbstractInternalQueryCache(String cacheId, String cacheName, QueryCacheConfig queryCacheConfig,
                                       IMap delegate, QueryCacheContext context) {
@@ -91,6 +91,11 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
 
     public QueryCacheContext getContext() {
         return context;
+    }
+
+    @Override
+    public String getPublisherListenerId() {
+        return publisherListenerId;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/InternalQueryCache.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.map.impl.querycache.subscriber;
 
+import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.EntryEventType;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.QueryCache;
@@ -57,6 +58,8 @@ public interface InternalQueryCache<K, V> extends QueryCache<K, V> {
 
     void setPublisherListenerId(String publisherListenerId);
 
+    String getPublisherListenerId();
+
     /**
      * @return internally used ID for this query cache
      */
@@ -67,7 +70,7 @@ public interface InternalQueryCache<K, V> extends QueryCache<K, V> {
      *
      * @return {@code true} if this query cache is at its max capacity,
      * otherwise return {@code false}
-     * @see com.hazelcast.config.QueryCacheConfig#populate
+     * @see QueryCacheConfig#isPopulate()
      */
     boolean reachedMaxCapacity();
 
@@ -75,4 +78,17 @@ public interface InternalQueryCache<K, V> extends QueryCache<K, V> {
      * @return extractors of this query cache instance.
      */
     Extractors getExtractors();
+
+    /**
+     * Recreates this query cache.
+     *
+     * Recreation steps are:
+     * <ul>
+     * <li>Reset local subscribers' state, clear all cache entries so far.</li>
+     * <li>Recreate/reset publisher (server) side
+     * resources by using this subscribers'metadata e.g. on
+     * server restart we can recreate server side resources.</li>
+     * </ul>
+     */
+    void recreate();
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEndToEndConstructor.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeQueryCacheEndToEndConstructor.java
@@ -72,6 +72,7 @@ public class NodeQueryCacheEndToEndConstructor extends AbstractQueryCacheEndToEn
     private Collection<QueryResult> createPublishersAndGetQueryResults(AccumulatorInfo info) {
         InvokerWrapper invokerWrapper = context.getInvokerWrapper();
         Collection<Member> members = context.getMemberList();
+
         List<Future<QueryResult>> futures = new ArrayList<Future<QueryResult>>(members.size());
         for (Member member : members) {
             Address address = member.getAddress();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeSubscriberContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NodeSubscriberContext.java
@@ -36,4 +36,9 @@ public class NodeSubscriberContext extends AbstractSubscriberContext {
     public SubscriberContextSupport getSubscriberContextSupport() {
         return subscriberContextSupport;
     }
+
+    @Override
+    public QueryCacheEndToEndConstructor newEndToEndConstructor(QueryCacheRequest request) {
+        return new NodeQueryCacheEndToEndConstructor(request);
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/NullQueryCache.java
@@ -79,6 +79,11 @@ public final class NullQueryCache implements InternalQueryCache {
     }
 
     @Override
+    public String getPublisherListenerId() {
+        return null;
+    }
+
+    @Override
     public String getCacheId() {
         return null;
     }
@@ -91,6 +96,11 @@ public final class NullQueryCache implements InternalQueryCache {
     @Override
     public Extractors getExtractors() {
         return null;
+    }
+
+    @Override
+    public void recreate() {
+
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/QueryCacheFactory.java
@@ -19,6 +19,7 @@ package com.hazelcast.map.impl.querycache.subscriber;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.IMap;
 import com.hazelcast.map.impl.querycache.QueryCacheContext;
+import com.hazelcast.map.listener.MapListener;
 import com.hazelcast.util.ConcurrencyUtil;
 import com.hazelcast.util.ConstructorFunction;
 
@@ -43,12 +44,24 @@ public class QueryCacheFactory {
 
         @Override
         public InternalQueryCache createNew(String cacheId) {
-            String cacheName = request.getCacheName();
             IMap delegate = request.getMap();
+            String mapName = request.getMapName();
+            String cacheName = request.getCacheName();
             QueryCacheContext context = request.getContext();
             QueryCacheConfig queryCacheConfig = request.getQueryCacheConfig();
 
-            return new DefaultQueryCache(cacheId, cacheName, queryCacheConfig, delegate, context);
+            DefaultQueryCache queryCache = new DefaultQueryCache(cacheId, cacheName, queryCacheConfig, delegate, context);
+
+            MapListener listener = request.getListener();
+            if (listener != null) {
+                // this is users listener which can be given as a parameter
+                // when calling `IMap.getQueryCache` method
+                request.getContext()
+                        .getSubscriberContext()
+                        .getEventService().addListener(mapName, cacheId, listener);
+            }
+
+            return queryCache;
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulator.java
@@ -34,27 +34,30 @@ import static com.hazelcast.map.impl.querycache.subscriber.EventPublisherHelper.
 import static java.lang.String.format;
 
 /**
- * If all incoming events are in the correct sequence order, this accumulator applies those events to
- * {@link com.hazelcast.map.QueryCache QueryCache}.
- * Otherwise, it informs registered callback if there is any.
- * <p>
+ * If all incoming events are in the correct sequence order, this
+ * accumulator applies those events to {@link com.hazelcast.map.QueryCache
+ * QueryCache}. Otherwise, it informs registered callback if there is
+ * any.
+ *
  * This class can be accessed by multiple-threads at a time.
  */
 public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData> {
 
-    /**
-     * When a partition's sequence order is broken, it will be registered here.
-     */
-    private final ConcurrentMap<Integer, Long> brokenSequences = new ConcurrentHashMap<Integer, Long>();
-
-    private final AccumulatorHandler handler;
     private final SubscriberSequencerProvider sequenceProvider;
+    /** When a partition's sequence order is broken, it will be registered here.*/
+    private final ConcurrentMap<Integer, Long> brokenSequences = new ConcurrentHashMap<Integer, Long>();
 
     protected SubscriberAccumulator(QueryCacheContext context, AccumulatorInfo info) {
         super(context, info);
+        this.sequenceProvider = new DefaultSubscriberSequencerProvider();
+    }
 
-        this.handler = createAccumulatorHandler();
-        this.sequenceProvider = createSequencerProvider();
+    @Override
+    public void reset() {
+        brokenSequences.clear();
+        sequenceProvider.resetAll();
+
+        super.reset();
     }
 
     ConcurrentMap<Integer, Long> getBrokenSequences() {
@@ -97,28 +100,6 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
         return false;
     }
 
-    private void removeFromBrokenSequences(QueryCacheEventData event) {
-        if (brokenSequences.isEmpty()) {
-            return;
-        }
-
-        int partitionId = event.getPartitionId();
-        long sequence = event.getSequence();
-
-        if (sequence == END_SEQUENCE) {
-            brokenSequences.remove(partitionId);
-        } else {
-            Long expected = brokenSequences.get(partitionId);
-            if (expected != null && expected == event.getSequence()) {
-                brokenSequences.remove(partitionId);
-            }
-        }
-
-        if (logger.isFinestEnabled()) {
-            logger.finest(format("Size of broken sequences=%d", brokenSequences.size()));
-        }
-    }
-
     private void handleUnexpectedEvent(QueryCacheEventData event) {
         // first add sequence of this unexpected event to broken-sequences
         int partitionId = event.getPartitionId();
@@ -147,6 +128,28 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
         }
     }
 
+    private void removeFromBrokenSequences(QueryCacheEventData event) {
+        if (brokenSequences.isEmpty()) {
+            return;
+        }
+
+        int partitionId = event.getPartitionId();
+        long sequence = event.getSequence();
+
+        if (sequence == END_SEQUENCE) {
+            brokenSequences.remove(partitionId);
+        } else {
+            Long expected = brokenSequences.get(partitionId);
+            if (expected != null && expected == event.getSequence()) {
+                brokenSequences.remove(partitionId);
+            }
+        }
+
+        if (logger.isFinestEnabled()) {
+            logger.finest(format("Size of broken sequences=%d", brokenSequences.size()));
+        }
+    }
+
     protected boolean isNextEvent(Sequenced event) {
         int partitionId = event.getPartitionId();
         long currentSequence = sequenceProvider.getSequence(partitionId);
@@ -165,8 +168,9 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
         return queryCacheFactory.getOrNull(cacheId);
     }
 
-    private SubscriberAccumulatorHandler createAccumulatorHandler() {
-        AccumulatorInfo info = getInfo();
+    @Override
+    protected AccumulatorHandler<QueryCacheEventData> createAccumulatorHandler(QueryCacheContext context,
+                                                                               AccumulatorInfo info) {
         boolean includeValue = info.isIncludeValue();
         InternalQueryCache queryCache = getQueryCache();
         InternalSerializationService serializationService = context.getSerializationService();
@@ -175,10 +179,6 @@ public class SubscriberAccumulator extends BasicAccumulator<QueryCacheEventData>
 
     private void addQueryCache(QueryCacheEventData eventData) {
         handler.handle(eventData, false);
-    }
-
-    private SubscriberSequencerProvider createSequencerProvider() {
-        return new DefaultSubscriberSequencerProvider();
     }
 
     private boolean isEndEvent(QueryCacheEventData event) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
@@ -57,6 +57,15 @@ class SubscriberAccumulatorHandler implements AccumulatorHandler<QueryCacheEvent
         this.evictAllRemovedCountHolders = initRemovedCountHolders(partitionCount);
     }
 
+    @Override
+    public void reset() {
+        queryCache.clear();
+        for (int i = 0; i < partitionCount; i++) {
+            clearAllRemovedCountHolders.set(i, new ConcurrentLinkedQueue<Integer>());
+            evictAllRemovedCountHolders.set(i, new ConcurrentLinkedQueue<Integer>());
+        }
+    }
+
     private static AtomicReferenceArray<Queue<Integer>> initRemovedCountHolders(int partitionCount) {
         AtomicReferenceArray<Queue<Integer>> removedCountHolders
                 = new AtomicReferenceArray<Queue<Integer>>(partitionCount + 1);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberContext.java
@@ -81,4 +81,10 @@ public interface SubscriberContext {
      * @see SubscriberContextSupport
      */
     SubscriberContextSupport getSubscriberContextSupport();
+
+    /**
+     * @param request see {@link QueryCacheRequest}
+     * @return a new instance of {@link QueryCacheEndToEndConstructor}
+     */
+    QueryCacheEndToEndConstructor newEndToEndConstructor(QueryCacheRequest request);
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberListener.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 /**
  * Subscriber side listener per {@code QueryCache} which listens events sent by publisher-sides.
  */
-class SubscriberListener implements ListenerAdapter<IMapEvent> {
+public class SubscriberListener implements ListenerAdapter<IMapEvent> {
 
     private final AccumulatorInfo info;
     private final Accumulator accumulator;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/PublisherCreateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/operation/PublisherCreateOperation.java
@@ -19,8 +19,8 @@ package com.hazelcast.map.impl.querycache.subscriber.operation;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.operation.MapOperation;
-import com.hazelcast.map.impl.query.QueryEngine;
 import com.hazelcast.map.impl.query.Query;
+import com.hazelcast.map.impl.query.QueryEngine;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultRow;
 import com.hazelcast.map.impl.query.Target;
@@ -135,7 +135,11 @@ public class PublisherCreateOperation extends MapOperation {
         PublisherContext publisherContext = getPublisherContext();
         MapPublisherRegistry mapPublisherRegistry = publisherContext.getMapPublisherRegistry();
         PublisherRegistry publisherRegistry = mapPublisherRegistry.getOrCreate(mapName);
+        // If InternalQueryCache#recreate is called, we forcibly
+        // remove and recreate registration matching with cacheId
+        publisherRegistry.remove(cacheId);
         PartitionAccumulatorRegistry partitionAccumulatorRegistry = publisherRegistry.getOrCreate(cacheId);
+
         partitionAccumulatorRegistry.setUuid(getCallerUuid());
     }
 
@@ -240,7 +244,7 @@ public class PublisherCreateOperation extends MapOperation {
         // values of the entries may be different if keyData-s are equal
         // so this `if` checks the existence of keyData in the set. If it is there, just removing it and adding
         // `the new row with the same keyData but possibly with the new value`.
-        // TODO
+        // TODO can cause duplicate event receive on client side
         //if (queryResultSet.contains(row)) {
         //    queryResultSet.remove(row);
         //}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/ServerQueryCacheRecreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/ServerQueryCacheRecreationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl.querycache;
+
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.QueryCacheConfig;
+import com.hazelcast.core.EntryAdapter;
+import com.hazelcast.core.EntryEvent;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.map.QueryCache;
+import com.hazelcast.map.impl.querycache.subscriber.InternalQueryCache;
+import com.hazelcast.query.Predicates;
+import com.hazelcast.query.SqlPredicate;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ServerQueryCacheRecreationTest extends HazelcastTestSupport {
+
+    private final String mapName = "mapName";
+    private final String queryCacheName = "queryCacheName";
+    private final TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+
+    private HazelcastInstance serverWithQueryCache;
+    private HazelcastInstance server;
+
+    @Override
+    protected Config getConfig() {
+        return smallInstanceConfig();
+    }
+
+    @Before
+    public void setUp() {
+        server = factory.newHazelcastInstance(getConfig());
+
+        QueryCacheConfig queryCacheConfig = new QueryCacheConfig(queryCacheName);
+        Config config = getConfig();
+        config.getMapConfig("default").addQueryCacheConfig(queryCacheConfig);
+        serverWithQueryCache = factory.newHazelcastInstance(config);
+    }
+
+    @Test
+    public void query_cache_recreates_itself_after_server_restart() {
+        IMap<Object, Object> map = server.getMap(mapName);
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+
+        final QueryCache<Object, Object> queryCache = serverWithQueryCache.getMap(mapName)
+                .getQueryCache(queryCacheName,
+                        Predicates.alwaysTrue(), true);
+
+        server.shutdown();
+        server = factory.newHazelcastInstance(getConfig());
+
+        map = server.getMap(mapName);
+
+        for (int i = 100; i < 200; i++) {
+            map.put(i, i);
+        }
+
+        waitAllForSafeState(server, serverWithQueryCache);
+
+        InternalQueryCache internalQueryCache = (InternalQueryCache) queryCache;
+        internalQueryCache.recreate();
+
+        for (int i = 200; i < 300; i++) {
+            map.put(i, i);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(300, queryCache.size());
+            }
+        });
+
+        Set<Object> keySet = queryCache.keySet();
+        for (int i = 0; i < 300; i++) {
+            assertTrue(keySet.contains(i));
+        }
+    }
+
+    @Test
+    public void listeners_still_works_after_query_cache_recreation() {
+        IMap<Object, Object> map = serverWithQueryCache.getMap(mapName);
+        QueryCache<Object, Object> queryCache = map.getQueryCache(queryCacheName,
+                Predicates.alwaysTrue(), true);
+        final AtomicInteger entryAddedCounter = new AtomicInteger();
+        queryCache.addEntryListener(new EntryAdapter() {
+            @Override
+            public void entryAdded(EntryEvent event) {
+                entryAddedCounter.incrementAndGet();
+            }
+        }, new SqlPredicate("__key >= 10"), true);
+
+        // Restart server
+        server.shutdown();
+        server = factory.newHazelcastInstance(getConfig());
+
+        // Recreate query cache on same reference
+        // Recreation empties query cache.
+        ((InternalQueryCache) queryCache).recreate();
+
+        for (int i = 0; i < 100; i++) {
+            map.put(i, i);
+        }
+
+        AssertTask assertTask = new AssertTask() {
+            @Override
+            public void run() {
+                assertEquals(90, entryAddedCounter.get());
+            }
+        };
+
+        assertTrueEventually(assertTask);
+        assertTrueAllTheTime(assertTask, 3);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/TestSubscriberContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/subscriber/TestSubscriberContext.java
@@ -106,5 +106,11 @@ public class TestSubscriberContext extends NodeSubscriberContext {
             }
             return super.isNextEvent(eventData);
         }
+
+        @Override
+        public void reset() {
+            lostSequenceNumber.clear();
+            super.reset();
+        }
     }
 }


### PR DESCRIPTION
…elf with this method.

Intention of this PR is to ease automatic client cluster diversion work by introducing a new method to InternalQueryCache interface.

Entrance point to the main enhancement in this PR: [InternalQueryCache#recreate](https://github.com/hazelcast/hazelcast/pull/14457/files#diff-3ec3c52e1c1472eacff96278d3231c1fR91)