### PR TITLE
Stop client connect mechanism upon lazy config error

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
@@ -27,6 +27,7 @@ import com.hazelcast.client.connection.Addresses;
 import com.hazelcast.client.impl.clientside.HazelcastClientInstanceImpl;
 import com.hazelcast.client.impl.clientside.LifecycleServiceImpl;
 import com.hazelcast.client.spi.impl.ClientExecutionServiceImpl;
+import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.core.LifecycleEvent;
 import com.hazelcast.core.Member;
 import com.hazelcast.logging.ILogger;
@@ -138,11 +139,19 @@ class ClusterConnector {
             client.onClusterConnect(connection);
             fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
             connectionStrategy.onClusterConnect();
+        } catch (ConfigurationException e) {
+            logger.warning("Exception during initial connection to " + address + ", exception " + e);
+            if (null != connection) {
+                connection.close("Could not connect to " + address + " as owner", e);
+            }
+
+            throw rethrow(e);
         } catch (Exception e) {
             logger.warning("Exception during initial connection to " + address + ", exception " + e);
             if (null != connection) {
                 connection.close("Could not connect to " + address + " as owner", e);
             }
+
             return null;
         }
         return connection;


### PR DESCRIPTION
Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2736
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2742

Previously (see 3.11) the expected exception was thrown by `ClientConnectionManagerImpl:initNetworking()` upon loading the SSL config. However, with the multi-endpoint setup, the channel-initializer is now lazy, it will load upon connection, for a given `EndpointQualifier`. Therefore, there is no `IOException` thrown anymore during init, but instead it's thrown when a connection is attempted. This follows a different path and as @vbekiaris pointed out here [#2681 (comment)](https://github.com/hazelcast/hazelcast-enterprise/pull/2681#issuecomment-464658820) its swallowed.

This fix allows for the TLS initialization process to throw a configuration exception which will break the retry mechanism and surface the issue.