### PR TITLE
Fixes discrepancy between programmatic and declarative config of WAN publisher endpoint

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -1548,7 +1548,8 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
                     handleProperties(child, publisherBuilder);
                 } else if ("queue-full-behavior".equals(nodeName)
                         || "initial-publisher-state".equals(nodeName)
-                        || "queue-capacity".equals(nodeName)) {
+                        || "queue-capacity".equals(nodeName)
+                        || "endpoint".equals(nodeName)) {
                     publisherBuilder.addPropertyValue(xmlToJavaName(nodeName), getTextContent(child));
                 } else if (AliasedDiscoveryConfigUtils.supports(nodeName)) {
                     handleAliasedDiscoveryStrategy(child, publisherBuilder, nodeName);

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -2858,6 +2858,15 @@
                             </xs:annotation>
                         </xs:element>
                         <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
+                        <xs:element name="endpoint" type="xs:string" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    Reference to the name of a WAN endpoint config or WAN server socket endpoint config.
+                                    The network settings from the referenced endpoint configuration will setup the network
+                                    configuration of connections to the target WAN cluster members.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
                     </xs:sequence>
                     <xs:attributeGroup ref="class-or-bean-name"/>
                     <xs:attribute name="group-name" use="required">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestAdvancedNetworkApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestAdvancedNetworkApplicationContext.java
@@ -23,6 +23,8 @@ import com.hazelcast.config.MemberAddressProviderConfig;
 import com.hazelcast.config.RestServerEndpointConfig;
 import com.hazelcast.config.ServerSocketEndpointConfig;
 import com.hazelcast.config.TcpIpConfig;
+import com.hazelcast.config.WanPublisherConfig;
+import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.EndpointQualifier;
@@ -45,6 +47,7 @@ import static com.hazelcast.test.HazelcastTestSupport.assertContains;
 import static com.hazelcast.test.HazelcastTestSupport.assertContainsAll;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
@@ -117,5 +120,17 @@ public class TestAdvancedNetworkApplicationContext {
         assertEquals(8080, restServerEndpointConfig.getPort());
         assertContainsAll(restServerEndpointConfig.getEnabledGroups(),
                 Arrays.asList(HEALTH_CHECK, CLUSTER_READ));
+
+        WanReplicationConfig testWan = config.getWanReplicationConfig("testWan");
+        WanPublisherConfig tokyoWanPublisherConfig = null;
+        for (WanPublisherConfig wanPublisherConfig : testWan.getWanPublisherConfigs()) {
+            if (wanPublisherConfig.getPublisherId().equals("tokyoPublisherId")) {
+                tokyoWanPublisherConfig = wanPublisherConfig;
+                break;
+            }
+        }
+
+        assertNotNull(tokyoWanPublisherConfig);
+        assertEquals("wan-tokyo", tokyoWanPublisherConfig.getEndpoint());
     }
 }

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
@@ -62,6 +62,7 @@
                         <hz:property name="snapshot.enabled">false</hz:property>
                         <hz:property name="group.password">pass</hz:property>
                     </hz:properties>
+                    <hz:endpoint>wan-tokyo</hz:endpoint>
                 </hz:wan-publisher>
                 <hz:wan-publisher group-name="istanbul"
                                   publisher-id="istanbulPublisherId"

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -702,7 +702,7 @@ public class ConfigXmlGenerator {
            .node("queue-capacity", p.getQueueCapacity())
            .appendProperties(p.getProperties());
         if (p.getEndpoint() != null) {
-            gen.node("endpoint-qualifier", p.getEndpoint());
+            gen.node("endpoint", p.getEndpoint());
         }
         wanReplicationSyncGenerator(gen, p.getWanSyncConfig());
         aliasedDiscoveryConfigsGenerator(gen, aliasedDiscoveryConfigsFrom(p));

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -562,7 +562,7 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
             handleDiscoveryStrategies(publisherConfig.getDiscoveryConfig(), targetChild);
         } else if ("wan-sync".equals(targetChildName)) {
             handleWanSync(publisherConfig.getWanSyncConfig(), targetChild);
-        } else if ("endpoint-qualifier".equals(targetChildName)) {
+        } else if ("endpoint".equals(targetChildName)) {
             publisherConfig.setEndpoint(getTextContent(targetChild));
         }
     }

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -2497,7 +2497,15 @@
             <xs:element name="eureka" type="aliased-discovery-strategy" minOccurs="0" maxOccurs="1"/>
             <xs:element name="discovery-strategies" type="discovery-strategies" minOccurs="0" maxOccurs="1"/>
             <xs:element name="wan-sync" type="wan-sync" minOccurs="0"/>
-            <xs:element name="endpoint-qualifier" type="xs:string" minOccurs="0"/>
+            <xs:element name="endpoint" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Reference to the name of a WAN endpoint config or WAN server socket endpoint config.
+                        The network settings from the referenced endpoint configuration will setup the network
+                        configuration of connections to the target WAN cluster members.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="properties" type="properties" minOccurs="0" maxOccurs="1"/>
         </xs:all>
         <xs:attribute name="group-name" type="xs:string" use="required">

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -1453,7 +1453,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "            <properties>\n"
                 + "                <property name=\"propName1\">propValue1</property>\n"
                 + "            </properties>\n"
-                + "            <endpoint-qualifier>nyc-endpoint-qualifier</endpoint-qualifier>\n"
+                + "            <endpoint>nyc-endpoint</endpoint>\n"
                 + "        </wan-publisher>\n"
                 + "        <wan-consumer>\n"
                 + "            <class-name>ConsumerClassName</class-name>\n"
@@ -1488,7 +1488,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(15000, publisherConfig.getQueueCapacity());
         assertEquals(DISCARD_AFTER_MUTATION, publisherConfig.getQueueFullBehavior());
         assertEquals(WanPublisherState.STOPPED, publisherConfig.getInitialPublisherState());
-        assertEquals("nyc-endpoint-qualifier", publisherConfig.getEndpoint());
+        assertEquals("nyc-endpoint", publisherConfig.getEndpoint());
 
         properties = publisherConfig.getProperties();
         assertNotNull(properties);


### PR DESCRIPTION
Renames `endpoint-qualifier` to `endpoint` in XSD, aligning with programmatic `WanPublisherConfig.get/setEndpoint`.

Also adds the missing `endpoint` config element in Spring config