### PR TITLE
Fix broken predicate in test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionRegressionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionRegressionTest.java
@@ -324,7 +324,7 @@ public class MapTransactionRegressionTest extends HazelcastTestSupport {
         };
 
         EntryObject e = new PredicateBuilder().getEntryObject();
-        Predicate<String, Integer> p = e.equal(1);
+        Predicate<String, Integer> p = e.get("this").equal(1);
         map.addEntryListener(l, p, null, false);
 
         for (Integer i = 0; i < 100; i++) {


### PR DESCRIPTION
PredicateBuilder.getEntryObject.equal syntax is not supported by any
version of Hazelcast. The test wasn't failing before by a pure
coincidence: the map is empty, so the predicate isn't invoked; but if
the map isn't empty, the test fails with NPE even in the previous
Hazelcast versions.

Fixes: https://github.com/hazelcast/hazelcast/issues/14475