### PR TITLE
Add 3.11 backward compatibility checks for CP Subsystem

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cp/internal/ClientCPSubsystemRollingUpgrade_3_11_Test.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cp/internal/ClientCPSubsystemRollingUpgrade_3_11_Test.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cp.internal;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.CPSubsystem;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
+import static com.hazelcast.test.OverridePropertyRule.set;
+
+// RU_COMPAT_3_11
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientCPSubsystemRollingUpgrade_3_11_Test extends HazelcastRaftTestSupport {
+
+    @Rule
+    public final OverridePropertyRule version_3_11_rule = set(HAZELCAST_INTERNAL_OVERRIDE_VERSION, Versions.V3_11.toString());
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Override
+    protected TestHazelcastInstanceFactory createTestFactory() {
+        return new TestHazelcastFactory();
+    }
+
+    @Test
+    public void whenCPDataStructureCreated_thenFailsWithUnsupportedOperationException() {
+        int clusterSize = 3;
+        for (int i = 0; i < clusterSize; i++) {
+            factory.newHazelcastInstance(createConfig(clusterSize, clusterSize));
+        }
+
+        HazelcastInstance client = ((TestHazelcastFactory) factory).newHazelcastClient();
+        CPSubsystem cpSubsystem = client.getCPSubsystem();
+
+        expectedException.expect(UnsupportedOperationException.class);
+        cpSubsystem.getAtomicLong("atomic");
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -33,6 +33,7 @@ import com.hazelcast.cp.internal.raftop.metadata.DestroyRaftNodesOp;
 import com.hazelcast.cp.internal.raftop.metadata.InitMetadataRaftGroupOp;
 import com.hazelcast.cp.internal.raftop.metadata.PublishActiveCPMembersOp;
 import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.NodeEngine;
@@ -1043,6 +1044,13 @@ public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRa
             // Hence, we need to check these flags in the reverse order here.
 
             if (!nodeEngine.getClusterService().isJoined()) {
+                scheduleSelf();
+                return true;
+            }
+
+            // RU_COMPAT_3_11
+            if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_12)) {
+                logger.fine("Cannot start initial CP members discovery since cluster version is less than 3.12.");
                 scheduleSelf();
                 return true;
             }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftInvocationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftInvocationManager.java
@@ -31,6 +31,7 @@ import com.hazelcast.cp.internal.raft.impl.util.SimpleCompletableFuture;
 import com.hazelcast.cp.internal.raftop.metadata.CreateRaftGroupOp;
 import com.hazelcast.cp.internal.raftop.metadata.GetActiveCPMembersOp;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
@@ -98,6 +99,10 @@ public class RaftInvocationManager {
     }
 
     private void checkCPSubsystemEnabled() {
+        // RU_COMPAT_3_11
+        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_12)) {
+            throw new UnsupportedOperationException("CP Subsystem is not available before version 3.12!");
+        }
         if (raftService.getConfig().getCPMemberCount() == 0) {
             throw new HazelcastException("CP Subsystem is not enabled!");
         }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -56,6 +56,7 @@ import com.hazelcast.cp.internal.raftop.metadata.RaftServicePreJoinOp;
 import com.hazelcast.cp.internal.raftop.metadata.RemoveCPMemberOp;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.GracefulShutdownAwareService;
 import com.hazelcast.spi.ManagedService;
@@ -450,6 +451,13 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
 
     @Override
     public Operation getPreJoinOperation() {
+        // RU_COMPAT_3_11
+        if (nodeEngine.getClusterService().getClusterVersion().isLessThan(Versions.V3_12)) {
+            return null;
+        }
+        if (config.getCPMemberCount() == 0) {
+            return null;
+        }
         boolean master = nodeEngine.getClusterService().isMaster();
         boolean discoveryCompleted = metadataGroupManager.isDiscoveryCompleted();
         RaftGroupId metadataGroupId = metadataGroupManager.getMetadataGroupId();

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/CPSubsystemRollingUpgrade_3_11_Test.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/CPSubsystemRollingUpgrade_3_11_Test.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.cp.internal.datastructures.atomiclong.RaftAtomicLongService;
+import com.hazelcast.instance.DefaultNodeExtension;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeExtension;
+import com.hazelcast.internal.cluster.Versions;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.mocknetwork.MockNodeContext;
+import com.hazelcast.version.Version;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.instance.BuildInfoProvider.HAZELCAST_INTERNAL_OVERRIDE_VERSION;
+import static com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance;
+import static com.hazelcast.test.OverridePropertyRule.set;
+import static com.hazelcast.test.TestHazelcastInstanceFactory.initOrCreateConfig;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+// RU_COMPAT_3_11
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class CPSubsystemRollingUpgrade_3_11_Test extends HazelcastRaftTestSupport {
+
+    @Rule
+    public final OverridePropertyRule version_3_11_rule = set(HAZELCAST_INTERNAL_OVERRIDE_VERSION, Versions.V3_11.toString());
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void whenGetCPSubsystem_onVersion_3_11_thenFailsWithUnsupportedOperationException() {
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfig(3, 3));
+        expectedException.expect(UnsupportedOperationException.class);
+        instance.getCPSubsystem();
+    }
+
+    @Test
+    public void whenGetCPSubsystem_afterVersionUpgrade_thenShouldSuccess() {
+        HazelcastInstance instance = newUpgradableHazelcastInstance(createConfig(3, 3));
+        instance.getCluster().changeClusterVersion(Versions.V3_12);
+        instance.getCPSubsystem();
+    }
+
+    @Test
+    public void whenCPSubsystemEnabled_onVersion_3_11_thenCPDiscoveryShouldNotComplete() {
+        int clusterSize = 3;
+        final HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
+        for (int i = 0; i < clusterSize; i++) {
+            instances[i] = factory.newHazelcastInstance(createConfig(clusterSize, clusterSize));
+        }
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                for (HazelcastInstance instance : instances) {
+                    RaftService service = getRaftService(instance);
+                    MetadataRaftGroupManager metadataGroupManager = service.getMetadataGroupManager();
+                    assertNull(metadataGroupManager.getLocalCPMember());
+                    assertFalse(metadataGroupManager.isDiscoveryCompleted());
+                    assertThat(metadataGroupManager.getActiveMembers(), Matchers.<CPMemberInfo>empty());
+                }
+            }
+        }, 5);
+    }
+
+    @Test
+    public void whenCPSubsystemEnabled_afterVersion_thenCPDiscoveryShouldComplete() {
+        int clusterSize = 3;
+        final HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
+        for (int i = 0; i < clusterSize; i++) {
+            instances[i] = newUpgradableHazelcastInstance(createConfig(clusterSize, clusterSize));
+        }
+
+        instances[0].getCluster().changeClusterVersion(Versions.V3_12);
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                for (HazelcastInstance instance : instances) {
+                    RaftService service = getRaftService(instance);
+                    MetadataRaftGroupManager metadataGroupManager = service.getMetadataGroupManager();
+                    assertTrue(metadataGroupManager.isDiscoveryCompleted());
+                    assertNotNull(metadataGroupManager.getLocalCPMember());
+                    assertThat(metadataGroupManager.getActiveMembers(), not(Matchers.<CPMemberInfo>empty()));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void whenCreateRaftGroupCalled_onVersion_3_11_thenFailsWithUnsupportedOperationException() {
+        int clusterSize = 3;
+        final HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
+        for (int i = 0; i < clusterSize; i++) {
+            instances[i] = factory.newHazelcastInstance(createConfig(clusterSize, clusterSize));
+        }
+
+        RaftService service = getRaftService(instances[0]);
+        expectedException.expect(UnsupportedOperationException.class);
+        service.getInvocationManager().createRaftGroup("default", 3);
+    }
+
+    @Test
+    public void whenCreateRaftGroupCalled_afterUpgrade_thenShouldSuccess() throws Exception {
+        int clusterSize = 3;
+        final HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
+        for (int i = 0; i < clusterSize; i++) {
+            instances[i] = newUpgradableHazelcastInstance(createConfig(clusterSize, clusterSize));
+        }
+
+        instances[0].getCluster().changeClusterVersion(Versions.V3_12);
+
+        RaftService service = getRaftService(instances[0]);
+        service.getInvocationManager().createRaftGroup("default", 3).get();
+    }
+
+    @Test
+    public void whenCPDataStructureCreated_onVersion_3_11_thenFailsWithUnsupportedOperationException() {
+        int clusterSize = 3;
+        final HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
+        for (int i = 0; i < clusterSize; i++) {
+            instances[i] = factory.newHazelcastInstance(createConfig(clusterSize, clusterSize));
+        }
+
+        RaftAtomicLongService service = getNodeEngineImpl(instances[0]).getService(RaftAtomicLongService.SERVICE_NAME);
+        expectedException.expect(UnsupportedOperationException.class);
+        service.createDistributedObject("atomic");
+    }
+
+    @Test
+    public void whenCPDataStructureCreated_afterUpgrade_thenShouldSuccess() {
+        int clusterSize = 3;
+        final HazelcastInstance[] instances = new HazelcastInstance[clusterSize];
+        for (int i = 0; i < clusterSize; i++) {
+            instances[i] = newUpgradableHazelcastInstance(createConfig(clusterSize, clusterSize));
+        }
+
+        instances[0].getCluster().changeClusterVersion(Versions.V3_12);
+        instances[0].getCPSubsystem().getAtomicLong("atomic").get();
+    }
+
+    private HazelcastInstance newUpgradableHazelcastInstance(Config config) {
+        return newHazelcastInstance(initOrCreateConfig(config), randomName(), new CustomNodeContext());
+    }
+
+    private class CustomNodeContext extends MockNodeContext {
+        CustomNodeContext() {
+            super(factory.getRegistry(), factory.nextAddress());
+        }
+
+        @Override
+        public NodeExtension createNodeExtension(Node node) {
+            return new AlwaysCompatibleNodeExtension(node);
+        }
+    }
+
+    private static class AlwaysCompatibleNodeExtension extends DefaultNodeExtension {
+        AlwaysCompatibleNodeExtension(Node node) {
+            super(node);
+        }
+
+        @Override
+        public boolean isNodeVersionCompatibleWith(Version clusterVersion) {
+            return true;
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNodeContext.java
@@ -46,7 +46,7 @@ public class MockNodeContext implements NodeContext {
     private final Set<Address> initiallyBlockedAddresses;
     private final List<String> nodeExtensionPriorityList;
 
-    protected MockNodeContext(TestNodeRegistry registry, Address thisAddress) {
+    public MockNodeContext(TestNodeRegistry registry, Address thisAddress) {
         this(registry, thisAddress, Collections.<Address>emptySet(), DefaultNodeContext.EXTENSION_PRIORITY_LIST);
     }
 


### PR DESCRIPTION
- CP member discovery should not start on 3.11,
but it should complete after upgrade.
- On 3.11, Raft pre-join operation should not be sent.
- Raft group creation and Raft invocations should fail on 3.11.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2788