### PR TITLE
Re-enable blocking check from generic client threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/client/CreateRaftGroupMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/client/CreateRaftGroupMessageTask.java
@@ -19,6 +19,7 @@ package com.hazelcast.cp.internal.datastructures.spi.client;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPGroupCreateCPGroupCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
+import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.cp.internal.RaftGroupId;
 import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.instance.Node;
@@ -29,7 +30,8 @@ import java.security.Permission;
 /**
  * Client message task for Raft group creation
  */
-public class CreateRaftGroupMessageTask extends AbstractMessageTask<CPGroupCreateCPGroupCodec.RequestParameters> {
+public class CreateRaftGroupMessageTask extends AbstractMessageTask<CPGroupCreateCPGroupCodec.RequestParameters>
+        implements BlockingMessageTask {
 
     public CreateRaftGroupMessageTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
@@ -74,6 +76,6 @@ public class CreateRaftGroupMessageTask extends AbstractMessageTask<CPGroupCreat
 
     @Override
     public Object[] getParameters() {
-        return new Object[] {parameters.proxyName};
+        return new Object[]{parameters.proxyName};
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -173,13 +173,13 @@ final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
 
     @Override
     public E get() throws InterruptedException, ExecutionException {
-//        assert (!Thread.currentThread().getName().contains("client.thread"));
+        assert (!Thread.currentThread().getName().contains("client.thread"));
         return super.get();
     }
 
     @Override
     public E get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-//        assert (!Thread.currentThread().getName().contains("client.thread"));
+        assert (!Thread.currentThread().getName().contains("client.thread"));
         return super.get(timeout, unit);
     }
 }


### PR DESCRIPTION
After marking jet threads we can reanable the check

related to https://github.com/hazelcast/hazelcast/issues/4641