### PR TITLE
Attempt to identify text protocol and fail-fast

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/AdvancedNetworkingClientCommunicationIntegrationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/connection/nio/AdvancedNetworkingClientCommunicationIntegrationTest.java
@@ -50,6 +50,8 @@ public class AdvancedNetworkingClientCommunicationIntegrationTest extends Abstra
 
         testClientConnectFailOnPort(MEMBER_PORT);
         testClientConnectFailOnPort(WAN1_PORT);
+        testClientConnectFailOnPort(REST_PORT);
+        testClientConnectFailOnPort(MEMCACHE_PORT);
     }
 
     private HazelcastInstance createClient(int port) {

--- a/hazelcast/src/main/java/com/hazelcast/instance/ProtocolType.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/ProtocolType.java
@@ -42,8 +42,8 @@ public enum ProtocolType {
     MEMBER(1, Protocols.CLUSTER),
     CLIENT(1, Protocols.CLIENT_BINARY_NEW),
     WAN(Integer.MAX_VALUE, Protocols.CLUSTER),
-    REST(1, Protocols.TEXT),
-    MEMCACHE(1, Protocols.TEXT);
+    REST(1, Protocols.REST),
+    MEMCACHE(1, Protocols.MEMCACHE);
 
     private static final Set<ProtocolType> PROTOCOL_TYPES_SET;
     private static final ProtocolType[] PROTOCOL_TYPES;

--- a/hazelcast/src/main/java/com/hazelcast/nio/Protocols.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/Protocols.java
@@ -40,9 +40,14 @@ public final class Protocols {
     public static final String CLIENT_BINARY_NEW = "CB2";
 
     /**
-     * Protocol that is used by Memcache And Http
+     * Protocol that is used by REST
      */
-    public static final String TEXT = "TXT";
+    public static final String REST = "HTTP";
+
+    /**
+     * Protocol that is used by Memcached
+     */
+    public static final String MEMCACHE = "Memcached";
 
     private Protocols() {
     }
@@ -56,8 +61,12 @@ public final class Protocols {
             return "Client Open Binary Protocol";
         }
 
-        if (TEXT.equals(protocol)) {
-            return "Text Protocol";
+        if (REST.equals(protocol)) {
+            return "REST Protocol";
+        }
+
+        if (MEMCACHE.equals(protocol)) {
+            return "MEMCACHE Protocol";
         }
 
         return "Unknown Protocol";

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TextHandshakeDecoder.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TextHandshakeDecoder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.nio.tcp;
+
+import com.hazelcast.instance.ProtocolType;
+import com.hazelcast.internal.networking.InboundHandler;
+import com.hazelcast.nio.ascii.MemcacheTextDecoder;
+import com.hazelcast.nio.ascii.RestApiTextDecoder;
+
+import java.nio.ByteBuffer;
+
+public class TextHandshakeDecoder
+        extends SingleProtocolDecoder {
+
+    public TextHandshakeDecoder(ProtocolType supportedProtocol, InboundHandler next) {
+        super(supportedProtocol, new InboundHandler[] {next}, null);
+    }
+
+    @Override
+    protected void verifyProtocol(String incomingProtocol) {
+        if (ProtocolType.REST.equals(supportedProtocol)) {
+            if (!RestApiTextDecoder.TEXT_PARSERS.isCommandPrefix(incomingProtocol)) {
+                throw new IllegalStateException("Unsupported protocol exchange detected, expected protocol: REST");
+            }
+        } else {
+            if (!MemcacheTextDecoder.TEXT_PARSERS.isCommandPrefix(incomingProtocol)) {
+                throw new IllegalStateException("Unsupported protocol exchange detected, " + "expected protocol: MEMCACHED");
+            }
+        }
+    }
+
+    @Override
+    protected void setupNextDecoder() {
+        super.setupNextDecoder();
+        // we need to restore whatever is read
+        ByteBuffer src = this.src;
+        ByteBuffer dst = (ByteBuffer) inboundHandlers[0].src();
+        src.flip();
+        dst.put(src);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/HTTPCommunicator.java
@@ -355,7 +355,7 @@ public class HTTPCommunicator {
         final int responseCode;
         final Map<String, List<String>> responseHeaders;
 
-        private ConnectionResponse(String response, int responseCode) {
+        ConnectionResponse(String response, int responseCode) {
             this(response, responseCode, null);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/InvalidEndpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/InvalidEndpointTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.ascii;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.RestServerEndpointConfig;
+import com.hazelcast.config.ServerSocketEndpointConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.TestAwareInstanceFactory;
+import com.hazelcast.test.annotation.SlowTest;
+import net.spy.memcached.ConnectionFactory;
+import net.spy.memcached.ConnectionFactoryBuilder;
+import net.spy.memcached.FailureMode;
+import net.spy.memcached.MemcachedClient;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.util.Collections;
+import java.util.concurrent.ExecutionException;
+
+import static com.hazelcast.instance.EndpointQualifier.MEMCACHE;
+import static com.hazelcast.instance.EndpointQualifier.REST;
+import static com.hazelcast.test.HazelcastTestSupport.ignore;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(SlowTest.class)
+public class InvalidEndpointTest {
+
+    protected final TestAwareInstanceFactory factory = new TestAwareInstanceFactory();
+
+    @After
+    public void tearDown() {
+        factory.terminateAll();
+    }
+
+    @Test
+    public void attemptHttpOnMemcacheEndpoint()
+            throws IOException {
+
+        Config config = createMemcacheEndpointConfig();
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+
+        // Invalid endpoint - points to MEMCACHE
+        String address = instance.getCluster().getLocalMember().getSocketAddress(MEMCACHE).toString();
+        String url = "http:/" + address + "/management/cluster/version";
+        try {
+            doHttpGet(url);
+            fail("Should not be able to connect");
+        } catch (SocketException e) {
+            ignore(e);
+        }
+    }
+
+    protected Config createMemcacheEndpointConfig() {
+        ServerSocketEndpointConfig endpointConfig = new ServerSocketEndpointConfig();
+        endpointConfig.setName("Text")
+                    .setPort(10000)
+                    .setPortAutoIncrement(true);
+
+        Config config = new Config();
+        config.getAdvancedNetworkConfig()
+              .setMemcacheEndpointConfig(endpointConfig)
+              .setEnabled(true);
+        return config;
+    }
+
+    @Test
+    public void attemptMemcacheOnHttpEndpoint()
+            throws IOException, InterruptedException {
+        Config config = createRestEndpointConfig();
+        HazelcastInstance instance = factory.newHazelcastInstance(config);
+
+        // Invalid endpoint - points to REST
+        InetSocketAddress address = instance.getCluster().getLocalMember().getSocketAddress(REST);
+        ConnectionFactory factory = new ConnectionFactoryBuilder()
+                .setOpTimeout(60 * 60 * 60)
+                .setDaemon(true)
+                .setFailureMode(FailureMode.Retry)
+                .build();
+        MemcachedClient client = new MemcachedClient(factory, Collections.singletonList(address));
+
+        try {
+            client.set("one", 0, "two").get();
+            fail("Should not be able to connect");
+        } catch (InterruptedException e) {
+            ignore(e);
+        } catch (ExecutionException e) {
+            ignore(e);
+        }
+    }
+
+    protected Config createRestEndpointConfig() {
+        RestServerEndpointConfig restEndpoint = new RestServerEndpointConfig();
+        restEndpoint.setName("Text")
+                    .setPort(10000)
+                    .setPortAutoIncrement(true)
+                    .enableAllGroups();
+
+        Config config = new Config();
+        config.getAdvancedNetworkConfig()
+              .setRestEndpointConfig(restEndpoint)
+              .setEnabled(true);
+        return config;
+    }
+
+    protected HTTPCommunicator.ConnectionResponse doHttpGet(String url) throws IOException {
+        CloseableHttpClient client = newHttpClient();
+        CloseableHttpResponse response = null;
+        try {
+            HttpGet request = new HttpGet(url);
+            request.setHeader("Content-type", "text/xml; charset=" + "UTF-8");
+            response = client.execute(request);
+            int responseCode = response.getStatusLine().getStatusCode();
+            HttpEntity entity = response.getEntity();
+            String responseStr = entity != null ? EntityUtils.toString(entity, "UTF-8") : "";
+            return new HTTPCommunicator.ConnectionResponse(responseStr, responseCode);
+        } finally {
+            IOUtil.closeResource(response);
+            IOUtil.closeResource(client);
+        }
+    }
+
+    protected CloseableHttpClient newHttpClient()
+            throws IOException {
+        return HttpClients.custom().build();
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestMultiendpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestMultiendpointTest.java
@@ -63,7 +63,6 @@ public class RestMultiendpointTest
 
         config.getAdvancedNetworkConfig()
               .setEnabled(true)
-              .setEnabled(true)
               .setMemberEndpointConfig(memberEndpointConfig)
               .setClientEndpointConfig(clientEndpointConfig)
               .setRestEndpointConfig(restEndpoint);

--- a/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkingCommunicationIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/networking/nio/AdvancedNetworkingCommunicationIntegrationTest.java
@@ -24,10 +24,6 @@ import com.hazelcast.internal.ascii.HTTPCommunicator;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.SocketException;
-import java.util.Collections;
 import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.FailureMode;
@@ -36,7 +32,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static com.hazelcast.internal.networking.nio.AbstractAdvancedNetworkIntegrationTest.MEMBER_PORT;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.util.Collections;
+
 import static com.hazelcast.test.HazelcastTestSupport.smallInstanceConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -69,6 +69,7 @@ public class AdvancedNetworkingCommunicationIntegrationTest extends AbstractAdva
         testRestCallFailsOnPort(hz, MEMBER_PORT);
         testRestCallFailsOnPort(hz, CLIENT_PORT);
         testRestCallFailsOnPort(hz, WAN1_PORT);
+        testRestCallFailsOnPort(hz, MEMCACHE_PORT);
     }
 
     @Test
@@ -91,6 +92,7 @@ public class AdvancedNetworkingCommunicationIntegrationTest extends AbstractAdva
         testMemcacheCallFailsOnPort(hz, MEMBER_PORT);
         testMemcacheCallFailsOnPort(hz, CLIENT_PORT);
         testMemcacheCallFailsOnPort(hz, WAN1_PORT);
+        testMemcacheCallFailsOnPort(hz, REST_PORT);
     }
 
     private void startMemberAndTryToJoinToPort(int port, int expectedClusterSize) {


### PR DESCRIPTION
Fixes points from https://github.com/hazelcast/hazelcast/issues/14532
EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2851

Added basic String matching during the handshake (similar to unified socket) to prevent wrong configurations and incorrect connection attempts on the TEXT based protocols.