### PR TITLE
Add `comparator-class-name` to EvictionConfig object in xml and yaml configs

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/AbstractQueryCacheConfigBuilderHelper.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/AbstractQueryCacheConfigBuilderHelper.java
@@ -92,6 +92,7 @@ abstract class AbstractQueryCacheConfigBuilderHelper implements QueryCacheConfig
         final Node size = node.getAttributes().getNamedItem("size");
         final Node maxSizePolicy = node.getAttributes().getNamedItem("max-size-policy");
         final Node evictionPolicy = node.getAttributes().getNamedItem("eviction-policy");
+        Node comparatorClassName = node.getAttributes().getNamedItem("comparator-class-name");
         if (size != null) {
             evictionConfig.setSize(Integer.parseInt(getTextContent(size)));
         }
@@ -106,6 +107,9 @@ abstract class AbstractQueryCacheConfigBuilderHelper implements QueryCacheConfig
                     EvictionPolicy.valueOf(
                             upperCaseInternal(getTextContent(evictionPolicy)))
             );
+        }
+        if (comparatorClassName != null) {
+            evictionConfig.setComparatorClassName(getTextContent(comparatorClassName));
         }
         return evictionConfig;
     }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientConfigXmlGenerator.java
@@ -375,7 +375,8 @@ public final class ClientConfigXmlGenerator {
                    .node("buffer-size", queryCache.getBufferSize())
                    .node("eviction", null, "size", queryCache.getEvictionConfig().getSize(),
                            "max-size-policy", queryCache.getEvictionConfig().getMaximumSizePolicy(),
-                           "eviction-policy", queryCache.getEvictionConfig().getEvictionPolicy());
+                           "eviction-policy", queryCache.getEvictionConfig().getEvictionPolicy(),
+                           "comparator-class-name", queryCache.getEvictionConfig().getComparatorClassName());
                 queryCachePredicate(gen, queryCache.getPredicateConfig());
                 entryListeners(gen, queryCache.getEntryListenerConfigs());
                 indexes(gen, queryCache.getIndexConfigs());
@@ -563,7 +564,7 @@ public final class ClientConfigXmlGenerator {
            .node("local-update-policy", nearCache.getLocalUpdatePolicy())
            .node("eviction", null, "size", eviction.getSize(),
                    "max-size-policy", eviction.getMaximumSizePolicy(),
-                   "eviction-policy", eviction.getEvictionPolicy())
+                   "eviction-policy", eviction.getEvictionPolicy(), "comparator-class-name", eviction.getComparatorClassName())
            .node("preloader", null, "enabled", preloader.isEnabled(),
                    "directory", preloader.getDirectory(),
                    "store-initial-delay-seconds", preloader.getStoreInitialDelaySeconds(),

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientDomConfigProcessor.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientDomConfigProcessor.java
@@ -327,6 +327,7 @@ class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
         Node size = node.getAttributes().getNamedItem("size");
         Node maxSizePolicy = node.getAttributes().getNamedItem("max-size-policy");
         Node evictionPolicy = node.getAttributes().getNamedItem("eviction-policy");
+        Node comparatorClassName = node.getAttributes().getNamedItem("comparator-class-name");
         if (size != null) {
             evictionConfig.setSize(Integer.parseInt(getTextContent(size)));
         }
@@ -338,6 +339,9 @@ class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
         if (evictionPolicy != null) {
             evictionConfig.setEvictionPolicy(EvictionPolicy.valueOf(upperCaseInternal(getTextContent(evictionPolicy)))
             );
+        }
+        if (comparatorClassName != null) {
+            evictionConfig.setComparatorClassName(getTextContent(comparatorClassName));
         }
         return evictionConfig;
     }

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-3.12.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-3.12.xsd
@@ -507,6 +507,7 @@
         <xs:attribute name="size" type="xs:nonNegativeInteger" default="10000" use="optional"/>
         <xs:attribute name="max-size-policy" type="max-size-policy" default="ENTRY_COUNT" use="optional"/>
         <xs:attribute name="eviction-policy" type="eviction-policy" default="LRU" use="optional"/>
+        <xs:attribute name="comparator-class-name" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="preloader">

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -247,6 +247,11 @@
         <local-update-policy>INVALIDATE</local-update-policy>
     </near-cache>
 
+    <near-cache name="NearCacheEvictionConfigExample">
+        <eviction eviction-policy="LRU" max-size-policy="ENTRY_COUNT" size="10000"
+                  comparator-class-name="com.hazelcast.examples.MyEvictionComparator"/>
+    </near-cache>
+
     <flake-id-generator name="default">
         <prefetch-count>100</prefetch-count>
         <prefetch-validity-millis>600000</prefetch-validity-millis>
@@ -265,7 +270,8 @@
             <in-memory-format>BINARY</in-memory-format>
             <coalesce>false</coalesce>
             <populate>true</populate>
-            <eviction eviction-policy="LRU" max-size-policy="ENTRY_COUNT" size="10000"/>
+            <eviction eviction-policy="LRU" max-size-policy="ENTRY_COUNT" size="10000"
+                      comparator-class-name="com.hazelcast.examples.MyEvictionComparator"/>
             <indexes>
                 <index ordered="false">name</index>
             </indexes>

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.yaml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.yaml
@@ -227,6 +227,13 @@ hazelcast-client:
       serialize-keys: true
       local-update-policy: INVALIDATE
 
+    NearCacheEvictionConfigExample:
+      eviction:
+        eviction-policy: LRU
+        max-size-policy: ENTRY_COUNT
+        size: 10000
+        comparator-class-name: com.hazelcast.examples.MyEvictionComparator
+
   flake-id-generator:
     default:
       prefetch-count: 100
@@ -252,6 +259,7 @@ hazelcast-client:
         eviction-policy: LRU
         max-size-policy: ENTRY_COUNT
         size: 10000
+        comparator-class-name: com.hazelcast.examples.MyEvictionComparator
       indexes:
         name:
           ordered: false

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -156,7 +156,7 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
 
     @Test
     public void testNearCacheConfigs() {
-        assertEquals(1, fullClientConfig.getNearCacheConfigMap().size());
+        assertEquals(2, fullClientConfig.getNearCacheConfigMap().size());
         final NearCacheConfig nearCacheConfig = fullClientConfig.getNearCacheConfig("asd");
 
         assertEquals(2000, nearCacheConfig.getMaxSize());
@@ -168,6 +168,13 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
         assertTrue(nearCacheConfig.isInvalidateOnChange());
         assertTrue(nearCacheConfig.isSerializeKeys());
         assertEquals(InMemoryFormat.OBJECT, nearCacheConfig.getInMemoryFormat());
+
+        final NearCacheConfig evictableNearCacheConfig = fullClientConfig.getNearCacheConfig("NearCacheEvictionConfigExample");
+        EvictionConfig nearCacheEvictionConfig = evictableNearCacheConfig.getEvictionConfig();
+        assertEquals(EvictionPolicy.LRU, nearCacheEvictionConfig.getEvictionPolicy());
+        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, nearCacheEvictionConfig.getMaximumSizePolicy());
+        assertEquals(10000, nearCacheEvictionConfig.getSize());
+        assertEquals("com.hazelcast.examples.MyEvictionComparator", nearCacheEvictionConfig.getComparatorClassName());
     }
 
     @Test
@@ -230,10 +237,11 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
         assertEquals(1, queryCacheClassPredicateConfig.getBatchSize());
         assertEquals(16, queryCacheClassPredicateConfig.getBufferSize());
         assertEquals(0, queryCacheClassPredicateConfig.getDelaySeconds());
-        assertEquals(EvictionPolicy.LRU, queryCacheClassPredicateConfig.getEvictionConfig().getEvictionPolicy());
-        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT,
-                queryCacheClassPredicateConfig.getEvictionConfig().getMaximumSizePolicy());
-        assertEquals(10000, queryCacheClassPredicateConfig.getEvictionConfig().getSize());
+        EvictionConfig evictionConfig = queryCacheClassPredicateConfig.getEvictionConfig();
+        assertEquals(EvictionPolicy.LRU, evictionConfig.getEvictionPolicy());
+        assertEquals(EvictionConfig.MaxSizePolicy.ENTRY_COUNT, evictionConfig.getMaximumSizePolicy());
+        assertEquals(10000, evictionConfig.getSize());
+        assertEquals("com.hazelcast.examples.MyEvictionComparator", evictionConfig.getComparatorClassName());
         assertEquals(InMemoryFormat.BINARY, queryCacheClassPredicateConfig.getInMemoryFormat());
         assertFalse(queryCacheClassPredicateConfig.isCoalesce());
         assertTrue(queryCacheClassPredicateConfig.isPopulate());


### PR DESCRIPTION
Added `comparator-class-name` to EvictionConfig object in both client config xml and client yaml configs.

fixes https://github.com/hazelcast/hazelcast/issues/14093