### PR TITLE
Fix serialization of PublishCompletedMigrationsOperation

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PublishCompletedMigrationsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PublishCompletedMigrationsOperation.java
@@ -81,8 +81,7 @@ public class PublishCompletedMigrationsOperation extends AbstractPartitionOperat
         int len = in.readInt();
         completedMigrations = new ArrayList<MigrationInfo>(len);
         for (int i = 0; i < len; i++) {
-            MigrationInfo migrationInfo = new MigrationInfo();
-            migrationInfo.readData(in);
+            MigrationInfo migrationInfo = in.readObject();
             completedMigrations.add(migrationInfo);
         }
     }
@@ -93,7 +92,7 @@ public class PublishCompletedMigrationsOperation extends AbstractPartitionOperat
         int len = completedMigrations.size();
         out.writeInt(len);
         for (MigrationInfo migrationInfo : completedMigrations) {
-            migrationInfo.writeData(out);
+            out.writeObject(migrationInfo);
         }
     }
 


### PR DESCRIPTION
`MigrationInfo` should be written/read via `out.writeObject()/in.readObject()`
to access cluster version information.

Fixes hazelcast/hazelcast-enterprise#2771
Fixes #14587