### PR TITLE
Apply multiple fixes on CP subsystem

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystem.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/CPSubsystem.java
@@ -214,6 +214,10 @@ public interface CPSubsystem {
     /**
      * Returns the local CP member if this Hazelcast member is part of CP subsystem,
      * returns null otherwise.
+     * <p>
+     * This field is initialized when the CP subsystem discovery process
+     * is completed if the local Hazelcast member is one of the first
+     * {@link CPSubsystemConfig#getCPMemberCount()} members in the cluster.
      *
      * @return local CP member if available, null otherwise
      */

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -101,7 +101,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
     private final CPSubsystemConfig config;
 
     // these fields are related to the local CP member but they are not maintained within the Metadata CP group
-    private final AtomicReference<CPMemberInfo> localMember = new AtomicReference<CPMemberInfo>();
+    private final AtomicReference<CPMemberInfo> localCPMember = new AtomicReference<CPMemberInfo>();
     private final AtomicReference<RaftGroupId> metadataGroupIdRef = new AtomicReference<RaftGroupId>(INITIAL_METADATA_GROUP_ID);
     private final AtomicBoolean discoveryCompleted = new AtomicBoolean();
 
@@ -136,7 +136,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
     }
 
     void initPromotedCPMember(CPMemberInfo member) {
-        if (!localMember.compareAndSet(null, member)) {
+        if (!localCPMember.compareAndSet(null, member)) {
             return;
         }
 
@@ -168,7 +168,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
         membershipChangeSchedule = null;
 
         metadataGroupIdRef.set(new RaftGroupId(METADATA_CP_GROUP_NAME, seed, 0));
-        localMember.set(null);
+        localCPMember.set(null);
         discoveryCompleted.set(false);
 
         scheduleDiscoverInitialCPMembersTask(false);
@@ -236,7 +236,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
     }
 
     CPMemberInfo getLocalCPMember() {
-        return localMember.get();
+        return localCPMember.get();
     }
 
     public RaftGroupId getMetadataGroupId() {
@@ -832,12 +832,12 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
 
     // could return stale information
     boolean isMetadataGroupLeader() {
-        CPMemberInfo member = getLocalCPMember();
-        if (member == null) {
+        CPMemberInfo localCPMember = getLocalCPMember();
+        if (localCPMember == null) {
             return false;
         }
         RaftNode raftNode = raftService.getRaftNode(getMetadataGroupId());
-        return raftNode != null && !raftNode.isTerminatedOrSteppedDown() && member.equals(raftNode.getLeader());
+        return raftNode != null && !raftNode.isTerminatedOrSteppedDown() && localCPMember.equals(raftNode.getLeader());
     }
 
     /**
@@ -922,7 +922,7 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
     }
 
     void broadcastActiveCPMembers() {
-        if (!isMetadataGroupLeader()) {
+        if (!(isDiscoveryCompleted() && isMetadataGroupLeader())) {
             return;
         }
 
@@ -982,9 +982,6 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
     private class BroadcastActiveCPMembersTask implements Runnable {
         @Override
         public void run() {
-            if (!isMetadataGroupLeader()) {
-                return;
-            }
             broadcastActiveCPMembers();
         }
     }
@@ -1026,15 +1023,6 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
             if (completeDiscoveryIfNotCPMember(discoveredCPMembers, localMemberCandidate)) {
                 return;
             }
-
-            // By default, we use the same member UUID for both AP and CP members.
-            // But it's not guaranteed to be same. For example;
-            // - During a split-brain merge, AP member UUID is renewed but CP member UUID remains the same.
-            // - While promoting a member to CP when Hot Restart is enabled, CP member doesn't use the AP member's UUID
-            // but instead generates a new UUID.
-            // We must set the local member before initializing the Metadata group
-            // so that the local RaftNode object will be created if I am a Metadata group member
-            localMember.set(localMemberCandidate);
 
             // we must update invocation manager's member list before making the first raft invocation
             updateInvocationManagerMembers(getMetadataGroupId().seed(), 0, discoveredCPMembers);
@@ -1109,17 +1097,23 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
 
         private boolean commitMetadataRaftGroupInit(CPMemberInfo localCPMemberCandidate, List<CPMemberInfo> discoveredCPMembers) {
             List<CPMemberInfo> metadataMembers = discoveredCPMembers.subList(0, config.getGroupSize());
+            RaftGroupId metadataGroupId = getMetadataGroupId();
             try {
-                RaftGroupId metadataGroupId = getMetadataGroupId();
-                if (metadataMembers.contains(getLocalCPMember())) {
-                    raftService.createRaftNode(metadataGroupId, metadataMembers);
+                if (metadataMembers.contains(localCPMemberCandidate)) {
+                    raftService.createRaftNode(metadataGroupId, metadataMembers, localCPMemberCandidate);
                 }
 
-                RaftOp op = new InitMetadataRaftGroupOp(localCPMemberCandidate, discoveredCPMembers,
-                        metadataGroupId.seed());
+                RaftOp op = new InitMetadataRaftGroupOp(localCPMemberCandidate, discoveredCPMembers, metadataGroupId.seed());
                 raftService.getInvocationManager().invoke(metadataGroupId, op).get();
+                // By default, we use the same member UUID for both AP and CP members.
+                // But it's not guaranteed to be same. For example;
+                // - During a split-brain merge, AP member UUID is renewed but CP member UUID remains the same.
+                // - While promoting a member to CP when Hot Restart is enabled, CP member doesn't use the AP member's UUID
+                // but instead generates a new UUID.
+                localCPMember.set(localCPMemberCandidate);
             } catch (Exception e) {
                 logger.severe("Could not initialize METADATA CP group with CP members: " + metadataMembers, e);
+                raftService.destroyRaftNode(metadataGroupId);
                 return false;
             }
             return true;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftGroupMembershipManager.java
@@ -81,7 +81,7 @@ class RaftGroupMembershipManager {
     }
 
     void init() {
-        if (getLocalMember() == null) {
+        if (raftService.getLocalCPMember() == null) {
             return;
         }
 
@@ -97,10 +97,6 @@ class RaftGroupMembershipManager {
                 CHECK_LOCAL_RAFT_NODES_TASK_PERIOD_IN_MILLIS, MILLISECONDS);
     }
 
-    private CPMemberInfo getLocalMember() {
-        return raftService.getMetadataGroupManager().getLocalCPMember();
-    }
-
     private boolean skipRunningTask() {
         return !raftService.getMetadataGroupManager().isMetadataGroupLeader();
     }
@@ -114,8 +110,11 @@ class RaftGroupMembershipManager {
                     continue;
                 }
 
-                if (raftNode.getStatus() == RaftNodeStatus.TERMINATED || raftNode.getStatus() == RaftNodeStatus.STEPPED_DOWN) {
+                if (raftNode.getStatus() == RaftNodeStatus.TERMINATED) {
                     raftService.destroyRaftNode(groupId);
+                    continue;
+                } else if (raftNode.getStatus() == RaftNodeStatus.STEPPED_DOWN) {
+                    raftService.stepDownRaftNode(groupId);
                     continue;
                 }
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/SnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/SnapshotTest.java
@@ -18,7 +18,6 @@ package com.hazelcast.cp.internal.raft.impl;
 
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
 import com.hazelcast.core.Endpoint;
-import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.cp.exception.StaleAppendRequestException;
 import com.hazelcast.cp.internal.raft.MembershipChangeMode;
 import com.hazelcast.cp.internal.raft.impl.command.UpdateRaftGroupMembersCmd;
@@ -440,7 +439,7 @@ public class SnapshotTest extends HazelcastTestSupport {
         }
 
         final RaftNodeImpl newRaftNode1 = group.createNewRaftNode();
-        final ICompletableFuture f1 = leader.replicateMembershipChange(newRaftNode1.getLocalMember(), MembershipChangeMode.ADD);
+        final Future f1 = leader.replicateMembershipChange(newRaftNode1.getLocalMember(), MembershipChangeMode.ADD);
 
         assertTrueEventually(new AssertTask() {
             @Override
@@ -617,7 +616,7 @@ public class SnapshotTest extends HazelcastTestSupport {
 
         final long lastLogIndex3 = getLastLogOrSnapshotEntry(leader).index();
 
-        ICompletableFuture f = leader.replicate(new ApplyRaftRunnable("after_membership_change_append"));
+        Future f = leader.replicate(new ApplyRaftRunnable("after_membership_change_append"));
 
         assertTrueEventually(new AssertTask() {
             @Override


### PR DESCRIPTION
* When the leader is stepping down, it will not accept any new appends.
It also notifies pending-response futures with `LeaderDemotedException`.

* `CPSubsystem.getLocalCPMember()` is initialized only after
the CP subsystem discovery process is completed.

* Metadata leader should not broadcast active CP members list before
the CP subsystem discovery is completed.

* We cannot shutdown **all** CP members concurrently. If we have `N` CP
members, we can concurrently shutdown `(N-2)` CP members first, wait for
them to complete their shutdown, and then shutdown the remaining `2`
CP members either serially or concurrently. This limitation is not
because of our design. Actually, concurrent shutdown of all CP members
boils down to the **Two Generals Problem**. While a CP member is shutting
down, it gracefully leaves all CP groups it is a part of. Consider the
following scenario for the simplest case where there are `3` CP members:
`[A, B, C]`, all of them are part of the Metadata CP group, and `A` is not
the CP group leader.
    - `A` commits its leave to `[A, B, C]` but does not receive the response.
    - `B` commits its leave to `[B, C]`, receives the response, and terminates.
    - `C` notices that it is the only CP member left and terminates directly.
    - `A` hangs because either `B` or `C` was the leader while `A` was leaving but
they left before `A` receives response of its leave.

* Because of the realization above, `Cluster.shutdown()` call shuts down
Hazelcast members one by one if the CP subsystem is enabled.

Fixes #14550
Fixes #14554
Fixes #14567 