### PR TITLE
Introduce separate endpoint views for unified socket

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/TextCommandServiceImpl.java
@@ -79,7 +79,6 @@ import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.TOUCH;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.UNKNOWN;
 import static com.hazelcast.internal.ascii.TextCommandConstants.TextCommandType.VERSION;
-import static com.hazelcast.instance.EndpointQualifier.REST;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.ThreadUtil.createThreadName;
 import static java.lang.Thread.currentThread;
@@ -176,10 +175,8 @@ public class TextCommandServiceImpl implements TextCommandService {
         stats.setDecrHits(decrementHits.get());
         stats.setDecrMisses(decrementMisses.get());
         NetworkingService cm = node.networkingService;
-        EndpointManager rem = cm.getEndpointManager(REST);
         EndpointManager mem = cm.getEndpointManager(MEMCACHE);
-        int totalText = (rem != null ? rem.getActiveConnections().size() : 0)
-                + (mem != null ? mem.getActiveConnections().size() : 0);
+        int totalText = (mem != null ? mem.getActiveConnections().size() : 0);
 
         AggregateEndpointManager aem = cm.getAggregateEndpointManager();
         stats.setCurrConnections(totalText);

--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -33,20 +33,20 @@ import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.json.JsonArray;
 import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.partition.InternalPartitionService;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.AggregateEndpointManager;
 import com.hazelcast.nio.EndpointManager;
 import com.hazelcast.nio.NetworkingService;
-import com.hazelcast.nio.Address;
 import com.hazelcast.util.StringUtil;
 
 import java.util.Collection;
 
+import static com.hazelcast.instance.EndpointQualifier.CLIENT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.MIME_TEXT_PLAIN;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_BINARY;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_PLAIN_TEXT;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.RES_200_WITH_NO_CONTENT;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.RES_503;
-import static com.hazelcast.instance.EndpointQualifier.CLIENT;
-import static com.hazelcast.instance.EndpointQualifier.REST;
 import static com.hazelcast.util.ExceptionUtil.peel;
 import static com.hazelcast.util.StringUtil.stringToBytes;
 
@@ -353,10 +353,10 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         res.append("\n");
         NetworkingService ns = node.getNetworkingService();
         EndpointManager cem = ns.getEndpointManager(CLIENT);
-        EndpointManager tem = ns.getEndpointManager(REST);
+        AggregateEndpointManager aem = ns.getAggregateEndpointManager();
         res.append("ConnectionCount: ").append(cem.getActiveConnections().size());
         res.append("\n");
-        res.append("AllConnectionCount: ").append(tem.getActiveConnections().size());
+        res.append("AllConnectionCount: ").append(aem.getActiveConnections().size());
         res.append("\n");
         command.setResponse(null, stringToBytes(res.toString()));
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpNetworkingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpNetworkingService.java
@@ -121,14 +121,10 @@ public class TcpIpNetworkingService
                                      ChannelInitializerProvider channelInitializerProvider,
                                      HazelcastProperties properties) {
         if (unifiedEndpointManager != null) {
-            //todo (TK): have separate view for REST & Memcache? might require further changes to JMX & MC REST
-            TextViewUnifiedEndpointManager textViewUnifiedEndpointManager
-                    = new TextViewUnifiedEndpointManager(unifiedEndpointManager);
-
             endpointManagers.put(MEMBER, new MemberViewUnifiedEndpointManager(unifiedEndpointManager));
             endpointManagers.put(CLIENT, new ClientViewUnifiedEndpointManager(unifiedEndpointManager));
-            endpointManagers.put(REST, textViewUnifiedEndpointManager);
-            endpointManagers.put(MEMCACHE, textViewUnifiedEndpointManager);
+            endpointManagers.put(REST,  new TextViewUnifiedEndpointManager(unifiedEndpointManager, true));
+            endpointManagers.put(MEMCACHE,  new TextViewUnifiedEndpointManager(unifiedEndpointManager, false));
         } else {
             for (EndpointConfig endpointConfig : config.getAdvancedNetworkConfig().getEndpointConfigs().values()) {
                 EndpointQualifier qualifier = endpointConfig.getQualifier();

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpUnifiedEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpUnifiedEndpointManager.java
@@ -45,6 +45,33 @@ class TcpIpUnifiedEndpointManager
                 metricsRegistry, properties, ProtocolType.valuesAsSet());
     }
 
+    Set<TcpIpConnection> getRestConnections() {
+        Set<TcpIpConnection> connections = activeConnections.isEmpty()
+                ? Collections.<TcpIpConnection>emptySet()
+                : new HashSet<TcpIpConnection>(activeConnections.size());
+
+        for (TcpIpConnection conn : activeConnections) {
+            if (conn.isAlive() && conn.getType() == REST_CLIENT) {
+                connections.add(conn);
+            }
+        }
+        return connections;
+    }
+
+    Set<TcpIpConnection> getMemachedConnections() {
+        Set<TcpIpConnection> connections = activeConnections.isEmpty()
+                ? Collections.<TcpIpConnection>emptySet()
+                : new HashSet<TcpIpConnection>(activeConnections.size());
+
+        for (TcpIpConnection conn : activeConnections) {
+            if (conn.isAlive() && conn.getType() == MEMCACHE_CLIENT) {
+                connections.add(conn);
+            }
+        }
+        return connections;
+    }
+
+
     Set<TcpIpConnection> getTextConnections() {
         Set<TcpIpConnection> connections = activeConnections.isEmpty()
                 ? Collections.<TcpIpConnection>emptySet()

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TextViewUnifiedEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TextViewUnifiedEndpointManager.java
@@ -28,14 +28,16 @@ class TextViewUnifiedEndpointManager
         implements EndpointManager<TcpIpConnection> {
 
     private final TcpIpUnifiedEndpointManager unifiedEndpointManager;
+    private final boolean rest;
 
-    TextViewUnifiedEndpointManager(TcpIpUnifiedEndpointManager unifiedEndpointManager) {
+    TextViewUnifiedEndpointManager(TcpIpUnifiedEndpointManager unifiedEndpointManager, boolean rest) {
         this.unifiedEndpointManager = unifiedEndpointManager;
+        this.rest = rest;
     }
 
     @Override
     public Set<TcpIpConnection> getActiveConnections() {
-        return unifiedEndpointManager.getTextConnections();
+        return rest ? unifiedEndpointManager.getRestConnections() : unifiedEndpointManager.getMemachedConnections();
     }
 
     @Override


### PR DESCRIPTION
Small change to support separate endpoint views for the unified socket setup. 
This should keep the two configurations (advanced & legacy) in sync.

Addressing https://github.com/hazelcast/hazelcast/pull/14383#discussion_r256369342 from https://github.com/hazelcast/hazelcast/issues/14497