### PR TITLE
Renamed Pipeline to Pipelining

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Pipelining.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Pipelining.java
@@ -29,10 +29,10 @@ import static com.hazelcast.util.Preconditions.checkPositive;
 
 
 /**
- * The Pipeline can be used to speed up requests. It is build on top of asynchronous
+ * The Pipelining can be used to speed up requests. It is build on top of asynchronous
  * requests like e.g. {@link IMap#getAsync(Object)} or any other asynchronous call.
  *
- * The main purpose of the pipeline is to control the number of concurrent requests
+ * The main purpose of the Pipelining is to control the number of concurrent requests
  * when using asynchronous invocations. This can be done by setting the depth using
  * the constructor. So you could set the depth to e.g 100 and do 1000 calls. That means
  * that at any given moment, there will only be 100 concurrent requests.
@@ -40,42 +40,42 @@ import static com.hazelcast.util.Preconditions.checkPositive;
  * It depends on the situation what the optimal depth (number of invocations in
  * flight) should be. If it is too high, you can run into memory related problems.
  * If it is too low, it will provide little or no performance advantage at all. In
- * most cases a pipeline and a few hundred map/cache puts/gets should not lead to any
- * problems. For testing purposes we frequently have a pipeline of 1000 or more
+ * most cases a Pipelining and a few hundred map/cache puts/gets should not lead to any
+ * problems. For testing purposes we frequently have a Pipelining of 1000 or more
  * concurrent requests to be able to saturate the system.
  *
- * The Pipeline can't be used for transaction purposes. So you can't create a
- * Pipeline, add a set of asynchronous request and then not call {@link #results()}
+ * The Pipelining can't be used for transaction purposes. So you can't create a
+ * Pipelining, add a set of asynchronous request and then not call {@link #results()}
  * to prevent executing these requests. Invocations can be executed before the
  * {@link #results()} is called.
  *
- * Pipelines can be used by both clients or members.
+ * Pipelining can be used by both clients or members.
  *
- * The Pipeline isn't threadsafe. So only a single thread should add requests to
- * the pipeline and wait for results.
+ * The Pipelining isn't threadsafe. So only a single thread should add requests to
+ * the Pipelining and wait for results.
  *
  * Currently all {@link ICompletableFuture} and their responses are stored in the
- * Pipeline. So be careful executing a huge number of request with a single pipeline
+ * Pipelining. So be careful executing a huge number of request with a single Pipelining
  * because it can lead to a huge memory bubble. In this cases it is better to
- * periodically, after waiting for completion, to replace the pipeline by a new one.
+ * periodically, after waiting for completion, to replace the Pipelining by a new one.
  * In the future we might provide this as an out of the box experience, but currently
  * we do not.
  *
- * A pipeline provides its own backpressure on the system. So there will not be more
- * in flight invocations than the depth of the pipeline. This means that the pipeline
+ * A Pipelining provides its own backpressure on the system. So there will not be more
+ * in flight invocations than the depth of the Pipelining. This means that the Pipelining
  * will work fine when backpressure on the client/member is disabled (default). Also
  * when it it enabled it will work fine, but keep in mind that the number of concurrent
- * invocations in the pipeline could be lower than the configured number of invocation
- * of the pipeline because the backpressure on the client/member is leading.
+ * invocations in the Pipelining could be lower than the configured number of invocation
+ * of the Pipelining because the backpressure on the client/member is leading.
  *
- * The Pipeline has been marked as Beta since we need to see how the API needs to
+ * The Pipelining has been marked as Beta since we need to see how the API needs to
  * evolve. But there is no problem using it in production. We use similar techniques
  * to achieve high performance.
  *
  * @param <E>
  */
 @Beta
-public class Pipeline<E> {
+public class Pipelining<E> {
 
     // we are using a caller runs executor to prevent having the overhead of creating a task and kicking an executor.
     // the only thing that gets executed in future callback is the return of the license to the semaphore.
@@ -90,13 +90,13 @@ public class Pipeline<E> {
     private final List<ICompletableFuture<E>> futures = new ArrayList<ICompletableFuture<E>>();
 
     /**
-     * Creates a pipeline with the given depth.
+     * Creates a Pipelining with the given depth.
      *
-     * @param depth the maximum number of concurrent calls allowed in this pipeline.
+     * @param depth the maximum number of concurrent calls allowed in this Pipelining.
      * @throws IllegalArgumentException if depth smaller than 1. But if you use depth 1, it means that
      *                                  every call is sync and you will not benefit from pipelining at all.
      */
-    public Pipeline(int depth) {
+    public Pipelining(int depth) {
         checkPositive(depth, "depth must be positive");
         this.semaphore = new Semaphore(depth);
     }
@@ -120,14 +120,14 @@ public class Pipeline<E> {
     }
 
     /**
-     * Adds a future to this Pipeline or blocks until there is capacity to add the future to the pipeline.
+     * Adds a future to this Pipelining or blocks until there is capacity to add the future to the Pipelining.
      * <p>
-     * This call blocks until there is space in the pipeline, but it doesn't mean that the invocation that
+     * This call blocks until there is space in the Pipelining, but it doesn't mean that the invocation that
      * returned the ICompletableFuture got blocked.
      *
      * @param future the future to add.
      * @return the future added.
-     * @throws InterruptedException if the Thread got interrupted while adding the request to the pipeline.
+     * @throws InterruptedException if the Thread got interrupted while adding the request to the Pipelining.
      * @throws NullPointerException if future is null.
      */
     public ICompletableFuture<E> add(ICompletableFuture<E> future) throws InterruptedException {

--- a/hazelcast/src/test/java/com/hazelcast/core/PipeliningTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/core/PipeliningTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
-public class PipelineTest extends HazelcastTestSupport {
+public class PipeliningTest extends HazelcastTestSupport {
 
     private HazelcastInstance hz;
 
@@ -44,13 +44,13 @@ public class PipelineTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructor_whenNegativeDepth() {
-        new Pipeline<String>(0);
+        new Pipelining<String>(0);
     }
 
     @Test(expected = NullPointerException.class)
     public void add_whenNull() throws InterruptedException {
-        Pipeline<String> pipeline = new Pipeline<String>(1);
-        pipeline.add(null);
+        Pipelining<String> pipelining = new Pipelining<String>(1);
+        pipelining.add(null);
     }
 
     @Test
@@ -65,11 +65,11 @@ public class PipelineTest extends HazelcastTestSupport {
             map.put(k, item);
         }
 
-        Pipeline<String> pipeline = new Pipeline<String>(1);
+        Pipelining<String> pipelining = new Pipelining<String>(1);
         for (int k = 0; k < items; k++) {
-            pipeline.add(map.getAsync(k));
+            pipelining.add(map.getAsync(k));
         }
 
-        assertEquals(expected, pipeline.results());
+        assertEquals(expected, pipelining.results());
     }
 }


### PR DESCRIPTION
This is done to prevent a name clash with the Pipeline from JET