### PR TITLE
Prevent expiration operation creation if partition is migrating

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/ClearExpiredRecordsTask.java
@@ -130,6 +130,10 @@ public abstract class ClearExpiredRecordsTask<T, S> implements Runnable {
             T container = this.containers[partitionId];
 
             IPartition partition = partitionService.getPartition(partitionId, false);
+            if (partition.isMigrating()) {
+                continue;
+            }
+
             if (partition.isLocal()) {
                 if (lostPartitionDetected) {
                     equalizeBackupSizeWithPrimary(container);


### PR DESCRIPTION
no need to fill logs with lots of failed expiry operation logs.

stumbled on during investigations of https://github.com/hazelcast/hazelcast-enterprise/issues/2723