### PR TITLE
Sets connection type on reading MEMBER protocol bytes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/BindHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/BindHandler.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.nio.tcp;
 
+import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.cluster.impl.BindMessage;
 import com.hazelcast.internal.cluster.impl.ExtendedBindMessage;
@@ -88,6 +89,9 @@ final class BindHandler {
         // is created from an outbound port (eg 192.168.1.1:54003 --> 192.168.1.2:5701), but
         // in 192.168.1.2:5701's connectionsMap the connection must be registered with
         // key 192.168.1.1:5701.
+        assert (tcpIpEndpointManager.getEndpointQualifier() != EndpointQualifier.MEMBER
+                || connection.getType() == ConnectionType.MEMBER) : "When handling MEMBER connections, connection type"
+                + " must be already set";
         boolean isMemberConnection = connection.getType() == ConnectionType.MEMBER;
         return bind0(connection,
                 isMemberConnection ? null : new Address(connection.getRemoteSocketAddress()),

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SingleProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SingleProtocolDecoder.java
@@ -20,6 +20,7 @@ import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.networking.HandlerStatus;
 import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.OutboundHandler;
+import com.hazelcast.nio.ConnectionType;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.nio.ByteBuffer;
@@ -74,6 +75,8 @@ public class SingleProtocolDecoder
 
             String protocol = loadProtocol();
             if (protocol.equals(supportedProtocol.getDescriptor())) {
+                // initialize the connection
+                initConnection();
                 // replace this handler with the next one
                 channel.inboundPipeline().replace(this, inboundHandlers);
             } else {
@@ -95,6 +98,13 @@ public class SingleProtocolDecoder
         byte[] protocolBytes = new byte[PROTOCOL_LENGTH];
         src.get(protocolBytes);
         return bytesToString(protocolBytes);
+    }
+
+    private void initConnection() {
+        if (supportedProtocol == ProtocolType.MEMBER) {
+            TcpIpConnection connection = (TcpIpConnection) channel.attributeMap().get(TcpIpConnection.class);
+            connection.setType(ConnectionType.MEMBER);
+        }
     }
 
     private boolean shouldSignalProtocolLoaded() {


### PR DESCRIPTION
Also adds cleanup for hazelcast clients used in AdvancedNetworkClientIntegrationTest

Fixes #14543 