### PR TITLE
Fix for NoDataMemberInClusterEx in ClientPartitionService

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientPartitionService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientPartitionService.java
@@ -37,10 +37,4 @@ public interface ClientPartitionService extends ClusterSwitchAwareService {
 
     Partition getPartition(int partitionId);
 
-    /**
-     * @param partitionCount new partition count
-     * @return true if partitions are not checked yet or last partition count is equal to the partition count provided,
-     * otherwise return false
-     */
-    boolean isPartitionCountConsistent(int partitionCount);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollection.java
@@ -31,6 +31,7 @@ import java.util.NoSuchElementException;
  * its internal {@link com.hazelcast.core.Member} collection. It reflects changes in the internal collection.
  * Mutating methods throw {@link java.lang.UnsupportedOperationException}
  * It is mainly used for querying a member list.
+ *
  * @param <M> A subclass of {@link com.hazelcast.core.Member} interface
  */
 public final class MemberSelectingCollection<M extends Member> implements Collection<M> {
@@ -46,13 +47,16 @@ public final class MemberSelectingCollection<M extends Member> implements Collec
 
     @Override
     public int size() {
+        return count(members, selector);
+    }
+
+    public static <M extends Member> int count(Collection<M> members, MemberSelector memberSelector) {
         int size = 0;
         for (M member : members) {
-            if (selector.select(member)) {
+            if (memberSelector.select(member)) {
                 size++;
             }
         }
-
         return size;
     }
 
@@ -174,7 +178,7 @@ public final class MemberSelectingCollection<M extends Member> implements Collec
             if (member != null || hasNext()) {
                 nextMember = member;
                 member = null;
-            } else  {
+            } else {
                 throw new NoSuchElementException();
             }
 


### PR DESCRIPTION
Now, it is possible to have an empty member list when switching clusters
PartitionService were relying on member list to check if cluster.
Therefore it could interpret an empty member list in case
of switching as no data member falsely.

if member list is empty we will return without waiting
getPartitionOwner method will return null as a result.
The callers of `getPartitionOwner` already handles null response

fixes hazelcast/hazelcast-enterprise#2770
tests hazelcast/hazelcast-enterprise#2794
