### PR TITLE
The ClientStatisticsTest.waitForFirstStatisticsCollection timeout may not be enough

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/statistics/ClientStatisticsTest.java
@@ -343,7 +343,7 @@ public class ClientStatisticsTest extends ClientTestSupport {
             public void run() {
                 getStats(client, clientEngine);
             }
-        }, STATS_PERIOD_SECONDS * 3);
+        });
     }
 
     private static void waitForNextStatsCollection(final HazelcastClientInstanceImpl client, final ClientEngineImpl clientEngine,


### PR DESCRIPTION
Increased the ClientStatisticsTest.waitForFirstStatisticsCollection timeout from 3 seconds to 120 seconds so that any latency during the run will not cause random test failures due to timings.

fixes https://github.com/hazelcast/hazelcast/issues/14453