### PR TITLE
Reduce stale join prevention timeout to a lower value

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -332,6 +332,7 @@ public class MembershipManager {
             handleMemberRemove(memberMapRef.get(), member);
         }
 
+        clusterService.getClusterJoinManager().insertIntoRecentlyJoinedMemberSet(addedMembers);
         sendMembershipEvents(currentMemberMap.getMembers(), addedMembers);
 
         removeFromMissingMembers(members);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -39,10 +39,12 @@ import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -65,7 +67,9 @@ import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.FINA
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.F_ID;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.HEARTBEAT;
 import static com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook.MEMBER_INFO_UPDATE;
+import static com.hazelcast.internal.cluster.impl.ClusterJoinManager.STALE_JOIN_PREVENTION_DURATION_PROP;
 import static com.hazelcast.spi.properties.GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS;
+import static com.hazelcast.test.OverridePropertyRule.clear;
 import static com.hazelcast.test.PacketFiltersUtil.delayOperationsFrom;
 import static com.hazelcast.test.PacketFiltersUtil.dropOperationsBetween;
 import static com.hazelcast.test.PacketFiltersUtil.rejectOperationsBetween;
@@ -87,6 +91,9 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class MembershipUpdateTest extends HazelcastTestSupport {
+
+    @Rule
+    public final OverridePropertyRule ruleStaleJoinPreventionDuration = clear(STALE_JOIN_PREVENTION_DURATION_PROP);
 
     private TestHazelcastInstanceFactory factory;
 
@@ -622,11 +629,10 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
     @Test
     public void memberListOrder_shouldBeSame_whenMemberRestartedWithSameIdentity() {
+        ruleStaleJoinPreventionDuration.setOrClearProperty("5");
+
         Config configMaster = new Config();
         configMaster.setProperty(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "5");
-        // Needed only on master to prevent accepting stale join requests.
-        // See ClusterJoinManager#checkRecentlyJoinedMemberUuidBeforeJoin(target, uuid)
-        configMaster.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "5");
         final HazelcastInstance hz1 = factory.newHazelcastInstance(configMaster);
 
         final HazelcastInstance hz2 = factory.newHazelcastInstance();
@@ -662,25 +668,53 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
 
     @Test
     public void shouldNotProcessStaleJoinRequest() {
-        HazelcastInstance hz1 = factory.newHazelcastInstance();
-        HazelcastInstance hz2 = factory.newHazelcastInstance();
+        final HazelcastInstance hz1 = factory.newHazelcastInstance();
+        final HazelcastInstance hz2 = factory.newHazelcastInstance();
+        assertClusterSizeEventually(2, hz1, hz2);
 
-        JoinRequest staleJoinReq = getNode(hz2).createJoinRequest(true);
+        final JoinRequest staleJoinReq = getNode(hz2).createJoinRequest(true);
         hz2.shutdown();
         assertClusterSizeEventually(1, hz1);
 
-        ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz1);
-        clusterService.getClusterJoinManager().handleJoinRequest(staleJoinReq, null);
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz1);
+                clusterService.getClusterJoinManager().handleJoinRequest(staleJoinReq, null);
 
-        assertClusterSize(1, hz1);
+                assertClusterSize(1, hz1);
+            }
+        }, 3);
+    }
+
+    @Test
+    public void shouldNotProcessStaleJoinRequest_whenMasterChanges() {
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
+        final HazelcastInstance hz2 = factory.newHazelcastInstance();
+        HazelcastInstance hz3 = factory.newHazelcastInstance();
+        assertClusterSizeEventually(3, hz1, hz2, hz3);
+
+        final JoinRequest staleJoinReq = getNode(hz3).createJoinRequest(true);
+        hz3.shutdown();
+        hz1.shutdown();
+        assertClusterSizeEventually(1, hz2);
+
+        assertTrueAllTheTime(new AssertTask() {
+            @Override
+            public void run() {
+                ClusterServiceImpl clusterService = (ClusterServiceImpl) getClusterService(hz2);
+                clusterService.getClusterJoinManager().handleJoinRequest(staleJoinReq, null);
+
+                assertClusterSize(1, hz2);
+            }
+        }, 3);
     }
 
     @Test
     public void memberJoinsEventually_whenMemberRestartedWithSameUuid_butMasterDoesNotNoticeItsLeave() throws Exception {
+        ruleStaleJoinPreventionDuration.setOrClearProperty("5");
+
         Config configMaster = new Config();
-        // Needed only on master to prevent accepting stale join requests.
-        // See ClusterJoinManager#checkRecentlyJoinedMemberUuidBeforeJoin(target, uuid)
-        configMaster.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "5");
         final HazelcastInstance hz1 = factory.newHazelcastInstance(configMaster);
         final HazelcastInstance hz2 = factory.newHazelcastInstance();
         final HazelcastInstance hz3 = factory.newHazelcastInstance();

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/FrozenPartitionTableTest.java
@@ -31,13 +31,14 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.exception.WrongTargetException;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
-import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
 import com.hazelcast.test.TestHazelcastInstanceFactory;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -49,6 +50,8 @@ import java.util.List;
 import static com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance;
 import static com.hazelcast.instance.TestUtil.terminateInstance;
 import static com.hazelcast.internal.cluster.impl.AdvancedClusterStateTest.changeClusterStateEventually;
+import static com.hazelcast.internal.cluster.impl.ClusterJoinManager.STALE_JOIN_PREVENTION_DURATION_PROP;
+import static com.hazelcast.test.OverridePropertyRule.clear;
 import static com.hazelcast.test.TestHazelcastInstanceFactory.initOrCreateConfig;
 import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
 import static java.util.Arrays.asList;
@@ -60,6 +63,9 @@ import static org.junit.Assert.fail;
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
 public class FrozenPartitionTableTest extends HazelcastTestSupport {
+
+    @Rule
+    public final OverridePropertyRule ruleStaleJoinPreventionDuration = clear(STALE_JOIN_PREVENTION_DURATION_PROP);
 
     @Test
     public void partitionTable_isFrozen_whenNodesLeave_duringClusterStateIsFrozen() {
@@ -196,11 +202,10 @@ public class FrozenPartitionTableTest extends HazelcastTestSupport {
 
     @Test
     public void partitionTable_shouldBeFixed_whenMemberRestarts_usingNewUuid() {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
-        Config configMaster = new Config();
-        configMaster.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "5");
+        ruleStaleJoinPreventionDuration.setOrClearProperty("5");
 
-        HazelcastInstance hz1 = factory.newHazelcastInstance(configMaster);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
         HazelcastInstance hz2 = factory.newHazelcastInstance();
         HazelcastInstance hz3 = factory.newHazelcastInstance();
 
@@ -224,11 +229,10 @@ public class FrozenPartitionTableTest extends HazelcastTestSupport {
 
     @Test
     public void partitionTable_shouldBeFixed_whenMemberRestarts_usingUuidOfAnotherMissingMember() {
-        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
-        Config configMaster = new Config();
-        configMaster.setProperty(GroupProperty.MAX_JOIN_SECONDS.getName(), "5");
+        ruleStaleJoinPreventionDuration.setOrClearProperty("5");
 
-        HazelcastInstance hz1 = factory.newHazelcastInstance(configMaster);
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        HazelcastInstance hz1 = factory.newHazelcastInstance();
         HazelcastInstance hz2 = factory.newHazelcastInstance();
         HazelcastInstance hz3 = factory.newHazelcastInstance();
         HazelcastInstance hz4 = factory.newHazelcastInstance();


### PR DESCRIPTION
Currently, `hazelcast.max.join.seconds` (5 mins default) is used
as the eviction timeout. (See https://github.com/hazelcast/hazelcast/pull/10415.)

This long timeout was not an issue, since without Hot Restart,
a restarting member cannot recover its UUID, which means it will be able
to join the cluster with its new identity. And with Hot Restart we assumed that,
until 3.12, a member can only restart with cluster state frozen/passive.

Now with 3.12, we allow a member to restart with Hot Restart enabled
when cluster state is active. But if it restarts before 5 minutes passing after its join,
it should wait until its UUID is evicted from recently-joined-members set.

A new internal property added, with default 30 seconds value,
to configure stale join prevention timeout. We only change its
value in unit tests, users should not change it.

Additionally, recently joined members set should be kept on all members,
not only on master.

Fixes hazelcast/hazelcast-enterprise#2842
