### PR TITLE
Change RingbufferTest filter to be IdentifiedDataSerializable to be used by non-Java client tests

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedDataSerializableFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedDataSerializableFactory.java
@@ -20,6 +20,7 @@
 
 package com.hazelcast.client.test;
 
+import com.hazelcast.client.test.ringbuffer.filter.StartsWithStringFilter;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.map.EntryBackupProcessor;
@@ -562,6 +563,8 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
                 return new Derived2DataSerializable();
             case 13:
                 return new CallableSignalsRunAndSleep();
+            case StartsWithStringFilter.CLASS_ID:
+                return new StartsWithStringFilter();
             default:
                 return null;
         }

--- a/hazelcast/src/test/java/com/hazelcast/client/test/ringbuffer/filter/StartsWithStringFilter.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/ringbuffer/filter/StartsWithStringFilter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This class is for Non-java clients. Please do not remove or modify.
+ */
+
+package com.hazelcast.client.test.ringbuffer.filter;
+
+import com.hazelcast.client.test.IdentifiedDataSerializableFactory;
+import com.hazelcast.core.IFunction;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+
+import java.io.IOException;
+
+public class StartsWithStringFilter implements IFunction<String, Boolean>, IdentifiedDataSerializable {
+    public static final int CLASS_ID = 14;
+
+    private String startString;
+
+    public StartsWithStringFilter(String startString) {
+        this.startString = startString;
+    }
+
+    public StartsWithStringFilter() {
+    }
+
+    @Override
+    public Boolean apply(String input) {
+        return input.startsWith(startString);
+    }
+
+    @Override
+    public int getFactoryId() {
+        return IdentifiedDataSerializableFactory.FACTORY_ID;
+    }
+
+    @Override
+    public int getId() {
+        return CLASS_ID;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out)
+            throws IOException {
+        out.writeUTF(startString);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in)
+            throws IOException {
+        startString = in.readUTF();
+    }
+}


### PR DESCRIPTION
Added the RingbufferTest filter to the test classes as IdentifiedDataSerializable so that it can be used by non-Java clients during the tests.