### PR TITLE
Multiple YAML configuration fixes

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -103,6 +103,10 @@
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]config[\\/]yaml[\\/]ScalarTextNodeAdapter"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]config[\\/]yaml[\\/]ElementAdapter"/>
 
+    <!-- YAML -->
+    <suppress checks="BooleanExpressionComplexity" files="com[\\/]hazelcast[\\/]internal[\\/]yaml[\\/]YamlUtil"/>
+
+
     <!-- Concurrent -->
     <suppress checks="Javadoc(Method|Type|Variable)" files="com[\\/]hazelcast[\\/]concurrent[\\/]"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]concurrent[\\/]atomiclong[\\/]AtomicLongProxy"/>

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientClasspathXmlConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientClasspathXmlConfig.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
@@ -36,7 +37,7 @@ public class ClientClasspathXmlConfig extends ClientConfig {
      *
      * @param resource the resource, an XML configuration file from the classpath
      * @throws IllegalArgumentException if the resource could not be found
-     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     * @throws HazelcastException if the XML content is invalid
      */
     public ClientClasspathXmlConfig(String resource) {
         this(resource, System.getProperties());
@@ -49,7 +50,7 @@ public class ClientClasspathXmlConfig extends ClientConfig {
      * @param resource   the resource, an XML configuration file from the classpath
      * @param properties the Properties to resolve variables in the XML
      * @throws IllegalArgumentException if the resource could not be found or if properties is {@code null}
-     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     * @throws HazelcastException if the XML content is invalid
      */
     public ClientClasspathXmlConfig(String resource, Properties properties) {
         this(Thread.currentThread().getContextClassLoader(), resource, properties);
@@ -62,7 +63,7 @@ public class ClientClasspathXmlConfig extends ClientConfig {
      * @param resource    the resource, an XML configuration file from the classpath
      * @param properties  the properties used to resolve variables in the XML
      * @throws IllegalArgumentException if classLoader or resource is {@code null}, or if the resource is not found
-     * @throws com.hazelcast.core.HazelcastException if the XML content is invalid
+     * @throws HazelcastException if the XML content is invalid
      */
     public ClientClasspathXmlConfig(ClassLoader classLoader, String resource, Properties properties) {
         if (classLoader == null) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientClasspathYamlConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientClasspathYamlConfig.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.config;
 
+import com.hazelcast.core.HazelcastException;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 
@@ -35,7 +36,7 @@ public class ClientClasspathYamlConfig extends ClientConfig {
      *
      * @param resource the resource, an YAML configuration file from the classpath
      * @throws IllegalArgumentException              if the resource could not be found
-     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     * @throws HazelcastException if the YAML content is invalid
      */
     public ClientClasspathYamlConfig(String resource) {
         this(resource, System.getProperties());
@@ -48,7 +49,7 @@ public class ClientClasspathYamlConfig extends ClientConfig {
      * @param resource   the resource, an YAML configuration file from the classpath
      * @param properties the Properties to resolve variables in the YAML
      * @throws IllegalArgumentException              if the resource could not be found or if properties is {@code null}
-     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     * @throws HazelcastException if the YAML content is invalid
      */
     public ClientClasspathYamlConfig(String resource, Properties properties) {
         this(Thread.currentThread().getContextClassLoader(), resource, properties);
@@ -61,7 +62,7 @@ public class ClientClasspathYamlConfig extends ClientConfig {
      * @param resource    the resource, an YAML configuration file from the classpath
      * @param properties  the properties used to resolve variables in the YAML
      * @throws IllegalArgumentException              if classLoader or resource is {@code null}, or if the resource is not found
-     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     * @throws HazelcastException if the YAML content is invalid
      */
     public ClientClasspathYamlConfig(ClassLoader classLoader, String resource, Properties properties) {
         if (classLoader == null) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientClasspathYamlConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientClasspathYamlConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * A {@link ClientConfig} which is initialized by loading an YAML configuration file from the classpath.
+ */
+public class ClientClasspathYamlConfig extends ClientConfig {
+    private static final ILogger LOGGER = Logger.getLogger(ClientClasspathYamlConfig.class);
+
+    /**
+     * Creates a config which is loaded from a classpath resource using the
+     * Thread.currentThread contextClassLoader. The System.properties are used to resolve variables
+     * in the YAML.
+     *
+     * @param resource the resource, an YAML configuration file from the classpath
+     * @throws IllegalArgumentException              if the resource could not be found
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public ClientClasspathYamlConfig(String resource) {
+        this(resource, System.getProperties());
+    }
+
+    /**
+     * Creates a config which is loaded from a classpath resource using the
+     * Thread.currentThread contextClassLoader.
+     *
+     * @param resource   the resource, an YAML configuration file from the classpath
+     * @param properties the Properties to resolve variables in the YAML
+     * @throws IllegalArgumentException              if the resource could not be found or if properties is {@code null}
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public ClientClasspathYamlConfig(String resource, Properties properties) {
+        this(Thread.currentThread().getContextClassLoader(), resource, properties);
+    }
+
+    /**
+     * Creates a config which is loaded from a classpath resource.
+     *
+     * @param classLoader the ClassLoader used to load the resource
+     * @param resource    the resource, an YAML configuration file from the classpath
+     * @param properties  the properties used to resolve variables in the YAML
+     * @throws IllegalArgumentException              if classLoader or resource is {@code null}, or if the resource is not found
+     * @throws com.hazelcast.core.HazelcastException if the YAML content is invalid
+     */
+    public ClientClasspathYamlConfig(ClassLoader classLoader, String resource, Properties properties) {
+        if (classLoader == null) {
+            throw new IllegalArgumentException("classLoader can't be null");
+        }
+        if (resource == null) {
+            throw new IllegalArgumentException("resource can't be null");
+        }
+        if (properties == null) {
+            throw new IllegalArgumentException("properties can't be null");
+        }
+
+        LOGGER.info("Configuring Hazelcast Client from '" + resource + "'.");
+        InputStream in = classLoader.getResourceAsStream(resource);
+        if (in == null) {
+            throw new IllegalArgumentException("Specified resource '" + resource + "' could not be found!");
+        }
+        YamlClientConfigBuilder yamlClientConfigBuilder = new YamlClientConfigBuilder(in);
+        yamlClientConfigBuilder.setProperties(properties);
+        yamlClientConfigBuilder.build(this, classLoader);
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/AbstractClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/AbstractClientConfigImportVariableReplacementTest.java
@@ -88,6 +88,9 @@ public abstract class AbstractClientConfigImportVariableReplacementTest extends 
     @Test
     public abstract void testReplaceVariablesUseSystemProperties() throws Exception;
 
+    @Test
+    public abstract void testReplaceVariablesWithClasspathConfig();
+
     protected static File createConfigFile(String filename, String suffix) throws IOException {
         File file = createTempFile(filename, suffix);
         file.setWritable(true);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/AbstractClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/AbstractClientConfigImportVariableReplacementTest.java
@@ -85,6 +85,9 @@ public abstract class AbstractClientConfigImportVariableReplacementTest extends 
     @Test
     public abstract void testImportGroupConfigFromClassPath();
 
+    @Test
+    public abstract void testReplaceVariablesUseSystemProperties() throws Exception;
+
     protected static File createConfigFile(String filename, String suffix) throws IOException {
         File file = createTempFile(filename, suffix);
         file.setWritable(true);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -358,7 +358,9 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
     static ClientConfig buildConfig(String xml, Properties properties) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
         XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder(bis);
-        configBuilder.setProperties(properties);
+        if (properties != null) {
+            configBuilder.setProperties(properties);
+        }
         return configBuilder.build();
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
@@ -317,4 +317,19 @@ public class XmlClientConfigImportVariableReplacementTest extends AbstractClient
         assertEquals("cluster1", groupConfig.getName());
         assertEquals("cluster1pass", groupConfig.getPassword());
     }
+
+    @Override
+    @Test
+    public void testReplaceVariablesUseSystemProperties() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "    <properties>\n"
+                + "        <property name=\"prop\">${variable}</property>\n"
+                + "    </properties>\n"
+                + HAZELCAST_CLIENT_END_TAG;
+
+        System.setProperty("variable", "foobar");
+        ClientConfig config = buildConfig(xml);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigImportVariableReplacementTest.java
@@ -332,4 +332,13 @@ public class XmlClientConfigImportVariableReplacementTest extends AbstractClient
 
         assertEquals("foobar", config.getProperty("prop"));
     }
+
+    @Override
+    @Test
+    public void testReplaceVariablesWithClasspathConfig() {
+        System.setProperty("variable", "foobar");
+        ClientConfig config = new ClientClasspathXmlConfig("test-hazelcast-client-variable.xml");
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigImportVariableReplacementTest.java
@@ -313,4 +313,17 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
         assertEquals("cluster1pass", groupConfig.getPassword());
     }
 
+    @Override
+    @Test
+    public void testReplaceVariablesUseSystemProperties() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  properties:\n"
+                + "    prop: ${variable}";
+
+        System.setProperty("variable", "foobar");
+        ClientConfig config = buildConfig(yaml);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigImportVariableReplacementTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigImportVariableReplacementTest.java
@@ -326,4 +326,15 @@ public class YamlClientConfigImportVariableReplacementTest extends AbstractClien
 
         assertEquals("foobar", config.getProperty("prop"));
     }
+
+    @Override
+    @Test
+    public void testReplaceVariablesWithClasspathConfig() {
+        Properties properties = new Properties();
+        properties.put("variable", "foobar");
+        ClientConfig config = new ClientClasspathYamlConfig("test-hazelcast-client-variable.yaml", properties);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractYamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractYamlConfigBuilder.java
@@ -48,7 +48,7 @@ import static com.hazelcast.util.StringUtil.isNullOrEmpty;
  */
 public abstract class AbstractYamlConfigBuilder {
     private final Set<String> currentlyImportedFiles = new HashSet<String>();
-    private Properties properties;
+    private Properties properties = System.getProperties();
 
     /**
      * Imports external YAML documents into the provided main YAML document.

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -1898,24 +1898,28 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
         }
     }
 
-    private void cacheListenerHandle(Node n, CacheSimpleConfig cacheSimpleConfig) {
+    protected void cacheListenerHandle(Node n, CacheSimpleConfig cacheSimpleConfig) {
         for (Node listenerNode : childElements(n)) {
             if ("cache-entry-listener".equals(cleanNodeName(listenerNode))) {
-                CacheSimpleEntryListenerConfig listenerConfig = new CacheSimpleEntryListenerConfig();
-                for (Node listenerChildNode : childElements(listenerNode)) {
-                    if ("cache-entry-listener-factory".equals(cleanNodeName(listenerChildNode))) {
-                        listenerConfig.setCacheEntryListenerFactory(getAttribute(listenerChildNode, "class-name"));
-                    }
-                    if ("cache-entry-event-filter-factory".equals(cleanNodeName(listenerChildNode))) {
-                        listenerConfig.setCacheEntryEventFilterFactory(getAttribute(listenerChildNode, "class-name"));
-                    }
-                }
-                NamedNodeMap attrs = listenerNode.getAttributes();
-                listenerConfig.setOldValueRequired(getBooleanValue(getTextContent(attrs.getNamedItem("old-value-required"))));
-                listenerConfig.setSynchronous(getBooleanValue(getTextContent(attrs.getNamedItem("synchronous"))));
-                cacheSimpleConfig.addEntryListenerConfig(listenerConfig);
+                handleCacheEntryListenerNode(cacheSimpleConfig, listenerNode);
             }
         }
+    }
+
+    protected void handleCacheEntryListenerNode(CacheSimpleConfig cacheSimpleConfig, Node listenerNode) {
+        CacheSimpleEntryListenerConfig listenerConfig = new CacheSimpleEntryListenerConfig();
+        for (Node listenerChildNode : childElements(listenerNode)) {
+            if ("cache-entry-listener-factory".equals(cleanNodeName(listenerChildNode))) {
+                listenerConfig.setCacheEntryListenerFactory(getAttribute(listenerChildNode, "class-name"));
+            }
+            if ("cache-entry-event-filter-factory".equals(cleanNodeName(listenerChildNode))) {
+                listenerConfig.setCacheEntryEventFilterFactory(getAttribute(listenerChildNode, "class-name"));
+            }
+        }
+        NamedNodeMap attrs = listenerNode.getAttributes();
+        listenerConfig.setOldValueRequired(getBooleanValue(getTextContent(attrs.getNamedItem("old-value-required"))));
+        listenerConfig.setSynchronous(getBooleanValue(getTextContent(attrs.getNamedItem("synchronous"))));
+        cacheSimpleConfig.addEntryListenerConfig(listenerConfig);
     }
 
     protected void mapWanReplicationRefHandle(Node n, MapConfig mapConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
@@ -491,7 +491,7 @@ class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
             msc.setMaxSizePolicy(MaxSizeConfig.MaxSizePolicy.valueOf(
                     upperCaseInternal(getTextContent(maxSizePolicy))));
         }
-        msc.setSize(getIntegerValue("max-size", attributes.getNamedItem("max-size").getNodeValue()));
+        msc.setSize(getIntegerValue("max-size", getTextContent(attributes.getNamedItem("max-size"))));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlMemberDomConfigProcessor.java
@@ -598,6 +598,13 @@ class YamlMemberDomConfigProcessor extends MemberDomConfigProcessor {
     }
 
     @Override
+    protected void cacheListenerHandle(Node n, CacheSimpleConfig cacheSimpleConfig) {
+        for (Node listenerNode : childElements(n)) {
+            handleCacheEntryListenerNode(cacheSimpleConfig, listenerNode);
+        }
+    }
+
+    @Override
     protected void handleItemListeners(Node n, Function<ItemListenerConfig, Void> configAddFunction) {
         for (Node listenerNode : childElements(n)) {
             NamedNodeMap attrs = listenerNode.getAttributes();

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/MutableYamlSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/MutableYamlSequence.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.yaml;
+
+/**
+ * Mutable interface of {@link YamlSequence}
+ */
+public interface MutableYamlSequence extends YamlSequence, MutableYamlNode {
+
+    /**
+     * Adds a new child node to the sequence
+     *
+     * @param node The child node
+     */
+    void addChild(YamlNode node);
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlSequenceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlSequenceImpl.java
@@ -24,7 +24,7 @@ import static com.hazelcast.internal.yaml.YamlUtil.asMapping;
 import static com.hazelcast.internal.yaml.YamlUtil.asScalar;
 import static com.hazelcast.internal.yaml.YamlUtil.asSequence;
 
-class YamlSequenceImpl extends AbstractYamlNode implements YamlSequence {
+class YamlSequenceImpl extends AbstractYamlNode implements MutableYamlSequence {
     private List<YamlNode> children = Collections.emptyList();
 
     YamlSequenceImpl(YamlNode parent, String nodeName) {
@@ -69,7 +69,8 @@ class YamlSequenceImpl extends AbstractYamlNode implements YamlSequence {
         return childAsScalar(index).nodeValue(type);
     }
 
-    void addChild(YamlNode child) {
+    @Override
+    public void addChild(YamlNode child) {
         getOrCreateChildren().add(child);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlUtil.java
@@ -136,4 +136,47 @@ public final class YamlUtil {
 
         return childName;
     }
+
+    /**
+     * Checks if the provided {@code node} is a mapping
+     *
+     * @param node The node to check
+     * @return {@code true} if the provided node is a mapping
+     */
+    public static boolean isMapping(YamlNode node) {
+        return node instanceof YamlMapping;
+    }
+
+    /**
+     * Checks if the provided {@code node} is a sequence
+     *
+     * @param node The node to check
+     * @return {@code true} if the provided node is a sequence
+     */
+    public static boolean isSequence(YamlNode node) {
+        return node instanceof YamlSequence;
+    }
+
+    /**
+     * Checks if the provided {@code node} is a scalar
+     *
+     * @param node The node to check
+     * @return {@code true} if the provided node is a scalar
+     */
+    public static boolean isScalar(YamlNode node) {
+        return node instanceof YamlScalar;
+    }
+
+    /**
+     * Checks if the two provided {@code nodes} are of the same type
+     *
+     * @param left  The left-side node of the check
+     * @param right The right-side node of the check
+     * @return {@code true} if the provided nodes are of the same type
+     */
+    public static boolean isOfSameType(YamlNode left, YamlNode right) {
+        return left instanceof YamlMapping && right instanceof YamlMapping
+                || left instanceof YamlSequence && right instanceof YamlSequence
+                || left instanceof YamlScalar && right instanceof YamlScalar;
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigImportVariableReplacementTest.java
@@ -145,6 +145,9 @@ public abstract class AbstractConfigImportVariableReplacementTest {
     @Test
     public abstract void testReplaceVariablesWithUrlConfig() throws Exception;
 
+    @Test
+    public abstract void testReplaceVariablesUseSystemProperties() throws Exception;
+
     protected void expectInvalid() {
         InvalidConfigurationTest.expectInvalid(rule);
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
@@ -585,6 +585,27 @@ public class XmlConfigImportVariableReplacementTest extends AbstractConfigImport
         assertEquals("foobar", config.getProperty("prop"));
     }
 
+    @Override
+    @Test
+    public void testReplaceVariablesUseSystemProperties() {
+        String configXml = HAZELCAST_START_TAG
+                + "    <properties>\n"
+                + "        <property name=\"prop\">${variable}</property>\n"
+                + "    </properties>\n"
+                + HAZELCAST_END_TAG;
+
+        System.setProperty("variable", "foobar");
+        Config config = buildConfig(configXml);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
+    private static Config buildConfig(String xml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
+        XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);
+        return configBuilder.build();
+    }
+
     private static Config buildConfig(String xml, Properties properties) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
         XmlConfigBuilder configBuilder = new XmlConfigBuilder(bis);

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
@@ -576,6 +576,26 @@ public class YamlConfigImportVariableReplacementTest extends AbstractConfigImpor
         assertEquals("foobar", config.getProperty("prop"));
     }
 
+    @Override
+    @Test
+    public void testReplaceVariablesUseSystemProperties() {
+        String configYaml = ""
+                + "hazelcast:\n"
+                + "  properties:\n"
+                + "    prop: ${variable}";
+
+        System.setProperty("variable", "foobar");
+        Config config = buildConfig(configYaml);
+
+        assertEquals("foobar", config.getProperty("prop"));
+    }
+
+    private static Config buildConfig(String yaml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(yaml.getBytes());
+        YamlConfigBuilder configBuilder = new YamlConfigBuilder(bis);
+        return configBuilder.build();
+    }
+
     private static Config buildConfig(String yaml, Properties properties) {
         ByteArrayInputStream bis = new ByteArrayInputStream(yaml.getBytes());
         YamlConfigBuilder configBuilder = new YamlConfigBuilder(bis);

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastException;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.util.RootCauseMatcher;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -30,6 +31,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintWriter;
+import java.util.List;
 import java.util.Properties;
 
 import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
@@ -588,6 +590,144 @@ public class YamlConfigImportVariableReplacementTest extends AbstractConfigImpor
         Config config = buildConfig(configYaml);
 
         assertEquals("foobar", config.getProperty("prop"));
+    }
+
+    @Test
+    public void testImportRedefinesSameConfigScalarThrows() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String importedYaml = ""
+                + "hazelcast:\n"
+                + "  group:\n"
+                + "    name: name1";
+        writeStringToStreamAndClose(os, importedYaml);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - ${config.location}\n"
+                + "  group:\n"
+                + "    name: name2";
+
+        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast/group/name"));
+
+        buildConfig(yaml, "config.location", file.getAbsolutePath());
+    }
+
+    @Test
+    public void testImportSameScalarConfig() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String importedYaml = ""
+                + "hazelcast:\n"
+                + "  group:\n"
+                + "    name: name";
+        writeStringToStreamAndClose(os, importedYaml);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - ${config.location}\n"
+                + "  group:\n"
+                + "    name: name";
+
+        Config config = buildConfig(yaml, "config.location", file.getAbsolutePath());
+        assertEquals("name", config.getGroupConfig().getName());
+    }
+
+    @Test
+    public void testImportNodeScalarVsSequenceThrows() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String importedYaml = ""
+                + "hazelcast:\n"
+                + "  group:\n"
+                + "    name: name1";
+        writeStringToStreamAndClose(os, importedYaml);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - ${config.location}\n"
+                + "  group:\n"
+                + "    name:\n"
+                + "      - seqName: {}";
+
+        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast/group/name"));
+
+        buildConfig(yaml, "config.location", file.getAbsolutePath());
+    }
+
+    @Test
+    public void testImportNodeScalarVsMappingThrows() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String importedYaml = ""
+                + "hazelcast:\n"
+                + "  group:\n"
+                + "    name: name1";
+        writeStringToStreamAndClose(os, importedYaml);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - ${config.location}\n"
+                + "  group:\n"
+                + "    name: {}";
+
+        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast/group/name"));
+
+        buildConfig(yaml, "config.location", file.getAbsolutePath());
+    }
+
+    @Test
+    public void testImportNodeSequenceVsMappingThrows() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String importedYaml = ""
+                + "hazelcast:\n"
+                + "  group:\n"
+                + "    name:\n"
+                + "      - seqname";
+        writeStringToStreamAndClose(os, importedYaml);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - ${config.location}\n"
+                + "  group:\n"
+                + "    name: {}";
+
+        rule.expect(new RootCauseMatcher(InvalidConfigurationException.class, "hazelcast/group/name"));
+
+        buildConfig(yaml, "config.location", file.getAbsolutePath());
+    }
+
+    @Test
+    public void testImportNodeSequenceVsSequenceMerges() throws Exception {
+        File file = createConfigFile("foo", "bar");
+        FileOutputStream os = new FileOutputStream(file);
+        String importedYaml = ""
+                + "hazelcast:\n"
+                + "  listeners:\n"
+                + "    - com.hazelcast.examples.MembershipListener\n";
+        writeStringToStreamAndClose(os, importedYaml);
+
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  import:\n"
+                + "    - ${config.location}\n"
+                + "  listeners:\n"
+                + "    - com.hazelcast.examples.MigrationListener\n";
+
+        Config config = buildConfig(yaml, "config.location", file.getAbsolutePath());
+        List<ListenerConfig> listenerConfigs = config.getListenerConfigs();
+        assertEquals(2, listenerConfigs.size());
+        for (ListenerConfig listenerConfig : listenerConfigs) {
+            assertTrue("com.hazelcast.examples.MembershipListener".equals(listenerConfig.getClassName())
+                    || "com.hazelcast.examples.MigrationListener".equals(listenerConfig.getClassName()));
+        }
+
     }
 
     private static Config buildConfig(String yaml) {

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -520,6 +520,10 @@
                 <cache-entry-listener-factory class-name="com.example.cache.MyEntryListenerFactory"/>
                 <cache-entry-event-filter-factory class-name="com.example.cache.MyEntryEventFilterFactory"/>
             </cache-entry-listener>
+            <cache-entry-listener>
+                <cache-entry-listener-factory class-name="com.example.cache.MyEntryListenerFactory2"/>
+                <cache-entry-event-filter-factory class-name="com.example.cache.MyEntryEventFilterFactory2"/>
+            </cache-entry-listener>
         </cache-entry-listeners>
         <in-memory-format>OBJECT</in-memory-format>
         <backup-count>2</backup-count>

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -521,13 +521,16 @@ hazelcast:
           time-unit: MICROSECONDS
 
       cache-entry-listeners:
-        cache-entry-listener:
-          old-value-required: true
+        - old-value-required: true
           synchronous: true
           cache-entry-listener-factory:
             class-name: com.example.cache.MyEntryListenerFactory
           cache-entry-event-filter-factory:
             class-name: com.example.cache.MyEntryEventFilterFactory
+        - cache-entry-listener-factory:
+            class-name: com.example.cache.MyEntryListenerFactory2
+          cache-entry-event-filter-factory:
+            class-name: com.example.cache.MyEntryEventFilterFactory2
       in-memory-format: OBJECT
       backup-count: 2
       async-backup-count: 2

--- a/hazelcast/src/test/resources/test-hazelcast-client-variable.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-client-variable.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.12.xsd">
+
+    <properties>
+        <property name="prop">${variable}</property>
+    </properties>
+
+</hazelcast-client>

--- a/hazelcast/src/test/resources/test-hazelcast-client-variable.yaml
+++ b/hazelcast/src/test/resources/test-hazelcast-client-variable.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+hazelcast-client:
+  properties:
+    prop: ${variable}


### PR DESCRIPTION
#### Use the system properties in YAML config builders by default
Properties field to be used by variable replacers in YAML config builders was `null`, led to NPE if `YamlConfigBuilder` was building config that had variables to replace, but no properties was explicitly passed. Now it takes the system properties by default just like XML builders do.

#### Add missing `ClientClasspathYamlConfig`

The class was missing, added with tests.

#### Allow multiple `cache-entry-listeners` to be configured

Previously only listeners named `cache-entry-listener` in the listeners mapping could be configured under cache, which allowed only one listener configuration. Instead of mapping, listeners are configured with sequences just like in other cases. The `hazelcast-fullconfig.yaml` covers this.

#### Fix NPE if map's `max-size` value is not defined

If there was a map defined with `max-size`, but without the `max-size`'s value an NPE was thrown. Now it reports this case as invalid configuration the same way XML configuration does.

#### Merge non-mapping nodes when importing

Importing YAML documents handled well only mappings. If the merging logic had to merge leaf nodes (scalars), an exception was thrown saying that the node is not a mapping. Now scalars are allowed to be merged, but only if their values are equal, otherwise an `InvalidConfigurationException` is thrown saying the configuration is ambiguous, including the given node's path from the root in the message.

Additionally, if the type of the nodes in the source and the target YAML is different (such as scalar vs mapping or sequence vs scalar) an `InvalidConfigurationException` is thrown because of ambiguous configuration, naming the different types at the node's path as the cause.

Merging sequences was not handled either, now they're merging. This allows duplicates at YAML level, because the sequences are backed by lists.