### PR TITLE
Pipelining perf improvement

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxySupport.java
@@ -115,6 +115,7 @@ import static com.hazelcast.map.impl.EntryRemovingProcessor.ENTRY_REMOVING_PROCE
 import static com.hazelcast.map.impl.LocalMapStatsProvider.EMPTY_LOCAL_MAP_STATS;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.query.Target.createPartitionTarget;
+import static com.hazelcast.util.ConcurrencyUtil.CALLER_RUNS;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static com.hazelcast.util.IterableUtil.nullToEmpty;
 import static com.hazelcast.util.MapUtil.createHashMap;
@@ -378,7 +379,7 @@ abstract class MapProxySupport<K, V>
                     .invoke();
 
             if (statisticsEnabled) {
-                future.andThen(new IncrementStatsExecutionCallback<Data>(operation, startTimeNanos));
+                future.andThen(new IncrementStatsExecutionCallback<Data>(operation, startTimeNanos), CALLER_RUNS);
             }
 
             return future;
@@ -458,7 +459,7 @@ abstract class MapProxySupport<K, V>
             InternalCompletableFuture<Data> future = operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId);
 
             if (statisticsEnabled) {
-                future.andThen(new IncrementStatsExecutionCallback<Data>(operation, startTimeNanos));
+                future.andThen(new IncrementStatsExecutionCallback<Data>(operation, startTimeNanos), CALLER_RUNS);
             }
             return future;
         } catch (Throwable t) {
@@ -642,7 +643,7 @@ abstract class MapProxySupport<K, V>
             InternalCompletableFuture<Data> future = operationService.invokeOnPartition(SERVICE_NAME, operation, partitionId);
 
             if (statisticsEnabled) {
-                future.andThen(new IncrementStatsExecutionCallback<Data>(operation, startTimeNanos));
+                future.andThen(new IncrementStatsExecutionCallback<Data>(operation, startTimeNanos), CALLER_RUNS);
             }
 
             return future;

--- a/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ConcurrencyUtil.java
@@ -17,6 +17,7 @@
 package com.hazelcast.util;
 
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
@@ -25,6 +26,23 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
  * from a {@link ConcurrentMap} with a {@link ConstructorFunction}.
  */
 public final class ConcurrencyUtil {
+
+    /**
+     * The Caller runs executor is an Executor that executes the task on the calling thread.
+     * This is useful when an Executor is required, but offloading to a different thread
+     * is very costly and it is faster to run on the calling thread.
+     */
+    public static final Executor CALLER_RUNS = new Executor() {
+        @Override
+        public void execute(Runnable command) {
+            command.run();
+        }
+
+        @Override
+        public String toString() {
+            return "CALLER_RUNS";
+        }
+    };
 
     private ConcurrencyUtil() {
     }


### PR DESCRIPTION
Replaced the semaphore based approach by a non blocking based approach in combination with LockSupport. I'm not sure of the perf degradation was caused by contention on the semaphore or due to gc related issues due to cleaning up the monitor. But the new approach performs a lot better.

Also map statistics are updated on the calling thread instead of offloaded to the ASYNC executor because it was faster.