### PR TITLE
Fix invalid json strings causing exceptions

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/JsonMetadataInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/JsonMetadataInitializer.java
@@ -39,7 +39,11 @@ public class JsonMetadataInitializer implements MetadataInitializer {
         if (data.isJson()) {
             JsonParser parser = FACTORY.createParser(new ByteArrayInputStream(data.toByteArray(),
                     HEAP_DATA_OVERHEAD + UTF_CHAR_COUNT_FIELD_SIZE, data.dataSize() - UTF_CHAR_COUNT_FIELD_SIZE));
-            return JsonSchemaHelper.createSchema(parser);
+            try {
+                return JsonSchemaHelper.createSchema(parser);
+            } finally {
+                parser.close();
+            }
         }
         return null;
     }
@@ -48,7 +52,11 @@ public class JsonMetadataInitializer implements MetadataInitializer {
         if (obj instanceof HazelcastJsonValue) {
             String str = ((HazelcastJsonValue) obj).toJsonString();
             JsonParser parser = FACTORY.createParser(str);
-            return JsonSchemaHelper.createSchema(parser);
+            try {
+                return JsonSchemaHelper.createSchema(parser);
+            } finally {
+                parser.close();
+            }
         }
         return null;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataRecordStoreMutationObserver.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/JsonMetadataRecordStoreMutationObserver.java
@@ -23,6 +23,9 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.Metadata;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
+import java.io.IOException;
+
+import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 
 /**
@@ -115,7 +118,10 @@ public class JsonMetadataRecordStoreMutationObserver implements RecordStoreMutat
             } else {
                 valueMetadata = metadataInitializer.createFromObject(serializationService.toObject(updateValue));
             }
-        } catch (Throwable e) {
+        } catch (IOException e) {
+            // silently ignore exception. Json string is allowed to be invalid.
+            ignore(e);
+        } catch (Exception e) {
             throw rethrow(e);
         }
         if (valueMetadata != null) {
@@ -155,6 +161,9 @@ public class JsonMetadataRecordStoreMutationObserver implements RecordStoreMutat
                 metadata.setValueMetadata(valueMetadata);
                 return metadata;
             }
+            return null;
+        } catch (IOException e) {
+            // silently ignore exception. Json string is allowed to be invalid.
             return null;
         } catch (Exception e) {
             throw rethrow(e);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractJsonGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractJsonGetter.java
@@ -132,6 +132,9 @@ public abstract class AbstractJsonGetter extends Getter {
                 }
             }
             return convertJsonTokenToValue(parser);
+        } catch (IOException e) {
+            // Just return null in case of exception. Json strings are allowed to be invalid.
+            return null;
         } finally {
             parser.close();
         }


### PR DESCRIPTION
Json strings in HazelcastJsonValues are allowed to be invalid. In that case we just need to ignore parse exceptions happening during metadata creation. Otherwise, HZ crashes.