### PR TITLE
[Backport] Fix socket channel leak when networking is restarted after cluster merge

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioChannelMemoryLeakTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/NioChannelMemoryLeakTest.java
@@ -25,19 +25,25 @@ import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.QuickTest;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import java.util.Set;
+
+import static com.hazelcast.core.Hazelcast.newHazelcastInstance;
 import static com.hazelcast.spi.properties.GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS;
 import static com.hazelcast.spi.properties.GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS;
-import static junit.framework.TestCase.assertEquals;
+import static com.hazelcast.spi.properties.GroupProperty.WAIT_SECONDS_BEFORE_JOIN;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class NioChannelMemoryLeakTest extends HazelcastTestSupport {
-
 
     @After
     public void cleanUp() {
@@ -46,24 +52,78 @@ public class NioChannelMemoryLeakTest extends HazelcastTestSupport {
 
     @Test
     public void testNioChannelLeak() {
-        Config config = new Config();
-        JoinConfig join = config.getNetworkConfig().getJoin();
-        join.getTcpIpConfig().addMember("127.0.0.1:6000").setEnabled(true);
-        join.getMulticastConfig().setEnabled(false);
-
+        Config config = getConfig();
         config.setProperty(MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "1");
         config.setProperty(MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "1");
+
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
         TcpIpConnectionManager connectionManager = (TcpIpConnectionManager) getConnectionManager(instance);
         final NioNetworking networking = (NioNetworking) connectionManager.getNetworking();
-        sleepSeconds(2);
+
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertEquals(0, networking.getChannels().size());
+                assertThat(networking.getChannels(), Matchers.<NioChannel>empty());
             }
         });
-        instance.shutdown();
     }
 
+    @Test
+    public void testNioChannelLeak_afterMultipleSplitBrainMerges() {
+        Config config = getConfig();
+        config.setProperty(WAIT_SECONDS_BEFORE_JOIN.getName(), "0");
+        config.setProperty(MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "99999999");
+        config.setProperty(MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "99999999");
+
+        final HazelcastInstance instance1 = newHazelcastInstance(config);
+        final HazelcastInstance instance2 = newHazelcastInstance(config);
+        final HazelcastInstance instance3 = newHazelcastInstance(config);
+        assertClusterSizeEventually(3, instance1, instance2, instance3);
+
+        for (int i = 0; i < 5; i++) {
+            closeConnectionBetween(instance1,  instance3);
+            closeConnectionBetween(instance2,  instance3);
+            assertClusterSizeEventually(2, instance1, instance2);
+            assertClusterSizeEventually(1, instance3);
+
+            getNode(instance3).getClusterService().merge(getAddress(instance1));
+            assertClusterSizeEventually(3, instance1, instance2, instance3);
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() {
+                assertNoChannelLeak(instance1);
+                assertNoChannelLeak(instance2);
+                assertNoChannelLeak(instance3);
+            }
+        });
+    }
+
+    private void assertNoChannelLeak(HazelcastInstance instance) {
+        int clusterSize = instance.getCluster().getMembers().size();
+        // There may be one or two channels between two members.
+        // Ideally there'll be only a single channel,
+        // but when two members initiate the connection concurrently,
+        // it may end up with two different connections between them.
+        int maxChannelCount = (clusterSize - 1) * 2;
+
+        TcpIpConnectionManager connectionManager = (TcpIpConnectionManager) getConnectionManager(instance);
+        NioNetworking networking = (NioNetworking) connectionManager.getNetworking();
+        Set<NioChannel> channels = networking.getChannels();
+
+        assertThat(channels.size(), lessThanOrEqualTo(maxChannelCount));
+        for (NioChannel channel : channels) {
+            assertTrue(channel.socketChannel().isOpen());
+        }
+    }
+
+    @Override
+    protected Config getConfig() {
+        Config config = new Config();
+        JoinConfig join = config.getNetworkConfig().getJoin();
+        join.getTcpIpConfig().addMember("127.0.0.1").setEnabled(true);
+        join.getMulticastConfig().setEnabled(false);
+        return config;
+    }
 }


### PR DESCRIPTION
Networking service is stopped and restarted during cluster merge.
But socket channel's `closeListenerExecutor` is not restarted even
though it's stopped during shutdown. That's why `ChannelCloseListener`
is not called and some resources leak, including `channels` set.

Additionally, `PublishAllTask` is re-scheduled each time networking
is started (when metrics is enabled). After each cluster merge,
there'll be an additional `PublishAllTask` is scheduled.

Fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2689