### PR TITLE
Fix ClientSelectors.ipSelector with 127.0.0.1

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientSelectorsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientSelectorsTest.java
@@ -26,7 +26,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -42,16 +44,32 @@ public class ClientSelectorsTest extends HazelcastTestSupport {
     public void testAny() {
         String name = randomString();
         Set<String> labels = Collections.emptySet();
-        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+        ClientImpl client = new ClientImpl(null, createInetSocketAddress("127.0.0.1"), name, labels);
         assertTrue(client.toString(), ClientSelectors.any().select(client));
+    }
+
+    private InetSocketAddress createInetSocketAddress(String name) {
+        try {
+            return new InetSocketAddress(InetAddress.getByName(name), 5000);
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test
     public void testNone() {
         String name = randomString();
         Set<String> labels = Collections.emptySet();
-        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+        ClientImpl client = new ClientImpl(null, createInetSocketAddress("127.0.0.1"), name, labels);
         assertFalse(client.toString(), ClientSelectors.none().select(client));
+    }
+
+    @Test
+    public void testLocalhostWithIp() throws UnknownHostException {
+        String name = randomString();
+        Set<String> labels = Collections.emptySet();
+        ClientImpl client = new ClientImpl(null, createInetSocketAddress("localhost"), name, labels);
+        assertTrue(client.toString(), ClientSelectors.ipSelector("127.0.0.1").select(client));
     }
 
     @Test
@@ -59,7 +77,7 @@ public class ClientSelectorsTest extends HazelcastTestSupport {
         String name = "client1";
         Set<String> labels = Collections.emptySet();
 
-        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+        ClientImpl client = new ClientImpl(null, createInetSocketAddress("127.0.0.1"), name, labels);
         assertTrue(client.toString(), ClientSelectors.nameSelector("client1").select(client));
         assertTrue(client.toString(), ClientSelectors.nameSelector("clie.*").select(client));
         assertTrue(client.toString(), ClientSelectors.nameSelector(".*lie.*").select(client));
@@ -73,7 +91,7 @@ public class ClientSelectorsTest extends HazelcastTestSupport {
 
     @Test
     public void testNameSelectorsWithNullInput() {
-        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), null, null);
+        ClientImpl client = new ClientImpl(null, createInetSocketAddress("127.0.0.1"), null, null);
         assertFalse(client.toString(), ClientSelectors.nameSelector("client").select(client));
     }
 
@@ -83,7 +101,7 @@ public class ClientSelectorsTest extends HazelcastTestSupport {
         HashSet<String> labels = new HashSet<String>();
         Collections.addAll(labels, "admin", "foo", "client1");
 
-        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+        ClientImpl client = new ClientImpl(null, createInetSocketAddress("127.0.0.1"), name, labels);
 
         assertTrue(client.toString(), ClientSelectors.labelSelector("client1").select(client));
         assertTrue(client.toString(), ClientSelectors.labelSelector("clie.*").select(client));
@@ -101,7 +119,7 @@ public class ClientSelectorsTest extends HazelcastTestSupport {
         String name = randomString();
         Set<String> labels = Collections.emptySet();
         String ip = "213.129.127.80";
-        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved(ip, 5000), name, labels);
+        ClientImpl client = new ClientImpl(null, createInetSocketAddress(ip), name, labels);
 
         assertTrue(client.toString(), ClientSelectors.ipSelector("213.129.127.80").select(client));
         assertTrue(client.toString(), ClientSelectors.ipSelector("213.129.127.*").select(client));
@@ -116,7 +134,7 @@ public class ClientSelectorsTest extends HazelcastTestSupport {
         String name = randomString();
         Set<String> labels = Collections.emptySet();
         String ip = "fe80:0:0:0:45c5:47ee:fe15:493a";
-        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved(ip, 5000), name, labels);
+        ClientImpl client = new ClientImpl(null, createInetSocketAddress(ip), name, labels);
         assertTrue(client.toString(), ClientSelectors.ipSelector("fe80:0:0:0:45c5:47ee:fe15:493a").select(client));
         assertTrue(client.toString(), ClientSelectors.ipSelector("fe80:0:0:0:45c5:47ee:fe15:*").select(client));
         assertTrue(client.toString(), ClientSelectors.ipSelector("fe80:0:0:0:45c5:47ee:fe15:0-5555").select(client));
@@ -130,7 +148,7 @@ public class ClientSelectorsTest extends HazelcastTestSupport {
         String name = "client1";
         Set<String> labels = Collections.emptySet();
 
-        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+        ClientImpl client = new ClientImpl(null, createInetSocketAddress("127.0.0.1"), name, labels);
         assertFalse(client.toString(), ClientSelectors.inverse(ClientSelectors.nameSelector("client1")).select(client));
     }
 
@@ -140,7 +158,7 @@ public class ClientSelectorsTest extends HazelcastTestSupport {
         HashSet<String> labels = new HashSet<String>();
         Collections.addAll(labels, "admin", "foo", "client1");
         String ip = "213.129.127.80";
-        ClientImpl client = new ClientImpl(null, InetSocketAddress.createUnresolved(ip, 5000), name, labels);
+        ClientImpl client = new ClientImpl(null, createInetSocketAddress(ip), name, labels);
 
         assertTrue(client.toString(), ClientSelectors.or(ClientSelectors.ipSelector("213.129.*.1-100"),
                 ClientSelectors.nameSelector("clie.*")).select(client));

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientSelectors.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientSelectors.java
@@ -89,7 +89,7 @@ public final class ClientSelectors {
         return new ClientSelector() {
             @Override
             public boolean select(Client client) {
-                return AddressUtil.matchInterface(client.getSocketAddress().getHostName(), ipMask);
+                return AddressUtil.matchInterface(client.getSocketAddress().getAddress().getHostAddress(), ipMask);
             }
 
             @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ClientBwListConfigHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ClientBwListConfigHandlerTest.java
@@ -33,7 +33,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -197,8 +199,8 @@ public class ClientBwListConfigHandlerTest extends HazelcastTestSupport {
                 new ClientBwListEntryDTO(Type.LABEL, "192.168.0.1"),
                 new ClientBwListEntryDTO(Type.IP_ADDRESS, "192.168.0.2"));
         configJson.get("clientBwList").asObject()
-                  .get("entries").asArray()
-                  .get(0).asObject().set("type", "invalid_type");
+                .get("entries").asArray()
+                .get(0).asObject().set("type", "invalid_type");
         handler.handleConfig(configJson);
 
         Client client1 = createClient("192.168.0.1", randomString());
@@ -226,8 +228,17 @@ public class ClientBwListConfigHandlerTest extends HazelcastTestSupport {
                 labelsSet.add(label);
             }
         }
-        Client client = new ClientImpl(null, InetSocketAddress.createUnresolved(ip, 5000), name, labelsSet);
+        Client client = new ClientImpl(null, createInetSocketAddress(ip), name, labelsSet);
         return client;
     }
+
+    private InetSocketAddress createInetSocketAddress(String name) {
+        try {
+            return new InetSocketAddress(InetAddress.getByName(name), 5000);
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ManagementCenterServiceIntegrationTest.java
@@ -44,8 +44,10 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.net.UnknownHostException;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -132,13 +134,21 @@ public class ManagementCenterServiceIntegrationTest {
 
                 String name = randomString();
                 Set<String> labels = new HashSet<String>();
-                Client client1 = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.1", 5000), name, labels);
+                Client client1 = new ClientImpl(null, createInetSocketAddress("127.0.0.1"), name, labels);
                 assertTrue(instance.node.clientEngine.isClientAllowed(client1));
 
-                Client client2 = new ClientImpl(null, InetSocketAddress.createUnresolved("127.0.0.2", 5000), name, labels);
+                Client client2 = new ClientImpl(null, createInetSocketAddress("127.0.0.2"), name, labels);
                 assertFalse(instance.node.clientEngine.isClientAllowed(client2));
             }
         });
+    }
+
+    private InetSocketAddress createInetSocketAddress(String name) {
+        try {
+            return new InetSocketAddress(InetAddress.getByName(name), 5000);
+        } catch (UnknownHostException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static int availablePort() {


### PR DESCRIPTION
Use ip representation of addresses instead of hostname to match
ip addresses provided by MC.

fixes https://github.com/hazelcast/hazelcast/issues/14654