### PR TITLE
Report waiting Raft operations via LiveOperationsTracker

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/cp/internal/datastructures/countdownlatch/RaftCountDownLatchClientBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cp/internal/datastructures/countdownlatch/RaftCountDownLatchClientBasicTest.java
@@ -20,9 +20,16 @@ import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICountDownLatch;
 import com.hazelcast.cp.internal.datastructures.countdownlatch.RaftCountDownLatchBasicTest;
+import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
 public class RaftCountDownLatchClientBasicTest extends RaftCountDownLatchBasicTest {
 
     private HazelcastInstance client;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cp/internal/datastructures/countdownlatch/RaftCountDownLatchLongAwaitClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cp/internal/datastructures/countdownlatch/RaftCountDownLatchLongAwaitClientTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.cp.internal.datastructures.countdownlatch;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.spi.properties.ClientProperty;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICountDownLatch;
+import com.hazelcast.cp.CPGroupId;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.cp.internal.datastructures.countdownlatch.RaftCountDownLatchService;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class RaftCountDownLatchLongAwaitClientTest extends HazelcastRaftTestSupport {
+
+    private HazelcastInstance[] instances;
+    private String objectName = "latch";
+    private String proxyName = objectName + "@group1";
+    private int groupSize = 3;
+    private CPGroupId groupId;
+    private final long callTimeoutSeconds = 15;
+    private HazelcastInstance client;
+
+    @Override
+    protected TestHazelcastInstanceFactory createTestFactory() {
+        return new TestHazelcastFactory();
+    }
+
+    @Before
+    public void setup() {
+        instances = newInstances(groupSize);
+        TestHazelcastFactory f = (TestHazelcastFactory) factory;
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setProperty(ClientProperty.INVOCATION_TIMEOUT_SECONDS.getName(), String.valueOf(callTimeoutSeconds));
+        client = f.newHazelcastClient(clientConfig);
+        groupId = ((RaftCountDownLatchProxy) client.getCPSubsystem().getCountDownLatch(proxyName)).getGroupId();
+    }
+
+    @Test
+    public void when_awaitDurationIsLongerThanOperationTimeout_then_invocationFromClientWaits() throws ExecutionException, InterruptedException {
+        final ICountDownLatch latch = client.getCPSubsystem().getCountDownLatch(proxyName);
+        final HazelcastInstance instance = getLeaderInstance(instances, groupId);
+        latch.trySetCount(1);
+
+        Future<Boolean> f = spawn(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return latch.await(5, TimeUnit.MINUTES);
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                RaftCountDownLatchService service = getNodeEngineImpl(instance).getService(RaftCountDownLatchService.SERVICE_NAME);
+                assertFalse(service.getLiveOperations().isEmpty());
+            }
+        });
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                RaftCountDownLatchService service = getNodeEngineImpl(instance).getService(RaftCountDownLatchService.SERVICE_NAME);
+                assertFalse(service.getLiveOperations().isEmpty());
+            }
+        }, callTimeoutSeconds + 5);
+
+        latch.countDown();
+
+        assertCompletesEventually(f);
+        assertTrue(f.get());
+    }
+
+    @Override
+    protected Config createConfig(int cpNodeCount, int groupSize) {
+        String callTimeoutStr = String.valueOf(SECONDS.toMillis(callTimeoutSeconds));
+        return super.createConfig(cpNodeCount, groupSize)
+                    .setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), callTimeoutStr);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/CallerAware.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/CallerAware.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal;
+
+import com.hazelcast.nio.Address;
+
+/**
+ * An abstraction to implement blocking Raft ops. A blocking Raft op requires
+ * caller information to be provided before the Raft op is being replicated
+ * and committed by the Raft consensus algorithm. The Raft invocation mechanism
+ * provides this functionality. Once the Raft op is committed, it is reported
+ * as a live operation to the Hazelcast's invocation system, even if the total
+ * wait duration is longer then the configured operation timeout duration.
+ * A blocking Raft op can fail with operation timeout if it is not committed
+ * before the configured operation timeout duration passes.
+ */
+public interface CallerAware {
+
+    /**
+     * Sets the caller information on the Raft op
+     */
+    void setCaller(Address callerAddress, long callId);
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatch.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatch.java
@@ -95,10 +95,10 @@ public class RaftCountDownLatch extends BlockingResource<AwaitInvocationKey> imp
         return true;
     }
 
-    boolean await(long commitIndex, UUID invocationUid, boolean wait) {
+    boolean await(AwaitInvocationKey key, boolean wait) {
         boolean success = (getRemainingCount() == 0);
         if (!success && wait) {
-            addWaitKey(invocationUid, new AwaitInvocationKey(commitIndex, invocationUid));
+            addWaitKey(key.invocationUid(), key);
         }
 
         return success;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchRegistry.java
@@ -70,10 +70,10 @@ public class RaftCountDownLatchRegistry extends ResourceRegistry<AwaitInvocation
         return t;
     }
 
-    boolean await(String name, long commitIndex, UUID invocationUid, long timeoutMs) {
-        boolean success = getOrInitResource(name).await(commitIndex, invocationUid, (timeoutMs > 0));
+    boolean await(String name, AwaitInvocationKey key, long timeoutMs) {
+        boolean success = getOrInitResource(name).await(key, (timeoutMs > 0));
         if (!success) {
-            addWaitKey(name, invocationUid, timeoutMs);
+            addWaitKey(name, key.invocationUid(), timeoutMs);
         }
 
         return success;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchService.java
@@ -58,10 +58,11 @@ public class RaftCountDownLatchService
         return t.element1;
     }
 
-    public boolean await(CPGroupId groupId, String name, long commitIndex, UUID invocationUid, long timeoutMillis) {
-        boolean success = getOrInitRegistry(groupId).await(name, commitIndex, invocationUid, timeoutMillis);
+    public boolean await(CPGroupId groupId, String name, AwaitInvocationKey key, long timeoutMillis) {
+        boolean success = getOrInitRegistry(groupId).await(name, key, timeoutMillis);
         if (!success) {
-            scheduleTimeout(groupId, name, invocationUid, timeoutMillis);
+            scheduleTimeout(groupId, name, key.invocationUid(), timeoutMillis);
+            addLiveOperation(key);
         }
 
         return success;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/RaftLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/RaftLock.java
@@ -93,14 +93,15 @@ public class RaftLock extends BlockingResource<LockInvocationKey> implements Ide
      * with one of the previous invocations of the current lock owner,
      * memorized result of the previous invocation is returned.
      */
-    AcquireResult acquire(long commitIndex, LockEndpoint endpoint, UUID invocationUid, boolean wait) {
+    AcquireResult acquire(LockInvocationKey key, boolean wait) {
+        LockEndpoint endpoint = key.endpoint();
+        UUID invocationUid = key.invocationUid();
         RaftLockOwnershipState memorized = ownerInvocationRefUids.get(Tuple2.of(endpoint, invocationUid));
         if (memorized != null) {
             AcquireStatus status = memorized.isLocked() ? SUCCESSFUL : FAILED;
             return new AcquireResult(status, memorized.getFence(), Collections.<LockInvocationKey>emptyList());
         }
 
-        LockInvocationKey key = new LockInvocationKey(endpoint, commitIndex, invocationUid);
         if (owner == null) {
             owner = key;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/RaftLockRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/RaftLockRegistry.java
@@ -70,25 +70,25 @@ class RaftLockRegistry extends ResourceRegistry<LockInvocationKey, RaftLock> imp
         return clone;
     }
 
-    AcquireResult acquire(long commitIndex, String name, LockEndpoint endpoint, UUID invocationUid) {
-        AcquireResult result = getOrInitResource(name).acquire(commitIndex, endpoint, invocationUid, true);
+    AcquireResult acquire(String name, LockInvocationKey key) {
+        AcquireResult result = getOrInitResource(name).acquire(key, true);
 
-        for (LockInvocationKey key : result.cancelledWaitKeys()) {
-            removeWaitKey(name, key);
+        for (LockInvocationKey cancelled : result.cancelledWaitKeys()) {
+            removeWaitKey(name, cancelled);
         }
 
         return result;
     }
 
-    AcquireResult tryAcquire(long commitIndex, String name, LockEndpoint endpoint, UUID invocationUid, long timeoutMs) {
-        AcquireResult result = getOrInitResource(name).acquire(commitIndex, endpoint, invocationUid, (timeoutMs > 0));
+    AcquireResult tryAcquire(String name, LockInvocationKey key, long timeoutMs) {
+        AcquireResult result = getOrInitResource(name).acquire(key, (timeoutMs > 0));
 
-        for (LockInvocationKey key : result.cancelledWaitKeys()) {
-            removeWaitKey(name, key);
+        for (LockInvocationKey cancelled : result.cancelledWaitKeys()) {
+            removeWaitKey(name, cancelled);
         }
 
         if (result.status() == WAIT_KEY_ADDED) {
-            addWaitKey(name, invocationUid, timeoutMs);
+            addWaitKey(name, key.invocationUid(), timeoutMs);
         }
 
         return result;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/BlockingResource.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/spi/blocking/BlockingResource.java
@@ -97,15 +97,13 @@ public abstract class BlockingResource<W extends WaitKey> implements DataSeriali
         return all;
     }
 
-    final void expireWaitKey(UUID invocationUid, List<Long> commitIndices) {
+    final void expireWaitKeys(UUID invocationUid, List<W> expired) {
         Iterator<WaitKeyContainer<W>> iter = waitKeys.values().iterator();
         while (iter.hasNext()) {
             WaitKeyContainer<W> container = iter.next();
             if (container.invocationUid().equals(invocationUid)) {
-                commitIndices.add(container.key().commitIndex());
-                for (W retry : container.retries()) {
-                    commitIndices.add(retry.commitIndex());
-                }
+                expired.add(container.key());
+                expired.addAll(container.retries());
                 iter.remove();
                 return;
             }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/ChangeRaftGroupMembershipOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/ChangeRaftGroupMembershipOp.java
@@ -17,16 +17,15 @@
 package com.hazelcast.cp.internal.operation;
 
 import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.cp.CPGroupId;
+import com.hazelcast.cp.internal.CPMemberInfo;
+import com.hazelcast.cp.internal.IndeterminateOperationStateAware;
+import com.hazelcast.cp.internal.RaftServiceDataSerializerHook;
+import com.hazelcast.cp.internal.raft.MembershipChangeMode;
+import com.hazelcast.cp.internal.raft.impl.RaftNode;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.cp.internal.raft.MembershipChangeMode;
-import com.hazelcast.cp.CPGroupId;
-import com.hazelcast.cp.internal.CPMemberInfo;
-import com.hazelcast.cp.internal.raft.impl.RaftNode;
-import com.hazelcast.cp.internal.RaftOp;
-import com.hazelcast.cp.internal.IndeterminateOperationStateAware;
-import com.hazelcast.cp.internal.RaftServiceDataSerializerHook;
 
 import java.io.IOException;
 
@@ -54,17 +53,12 @@ public class ChangeRaftGroupMembershipOp extends RaftReplicateOp implements Inde
     }
 
     @Override
-    ICompletableFuture replicate(RaftNode raftNode) {
+    protected ICompletableFuture replicate(RaftNode raftNode) {
         if (membersCommitIndex == NAN_MEMBERS_COMMIT_INDEX) {
             return raftNode.replicateMembershipChange(member, membershipChangeMode);
         } else {
             return raftNode.replicateMembershipChange(member, membershipChangeMode, membersCommitIndex);
         }
-    }
-
-    @Override
-    protected RaftOp getRaftOp() {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/DestroyRaftGroupOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/DestroyRaftGroupOp.java
@@ -17,13 +17,12 @@
 package com.hazelcast.cp.internal.operation;
 
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.cp.CPGroupId;
-import com.hazelcast.cp.internal.raft.command.DestroyRaftGroupCmd;
-import com.hazelcast.cp.internal.raft.impl.RaftNode;
-import com.hazelcast.cp.internal.RaftOp;
 import com.hazelcast.cp.internal.IndeterminateOperationStateAware;
 import com.hazelcast.cp.internal.RaftServiceDataSerializerHook;
+import com.hazelcast.cp.internal.raft.command.DestroyRaftGroupCmd;
+import com.hazelcast.cp.internal.raft.impl.RaftNode;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 /**
  * Replicates a {@link DestroyRaftGroupCmd} to a Raft group.
@@ -38,13 +37,8 @@ public class DestroyRaftGroupOp extends RaftReplicateOp implements Indeterminate
     }
 
     @Override
-    ICompletableFuture replicate(RaftNode raftNode) {
+    protected ICompletableFuture replicate(RaftNode raftNode) {
         return raftNode.replicate(new DestroyRaftGroupCmd());
-    }
-
-    @Override
-    protected RaftOp getRaftOp() {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftReplicateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftReplicateOp.java
@@ -72,10 +72,7 @@ public abstract class RaftReplicateOp extends Operation implements IdentifiedDat
         replicate(raftNode).andThen(this);
     }
 
-    ICompletableFuture replicate(RaftNode raftNode) {
-        RaftOp op = getRaftOp();
-        return raftNode.replicate(op);
-    }
+    protected abstract ICompletableFuture replicate(RaftNode raftNode);
 
     @Override
     public void onResponse(Object response) {
@@ -86,8 +83,6 @@ public abstract class RaftReplicateOp extends Operation implements IdentifiedDat
     public void onFailure(Throwable t) {
         sendResponse(t);
     }
-
-    protected abstract RaftOp getRaftOp();
 
     @Override
     public final boolean returnsResponse() {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchAdvancedTest.java
@@ -58,7 +58,7 @@ public class RaftCountDownLatchAdvancedTest extends HazelcastRaftTestSupport {
 
     private HazelcastInstance[] instances;
     private ICountDownLatch latch;
-    private String objectName = "semaphore";
+    private String objectName = "latch";
     private String proxyName = objectName + "@group1";
     private int groupSize = 3;
 
@@ -93,7 +93,7 @@ public class RaftCountDownLatchAdvancedTest extends HazelcastRaftTestSupport {
 
         CPGroupId groupId = getGroupId(latch);
         HazelcastInstance leader = getLeaderInstance(instances, groupId);
-        RaftCountDownLatchService service = getNodeEngineImpl(leader).getService(RaftCountDownLatchService.SERVICE_NAME);
+        final RaftCountDownLatchService service = getNodeEngineImpl(leader).getService(RaftCountDownLatchService.SERVICE_NAME);
         final RaftCountDownLatchRegistry registry = service.getRegistryOrNull(groupId);
 
         final CountDownLatch threadLatch = new CountDownLatch(1);
@@ -113,6 +113,7 @@ public class RaftCountDownLatchAdvancedTest extends HazelcastRaftTestSupport {
             @Override
             public void run() {
                 assertFalse(registry.getWaitTimeouts().isEmpty());
+                assertFalse(service.getLiveOperations().isEmpty());
             }
         });
 
@@ -121,6 +122,7 @@ public class RaftCountDownLatchAdvancedTest extends HazelcastRaftTestSupport {
         assertOpenEventually(threadLatch);
 
         assertTrue(registry.getWaitTimeouts().isEmpty());
+        assertTrue(service.getLiveOperations().isEmpty());
     }
 
     @Test
@@ -136,6 +138,7 @@ public class RaftCountDownLatchAdvancedTest extends HazelcastRaftTestSupport {
 
         assertFalse(success);
         assertTrue(registry.getWaitTimeouts().isEmpty());
+        assertTrue(service.getLiveOperations().isEmpty());
     }
 
     @Test
@@ -168,6 +171,7 @@ public class RaftCountDownLatchAdvancedTest extends HazelcastRaftTestSupport {
         latch.destroy();
 
         assertTrue(registry.getWaitTimeouts().isEmpty());
+        assertTrue(service.getLiveOperations().isEmpty());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchLongAwaitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/countdownlatch/RaftCountDownLatchLongAwaitTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.datastructures.countdownlatch;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ICountDownLatch;
+import com.hazelcast.cp.CPGroupId;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.cp.internal.datastructures.countdownlatch.proxy.RaftCountDownLatchProxy;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class RaftCountDownLatchLongAwaitTest extends HazelcastRaftTestSupport {
+
+    private HazelcastInstance[] instances;
+    private String objectName = "latch";
+    private String proxyName = objectName + "@group1";
+    private int groupSize = 3;
+    private CPGroupId groupId;
+    private final long callTimeoutSeconds = 15;
+
+    @Before
+    public void setup() {
+        instances = newInstances(groupSize);
+        groupId = ((RaftCountDownLatchProxy) instances[0].getCPSubsystem().getCountDownLatch(proxyName)).getGroupId();
+    }
+
+    @Test
+    public void when_awaitDurationIsLongerThanOperationTimeout_then_invocationFromLeaderInstanceWaits()
+            throws ExecutionException, InterruptedException {
+        testLongAwait(getLeaderInstance(instances, groupId));
+    }
+
+    @Test
+    public void when_awaitDurationIsLongerThanOperationTimeout_then_invocationFromNonLeaderInstanceWaits()
+            throws ExecutionException, InterruptedException {
+        testLongAwait(getRandomFollowerInstance(instances, groupId));
+    }
+
+    private void testLongAwait(final HazelcastInstance instance) throws ExecutionException, InterruptedException {
+        final ICountDownLatch latch = instance.getCPSubsystem().getCountDownLatch(proxyName);
+        latch.trySetCount(1);
+
+        Future<Boolean> f = spawn(new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return latch.await(5, TimeUnit.MINUTES);
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                RaftCountDownLatchService service = getNodeEngineImpl(instance).getService(RaftCountDownLatchService.SERVICE_NAME);
+                assertFalse(service.getLiveOperations().isEmpty());
+            }
+        });
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                RaftCountDownLatchService service = getNodeEngineImpl(instance).getService(RaftCountDownLatchService.SERVICE_NAME);
+                assertFalse(service.getLiveOperations().isEmpty());
+            }
+        }, callTimeoutSeconds + 5);
+
+        latch.countDown();
+
+        assertCompletesEventually(f);
+        assertTrue(f.get());
+    }
+
+    @Override
+    protected Config createConfig(int cpNodeCount, int groupSize) {
+        String callTimeoutStr = String.valueOf(SECONDS.toMillis(callTimeoutSeconds));
+        return super.createConfig(cpNodeCount, groupSize)
+                    .setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), callTimeoutStr);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockLongAwaitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/FencedLockLongAwaitTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.datastructures.lock;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.OperationTimeoutException;
+import com.hazelcast.cp.CPGroupId;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.cp.lock.FencedLock;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class FencedLockLongAwaitTest extends HazelcastRaftTestSupport {
+
+    private HazelcastInstance[] instances;
+    private String objectName = "lock";
+    private String proxyName = objectName + "@group1";
+    private int groupSize = 3;
+    private CPGroupId groupId;
+    private final long callTimeoutSeconds = 15;
+
+    @Before
+    public void setup() {
+        instances = newInstances(groupSize);
+        groupId = instances[0].getCPSubsystem().getLock(proxyName).getGroupId();
+    }
+
+    @Test(timeout = 300000)
+    public void when_awaitDurationIsLongerThanOperationTimeout_then_invocationFromLeaderInstanceWaits() throws ExecutionException, InterruptedException {
+        testLongAwait(getLeaderInstance(instances, groupId));
+    }
+
+    @Test(timeout = 300000)
+    public void when_awaitDurationIsLongerThanOperationTimeout_then_invocationFromNonLeaderInstanceWaits() throws ExecutionException, InterruptedException {
+        testLongAwait(getRandomFollowerInstance(instances, groupId));
+    }
+
+    @Test(timeout = 300000)
+    public void when_longWaitOperationIsNotCommitted_then_itFailsWithOperationTimeoutException() {
+        HazelcastInstance apInstance = factory.newHazelcastInstance(createConfig(groupSize, groupSize));
+        final FencedLock lock = apInstance.getCPSubsystem().getLock(proxyName);
+        spawn(new Runnable() {
+            @Override
+            public void run() {
+                lock.lock();
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertTrue(lock.isLocked());
+            }
+        });
+
+        HazelcastInstance leader = getLeaderInstance(instances, groupId);
+        for (int i = 0; i < groupSize; i++) {
+            HazelcastInstance instance = instances[i];
+            if (instance != leader) {
+                instance.getLifecycleService().terminate();
+            }
+        }
+
+        try {
+            lock.lock();
+            fail();
+        } catch (OperationTimeoutException ignored) {
+        }
+    }
+
+    private void testLongAwait(final HazelcastInstance instance) throws ExecutionException, InterruptedException {
+        final FencedLock lock = instance.getCPSubsystem().getLock(proxyName);
+        lock.lock();
+
+        Future<Object> f1 = spawn(new Callable<Object>() {
+            @Override
+            public Object call() {
+                if (!lock.tryLock(5, TimeUnit.MINUTES)) {
+                    throw new IllegalStateException();
+                }
+
+                lock.unlock();
+
+                return null;
+            }
+        });
+
+        Future<Object> f2 = spawn(new Callable<Object>() {
+            @Override
+            public Object call() {
+                lock.lock();
+                lock.unlock();
+
+                return null;
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                RaftLockService service = getNodeEngineImpl(instance).getService(RaftLockService.SERVICE_NAME);
+                assertEquals(2, service.getLiveOperations().size());
+            }
+        });
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                RaftLockService service = getNodeEngineImpl(instance).getService(RaftLockService.SERVICE_NAME);
+                assertEquals(2, service.getLiveOperations().size());
+            }
+        }, callTimeoutSeconds + 5);
+
+        lock.unlock();
+
+        assertCompletesEventually(f1);
+        assertCompletesEventually(f2);
+
+        f1.get();
+        f2.get();
+    }
+
+    @Override
+    protected Config createConfig(int cpNodeCount, int groupSize) {
+        String callTimeoutStr = String.valueOf(SECONDS.toMillis(callTimeoutSeconds));
+        return super.createConfig(cpNodeCount, groupSize)
+                    .setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), callTimeoutStr);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/RaftSemaphoreLongAwaitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/RaftSemaphoreLongAwaitTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.datastructures.semaphore;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.ISemaphore;
+import com.hazelcast.cp.CPGroupId;
+import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
+import com.hazelcast.cp.internal.datastructures.semaphore.proxy.RaftSessionAwareSemaphoreProxy;
+import com.hazelcast.spi.properties.GroupProperty;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class RaftSemaphoreLongAwaitTest extends HazelcastRaftTestSupport {
+
+    private HazelcastInstance[] instances;
+    private String objectName = "semaphore";
+    private String proxyName = objectName + "@group1";
+    private int groupSize = 3;
+    private CPGroupId groupId;
+    private final long callTimeoutSeconds = 15;
+
+    @Before
+    public void setup() {
+        instances = newInstances(groupSize);
+        groupId = ((RaftSessionAwareSemaphoreProxy) instances[0].getCPSubsystem().getSemaphore(proxyName)).getGroupId();
+    }
+
+    @Test(timeout = 300000)
+    public void when_awaitDurationIsLongerThanOperationTimeout_then_invocationFromLeaderInstanceWaits() throws ExecutionException, InterruptedException {
+        testLongAwait(getLeaderInstance(instances, groupId));
+    }
+
+    @Test(timeout = 300000)
+    public void when_awaitDurationIsLongerThanOperationTimeout_then_invocationFromNonLeaderInstanceWaits() throws ExecutionException, InterruptedException {
+        testLongAwait(getRandomFollowerInstance(instances, groupId));
+    }
+
+    private void testLongAwait(final HazelcastInstance instance) throws ExecutionException, InterruptedException {
+        final ISemaphore semaphore = instance.getCPSubsystem().getSemaphore(proxyName);
+
+        Future<Object> f1 = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws Exception {
+                if (!semaphore.tryAcquire(1, 5, TimeUnit.MINUTES)) {
+                    throw new IllegalStateException();
+                }
+
+                semaphore.release();
+
+                return null;
+            }
+        });
+
+        Future<Object> f2 = spawn(new Callable<Object>() {
+            @Override
+            public Object call() throws InterruptedException {
+                semaphore.acquire();
+                semaphore.release();
+
+                return null;
+            }
+        });
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                RaftSemaphoreService service = getNodeEngineImpl(instance).getService(RaftSemaphoreService.SERVICE_NAME);
+                assertEquals(2, service.getLiveOperations().size());
+            }
+        });
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                RaftSemaphoreService service = getNodeEngineImpl(instance).getService(RaftSemaphoreService.SERVICE_NAME);
+                assertEquals(2, service.getLiveOperations().size());
+            }
+        }, callTimeoutSeconds + 5);
+
+        semaphore.increasePermits(1);
+
+        assertCompletesEventually(f1);
+        assertCompletesEventually(f2);
+
+        f1.get();
+        f2.get();
+    }
+
+    @Override
+    protected Config createConfig(int cpNodeCount, int groupSize) {
+        String callTimeoutStr = String.valueOf(SECONDS.toMillis(callTimeoutSeconds));
+        return super.createConfig(cpNodeCount, groupSize)
+                    .setProperty(GroupProperty.OPERATION_CALL_TIMEOUT_MILLIS.getName(), callTimeoutStr);
+    }
+
+}


### PR DESCRIPTION
If a committed Raft operation, like a lock() call, waits longer than
operation timeout, it should not fail with operation timeout exception.
LiveOperationsTracker API is used by blocking Raft services to report
such operations.