### PR TITLE
Check for nulls in YAML configs and report the path

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientConfigBuilder.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.config;
 import com.hazelcast.config.AbstractYamlConfigBuilder;
 import com.hazelcast.config.ConfigLoader;
 import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.yaml.YamlDomChecker;
 import com.hazelcast.internal.yaml.YamlLoader;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
@@ -148,6 +149,8 @@ public class YamlClientConfigBuilder extends AbstractYamlConfigBuilder {
             throw new InvalidConfigurationException("No mapping with hazelcast-client key is found in the provided "
                     + "configuration");
         }
+
+        YamlDomChecker.check(clientRoot);
 
         Node w3cRootNode = asW3cNode(clientRoot);
         replaceVariables(w3cRootNode);

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.config.yaml.YamlDomChecker;
 import com.hazelcast.internal.yaml.YamlLoader;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
@@ -142,10 +143,12 @@ public class YamlConfigBuilder extends AbstractYamlConfigBuilder implements Conf
             throw new InvalidConfigurationException("Invalid YAML configuration", ex);
         }
 
-        YamlNode imdgRoot = yamlRootNode.childAsMapping(ConfigSections.HAZELCAST.name().toLowerCase());
+        YamlNode imdgRoot = yamlRootNode.childAsMapping(ConfigSections.HAZELCAST.name);
         if (imdgRoot == null) {
             throw new InvalidConfigurationException("No mapping with hazelcast key is found in the provided configuration");
         }
+
+        YamlDomChecker.check(imdgRoot);
 
         Node w3cRootNode = asW3cNode(imdgRoot);
         replaceVariables(w3cRootNode);

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlDomChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlDomChecker.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.yaml;
+
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.internal.yaml.YamlMapping;
+import com.hazelcast.internal.yaml.YamlNameNodePair;
+import com.hazelcast.internal.yaml.YamlNode;
+import com.hazelcast.internal.yaml.YamlScalar;
+import com.hazelcast.internal.yaml.YamlSequence;
+import com.hazelcast.internal.yaml.YamlUtil;
+
+/**
+ * Utility class for checking the provided YAML DOM for {@code null}
+ * scalar values and mappings or sequences with {@code null} child nodes.
+ */
+public final class YamlDomChecker {
+
+    private YamlDomChecker() {
+    }
+
+    /**
+     * Performs {@null} checks on the provided YAML node recursively.
+     *
+     * @param node The YAML node to check for {@code null}s
+     */
+    public static void check(YamlNode node) {
+        if (node instanceof YamlMapping) {
+            for (YamlNameNodePair nodePair : ((YamlMapping) node).childrenPairs()) {
+                YamlNode child = nodePair.childNode();
+                if (child == null) {
+                    String path = YamlUtil.constructPath(node, nodePair.nodeName());
+                    reportNullEntryOnConcretePath(path);
+                }
+
+                check(nodePair.childNode());
+
+            }
+        } else if (node instanceof YamlSequence) {
+            for (YamlNode child : ((YamlSequence) node).children()) {
+                if (child == null) {
+                    throw new InvalidConfigurationException("There is a null configuration entry under sequence " + node.path()
+                            + ". Please check if the provided YAML configuration is well-indented and no blocks started without "
+                            + "sub-nodes.");
+                }
+
+                check(child);
+            }
+        } else {
+            if (((YamlScalar) node).nodeValue() == null) {
+                reportNullEntryOnConcretePath(node.path());
+            }
+        }
+    }
+
+    private static void reportNullEntryOnConcretePath(String path) {
+        throw new InvalidConfigurationException("The configuration entry under " + path
+                + " is null. Please check if the provided YAML configuration is well-indented and no blocks started"
+                + " without sub-nodes.");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlOrderedMappingImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/yaml/YamlOrderedMappingImpl.java
@@ -92,6 +92,11 @@ final class YamlOrderedMappingImpl implements YamlOrderedMapping {
     }
 
     @Override
+    public String path() {
+        return wrappedMapping.path();
+    }
+
+    @Override
     public YamlNode child(int index) {
         if (index >= randomAccessChildren.size()) {
             return null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/AbstractYamlNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/AbstractYamlNode.java
@@ -16,13 +16,17 @@
 
 package com.hazelcast.internal.yaml;
 
+import static com.hazelcast.internal.yaml.YamlUtil.constructPath;
+
 public abstract class AbstractYamlNode implements MutableYamlNode {
     private final YamlNode parent;
     private String nodeName;
+    private String path;
 
     AbstractYamlNode(YamlNode parent, String nodeName) {
         this.parent = parent;
         this.nodeName = nodeName;
+        this.path = constructPath(parent, nodeName);
     }
 
     @Override
@@ -33,10 +37,16 @@ public abstract class AbstractYamlNode implements MutableYamlNode {
     @Override
     public void setNodeName(String nodeName) {
         this.nodeName = nodeName;
+        this.path = constructPath(parent, nodeName);
     }
 
     @Override
     public YamlNode parent() {
         return parent;
+    }
+
+    @Override
+    public String path() {
+        return path;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlNode.java
@@ -36,4 +36,11 @@ public interface YamlNode {
      */
     String nodeName();
 
+    /**
+     * Returns the path of the node from the root of the YAML structure.
+     *
+     * @return the path of the node
+     */
+    String path();
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
@@ -18,10 +18,14 @@ package com.hazelcast.internal.yaml;
 
 import com.hazelcast.internal.util.JavaVersion;
 
+import java.util.regex.Pattern;
+
 /**
  * Utility class for working with YAML nodes.
  */
 public final class YamlUtil {
+    private static final Pattern NAME_APOSTROPHE_PATTERN = Pattern.compile("(.*[\\t\\s,;:]+.*)");
+
     private YamlUtil() {
     }
 
@@ -111,5 +115,25 @@ public final class YamlUtil {
         if (!JavaVersion.isAtLeast(JavaVersion.JAVA_1_8)) {
             throw new UnsupportedOperationException("Processing YAML documents requires Java 8 or higher version");
         }
+    }
+
+    /**
+     * Constructs the path of the node with the provided {@code parent}
+     * node and {@code nodeName}.
+     *
+     * @param parent    The parent node
+     * @param childName The name of the node the path is constructed for
+     * @return the constructed path of the node
+     */
+    public static String constructPath(YamlNode parent, String childName) {
+        if (childName != null) {
+            childName = NAME_APOSTROPHE_PATTERN.matcher(childName).replaceAll("\"$1\"");
+        }
+
+        if (parent != null && parent.path() != null) {
+            return parent.path() + "/" + childName;
+        }
+
+        return childName;
     }
 }


### PR DESCRIPTION
Configurations with nulls indicate user mistakes that are potentially easy to commit. Examples leading to nulls in the config:
- Indentation error might lead to a mapping with null children
- Forgotten dash in a sequence leads to null children
- Explicit nulls as scalar values

The change in this commit checks for null values or nodes and reports the first node containing null with its path from the root in the message of the thrown InvalidConfigurationException.

Before this change the thrown exception was:
```
Exception in thread "main" java.lang.NullPointerException
	at com.hazelcast.config.ConfigReplacerHelper.traverseChildrenAndReplaceVariables(ConfigReplacerHelper.java:44)
	at com.hazelcast.config.ConfigReplacerHelper.traverseChildrenAndReplaceVariables(ConfigReplacerHelper.java:57)
	at com.hazelcast.config.ConfigReplacerHelper.traverseChildrenAndReplaceVariables(ConfigReplacerHelper.java:57)
	at com.hazelcast.config.ConfigReplacerHelper.traverseChildrenAndReplaceVariables(ConfigReplacerHelper.java:38)
	at com.hazelcast.config.AbstractYamlConfigBuilder.replaceVariables(AbstractYamlConfigBuilder.java:167)
	at com.hazelcast.client.config.YamlClientConfigBuilder.parseAndBuildConfig(YamlClientConfigBuilder.java:153)
	at com.hazelcast.client.config.YamlClientConfigBuilder.build(YamlClientConfigBuilder.java:130)
	at com.hazelcast.client.config.YamlClientConfigBuilder.build(YamlClientConfigBuilder.java:119)
	at com.hazelcast.client.config.YamlClientConfigBuilder.build(YamlClientConfigBuilder.java:114)
	at com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.createDefaultClientConfig(FailoverClientConfigSupport.java:94)
	at com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.resolveClientConfig(FailoverClientConfigSupport.java:114)
	at com.hazelcast.client.HazelcastClient.newHazelcastClient(HazelcastClient.java:105)
```

Now this is thrown:

```
com.hazelcast.config.InvalidConfigurationException: The configuration entry under hazelcast/map/personsWithCompositeIndex/indexes/"name.forename, name.surname" is null. Please check if the provided YAML configuration is well-indented and no blocks started without sub-nodes.
	at com.hazelcast.config.yaml.YamlDomChecker.reportNullEntryOnConcretePath(YamlDomChecker.java:71)
	at com.hazelcast.config.yaml.YamlDomChecker.check(YamlDomChecker.java:47)
	at com.hazelcast.config.yaml.YamlDomChecker.check(YamlDomChecker.java:50)
	at com.hazelcast.config.yaml.YamlDomChecker.check(YamlDomChecker.java:50)
	at com.hazelcast.config.yaml.YamlDomChecker.check(YamlDomChecker.java:50)
	at com.hazelcast.config.YamlConfigBuilder.parseAndBuildConfig(YamlConfigBuilder.java:151)
	at com.hazelcast.config.YamlConfigBuilder.build(YamlConfigBuilder.java:131)
	at com.hazelcast.config.ClasspathYamlConfig.<init>(ClasspathYamlConfig.java:98)
	at com.hazelcast.config.ClasspathYamlConfig.<init>(ClasspathYamlConfig.java:57)
	at com.hazelcast.config.ClasspathYamlConfig.<init>(ClasspathYamlConfig.java:44)
	at yaml.YamlTest.main(YamlTest.java:39)
```

The exceptions were thrown for the following composite index configuration:
```
...
map:
    personsWithIndex:
      indexes:
        name.forename:
          ordered: false
        name.surname:
          ordered: false
    personsWithCompositeIndex:
      indexes:
          name.forename, name.surname:     <--- indentation error here
          ordered: false
...
```