### PR TITLE
Fix discoveryService.next/current behavior

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/HazelcastClient.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.resolveClientConfig;
+import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.resolveClientFailoverConfig;
 
 /**
  * The HazelcastClient is comparable to the {@link com.hazelcast.core.Hazelcast} class and provides the ability
@@ -102,7 +103,7 @@ public final class HazelcastClient {
      * @see #getHazelcastClientByName(String) (String)
      */
     public static HazelcastInstance newHazelcastClient() {
-        return newHazelcastClientInternal(null, resolveClientConfig());
+        return newHazelcastClientInternal(null, resolveClientConfig(null), null);
     }
 
     /**
@@ -119,7 +120,7 @@ public final class HazelcastClient {
      * @see #getHazelcastClientByName(String) (String)
      */
     public static HazelcastInstance newHazelcastClient(ClientConfig config) {
-        return newHazelcastClientInternal(null, resolveClientConfig(config));
+        return newHazelcastClientInternal(null, resolveClientConfig(config), null);
     }
 
     /**
@@ -141,16 +142,18 @@ public final class HazelcastClient {
      * @return the client instance
      */
     public static HazelcastInstance newHazelcastFailoverClient(ClientFailoverConfig clientFailoverConfig) {
-        return newHazelcastClientInternal(null, resolveClientConfig(clientFailoverConfig));
+        return newHazelcastClientInternal(null, null, resolveClientFailoverConfig(clientFailoverConfig));
     }
 
-    static HazelcastInstance newHazelcastClientInternal(AddressProvider addressProvider, ClientFailoverConfig failoverConfig) {
+    static HazelcastInstance newHazelcastClientInternal(AddressProvider addressProvider, ClientConfig clientConfig,
+                                                        ClientFailoverConfig failoverConfig) {
         final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         HazelcastClientProxy proxy;
         try {
             Thread.currentThread().setContextClassLoader(HazelcastClient.class.getClassLoader());
             ClientConnectionManagerFactory factory = new DefaultClientConnectionManagerFactory();
-            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(failoverConfig, factory, addressProvider);
+            HazelcastClientInstanceImpl client =
+                    new HazelcastClientInstanceImpl(clientConfig, failoverConfig, factory, addressProvider);
             client.start();
             OutOfMemoryErrorDispatcher.registerClient(client);
             proxy = new HazelcastClientProxy(client);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -137,7 +137,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         this.outboundPortCount = outboundPorts.size();
         this.heartbeat = new HeartbeatManager(this, client);
         this.authenticationTimeout = heartbeat.getHeartbeatTimeout();
-        this.failoverConfigProvided = client.getFailoverConfig().getClientConfigs().size() > 1;
+        this.failoverConfigProvided = client.getFailoverConfig() != null;
     }
 
     private Collection<Integer> getOutboundPorts(ClientNetworkConfig networkConfig) {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnectorServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnectorServiceImpl.java
@@ -197,7 +197,6 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
 
         // we reset the search so that we will iterate the list try-count times, each time we start searching for a new cluster
         discoveryService.resetSearch();
-        discoveryService.next();
 
         while (discoveryService.hasNext() && client.getLifecycleService().isRunning()) {
             CandidateClusterContext candidateClusterContext = discoveryService.next();

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDiscoveryService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDiscoveryService.java
@@ -50,8 +50,8 @@ public class ClientDiscoveryService implements Iterator<CandidateClusterContext>
         if (currentTryCount == configsMaxTryCount) {
             throw new NoSuchElementException("Has no alternative cluster");
         }
-        CandidateClusterContext candidateClusterContext = discoveryServices.get((int) (head % size));
         head++;
+        CandidateClusterContext candidateClusterContext = discoveryServices.get((int) (head % size));
         if (head % size == 0) {
             currentTryCount++;
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
@@ -45,7 +45,7 @@ public final class FailoverClientConfigSupport {
      * @return resolvedConfigs
      * @throws InvalidConfigurationException when given config is not valid
      */
-    public static ClientFailoverConfig resolveClientConfig(ClientFailoverConfig clientFailoverConfig) {
+    public static ClientFailoverConfig resolveClientFailoverConfig(ClientFailoverConfig clientFailoverConfig) {
         if (clientFailoverConfig == null) {
             XmlClientFailoverConfigBuilder configBuilder = new XmlClientFailoverConfigBuilder();
             clientFailoverConfig = configBuilder.build();
@@ -55,21 +55,21 @@ public final class FailoverClientConfigSupport {
     }
 
     /**
-     * Returns a ClientFailoverConfig with single client config. If clientConfig is null,
-     * We create it via XmlClientConfigBuilder().build()
+     * If clientConfig is null, it is created via XmlClientConfigBuilder().build()
+     *
+     * used with
+     * HazelcastClient.newHazelcastClient() or
+     * HazelcastClient.newHazelcastClient(ClientConfig config)
      *
      * @param config provided via HazelcastClient.newHazelcastClient(ClientConfig config)
      * @return resolvedConfigs
      * @throws InvalidConfigurationException when given config is not valid
      */
-    public static ClientFailoverConfig resolveClientConfig(ClientConfig config) {
+    public static ClientConfig resolveClientConfig(ClientConfig config) {
         if (config == null) {
-            config = createDefaultClientConfig();
+            return createDefaultClientConfig();
         }
-        ClientFailoverConfig resolvedConfig = new ClientFailoverConfig();
-        resolvedConfig.addClientConfig(config);
-        resolvedConfig.setTryCount(1);
-        return resolvedConfig;
+        return config;
     }
 
     private static ClientConfig createDefaultClientConfig() {
@@ -99,22 +99,6 @@ public final class FailoverClientConfigSupport {
             config = new XmlClientConfigBuilder(xmlConfigLocator).build();
         }
         return config;
-    }
-
-    /**
-     * Creates ClientFailoverConfig is created which is equivalent of single client config.
-     *
-     * used with HazelcastClient.newHazelcastClient()
-     *
-     * @return resolved configs
-     */
-    public static ClientFailoverConfig resolveClientConfig() {
-        ClientFailoverConfig resolvedConfig = new ClientFailoverConfig();
-
-        ClientConfig config = createDefaultClientConfig();
-        resolvedConfig.addClientConfig(config);
-        resolvedConfig.setTryCount(1);
-        return resolvedConfig;
     }
 
     /**

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -149,6 +149,7 @@ import com.hazelcast.transaction.impl.xa.XAService;
 import com.hazelcast.util.ServiceLoader;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -201,10 +202,17 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     private final ClientDiscoveryService clientDiscoveryService;
     private final ClientProxySessionManager proxySessionManager;
 
-    public HazelcastClientInstanceImpl(ClientFailoverConfig clientFailoverConfig,
+    public HazelcastClientInstanceImpl(ClientConfig clientConfig,
+                                       ClientFailoverConfig clientFailoverConfig,
                                        ClientConnectionManagerFactory clientConnectionManagerFactory,
                                        AddressProvider externalAddressProvider) {
-        this.config = clientFailoverConfig.getClientConfigs().get(0);
+        assert clientConfig != null || clientFailoverConfig != null : "At most one type of config can be provided";
+        assert clientConfig == null || clientFailoverConfig == null : "At least one config should be provided ";
+        if (clientConfig != null) {
+            this.config = clientConfig;
+        } else {
+            this.config = clientFailoverConfig.getClientConfigs().get(0);
+        }
         this.clientFailoverConfig = clientFailoverConfig;
         if (config.getInstanceName() != null) {
             instanceName = config.getInstanceName();
@@ -276,8 +284,15 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
     }
 
     private ClientDiscoveryService initClientDiscoveryService(AddressProvider externalAddressProvider) {
-        int tryCount = clientFailoverConfig.getTryCount();
-        List<ClientConfig> configs = clientFailoverConfig.getClientConfigs();
+        int tryCount;
+        List<ClientConfig> configs;
+        if (clientFailoverConfig == null) {
+            tryCount = 0;
+            configs = Collections.singletonList(config);
+        } else {
+            tryCount = clientFailoverConfig.getTryCount();
+            configs = clientFailoverConfig.getClientConfigs();
+        }
         ClientDiscoveryServiceBuilder builder = new ClientDiscoveryServiceBuilder(tryCount, configs, loggingService,
                 externalAddressProvider, properties, clientExtension);
         return builder.build();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientUtil.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientUtil.java
@@ -18,7 +18,6 @@ package com.hazelcast.client;
 
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.client.connection.AddressProvider;
-import com.hazelcast.client.impl.clientside.FailoverClientConfigSupport;
 import com.hazelcast.core.HazelcastInstance;
 
 import static com.hazelcast.client.HazelcastClient.newHazelcastClientInternal;
@@ -26,6 +25,6 @@ import static com.hazelcast.client.HazelcastClient.newHazelcastClientInternal;
 public class HazelcastClientUtil {
 
     public static HazelcastInstance newHazelcastClient(AddressProvider addressProvider, ClientConfig clientConfig) {
-        return newHazelcastClientInternal(addressProvider, FailoverClientConfigSupport.resolveClientConfig(clientConfig));
+        return newHazelcastClientInternal(addressProvider, clientConfig, null);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientClusterDiscoveryServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientClusterDiscoveryServiceTest.java
@@ -28,8 +28,10 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 import java.util.NoSuchElementException;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -74,7 +76,7 @@ public class ClientClusterDiscoveryServiceTest {
 
         discoveryService.resetSearch();
 
-        assertEquals(arrayList.get(2), discoveryService.next());
+        assertEquals(arrayList.get(3), discoveryService.next());
 
     }
 
@@ -113,4 +115,40 @@ public class ClientClusterDiscoveryServiceTest {
 
     }
 
+    @Test
+    public void testCurrentAndNextReturnsCorrect() {
+        ArrayList<CandidateClusterContext> arrayList = new ArrayList<CandidateClusterContext>();
+
+        CandidateClusterContext first = createContext();
+        arrayList.add(first);
+        CandidateClusterContext second = createContext();
+        arrayList.add(second);
+        ClientDiscoveryService discoveryService = new ClientDiscoveryService(10, arrayList);
+
+        assertEquals(first, discoveryService.current());
+        discoveryService.resetSearch();
+        assertTrue(discoveryService.hasNext());
+
+        assertEquals(second, discoveryService.next());
+        assertEquals(second, discoveryService.current());
+
+        assertEquals(first, discoveryService.next());
+        assertEquals(first, discoveryService.current());
+    }
+
+    @Test
+    public void testSingleCandidateBehavior() {
+        ArrayList<CandidateClusterContext> arrayList = new ArrayList<CandidateClusterContext>();
+
+        arrayList.add(createContext());
+        ClientDiscoveryService discoveryService = new ClientDiscoveryService(1, arrayList);
+
+        assertNotNull(discoveryService.current());
+        discoveryService.resetSearch();
+        assertTrue(discoveryService.hasNext());
+
+        assertNotNull(discoveryService.next());
+        assertNotNull(discoveryService.current());
+        assertFalse(discoveryService.hasNext());
+    }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/FailoverConfigTest.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.resolveClientConfig;
+import static com.hazelcast.client.impl.clientside.FailoverClientConfigSupport.resolveClientFailoverConfig;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -101,7 +101,7 @@ public class FailoverConfigTest {
         ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
         clientFailoverConfig.addClientConfig(new ClientConfig());
         clientFailoverConfig.addClientConfig(new ClientConfig());
-        resolveClientConfig(clientFailoverConfig);
+        resolveClientFailoverConfig(clientFailoverConfig);
     }
 
     @Test
@@ -113,7 +113,7 @@ public class FailoverConfigTest {
         alternativeConfig.getGroupConfig().setName("alternative");
         clientFailoverConfig.addClientConfig(alternativeConfig);
 
-        resolveClientConfig(clientFailoverConfig);
+        resolveClientFailoverConfig(clientFailoverConfig);
     }
 
     @Test(expected = InvalidConfigurationException.class)
@@ -126,7 +126,7 @@ public class FailoverConfigTest {
         alternativeConfig.setProperty("newProperty", "newValue");
         clientFailoverConfig.addClientConfig(alternativeConfig);
 
-        resolveClientConfig(clientFailoverConfig);
+        resolveClientFailoverConfig(clientFailoverConfig);
     }
 
     @Test
@@ -141,32 +141,18 @@ public class FailoverConfigTest {
         alternativeConfig.getSecurityConfig().setCredentialsFactoryConfig(credentialsFactoryConfig);
         clientFailoverConfig.addClientConfig(alternativeConfig);
 
-        resolveClientConfig(clientFailoverConfig);
+        resolveClientFailoverConfig(clientFailoverConfig);
     }
 
     @Test(expected = HazelcastException.class)
     public void test_throwsException_whenFailoverConfigIsIntended_butPassedNull() {
-        ClientFailoverConfig clientFailoverConfig = resolveClientConfig((ClientFailoverConfig) null);
-        assertEquals(1, clientFailoverConfig.getClientConfigs().size());
-        assertEquals("dev", clientFailoverConfig.getClientConfigs().get(0).getGroupConfig().getName());
-    }
-
-    @Test
-    public void test_returnsDefaultConfigWhen_ClienConfig_passedNull() {
-        ClientFailoverConfig clientFailoverConfig = resolveClientConfig((ClientConfig) null);
-        assertEquals(1, clientFailoverConfig.getClientConfigs().size());
-        assertEquals("dev", clientFailoverConfig.getClientConfigs().get(0).getGroupConfig().getName());
-    }
-
-    @Test
-    public void test_returnsDefaultConfigWhenEmpty() {
-        ClientFailoverConfig clientFailoverConfig = resolveClientConfig();
+        ClientFailoverConfig clientFailoverConfig = resolveClientFailoverConfig(null);
         assertEquals(1, clientFailoverConfig.getClientConfigs().size());
         assertEquals("dev", clientFailoverConfig.getClientConfigs().get(0).getGroupConfig().getName());
     }
 
     @Test(expected = InvalidConfigurationException.class)
     public void test_throwsException_whenFailoverConfigIsEmpty() {
-        resolveClientConfig(new ClientFailoverConfig());
+        resolveClientFailoverConfig(new ClientFailoverConfig());
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/ConnectMemberListOrderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/ConnectMemberListOrderTest.java
@@ -105,7 +105,7 @@ public class ConnectMemberListOrderTest extends ClientTestSupport {
         HazelcastClientInstanceImpl instanceImpl = getHazelcastClientInstanceImpl(client);
         ClientDiscoveryService clientDiscoveryService = instanceImpl.getClientDiscoveryService();
         clientDiscoveryService.resetSearch();
-        CandidateClusterContext clusterContext = clientDiscoveryService.next();
+        CandidateClusterContext clusterContext = clientDiscoveryService.current();
         ClusterConnectorServiceImpl clusterConnectorService = (ClusterConnectorServiceImpl) instanceImpl.getClusterConnectorService();
         return clusterConnectorService.getPossibleMemberAddresses(clusterContext.getAddressProvider());
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestHazelcastFactory.java
@@ -19,7 +19,6 @@ package com.hazelcast.client.test;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientAwsConfig;
 import com.hazelcast.client.config.ClientConfig;
-import com.hazelcast.client.config.ClientFailoverConfig;
 import com.hazelcast.client.config.XmlClientConfigBuilder;
 import com.hazelcast.client.connection.AddressProvider;
 import com.hazelcast.client.connection.Addresses;
@@ -68,17 +67,13 @@ public class TestHazelcastFactory extends TestHazelcastInstanceFactory {
             config = new XmlClientConfigBuilder().build();
         }
 
-        ClientFailoverConfig resolvedConfig = new ClientFailoverConfig();
-        resolvedConfig.addClientConfig(config);
-        resolvedConfig.setTryCount(1);
-
         Thread currentThread = Thread.currentThread();
         ClassLoader tccl = currentThread.getContextClassLoader();
         try {
             if (tccl == ClassLoader.getSystemClassLoader()) {
                 currentThread.setContextClassLoader(HazelcastClient.class.getClassLoader());
             }
-            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(resolvedConfig,
+            HazelcastClientInstanceImpl client = new HazelcastClientInstanceImpl(config, null,
                     clientRegistry.createClientServiceFactory(), createAddressProvider(config));
             client.start();
             clients.add(client);


### PR DESCRIPTION
Relation of `next` and `current` behavior was wrong.
After the fix, `current` returns whatever the last `next` call returns.
unit-tests are added in this pr.

Secondly, fixed the behavior when there is single cluster in
ClientFailoverConfig. unit-tests are refactored accordingly.

There are also related user API level tests here.
https://github.com/hazelcast/hazelcast-enterprise/pull/2829

fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2820