### PR TITLE
Notify WAN invocations of closed connections

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/InternalOperationService.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.impl.operationservice;
 
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.internal.management.dto.SlowOperationDTO;
+import com.hazelcast.nio.Address;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.impl.PartitionSpecificRunnable;
@@ -145,4 +146,11 @@ public interface InternalOperationService extends OperationService {
     List<SlowOperationDTO> getSlowOperationDTOs();
 
     <V> void asyncInvokeOnPartition(String serviceName, Operation op, int partitionId, ExecutionCallback<V> callback);
+
+    /**
+     * Cleans up heartbeats and fails invocations for the given endpoint.
+     *
+     * @param endpoint the endpoint that has left
+     */
+    void onEndpointLeft(Address endpoint);
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationMonitor.java
@@ -193,6 +193,11 @@ public class InvocationMonitor implements Consumer<Packet>, MetricsProvider {
         scheduler.execute(new OnMemberLeftTask(member, memberListVersion));
     }
 
+    /**
+     * Cleans up heartbeats and fails invocations for the given endpoint.
+     *
+     * @param endpoint the endpoint that has left
+     */
     void onEndpointLeft(Address endpoint) {
         scheduler.execute(new OnEndpointLeftTask(endpoint));
     }
@@ -346,6 +351,9 @@ public class InvocationMonitor implements Consumer<Packet>, MetricsProvider {
         }
     }
 
+    /**
+     * Task for cleaning up heartbeats and failing invocations for an endpoint which has left.
+     */
     private final class OnEndpointLeftTask extends MonitorTask {
         private final Address endpoint;
 
@@ -359,7 +367,7 @@ public class InvocationMonitor implements Consumer<Packet>, MetricsProvider {
 
             for (Invocation invocation : invocationRegistry) {
                 if (endpoint.equals(invocation.getTargetAddress())) {
-                    invocation.notifyError(new MemberLeftException("Endpoint " + endpoint + " has "));
+                    invocation.notifyError(new MemberLeftException("Endpoint " + endpoint + " has left"));
                 }
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -444,11 +444,7 @@ public final class OperationServiceImpl implements InternalOperationService, Met
         invocationMonitor.onMemberLeft(member);
     }
 
-    /**
-     * Cleans up heartbeats and fails invocations for the given endpoint.
-     *
-     * @param endpoint the endpoint that has left
-     */
+    @Override
     public void onEndpointLeft(Address endpoint) {
         invocationMonitor.onEndpointLeft(endpoint);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -444,6 +444,11 @@ public final class OperationServiceImpl implements InternalOperationService, Met
         invocationMonitor.onMemberLeft(member);
     }
 
+    /**
+     * Cleans up heartbeats and fails invocations for the given endpoint.
+     *
+     * @param endpoint the endpoint that has left
+     */
     public void onEndpointLeft(Address endpoint) {
         invocationMonitor.onEndpointLeft(endpoint);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -444,6 +444,10 @@ public final class OperationServiceImpl implements InternalOperationService, Met
         invocationMonitor.onMemberLeft(member);
     }
 
+    public void onEndpointLeft(Address endpoint) {
+        invocationMonitor.onEndpointLeft(endpoint);
+    }
+
     public void reset() {
         Throwable cause = new LocalMemberResetException(node.getLocalMember() + " has reset.");
         invocationRegistry.reset(cause);

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
@@ -185,6 +185,9 @@ public class MockConnection implements Connection {
 
     @Override
     public String toString() {
-        return "MockConnection{" + "localEndpoint=" + localEndpoint + ", remoteEndpoint=" + remoteEndpoint + '}';
+        return "MockConnection{"
+                + "localEndpoint=" + localEndpoint
+                + ", remoteNodeEngine=" + remoteNodeEngine
+                + ", alive=" + isAlive() + '}';
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockConnection.java
@@ -187,7 +187,7 @@ public class MockConnection implements Connection {
     public String toString() {
         return "MockConnection{"
                 + "localEndpoint=" + localEndpoint
-                + ", remoteNodeEngine=" + remoteNodeEngine
+                + ", remoteEndpoint=" + remoteEndpoint
                 + ", alive=" + isAlive() + '}';
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNetworkingService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNetworkingService.java
@@ -17,9 +17,9 @@
 package com.hazelcast.test.mocknetwork;
 
 import com.hazelcast.core.Member;
+import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
-import com.hazelcast.instance.EndpointQualifier;
 import com.hazelcast.internal.networking.Networking;
 import com.hazelcast.internal.util.concurrent.ThreadFactoryImpl;
 import com.hazelcast.logging.ILogger;
@@ -278,6 +278,14 @@ class MockNetworkingService
                 if (!ns.mapConnections.remove(endPoint, connection)) {
                     return;
                 }
+
+                NetworkingService remoteNetworkingService = connection.remoteNodeEngine.getNode().getNetworkingService();
+                Connection remoteConnection = remoteNetworkingService.getEndpointManager(MEMBER)
+                                                                     .getConnection(connection.localEndpoint);
+                if (remoteConnection != null) {
+                    remoteConnection.close("Connection closed by the other side", null);
+                }
+
                 ns.logger.info("Removed connection to endpoint: " + endPoint + ", connection: " + connection);
                 fireConnectionRemovedEvent(connection, endPoint);
             }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNetworkingService.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/MockNetworkingService.java
@@ -280,7 +280,10 @@ class MockNetworkingService
                 }
 
                 NetworkingService remoteNetworkingService = connection.remoteNodeEngine.getNode().getNetworkingService();
-                Connection remoteConnection = remoteNetworkingService.getEndpointManager(MEMBER)
+                // all mock implementations of networking service ignore the provided endpoint qualifier
+                // so we pass in null. Once they are changed to use the parameter, we should be notified
+                // and this parameter can be changed
+                Connection remoteConnection = remoteNetworkingService.getEndpointManager(null)
                                                                      .getConnection(connection.localEndpoint);
                 if (remoteConnection != null) {
                     remoteConnection.close("Connection closed by the other side", null);


### PR DESCRIPTION
To speed up failover of WAN batch invocations to the target cluster, we
need to react to closed connections. In a single cluster, invocations
are cleaned up as a result of a member leave event but for WAN, we don't
receive events from the target cluster so a closed connection is the
best way of determining that the invocation has failed and can be
retried. Otherwise, the connection will hang for the duration of the
operation timeout before failing, the connection being closed and
the WAN invocation being retried.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2635