### PR TITLE
Reject sync InvokeOnPartitions from an async thread

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationservice/impl/InvokeOnPartitions.java
@@ -85,6 +85,9 @@ final class InvokeOnPartitions {
      * Executes all the operations on the partitions.
      */
     <T> Map<Integer, T> invoke() throws Exception {
+        if (Thread.currentThread().getName().contains(".async.thread-")) {
+            throw new RuntimeException("Cannot execute on async thread");
+        }
         return this.<T>invokeAsync().get();
     }
 


### PR DESCRIPTION
This PR adds a check that `InvokeOnPartitions.invoke()` cannot be called from an async thread because it is deadlock prone. Deadlock happens like this:
- on async thread, `InvokeOnPartitions.invoke()` is called. It sends a `PartitionIteratingOperation` and blocks until it returns
- when handling the response of `PartitionIteratingOperation`, the action in `andThen` executes on an async thread. However if there was just one async thread, it will deadlock.

We attempted to resolve it by using `CALLER_RUNS` for `andThen`. But this doesn't work for retries because the future can be completed on either a response thread or partition thread depending on whether it's a response from remote or local operation. And we can't execute operations for the (probably) very same reason from a partition thread, there's similar check that throws in such case.

Related to #14733