### PR TITLE
Remove event count assertion.

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/eviction/CacheExpirationTest.java
@@ -286,10 +286,9 @@ public class CacheExpirationTest extends CacheTestSupport {
 
     @Test
     public void test_backupOperationAppliesDefaultExpiryPolicy() {
-        SimpleExpiryListener listener = new SimpleExpiryListener();
         HazelcastExpiryPolicy defaultExpiryPolicy = new HazelcastExpiryPolicy(FIVE_SECONDS, FIVE_SECONDS, FIVE_SECONDS);
 
-        CacheConfig cacheConfig = createCacheConfig(defaultExpiryPolicy, listener);
+        CacheConfig cacheConfig = createCacheConfig(defaultExpiryPolicy);
         ICache cache = createCache(cacheConfig);
 
         for (int i = 0; i < 100; i++) {
@@ -321,7 +320,6 @@ public class CacheExpirationTest extends CacheTestSupport {
         }
 
         assertEquals(0, unExpiredCount);
-        assertEqualsEventually(100, listener.expirationCount);
     }
 
     @Test


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/14434

Backup promotion upon terminate can cause duplicate expiration
event creation. This test's main purpose is to make sure
promoted entries are expired and counting the number of
events is out of the scope.