### PR TITLE
Strict version checking while applying completed migrations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -343,14 +343,11 @@ public class PartitionStateManager {
     }
 
     void incrementVersion(int delta) {
-        if (delta >= 0) {
-            stateVersion.addAndGet(delta);
-        } else {
-            logger.warning("partition table version not incremented by " + delta);
-        }
+        assert delta > 0 : "Delta: " + delta;
+        stateVersion.addAndGet(delta);
     }
 
-    public void incrementVersion() {
+    void incrementVersion() {
         stateVersion.incrementAndGet();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -112,7 +112,7 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
             return;
         }
         InternalPartitionServiceImpl partitionService = getService();
-        if (!partitionService.applyCompletedMigrations(completedMigrations, partitionStateVersion, migrationInfo.getMaster())) {
+        if (!partitionService.applyCompletedMigrations(completedMigrations, migrationInfo.getMaster())) {
             throw new PartitionStateVersionMismatchException(partitionStateVersion, partitionService.getPartitionStateVersion());
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationCommitOperation.java
@@ -45,8 +45,6 @@ public class MigrationCommitOperation extends AbstractPartitionOperation impleme
 
     private MigrationInfo migration;
 
-    private int newPartitionStateVersion;
-
     private String expectedMemberUuid;
 
     private transient boolean success;
@@ -60,9 +58,8 @@ public class MigrationCommitOperation extends AbstractPartitionOperation impleme
         this.expectedMemberUuid = expectedMemberUuid;
     }
 
-    public MigrationCommitOperation(MigrationInfo migration, int newPartitionStateVersion, String expectedMemberUuid) {
+    public MigrationCommitOperation(MigrationInfo migration, String expectedMemberUuid) {
         this.migration = migration;
-        this.newPartitionStateVersion = newPartitionStateVersion;
         this.expectedMemberUuid = expectedMemberUuid;
     }
 
@@ -79,7 +76,7 @@ public class MigrationCommitOperation extends AbstractPartitionOperation impleme
         InternalPartitionServiceImpl service = getService();
 
         if (nodeEngine.getClusterService().getClusterVersion().isGreaterOrEqual(Versions.V3_12)) {
-            success = service.commitMigrationOnDestination(migration, newPartitionStateVersion, getCallerAddress());
+            success = service.commitMigrationOnDestination(migration, getCallerAddress());
         } else {
             // RU_COMPAT_3_11
             partitionState.setMaster(getCallerAddress());
@@ -113,7 +110,6 @@ public class MigrationCommitOperation extends AbstractPartitionOperation impleme
 
         if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
             migration = in.readObject();
-            newPartitionStateVersion = in.readInt();
         } else {
             // RU_COMPAT_3_11
             partitionState = new PartitionRuntimeState();
@@ -128,7 +124,6 @@ public class MigrationCommitOperation extends AbstractPartitionOperation impleme
 
         if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
             out.writeObject(migration);
-            out.writeInt(newPartitionStateVersion);
         } else {
             // RU_COMPAT_3_11
             partitionState.writeData(out);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PublishCompletedMigrationsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PublishCompletedMigrationsOperation.java
@@ -41,23 +41,19 @@ public class PublishCompletedMigrationsOperation extends AbstractPartitionOperat
 
     private Collection<MigrationInfo> completedMigrations;
 
-    private int newPartitionStateVersion;
-
     private transient boolean success;
 
     public PublishCompletedMigrationsOperation() {
     }
 
-    public PublishCompletedMigrationsOperation(Collection<MigrationInfo> completedMigrations,
-            int newPartitionStateVersion) {
+    public PublishCompletedMigrationsOperation(Collection<MigrationInfo> completedMigrations) {
         this.completedMigrations = completedMigrations;
-        this.newPartitionStateVersion = newPartitionStateVersion;
     }
 
     @Override
     public void run() {
         InternalPartitionServiceImpl service = getService();
-        success = service.applyCompletedMigrations(completedMigrations, newPartitionStateVersion, getCallerAddress());
+        success = service.applyCompletedMigrations(completedMigrations, getCallerAddress());
     }
 
     @Override
@@ -89,7 +85,6 @@ public class PublishCompletedMigrationsOperation extends AbstractPartitionOperat
             migrationInfo.readData(in);
             completedMigrations.add(migrationInfo);
         }
-        newPartitionStateVersion = in.readInt();
     }
 
     @Override
@@ -100,7 +95,6 @@ public class PublishCompletedMigrationsOperation extends AbstractPartitionOperat
         for (MigrationInfo migrationInfo : completedMigrations) {
             migrationInfo.writeData(out);
         }
-        out.writeInt(newPartitionStateVersion);
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractPartitionAssignmentsCorrectnessTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/AbstractPartitionAssignmentsCorrectnessTest.java
@@ -18,8 +18,6 @@ package com.hazelcast.internal.partition;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.instance.Node;
-import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
@@ -27,8 +25,6 @@ import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
-
-import static org.junit.Assert.assertNotNull;
 
 public abstract class AbstractPartitionAssignmentsCorrectnessTest extends PartitionCorrectnessTestSupport {
 
@@ -83,30 +79,9 @@ public abstract class AbstractPartitionAssignmentsCorrectnessTest extends Partit
     static void assertPartitionAssignmentsEventually(final TestHazelcastInstanceFactory factory) {
         assertTrueEventually(new AssertTask() {
             @Override
-            public void run() throws Exception {
+            public void run() {
                 assertPartitionAssignments(factory);
             }
         });
-    }
-
-    static void assertPartitionAssignments(TestHazelcastInstanceFactory factory) {
-        Collection<HazelcastInstance> instances = factory.getAllHazelcastInstances();
-        final int replicaCount = Math.min(instances.size(), InternalPartition.MAX_REPLICA_COUNT);
-
-        for (HazelcastInstance hz : instances) {
-            Node node = getNode(hz);
-            InternalPartitionService partitionService = node.getPartitionService();
-            InternalPartition[] partitions = partitionService.getInternalPartitions();
-            ClusterServiceImpl clusterService = node.getClusterService();
-            Address thisAddress = node.getThisAddress();
-
-            for (InternalPartition partition : partitions) {
-                for (int i = 0; i < replicaCount; i++) {
-                    Address replicaAddress = partition.getReplicaAddress(i);
-                    assertNotNull("On " + thisAddress + ", Replica " + i + " is not found in " + partition, replicaAddress);
-                    assertNotNull("On " + thisAddress + ", Not member: " + replicaAddress, clusterService.getMember(replicaAddress));
-                }
-            }
-        }
     }
 }


### PR DESCRIPTION
Currently when a list of completed migrations are received,
they are applied if their version is greater than local version.

But migrations are not the only source of partition state mutation.
Partition state can change when a member crashes without relying
on migrations.

That's why, when partition state changes without migrations,
a member should apply those changes before applying completed
migrations.

To provide that, added versions to each completed migration
and those versions are checked while applying them.
If there are gaps between completed migrations, that means
a complete partition state should be received before applying them.

Fixes #14492
Fixes #14491
Fixes #14498
Fixes #14551
Fixes #8063
Fixes #14568
Fixes #14565