### PR TITLE
Add termination logic to ungraceful shutdown operations.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
@@ -28,7 +28,6 @@ import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.test.backup.BackupAccessor;
 import com.hazelcast.test.backup.TestBackupUtils;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -286,7 +285,6 @@ public class CacheExpirationTest extends CacheTestSupport {
     }
 
     @Test
-    @Ignore("https://github.com/hazelcast/hazelcast-enterprise/issues/2723")
     public void test_backupOperationAppliesDefaultExpiryPolicy() {
         SimpleExpiryListener listener = new SimpleExpiryListener();
         HazelcastExpiryPolicy defaultExpiryPolicy = new HazelcastExpiryPolicy(FIVE_SECONDS, FIVE_SECONDS, FIVE_SECONDS);


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast-enterprise/issues/2723

In case of exceptions, like the exceptions during migrations, ungraceful shutdown operations were getting exceptions and this was causing long running ungraceful shutdown. With this PR, we are finishing those operations immediately if there is an exception. 

ee counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/2817