### PR TITLE
Reset follower back-off flag when only received response is accepted

### DIFF
--- a/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-3.12.xsd
@@ -4655,7 +4655,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="append-request-max-entry-count" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="50">
+            <xs:element name="append-request-max-entry-count" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="100">
                 <xs:annotation>
                     <xs:documentation>
                         Max entry count that can be sent in a single batch of append entries request
@@ -4663,7 +4663,7 @@
                 </xs:annotation>
             </xs:element>
             <xs:element name="commit-index-advance-count-to-snapshot" type="xs:unsignedInt" minOccurs="0" maxOccurs="1"
-                        default="1000">
+                        default="10000">
                 <xs:annotation>
                     <xs:documentation>
                         Number of new commits to initiate a new snapshot after the last snapshot

--- a/hazelcast/src/main/java/com/hazelcast/config/cp/RaftAlgorithmConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/cp/RaftAlgorithmConfig.java
@@ -39,13 +39,13 @@ public class RaftAlgorithmConfig {
      * Default max append request entry count.
      * See {@link #appendRequestMaxEntryCount}.
      */
-    public static final int DEFAULT_APPEND_REQUEST_MAX_ENTRY_COUNT = 50;
+    public static final int DEFAULT_APPEND_REQUEST_MAX_ENTRY_COUNT = 100;
 
     /**
      * Default commit index advance to initiate a snapshot.
      * See {@link #commitIndexAdvanceCountToSnapshot}.
      */
-    public static final int DEFAULT_COMMIT_INDEX_ADVANCE_COUNT_TO_SNAPSHOT = 1000;
+    public static final int DEFAULT_COMMIT_INDEX_ADVANCE_COUNT_TO_SNAPSHOT = 10000;
 
     /**
      * Default max allowed uncommitted entry count.

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendFailureResponseHandlerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendFailureResponseHandlerTask.java
@@ -79,13 +79,14 @@ public class AppendFailureResponseHandlerTask extends AbstractResponseHandlerTas
         LeaderState leaderState = state.leaderState();
         FollowerState followerState = leaderState.getFollowerState(resp.follower());
 
-        // Received a response for the last append request. Resetting the flag...
-        followerState.resetAppendRequestBackoff();
 
         long nextIndex = followerState.nextIndex();
         long matchIndex = followerState.matchIndex();
 
         if (resp.expectedNextIndex() == nextIndex) {
+            // Received a response for the last append request. Resetting the flag...
+            followerState.resetAppendRequestBackoff();
+
             // this is the response of the request I have sent for this nextIndex
             nextIndex--;
             if (nextIndex <= matchIndex) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendSuccessResponseHandlerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendSuccessResponseHandlerTask.java
@@ -98,13 +98,14 @@ public class AppendSuccessResponseHandlerTask extends AbstractResponseHandlerTas
         LeaderState leaderState = state.leaderState();
         FollowerState followerState = leaderState.getFollowerState(follower);
 
-        // Received a response for the last append request. Resetting the flag...
-        followerState.resetAppendRequestBackoff();
 
         long matchIndex = followerState.matchIndex();
         long followerLastLogIndex = resp.lastLogIndex();
 
         if (followerLastLogIndex > matchIndex) {
+            // Received a response for the last append request. Resetting the flag...
+            followerState.resetAppendRequestBackoff();
+
             long newNextIndex = followerLastLogIndex + 1;
             followerState.matchIndex(followerLastLogIndex);
             followerState.nextIndex(newNextIndex);

--- a/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-3.12.xsd
@@ -4653,7 +4653,7 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="append-request-max-entry-count" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="50">
+            <xs:element name="append-request-max-entry-count" type="xs:unsignedInt" minOccurs="0" maxOccurs="1" default="100">
                 <xs:annotation>
                     <xs:documentation>
                         Maximum number of entries that can be sent in a single batch of append entries request
@@ -4661,7 +4661,7 @@
                 </xs:annotation>
             </xs:element>
             <xs:element name="commit-index-advance-count-to-snapshot" type="xs:unsignedInt" minOccurs="0" maxOccurs="1"
-                        default="1000">
+                        default="10000">
                 <xs:annotation>
                     <xs:documentation>
                         Number of new commits to initiate a new snapshot after the last snapshot

--- a/hazelcast/src/main/resources/hazelcast-default.xml
+++ b/hazelcast/src/main/resources/hazelcast-default.xml
@@ -394,8 +394,8 @@
             <leader-election-timeout-in-millis>2000</leader-election-timeout-in-millis>
             <leader-heartbeat-period-in-millis>5000</leader-heartbeat-period-in-millis>
             <max-missed-leader-heartbeat-count>5</max-missed-leader-heartbeat-count>
-            <append-request-max-entry-count>50</append-request-max-entry-count>
-            <commit-index-advance-count-to-snapshot>1000</commit-index-advance-count-to-snapshot>
+            <append-request-max-entry-count>100</append-request-max-entry-count>
+            <commit-index-advance-count-to-snapshot>10000</commit-index-advance-count-to-snapshot>
             <uncommitted-entry-count-to-reject-new-appends>100</uncommitted-entry-count-to-reject-new-appends>
             <append-request-backoff-timeout-in-millis>100</append-request-backoff-timeout-in-millis>
         </raft-algorithm>

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -380,8 +380,8 @@ hazelcast:
       leader-election-timeout-in-millis: 2000
       leader-heartbeat-period-in-millis: 5000
       max-missed-leader-heartbeat-count: 5
-      append-request-max-entry-count: 50
-      commit-index-advance-count-to-snapshot: 1000
+      append-request-max-entry-count: 100
+      commit-index-advance-count-to-snapshot: 10000
       uncommitted-entry-count-to-reject-new-appends: 100
       append-request-backoff-timeout-in-millis: 100
 #    semaphores:


### PR DESCRIPTION
Additionally, tune two Raft algorithm config default values:

- `appendRequestMaxEntryCount`: from 50 to 100
- `commitIndexAdvanceCountToSnapshot`: from 1000 to 10k

_These changes are due to analyses after stress testing._