### PR TITLE
Remove password from the default Hazelcast configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -28,6 +28,7 @@ import com.hazelcast.config.ConfigurationException;
 import com.hazelcast.config.DiscoveryConfig;
 import com.hazelcast.config.DiscoveryStrategyConfig;
 import com.hazelcast.config.EndpointConfig;
+import com.hazelcast.config.GroupConfig;
 import com.hazelcast.config.JoinConfig;
 import com.hazelcast.config.ListenerConfig;
 import com.hazelcast.config.MemberAttributeConfig;
@@ -926,7 +927,10 @@ public class Node {
     }
 
     private void logGroupPasswordInfo() {
-        if (!isNullOrEmpty(config.getGroupConfig().getPassword())) {
+        String password = config.getGroupConfig().getPassword();
+        if (!(config.getSecurityConfig().isEnabled()
+                || isNullOrEmpty(password)
+                || GroupConfig.DEFAULT_GROUP_PASSWORD.equals(password))) {
             logger.info("A non-empty group password is configured for the Hazelcast member."
                     + " Since version 3.8.2, members with the same group name,"
                     + " but with different group passwords (that do not use authentication) form a cluster."

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -33,7 +33,6 @@
 
     <group>
         <name>dev</name>
-        <password>dev-pass</password>
     </group>
     <management-center enabled="false">http://localhost:8080/hazelcast-mancenter</management-center>
     <network>

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -21,7 +21,6 @@
 hazelcast:
   group:
     name: dev
-    password: dev-pass
   management-center:
     enabled: false
     url: http://localhost:8080/hazelcast-mancenter

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -80,8 +80,9 @@
 
     <!--
         Specifies the name and password for a cluster group you create.
-        Cluster groups allow you to create separate sub-clusters within your Hazelcast cluster to
-        create a simple security. They are also referenced in the WAN Replication configuration.
+        Cluster groups allow you to create separate sub-clusters with different names.
+        They are also referenced in the WAN Replication configuration.
+        The group password is only used when the security is enabled (Enterprise edition feature).
     -->
     <group>
         <name>dev</name>

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -69,8 +69,9 @@ hazelcast:
           secretKeyFactoryAlgorithm: PBKDF2WithHmacSHA1
   #
   # Specifies the name and password for a cluster group you create.
-  # Cluster groups allow you to create separate sub-clusters within your Hazelcast cluster to
-  # create a simple security. They are also referenced in the WAN Replication configuration.
+  # Cluster groups allow you to create separate sub-clusters with different names.
+  # They are also referenced in the WAN Replication configuration.
+  # The group password is only used when the security is enabled (Enterprise edition feature).
   group:
     name: dev
     password: dev-pass


### PR DESCRIPTION
Fixes #14260.

As the default Hazelcast configuration doesn't use Group password, we can remove it.

This PR also improves the non-empty password INFO message. It's newly only logged when all the following conditions are met:
* security is disabled
* password is not empty
* password is not the Hazelcast default one