### PR TITLE
Fix multi-endpoint text decoder when on root mode

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -54,6 +54,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.instance.EndpointQualifier.MEMCACHE;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ADD;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.APPEND;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.BULK_GET;
@@ -175,9 +176,13 @@ public class TextCommandServiceImpl implements TextCommandService {
         stats.setDecrHits(decrementHits.get());
         stats.setDecrMisses(decrementMisses.get());
         NetworkingService cm = node.networkingService;
-        EndpointManager tem = cm.getEndpointManager(REST);
+        EndpointManager rem = cm.getEndpointManager(REST);
+        EndpointManager mem = cm.getEndpointManager(MEMCACHE);
+        int totalText = (rem != null ? rem.getActiveConnections().size() : 0)
+                + (mem != null ? mem.getActiveConnections().size() : 0);
+
         AggregateEndpointManager aem = cm.getAggregateEndpointManager();
-        stats.setCurrConnections(tem.getActiveConnections().size());
+        stats.setCurrConnections(totalText);
         stats.setTotalConnections(aem.getActiveConnections().size());
         return stats;
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/MemcacheTextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/MemcacheTextDecoder.java
@@ -16,6 +16,19 @@
 
 package com.hazelcast.nio.ascii;
 
+import com.hazelcast.internal.ascii.CommandParser;
+import com.hazelcast.internal.ascii.memcache.DeleteCommandParser;
+import com.hazelcast.internal.ascii.memcache.GetCommandParser;
+import com.hazelcast.internal.ascii.memcache.IncrementCommandParser;
+import com.hazelcast.internal.ascii.memcache.SetCommandParser;
+import com.hazelcast.internal.ascii.memcache.SimpleCommandParser;
+import com.hazelcast.internal.ascii.memcache.TouchCommandParser;
+import com.hazelcast.nio.tcp.TcpIpConnection;
+import com.hazelcast.spi.annotation.PrivateApi;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ADD;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.APPEND;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.DECREMENT;
@@ -27,19 +40,6 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.STATS;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.TOUCH;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.VERSION;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import com.hazelcast.internal.ascii.CommandParser;
-import com.hazelcast.internal.ascii.memcache.DeleteCommandParser;
-import com.hazelcast.internal.ascii.memcache.GetCommandParser;
-import com.hazelcast.internal.ascii.memcache.IncrementCommandParser;
-import com.hazelcast.internal.ascii.memcache.SetCommandParser;
-import com.hazelcast.internal.ascii.memcache.SimpleCommandParser;
-import com.hazelcast.internal.ascii.memcache.TouchCommandParser;
-import com.hazelcast.nio.tcp.TcpIpConnection;
-import com.hazelcast.spi.annotation.PrivateApi;
 
 @PrivateApi
 public class MemcacheTextDecoder extends TextDecoder {
@@ -65,7 +65,7 @@ public class MemcacheTextDecoder extends TextDecoder {
         TEXT_PARSERS = new TextParsers(parsers);
     }
 
-    public MemcacheTextDecoder(TcpIpConnection connection, TextEncoder encoder) {
-        super(connection, encoder, AllowingTextProtocolFilter.INSTANCE, TEXT_PARSERS);
+    public MemcacheTextDecoder(TcpIpConnection connection, TextEncoder encoder, boolean rootDecoder) {
+        super(connection, encoder, AllowingTextProtocolFilter.INSTANCE, TEXT_PARSERS, rootDecoder);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/RestApiTextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/RestApiTextDecoder.java
@@ -43,8 +43,8 @@ public class RestApiTextDecoder extends TextDecoder {
         TEXT_PARSERS = new TextParsers(parsers);
     }
 
-    public RestApiTextDecoder(TcpIpConnection connection, TextEncoder encoder) {
-        super(connection, encoder, createFilter(connection), TEXT_PARSERS);
+    public RestApiTextDecoder(TcpIpConnection connection, TextEncoder encoder, boolean rootDecoder) {
+        super(connection, encoder, createFilter(connection), TEXT_PARSERS, rootDecoder);
     }
 
     private static RestApiFilter createFilter(TcpIpConnection connection) {

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextChannelInitializer.java
@@ -32,6 +32,7 @@ public class TextChannelInitializer
         this.rest = rest;
     }
 
+
     @Override
     public void initChannel(Channel channel) {
         super.initChannel(channel);

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextChannelInitializer.java
@@ -42,7 +42,7 @@ public class TextChannelInitializer
 
         channel.outboundPipeline().addLast(encoder);
         channel.inboundPipeline().addLast(rest
-                ? new RestApiTextDecoder(connection, encoder)
-                : new MemcacheTextDecoder(connection, encoder));
+                ? new RestApiTextDecoder(connection, encoder, true)
+                : new MemcacheTextDecoder(connection, encoder, true));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextDecoder.java
@@ -16,20 +16,11 @@
 
 package com.hazelcast.nio.ascii;
 
-import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
-import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.UNKNOWN;
-import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
-import static com.hazelcast.nio.IOUtil.compactOrClear;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-
 import com.hazelcast.internal.ascii.CommandParser;
 import com.hazelcast.internal.ascii.TextCommand;
 import com.hazelcast.internal.ascii.TextCommandService;
 import com.hazelcast.internal.ascii.memcache.ErrorCommand;
 import com.hazelcast.internal.ascii.rest.HttpCommand;
-
 import com.hazelcast.internal.networking.HandlerStatus;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.logging.ILogger;
@@ -38,6 +29,14 @@ import com.hazelcast.nio.IOService;
 import com.hazelcast.nio.tcp.TcpIpConnection;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.util.StringUtil;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.ERROR_CLIENT;
+import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.UNKNOWN;
+import static com.hazelcast.internal.networking.HandlerStatus.CLEAN;
+import static com.hazelcast.nio.IOUtil.compactOrClear;
 
 @PrivateApi
 public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
@@ -73,6 +72,11 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
 
     public void sendResponse(TextCommand command) {
         encoder.enqueue(command);
+    }
+
+    @Override
+    public void handlerAdded() {
+        initSrcBuffer();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextDecoder.java
@@ -58,9 +58,10 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
     private final TextProtocolFilter textProtocolFilter;
     private final ILogger logger;
     private final TextParsers textParsers;
+    private final boolean rootDecoder;
 
     public TextDecoder(TcpIpConnection connection, TextEncoder encoder, TextProtocolFilter textProtocolFilter,
-            TextParsers textParsers) {
+            TextParsers textParsers, boolean rootDecoder) {
         IOService ioService = connection.getEndpointManager().getNetworkingService().getIoService();
         this.textCommandService = ioService.getTextCommandService();
         this.encoder = encoder;
@@ -68,6 +69,7 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
         this.textProtocolFilter = textProtocolFilter;
         this.textParsers = textParsers;
         this.logger = ioService.getLoggingService().getLogger(getClass());
+        this.rootDecoder = rootDecoder;
     }
 
     public void sendResponse(TextCommand command) {
@@ -76,7 +78,9 @@ public abstract class TextDecoder extends InboundHandler<ByteBuffer, Void> {
 
     @Override
     public void handlerAdded() {
-        initSrcBuffer();
+        if (rootDecoder) {
+            initSrcBuffer();
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/UnifiedProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/UnifiedProtocolDecoder.java
@@ -157,8 +157,9 @@ public class UnifiedProtocolDecoder
 
         channel.attributeMap().put(TextEncoder.TEXT_ENCODER, encoder);
 
-        TextDecoder decoder = restApi ? new RestApiTextDecoder(connection, encoder)
-                : new MemcacheTextDecoder(connection, encoder);
+        TextDecoder decoder = restApi
+                ? new RestApiTextDecoder(connection, encoder, false)
+                : new MemcacheTextDecoder(connection, encoder, false);
         decoder.src(newByteBuffer(config.getOption(SO_RCVBUF), config.getOption(DIRECT_BUF)));
         // we need to restore whatever is read
         decoder.src().put(stringToBytes(protocol));

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedMultiendpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedMultiendpointTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 public class MemcachedMultiendpointTest
         extends MemcachedTest {
 
+    @Override
     public void setup() throws Exception {
         AdvancedNetworkConfig anc = config.getAdvancedNetworkConfig();
         anc.setEnabled(true)

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedMultiendpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedMultiendpointTest.java
@@ -1,0 +1,31 @@
+package com.hazelcast.internal.ascii;
+
+import com.hazelcast.config.AdvancedNetworkConfig;
+import com.hazelcast.config.JoinConfig;
+import com.hazelcast.config.ServerSocketEndpointConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category(QuickTest.class)
+public class MemcachedMultiendpointTest
+        extends MemcachedTest {
+
+    public void setup() throws Exception {
+        AdvancedNetworkConfig anc = config.getAdvancedNetworkConfig();
+        anc.setEnabled(true)
+           .setMemcacheEndpointConfig(new ServerSocketEndpointConfig());
+
+        // Join is disabled intentionally. will start standalone HazelcastInstances.
+        JoinConfig join = anc.getJoin();
+        join.getMulticastConfig().setEnabled(false);
+        join.getTcpIpConfig().setEnabled(false);
+
+        instance = Hazelcast.newHazelcastInstance(config);
+        client = getMemcachedClient(instance);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedMultiendpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedMultiendpointTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.internal.ascii;
 
 import com.hazelcast.config.AdvancedNetworkConfig;

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/MemcachedTest.java
@@ -48,7 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ConcurrentModificationException;
 
-
+import static com.hazelcast.instance.EndpointQualifier.MEMCACHE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -57,9 +57,9 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class MemcachedTest extends HazelcastTestSupport {
 
-    private Config config = new Config();
-    private HazelcastInstance instance;
-    private MemcachedClient client;
+    protected Config config = new Config();
+    protected HazelcastInstance instance;
+    protected MemcachedClient client;
 
     @Before
     public void setup() throws Exception {
@@ -363,7 +363,7 @@ public class MemcachedTest extends HazelcastTestSupport {
     @SuppressWarnings("checkstyle:parameternumber")
     private void checkStats(int sets, int gets, int getHits, int getMisses, int deleteHits, int deleteMisses,
                             int incHits, int incMisses, int decHits, int decMisses) {
-        InetSocketAddress address = instance.getCluster().getLocalMember().getSocketAddress();
+        InetSocketAddress address = instance.getCluster().getLocalMember().getSocketAddress(MEMCACHE);
         Map<String, String> stats = client.getStats().get(address);
 
         assertEquals(String.valueOf(sets), stats.get("cmd_set"));
@@ -378,8 +378,8 @@ public class MemcachedTest extends HazelcastTestSupport {
         assertEquals(String.valueOf(decMisses), stats.get("decr_misses"));
     }
 
-    private MemcachedClient getMemcachedClient(HazelcastInstance instance) throws Exception {
-        InetSocketAddress address = instance.getCluster().getLocalMember().getSocketAddress();
+    protected MemcachedClient getMemcachedClient(HazelcastInstance instance) throws Exception {
+        InetSocketAddress address = instance.getCluster().getLocalMember().getSocketAddress(MEMCACHE);
         ConnectionFactory factory = new ConnectionFactoryBuilder()
                 .setOpTimeout(60 * 60 * 60)
                 .setDaemon(true)

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterMultiendpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterMultiendpointTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii;
+
+import com.hazelcast.config.AdvancedNetworkConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.RestServerEndpointConfig;
+
+public class RestClusterMultiendpointTest
+        extends RestClusterTest {
+
+    @Override
+    protected Config createConfigWithRestEnabled() {
+        Config config = new Config();
+        AdvancedNetworkConfig anc = config.getAdvancedNetworkConfig();
+        anc.setEnabled(true)
+           .setRestEndpointConfig(new RestServerEndpointConfig().enableAllGroups());
+        return config;
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestMultiendpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestMultiendpointTest.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.ascii;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.RestServerEndpointConfig;
 import com.hazelcast.config.ServerSocketEndpointConfig;
@@ -24,7 +25,6 @@ import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -43,10 +43,9 @@ import static org.junit.Assert.assertTrue;
 public class RestMultiendpointTest
         extends RestTest {
 
-    @Before
-    public void setup() {
+    @Override
+    public Config setup() {
         config.getGroupConfig().setName(randomString());
-
         ServerSocketEndpointConfig memberEndpointConfig = new ServerSocketEndpointConfig();
         memberEndpointConfig.setName("MEMBER")
                       .setPort(6000)
@@ -60,7 +59,8 @@ public class RestMultiendpointTest
         RestServerEndpointConfig restEndpoint = new RestServerEndpointConfig();
         restEndpoint.setName("Text")
                     .setPort(10000)
-                    .setPortAutoIncrement(true);
+                    .setPortAutoIncrement(true)
+                    .enableAllGroups();
 
         config.getAdvancedNetworkConfig()
               .setEnabled(true)
@@ -83,10 +83,12 @@ public class RestMultiendpointTest
         remoteInstance = Hazelcast.newHazelcastInstance(config);
 
         communicator = new HTTPCommunicator(instance);
+        return config;
     }
 
     @Test
     public void assertAdvancedNetworkInUse() {
+        setup();
         int numberOfEndpointsInConfig = config.getAdvancedNetworkConfig().getEndpointConfigs().size();
         MemberImpl local = getNode(instance).getClusterService().getLocalMember();
         assertTrue(local.getAddressMap().size() == numberOfEndpointsInConfig);

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestMultiendpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestMultiendpointTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.RestServerEndpointConfig;
 import com.hazelcast.config.ServerSocketEndpointConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.test.HazelcastSerialClassRunner;
@@ -78,9 +77,9 @@ public class RestMultiendpointTest
                 .addMember("127.0.0.1:6000")
                 .addMember("127.0.0.1:6001");
 
-        instance = Hazelcast.newHazelcastInstance(config);
+        instance = factory.newHazelcastInstance(config);
 
-        remoteInstance = Hazelcast.newHazelcastInstance(config);
+        remoteInstance = factory.newHazelcastInstance(config);
 
         communicator = new HTTPCommunicator(instance);
         return config;

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -66,7 +66,7 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class RestTest {
 
-    private final TestAwareInstanceFactory factory = new TestAwareInstanceFactory();
+    protected final TestAwareInstanceFactory factory = new TestAwareInstanceFactory();
 
     protected HazelcastInstance instance;
     protected HazelcastInstance remoteInstance;

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -76,7 +76,7 @@ public class RestTest {
         Hazelcast.shutdownAll();
     }
 
-    private Config setup() {
+    public Config setup() {
         Config config = new Config();
         RestApiConfig restApiConfig = new RestApiConfig().setEnabled(true).enableAllGroups();
         config.getNetworkConfig().setRestApiConfig(restApiConfig);

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestTest.java
@@ -24,9 +24,9 @@ import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.IQueue;
+import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.management.dto.WanReplicationConfigDTO;
 import com.hazelcast.internal.management.request.UpdatePermissionConfigRequest;
-import com.hazelcast.nio.Address;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.TestAwareInstanceFactory;
@@ -39,11 +39,13 @@ import org.junit.runner.RunWith;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.HashSet;
 import java.util.Set;
 
 import static com.hazelcast.nio.IOUtil.readFully;
+import static com.hazelcast.test.HazelcastTestSupport.getNode;
 import static com.hazelcast.test.HazelcastTestSupport.randomMapName;
 import static com.hazelcast.test.HazelcastTestSupport.randomName;
 import static com.hazelcast.test.HazelcastTestSupport.randomString;
@@ -359,8 +361,10 @@ public class RestTest {
     @Test
     public void testNoHeaders() throws IOException {
         setup();
-        Address address = HazelcastTestSupport.getAddress(instance);
-        Socket socket = new Socket(address.getInetAddress(), address.getPort());
+        InetSocketAddress address = getNode(instance).getLocalMember().getSocketAddress(EndpointQualifier.REST);
+
+        HazelcastTestSupport.getAddress(instance);
+        Socket socket = new Socket(address.getAddress(), address.getPort());
         socket.setSoTimeout(5000);
         try {
             OutputStream os = socket.getOutputStream();


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/14516

Fix Text decoder when on root mode to initialize the src buffer propertly.
Add memcached tests for multiendpoint config
