### PR TITLE
Fix JsonGetterContextCacheTest.testCacheSizeIsLimited

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/JsonGetterContextCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/JsonGetterContextCacheTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -58,7 +59,7 @@ public class JsonGetterContextCacheTest {
         cache.getContext("h");
         cache.getContext("i");
 
-        assertEquals(3, cache.getCacheSize());
+        assertTrue(cache.getCacheSize() <= 3);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/JsonGetterContextCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/JsonGetterContextCacheTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
Since the eviction algorithm for getter context is doing random
sampling, it may evict one more entry which causes it to drop below the
threshold. This is acceptable so we simply fix the assertion.

Fixes: https://github.com/hazelcast/hazelcast/issues/14513