### PR TITLE
Update default value in CPSubsystemConfig

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -4545,23 +4545,21 @@
             <xs:element name="missing-cp-member-auto-removal-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Duration to wait before automatically removing a missing CP member from
-                        the CP subsystem. It is 0 by default and disabled. When a CP member
-                        leaves the cluster, it is not automatically removed from
-                        the CP subsystem, since the missing CP member could be still alive
-                        and left the cluster because of a network partition. On the other hand,
-                        if a missing CP member is actually crashed, it creates a danger for its
-                        CP groups, because it will be still part of majority calculations.
-                        This situation could lead to losing majority of CP groups if multiple
-                        CP members leave the cluster over time.
-                        If this configuration is enabled, missing CP members will be
-                        automatically removed from the CP subsystem after some time.
-                        This feature is very useful in terms of fault tolerance when
-                        CP member count is also configured to be larger than group size.
-                        In this case, a missing CP member will be safely replaced in its CP
-                        groups with other available CP members in the CP subsystem. This
-                        configuration also implies that no network partition is expected to be
-                        longer than the configured duration.
+                        Duration to wait before automatically removing a missing CP member
+                        from the CP subsystem. When a CP member leaves the cluster, it is not
+                        automatically removed from the CP subsystem, since it could be still
+                        alive and left the cluster because of a network partition.
+                        On the other hand, if a missing CP member is actually crashed,
+                        it creates a danger for its CP groups, because it will be still part of
+                        majority calculations. This situation could lead to losing majority of
+                        CP groups if multiple CP members leave the cluster over time.
+                        With the default configuration, missing CP members will be automatically
+                        removed from the CP subsystem after 4 hours. This feature is very useful
+                        in terms of fault tolerance when CP member count is also configured
+                        to be larger than group size. In this case, a missing CP member will be
+                        safely replaced in its CP groups with other available CP members
+                        in the CP subsystem. This configuration also implies that no network
+                        partition is expected to be longer than the configured duration.
                         Must be greater than or equal to session-time-to-live-seconds.
                     </xs:documentation>
                 </xs:annotation>

--- a/hazelcast/src/main/java/com/hazelcast/config/cp/CPSubsystemConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/cp/CPSubsystemConfig.java
@@ -129,6 +129,13 @@ public class CPSubsystemConfig {
      */
     public static final int MAX_GROUP_SIZE = 7;
 
+    /**
+     * Default duration to wait before automatically removing
+     * a missing CP member from the CP subsystem.
+     * See {@link #missingCPMemberAutoRemovalSeconds}
+     */
+    public static final int DEFAULT_MISSING_CP_MEMBER_AUTO_REMOVAL_SECONDS = (int) TimeUnit.HOURS.toSeconds(4);
+
 
     /**
      * Number of {@link CPMember}s to initialize the {@link CPSubsystem}.
@@ -188,28 +195,26 @@ public class CPSubsystemConfig {
     private int sessionHeartbeatIntervalSeconds = DEFAULT_HEARTBEAT_INTERVAL_SECONDS;
 
     /**
-     * Duration to wait before automatically removing a missing CP member from
-     * the CP subsystem. It is 0 by default and disabled. When a CP member
-     * leaves the cluster, it is not automatically removed from
-     * the CP subsystem, since the missing CP member could be still alive
-     * and left the cluster because of a network partition. On the other hand,
-     * if a missing CP member is actually crashed, it creates a danger for its
-     * CP groups, because it will be still part of majority calculations.
-     * This situation could lead to losing majority of CP groups if multiple
-     * CP members leave the cluster over time.
+     * Duration to wait before automatically removing a missing CP member
+     * from the CP subsystem. When a CP member leaves the cluster, it is not
+     * automatically removed from the CP subsystem, since it could be still
+     * alive and left the cluster because of a network partition.
+     * On the other hand, if a missing CP member is actually crashed,
+     * it creates a danger for its CP groups, because it will be still part of
+     * majority calculations. This situation could lead to losing majority of
+     * CP groups if multiple CP members leave the cluster over time.
      * <p>
-     * If this configuration is enabled, missing CP members will be
-     * automatically removed from the CP subsystem after some time.
-     * This feature is very useful in terms of fault tolerance when
-     * CP member count is also configured to be larger than group size.
-     * In this case, a missing CP member will be safely replaced in its CP
-     * groups with other available CP members in the CP subsystem. This
-     * configuration also implies that no network partition is expected to be
-     * longer than the configured duration.
+     * With the default configuration, missing CP members will be automatically
+     * removed from the CP subsystem after 4 hours. This feature is very useful
+     * in terms of fault tolerance when CP member count is also configured
+     * to be larger than group size. In this case, a missing CP member will be
+     * safely replaced in its CP groups with other available CP members
+     * in the CP subsystem. This configuration also implies that no network
+     * partition is expected to be longer than the configured duration.
      * <p>
      * Must be greater than or equal to {@link #sessionTimeToLiveSeconds}
      */
-    private long missingCPMemberAutoRemovalSeconds;
+    private int missingCPMemberAutoRemovalSeconds = DEFAULT_MISSING_CP_MEMBER_AUTO_REMOVAL_SECONDS;
 
     /**
      * Offers a choice between at-least-once and at-most-once execution
@@ -332,7 +337,7 @@ public class CPSubsystemConfig {
      * @return duration for a CP session to be kept alive
      *         after the last heartbeat
      */
-    public long getSessionTimeToLiveSeconds() {
+    public int getSessionTimeToLiveSeconds() {
         return sessionTimeToLiveSeconds;
     }
 
@@ -374,7 +379,7 @@ public class CPSubsystemConfig {
      * @return duration to wait before automatically removing
      *         a missing CP member from the CP subsystem
      */
-    public long getMissingCPMemberAutoRemovalSeconds() {
+    public int getMissingCPMemberAutoRemovalSeconds() {
         return missingCPMemberAutoRemovalSeconds;
     }
 
@@ -384,7 +389,7 @@ public class CPSubsystemConfig {
      *
      * @return this config instance
      */
-    public CPSubsystemConfig setMissingCPMemberAutoRemovalSeconds(long missingCPMemberAutoRemovalSeconds) {
+    public CPSubsystemConfig setMissingCPMemberAutoRemovalSeconds(int missingCPMemberAutoRemovalSeconds) {
         checkTrue(missingCPMemberAutoRemovalSeconds >= 0, "missing cp member auto-removal seconds must be non-negative");
         this.missingCPMemberAutoRemovalSeconds = missingCPMemberAutoRemovalSeconds;
         return this;

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicCPSubsystemConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/DynamicCPSubsystemConfig.java
@@ -53,7 +53,7 @@ class DynamicCPSubsystemConfig extends CPSubsystemConfig {
     }
 
     @Override
-    public CPSubsystemConfig setMissingCPMemberAutoRemovalSeconds(long missingCPMemberAutoRemovalSeconds) {
+    public CPSubsystemConfig setMissingCPMemberAutoRemovalSeconds(int missingCPMemberAutoRemovalSeconds) {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -4544,23 +4544,21 @@
             <xs:element name="missing-cp-member-auto-removal-seconds" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="0">
                 <xs:annotation>
                     <xs:documentation>
-                        Duration to wait before automatically removing a missing CP member from
-                        the CP subsystem. It is 0 by default and disabled. When a CP member
-                        leaves the cluster, it is not automatically removed from
-                        the CP subsystem, since the missing CP member could be still alive
-                        and left the cluster because of a network partition. On the other hand,
-                        if a missing CP member is actually crashed, it creates a danger for its
-                        CP groups, because it will be still part of majority calculations.
-                        This situation could lead to losing majority of CP groups if multiple
-                        CP members leave the cluster over time.
-                        If this configuration is enabled, missing CP members will be
-                        automatically removed from the CP subsystem after some time.
-                        This feature is very useful in terms of fault tolerance when
-                        CP member count is also configured to be larger than group size.
-                        In this case, a missing CP member will be safely replaced in its CP
-                        groups with other available CP members in the CP subsystem. This
-                        configuration also implies that no network partition is expected to be
-                        longer than the configured duration.
+                        Duration to wait before automatically removing a missing CP member
+                        from the CP subsystem. When a CP member leaves the cluster, it is not
+                        automatically removed from the CP subsystem, since it could be still
+                        alive and left the cluster because of a network partition.
+                        On the other hand, if a missing CP member is actually crashed,
+                        it creates a danger for its CP groups, because it will be still part of
+                        majority calculations. This situation could lead to losing majority of
+                        CP groups if multiple CP members leave the cluster over time.
+                        With the default configuration, missing CP members will be automatically
+                        removed from the CP subsystem after 4 hours. This feature is very useful
+                        in terms of fault tolerance when CP member count is also configured
+                        to be larger than group size. In this case, a missing CP member will be
+                        safely replaced in its CP groups with other available CP members
+                        in the CP subsystem. This configuration also implies that no network
+                        partition is expected to be longer than the configured duration.
                         Must be greater than or equal to session-time-to-live-seconds.
                     </xs:documentation>
                 </xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -389,7 +389,7 @@
         <group-size>0</group-size>
         <session-time-to-live-seconds>300</session-time-to-live-seconds>
         <session-heartbeat-interval-seconds>5</session-heartbeat-interval-seconds>
-        <missing-cp-member-auto-removal-seconds>0</missing-cp-member-auto-removal-seconds>
+        <missing-cp-member-auto-removal-seconds>14400</missing-cp-member-auto-removal-seconds>
         <fail-on-indeterminate-operation-state>false</fail-on-indeterminate-operation-state>
         <raft-algorithm>
             <leader-election-timeout-in-millis>2000</leader-election-timeout-in-millis>

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -373,7 +373,7 @@ hazelcast:
     group-size: 0
     session-time-to-live-seconds: 300
     session-heartbeat-interval-seconds: 5
-    missing-cp-member-auto-removal-seconds: 0
+    missing-cp-member-auto-removal-seconds: 14400
     fail-on-indeterminate-operation-state: false
     raft-algorithm:
       leader-election-timeout-in-millis: 2000


### PR DESCRIPTION
`missingCPMemberAutoRemovalSeconds` is set to 4 hours by default.