### PR TITLE
Improve hiccup resilience of ScheduledExecutorServiceBasicTest.ScheduledExecutorServiceBasicTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceBasicTest.java
@@ -780,7 +780,7 @@ public class ScheduledExecutorServiceBasicTest extends ScheduledExecutorServiceT
 
         IScheduledFuture future = s.scheduleAtFixedRate(new ICountdownLatchRunnableTask("latch"), 0, 1, SECONDS);
 
-        latch.await(10, SECONDS);
+        latch.await(20, SECONDS);
         future.cancel(false);
 
         assertEquals(0, latch.getCount());


### PR DESCRIPTION
Double the time available for the task to be scheduled three times.

Fixes #14680