### PR TITLE
Fixes operation stats for some map methods

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStatsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapStatsTest.java
@@ -51,8 +51,13 @@ public class ClientMapStatsTest extends LocalMapStatsTest {
     }
 
     @Override
-    protected LocalMapStats geMapStats() {
+    protected LocalMapStats getMapStats() {
         return member.getMap(mapName).getLocalMapStats();
+    }
+
+    @Override
+    public void testOtherOperationCount_localKeySet() {
+        // localKeySet is not supported on client
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapQueryMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/DefaultMapQueryMessageTask.java
@@ -47,5 +47,4 @@ public abstract class DefaultMapQueryMessageTask<P>
     protected void extractAndAppendResult(Collection<QueryResultRow> results, QueryResult queryResult) {
         results.addAll(queryResult.getRows());
     }
-
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapContainsValueMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapContainsValueMessageTask.java
@@ -29,6 +29,8 @@ import com.hazelcast.spi.OperationFactory;
 import java.security.Permission;
 import java.util.Map;
 
+import static com.hazelcast.map.impl.LocalMapStatsUtil.incrementOtherOperationsCount;
+
 public class MapContainsValueMessageTask
         extends AbstractMapAllPartitionsMessageTask<MapContainsValueCodec.RequestParameters> {
 
@@ -51,6 +53,7 @@ public class MapContainsValueMessageTask
                 break;
             }
         }
+        incrementOtherOperationsCount((MapService) getService(MapService.SERVICE_NAME), parameters.name);
         return result;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEntrySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapEntrySetMessageTask.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapEntrySetCodec;
 import com.hazelcast.instance.Node;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.QueryResultRow;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
@@ -34,6 +35,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import static com.hazelcast.map.impl.LocalMapStatsUtil.incrementOtherOperationsCount;
+
 public class MapEntrySetMessageTask
         extends DefaultMapQueryMessageTask<MapEntrySetCodec.RequestParameters> {
 
@@ -47,6 +50,7 @@ public class MapEntrySetMessageTask
         for (QueryResultRow row : result) {
             entries.add(row);
         }
+        incrementOtherOperationsCount((MapService) getService(MapService.SERVICE_NAME), parameters.name);
         return entries;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapIsEmptyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapIsEmptyMessageTask.java
@@ -21,6 +21,7 @@ import com.hazelcast.client.impl.protocol.codec.MapIsEmptyCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractAllPartitionsMessageTask;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.operation.IsEmptyOperationFactory;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
@@ -29,6 +30,8 @@ import com.hazelcast.spi.OperationFactory;
 
 import java.security.Permission;
 import java.util.Map;
+
+import static com.hazelcast.map.impl.LocalMapStatsUtil.incrementOtherOperationsCount;
 
 public class MapIsEmptyMessageTask
         extends AbstractAllPartitionsMessageTask<MapIsEmptyCodec.RequestParameters> {
@@ -45,14 +48,15 @@ public class MapIsEmptyMessageTask
     @Override
     protected Object reduce(Map<Integer, Object> map) {
         MapService mapService = getService(MapService.SERVICE_NAME);
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         boolean response = true;
         for (Object result : map.values()) {
-            boolean isEmpty = (Boolean) mapService.getMapServiceContext().toObject(result);
+            boolean isEmpty = (Boolean) mapServiceContext.toObject(result);
             if (!isEmpty) {
                 response = false;
             }
         }
-
+        incrementOtherOperationsCount(mapService, parameters.name);
         return response;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapKeySetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapKeySetMessageTask.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapKeySetCodec;
 import com.hazelcast.instance.Node;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.QueryResultRow;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
@@ -33,6 +34,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static com.hazelcast.map.impl.LocalMapStatsUtil.incrementOtherOperationsCount;
+
 public class MapKeySetMessageTask
         extends DefaultMapQueryMessageTask<MapKeySetCodec.RequestParameters> {
 
@@ -46,6 +49,7 @@ public class MapKeySetMessageTask
         for (QueryResultRow resultEntry : result) {
             keys.add(resultEntry.getKey());
         }
+        incrementOtherOperationsCount((MapService) getService(MapService.SERVICE_NAME), parameters.name);
         return keys;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSizeMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapSizeMessageTask.java
@@ -28,6 +28,8 @@ import com.hazelcast.spi.OperationFactory;
 import java.security.Permission;
 import java.util.Map;
 
+import static com.hazelcast.map.impl.LocalMapStatsUtil.incrementOtherOperationsCount;
+
 public class MapSizeMessageTask
         extends AbstractMapAllPartitionsMessageTask<MapSizeCodec.RequestParameters> {
 
@@ -49,6 +51,7 @@ public class MapSizeMessageTask
             Integer size = (Integer) mapService.getMapServiceContext().toObject(result);
             total += size;
         }
+        incrementOtherOperationsCount(mapService, parameters.name);
         return total;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapValuesMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapValuesMessageTask.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapValuesCodec;
 import com.hazelcast.instance.Node;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.QueryResultRow;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
@@ -33,6 +34,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import static com.hazelcast.map.impl.LocalMapStatsUtil.incrementOtherOperationsCount;
+
 public class MapValuesMessageTask
         extends DefaultMapQueryMessageTask<MapValuesCodec.RequestParameters> {
 
@@ -46,6 +49,7 @@ public class MapValuesMessageTask
         for (QueryResultRow resultEntry : result) {
             values.add(resultEntry.getValue());
         }
+        incrementOtherOperationsCount((MapService) getService(MapService.SERVICE_NAME), parameters.name);
         return values;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapValuesWithPredicateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapValuesWithPredicateMessageTask.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.task.map;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapValuesWithPredicateCodec;
 import com.hazelcast.instance.Node;
+import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.QueryResultRow;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.serialization.Data;
@@ -28,6 +29,8 @@ import com.hazelcast.util.IterationType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import static com.hazelcast.map.impl.LocalMapStatsUtil.incrementOtherOperationsCount;
 
 public class MapValuesWithPredicateMessageTask
         extends DefaultMapQueryMessageTask<MapValuesWithPredicateCodec.RequestParameters> {
@@ -42,6 +45,7 @@ public class MapValuesWithPredicateMessageTask
         for (QueryResultRow resultEntry : result) {
             values.add(resultEntry.getValue());
         }
+        incrementOtherOperationsCount((MapService) getService(MapService.SERVICE_NAME), parameters.name);
         return values;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LocalMapStatsUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.map.impl;
+
+import com.hazelcast.monitor.impl.LocalMapStatsImpl;
+
+/**
+ * Utility methods for {@link LocalMapStatsImpl}
+ */
+public final class LocalMapStatsUtil {
+
+    private LocalMapStatsUtil() {
+
+    }
+
+    /**
+     * Increments other operations count statistic in local map statistics.
+     * @param service
+     * @param mapName
+     */
+    public static void incrementOtherOperationsCount(MapService service, String mapName) {
+        MapServiceContext mapServiceContext = service.getMapServiceContext();
+        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
+        if (mapContainer.getMapConfig().isStatisticsEnabled()) {
+            LocalMapStatsImpl localMapStats = mapServiceContext.getLocalMapStatsProvider().getLocalMapStatsImpl(mapName);
+            localMapStats.incrementOtherOperations();
+        }
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/ContainsValueOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
@@ -42,10 +41,6 @@ public class ContainsValueOperation extends MapOperation implements PartitionAwa
     @Override
     public void run() {
         contains = recordStore.containsValue(testValue);
-        if (mapContainer.getMapConfig().isStatisticsEnabled()) {
-            LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
-            localMapStatsProvider.getLocalMapStatsImpl(name).incrementOtherOperations();
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapIsEmptyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapIsEmptyOperation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ReadonlyOperation;
 
@@ -34,11 +33,6 @@ public class MapIsEmptyOperation extends MapOperation implements PartitionAwareO
 
     public void run() {
         empty = recordStore.isEmpty();
-        if (mapContainer.getMapConfig().isStatisticsEnabled()) {
-            LocalMapStatsImpl localMapStatsImpl = mapServiceContext.getLocalMapStatsProvider()
-                    .getLocalMapStatsImpl(name);
-            localMapStatsImpl.incrementOtherOperations();
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapSizeOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapSizeOperation.java
@@ -16,9 +16,7 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.map.impl.LocalMapStatsProvider;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.monitor.impl.LocalMapStatsImpl;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ReadonlyOperation;
 
@@ -37,11 +35,6 @@ public class MapSizeOperation extends MapOperation implements PartitionAwareOper
     public void run() {
         recordStore.checkIfLoaded();
         size = recordStore.size();
-        if (mapContainer.getMapConfig().isStatisticsEnabled()) {
-            LocalMapStatsProvider localMapStatsProvider = mapServiceContext.getLocalMapStatsProvider();
-            LocalMapStatsImpl localMapStatsImpl = localMapStatsProvider.getLocalMapStatsImpl(name);
-            localMapStatsImpl.incrementOtherOperations();
-        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -733,6 +733,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     private Set executePredicate(Predicate predicate, IterationType iterationType, boolean uniqueResult) {
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
         QueryResult result = executeQueryInternal(predicate, iterationType, Target.ALL_NODES);
+        incrementOtherOperationsStat();
         return transformToSet(serializationService, result, predicate, iterationType, uniqueResult, false);
     }
 
@@ -746,6 +747,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     public Set<K> localKeySet(Predicate predicate) {
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
         QueryResult result = executeQueryInternal(predicate, IterationType.KEY, Target.LOCAL_NODE);
+        incrementOtherOperationsStat();
         return transformToSet(serializationService, result, predicate, IterationType.KEY, false, false);
     }
 


### PR DESCRIPTION
Some operation stats incorrectly reported operations per partition. Now all operation stats are converted to report number per user call.

Ground work for https://github.com/hazelcast/hazelcast-enterprise/issues/2704