### PR TITLE
Write through optimization

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -79,6 +79,7 @@ import static com.hazelcast.client.spi.properties.ClientProperty.ALLOW_INVOCATIO
 import static com.hazelcast.client.spi.properties.ClientProperty.IO_BALANCER_INTERVAL_SECONDS;
 import static com.hazelcast.client.spi.properties.ClientProperty.IO_INPUT_THREAD_COUNT;
 import static com.hazelcast.client.spi.properties.ClientProperty.IO_OUTPUT_THREAD_COUNT;
+import static com.hazelcast.client.spi.properties.ClientProperty.IO_WRITE_THROUGH_ENABLED;
 import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -181,7 +182,9 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                         .errorHandler(new ClientConnectionChannelErrorHandler())
                         .inputThreadCount(inputThreads)
                         .outputThreadCount(outputThreads)
-                        .balancerIntervalSeconds(properties.getInteger(IO_BALANCER_INTERVAL_SECONDS)));
+                        .balancerIntervalSeconds(properties.getInteger(IO_BALANCER_INTERVAL_SECONDS))
+                        .writeThroughEnabled(properties.getBoolean(IO_WRITE_THROUGH_ENABLED))
+                        .concurrencyDetection(client.getConcurrencyDetection()));
     }
 
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientInvocationService.java
@@ -43,6 +43,4 @@ public interface ClientInvocationService {
     boolean isRedoOperation();
 
     Consumer<ClientMessage> getResponseHandler();
-
-    long concurrentInvocations();
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AbstractClientInvocationService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/AbstractClientInvocationService.java
@@ -75,27 +75,19 @@ public abstract class AbstractClientInvocationService implements ClientInvocatio
         this.invocationLogger = client.getLoggingService().getLogger(ClientInvocationService.class);
         this.invocationTimeoutMillis = initInvocationTimeoutMillis();
         this.invocationRetryPauseMillis = initInvocationRetryPauseMillis();
-        this.responseHandlerSupplier = new ClientResponseHandlerSupplier(this);
+        this.responseHandlerSupplier = new ClientResponseHandlerSupplier(this, client.getConcurrencyDetection());
 
         HazelcastProperties properties = client.getProperties();
-        int maxAllowedConcurrentInvocations = properties.getInteger(MAX_CONCURRENT_INVOCATIONS);
-        long backofftimeoutMs = properties.getLong(BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS);
-        // clients needs to have a call id generator capable of determining how many
-        // pending calls there are. So backpressure needs to be on
-        this.callIdSequence = CallIdFactory
-                .newCallIdSequence(true, maxAllowedConcurrentInvocations, backofftimeoutMs);
+        this.callIdSequence = CallIdFactory.newCallIdSequence(
+                properties.getInteger(MAX_CONCURRENT_INVOCATIONS),
+                properties.getLong(BACKPRESSURE_BACKOFF_TIMEOUT_MILLIS),
+                client.getConcurrencyDetection());
 
         client.getMetricsRegistry().scanAndRegister(this, "invocations");
     }
 
-    @Override
-    public long concurrentInvocations() {
-        return callIdSequence.concurrentInvocations();
-    }
-
     private long initInvocationRetryPauseMillis() {
         return client.getProperties().getPositiveMillisOrDefault(INVOCATION_RETRY_PAUSE_MILLIS);
-
     }
 
     private long initInvocationTimeoutMillis() {

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/properties/ClientProperty.java
@@ -168,6 +168,30 @@ public final class ClientProperty {
             = new HazelcastProperty("hazelcast.client.io.balancer.interval.seconds", 20, SECONDS);
 
     /**
+     * Optimization that allows sending of packets over the network to be done on the calling thread if the
+     * conditions are right. This can reduce latency and increase performance for low threaded environments.
+     *
+     * It is disabled.
+     */
+    public static final HazelcastProperty IO_WRITE_THROUGH_ENABLED
+            = new HazelcastProperty("hazelcast.client.io.write.through", false);
+
+    /**
+     * Property needed for concurrency detection so that write through and dynamic response handling
+     * can be done correctly. This property sets the window the concurrency detection will signalling
+     * that concurrency has been detected, even if there are no further updates in that window.
+     *
+     * Normally in a concurrency system the windows keeps sliding forward so it will always remain
+     * concurrent.
+     *
+     * Setting it too high effectively disabled the optimization because once concurrency has been detected
+     * it will keep that way. Setting it too low could lead to suboptimal performance because the system
+     * will try write through and other optimization even though the system is concurrent.
+     */
+    public static final HazelcastProperty CONCURRENT_WINDOW_MS
+            = new HazelcastProperty("hazelcast.client.concurrent.window.ms", 100, MILLISECONDS);
+
+    /**
      * The number of response threads.
      *
      * By default there are 2 response threads; this gives stable and good performance.

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientResponseHandlerSupplierTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/ClientResponseHandlerSupplierTest.java
@@ -96,7 +96,8 @@ public class ClientResponseHandlerSupplierTest extends ClientTestSupport {
         HazelcastClientInstanceImpl clientInstanceImpl = getHazelcastClientInstanceImpl(client);
         AbstractClientInvocationService invocationService = (AbstractClientInvocationService) clientInstanceImpl.getInvocationService();
 
-        ClientResponseHandlerSupplier responseHandlerSupplier = new ClientResponseHandlerSupplier(invocationService);
+        ClientResponseHandlerSupplier responseHandlerSupplier =
+                new ClientResponseHandlerSupplier(invocationService, clientInstanceImpl.getConcurrencyDetection());
         return responseHandlerSupplier.get();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultNodeContext.java
@@ -43,6 +43,7 @@ import static com.hazelcast.config.ConfigAccessor.getActiveMemberNetworkConfig;
 import static com.hazelcast.spi.properties.GroupProperty.IO_BALANCER_INTERVAL_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.IO_INPUT_THREAD_COUNT;
 import static com.hazelcast.spi.properties.GroupProperty.IO_OUTPUT_THREAD_COUNT;
+import static com.hazelcast.spi.properties.GroupProperty.IO_WRITE_THROUGH_ENABLED;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
@@ -173,6 +174,8 @@ public class DefaultNodeContext implements NodeContext {
                         .errorHandler(errorHandler)
                         .inputThreadCount(props.getInteger(IO_INPUT_THREAD_COUNT))
                         .outputThreadCount(props.getInteger(IO_OUTPUT_THREAD_COUNT))
-                        .balancerIntervalSeconds(props.getInteger(IO_BALANCER_INTERVAL_SECONDS)));
+                        .balancerIntervalSeconds(props.getInteger(IO_BALANCER_INTERVAL_SECONDS))
+                        .writeThroughEnabled(props.getBoolean(IO_WRITE_THROUGH_ENABLED))
+                        .concurrencyDetection(node.nodeEngine.getConcurrencyDetection()));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioInboundPipeline.java
@@ -157,6 +157,11 @@ public final class NioInboundPipeline extends NioPipeline implements InboundPipe
             }
         } while (!cleanPipeline);
 
+        if (migrationRequested()) {
+            startMigration();
+            return;
+        }
+
         if (unregisterRead) {
             unregisterOp(OP_READ);
         }
@@ -266,7 +271,7 @@ public final class NioInboundPipeline extends NioPipeline implements InboundPipe
 
     @Override
     public NioInboundPipeline wakeup() {
-        addTaskAndWakeup(new NioPipelineTask(this) {
+        ownerAddTaskAndWakeup(new NioPipelineTask(this) {
             @Override
             protected void run0() throws IOException {
                 registerOp(OP_READ);

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -29,6 +29,7 @@ import com.hazelcast.internal.networking.InboundHandler;
 import com.hazelcast.internal.networking.Networking;
 import com.hazelcast.internal.networking.OutboundHandler;
 import com.hazelcast.internal.networking.nio.iobalancer.IOBalancer;
+import com.hazelcast.internal.util.ConcurrencyDetection;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.util.concurrent.BackoffIdleStrategy;
@@ -98,6 +99,8 @@ public final class NioNetworking implements Networking {
     private final BackoffIdleStrategy idleStrategy;
     private final boolean selectorWorkaroundTest;
     private volatile ExecutorService closeListenerExecutor;
+    private final ConcurrencyDetection concurrencyDetection;
+    private final boolean writeThroughEnabled;
     private volatile IOBalancer ioBalancer;
     private volatile NioThread[] inputThreads;
     private volatile NioThread[] outputThreads;
@@ -126,6 +129,8 @@ public final class NioNetworking implements Networking {
         this.selectorMode = ctx.selectorMode;
         this.selectorWorkaroundTest = ctx.selectorWorkaroundTest;
         this.idleStrategy = ctx.idleStrategy;
+        this.concurrencyDetection = ctx.concurrencyDetection;
+        this.writeThroughEnabled = ctx.writeThroughEnabled;
     }
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "used only for testing")
@@ -153,6 +158,7 @@ public final class NioNetworking implements Networking {
             logger.fine("TcpIpConnectionManager configured with Non Blocking IO-threading model: "
                     + inputThreadCount + " input threads and "
                     + outputThreadCount + " output threads");
+            logger.fine("write through enabled:" + writeThroughEnabled);
         }
 
         logger.log(selectorMode != SELECT ? Level.INFO : FINE, "IO threads selector mode is " + selectorMode);
@@ -269,7 +275,9 @@ public final class NioNetworking implements Networking {
                 threads[index],
                 errorHandler,
                 loggingService.getLogger(NioOutboundPipeline.class),
-                ioBalancer);
+                ioBalancer,
+                concurrencyDetection,
+                writeThroughEnabled);
     }
 
     private NioInboundPipeline newInboundPipeline(NioChannel channel) {
@@ -379,12 +387,27 @@ public final class NioNetworking implements Networking {
         // In Hazelcast 3.8, selector mode must be set via HazelcastProperties
         private SelectorMode selectorMode = SelectorMode.getConfiguredValue();
         private boolean selectorWorkaroundTest = Boolean.getBoolean("hazelcast.io.selector.workaround.test");
+        private ConcurrencyDetection concurrencyDetection;
+
+        // if the calling thread is allowed to write through to the socket if that is possible.
+        // this is an optimization that can speed up low threaded setups
+        private boolean writeThroughEnabled;
 
         public Context() {
             String selectorModeString = SelectorMode.getConfiguredString();
             if (selectorModeString.startsWith(SELECT_NOW_STRING + ",")) {
                 idleStrategy = createBackoffIdleStrategy(selectorModeString);
             }
+        }
+
+        public Context writeThroughEnabled(boolean writeThroughEnabled) {
+            this.writeThroughEnabled = writeThroughEnabled;
+            return this;
+        }
+
+        public Context concurrencyDetection(ConcurrencyDetection concurrencyDetection) {
+            this.concurrencyDetection = concurrencyDetection;
+            return this;
         }
 
         public Context selectorWorkaroundTest(boolean selectorWorkaroundTest) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipelineTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioPipelineTask.java
@@ -28,7 +28,7 @@ import static java.lang.Thread.currentThread;
  * NioThread that doesn't own the pipeline any longer. Therefor this task does a
  * check when it is executed if the owner of the pipeline is the same as the
  * current thread. If it is, then the {@link #run0()} is called. If it isn't, the
- * task is send to the {@link NioPipeline#addTaskAndWakeup(Runnable)} which will
+ * task is send to the {@link NioPipeline#ownerAddTaskAndWakeup(Runnable)} which will
  * make sure the task is send to the right NioThread.
  */
 abstract class NioPipelineTask implements Runnable {
@@ -52,7 +52,7 @@ abstract class NioPipelineTask implements Runnable {
             // the pipeline is migrating or already has migrated
             // lets lets reschedule this task on the pipeline so
             // it will be picked up by the new owner.
-            pipeline.addTaskAndWakeup(this);
+            pipeline.ownerAddTaskAndWakeup(this);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyDetection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ConcurrencyDetection.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.lang.System.nanoTime;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Responsible for tracking if concurrency is detected.
+ * <p>
+ * Concurrency is currently triggered at 2 levels:
+ * - number of concurrent invocations
+ * - contention on the io system.
+ */
+public abstract class ConcurrencyDetection {
+
+    private final boolean enabled;
+
+    private ConcurrencyDetection(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Checks if any concurrency is detected.
+     * <p>
+     * This call is thread-safe;
+     *
+     * @return true if detected, false otherwise.
+     */
+    public abstract boolean isDetected();
+
+    /**
+     * Called when concurrency is detected.
+     * <p>
+     * This call is thread-safe;
+     */
+    public abstract void onDetected();
+
+    /**
+     * Checks if this ConcurrencyDetection is enabled.
+     * <p>
+     * This is useful if you want to fall back to legacy mode.
+     *
+     * @return true if enabled, false otherwise.
+     */
+    public boolean enabled() {
+        return enabled;
+    }
+
+    public static ConcurrencyDetection createEnabled(long durationMs) {
+        return new EnabledConcurrencyDetection(durationMs);
+    }
+
+    public static ConcurrencyDetection createDisabled() {
+        return new DisabledConcurrencyDetection();
+    }
+
+    /**
+     * The DisabledConcurrencyDetection indicates that there is always concurrency,
+     * even if there is on concurrency. This prevent write through and therefore lets the
+     * system behave as before the write through was added.
+     */
+    private static final class DisabledConcurrencyDetection extends ConcurrencyDetection {
+
+        public DisabledConcurrencyDetection() {
+            super(false);
+        }
+
+        @Override
+        public boolean isDetected() {
+            return true;
+        }
+
+        @Override
+        public void onDetected() {
+            //no-op
+        }
+    }
+
+    private static final class EnabledConcurrencyDetection extends ConcurrencyDetection {
+
+        private final long windowNanos;
+        private final AtomicLong expirationNanosRef = new AtomicLong(System.nanoTime());
+        private final long halfWindowNanos;
+
+        private EnabledConcurrencyDetection(long delayMs) {
+            super(true);
+            this.windowNanos = MILLISECONDS.toNanos(delayMs);
+            this.halfWindowNanos = windowNanos / 2;
+        }
+
+        @Override
+        public boolean isDetected() {
+            return nanoTime() - expirationNanosRef.get() < 0;
+        }
+
+        @Override
+        public void onDetected() {
+            long nowNanos = nanoTime();
+            long expirationNanos = expirationNanosRef.get();
+
+            if (nowNanos - (expirationNanos - halfWindowNanos) > 0) {
+                expirationNanosRef.lazySet(nowNanos + windowNanos);
+            }
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -41,6 +41,7 @@ import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.usercodedeployment.UserCodeDeploymentClassLoader;
 import com.hazelcast.internal.usercodedeployment.UserCodeDeploymentService;
+import com.hazelcast.internal.util.ConcurrencyDetection;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.LoggingService;
 import com.hazelcast.logging.LoggingServiceImpl;
@@ -70,6 +71,7 @@ import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
 import com.hazelcast.spi.impl.servicemanager.ServiceManager;
 import com.hazelcast.spi.impl.servicemanager.impl.ServiceManagerImpl;
 import com.hazelcast.spi.merge.SplitBrainMergePolicyProvider;
+import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.transaction.TransactionManagerService;
@@ -84,6 +86,8 @@ import java.util.LinkedList;
 
 import static com.hazelcast.internal.diagnostics.Diagnostics.METRICS_DISTRIBUTED_DATASTRUCTURES;
 import static com.hazelcast.internal.diagnostics.Diagnostics.METRICS_LEVEL;
+import static com.hazelcast.spi.properties.GroupProperty.BACKPRESSURE_ENABLED;
+import static com.hazelcast.spi.properties.GroupProperty.CONCURRENT_WINDOW_MS;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ExceptionUtil.rethrow;
 import static java.lang.System.currentTimeMillis;
@@ -120,12 +124,14 @@ public class NodeEngineImpl implements NodeEngine {
     private final QuorumServiceImpl quorumService;
     private final Diagnostics diagnostics;
     private final SplitBrainMergePolicyProvider splitBrainMergePolicyProvider;
+    private final ConcurrencyDetection concurrencyDetection;
 
     @SuppressWarnings("checkstyle:executablestatementcount")
     public NodeEngineImpl(Node node) {
         this.node = node;
         try {
             this.serializationService = node.getSerializationService();
+            this.concurrencyDetection = newConcurrencyDetection();
             this.loggingService = node.loggingService;
             this.logger = node.getLogger(NodeEngine.class.getName());
             this.metricsRegistry = newMetricRegistry(node);
@@ -165,6 +171,18 @@ public class NodeEngineImpl implements NodeEngine {
                 ignore(ignored);
             }
             throw rethrow(e);
+        }
+    }
+
+    private ConcurrencyDetection newConcurrencyDetection() {
+        HazelcastProperties properties = node.getProperties();
+        boolean writeThrough = properties.getBoolean(GroupProperty.IO_WRITE_THROUGH_ENABLED);
+        boolean backPressureEnabled = properties.getBoolean(BACKPRESSURE_ENABLED);
+
+        if (writeThrough || backPressureEnabled) {
+            return ConcurrencyDetection.createEnabled(properties.getInteger(CONCURRENT_WINDOW_MS));
+        } else {
+            return ConcurrencyDetection.createDisabled();
         }
     }
 
@@ -213,6 +231,10 @@ public class NodeEngineImpl implements NodeEngine {
         diagnostics.start();
 
         node.getNodeExtension().registerPlugins(diagnostics);
+    }
+
+    public ConcurrencyDetection getConcurrencyDetection() {
+        return concurrencyDetection;
     }
 
     public Consumer<Packet> getPacketDispatcher() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulator.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi.impl.operationservice.impl;
 
+import com.hazelcast.internal.util.ConcurrencyDetection;
 import com.hazelcast.internal.util.ThreadLocalRandomProvider;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.BackupAwareOperation;
@@ -151,8 +152,8 @@ class BackpressureRegulator {
         }
     }
 
-    CallIdSequence newCallIdSequence() {
-        return CallIdFactory.newCallIdSequence(enabled, maxConcurrentInvocations, backoffTimeoutMs);
+    CallIdSequence newCallIdSequence(ConcurrencyDetection concurrencyDetection) {
+        return CallIdFactory.newCallIdSequence(maxConcurrentInvocations, backoffTimeoutMs, concurrencyDetection);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl.java
@@ -153,7 +153,8 @@ public final class OperationServiceImpl implements InternalOperationService, Met
                 node.getLogger(OutboundResponseHandler.class));
 
         this.invocationRegistry = new InvocationRegistry(
-                node.getLogger(OperationServiceImpl.class), backpressureRegulator.newCallIdSequence());
+                node.getLogger(OperationServiceImpl.class),
+                backpressureRegulator.newCallIdSequence(nodeEngine.getConcurrencyDetection()));
 
         this.invocationMonitor = new InvocationMonitor(
                 nodeEngine, thisAddress, node.getProperties(), invocationRegistry,

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/AbstractCallIdSequence.java
@@ -16,11 +16,14 @@
 
 package com.hazelcast.spi.impl.sequence;
 
+import com.hazelcast.internal.util.ConcurrencyDetection;
+
 import java.util.concurrent.atomic.AtomicLongArray;
 
 import static com.hazelcast.nio.Bits.CACHE_LINE_LENGTH;
 import static com.hazelcast.nio.Bits.LONG_SIZE_IN_BYTES;
 import static com.hazelcast.util.Preconditions.checkPositive;
+import static com.hazelcast.util.QuickMath.modPowerOfTwo;
 
 /**
  * A {@link CallIdSequence} that provides backpressure by taking
@@ -37,16 +40,20 @@ import static com.hazelcast.util.Preconditions.checkPositive;
 public abstract class AbstractCallIdSequence implements CallIdSequence {
     private static final int INDEX_HEAD = 7;
     private static final int INDEX_TAIL = 15;
+    private static final int MAX_CONCURRENT_CALLS = Integer.getInteger("hazelcast.concurrent.invocations.max", 10);
+    private static final int MOD = 8;
 
     // instead of using 2 AtomicLongs, we use an array if width of 3 cache lines to prevent any false sharing.
     private final AtomicLongArray longs = new AtomicLongArray(3 * CACHE_LINE_LENGTH / LONG_SIZE_IN_BYTES);
 
     private final int maxConcurrentInvocations;
+    private final ConcurrencyDetection concurrencyDetection;
 
-    public AbstractCallIdSequence(int maxConcurrentInvocations) {
+    public AbstractCallIdSequence(int maxConcurrentInvocations, ConcurrencyDetection concurrencyDetection) {
         checkPositive(maxConcurrentInvocations,
                 "maxConcurrentInvocations should be a positive number. maxConcurrentInvocations=" + maxConcurrentInvocations);
 
+        this.concurrencyDetection = concurrencyDetection;
         this.maxConcurrentInvocations = maxConcurrentInvocations;
     }
 
@@ -77,7 +84,13 @@ public abstract class AbstractCallIdSequence implements CallIdSequence {
     }
 
     public long forceNext() {
-        return longs.incrementAndGet(INDEX_HEAD);
+        long l = longs.incrementAndGet(INDEX_HEAD);
+        // we don't want to check for every call, so we'll check 1 in 8 calls. If there is sufficient concurrency
+        // one of the calls will trigger the onDetected.
+        if (modPowerOfTwo(l, MOD) == 0 && concurrentInvocations() > MAX_CONCURRENT_CALLS) {
+            concurrencyDetection.onDetected();
+        }
+        return l;
     }
 
     long getTail() {
@@ -88,7 +101,6 @@ public abstract class AbstractCallIdSequence implements CallIdSequence {
         return concurrentInvocations() < maxConcurrentInvocations;
     }
 
-    @Override
     public long concurrentInvocations() {
         return longs.get(INDEX_HEAD) - longs.get(INDEX_TAIL);
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequence.java
@@ -75,11 +75,4 @@ public interface CallIdSequence {
      * <strong>ONLY FOR TESTING. Must not be used for production code.</strong>
      */
     long getLastCallId();
-
-    /**
-     * Returns the number of concurrent invocations.
-     *
-     * @return the number of concurrent invocations. Returns -1 if not known.
-     */
-    long concurrentInvocations();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressure.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.sequence;
 
 import com.hazelcast.core.HazelcastOverloadException;
+import com.hazelcast.internal.util.ConcurrencyDetection;
 import com.hazelcast.util.concurrent.BackoffIdleStrategy;
 import com.hazelcast.util.concurrent.IdleStrategy;
 
@@ -44,8 +45,10 @@ public final class CallIdSequenceWithBackpressure extends AbstractCallIdSequence
 
     private final long backoffTimeoutNanos;
 
-    public CallIdSequenceWithBackpressure(int maxConcurrentInvocations, long backoffTimeoutMs) {
-        super(maxConcurrentInvocations);
+    public CallIdSequenceWithBackpressure(int maxConcurrentInvocations,
+                                          long backoffTimeoutMs,
+                                          ConcurrencyDetection concurrencyDetection) {
+        super(maxConcurrentInvocations, concurrencyDetection);
 
         checkPositive(backoffTimeoutMs, "backoffTimeoutMs should be a positive number. backoffTimeoutMs=" + backoffTimeoutMs);
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithoutBackpressure.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithoutBackpressure.java
@@ -49,9 +49,4 @@ public final class CallIdSequenceWithoutBackpressure implements CallIdSequence {
     public void complete() {
         //no-op
     }
-
-    @Override
-    public long concurrentInvocations() {
-        return -1;
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequence.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequence.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.sequence;
 
 import com.hazelcast.core.HazelcastOverloadException;
+import com.hazelcast.internal.util.ConcurrencyDetection;
 
 /**
  * A {@link CallIdSequence} that provides backpressure by taking
@@ -31,8 +32,9 @@ import com.hazelcast.core.HazelcastOverloadException;
  * So perhaps there are a few threads that at the same time see that the there is space and do a next.
  */
 public class FailFastCallIdSequence extends AbstractCallIdSequence {
-    public FailFastCallIdSequence(int maxConcurrentInvocations) {
-        super(maxConcurrentInvocations);
+
+    public FailFastCallIdSequence(int maxConcurrentInvocations, ConcurrencyDetection concurrencyDetection) {
+        super(maxConcurrentInvocations, concurrencyDetection);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -218,6 +218,31 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.io.output.thread.count", IO_THREAD_COUNT);
 
     /**
+     * Optimization that allows sending of packets over the network to be done on the calling thread if the
+     * conditions are right. This can reduce latency and increase performance for low threaded environments.
+     *
+     * It is disabled by default.
+     */
+    public static final HazelcastProperty IO_WRITE_THROUGH_ENABLED
+            = new HazelcastProperty("hazelcast.io.write.through", false);
+
+    /**
+     * Property needed for concurrency detection so that write through can be done correctly.
+     * This property sets the window the concurrency detection will signalling
+     * that concurrency has been detected, even if there are no further updates in that window.
+     *
+     * Normally in a concurrency system the windows keeps sliding forward so it will always remain
+     * concurrent.
+     *
+     * Setting it too high effectively disabled the optimization because once concurrency has been detected
+     * it will keep that way. Setting it too low could lead to suboptimal performance because the system
+     * will try write through and other optimization even though the system is concurrent.
+     */
+    public static final HazelcastProperty CONCURRENT_WINDOW_MS
+            = new HazelcastProperty("hazelcast.concurrent.window.ms", 100, MILLISECONDS);
+
+
+    /**
      * The interval in seconds between {@link com.hazelcast.internal.networking.nio.iobalancer.IOBalancer IOBalancer}
      * executions. The shorter intervals will catch I/O Imbalance faster, but they will cause higher overhead.
      * <p/>

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.config.Config;
+import com.hazelcast.internal.util.ConcurrencyDetection;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.BackupAwareOperation;
 import com.hazelcast.spi.Operation;
@@ -95,7 +96,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
         HazelcastProperties hazelcastProperties = new HazelcastProperties(config);
         BackpressureRegulator backpressureRegulator = new BackpressureRegulator(hazelcastProperties, logger);
 
-        CallIdSequence callIdSequence = backpressureRegulator.newCallIdSequence();
+        CallIdSequence callIdSequence = backpressureRegulator.newCallIdSequence(ConcurrencyDetection.createEnabled(100));
 
         assertInstanceOf(CallIdSequenceWithBackpressure.class, callIdSequence);
         assertEquals(backpressureRegulator.getMaxConcurrentInvocations(), callIdSequence.getMaxConcurrentInvocations());
@@ -108,7 +109,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
         HazelcastProperties hazelcastProperties = new HazelcastProperties(config);
         BackpressureRegulator backpressureRegulator = new BackpressureRegulator(hazelcastProperties, logger);
 
-        CallIdSequence callIdSequence = backpressureRegulator.newCallIdSequence();
+        CallIdSequence callIdSequence = backpressureRegulator.newCallIdSequence(ConcurrencyDetection.createDisabled());
 
         assertInstanceOf(CallIdSequenceWithoutBackpressure.class, callIdSequence);
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/InvocationRegistryTest.java
@@ -18,6 +18,7 @@ package com.hazelcast.spi.impl.operationservice.impl;
 
 import com.hazelcast.core.HazelcastInstanceNotActiveException;
 import com.hazelcast.core.MemberLeftException;
+import com.hazelcast.internal.util.ConcurrencyDetection;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.Invocation.Context;
@@ -49,8 +50,9 @@ public class InvocationRegistryTest extends HazelcastTestSupport {
     @Before
     public void setup() {
         logger = Mockito.mock(ILogger.class);
-        final int capacity = 2;
-        invocationRegistry = new InvocationRegistry(logger, new CallIdSequenceWithBackpressure(capacity, 1000));
+        int capacity = 2;
+        invocationRegistry = new InvocationRegistry(logger,
+                new CallIdSequenceWithBackpressure(capacity, 1000,  ConcurrencyDetection.createDisabled()));
     }
 
     private Invocation newInvocation() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/CallIdSequenceWithBackpressureTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.sequence;
 
 import com.hazelcast.core.HazelcastOverloadException;
+import com.hazelcast.internal.util.ConcurrencyDetection;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.DummyBackupAwareOperation;
 import com.hazelcast.spi.impl.operationservice.impl.DummyOperation;
@@ -40,7 +41,7 @@ import static org.junit.Assert.fail;
 @Category({QuickTest.class, ParallelTest.class})
 public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
 
-    CallIdSequenceWithBackpressure sequence = new CallIdSequenceWithBackpressure(100, 60000);
+    CallIdSequenceWithBackpressure sequence = new CallIdSequenceWithBackpressure(100, 60000, ConcurrencyDetection.createDisabled());
 
     @Test
     public void test() {
@@ -69,7 +70,7 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
 
     @Test
     public void next_whenNoCapacity_thenBlockTillCapacity() throws InterruptedException {
-        sequence = new CallIdSequenceWithBackpressure(1, 60000);
+        sequence = new CallIdSequenceWithBackpressure(1, 60000, ConcurrencyDetection.createDisabled());
         final long oldLastCallId = sequence.getLastCallId();
 
         final CountDownLatch nextCalledLatch = new CountDownLatch(1);
@@ -94,7 +95,7 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
 
     @Test
     public void next_whenNoCapacity_thenBlockTillTimeout() {
-        sequence = new CallIdSequenceWithBackpressure(1, 2000);
+        sequence = new CallIdSequenceWithBackpressure(1, 2000, ConcurrencyDetection.createDisabled());
 
         // first invocation consumes the available call ID
         nextCallId(sequence, false);
@@ -112,7 +113,7 @@ public class CallIdSequenceWithBackpressureTest extends HazelcastTestSupport {
 
     @Test
     public void when_overCapacityButPriorityItem_then_noBackpressure() {
-        final CallIdSequenceWithBackpressure sequence = new CallIdSequenceWithBackpressure(1, 60000);
+        CallIdSequenceWithBackpressure sequence = new CallIdSequenceWithBackpressure(1, 60000, ConcurrencyDetection.createDisabled());
 
         // occupy the single call ID slot
         nextCallId(sequence, true);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequenceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/sequence/FailFastCallIdSequenceTest.java
@@ -17,6 +17,7 @@
 package com.hazelcast.spi.impl.sequence;
 
 import com.hazelcast.core.HazelcastOverloadException;
+import com.hazelcast.internal.util.ConcurrencyDetection;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.RequireAssertEnabled;
@@ -34,14 +35,14 @@ public class FailFastCallIdSequenceTest extends HazelcastTestSupport {
 
     @Test
     public void testGettersAndDefaults() {
-        CallIdSequence sequence = new FailFastCallIdSequence(100);
+        CallIdSequence sequence = new FailFastCallIdSequence(100, ConcurrencyDetection.createDisabled());
         assertEquals(0, sequence.getLastCallId());
         assertEquals(100, sequence.getMaxConcurrentInvocations());
     }
 
     @Test
     public void whenNext_thenSequenceIncrements() {
-        CallIdSequence sequence = new FailFastCallIdSequence(100);
+        CallIdSequence sequence = new FailFastCallIdSequence(100, ConcurrencyDetection.createDisabled());
         long oldSequence = sequence.getLastCallId();
         long result = sequence.next();
         assertEquals(oldSequence + 1, result);
@@ -50,7 +51,7 @@ public class FailFastCallIdSequenceTest extends HazelcastTestSupport {
 
     @Test(expected = HazelcastOverloadException.class)
     public void next_whenNoCapacity_thenThrowException() throws InterruptedException {
-        CallIdSequence sequence = new FailFastCallIdSequence(1);
+        CallIdSequence sequence = new FailFastCallIdSequence(1, ConcurrencyDetection.createDisabled());
 
         // take the only slot available
         sequence.next();
@@ -61,7 +62,7 @@ public class FailFastCallIdSequenceTest extends HazelcastTestSupport {
 
     @Test
     public void when_overCapacityButPriorityItem_then_noException() {
-        CallIdSequence sequence = new FailFastCallIdSequence(1);
+        CallIdSequence sequence = new FailFastCallIdSequence(1, ConcurrencyDetection.createDisabled());
 
         // take the only slot available
         assertEquals(1, sequence.next());
@@ -71,7 +72,7 @@ public class FailFastCallIdSequenceTest extends HazelcastTestSupport {
 
     @Test
     public void whenComplete_thenTailIncrements() {
-        FailFastCallIdSequence sequence = new FailFastCallIdSequence(100);
+        FailFastCallIdSequence sequence = new FailFastCallIdSequence(100, ConcurrencyDetection.createDisabled());
         sequence.next();
 
         long oldSequence = sequence.getLastCallId();
@@ -85,7 +86,7 @@ public class FailFastCallIdSequenceTest extends HazelcastTestSupport {
     @Test(expected = AssertionError.class)
     @RequireAssertEnabled
     public void complete_whenNoMatchingNext() {
-        CallIdSequence sequence = new FailFastCallIdSequence(100);
+        CallIdSequence sequence = new FailFastCallIdSequence(100, ConcurrencyDetection.createDisabled());
 
         sequence.next();
         sequence.complete();


### PR DESCRIPTION
Optimization for low threaded environments that reduces latency and increases throughput.

HZ is using a SEDA architecture and this works great if there are many concurrent requests. However the stages in a SEDA architecture increase latency when there is not a lot of work to do due to thread handovers which involve blocking/notification.

This PR dynamically adds/removes stages from the SEDA architecture based on if concurrency is detected. For a normal request on the client side the stage where an item gets written to the socket, is now directly executed from the calling thread if write through is enabled and no concurrency is detected. The same goes on the server where a thread can directly write to the socket.

This optimization is disabled by default but probably will be enabled by default in a subsequent release.

A new abstraction has been introduced called the ConcurrencyDetection.

it has 2 methods: is concurrency detected. This is used where you want to optimize based on if concurrency is detected. So in particular write through which is used in the outbound pipeline and dynamic response handling on client (so process response on IO thread instead of handing it over to response thread).

And the other method is to signal of concurrency is detected. The 2 sources of input for detection is the invocation registry (the callIdgenerator to be more precise). If the number of concurrent calls exceeds a certain threshold, the ConcurrencyDetection is notified that concurrency has been detected. Also in the pipeline when cas'ing the pipeline fails, the ConcurrencyDetection is notified.

The ConcurrencyDetection internally uses a sliding window approach. This window is continuously moved forward if concurrency is detected. Only when concurrency isn't detected for some time, then ConcurrencyDetection will say no concurrency has been detected and the optimizations can take place.

