### PR TITLE
Shade and relocate Jackson

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -128,6 +128,7 @@
                                 <Import-Package>
                                     !org.junit,
                                     !com.hazelcast.*,
+                                    !com.fasterxml.jackson.*,
                                     sun.misc;resolution:=optional,
                                     javax.cache;resolution:=optional,
                                     javax.cache.*;resolution:=optional,
@@ -221,9 +222,16 @@
                             <shadeTestJar>true</shadeTestJar>
                             <artifactSet>
                                 <includes>
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
                                     <include>com.hazelcast:hazelcast-client-protocol</include>
                                 </includes>
                             </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>com.hazelcast.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>
@@ -286,9 +294,8 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.7</version>
-            <scope>provided</scope>
-            <optional>true</optional>
+            <version>${jackson.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <log4j2.version>2.3</log4j2.version>
         <slf4j.api.version>1.7.25</slf4j.api.version>
 
+        <jackson.version>2.9.7</jackson.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.19.0</mockito.version>


### PR DESCRIPTION
Jackson jar is shaded in hazelcast.jar as a compile time dependency. It is also relocated. This is part of Json querying work.