### PR TITLE
Fix YAML test issues on JDK6 and 7

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
+import static com.hazelcast.internal.yaml.YamlUtil.ensureRunningOnJava8OrHigher;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
 /**
@@ -118,6 +119,8 @@ public class YamlConfigBuilder implements ConfigBuilder {
     }
 
     Config build(Config config) {
+        ensureRunningOnJava8OrHigher();
+
         config.setConfigurationFile(configurationFile);
         config.setConfigurationUrl(configurationUrl);
         try {

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlLoader.java
@@ -16,10 +16,10 @@
 
 package com.hazelcast.internal.yaml;
 
-import com.hazelcast.internal.util.JavaVersion;
-
 import java.io.InputStream;
 import java.io.Reader;
+
+import static com.hazelcast.internal.yaml.YamlUtil.ensureRunningOnJava8OrHigher;
 
 /**
  * YAML loader that can load, parse YAML documents and can build a tree
@@ -154,9 +154,7 @@ public final class YamlLoader {
     }
 
     private static YamlDocumentLoader getLoad() {
-        if (!JavaVersion.isAtLeast(JavaVersion.JAVA_1_8)) {
-            throw new UnsupportedOperationException("Processing YAML documents requires Java 8 or higher version");
-        }
+        ensureRunningOnJava8OrHigher();
 
         return new ReflectiveYamlDocumentLoader();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.internal.yaml;
 
+import com.hazelcast.internal.util.JavaVersion;
+
 /**
  * Utility class for working with YAML nodes.
  */
@@ -77,5 +79,19 @@ public final class YamlUtil {
         }
 
         return (YamlScalar) node;
+    }
+
+    /**
+     * Checks if the runtime environment is Java8 or higher. If the
+     * runtime is an older version the check throws
+     * {@link UnsupportedOperationException}.
+     *
+     * @throws UnsupportedOperationException If the runtime environment
+     *                                       is not Java8 or higher
+     */
+    public static void ensureRunningOnJava8OrHigher() {
+        if (!JavaVersion.isAtLeast(JavaVersion.JAVA_1_8)) {
+            throw new UnsupportedOperationException("Processing YAML documents requires Java 8 or higher version");
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ServiceConfigTest.java
@@ -49,6 +49,8 @@ public class ServiceConfigTest extends HazelcastTestSupport {
 
     @Test
     public void testYaml() {
+        assumeThatJDK8OrHigher();
+
         Config config = new ClasspathYamlConfig("com/hazelcast/config/hazelcast-service.yaml");
         ServiceConfig serviceConfig = config.getServicesConfig().getServiceConfig("my-service");
         assertEquals("com.hazelcast.examples.MyService", serviceConfig.getClassName());

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlYamlConfigBuilderEqualsTest.java
@@ -17,8 +17,10 @@
 package com.hazelcast.config;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -31,7 +33,13 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class XmlYamlConfigBuilderEqualsTest {
+public class XmlYamlConfigBuilderEqualsTest extends HazelcastTestSupport {
+
+    @Before
+    public void assumeRunningOnJdk8() {
+        assumeThatJDK8OrHigher();
+    }
+
     @Test
     public void testFullConfig() {
         Config xmlConfig = new ClasspathXmlConfig("hazelcast-fullconfig.xml");

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -28,6 +28,7 @@ import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.topic.TopicOverloadPolicy;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -80,6 +81,11 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
+
+    @Before
+    public void assumeRunningOnJdk8() {
+        assumeThatJDK8OrHigher();
+    }
 
     @Override
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigWithSystemPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigWithSystemPropertyTest.java
@@ -30,6 +30,7 @@ import java.io.PrintWriter;
 import java.net.URL;
 import java.net.URLDecoder;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
 import static java.io.File.createTempFile;
 import static org.junit.Assert.assertEquals;
 
@@ -43,8 +44,14 @@ import static org.junit.Assert.assertEquals;
 public class YamlConfigWithSystemPropertyTest {
 
     @Before
+    public void setUp() {
+        assumeThatJDK8OrHigher();
+
+        System.clearProperty("hazelcast.config");
+    }
+
     @After
-    public void beforeAndAfter() {
+    public void tearDown() {
         System.clearProperty("hazelcast.config");
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlOnlyConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlOnlyConfigBuilderTest.java
@@ -19,11 +19,14 @@ package com.hazelcast.config;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.ByteArrayInputStream;
+
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
 
 /**
  * Test cases specific only to YAML based configuration. The cases not
@@ -39,6 +42,11 @@ import java.io.ByteArrayInputStream;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class YamlOnlyConfigBuilderTest {
+
+    @Before
+    public void assumeRunningOnJdk8() {
+        assumeThatJDK8OrHigher();
+    }
 
     @Test(expected = InvalidConfigurationException.class)
     public void testMapQueryCachePredicateBothClassNameAndSql() {


### PR DESCRIPTION
- Makes YAML code failing fast on pre-JDK8 versions so that the root
cause exception is thrown instead of an InvalidConfigurationException nesting the root cause
- Ignore the failing YAML tests on pre-JDK8 versions

Fixes #14501