### PR TITLE
Refactor HazelcastJsonValue and config

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -727,13 +727,13 @@
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
-                                <xs:attribute name="preprocessing-policy" use="optional" type="preprocessing-policy" default="OFF">
+                                <xs:attribute name="metadata-policy" use="optional" type="metadata-policy" default="CREATE_ON_UPDATE">
                                     <xs:annotation>
                                         <xs:documentation>
-                                            Pre-processing policy for this map.
+                                            Metadata policy for this map.
                                             Valid values are:
-                                            CREATION_TIME (default): Objects of supported types are pre-processed when they are created and updated.
-                                            OFF: No pre-processing is done.
+                                            CREATE_ON_UPDATE (default): Objects of supported types are pre-processed when they are created and updated.
+                                            OFF: No metadata is created.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -3303,9 +3303,9 @@
     <xs:simpleType name="parameterized-backup-count">
         <xs:union memberTypes="backup-count parameterizedValueType"/>
     </xs:simpleType>
-    <xs:simpleType name="preprocessing-policy">
+    <xs:simpleType name="metadata-policy">
         <xs:restriction base="non-space-string">
-            <xs:enumeration value="CREATION_TIME"/>
+            <xs:enumeration value="CREATE_ON_UPDATE"/>
             <xs:enumeration value="OFF"/>
         </xs:restriction>
     </xs:simpleType>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -71,7 +71,7 @@ import com.hazelcast.config.PNCounterConfig;
 import com.hazelcast.config.PartitionGroupConfig;
 import com.hazelcast.config.PermissionConfig;
 import com.hazelcast.config.PermissionConfig.PermissionType;
-import com.hazelcast.config.PreprocessingPolicy;
+import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.config.QueueStoreConfig;
@@ -319,7 +319,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals(0, testMapConfig.getTimeToLiveSeconds());
         assertTrue(testMapConfig.getHotRestartConfig().isEnabled());
         assertTrue(testMapConfig.getHotRestartConfig().isFsync());
-        assertEquals(PreprocessingPolicy.CREATION_TIME, testMapConfig.getPreprocessingPolicy());
+        assertEquals(MetadataPolicy.OFF, testMapConfig.getMetadataPolicy());
         assertEquals(1000, testMapConfig.getMinEvictionCheckMillis());
         assertTrue(testMapConfig.isReadBackupData());
         assertEquals(2, testMapConfig.getMapIndexConfigs().size());

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -383,7 +383,7 @@
                     read-backup-data="true"
                     eviction-policy="NONE"
                     in-memory-format="BINARY"
-                    preprocessing-policy="CREATION_TIME">
+                    metadata-policy="OFF">
                 <hz:map-store enabled="true" class-name="com.hazelcast.spring.DummyStore" write-delay-seconds="0"
                               initial-mode="EAGER" write-batch-size="10"/>
                 <hz:near-cache time-to-live-seconds="0" max-idle-seconds="60" eviction-policy="LRU" max-size="5000"

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -882,7 +882,7 @@ public class ConfigXmlGenerator {
                     .node("merge-policy", mergePolicyConfig.getPolicy(), "batch-size", mergePolicyConfig.getBatchSize())
                     .node("quorum-ref", m.getQuorumName())
                     .node("read-backup-data", m.isReadBackupData())
-                    .node("preprocessing-policy", m.getPreprocessingPolicy());
+                    .node("metadata-policy", m.getMetadataPolicy());
 
             appendHotRestartConfig(gen, m.getHotRestartConfig());
             mapStoreConfigXmlGenerator(gen, m);

--- a/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MapConfig.java
@@ -106,9 +106,9 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
     public static final CacheDeserializedValues DEFAULT_CACHED_DESERIALIZED_VALUES = CacheDeserializedValues.INDEX_ONLY;
 
     /**
-     * Default pre-processing policy
+     * Default metadata policy
      */
-    public static final PreprocessingPolicy DEFAULT_PREPROCESSING_POLICY = PreprocessingPolicy.CREATION_TIME;
+    public static final MetadataPolicy DEFAULT_METADATA_POLICY = MetadataPolicy.CREATE_ON_UPDATE;
 
     private String name;
 
@@ -160,7 +160,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
 
     private String quorumName;
 
-    private PreprocessingPolicy preprocessingPolicy = DEFAULT_PREPROCESSING_POLICY;
+    private MetadataPolicy metadataPolicy = DEFAULT_METADATA_POLICY;
 
     private HotRestartConfig hotRestartConfig = new HotRestartConfig();
 
@@ -186,7 +186,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         this.minEvictionCheckMillis = config.minEvictionCheckMillis;
         this.timeToLiveSeconds = config.timeToLiveSeconds;
         this.maxIdleSeconds = config.maxIdleSeconds;
-        this.preprocessingPolicy = config.preprocessingPolicy;
+        this.metadataPolicy = config.metadataPolicy;
         this.maxSizeConfig = config.maxSizeConfig != null ? new MaxSizeConfig(config.maxSizeConfig) : null;
         this.evictionPolicy = config.evictionPolicy;
         this.mapEvictionPolicy = config.mapEvictionPolicy;
@@ -712,22 +712,22 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
     }
 
     /**
-     * Returns {@link PreprocessingPolicy} for this map.
+     * Returns {@link MetadataPolicy} for this map.
      *
-     * @return {@link PreprocessingPolicy} for this map
+     * @return {@link MetadataPolicy} for this map
      */
-    public PreprocessingPolicy getPreprocessingPolicy() {
-        return preprocessingPolicy;
+    public MetadataPolicy getMetadataPolicy() {
+        return metadataPolicy;
     }
 
     /**
-     * Sets the pre-processing policy. See {@link PreprocessingPolicy} for
-     * more information
+     * Sets the metadata policy. See {@link MetadataPolicy} for more
+     * information.
      *
-     * @param preprocessing
+     * @param metadataPolicy
      */
-    public MapConfig setPreprocessingPolicy(PreprocessingPolicy preprocessing) {
-        this.preprocessingPolicy = preprocessing;
+    public MapConfig setMetadataPolicy(MetadataPolicy metadataPolicy) {
+        this.metadataPolicy = metadataPolicy;
         return this;
     }
 
@@ -964,7 +964,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         if (inMemoryFormat != that.inMemoryFormat) {
             return false;
         }
-        if (preprocessingPolicy != that.preprocessingPolicy) {
+        if (metadataPolicy != that.metadataPolicy) {
             return false;
         }
         if (wanReplicationRef != null ? !wanReplicationRef.equals(that.wanReplicationRef) : that.wanReplicationRef != null) {
@@ -1012,7 +1012,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         result = 31 * result + cacheDeserializedValues.hashCode();
         result = 31 * result + (mergePolicyConfig != null ? mergePolicyConfig.hashCode() : 0);
         result = 31 * result + inMemoryFormat.hashCode();
-        result = 31 * result + preprocessingPolicy.hashCode();
+        result = 31 * result + metadataPolicy.hashCode();
         result = 31 * result + (wanReplicationRef != null ? wanReplicationRef.hashCode() : 0);
         result = 31 * result + getEntryListenerConfigs().hashCode();
         result = 31 * result + getMapIndexConfigs().hashCode();
@@ -1031,7 +1031,7 @@ public class MapConfig implements SplitBrainMergeTypeProvider, IdentifiedDataSer
         return "MapConfig{"
                 + "name='" + name + '\''
                 + ", inMemoryFormat=" + inMemoryFormat + '\''
-                + ", preprocessingPolicy=" + preprocessingPolicy
+                + ", metadataPolicy=" + metadataPolicy
                 + ", backupCount=" + backupCount
                 + ", asyncBackupCount=" + asyncBackupCount
                 + ", timeToLiveSeconds=" + timeToLiveSeconds

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -1552,8 +1552,8 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             String value = getTextContent(node).trim();
             if ("backup-count".equals(nodeName)) {
                 mapConfig.setBackupCount(getIntegerValue("backup-count", value));
-            } else if ("preprocessing-policy".equals(nodeName)) {
-                mapConfig.setPreprocessingPolicy(PreprocessingPolicy.valueOf(upperCaseInternal(value)));
+            } else if ("metadata-policy".equals(nodeName)) {
+                mapConfig.setMetadataPolicy(MetadataPolicy.valueOf(upperCaseInternal(value)));
             } else if ("in-memory-format".equals(nodeName)) {
                 mapConfig.setInMemoryFormat(InMemoryFormat.valueOf(upperCaseInternal(value)));
             } else if ("async-backup-count".equals(nodeName)) {

--- a/hazelcast/src/main/java/com/hazelcast/config/MetadataPolicy.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MetadataPolicy.java
@@ -21,17 +21,17 @@ package com.hazelcast.config;
  * create additional metadata about them. This metadata then is used
  * to make querying and indexing faster.
  */
-public enum PreprocessingPolicy {
+public enum MetadataPolicy {
 
     /**
      * Hazelcast processes supported objects at the time of creation
      * and updates. This may increase put latency for the specific
      * data structure that this option is configured with.
      */
-    CREATION_TIME,
+    CREATE_ON_UPDATE,
 
     /**
-     * Turns of pre-processing.
+     * Turns off metadata creation.
      */
     OFF
 }

--- a/hazelcast/src/main/java/com/hazelcast/core/HazelcastJsonValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/HazelcastJsonValue.java
@@ -35,7 +35,10 @@ package com.hazelcast.core;
  */
 public interface HazelcastJsonValue {
 
-    @Override
-    String toString();
+    /**
+     * This method returns a Json representation of the object
+     * @return Json representation
+     */
+    String toJsonString();
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/JavaDefaultSerializers.java
@@ -325,11 +325,11 @@ public final class JavaDefaultSerializers {
         }
     }
 
-    public static final class JsonStringSerializer extends SingletonSerializer<HazelcastJsonValue> {
+    public static final class HazelcastJsonValueSerializer extends SingletonSerializer<HazelcastJsonValue> {
 
         @Override
         public void write(ObjectDataOutput out, HazelcastJsonValue object) throws IOException {
-            out.writeUTF(object.toString());
+            out.writeUTF(object.toJsonString());
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationServiceV1.java
@@ -74,7 +74,7 @@ import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.C
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.DateSerializer;
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.EnumSerializer;
 import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.JavaSerializer;
-import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.JsonStringSerializer;
+import static com.hazelcast.internal.serialization.impl.JavaDefaultSerializers.HazelcastJsonValueSerializer;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.createSerializerAdapter;
 import static com.hazelcast.util.MapUtil.createHashMap;
 
@@ -181,7 +181,7 @@ public class SerializationServiceV1 extends AbstractSerializationService {
 
         safeRegister(Serializable.class, javaSerializerAdapter);
         safeRegister(Externalizable.class, javaExternalizableAdapter);
-        safeRegister(HazelcastJsonValue.class, new JsonStringSerializer());
+        safeRegister(HazelcastJsonValue.class, new HazelcastJsonValueSerializer());
     }
 
     public void registerClassDefinitions(Collection<ClassDefinition> classDefinitions, boolean checkClassDefErrors) {

--- a/hazelcast/src/main/java/com/hazelcast/json/HazelcastJsonImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/json/HazelcastJsonImpl.java
@@ -27,7 +27,7 @@ class HazelcastJsonImpl implements HazelcastJsonValue {
     }
 
     @Override
-    public String toString() {
+    public String toJsonString() {
         return string;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/JsonMetadataInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/JsonMetadataInitializer.java
@@ -44,7 +44,7 @@ public class JsonMetadataInitializer implements MetadataInitializer {
 
     public Object createFromObject(Object obj) throws IOException {
         if (obj instanceof HazelcastJsonValue) {
-            String str = obj.toString();
+            String str = ((HazelcastJsonValue) obj).toJsonString();
             JsonParser parser = FACTORY.createParser(str);
             return JsonSchemaHelper.createSchema(parser);
         }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapContainer.java
@@ -23,7 +23,7 @@ import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.InvalidConfigurationException;
 import com.hazelcast.config.MapConfig;
-import com.hazelcast.config.PreprocessingPolicy;
+import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.config.WanConsumerConfig;
 import com.hazelcast.config.WanPublisherConfig;
 import com.hazelcast.config.WanReplicationConfig;
@@ -129,7 +129,7 @@ public class MapContainer {
         this.quorumName = mapConfig.getQuorumName();
         this.serializationService = ((InternalSerializationService) nodeEngine.getSerializationService());
         MetadataInitializer metadataInitializer;
-        if (mapConfig.getPreprocessingPolicy() == PreprocessingPolicy.CREATION_TIME) {
+        if (mapConfig.getMetadataPolicy() == MetadataPolicy.CREATE_ON_UPDATE) {
             metadataInitializer = new JsonMetadataInitializer();
         } else {
             metadataInitializer = new NoMetadataInitializer();

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/QueryableEntry.java
@@ -91,7 +91,7 @@ public abstract class QueryableEntry<K, V> implements Extractable, Map.Entry<K, 
             result = extractAttributeValueFromTargetObject(extractors, attributeName, target, metadata);
         }
         if (result instanceof HazelcastJsonValue) {
-            return Json.parse(result.toString());
+            return Json.parse(((HazelcastJsonValue) result).toJsonString());
         }
         return result;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonGetter.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.internal.serialization.impl.NavigableJsonInputAdapter;
 import com.hazelcast.internal.serialization.impl.StringNavigableJsonAdapter;
+import com.hazelcast.query.QueryException;
 
 import java.io.IOException;
 
@@ -42,6 +43,10 @@ public final class JsonGetter extends AbstractJsonGetter {
 
     @Override
     JsonParser createParser(Object obj) throws IOException {
-        return factory.createParser(obj.toString());
+        if (obj instanceof HazelcastJsonValue) {
+            return factory.createParser(((HazelcastJsonValue) obj).toJsonString());
+        } else {
+            throw new QueryException("Queried object is not of HazelcastJsonValue type. It is " + obj.getClass());
+        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/JsonGetter.java
@@ -37,7 +37,7 @@ public final class JsonGetter extends AbstractJsonGetter {
     @Override
     protected NavigableJsonInputAdapter annotate(Object object) {
         HazelcastJsonValue hazelcastJson = (HazelcastJsonValue) object;
-        return new StringNavigableJsonAdapter(hazelcastJson.toString(), 0);
+        return new StringNavigableJsonAdapter(hazelcastJson.toJsonString(), 0);
     }
 
     @Override

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -116,15 +116,15 @@
 
     <xs:complexType name="map">
         <xs:all>
-            <xs:element name="preprocessing-policy" type="preprocessing-policy" minOccurs="0" maxOccurs="1" default="OFF">
+            <xs:element name="metadata-policy" type="metadata-policy" minOccurs="0" maxOccurs="1" default="OFF">
                 <xs:annotation>
                     <xs:documentation>
-                        Pre-processing policy for this map. Hazelcast may process objects of supported types ahead of time to
+                        Metadata policy for this map. Hazelcast may process objects of supported types ahead of time to
                         create additional metadata about them. This metadata then is used to make querying and indexing faster.
-                        Turning on preprocessing may decrease put throughput.
+                        Metadata creation may decrease put throughput.
                         Valid values are:
-                        CREATION_TIME: Objects of supported types are pre-processed when they are created and updated.
-                        OFF (default): No pre-processing is done.
+                        CREATE_ON_UPDATE (default): Objects of supported types are pre-processed when they are created and updated.
+                        OFF: No metadata is created.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -3000,9 +3000,9 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="preprocessing-policy">
+    <xs:simpleType name="metadata-policy">
         <xs:restriction base="non-space-string">
-            <xs:enumeration value="CREATION_TIME"/>
+            <xs:enumeration value="CREATE_ON_UPDATE"/>
             <xs:enumeration value="OFF"/>
         </xs:restriction>
     </xs:simpleType>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -163,14 +163,14 @@
         <in-memory-format>BINARY</in-memory-format>
 
         <!--
-            Pre-processing policy for this map. Hazelcast may process objects of supported types ahead of time to
+            Metadata creation policy for this map. Hazelcast may process objects of supported types ahead of time to
             create additional metadata about them. This metadata then is used to make querying and indexing faster.
-            Turning on preprocessing may decrease put throughput.
+            Metadata creation may decrease put throughput.
             Valid values are:
-            CREATION_TIME (default): Objects of supported types are pre-processed when they are created and updated.
-            OFF: No pre-processing is done.
+            CREATE_ON_UPDATE (default): Objects of supported types are pre-processed when they are created and updated.
+            OFF: No metadata is created.
         -->
-        <preprocessing-policy>CREATION_TIME</preprocessing-policy>
+        <metadata-policy>CREATE_ON_UPDATE</metadata-policy>
 
         <!--
             Number of backups. If 1 is set as the backup-count for example,

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -882,13 +882,13 @@
         rely on it. If true, it increases the speed of query processes in the map. It only works when
         <in-memory-format> is set to BINARY and performs a pre-caching on the entries queried. Its default
         value is false.
-        * <preprocessing-policy>
-        Pre-processing policy for this map. Hazelcast may process objects of supported types ahead of time to
+        * <metadata-policy>
+        Metadata policy for this map. Hazelcast may process objects of supported types ahead of time to
         create additional metadata about them. This metadata then is used to make querying and indexing faster.
-        Turning on preprocessing may decrease put throughput.
+        Metadata creation may decrease put throughput.
         Valid values are:
-        CREATION_TIME (default): Objects of supported types are pre-processed when they are created and updated.
-        OFF: No pre-processing is done.
+        CREATE_ON_UPDATE (default): Objects of supported types are pre-processed when they are created and updated.
+        OFF: No metadata is created.
         * <cache-deserialized-values>:
         Controls caching of deserialized values. Caching makes the query evaluation faster, but it costs memory.
         Available values are as follows:
@@ -1130,7 +1130,7 @@
      -->
     <map name="default">
         <in-memory-format>BINARY</in-memory-format>
-        <preprocessing-policy>CREATION_TIME</preprocessing-policy>
+        <metadata-policy>CREATE_ON_UPDATE</metadata-policy>
         <statistics-enabled>true</statistics-enabled>
         <optimize-queries>true</optimize-queries>
         <cache-deserialized-values>INDEX-ONLY</cache-deserialized-values>

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -153,10 +153,10 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testMapConfig_minEvictionCheckMillis_defaultValue();
 
     @Test
-    public abstract void testMapConfig_preprocessingPolicy();
+    public abstract void testMapConfig_metadataPolicy();
 
     @Test
-    public abstract void testMapConfig_preprocessingPolicy_defaultValue();
+    public abstract void testMapConfig_metadataPolicy_defaultValue();
 
     @Test
     public abstract void testMapConfig_evictions();

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigCompatibilityChecker.java
@@ -764,7 +764,7 @@ public class ConfigCompatibilityChecker {
 
             return nullSafeEqual(c1.getName(), c2.getName())
                     && nullSafeEqual(c1.getInMemoryFormat(), c2.getInMemoryFormat())
-                    && nullSafeEqual(c1.getPreprocessingPolicy(), c2.getPreprocessingPolicy())
+                    && nullSafeEqual(c1.getMetadataPolicy(), c2.getMetadataPolicy())
                     && nullSafeEqual(c1.isStatisticsEnabled(), c2.isStatisticsEnabled())
                     && nullSafeEqual(c1.isOptimizeQueries(), c2.isOptimizeQueries())
                     && nullSafeEqual(c1.getCacheDeserializedValues(), c2.getCacheDeserializedValues())

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -992,7 +992,7 @@ public class ConfigXmlGeneratorTest {
         MapConfig expectedConfig = new MapConfig()
                 .setName("carMap")
                 .setInMemoryFormat(InMemoryFormat.NATIVE)
-                .setPreprocessingPolicy(PreprocessingPolicy.CREATION_TIME)
+                .setMetadataPolicy(MetadataPolicy.CREATE_ON_UPDATE)
                 .setEvictionPolicy(EvictionPolicy.LRU)
                 .setMaxIdleSeconds(100)
                 .setTimeToLiveSeconds(1000)

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1031,22 +1031,22 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
-    public void testMapConfig_preprocessingPolicy() {
+    public void testMapConfig_metadataPolicy() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
-                + "<preprocessing-policy>OFF</preprocessing-policy>"
+                + "<metadata-policy>CREATE_ON_UPDATE</metadata-policy>"
                 + "</map>"
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
         MapConfig mapConfig = config.getMapConfig("mymap");
 
-        assertEquals(PreprocessingPolicy.OFF, mapConfig.getPreprocessingPolicy());
+        assertEquals(MetadataPolicy.CREATE_ON_UPDATE, mapConfig.getMetadataPolicy());
     }
 
     @Override
     @Test
-    public void testMapConfig_preprocessingPolicy_defaultValue() {
+    public void testMapConfig_metadataPolicy_defaultValue() {
         String xml = HAZELCAST_START_TAG
                 + "<map name=\"mymap\">"
                 + "</map>"
@@ -1055,7 +1055,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         Config config = buildConfig(xml);
         MapConfig mapConfig = config.getMapConfig("mymap");
 
-        assertEquals(PreprocessingPolicy.CREATION_TIME, mapConfig.getPreprocessingPolicy());
+        assertEquals(MetadataPolicy.CREATE_ON_UPDATE, mapConfig.getMetadataPolicy());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -1054,22 +1054,22 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
 
     @Override
     @Test
-    public void testMapConfig_preprocessingPolicy() {
+    public void testMapConfig_metadataPolicy() {
         String yaml = ""
                 + "hazelcast:\n"
                 + "  map:\n"
                 + "    mymap:\n"
-                + "      preprocessing-policy: OFF";
+                + "      metadata-policy: OFF";
 
         Config config = buildConfig(yaml);
         MapConfig mapConfig = config.getMapConfig("mymap");
 
-        assertEquals(PreprocessingPolicy.OFF, mapConfig.getPreprocessingPolicy());
+        assertEquals(MetadataPolicy.OFF, mapConfig.getMetadataPolicy());
     }
 
     @Override
     @Test
-    public void testMapConfig_preprocessingPolicy_defaultValue() {
+    public void testMapConfig_metadataPolicy_defaultValue() {
         String yaml = ""
                 + "hazelcast:\n"
                 + "  map:\n"
@@ -1078,7 +1078,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         Config config = buildConfig(yaml);
         MapConfig mapConfig = config.getMapConfig("mymap");
 
-        assertEquals(PreprocessingPolicy.CREATION_TIME, mapConfig.getPreprocessingPolicy());
+        assertEquals(MetadataPolicy.CREATE_ON_UPDATE, mapConfig.getMetadataPolicy());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonMixedTypeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonMixedTypeTest.java
@@ -105,7 +105,7 @@ public class MapPredicateJsonMixedTypeTest extends HazelcastTestSupport {
         map.put("k_int_2", 11);
 
         assertEquals(5, map.get("k_int"));
-        assertEquals(10, Json.parse(map.get("k_json").toString()).asInt());
+        assertEquals(10, Json.parse(((HazelcastJsonValue) map.get("k_json")).toJsonString()).asInt());
         assertEquals(11, map.get("k_int_2"));
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
@@ -502,7 +502,7 @@ public class MapPredicateJsonTest extends HazelcastTestSupport {
         Collection<HazelcastJsonValue> vals = map.values(Predicates.greaterEqual("this", 3));
         assertEquals(7, vals.size());
         for (HazelcastJsonValue value : vals) {
-            int intValue = Json.parse(value.toString()).asInt();
+            int intValue = Json.parse(value.toJsonString()).asInt();
             assertTrue(intValue >= 3);
             assertGreaterOrEquals("predicate result ", intValue, 3);
         }
@@ -517,7 +517,7 @@ public class MapPredicateJsonTest extends HazelcastTestSupport {
         Collection<HazelcastJsonValue> vals = map.values(Predicates.greaterEqual("this", "s3"));
         assertEquals(7, vals.size());
         for (HazelcastJsonValue value : vals) {
-            String stringVal = Json.parse(value.toString()).asString();
+            String stringVal = Json.parse(value.toJsonString()).asString();
             assertTrue(stringVal.compareTo("s3") >= 0);
         }
     }
@@ -532,7 +532,7 @@ public class MapPredicateJsonTest extends HazelcastTestSupport {
         assertEquals(7, vals.size());
         for (Map.Entry<Integer, HazelcastJsonValue> entry : vals) {
             assertTrue(entry.getKey() < 7);
-            assertEquals("true", entry.getValue().toString());
+            assertEquals("true", entry.getValue().toJsonString());
         }
 
     }

--- a/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/MapPredicateJsonTest.java
@@ -18,7 +18,7 @@ package com.hazelcast.json;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.PreprocessingPolicy;
+import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.core.IMap;
@@ -59,15 +59,15 @@ public class MapPredicateJsonTest extends HazelcastTestSupport {
     public InMemoryFormat inMemoryFormat;
 
     @Parameter(1)
-    public PreprocessingPolicy preprocessingPolicy;
+    public MetadataPolicy metadataPolicy;
 
-    @Parameterized.Parameters(name = "inMemoryFormat: {0}, preprocessingPolicy: {1}")
+    @Parameterized.Parameters(name = "inMemoryFormat: {0}, metadataPolicy: {1}")
     public static Collection<Object[]> parameters() {
         return asList(new Object[][] {
-                {InMemoryFormat.BINARY, PreprocessingPolicy.OFF},
-                {InMemoryFormat.BINARY, PreprocessingPolicy.CREATION_TIME},
-                {InMemoryFormat.OBJECT, PreprocessingPolicy.OFF},
-                {InMemoryFormat.OBJECT, PreprocessingPolicy.CREATION_TIME},
+                {InMemoryFormat.BINARY, MetadataPolicy.OFF},
+                {InMemoryFormat.BINARY, MetadataPolicy.CREATE_ON_UPDATE},
+                {InMemoryFormat.OBJECT, MetadataPolicy.OFF},
+                {InMemoryFormat.OBJECT, MetadataPolicy.CREATE_ON_UPDATE},
         });
     }
 
@@ -83,7 +83,7 @@ public class MapPredicateJsonTest extends HazelcastTestSupport {
         Config config = super.getConfig();
         config.getMapConfig("default")
                 .setInMemoryFormat(inMemoryFormat)
-                .setPreprocessingPolicy(preprocessingPolicy);
+                .setMetadataPolicy(metadataPolicy);
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/AbstractJsonSchemaTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/AbstractJsonSchemaTest.java
@@ -55,7 +55,7 @@ public abstract class AbstractJsonSchemaTest {
 
     protected NavigableJsonInputAdapter toAdapter(HazelcastJsonValue jsonValue) {
         if (getInMemoryFormay() == InMemoryFormat.OBJECT) {
-            return new StringNavigableJsonAdapter(jsonValue.toString(), 0);
+            return new StringNavigableJsonAdapter(jsonValue.toJsonString(), 0);
         } else {
             return new DataInputNavigableJsonAdapter(serializationService.createObjectDataInput(serializationService.toData(jsonValue)), JSON_UTF8_START_OFFSET);
         }

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationMigrationTest.java
@@ -17,7 +17,7 @@
 package com.hazelcast.json.internal;
 
 import com.hazelcast.config.Config;
-import com.hazelcast.config.PreprocessingPolicy;
+import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.core.IMap;
@@ -116,7 +116,7 @@ public class JsonMetadataCreationMigrationTest extends HazelcastTestSupport {
         config.getMapConfig("default")
                 .setBackupCount(NODE_COUNT - 1)
                 .setAsyncBackupCount(0)
-                .setPreprocessingPolicy(PreprocessingPolicy.CREATION_TIME);
+                .setMetadataPolicy(MetadataPolicy.CREATE_ON_UPDATE);
         return config;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.json.internal;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
 import com.hazelcast.config.MapStoreConfig;
-import com.hazelcast.config.PreprocessingPolicy;
+import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.core.IMap;
@@ -69,7 +69,7 @@ public class JsonMetadataCreationTest extends HazelcastTestSupport {
     private HazelcastInstance[] instances;
     private IMap map;
     private IMap mapWithMapStore;
-    private IMap mapWithoutPreprocessing;
+    private IMap mapWithoutMetadata;
 
     @Parameterized.Parameters(name = "InMemoryFormat: {0}")
     public static Collection<Object[]> parameters() {
@@ -87,7 +87,7 @@ public class JsonMetadataCreationTest extends HazelcastTestSupport {
         factory = createHazelcastInstanceFactory(NODE_COUNT);
         instances = factory.newInstances(getConfig());
         map = instances[0].getMap(randomMapName());
-        mapWithoutPreprocessing = instances[0].getMap("noprocessing" + randomMapName());
+        mapWithoutMetadata = instances[0].getMap("noprocessing" + randomMapName());
         mapWithMapStore = instances[0].getMap("mapStore" + randomName());
     }
 
@@ -100,11 +100,11 @@ public class JsonMetadataCreationTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testPutDoesNotCreateMetadata_whenPreprocessingIsOff() {
+    public void testPutDoesNotCreateMetadata_whenMetadataPolicyIsOff() {
         for (int i = 0; i < ENTRY_COUNT; i++) {
-            mapWithoutPreprocessing.put(createValue("key", i), createValue("value", i));
+            mapWithoutMetadata.put(createValue("key", i), createValue("value", i));
         }
-        assertMetadataNotCreated(mapWithoutPreprocessing.getName());
+        assertMetadataNotCreated(mapWithoutMetadata.getName());
     }
 
     @Test
@@ -292,9 +292,9 @@ public class JsonMetadataCreationTest extends HazelcastTestSupport {
                 .setBackupCount(getNodeCount() - 1)
                 .setAsyncBackupCount(0)
                 .setInMemoryFormat(getInMemoryFormat())
-                .setPreprocessingPolicy(PreprocessingPolicy.CREATION_TIME);
+                .setMetadataPolicy(MetadataPolicy.CREATE_ON_UPDATE);
         config.getMapConfig("noprocessing*")
-                .setPreprocessingPolicy(PreprocessingPolicy.OFF)
+                .setMetadataPolicy(MetadataPolicy.OFF)
                 .setInMemoryFormat(getInMemoryFormat());
         config.getMapConfig("mapStore*")
                 .setInMemoryFormat(getInMemoryFormat())

--- a/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/json/internal/JsonMetadataCreationTest.java
@@ -320,7 +320,7 @@ public class JsonMetadataCreationTest extends HazelcastTestSupport {
 
         @Override
         public HazelcastJsonValue load(HazelcastJsonValue key) {
-            int value = Json.parse(key.toString()).asObject().get("value").asInt();
+            int value = Json.parse(key.toJsonString()).asObject().get("value").asInt();
             return createValue("value", value);
         }
 
@@ -328,7 +328,7 @@ public class JsonMetadataCreationTest extends HazelcastTestSupport {
         public Map<HazelcastJsonValue, HazelcastJsonValue> loadAll(Collection<HazelcastJsonValue> keys) {
             Map<HazelcastJsonValue, HazelcastJsonValue> localMap = new HashMap<HazelcastJsonValue, HazelcastJsonValue>();
             for (HazelcastJsonValue key : keys) {
-                int value = Json.parse(key.toString()).asObject().get("value").asInt();
+                int value = Json.parse(key.toJsonString()).asObject().get("value").asInt();
                 localMap.put(key, createValue("value", value));
             }
 
@@ -349,7 +349,7 @@ public class JsonMetadataCreationTest extends HazelcastTestSupport {
         @Override
         public Object process(Map.Entry<HazelcastJsonValue, Object> entry) {
             HazelcastJsonValue key = entry.getKey();
-            int value = Json.parse(key.toString()).asObject().get("value").asInt();
+            int value = Json.parse(key.toJsonString()).asObject().get("value").asInt();
             entry.setValue(createValue("value", value));
             return null;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -1303,7 +1303,7 @@ public class BasicMapTest extends HazelcastTestSupport {
         HazelcastJsonValue retrieved = map.get("item1");
 
         assertEquals(value, retrieved);
-        assertEquals(4, Json.parse(retrieved.toString()).asObject().get("age").asInt());
+        assertEquals(4, Json.parse(retrieved.toJsonString()).asObject().get("age").asInt());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -491,14 +491,14 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         for (String key : keys) {
             HazelcastJsonValue jsonObject = map.get(key);
             assertNotNull(jsonObject);
-            assertTrue(Json.parse(jsonObject.toString()).asObject().get(JsonStringPropAdder.NEW_FIELD).asBoolean());
+            assertTrue(Json.parse(jsonObject.toJsonString()).asObject().get(JsonStringPropAdder.NEW_FIELD).asBoolean());
         }
 
         instance1.shutdown();
         for (Object key : keys) {
             HazelcastJsonValue jsonObject = map.get(key);
             assertNotNull(jsonObject);
-            assertTrue(Json.parse(jsonObject.toString()).asObject().get(JsonStringPropAdder.NEW_FIELD).asBoolean());
+            assertTrue(Json.parse(jsonObject.toJsonString()).asObject().get(JsonStringPropAdder.NEW_FIELD).asBoolean());
         }
     }
 
@@ -1847,7 +1847,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
         @Override
         public Object process(Map.Entry<String, HazelcastJsonValue> entry) {
             HazelcastJsonValue value = entry.getValue();
-            JsonValue jsonValue = Json.parse(value.toString());
+            JsonValue jsonValue = Json.parse(value.toJsonString());
             jsonValue.asObject().add(NEW_FIELD, true);
             entry.setValue(HazelcastJson.fromString(jsonValue.toString()));
             return null;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl;
 import com.hazelcast.config.CacheDeserializedValues;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.InMemoryFormat;
-import com.hazelcast.config.PreprocessingPolicy;
+import com.hazelcast.config.MetadataPolicy;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.instance.Node;
@@ -65,14 +65,14 @@ public class JsonIndexIntegrationTest extends HazelcastTestSupport {
     public CacheDeserializedValues cacheDeserializedValues;
 
     @Parameterized.Parameter(2)
-    public PreprocessingPolicy preprocessingPolicy;
+    public MetadataPolicy metadataPolicy;
 
-    @Parameterized.Parameters(name = "inMemoryFormat: {0}, cacheDeserializedValues: {1}, preprocessing: {2}")
+    @Parameterized.Parameters(name = "inMemoryFormat: {0}, cacheDeserializedValues: {1}, metadataPolicy: {2}")
     public static Collection<Object[]> parametersInMemoryFormat() {
         List<Object[]> parameters = new ArrayList<Object[]>();
         for (InMemoryFormat imf: new InMemoryFormat[]{InMemoryFormat.OBJECT, InMemoryFormat.BINARY}) {
             for (CacheDeserializedValues cdv: CacheDeserializedValues.values()) {
-                for (PreprocessingPolicy pp: PreprocessingPolicy.values()) {
+                for (MetadataPolicy pp: MetadataPolicy.values()) {
                     parameters.add(new Object[]{imf, cdv, pp});
                 }
             }
@@ -85,7 +85,7 @@ public class JsonIndexIntegrationTest extends HazelcastTestSupport {
         Config config = super.getConfig();
         config.getMapConfig(MAP_NAME)
                 .setInMemoryFormat(inMemoryFormat)
-                .setPreprocessingPolicy(preprocessingPolicy)
+                .setMetadataPolicy(metadataPolicy)
                 .setCacheDeserializedValues(cacheDeserializedValues);
         return config;
     }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/JsonIndexIntegrationTest.java
@@ -179,7 +179,7 @@ public class JsonIndexIntegrationTest extends HazelcastTestSupport {
 
         @Override
         public Object process(Map.Entry<Integer, HazelcastJsonValue> entry) {
-            JsonObject jsonObject = Json.parse(entry.getValue().toString()).asObject();
+            JsonObject jsonObject = Json.parse(entry.getValue().toJsonString()).asObject();
             jsonObject.set("age", 0);
             jsonObject.set("active", false);
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/AbstractJsonGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/AbstractJsonGetterTest.java
@@ -137,7 +137,7 @@ public class AbstractJsonGetterTest {
     }
 
     private JsonSchemaNode createMetadata(HazelcastJsonValue value) throws IOException {
-        return JsonSchemaHelper.createSchema(factory.createParser(value.toString()));
+        return JsonSchemaHelper.createSchema(factory.createParser(value.toJsonString()));
     }
 
     private class GetterRunner implements Runnable {

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -350,14 +350,14 @@
         <in-memory-format>OBJECT</in-memory-format>
 
         <!--
-            Pre-processing policy for this map. Hazelcast may process objects of supported types ahead of time to
+            Metadata policy for this map. Hazelcast may process objects of supported types ahead of time to
             create additional metadata about them. This metadata then is used to make querying and indexing faster.
-            Turning on preprocessing may decrease put throughput.
+            Metadata creation may decrease put throughput.
             Valid values are:
-            CREATION_TIME (default): Objects of supported types are pre-processed when they are created and updated.
-            OFF: No pre-processing is done.
+            CREATE_ON_UPDATE (default): Objects of supported types are pre-processed when they are created and updated.
+            OFF: No metadata is created.
         -->
-        <preprocessing-policy>CREATION_TIME</preprocessing-policy>
+        <metadata-policy>CREATE_ON_UPDATE</metadata-policy>
 
         <!--
             Whether statistical information (hits, creation time, last access time etc.) should be gathered and stored.


### PR DESCRIPTION
depends on https://github.com/hazelcast/hazelcast/pull/14393

- Changes `HazelcastJsonValue#toString` to `HazelcastJsonValue#toJsonString`.
- Renames `preprocessing-policy` in map config to `metadata-policy`
    - CREATION_TIME -> CREATE_ON_UPDATE