### PR TITLE
 Increment partition state version up to the latest completed migration during master change

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -445,6 +445,8 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                         }
                     }
                 }
+
+                migrationManager.onClusterVersionChange(newVersion);
             } finally {
                 lock.unlock();
             }
@@ -662,7 +664,6 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
         assert !((ReentrantLock) lock).isHeldByCurrentThread();
         assert partitionStateManager.isInitialized();
         assert node.isMaster();
-        assert areMigrationTasksAllowed();
 
         PartitionRuntimeState partitionState = createPartitionStateInternal();
         assert partitionState != null;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionStateOperation.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.internal.partition.operation;
 
+import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.operations.JoinOperation;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
@@ -27,6 +28,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.impl.Versioned;
+import com.hazelcast.version.Version;
 
 import java.io.IOException;
 
@@ -84,15 +86,27 @@ public final class PartitionStateOperation extends AbstractPartitionOperation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        partitionState = new PartitionRuntimeState();
-        partitionState.readData(in);
+        // RU_COMPAT_3_11
+        Version version = in.getVersion();
+        if (version.isGreaterOrEqual(Versions.V3_12)) {
+            partitionState = in.readObject();
+        } else {
+            partitionState = new PartitionRuntimeState();
+            partitionState.readData(in);
+        }
         sync = in.readBoolean();
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        partitionState.writeData(out);
+        // RU_COMPAT_3_11
+        Version version = out.getVersion();
+        if (version.isGreaterOrEqual(Versions.V3_12)) {
+            out.writeObject(partitionState);
+        } else {
+            partitionState.writeData(out);
+        }
         out.writeBoolean(sync);
     }
 


### PR DESCRIPTION
During master change, when a former master terminates, new master fetches partition states
from all members, and determines the most recent partition table and completed migrations.

After deciding the partition table, partition state version will be incremented
to make it greater than the final version of the latest completed migration.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2868
RU Compat test for 3.11 -> 3.12 upgrade: https://github.com/hazelcast/hazelcast-enterprise/pull/2869