### PR TITLE
Proper initialization of channel initializer provider

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestAwareClientFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestAwareClientFactory.java
@@ -20,6 +20,7 @@ import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.config.ClientNetworkConfig;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.test.TestAwareInstanceFactory;
 
 import java.util.List;
@@ -54,7 +55,7 @@ public class TestAwareClientFactory extends TestAwareInstanceFactory {
         }
         ClientNetworkConfig networkConfig = config.getNetworkConfig();
         for (HazelcastInstance member : members) {
-            networkConfig.addAddress("127.0.0.1:" + getPort(member));
+            networkConfig.addAddress("127.0.0.1:" + getPort(member, EndpointQualifier.CLIENT));
         }
         HazelcastInstance hz = HazelcastClient.newHazelcastClient(config);
         getOrInitInstances(perMethodClients).add(hz);

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeExtension.java
@@ -274,7 +274,9 @@ public class DefaultNodeExtension implements NodeExtension {
 
     @Override
     public ChannelInitializerProvider createChannelInitializerProvider(IOService ioService) {
-        return new DefaultChannelInitializerProvider(ioService, node.getConfig());
+        DefaultChannelInitializerProvider provider = new DefaultChannelInitializerProvider(ioService, node.getConfig());
+        provider.init();
+        return provider;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -222,6 +222,7 @@ public final class NioNetworking implements Networking {
     public Channel register(EndpointQualifier endpointQualifier, ChannelInitializerProvider channelInitializerProvider,
                             SocketChannel socketChannel, boolean clientMode) throws IOException {
         ChannelInitializer initializer = channelInitializerProvider.provide(endpointQualifier);
+        assert initializer != null : "Found NULL channel initializer for endpoint-qualifier " + endpointQualifier;
         NioChannel channel = new NioChannel(socketChannel, clientMode, initializer, metricsRegistry, closeListenerExecutor);
 
         socketChannel.configureBlocking(false);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberProtocolEncoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberProtocolEncoder.java
@@ -49,7 +49,7 @@ public class MemberProtocolEncoder extends OutboundHandler<Void, ByteBuffer> {
      *                          upon match of protocol bytes
      */
     @SuppressFBWarnings("EI_EXPOSE_REP2")
-    MemberProtocolEncoder(OutboundHandler[] next) {
+    public MemberProtocolEncoder(OutboundHandler[] next) {
         this.outboundHandlers = next;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/SingleProtocolDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/SingleProtocolDecoder.java
@@ -37,7 +37,7 @@ public class SingleProtocolDecoder
     private final InboundHandler[] inboundHandlers;
     private final MemberProtocolEncoder encoder;
 
-    SingleProtocolDecoder(ProtocolType supportedProtocol, InboundHandler next) {
+    public SingleProtocolDecoder(ProtocolType supportedProtocol, InboundHandler next) {
         this(supportedProtocol, new InboundHandler[] {next}, null);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpUnifiedEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpUnifiedEndpointManager.java
@@ -71,8 +71,6 @@ class TcpIpUnifiedEndpointManager
         return connections;
     }
 
-    //TODO (TK) Cache the values
-
     @Probe(name = "clientCount", level = MANDATORY)
     public int getCurrentClientConnectionsCount() {
         return getCurrentClientConnections().size();

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -28,6 +28,7 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.Partition;
 import com.hazelcast.core.PartitionService;
 import com.hazelcast.instance.BuildInfoProvider;
+import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.Node;
@@ -295,6 +296,10 @@ public abstract class HazelcastTestSupport {
 
     public static Address getAddress(HazelcastInstance hz) {
         return getClusterService(hz).getThisAddress();
+    }
+
+    public static Address getAddress(HazelcastInstance hz, EndpointQualifier qualifier) {
+        return new Address(getClusterService(hz).getLocalMember().getSocketAddress(qualifier));
     }
 
     public static Packet toPacket(HazelcastInstance local, HazelcastInstance remote, Operation operation) {


### PR DESCRIPTION
Proper initialization of `ChannelInitializerProvider` and improve client port tracking for test instance factory.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2755
Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2725

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2763