### PR TITLE
B/W list clients filtering support for MC-IMDG communication

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ClientBwListConfigHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ClientBwListConfigHandler.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management;
+
+import com.hazelcast.client.impl.ClientEngine;
+import com.hazelcast.client.impl.ClientSelector;
+import com.hazelcast.client.impl.ClientSelectors;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.management.dto.ClientBwListDTO;
+import com.hazelcast.internal.management.dto.ClientBwListEntryDTO;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static com.hazelcast.util.JsonUtil.getObject;
+
+/**
+ * Handles client B/W list configuration received from Management Center and applies changes.
+ *
+ * @see ManagementCenterService ManagementCenterService for more details on usage.
+ */
+public class ClientBwListConfigHandler {
+
+    private static final ILogger LOGGER = Logger.getLogger(ClientBwListConfigHandler.class);
+
+    private final ClientEngine clientEngine;
+
+    public ClientBwListConfigHandler(ClientEngine clientEngine) {
+        this.clientEngine = clientEngine;
+    }
+
+    /**
+     * Handles Management Center connection lost event: removes any client B/W list filtering.
+     */
+    public void handleLostConnection() {
+        try {
+            clientEngine.applySelector(ClientSelectors.any());
+        } catch (Exception e) {
+            LOGGER.warning("Could not clean up client B/W list filtering.", e);
+        }
+    }
+
+    /**
+     * Parses client B/W list filtering configuration in JSON format and applies the configuration.
+     *
+     * @param configJson Configuration object
+     */
+    public void handleConfig(JsonObject configJson) {
+        try {
+            JsonObject bwListConfigJson = getObject(configJson, "clientBwList");
+            ClientBwListDTO configDTO = new ClientBwListDTO();
+            configDTO.fromJson(bwListConfigJson);
+            applyConfig(configDTO);
+        } catch (Exception e) {
+            LOGGER.warning("Could not apply client B/W list filtering.", e);
+        }
+    }
+
+    private void applyConfig(ClientBwListDTO configDTO) {
+        ClientSelector selector = null;
+        switch (configDTO.mode) {
+            case DISABLED:
+                selector = ClientSelectors.any();
+                break;
+            case WHITELIST:
+                selector = createSelector(configDTO.entries);
+                break;
+            case BLACKLIST:
+                selector = ClientSelectors.inverse(createSelector(configDTO.entries));
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown client B/W list mode: " + configDTO.mode);
+        }
+
+        clientEngine.applySelector(selector);
+    }
+
+    private static ClientSelector createSelector(List<ClientBwListEntryDTO> entries) {
+        ClientSelector selector = ClientSelectors.none();
+        for (ClientBwListEntryDTO entryDTO : entries) {
+            ClientSelector entrySelector = createSelector(entryDTO);
+            selector = ClientSelectors.or(selector, entrySelector);
+        }
+        return selector;
+    }
+
+    private static ClientSelector createSelector(ClientBwListEntryDTO entry) {
+        switch (entry.type) {
+            case IP_ADDRESS:
+                return ClientSelectors.ipSelector(entry.value);
+            case INSTANCE_NAME:
+                return ClientSelectors.nameSelector(sanitizeValueWithWildcards(entry.value));
+            case LABEL:
+                return ClientSelectors.labelSelector(sanitizeValueWithWildcards(entry.value));
+            default:
+                throw new IllegalArgumentException("Unknown client B/W list entry type: " + entry.type);
+        }
+    }
+
+    /**
+     * Sanitizes values in order to replace any regexp-specific char sequences, except for wildcards ('*').
+     * First, quotes the input string to escape any regexp-specific char sequences. Second, replaces escaped wildcards
+     * with the appropriate char sequence. Example: "green*client" => "\Qgreen\E.*\Qclient\E".
+     */
+    private static String sanitizeValueWithWildcards(String value) {
+        String quoted = Pattern.quote(value);
+        return quoted.replaceAll("\\*", "\\\\E.*\\\\Q");
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientBwListDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientBwListDTO.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.internal.json.JsonArray;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.JsonValue;
+import com.hazelcast.internal.management.JsonSerializable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.hazelcast.util.JsonUtil.getArray;
+import static com.hazelcast.util.JsonUtil.getString;
+
+/**
+ * A serializable DTO that describes client B/W list filtering configuration received from Management Center.
+ */
+public class ClientBwListDTO implements JsonSerializable {
+
+    public Mode mode;
+    public List<ClientBwListEntryDTO> entries;
+
+    public ClientBwListDTO() {
+    }
+
+    public ClientBwListDTO(Mode mode, List<ClientBwListEntryDTO> entries) {
+        this.mode = mode;
+        this.entries = entries;
+    }
+
+    @Override
+    public JsonObject toJson() {
+        JsonObject object = new JsonObject();
+        object.add("mode", mode.toString());
+
+        if (entries != null) {
+            JsonArray entriesArray = new JsonArray();
+            for (ClientBwListEntryDTO entry : entries) {
+                JsonObject json = entry.toJson();
+                if (json != null) {
+                    entriesArray.add(json);
+                }
+            }
+            object.add("entries", entriesArray);
+        }
+
+        return object;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        String modeStr = getString(json, "mode");
+        mode = Mode.valueOf(modeStr);
+
+        entries = new ArrayList<ClientBwListEntryDTO>();
+        JsonArray entriesArray = getArray(json, "entries");
+        for (JsonValue jsonValue : entriesArray) {
+            ClientBwListEntryDTO entryDTO = new ClientBwListEntryDTO();
+            entryDTO.fromJson(jsonValue.asObject());
+            entries.add(entryDTO);
+        }
+    }
+
+    public enum Mode {
+
+        DISABLED, WHITELIST, BLACKLIST
+
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientBwListEntryDTO.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/dto/ClientBwListEntryDTO.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management.dto;
+
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.management.JsonSerializable;
+
+import static com.hazelcast.util.JsonUtil.getString;
+
+/**
+ * A serializable DTO for client B/W list filtering configuration entries.
+ */
+public class ClientBwListEntryDTO implements JsonSerializable {
+
+    public Type type;
+    public String value;
+
+    public ClientBwListEntryDTO() {
+    }
+
+    public ClientBwListEntryDTO(Type type, String value) {
+        this.type = type;
+        this.value = value;
+    }
+
+    public JsonObject toJson() {
+        JsonObject root = new JsonObject();
+        root.add("type", type.toString());
+        root.add("value", value);
+        return root;
+    }
+
+    @Override
+    public void fromJson(JsonObject json) {
+        String typeStr = getString(json, "type");
+        type = Type.valueOf(typeStr);
+        value = getString(json, "value");
+    }
+
+    public enum Type {
+
+        IP_ADDRESS, INSTANCE_NAME, LABEL
+
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ClientBwListConfigHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ClientBwListConfigHandlerTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.management;
+
+import com.hazelcast.client.impl.ClientEngine;
+import com.hazelcast.client.impl.ClientImpl;
+import com.hazelcast.client.impl.ClientSelectors;
+import com.hazelcast.core.Client;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.management.dto.ClientBwListDTO;
+import com.hazelcast.internal.management.dto.ClientBwListEntryDTO;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.hazelcast.internal.management.dto.ClientBwListDTO.Mode;
+import static com.hazelcast.internal.management.dto.ClientBwListEntryDTO.Type;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientBwListConfigHandlerTest extends HazelcastTestSupport {
+
+    private ClientEngine clientEngine;
+    private ClientBwListConfigHandler handler;
+
+    @Before
+    public void setUp() {
+        HazelcastInstance instance = createHazelcastInstance();
+        clientEngine = getNode(instance).getClientEngine();
+        handler = new ClientBwListConfigHandler(clientEngine);
+    }
+
+    @Test
+    public void testHandleLostConnection() {
+        clientEngine.applySelector(ClientSelectors.none());
+
+        handler.handleLostConnection();
+
+        Client client = createClient("127.0.0.1", randomString());
+
+        assertTrue(clientEngine.isClientAllowed(client));
+    }
+
+    @Test
+    public void testHandleWhitelist() {
+        JsonObject configJson = createConfig(Mode.WHITELIST,
+                new ClientBwListEntryDTO(Type.IP_ADDRESS, "127.0.0.*"),
+                new ClientBwListEntryDTO(Type.IP_ADDRESS, "192.168.0.1"),
+                new ClientBwListEntryDTO(Type.IP_ADDRESS, "192.168.0.42-43"),
+                new ClientBwListEntryDTO(Type.IP_ADDRESS, "fe80:0:0:0:45c5:47ee:fe15:493a"),
+                new ClientBwListEntryDTO(Type.INSTANCE_NAME, "client*"),
+                new ClientBwListEntryDTO(Type.LABEL, "label*"));
+        handler.handleConfig(configJson);
+
+        Client[] allowed = {
+                createClient("127.0.0.3", "a_name"),
+                createClient("192.168.0.1", "a_name"),
+                createClient("192.168.0.42", "a_name"),
+                createClient("fe80:0:0:0:45c5:47ee:fe15:493a", "a_name"),
+                createClient("192.168.0.101", "client4"),
+                createClient("192.168.0.101", "a_name", "label")
+        };
+        for (Client client : allowed) {
+            assertTrue(clientEngine.isClientAllowed(client));
+        }
+
+        Client[] denied = {
+                createClient("192.168.0.101", "a_name", "random"),
+                createClient("fe70:0:0:0:35c5:16ee:fe15:491a", "a_name", "random")
+        };
+        for (Client client : denied) {
+            assertFalse(clientEngine.isClientAllowed(client));
+        }
+    }
+
+    @Test
+    public void testHandleBlacklist() {
+        JsonObject configJson = createConfig(Mode.BLACKLIST,
+                new ClientBwListEntryDTO(Type.IP_ADDRESS, "127.0.0.*"),
+                new ClientBwListEntryDTO(Type.IP_ADDRESS, "192.168.0.1"),
+                new ClientBwListEntryDTO(Type.IP_ADDRESS, "192.168.*.42"),
+                new ClientBwListEntryDTO(Type.IP_ADDRESS, "fe80:0:0:0:45c5:47ee:fe15:*"),
+                new ClientBwListEntryDTO(Type.INSTANCE_NAME, "*_client"),
+                new ClientBwListEntryDTO(Type.LABEL, "test*label"));
+        handler.handleConfig(configJson);
+
+        Client[] allowed = {
+                createClient("192.168.0.101", "a_name", "random"),
+                createClient("fe70:0:0:0:35c5:16ee:fe15:491a", "a_name", "random")
+        };
+        for (Client client : allowed) {
+            assertTrue(clientEngine.isClientAllowed(client));
+        }
+
+        Client[] denied = {
+                createClient("127.0.0.3", "a_name"),
+                createClient("192.168.0.1", "a_name"),
+                createClient("192.168.0.42", "a_name"),
+                createClient("fe80:0:0:0:45c5:47ee:fe15:493a", "a_name"),
+                createClient("192.168.0.101", "java_client"),
+                createClient("192.168.0.101", "a_name", "test_label"),
+                createClient("192.168.0.101", "a_name", "testlabel")
+        };
+        for (Client client : denied) {
+            assertFalse(clientEngine.isClientAllowed(client));
+        }
+    }
+
+    @Test
+    public void testHandleEmptyWhitelist() {
+        JsonObject configJson = createConfig(Mode.WHITELIST);
+        handler.handleConfig(configJson);
+
+        Client client = createClient("127.0.0.1", "a_name");
+        assertFalse(clientEngine.isClientAllowed(client));
+    }
+
+    @Test
+    public void testHandleEmptyBlacklist() {
+        clientEngine.applySelector(ClientSelectors.none());
+
+        JsonObject configJson = createConfig(Mode.BLACKLIST);
+        handler.handleConfig(configJson);
+
+        Client client = createClient("127.0.0.1", "a_name");
+        assertTrue(clientEngine.isClientAllowed(client));
+    }
+
+    @Test
+    public void testHandleDisabledMode() {
+        clientEngine.applySelector(ClientSelectors.none());
+
+        JsonObject configJson = createConfig(Mode.DISABLED);
+        handler.handleConfig(configJson);
+
+        Client client = createClient("127.0.0.1", randomString());
+        assertTrue(clientEngine.isClientAllowed(client));
+    }
+
+    @Test
+    public void testHandleEmptyConfig() {
+        clientEngine.applySelector(ClientSelectors.none());
+
+        JsonObject configJson = new JsonObject();
+        handler.handleConfig(configJson);
+
+        Client client = createClient("127.0.0.1", randomString());
+        assertFalse(clientEngine.isClientAllowed(client));
+    }
+
+    @Test
+    public void testHandleInvalidMode() {
+        clientEngine.applySelector(ClientSelectors.none());
+
+        JsonObject configJson = createConfig(Mode.DISABLED);
+        configJson.get("clientBwList").asObject().set("mode", "invalid_mode");
+        handler.handleConfig(configJson);
+
+        Client client = createClient("127.0.0.1", randomString());
+        assertFalse(clientEngine.isClientAllowed(client));
+    }
+
+    @Test
+    public void testHandleInvalidEntry() {
+        clientEngine.applySelector(ClientSelectors.none());
+
+        JsonObject configJson = createConfig(Mode.WHITELIST,
+                new ClientBwListEntryDTO(Type.LABEL, "192.168.0.1"),
+                new ClientBwListEntryDTO(Type.IP_ADDRESS, "192.168.0.2"));
+        configJson.get("clientBwList").asObject()
+                  .get("entries").asArray()
+                  .get(0).asObject().set("type", "invalid_type");
+        handler.handleConfig(configJson);
+
+        Client client1 = createClient("192.168.0.1", randomString());
+        assertFalse(clientEngine.isClientAllowed(client1));
+
+        Client client2 = createClient("192.168.0.2", randomString());
+        assertFalse(clientEngine.isClientAllowed(client2));
+    }
+
+    private JsonObject createConfig(Mode mode, ClientBwListEntryDTO... entries) {
+        List<ClientBwListEntryDTO> entriesList = new ArrayList<ClientBwListEntryDTO>();
+        if (entries != null) {
+            entriesList.addAll(Arrays.asList(entries));
+        }
+        ClientBwListDTO configDTO = new ClientBwListDTO(mode, entriesList);
+        JsonObject result = new JsonObject();
+        result.add("clientBwList", configDTO.toJson());
+        return result;
+    }
+
+    private Client createClient(String ip, String name, String... labels) {
+        Set<String> labelsSet = new HashSet<>();
+        if (labels != null && labels.length > 0) {
+            for (String label : labels) {
+                labelsSet.add(label);
+            }
+        }
+        Client client = new ClientImpl(null, InetSocketAddress.createUnresolved(ip, 5000), name, labelsSet);
+        return client;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -16,15 +16,19 @@
 
 package com.hazelcast.internal.management;
 
-import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
-import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-
-import java.io.IOException;
-import java.net.ServerSocket;
-
+import com.hazelcast.client.impl.ClientImpl;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Client;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.internal.json.Json;
+import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.json.ParseException;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -32,21 +36,27 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import com.hazelcast.config.Config;
-import com.hazelcast.core.Hazelcast;
-import com.hazelcast.instance.HazelcastInstanceFactory;
-import com.hazelcast.internal.json.Json;
-import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.internal.json.ParseException;
-import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelClassRunner;
-import com.hazelcast.test.annotation.QuickTest;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertTrueEventually;
+import static com.hazelcast.test.HazelcastTestSupport.randomString;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category(QuickTest.class)
@@ -55,18 +65,25 @@ public class ManagementCenterServiceIntegrationTest {
     private static final String clusterName = "Session Integration (AWS discovery)";
 
     private static MancenterMock mancenterMock;
+    private static HazelcastInstanceImpl instance;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
         HazelcastInstanceFactory.terminateAll();
         mancenterMock = new MancenterMock(availablePort());
-        Hazelcast.newHazelcastInstance(getManagementCenterConfig());
+        HazelcastInstanceProxy proxy = (HazelcastInstanceProxy) Hazelcast.newHazelcastInstance(getManagementCenterConfig());
+        instance = proxy.getOriginal();
     }
 
     @AfterClass
-    public static void tearDown() throws Exception {
+    public static void tearDownClass() {
         HazelcastInstanceFactory.terminateAll();
         mancenterMock.stop();
+    }
+
+    @After
+    public void tearDown() {
+        mancenterMock.resetClientBwList();
     }
 
     @Test
@@ -98,6 +115,28 @@ public class ManagementCenterServiceIntegrationTest {
             public void run() throws Exception {
                 String responseString = doHttpGet("/mancen/getClusterName");
                 assertEquals(clusterName, responseString);
+            }
+        });
+    }
+
+    @Test
+    public void testClientBwListApplies() {
+        mancenterMock.enableClientWhitelist("127.0.0.1");
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                String responseString = doHttpGet("/mancen/memberStateCheck");
+                assertNotNull(responseString);
+                assertNotEquals("", responseString);
+
+                String name = randomString();
+                Set<String> labels = new HashSet<String>();
+                Client client1 = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+                assertTrue(instance.node.clientEngine.isClientAllowed(client1));
+
+                Client client2 = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.2", 5000), name, labels);
+                assertFalse(instance.node.clientEngine.isClientAllowed(client2));
             }
         });
     }


### PR DESCRIPTION
Management Center will curate lists of black-listed and white-listed clients that are allowed to connect to the cluster. IMDG nodes will receive information about active list from MC (during startup and later on) and apply it for all current and future clients. Exchange of client B/W list's MD5 hash will be used to avoid extra traffic.

This would add support blue/green deployments on MC side.

Depends on #14342