### PR TITLE
Partially revert membership change fix in the Raft core

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeStatus.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeStatus.java
@@ -38,8 +38,7 @@ public enum RaftNodeStatus {
 
     /**
      * When a node is removed from the cluster after a membership change is
-     * committed, or a new Raft node could not be added to the Raft group,
-     * its status becomes {@code STEPPED_DOWN}.
+     * committed, its status becomes {@code STEPPED_DOWN}.
      */
     STEPPED_DOWN,
 


### PR DESCRIPTION
A membership change fix is applied in the Raft core with
5c6d2e18bdc2daec12df4cefad9c12bab3ea4b30 commit. In this fix, a Raft
node which is being added to a CP group steps down itself if it notices
that its member-add log entry is reverted. It turns out that this is not
a Raft node's decision to make. A Raft node cannot step down itself for
this case because it does not know if a new member-add entry is present
in the further indices of the Raft log or not. It is up to
the "operator" to deal with this case. The Metadata CP group is
the operator in our system and it resolves this case by replicating
the failed member-add again.

Long story short, no fix is a real fix until proven with a test.