### PR TITLE
Avoid converting composite values in-place

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryRunner.java
@@ -83,7 +83,6 @@ public class QueryRunner {
      * @param fetchSize   the soft limit for the number of items to be queried
      * @return the queried entries along with the next {@code tableIndex} to resume querying
      */
-    @SuppressWarnings("unchecked")
     public ResultSegment runPartitionScanQueryOnPartitionChunk(Query query, int partitionId, int tableIndex, int fetchSize) {
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
         Predicate predicate = queryOptimizer.optimize(query.getPredicate(), mapContainer.getIndexes(partitionId));
@@ -100,7 +99,6 @@ public class QueryRunner {
 
     // MIGRATION SAFE QUERYING -> MIGRATION STAMPS ARE VALIDATED (does not have to run on a partition thread)
     // full query = index query (if possible), then partition-scan query
-    @SuppressWarnings("unchecked")
     public Result runIndexOrPartitionScanQueryOnOwnedPartitions(Query query) {
         int migrationStamp = getMigrationStamp();
         Collection<Integer> initialPartitions = mapServiceContext.getOwnedPartitions();
@@ -149,7 +147,6 @@ public class QueryRunner {
      * @return the result of the query; if the result has {@code null} {@link
      * Result#getPartitionIds() partition IDs} this indicates a failure.
      */
-    @SuppressWarnings("unchecked")
     public Result runIndexQueryOnOwnedPartitions(Query query) {
         int migrationStamp = getMigrationStamp();
         Collection<Integer> initialPartitions = mapServiceContext.getOwnedPartitions();
@@ -181,7 +178,6 @@ public class QueryRunner {
 
     // MIGRATION UNSAFE QUERYING - MIGRATION STAMPS ARE NOT VALIDATED, so assumes a run on partition-thread
     // for a single partition. If the index is global it won't be asked
-    @SuppressWarnings("unchecked")
     public Result runPartitionIndexOrPartitionScanQueryOnGivenOwnedPartition(Query query, int partitionId) {
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
         List<Integer> partitions = singletonList(partitionId);
@@ -208,7 +204,6 @@ public class QueryRunner {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
     Result runPartitionScanQueryOnGivenOwnedPartition(Query query, int partitionId) {
         MapContainer mapContainer = mapServiceContext.getMapContainer(query.getMapName());
         Predicate predicate = queryOptimizer.optimize(query.getPredicate(), mapContainer.getIndexes(partitionId));

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/CompositeConverter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/CompositeConverter.java
@@ -89,18 +89,18 @@ public class CompositeConverter implements TypeConverter {
         }
         CompositeValue compositeValue = (CompositeValue) value;
 
-        // Components are converted in-place to reduce littering. Composite
-        // values are never exposed to user code, so that's not a problem to
-        // mutate them.
         Comparable[] components = compositeValue.getComponents();
+        Comparable[] converted = new Comparable[components.length];
         for (int i = 0; i < components.length; ++i) {
             Comparable component = components[i];
-            if (component != NULL && component != NEGATIVE_INFINITY && component != POSITIVE_INFINITY) {
-                components[i] = converters[i].convert(component);
+            if (component == NULL || component == NEGATIVE_INFINITY || component == POSITIVE_INFINITY) {
+                converted[i] = component;
+            } else {
+                converted[i] = converters[i].convert(component);
             }
         }
 
-        return value;
+        return new CompositeValue(converted);
     }
 
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/CompositeConverterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/CompositeConverterTest.java
@@ -24,6 +24,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
+import static com.hazelcast.query.impl.AbstractIndex.NULL;
+import static com.hazelcast.query.impl.CompositeValue.NEGATIVE_INFINITY;
+import static com.hazelcast.query.impl.CompositeValue.POSITIVE_INFINITY;
 import static com.hazelcast.query.impl.TypeConverters.BOOLEAN_CONVERTER;
 import static com.hazelcast.query.impl.TypeConverters.IDENTITY_CONVERTER;
 import static com.hazelcast.query.impl.TypeConverters.INTEGER_CONVERTER;
@@ -78,6 +81,13 @@ public class CompositeConverterTest {
                 converter(INTEGER_CONVERTER, BOOLEAN_CONVERTER, STRING_CONVERTER).convert(value(1, true, "foo")));
         assertEquals(value(1, false, "1"),
                 converter(INTEGER_CONVERTER, BOOLEAN_CONVERTER, STRING_CONVERTER).convert(value(1.0, "non-true", 1)));
+    }
+
+    @Test
+    public void testSpecialValuesArePreserved() {
+        assertEquals(value(NULL), converter(INTEGER_CONVERTER).convert(value(NULL)));
+        assertEquals(value(NEGATIVE_INFINITY), converter(INTEGER_CONVERTER).convert(value(NEGATIVE_INFINITY)));
+        assertEquals(value(POSITIVE_INFINITY), converter(INTEGER_CONVERTER).convert(value(POSITIVE_INFINITY)));
     }
 
     private static CompositeConverter converter(TypeConverter... converters) {


### PR DESCRIPTION
It's not safe to convert a composite value in-place for HD, since
it may undergo some other transformation, e.g. canonicalization,
at the same time on a different thread.

Also, unneeded warning suppressions are cleaned up in QueryRunner.

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/2861