### PR TITLE
Improve hiccup resilience of LockMBean remaining lease time test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/LockMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/LockMBeanTest.java
@@ -102,14 +102,14 @@ public class LockMBeanTest extends HazelcastTestSupport {
 
     @Test
     public void testMBeanHasLeaseTime_whenLockedWithLeaseTime_mustHaveRemainingLeaseBeforeItExpires() throws Exception {
-        lock.lock(1000, TimeUnit.MILLISECONDS);
+        lock.lock(10000, TimeUnit.MILLISECONDS);
         long startTime = Clock.currentTimeMillis();
 
         long remainingLeaseTime = getLongAttribute("remainingLeaseTime");
         long timePassed = Clock.currentTimeMillis() - startTime;
         boolean hasLeaseRemaining = remainingLeaseTime > 0;
 
-        assertTrue(hasLeaseRemaining || timePassed >= 1000);
+        assertTrue(hasLeaseRemaining || timePassed >= 10000);
     }
 
     @Test


### PR DESCRIPTION
If there is a long enough hiccup between lock.lock() and taking startTime the
test may fail with no remaining lease time and not enough time passed.
Hiccup resilience of the test is improved by increasing the lease time
to 10 seconds.

Fixes #3774