### PR TITLE
disabled test_backupOperationAppliesDefaultExpiryPolicy

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.backup.BackupAccessor;
 import com.hazelcast.test.backup.TestBackupUtils;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -285,6 +286,7 @@ public class CacheExpirationTest extends CacheTestSupport {
     }
 
     @Test
+    @Ignore("https://github.com/hazelcast/hazelcast-enterprise/issues/2723")
     public void test_backupOperationAppliesDefaultExpiryPolicy() {
         SimpleExpiryListener listener = new SimpleExpiryListener();
         HazelcastExpiryPolicy defaultExpiryPolicy = new HazelcastExpiryPolicy(FIVE_SECONDS, FIVE_SECONDS, FIVE_SECONDS);


### PR DESCRIPTION
It needs a fix from [hazelcast-enterprise/issues/2723](https://github.com/hazelcast/hazelcast-enterprise/issues/2723)
