### PR TITLE
[WIP]Fixes Set/List destroy race

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/collections/impl/set/ListBasicClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/collections/impl/set/ListBasicClientTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.collections.impl.set;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.collection.impl.list.ListAbstractTest;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ListBasicClientTest extends ListAbstractTest {
+
+    private TestHazelcastFactory factory = new TestHazelcastFactory();
+
+    @After
+    public void teardown() {
+        factory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance[] newInstances(Config config) {
+        HazelcastInstance member = factory.newHazelcastInstance(config);
+        HazelcastInstance client = factory.newHazelcastClient();
+
+        return new HazelcastInstance[]{client, member};
+    }
+}


### PR DESCRIPTION
Collection destroy operation runs in the calling thread. It clears the internal hash sets and lists. However, internal data structures are not thread safe. So destroy operation must run on partition thread.

https://github.com/hazelcast/hazelcast/issues/14572