### PR TITLE
[3.11] Ignore EXTENDED_BIND messages in 3.11.x series

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Packet.java
@@ -310,11 +310,15 @@ public final class Packet extends HeapData implements OutboundFrame {
          */
         BIND,
         /**
-         * Unused packet type. Available for future use.
+         * The type of Extended Bind packet, since Hazelcast 3.12.
+         *
+         * In 3.11.x we are ignoring this packet. This works because
+         * Hazelcast 3.12 sends both BIND and EXTENDED_BIND packets.
+         *
          * <p>
          * {@code ordinal = 5}
          */
-        UNDEFINED5,
+        EXTENDED_BIND,
         /**
          * Unused packet type. Available for future use.
          * <p>

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/PacketDispatcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/PacketDispatcher.java
@@ -70,6 +70,15 @@ public final class PacketDispatcher implements Consumer<Packet> {
                 case EVENT:
                     eventService.accept(packet);
                     break;
+                case EXTENDED_BIND:
+                    // 3.11 members ignore EXTENDED_BINDS messages.
+                    //
+                    // Reasoning:
+                    // EXTENDED_BINDS were introduced in Hazelcast 3.12. Hazelcast 3.11 has no good way
+                    // to handle them. We can ignore them because 3.12 members send EXTENDED_BIND
+                    // immediately followed by the old BIND. So we ignore EXTENDED_BIND and then we process
+                    // the old BIND.
+                    break;
                 case BIND:
                     connectionManager.accept(packet);
                     break;


### PR DESCRIPTION
This is to prevent flooding logs with SEVERE messages when running 3.11.x and 3.12.x members
in the same cluster.

Example of error message which 3.11.x prints withot this change:
`SEVERE: [127.0.0.1]:5701 [dev] [3.11] Header flags [100001] specify an undefined packet type UNDEFINED5`