### PR TITLE
Ignore join request with an existing member's uuid, instead of failing

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -685,8 +685,6 @@ public class ClusterJoinManager {
                 String message = "There's already an existing member " + member + " with the same UUID. "
                         + target + " is not allowed to join.";
                 logger.warning(message);
-                OperationService operationService = nodeEngine.getOperationService();
-                operationService.send(new BeforeJoinCheckFailureOp(message), target);
             } else {
                 sendMasterAnswer(target);
             }


### PR DESCRIPTION
When a member is restarted with the same UUID, using Hot Restart,
cluster may not notice that early and master will reject the join request.
Because it assumes that UUID is still used by an active member.

Instead of sending failure to joining member, master will ignore the request.
Terminating that member was too aggressive.

Fixes hazelcast/hazelcast-enterprise#2721