### PR TITLE
Fix the check for illegal wait on the wrong thread

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/util/executor/PoolExecutorUnblockableThreadFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/executor/PoolExecutorUnblockableThreadFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.executor;
+
+import com.hazelcast.util.executor.PoolExecutorThreadFactory;
+
+public class PoolExecutorUnblockableThreadFactory extends PoolExecutorThreadFactory {
+
+    public PoolExecutorUnblockableThreadFactory(String threadNamePrefix, ClassLoader classLoader) {
+        super(threadNamePrefix, classLoader);
+    }
+
+    @Override
+    protected ManagedThread createThread(Runnable r, String name, int id) {
+        return new UnblockableManagedThread(r, name, id);
+    }
+
+    private class UnblockableManagedThread extends ManagedThread implements UnblockableThread {
+
+        UnblockableManagedThread(Runnable target, String name, int id) {
+            super(target, name, id);
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/executor/PoolExecutorUnblockableThreadFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/executor/PoolExecutorUnblockableThreadFactory.java
@@ -18,6 +18,10 @@ package com.hazelcast.internal.util.executor;
 
 import com.hazelcast.util.executor.PoolExecutorThreadFactory;
 
+/**
+ * This factory is implemented to have a thread factory that creates threads with `UnblockableThread` interface.
+ * see @{@link UnblockableThread}
+ */
 public class PoolExecutorUnblockableThreadFactory extends PoolExecutorThreadFactory {
 
     public PoolExecutorUnblockableThreadFactory(String threadNamePrefix, ClassLoader classLoader) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/executor/UnblockableThread.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/executor/UnblockableThread.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.executor;
+
+/**
+ * Marker interface for threads that waiting for the responses operations are not allowed.
+ * InvocationFuture.get/join operations have the following check
+ * assert !(waiter instanceof UnblockableThread);
+ */
+public interface UnblockableThread {
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
@@ -102,8 +102,26 @@ public interface ExecutionService {
      */
     String MAP_LOAD_ALL_KEYS_EXECUTOR = "hz:map-loadAllKeys";
 
+    /**
+     * @param name          for the executor service
+     * @param poolSize      the maximum number of threads to allow in the pool
+     * @param queueCapacity the queue to use for holding tasks before they are executed.
+     * @param type          @{@link ExecutorType#CACHED} or @{@link ExecutorType#CONCRETE}
+     * @return the created managed executor service
+     */
     ManagedExecutorService register(String name, int poolSize, int queueCapacity, ExecutorType type);
 
+    /**
+     * This register method creates the executor only on @{@link ExecutorType#CONCRETE} type.
+     * The executors with @{@link ExecutorType#CACHED} types can not have custom thread factory since they will share the
+     * threads with other @{@link ExecutorType#CACHED} executors.
+     *
+     * @param name          for the executor service
+     * @param poolSize      the maximum number of threads to allow in the pool
+     * @param queueCapacity the queue to use for holding tasks before they are executed.
+     * @param threadFactory custom thread factory for the managed executor service.
+     * @return managed executor service
+     */
     ManagedExecutorService register(String name, int poolSize, int queueCapacity, ThreadFactory threadFactory);
 
     ManagedExecutorService getExecutor(String name);

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
@@ -23,6 +23,7 @@ import com.hazelcast.util.executor.ManagedExecutorService;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -102,6 +103,8 @@ public interface ExecutionService {
     String MAP_LOAD_ALL_KEYS_EXECUTOR = "hz:map-loadAllKeys";
 
     ManagedExecutorService register(String name, int poolSize, int queueCapacity, ExecutorType type);
+
+    ManagedExecutorService register(String name, int poolSize, int queueCapacity, ThreadFactory threadFactory);
 
     ManagedExecutorService getExecutor(String name);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvocationFuture.java
@@ -171,15 +171,4 @@ final class InvocationFuture<E> extends AbstractInvocationFuture<E> {
         }
     }
 
-    @Override
-    public E get() throws InterruptedException, ExecutionException {
-        assert (!Thread.currentThread().getName().contains("client.thread"));
-        return super.get();
-    }
-
-    @Override
-    public E get(final long timeout, final TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-        assert (!Thread.currentThread().getName().contains("client.thread"));
-        return super.get(timeout, unit);
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/ExecutorType.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/ExecutorType.java
@@ -17,5 +17,12 @@
 package com.hazelcast.util.executor;
 
 public enum ExecutorType {
-    CACHED, CONCRETE
+    /**
+     * Executor will use share ThreadPoolExecutor with unlimited pools size with other CACHED Executors
+     */
+    CACHED,
+    /**
+     * Executor will have its own ThreadPoolExecutor
+     */
+    CONCRETE
 }

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/PoolExecutorThreadFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/PoolExecutorThreadFactory.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.hazelcast.util.EmptyStatement.ignore;
 
-public final class PoolExecutorThreadFactory extends AbstractExecutorThreadFactory {
+public class PoolExecutorThreadFactory extends AbstractExecutorThreadFactory {
 
     private final String threadNamePrefix;
     private final AtomicInteger idGen = new AtomicInteger(0);
@@ -41,12 +41,16 @@ public final class PoolExecutorThreadFactory extends AbstractExecutorThreadFacto
             id = idGen.incrementAndGet();
         }
         String name = threadNamePrefix + id;
+        return createThread(r, name, id);
+    }
+
+    protected ManagedThread createThread(Runnable r, String name, int id) {
         return new ManagedThread(r, name, id);
     }
 
-    private class ManagedThread extends HazelcastManagedThread {
+    protected class ManagedThread extends HazelcastManagedThread {
 
-        protected final int id;
+        private final int id;
 
         public ManagedThread(Runnable target, String name, int id) {
             super(target, name);


### PR DESCRIPTION
The tasks that run on server side client generic thread should not be
blocking. We had a check with thread name to prevent this illegal
usage in the future. The check is improved with the proper interface.
`UnblockableThread` interface is implemented for this purpose.

Code executing on these threads are not allowed to call invocationFuture.get/join.

related to https://github.com/hazelcast/hazelcast/issues/4641