### PR TITLE
Fix closed connection related REST tests for different environments

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterMultiendpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterMultiendpointTest.java
@@ -19,17 +19,29 @@ package com.hazelcast.internal.ascii;
 import com.hazelcast.config.AdvancedNetworkConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.RestServerEndpointConfig;
+import org.junit.Ignore;
 
 public class RestClusterMultiendpointTest
         extends RestClusterTest {
 
     @Override
+    protected Config createConfig() {
+        Config c = new Config();
+        AdvancedNetworkConfig anc = c.getAdvancedNetworkConfig();
+        anc.setEnabled(true);
+        return c;
+    }
+
+    @Override
     protected Config createConfigWithRestEnabled() {
-        Config config = new Config();
-        AdvancedNetworkConfig anc = config.getAdvancedNetworkConfig();
-        anc.setEnabled(true)
-           .setRestEndpointConfig(new RestServerEndpointConfig().enableAllGroups());
+        Config config = createConfig();
+        config.getAdvancedNetworkConfig().setRestEndpointConfig(new RestServerEndpointConfig().enableAllGroups());
         return config;
     }
 
+    @Override
+    @Ignore("There is no port set for multi-endpoint when REST is disabled")
+    public void testDisabledRest()
+            throws Exception {
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestClusterTest.java
@@ -40,7 +40,6 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
-import java.net.SocketException;
 import java.util.concurrent.CountDownLatch;
 
 import static com.hazelcast.test.HazelcastTestSupport.assertClusterStateEventually;
@@ -70,8 +69,12 @@ public class RestClusterTest {
         factory.terminateAll();
     }
 
+    protected Config createConfig() {
+        return new Config();
+    }
+
     protected Config createConfigWithRestEnabled() {
-        Config config = new Config();
+        Config config = createConfig();
         RestApiConfig restApiConfig = new RestApiConfig().setEnabled(true).enableAllGroups();
         config.getNetworkConfig().setRestApiConfig(restApiConfig);
         return config;
@@ -85,13 +88,14 @@ public class RestClusterTest {
     @Test
     public void testDisabledRest() throws Exception {
         // REST should be disabled by default
-        HazelcastInstance instance = factory.newHazelcastInstance(new Config());
+        HazelcastInstance instance = factory.newHazelcastInstance(createConfig());
         HTTPCommunicator communicator = new HTTPCommunicator(instance);
 
         try {
             communicator.getClusterInfo();
             fail("Rest is disabled. Not expected to reach here!");
-        } catch (SocketException ignored) {
+        } catch (IOException ignored) {
+            // ignored
         }
     }
 
@@ -298,7 +302,7 @@ public class RestClusterTest {
         assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, communicator.getClusterHealthResponseCode("/unknown-parameter"));
     }
 
-    @Test(expected = SocketException.class)
+    @Test(expected = IOException.class)
     public void fail_with_deactivatedHealthCheck() throws Exception {
         // Healthcheck REST URL is deactivated by default - no passed config on purpose
         HazelcastInstance instance = factory.newHazelcastInstance(null);


### PR DESCRIPTION
There seems to be a discrepancy among different environments and how connection close is handled.
For example Windows is throwing a `NoHttpResponseException` upon `socket.read() == -1` whereas on *nix environment it detects the stale connection and throws a `SocketException`

Fix changes the expected exception to be the base class of both mentioned above.
Verified that the connection is properly closed on the server side to make sure we have no problem there. I also found references of this issue online with the Apache library we use.

One test is ignored for multi-endpoint since there is no port to target to make the assertion, its not relevant on this setup.

Fixes: https://github.com/hazelcast/hazelcast/issues/14470