### PR TITLE
[BACKPORT 3.11.z] Add OnJoinPermissionOperation support to member configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/OnJoinPermissionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/OnJoinPermissionOperation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+/**
+ * Enum of operation names for handling client permissions when the member is joining into the cluster.
+ */
+public enum OnJoinPermissionOperation {
+
+    /**
+     * Operation which replaces locally configured permissions by the ones received from cluster.
+     */
+    RECEIVE,
+    /**
+     * Operation which refreshes cluster permissions with locally specified ones.
+     */
+    SEND,
+    /**
+     * No-op - neither receives nor sends permissions.
+     */
+    NONE;
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/OnJoinPermissionOperationName.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/OnJoinPermissionOperationName.java
@@ -19,7 +19,7 @@ package com.hazelcast.config;
 /**
  * Enum of operation names for handling client permissions when the member is joining into the cluster.
  */
-public enum OnJoinPermissionOperation {
+public enum OnJoinPermissionOperationName {
 
     /**
      * Operation which replaces locally configured permissions by the ones received from cluster.

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/OnJoinOp.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.internal.cluster.impl.operations;
 
-import com.hazelcast.config.OnJoinPermissionOperation;
+import com.hazelcast.config.OnJoinPermissionOperationName;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.internal.management.operation.UpdatePermissionConfigOperation;
 import com.hazelcast.nio.Address;
@@ -75,9 +75,9 @@ public class OnJoinOp
     @Override
     public void run() throws Exception {
         if (operations != null && operations.length > 0) {
-            OnJoinPermissionOperation onJoinOp = getNodeEngine().getProperties().getEnum(ON_JOIN_PERMISSIONS_OPERATION,
-                    OnJoinPermissionOperation.class);
-            boolean runPermissionUpdates = onJoinOp == OnJoinPermissionOperation.RECEIVE;
+            OnJoinPermissionOperationName onJoinOp = getNodeEngine().getProperties().getEnum(ON_JOIN_PERMISSIONS_OPERATION,
+                    OnJoinPermissionOperationName.class);
+            boolean runPermissionUpdates = onJoinOp == OnJoinPermissionOperationName.RECEIVE;
             for (Operation op : operations) {
                 if ((op instanceof UpdatePermissionConfigOperation) && !runPermissionUpdates) {
                     continue;

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.spi.properties;
 
-import com.hazelcast.config.OnJoinPermissionOperation;
+import com.hazelcast.config.OnJoinPermissionOperationName;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.IndeterminateOperationStateException;
@@ -31,7 +31,7 @@ import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.predicates.QueryOptimizerFactory;
 import com.hazelcast.spi.InvocationBuilder;
 
-import static com.hazelcast.config.OnJoinPermissionOperation.RECEIVE;
+import static com.hazelcast.config.OnJoinPermissionOperationName.RECEIVE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -1038,7 +1038,7 @@ public final class GroupProperty {
      * Operation names for handling client permissions when the member is joining into the cluster. Allowed values:
      * {@code "RECEIVE"} (default), {@code "SEND"}, {@code "NONE"}.
      *
-     * @see OnJoinPermissionOperation
+     * @see OnJoinPermissionOperationName
      * @deprecated This property is only available in Hazelcast 3.11.z patch stream (starting 3.11.2). Use
      *             {@code SecurityConfig.setOnJoinPermissionOperation(...)} instead in Hazelcast 3.12 and newer.
      */

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.properties;
 
+import com.hazelcast.config.OnJoinPermissionOperation;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.IndeterminateOperationStateException;
@@ -30,6 +31,7 @@ import com.hazelcast.query.impl.IndexCopyBehavior;
 import com.hazelcast.query.impl.predicates.QueryOptimizerFactory;
 import com.hazelcast.spi.InvocationBuilder;
 
+import static com.hazelcast.config.OnJoinPermissionOperation.RECEIVE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -1031,6 +1033,18 @@ public final class GroupProperty {
      */
     public static final HazelcastProperty SEARCH_DYNAMIC_CONFIG_FIRST
             = new HazelcastProperty("hazelcast.data.search.dynamic.config.first.enabled", false);
+
+    /**
+     * Operation names for handling client permissions when the member is joining into the cluster. Allowed values:
+     * {@code "RECEIVE"} (default), {@code "SEND"}, {@code "NONE"}.
+     *
+     * @see OnJoinPermissionOperation
+     * @deprecated This property is only available in Hazelcast 3.11.z patch stream (starting 3.11.2). Use
+     *             {@code SecurityConfig.setOnJoinPermissionOperation(...)} instead in Hazelcast 3.12 and newer.
+     */
+    @Deprecated
+    public static final HazelcastProperty ON_JOIN_PERMISSIONS_OPERATION = new HazelcastProperty(
+            "hazelcast.security.permissions.operation.on-join", RECEIVE.name());
 
     private GroupProperty() {
     }


### PR DESCRIPTION
Backport of #14455 

This backport differs just in configuration part. Instead of XML+Java config model support the behavior is controlled by a new Hazelcast group property `hazelcast.security.permissions.operation.on-join`.
Allowed values remain the same:
* `"RECEIVE"` (default)
* `"SEND"`
* `"NONE"`