### PR TITLE
Make XMLConfigBuilder.setProperties() public again

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigBuilder.java
@@ -125,7 +125,7 @@ public class XmlConfigBuilder extends AbstractXmlConfigBuilder implements Config
      * @param properties the new properties
      * @return the XmlConfigBuilder
      */
-    protected XmlConfigBuilder setProperties(Properties properties) {
+    public XmlConfigBuilder setProperties(Properties properties) {
         super.setPropertiesInternal(properties);
         return this;
     }


### PR DESCRIPTION
Making it protected broke the code samples build, reverting its
visibility to public

(cherry picked from commit ff3947bf3e9cfd95f9368a5faeb6cdebd3f0bf30)