### PR TITLE
Fix parsing of reuse-address in Spring

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -724,22 +724,26 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             AbstractBeanDefinition beanDefinition = endpointConfigBuilder.getBeanDefinition();
             fillAttributeValues(node, endpointConfigBuilder);
             for (Node child : childElements(node)) {
-                String nodeName = cleanNodeName(child);
-                if ("outbound-ports".equals(nodeName)) {
-                    handleOutboundPorts(child, endpointConfigBuilder);
-                } else if ("interfaces".equals(nodeName)) {
-                    handleInterfaces(child, endpointConfigBuilder);
-                } else if ("symmetric-encryption".equals(nodeName)) {
-                    handleSymmetricEncryption(child, endpointConfigBuilder);
-                } else if ("ssl".equals(nodeName)) {
-                    handleSSLConfig(child, endpointConfigBuilder);
-                } else if ("socket-interceptor".equals(nodeName)) {
-                    handleSocketInterceptorConfig(child, endpointConfigBuilder);
-                } else if ("socket-options".equals(nodeName)) {
-                    handleEndpointSocketOptions(child, endpointConfigBuilder);
-                }
+                handleEndpointConfigCommons(child, endpointConfigBuilder);
             }
             endpointConfigsMap.put(createEndpointQualifier(type, node), beanDefinition);
+        }
+
+        private void handleEndpointConfigCommons(Node node, BeanDefinitionBuilder endpointConfigBuilder) {
+            String nodeName = cleanNodeName(node);
+            if ("outbound-ports".equals(nodeName)) {
+                handleOutboundPorts(node, endpointConfigBuilder);
+            } else if ("interfaces".equals(nodeName)) {
+                handleInterfaces(node, endpointConfigBuilder);
+            } else if ("symmetric-encryption".equals(nodeName)) {
+                handleSymmetricEncryption(node, endpointConfigBuilder);
+            } else if ("ssl".equals(nodeName)) {
+                handleSSLConfig(node, endpointConfigBuilder);
+            } else if ("socket-interceptor".equals(nodeName)) {
+                handleSocketInterceptorConfig(node, endpointConfigBuilder);
+            } else if ("socket-options".equals(nodeName)) {
+                handleEndpointSocketOptions(node, endpointConfigBuilder);
+            }
         }
 
         void handleMemberServerSocketEndpointConfig(Node node) {
@@ -786,18 +790,11 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             fillAttributeValues(node, endpointBuilder);
             for (Node child : childElements(node)) {
                 String nodeName = cleanNodeName(child);
-                if ("outbound-ports".equals(nodeName)) {
-                    handleOutboundPorts(child, endpointBuilder);
-                } else if ("interfaces".equals(nodeName)) {
-                    handleInterfaces(child, endpointBuilder);
-                } else if ("symmetric-encryption".equals(nodeName)) {
-                    handleSymmetricEncryption(child, endpointBuilder);
-                } else if ("ssl".equals(nodeName)) {
-                    handleSSLConfig(child, endpointBuilder);
-                } else if ("socket-interceptor".equals(nodeName)) {
-                    handleSocketInterceptorConfig(child, endpointBuilder);
-                } else if ("socket-options".equals(nodeName)) {
-                    handleEndpointSocketOptions(child, endpointBuilder);
+                if ("reuse-address".equals(nodeName)) {
+                    String value = getTextContent(child).trim();
+                    endpointBuilder.addPropertyValue("reuseAddress", value);
+                } else {
+                    handleEndpointConfigCommons(child, endpointBuilder);
                 }
             }
             endpointConfigsMap.put(createEndpointQualifier(type, node), beanDefinition);

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestAdvancedNetworkApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestAdvancedNetworkApplicationContext.java
@@ -25,14 +25,12 @@ import com.hazelcast.config.ServerSocketEndpointConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.config.WanPublisherConfig;
 import com.hazelcast.config.WanReplicationConfig;
-import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -56,8 +54,6 @@ import static org.junit.Assert.assertTrue;
 @Category(QuickTest.class)
 public class TestAdvancedNetworkApplicationContext {
 
-    private Config config;
-
     @Resource(name = "instance")
     private HazelcastInstance instance;
 
@@ -68,13 +64,9 @@ public class TestAdvancedNetworkApplicationContext {
     }
 
 
-    @Before
-    public void before() {
-        config = instance.getConfig();
-    }
-
     @Test
     public void testAdvancedNetworkConfig() {
+        Config config = instance.getConfig();
         AdvancedNetworkConfig advancedNetworkConfig = config.getAdvancedNetworkConfig();
         assertTrue(advancedNetworkConfig.isEnabled());
 
@@ -91,10 +83,10 @@ public class TestAdvancedNetworkApplicationContext {
 
         assertEquals(5700, memberEndpointConfig.getPort());
         assertEquals(99, memberEndpointConfig.getPortCount());
-        assertTrue(memberEndpointConfig.isPortAutoIncrement());
+        assertFalse(memberEndpointConfig.isPortAutoIncrement());
         assertTrue(memberEndpointConfig.getInterfaces().isEnabled());
         assertContains(memberEndpointConfig.getInterfaces().getInterfaces(), "127.0.0.1");
-        assertFalse(memberEndpointConfig.isReuseAddress());
+        assertTrue(memberEndpointConfig.isReuseAddress());
         assertTrue(memberEndpointConfig.getSocketInterceptorConfig().isEnabled());
         assertEquals("com.hazelcast.SocketInterceptor",
                 memberEndpointConfig.getSocketInterceptorConfig().getClassName());
@@ -115,12 +107,12 @@ public class TestAdvancedNetworkApplicationContext {
                 .getEndpointConfigs().get(EndpointQualifier.CLIENT);
         assertEquals(9919, clientEndpointConfig.getPort());
         assertEquals(10, clientEndpointConfig.getPortCount());
-        assertTrue(clientEndpointConfig.isPortAutoIncrement());
+        assertFalse(clientEndpointConfig.isPortAutoIncrement());
         assertTrue(clientEndpointConfig.isReuseAddress());
 
         RestServerEndpointConfig restServerEndpointConfig = advancedNetworkConfig.getRestEndpointConfig();
-        assertEquals(8080, restServerEndpointConfig.getPort());
-        assertFalse(restServerEndpointConfig.isPortAutoIncrement());
+        assertEquals(9999, restServerEndpointConfig.getPort());
+        assertTrue(restServerEndpointConfig.isPortAutoIncrement());
         assertContainsAll(restServerEndpointConfig.getEnabledGroups(),
                 Arrays.asList(HEALTH_CHECK, CLUSTER_READ));
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestAdvancedNetworkApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestAdvancedNetworkApplicationContext.java
@@ -28,6 +28,7 @@ import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.AfterClass;
@@ -63,8 +64,9 @@ public class TestAdvancedNetworkApplicationContext {
     @BeforeClass
     @AfterClass
     public static void start() {
-        Hazelcast.shutdownAll();
+        HazelcastInstanceFactory.terminateAll();
     }
+
 
     @Before
     public void before() {
@@ -89,10 +91,10 @@ public class TestAdvancedNetworkApplicationContext {
 
         assertEquals(5700, memberEndpointConfig.getPort());
         assertEquals(99, memberEndpointConfig.getPortCount());
-        assertFalse(memberEndpointConfig.isPortAutoIncrement());
+        assertTrue(memberEndpointConfig.isPortAutoIncrement());
         assertTrue(memberEndpointConfig.getInterfaces().isEnabled());
         assertContains(memberEndpointConfig.getInterfaces().getInterfaces(), "127.0.0.1");
-        assertTrue(memberEndpointConfig.isReuseAddress());
+        assertFalse(memberEndpointConfig.isReuseAddress());
         assertTrue(memberEndpointConfig.getSocketInterceptorConfig().isEnabled());
         assertEquals("com.hazelcast.SocketInterceptor",
                 memberEndpointConfig.getSocketInterceptorConfig().getClassName());
@@ -118,6 +120,7 @@ public class TestAdvancedNetworkApplicationContext {
 
         RestServerEndpointConfig restServerEndpointConfig = advancedNetworkConfig.getRestEndpointConfig();
         assertEquals(8080, restServerEndpointConfig.getPort());
+        assertFalse(restServerEndpointConfig.isPortAutoIncrement());
         assertContainsAll(restServerEndpointConfig.getEnabledGroups(),
                 Arrays.asList(HEALTH_CHECK, CLUSTER_READ));
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
@@ -162,7 +162,7 @@
                                namespace="hazelcast"/>
                 </hz:join>
                 <hz:member-server-socket-endpoint-config name="member-server-socket"
-                        port="${cluster.port}" port-auto-increment="true" port-count="99">
+                        port="${cluster.port}" port-auto-increment="false" port-count="99">
                     <hz:outbound-ports>
                         <hz:ports>35000-35100</hz:ports>
                         <hz:ports>36000,36100</hz:ports>
@@ -170,7 +170,7 @@
                     <hz:interfaces enabled="true">
                         <hz:interface>127.0.0.1</hz:interface>
                     </hz:interfaces>
-                    <hz:reuse-address>false</hz:reuse-address>
+                    <hz:reuse-address>true</hz:reuse-address>
                     <hz:socket-interceptor enabled="true" class-name="com.hazelcast.SocketInterceptor"/>
                     <hz:ssl enabled="false" factory-class-name="com.hazelcast.SSLContextFactory"/>
                     <hz:symmetric-encryption enabled="false"/>
@@ -200,7 +200,7 @@
                                              iteration-count="19"/>
                 </hz:wan-endpoint-config>
 
-                <hz:client-server-socket-endpoint-config port="9919" port-auto-increment="true" port-count="10">
+                <hz:client-server-socket-endpoint-config port="9919" port-auto-increment="false" port-count="10">
                     <hz:reuse-address>true</hz:reuse-address>
                 </hz:client-server-socket-endpoint-config>
 
@@ -221,7 +221,8 @@
                     </hz:icmp>
                 </hz:failure-detector>
 
-                <hz:rest-server-socket-endpoint-config port="8080" port-auto-increment="false">
+                <hz:rest-server-socket-endpoint-config port="9999" port-auto-increment="true">
+                    <hz:reuse-address>false</hz:reuse-address>
                     <hz:endpoint-groups>
                         <hz:endpoint-group name="HEALTH_CHECK" enabled="true"/>
                         <hz:endpoint-group name="CLUSTER_READ" enabled="true"/>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
@@ -162,7 +162,7 @@
                                namespace="hazelcast"/>
                 </hz:join>
                 <hz:member-server-socket-endpoint-config name="member-server-socket"
-                        port="${cluster.port}" port-auto-increment="false" port-count="99">
+                        port="${cluster.port}" port-auto-increment="true" port-count="99">
                     <hz:outbound-ports>
                         <hz:ports>35000-35100</hz:ports>
                         <hz:ports>36000,36100</hz:ports>
@@ -170,7 +170,7 @@
                     <hz:interfaces enabled="true">
                         <hz:interface>127.0.0.1</hz:interface>
                     </hz:interfaces>
-                    <hz:reuse-address>true</hz:reuse-address>
+                    <hz:reuse-address>false</hz:reuse-address>
                     <hz:socket-interceptor enabled="true" class-name="com.hazelcast.SocketInterceptor"/>
                     <hz:ssl enabled="false" factory-class-name="com.hazelcast.SSLContextFactory"/>
                     <hz:symmetric-encryption enabled="false"/>
@@ -221,7 +221,7 @@
                     </hz:icmp>
                 </hz:failure-detector>
 
-                <hz:rest-server-socket-endpoint-config port="8080">
+                <hz:rest-server-socket-endpoint-config port="8080" port-auto-increment="false">
                     <hz:endpoint-groups>
                         <hz:endpoint-group name="HEALTH_CHECK" enabled="true"/>
                         <hz:endpoint-group name="CLUSTER_READ" enabled="true"/>


### PR DESCRIPTION
Fixes https://github.com/hazelcast/hazelcast/issues/14514

There was no parsing for `reuse-address` for Spring, and the test was checking against the defaults for this property. However, the default for Windows was different, see. https://github.com/hazelcast/hazelcast/blob/master/hazelcast/src/main/java/com/hazelcast/config/ServerSocketEndpointConfig.java#L56