### PR TITLE
Raft follower truncates AppendRequestRPC entries to fit its log capacity

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/log/RaftLog.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/log/RaftLog.java
@@ -146,8 +146,18 @@ public class RaftLog {
         return truncated;
     }
 
+    /**
+     * Returns the number of empty indices in the Raft log
+     */
+    public int availableCapacity() {
+        return (int) (logs.getCapacity() - logs.size());
+    }
+
+    /**
+     * Returns true if the Raft log contains empty indices for the requested amount
+     */
     public boolean checkAvailableCapacity(int requestedCapacity) {
-        return (logs.getCapacity() - logs.size()) >= requestedCapacity;
+        return availableCapacity() >= requestedCapacity;
     }
 
     /**


### PR DESCRIPTION
When a Raft follower falls behind the leader, its log may need a few
more entries to take the next snapshot and truncate the log. Since
AppendEntriesRPC contains a batch of log entries, entries in the next
RPC may not fit into the log of the slow follower. In this case, the
follower truncates the entries in the RPC and appends them only as much
as its capacity. After this moment, the follower will take a snapshot
and append the remaining entries in further AppendEntriesRPCs without
any problem.

For instance, the leader sends 5 entries in an AppendEntriesRPC:
`[Entry1, Entry2, Entry3, Entry4, Entry5]` but the follower has only 2
free indices left in its log. So, the follower appends only
`[Entry1, Entry2]` and sends the response back to the leader.
In the mean while, it takes a snapshot and truncates its log. Then,
the leader will send another AppendEntriesRPC with
`[Entry3, Entry4, Entry5]` and the follower is able to append them because
it has already created sufficient free space by taking a snapshot after
the previous AppendEntriesRPC.

Fixes #14519