### PR TITLE
Protect sensitive configuration by Security Manager permission check

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -26,6 +26,7 @@ import com.hazelcast.internal.journal.EventJournal;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.partition.strategy.StringPartitioningStrategy;
+import com.hazelcast.security.jsm.HazelcastRuntimePermission;
 import com.hazelcast.util.StringUtil;
 import com.hazelcast.util.function.BiConsumer;
 
@@ -3387,8 +3388,14 @@ public class Config {
      * is used to enable enterprise features.
      *
      * @return the license key
+     * @throws SecurityException If a security manager exists and the calling method doesn't have corresponding
+     *         {@link HazelcastRuntimePermission}
      */
     public String getLicenseKey() {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(new HazelcastRuntimePermission("com.hazelcast.config.Config.getLicenseKey"));
+        }
         return licenseKey;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NetworkConfig.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.config;
 
+import com.hazelcast.security.jsm.HazelcastRuntimePermission;
 import com.hazelcast.util.StringUtil;
 
 import java.util.Collection;
@@ -315,8 +316,14 @@ public class NetworkConfig {
      *
      * @return the SSLConfig
      * @see #setSSLConfig(SSLConfig)
+     * @throws SecurityException If a security manager exists and the calling method doesn't have corresponding
+     *         {@link HazelcastRuntimePermission}
      */
     public SSLConfig getSSLConfig() {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(new HazelcastRuntimePermission("com.hazelcast.config.NetworkConfig.getSSLConfig"));
+        }
         return sslConfig;
     }
 
@@ -326,8 +333,14 @@ public class NetworkConfig {
      * @param sslConfig the SSLConfig
      * @return the updated NetworkConfig
      * @see #getSSLConfig()
+     * @throws SecurityException If a security manager exists and the calling method doesn't have corresponding
+     *         {@link HazelcastRuntimePermission}
      */
     public NetworkConfig setSSLConfig(SSLConfig sslConfig) {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            sm.checkPermission(new HazelcastRuntimePermission("com.hazelcast.config.NetworkConfig.setSSLConfig"));
+        }
         this.sslConfig = sslConfig;
         return this;
     }

--- a/hazelcast/src/main/java/com/hazelcast/security/jsm/HazelcastRuntimePermission.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/jsm/HazelcastRuntimePermission.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.security.jsm;
+
+import java.security.BasicPermission;
+
+/**
+ * Class which holds named Hazelcast permissions for Security Manager checks. The list of actions is unused in this class.
+ * Permission name supports {@code *} wildcard as defined in {@link BasicPermission} class.
+ * <p>
+ * Usage of protected method name as a target name is recommended. E.g.
+ *
+ * <pre>
+ * SecurityManager sm = System.getSecurityManager();
+ * if (sm != null) {
+ *     sm.checkPermission(new HazelcastRuntimePermission("com.hazelcast.config.Config.getLicenseKey"));
+ * }
+ * </pre>
+ */
+public class HazelcastRuntimePermission extends BasicPermission {
+
+    private static final long serialVersionUID = -8927678876656102420L;
+
+    /**
+     * Creates permission with given name.
+     */
+    public HazelcastRuntimePermission(String name) {
+        super(name);
+    }
+
+    /**
+     * Creates permission with given name. The actions list is ignored.
+     */
+    public HazelcastRuntimePermission(String name, String actions) {
+        super(name, actions);
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/security/jsm/package-info.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/jsm/package-info.java
@@ -15,8 +15,8 @@
  */
 
 /**
- * Contains Hazelcast client permissions.
+ * Contains Java Security Manager permissions.
  *
- * @see com.hazelcast.security.jsm
+ * @see com.hazelcast.security.permission
  */
-package com.hazelcast.security.permission;
+package com.hazelcast.security.jsm;


### PR DESCRIPTION
This PR adds security manager protection to member config methods.

This allows using user-code deployments in a more secure way.
