### PR TITLE
Addresses leftovers of advanced network configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
@@ -36,8 +36,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static com.hazelcast.internal.cluster.Versions.V3_12;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
+import static com.hazelcast.internal.cluster.Versions.V3_12;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readNullableMap;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeNullableMap;
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -241,19 +241,7 @@ public abstract class AbstractMember implements Member, Versioned {
         }
 
         Member that = (Member) obj;
-        if (!(address.equals(that.getAddress()))) {
-            return false;
-        }
-
-        if (!(uuid.equals(that.getUuid()))) {
-            return false;
-        }
-
-        if (addressMap == null) {
-            return that.getAddressMap() == null;
-        }
-
-        return addressMap.equals(that.getAddressMap());
+        return address.equals(that.getAddress()) && uuid.equals(that.getUuid());
     }
 
     private void writeAddressMap(ObjectDataOutput out) throws IOException {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -628,7 +628,6 @@ public class ClusterJoinManager {
     }
 
     private boolean checkIfJoinRequestFromAnExistingMember(JoinMessage joinMessage, Connection connection) {
-        // todo check relationship between Connection and joinMessage.getAddress
         Address target = joinMessage.getAddress();
         MemberImpl member = clusterService.getMember(target);
         if (member == null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/PartitionServiceMBean.java
@@ -20,7 +20,6 @@ import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.nio.Address;
 
-import java.net.InetSocketAddress;
 import java.util.Map;
 
 import static com.hazelcast.internal.jmx.ManagementService.quote;
@@ -57,9 +56,8 @@ public class PartitionServiceMBean extends HazelcastMBean<InternalPartitionServi
     @ManagedAnnotation("activePartitionCount")
     @ManagedDescription("Number of active partitions")
     public int getActivePartitionCount() {
-        // todo allocating a new Address each time ??
-        InetSocketAddress thisAddress = hazelcastInstance.getCluster().getLocalMember().getSocketAddress();
-        return managedObject.getMemberPartitionsIfAssigned(new Address(thisAddress)).size();
+        Address thisAddress = hazelcastInstance.getCluster().getLocalMember().getAddress();
+        return managedObject.getMemberPartitionsIfAssigned(thisAddress).size();
     }
 
     @ManagedAnnotation("isClusterSafe")

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/EventServiceImpl.java
@@ -519,7 +519,6 @@ public class EventServiceImpl implements InternalEventService, MetricsProvider {
             Packet packet = new Packet(serializationService.toBytes(eventEnvelope), orderKey)
                     .setPacketType(Packet.Type.EVENT);
 
-            //TODO (TK) : Can the subscriber be other than MEMBER?
             EndpointManager em = nodeEngine.getNode().getNetworkingService().getEndpointManager(MEMBER);
             if (!em.transmit(packet, subscriber)) {
                 if (nodeEngine.isRunning()) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/PartitionServiceMBeanTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/PartitionServiceMBeanTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.jmx;
+
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.monitor.impl.MemberPartitionStateImpl.DEFAULT_PARTITION_COUNT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class PartitionServiceMBeanTest extends HazelcastTestSupport {
+
+    public static final String TYPE_NAME = "HazelcastInstance.PartitionServiceMBean";
+
+    private MBeanDataHolder holder;
+    private String hzName;
+
+    @Before
+    public void setUp() throws Exception {
+        holder = new MBeanDataHolder(createHazelcastInstanceFactory(1));
+        hzName = holder.getHz().getName();
+    }
+
+    @Test
+    public void testPartitionCount() throws Exception {
+        assertEquals(DEFAULT_PARTITION_COUNT, (int) getIntAttribute("partitionCount"));
+    }
+
+    @Test
+    public void testActivePartitionCount() throws Exception {
+        warmUpPartitions(holder.getHz());
+        assertEquals(DEFAULT_PARTITION_COUNT, (int) getIntAttribute("activePartitionCount"));
+    }
+
+    @Test
+    public void testClusterSafe() throws Exception {
+        assertTrue((Boolean) holder.getMBeanAttribute(TYPE_NAME, hzName, "isClusterSafe"));
+    }
+
+    @Test
+    public void testLocalMemberSafe() throws Exception {
+        assertTrue((Boolean) holder.getMBeanAttribute(TYPE_NAME, hzName, "isLocalMemberSafe"));
+    }
+
+    private Integer getIntAttribute(String name) throws Exception {
+        return (Integer) holder.getMBeanAttribute(TYPE_NAME, hzName, name);
+    }
+}


### PR DESCRIPTION
- Member equality takes into account address & UUID, not complete
address map
- Avoid Address object allocation in PartitionServiceMBean

Fixes some items from #14497 