### PR TITLE
Fix race in the client partition service

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -115,7 +115,7 @@ public final class ClientPartitionServiceImpl
     }
 
     private void waitForPartitionsFetchedOnce() {
-        while (partitions.isEmpty() && client.getConnectionManager().isAlive()) {
+        while ((partitions.isEmpty() || partitionCount == 0) && client.getConnectionManager().isAlive()) {
             if (isClusterFormedByOnlyLiteMembers()) {
                 throw new NoDataMemberInClusterException(
                         "Partitions can't be assigned since all nodes in the cluster are lite members");


### PR DESCRIPTION
Reasoning:
It is a regression caused by this line:
https://github.com/hazelcast/hazelcast/pull/14342/files#diff-9caf7fbb823cf694ab81b4b0deb7a762R118

The `partitions` map might not be empty yet `partitionCount` can still
be `0`. as they are initialized in the same order. This means the
`waitForPartitionsFetchedOnce` might return too soon.