### PR TITLE
Ignore sendPartitionRuntimeState calls if node is not running

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -585,6 +585,9 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
     }
 
     void sendPartitionRuntimeState(Address target) {
+        if (!node.isRunning()) {
+            return;
+        }
         assert partitionStateManager.isInitialized();
         assert node.isMaster();
         assert areMigrationTasksAllowed();


### PR DESCRIPTION
If the node is shutting down, the method can still be called. This may
cause assertion failures since partitionStateManager.isInitialized() is
false and the node is no longer master. This prints out assertion errors
in test logs even though the test passes and may mislead if the test
fails because of a different cause.
If the node is not running, we ignore the call.