### PR TITLE
Fixes client issues with multi endpoint config

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/io/AdvancedNetworkClientIntegrationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/io/AdvancedNetworkClientIntegrationTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.io;
+
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.ServerSocketEndpointConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MemberAttributeEvent;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.core.MembershipListener;
+import com.hazelcast.core.Partition;
+import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
+import com.hazelcast.scheduledexecutor.IScheduledFuture;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.instance.EndpointQualifier.CLIENT;
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
+import static com.hazelcast.test.HazelcastTestSupport.assertContains;
+import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class AdvancedNetworkClientIntegrationTest {
+
+    private static final int CLUSTER_SIZE = 3;
+    private static final int BASE_CLIENT_PORT = 9090;
+
+    HazelcastInstance[] instances = new HazelcastInstance[CLUSTER_SIZE];
+
+    @Before
+    public void setup() {
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            instances[i] = Hazelcast.newHazelcastInstance(getConfig());
+        }
+    }
+
+    @After
+    public void tearDown() {
+        for (int i = 0; i < CLUSTER_SIZE; i++) {
+            instances[i].getLifecycleService().terminate();
+        }
+    }
+
+    @Test
+    public void clientSmokeTest() {
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(getClientConfig());
+        IMap<Integer, Integer> map = client.getMap("test");
+        for (int i = 0; i < 1000; i++) {
+            map.put(i, i);
+        }
+        assertEquals(1000, map.size());
+    }
+
+    @Test
+    public void testClientMembersList() {
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(getClientConfig());
+        Set<Member> clientViewOfMembers = client.getCluster().getMembers();
+        Set<Member> members = instances[1].getCluster().getMembers();
+
+        Set<Address> clientViewOfAddresses = new HashSet<Address>();
+        for (Member member : clientViewOfMembers) {
+            clientViewOfAddresses.add(member.getAddress());
+        }
+
+        for (Member member : members) {
+            assertContains(clientViewOfAddresses, member.getAddressMap().get(CLIENT));
+        }
+    }
+
+    @Test
+    public void testClientMembershipEvent() {
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(getClientConfig());
+        final AtomicReference<Member> memberAdded = new AtomicReference<Member>();
+        final AtomicReference<Member> memberRemoved = new AtomicReference<Member>();
+        Address removedMemberAddress = instances[2].getCluster().getLocalMember().getAddressMap().get(CLIENT);
+
+        client.getCluster().addMembershipListener(new MembershipListener() {
+            @Override
+            public void memberAdded(MembershipEvent membershipEvent) {
+                memberAdded.set(membershipEvent.getMember());
+            }
+
+            @Override
+            public void memberRemoved(MembershipEvent membershipEvent) {
+                memberRemoved.set(membershipEvent.getMember());
+            }
+
+            @Override
+            public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
+
+            }
+        });
+
+        instances[2].shutdown();
+        assertClusterSizeEventually(2, instances[0]);
+
+        assertEquals(memberRemoved.get().getAddress(), removedMemberAddress);
+
+        instances[2] = Hazelcast.newHazelcastInstance(getConfig());
+        assertClusterSizeEventually(3, instances);
+
+        assertEquals(memberAdded.get().getAddress(), instances[2].getCluster().getLocalMember().getAddressMap().get(CLIENT));
+    }
+
+    @Test
+    public void testPartitions() {
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(getClientConfig());
+        Iterator<Partition> memberPartitions = instances[0].getPartitionService().getPartitions().iterator();
+        Set<Partition> partitions = client.getPartitionService().getPartitions();
+
+        for (Partition partition : partitions) {
+            Partition memberPartition = memberPartitions.next();
+            assertEquals(memberPartition.getPartitionId(), partition.getPartitionId());
+            assertEquals(memberPartition.getOwner().getAddressMap().get(CLIENT),
+                        partition.getOwner().getAddress());
+        }
+    }
+
+    @Test
+    public void testGetScheduledFutures() throws Exception {
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(getClientConfig());
+        IScheduledExecutorService executorService = client.getScheduledExecutorService("test");
+        Member targetMember = client.getCluster().getMembers().iterator().next();
+
+        IScheduledFuture<Address> future = executorService.scheduleOnMember(new ReportExecutionMember(),
+                targetMember, 3, TimeUnit.SECONDS);
+        Map<Member, List<IScheduledFuture<Address>>> futures = executorService.getAllScheduledFutures();
+
+        assertContains(futures.keySet(), targetMember);
+
+        IScheduledFuture<Address> futureOfMember = futures.get(targetMember).get(0);
+        assertEquals(futureOfMember.get(), future.get());
+    }
+
+    @Test
+    public void testScheduleOnMember() throws Exception {
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(getClientConfig());
+        IScheduledExecutorService executorService = client.getScheduledExecutorService("test");
+        Member targetMember = client.getCluster().getMembers().iterator().next();
+
+        IScheduledFuture<Address> future = executorService.scheduleOnMember(new ReportExecutionMember(),
+                targetMember, 3, TimeUnit.SECONDS);
+
+        assertEquals(targetMember.getAddress(), future.getHandler().getAddress());
+
+        Address clusterMemberAddress = null;
+        for (HazelcastInstance instance : instances) {
+            if (targetMember.getAddress().equals(instance.getCluster().getLocalMember().getAddressMap().get(CLIENT))) {
+                clusterMemberAddress = instance.getCluster().getLocalMember().getAddress();
+            }
+        }
+
+        assertEquals(future.get(), clusterMemberAddress);
+
+    }
+
+    public static class ReportExecutionMember implements Callable<Address>, Serializable, HazelcastInstanceAware {
+
+        private volatile HazelcastInstance instance;
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.instance = hazelcastInstance;
+        }
+
+        @Override
+        public Address call() {
+            return instance.getCluster().getLocalMember().getAddress();
+        }
+    }
+
+
+
+    Config getConfig() {
+        Config config = smallInstanceConfig();
+        config.getAdvancedNetworkConfig().setEnabled(true)
+              .setClientEndpointConfig(new ServerSocketEndpointConfig().setPort(BASE_CLIENT_PORT));
+        config.getAdvancedNetworkConfig()
+              .getJoin().getMulticastConfig().setEnabled(false);
+        config.getAdvancedNetworkConfig()
+              .getJoin().getTcpIpConfig().setEnabled(true).addMember("127.0.0.1");
+        return config;
+    }
+
+    ClientConfig getClientConfig() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().addAddress("127.0.0.1:9090");
+        return clientConfig;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
@@ -56,6 +56,10 @@ public interface ClientEngine extends Consumer<ClientMessage> {
 
     ILogger getLogger(Class clazz);
 
+    /**
+     * @return  the address of this member that listens for CLIENT protocol connections. When advanced network config
+     *          is in use, it will be different from the MEMBER listening address reported eg by {@code Node.getThisAddress()}
+     */
     Address getThisAddress();
 
     String getThisUuid();
@@ -162,4 +166,26 @@ public interface ClientEngine extends Consumer<ClientMessage> {
      */
     void applySelector(ClientSelector selector);
 
+
+    /**
+     * Locates the cluster member that has the provided client address and returns its member address,
+     * to be used for intra-cluster communication. This is required when clients deliver messages with
+     * designated target members, since clients may be unaware of the actual member address (when
+     * advanced network config is enabled).
+     * Throws a {@link com.hazelcast.spi.exception.TargetNotMemberException} when no member with the
+     * provided client address can be located.
+     *
+     * @param clientAddress the client address of the member
+     * @return              the member address of the member
+     */
+    Address memberAddressOf(Address clientAddress);
+
+    /**
+     * Locates the client address of the given member address. Performs the reverse transformation
+     * of {@link #memberAddressOf(Address)}.
+     *
+     * @param memberAddress the member address of the member
+     * @return              the client address of the member
+     */
+    Address clientAddressOf(Address memberAddress);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
@@ -26,6 +26,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.ProxyService;
+import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.transaction.TransactionManagerService;
 
@@ -139,5 +140,17 @@ public class NoOpClientEngine implements ClientEngine {
     @Override
     public void accept(ClientMessage clientMessage) {
 
+    }
+
+    @Override
+    public Address memberAddressOf(Address clientAddress) {
+        throw new TargetNotMemberException("NoOpClientEngine does not supply translation from client to "
+                + "member address");
+    }
+
+    @Override
+    public Address clientAddressOf(Address clientAddress) {
+        throw new TargetNotMemberException("NoOpClientEngine does not supply translation from member to "
+                + "client address");
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.protocol;
 
+import com.hazelcast.client.impl.ClientEngine;
 import com.hazelcast.client.impl.protocol.exception.MaxMessageSizeExceeded;
 import com.hazelcast.client.impl.protocol.util.BufferBuilder;
 import com.hazelcast.client.impl.protocol.util.ClientProtocolBuffer;
@@ -112,6 +113,7 @@ public class ClientMessage
     private transient boolean isRetryable;
     private transient boolean acquiresResource;
     private transient String operationName;
+    private transient ClientEngine clientEngine;
     private Connection connection;
 
     protected ClientMessage() {
@@ -123,6 +125,14 @@ public class ClientMessage
 
     public void setConnection(Connection connection) {
         this.connection = connection;
+    }
+
+    public void setClientEngine(ClientEngine clientEngine) {
+        this.clientEngine = clientEngine;
+    }
+
+    public ClientEngine getClientEngine() {
+        return clientEngine;
     }
 
     protected void wrapForEncode(ClientProtocolBuffer buffer, int offset) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -116,6 +116,7 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
         if (!node.getNodeExtension().isStartCompleted()) {
             throw new HazelcastInstanceNotActiveException("Hazelcast instance is not ready yet!");
         }
+        clientMessage.setClientEngine(clientEngine);
         parameters = decodeClientMessage(clientMessage);
         Credentials credentials = endpoint.getCredentials();
         interceptBefore(credentials);
@@ -234,6 +235,10 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
 
     protected final BuildInfo getMemberBuildInfo() {
         return node.getBuildInfo();
+    }
+
+    protected boolean isAdvancedNetworkEnabled() {
+        return node.getConfig().getAdvancedNetworkConfig().isEnabled();
     }
 
     private Throwable peelIfNeeded(Throwable t) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddDistributedObjectListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddDistributedObjectListenerMessageTask.java
@@ -115,7 +115,7 @@ public class AddDistributedObjectListenerMessageTask
         }
 
         ClusterService clusterService = clientEngine.getClusterService();
-        boolean currentMemberIsMaster = clusterService.getMasterAddress().equals(clientEngine.getThisAddress());
+        boolean currentMemberIsMaster = clusterService.isMaster();
         if (parameters.localOnly && !currentMemberIsMaster) {
             //if client registered localOnly, only master is allowed to send request
             return false;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorGetAllScheduledMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorGetAllScheduledMessageTask.java
@@ -21,12 +21,16 @@ import com.hazelcast.client.impl.protocol.codec.ScheduledExecutorGetAllScheduled
 import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
 import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.core.Member;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.scheduledexecutor.impl.DistributedScheduledExecutorService;
 import com.hazelcast.scheduledexecutor.impl.InvokeOnMembers;
+import com.hazelcast.scheduledexecutor.impl.ScheduledTaskHandlerAccessor;
 import com.hazelcast.scheduledexecutor.impl.operations.GetAllScheduledOnMemberOperation;
 import com.hazelcast.scheduledexecutor.impl.operations.GetAllScheduledOnPartitionOperationFactory;
 import com.hazelcast.security.permission.ActionConstants;
@@ -47,8 +51,11 @@ public class ScheduledExecutorGetAllScheduledMessageTask
         extends AbstractMessageTask<ScheduledExecutorGetAllScheduledFuturesCodec.RequestParameters>
         implements BlockingMessageTask {
 
+    private final boolean advancedNetworkEnabled;
+
     public ScheduledExecutorGetAllScheduledMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
+        this.advancedNetworkEnabled = isAdvancedNetworkEnabled();
     }
 
     @Override
@@ -124,21 +131,55 @@ public class ScheduledExecutorGetAllScheduledMessageTask
         IPartitionService partitionService = nodeEngine.getPartitionService();
 
         for (Map.Entry<?, ?> entry : taskHandlersMap.entrySet()) {
-            Member owner;
+            MemberImpl owner;
             Object key = entry.getKey();
             if (key instanceof Number) {
                 owner = clusterService.getMember(partitionService.getPartitionOwner((Integer) key));
             } else {
-                owner = (Member) key;
+                owner = (MemberImpl) key;
             }
 
+            owner = translateMemberAddress(owner);
+
             List<ScheduledTaskHandler> handlers = (List<ScheduledTaskHandler>) entry.getValue();
+            translateTaskHandlerAddresses(handlers);
 
             if (accumulator.containsKey(owner)) {
                 List<ScheduledTaskHandler> memberUrns = accumulator.get(owner);
                 memberUrns.addAll(handlers);
             } else {
                 accumulator.put(owner, handlers);
+            }
+        }
+    }
+
+    private MemberImpl translateMemberAddress(MemberImpl member) {
+        if (!advancedNetworkEnabled) {
+            return member;
+        }
+
+        Address clientAddress = member.getAddressMap().get(EndpointQualifier.CLIENT);
+
+        MemberImpl result = new MemberImpl.Builder(clientAddress)
+                .version(member.getVersion())
+                .uuid(member.getUuid())
+                .localMember(member.localMember())
+                .liteMember(member.isLiteMember())
+                .memberListJoinVersion(member.getMemberListJoinVersion())
+                .attributes(member.getAttributes())
+                .build();
+        return result;
+    }
+
+    private void translateTaskHandlerAddresses(List<ScheduledTaskHandler> handlers) {
+        if (!advancedNetworkEnabled) {
+            return;
+        }
+
+        for (ScheduledTaskHandler handler : handlers) {
+            if (handler.getAddress() != null) {
+                ScheduledTaskHandlerAccessor.setAddress(handler,
+                        clientEngine.clientAddressOf(handler.getAddress()));
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -779,7 +779,7 @@ public class Node {
         MemberImpl localMember = getLocalMember();
         return new JoinRequest(Packet.VERSION, buildInfo.getBuildNumber(), version, address,
                 localMember.getUuid(), localMember.isLiteMember(), createConfigCheck(), credentials,
-                localMember.getAttributes(), excludedMemberUuids);
+                localMember.getAttributes(), excludedMemberUuids, localMember.getAddressMap());
     }
 
     public ConfigCheck createConfigCheck() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersView.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersView.java
@@ -65,7 +65,7 @@ public final class MembersView implements IdentifiedDataSerializable, Versioned 
         int newVersion = max(source.version, source.size());
         for (MemberInfo newMember : newMembers) {
             MemberInfo m = new MemberInfo(newMember.getAddress(), newMember.getUuid(), newMember.getAttributes(),
-                    newMember.isLiteMember(), newMember.getVersion(), ++newVersion);
+                    newMember.isLiteMember(), newMember.getVersion(), ++newVersion, newMember.getAddressMap());
             list.add(m);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskHandlerAccessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskHandlerAccessor.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.scheduledexecutor.impl;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
+
+public final class ScheduledTaskHandlerAccessor {
+
+    private ScheduledTaskHandlerAccessor() {
+
+    }
+
+    public static void setAddress(ScheduledTaskHandler handler, Address newAddress) {
+        ((ScheduledTaskHandlerImpl) handler).setAddress(newAddress);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskHandlerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/scheduledexecutor/impl/ScheduledTaskHandlerImpl.java
@@ -158,6 +158,10 @@ public final class ScheduledTaskHandlerImpl
                 + schedulerName + '\'' + ", taskName='" + taskName + '\'' + '}';
     }
 
+    void setAddress(Address address) {
+        this.address = address;
+    }
+
     public static ScheduledTaskHandler of(Address addr, String schedulerName, String taskName) {
         return new ScheduledTaskHandlerImpl(addr, schedulerName, taskName);
     }

--- a/hazelcast/src/test/java/com/hazelcast/instance/DefaultNodeExtensionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/DefaultNodeExtensionTest.java
@@ -98,7 +98,7 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
     @Test
     public void test_joinRequestAllowed_whenSameVersion() {
         JoinRequest joinRequest = new JoinRequest(Packet.VERSION, buildNumber, nodeVersion, joinAddress, newUnsecureUuidString(),
-                false, null, null, null, null);
+                false, null, null, null, null, null);
 
         nodeExtension.validateJoinRequest(joinRequest);
     }
@@ -108,7 +108,7 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
         MemberVersion nextPatchVersion = MemberVersion.of(nodeVersion.getMajor(), nodeVersion.getMinor(),
                 nodeVersion.getPatch() + 1);
         JoinRequest joinRequest = new JoinRequest(Packet.VERSION, buildNumber, nextPatchVersion, joinAddress,
-                newUnsecureUuidString(), false, null, null, null, null);
+                newUnsecureUuidString(), false, null, null, null, null, null);
 
         nodeExtension.validateJoinRequest(joinRequest);
     }
@@ -118,7 +118,7 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
         MemberVersion nextMinorVersion = MemberVersion.of(nodeVersion.getMajor(), nodeVersion.getMinor() + 1,
                 nodeVersion.getPatch());
         JoinRequest joinRequest = new JoinRequest(Packet.VERSION, buildNumber, nextMinorVersion, joinAddress,
-                newUnsecureUuidString(), false, null, null, null, null);
+                newUnsecureUuidString(), false, null, null, null, null, null);
 
         expected.expect(VersionMismatchException.class);
         expected.expectMessage(containsString("Rolling Member Upgrades are only supported in Hazelcast Enterprise"));
@@ -130,7 +130,7 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
         MemberVersion nextMinorVersion = MemberVersion.of(nodeVersion.getMajor(), nodeVersion.getMinor() - 1,
                 nodeVersion.getPatch());
         JoinRequest joinRequest = new JoinRequest(Packet.VERSION, buildNumber, nextMinorVersion, joinAddress,
-                newUnsecureUuidString(), false, null, null, null, null);
+                newUnsecureUuidString(), false, null, null, null, null, null);
 
         expected.expect(VersionMismatchException.class);
         expected.expectMessage(containsString("Rolling Member Upgrades are only supported for the next minor version"));
@@ -143,7 +143,7 @@ public class DefaultNodeExtensionTest extends HazelcastTestSupport {
         MemberVersion nextMajorVersion = MemberVersion.of(nodeVersion.getMajor() + 1, nodeVersion.getMinor(),
                 nodeVersion.getPatch());
         JoinRequest joinRequest = new JoinRequest(Packet.VERSION, buildNumber, nextMajorVersion, joinAddress,
-                newUnsecureUuidString(), false, null, null, null, null);
+                newUnsecureUuidString(), false, null, null, null, null, null);
 
         expected.expect(VersionMismatchException.class);
         expected.expectMessage(containsString("Rolling Member Upgrades are only supported for the same major version"));

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -27,7 +27,6 @@ import com.hazelcast.internal.json.Json;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.json.ParseException;
 import com.hazelcast.test.AssertTask;
-import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.apache.http.HttpEntity;

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkIntegrationTest.java
@@ -22,6 +22,7 @@ import com.hazelcast.config.RestServerEndpointConfig;
 import com.hazelcast.config.ServerSocketEndpointConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -39,7 +40,9 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.hazelcast.test.HazelcastTestSupport.assertClusterSizeEventually;
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -71,6 +74,22 @@ public class AdvancedNetworkIntegrationTest {
         Config config = createCompleteMultiSocketConfig();
         HazelcastInstance hz = newHazelcastInstance(config);
         assertLocalPortsOpen(MEMBER_PORT, CLIENT_PORT, WAN1_PORT, WAN2_PORT, REST_PORT, MEMCACHE_PORT);
+    }
+
+    @Test
+    public void testMembersReportAllAddresses() {
+        Config config = createCompleteMultiSocketConfig();
+        for (int i = 0; i < 3; i++) {
+            newHazelcastInstance(config);
+        }
+        assertClusterSizeEventually(3, instances);
+
+        for (HazelcastInstance hz : instances) {
+            Set<Member> members = hz.getCluster().getMembers();
+            for (Member member : members) {
+                assertEquals(6, member.getAddressMap().size());
+            }
+        }
     }
 
     @Test(expected = AssertionError.class)

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.8.0-5</client.protocol.version>
+        <client.protocol.version>1.8.0-6</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>6</jdk.version>


### PR DESCRIPTION
* All members in the cluster become aware of each other member's addresses; previously only the `MEMBER` address was published
* `ClientEngine#getThisAddress` now reports the `CLIENT` address when the member is configured with multi-endpoint config
* Adapts address data sent to clients (as part of member, partitions or other data), so clients maintain a view of `CLIENT` sockets of cluster members.

Best reviewed commit by commit
Depends on a new release of `hazelcast-client-protocol` incorporating https://github.com/hazelcast/hazelcast-client-protocol/pull/172
EE adaptation PR: https://github.com/hazelcast/hazelcast-enterprise/pull/2749
(also tests clients 3.6-3.11 for compatibility with multi-endpoint 3.12 cluster)