### PR TITLE
Skip processing empty partition table

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientPartitionListenerService.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientPartitionListenerService.java
@@ -78,7 +78,12 @@ public class ClientPartitionListenerService {
         partitionListeningEndpoints.remove(clientEndpoint);
     }
 
-    // return address->partitions mapping, where address is the client address of the member
+    /**
+     * If any partition does not have an owner, this method returns empty collection
+     *
+     * @param partitionTableView will be converted to address->partitions mapping
+     * @return address->partitions mapping, where address is the client address of the member
+     */
     public Collection<Map.Entry<Address, List<Integer>>> getPartitions(PartitionTableView partitionTableView) {
 
         Map<Address, List<Integer>> partitionsMap = new HashMap<Address, List<Integer>>();

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetPartitionsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/GetPartitionsMessageTask.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.client.impl.protocol.task;
 
+import com.hazelcast.client.impl.ClientPartitionListenerService;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.ClientGetPartitionsCodec;
 import com.hazelcast.instance.Node;
@@ -36,6 +37,10 @@ public class GetPartitionsMessageTask
         super(clientMessage, node, connection);
     }
 
+    /**
+     * The partitions can be empty on the response
+     * see {@link ClientPartitionListenerService#getPartitions(PartitionTableView)}
+     */
     protected Object call() {
         InternalPartitionService service = getService(InternalPartitionService.SERVICE_NAME);
         service.firstArrangement();


### PR DESCRIPTION
Member can return empty partition table any time.
Client was able to skip emptyPartitionTable.
Regression caused by this pr
https://github.com/hazelcast/hazelcast/pull/14635

Behaviour is restored to old one.

fixes
https://github.com/hazelcast/hazelcast/issues/14707
https://github.com/hazelcast/hazelcast-enterprise/issues/2820