### PR TITLE
Fix migration finalization while applying completed migrations

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -944,8 +944,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                     }
                     InternalPartitionImpl partition = partitionStateManager.getPartitionImpl(migration.getPartitionId());
                     migrationManager.applyMigration(partition, migration);
-                    migrationManager.scheduleActiveMigrationFinalization(migration);
                 }
+                migrationManager.scheduleActiveMigrationFinalization(migration);
             }
 
             if (logger.isFineEnabled()) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -982,8 +982,7 @@ public class MigrationManager {
                 processMigrationResult(partitionOwner, result);
             } catch (Throwable t) {
                 final Level level = migrationInfo.isValid() ? Level.WARNING : Level.FINE;
-                logger.log(level, "Error [" + t.getClass() + ": " + t.getMessage() + "] during " + migrationInfo, t);
-                logger.finest(t);
+                logger.log(level, "Error during " + migrationInfo, t);
                 migrationOperationFailed(partitionOwner);
             } finally {
                 stats.recordMigrationTaskTime(System.nanoTime() - start);


### PR DESCRIPTION
Completed migrations, regardless of its status being success
or failure, should be finalized.

This is broken by mistake in https://github.com/hazelcast/hazelcast/pull/14526.