### PR TITLE
Rename LockAcquireLimitExceededException to LockAcquireLimitReachedException

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientExceptionFactory.java
@@ -41,7 +41,7 @@ import com.hazelcast.cp.exception.NotLeaderException;
 import com.hazelcast.cp.exception.StaleAppendRequestException;
 import com.hazelcast.cp.internal.datastructures.exception.WaitKeyCancelledException;
 import com.hazelcast.cp.internal.session.SessionExpiredException;
-import com.hazelcast.cp.lock.exception.LockAcquireLimitExceededException;
+import com.hazelcast.cp.lock.exception.LockAcquireLimitReachedException;
 import com.hazelcast.cp.lock.exception.LockOwnershipLostException;
 import com.hazelcast.crdt.MutationDisallowedException;
 import com.hazelcast.crdt.TargetNotReplicaException;
@@ -108,7 +108,7 @@ import java.util.regex.Pattern;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CANNOT_REPLICATE_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.CP_GROUP_DESTROYED_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LEADER_DEMOTED_EXCEPTION;
-import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LOCK_ACQUIRE_LIMIT_EXCEEDED_EXCEPTION;
+import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LOCK_ACQUIRE_LIMIT_REACHED_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.LOCK_OWNERSHIP_LOST_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.NOT_LEADER_EXCEPTION;
 import static com.hazelcast.client.impl.protocol.ClientProtocolErrorCodes.SESSION_EXPIRED_EXCEPTION;
@@ -695,10 +695,10 @@ public class ClientExceptionFactory {
                 return new WaitKeyCancelledException(message, cause);
             }
         });
-        register(LOCK_ACQUIRE_LIMIT_EXCEEDED_EXCEPTION, LockAcquireLimitExceededException.class, new ExceptionFactory() {
+        register(LOCK_ACQUIRE_LIMIT_REACHED_EXCEPTION, LockAcquireLimitReachedException.class, new ExceptionFactory() {
             @Override
             public Throwable createException(String message, Throwable cause) {
-                return new LockAcquireLimitExceededException(message);
+                return new LockAcquireLimitReachedException(message);
             }
         });
         register(LOCK_OWNERSHIP_LOST_EXCEPTION, LockOwnershipLostException.class, new ExceptionFactory() {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientExceptions.java
@@ -36,7 +36,7 @@ import com.hazelcast.cp.exception.CannotReplicateException;
 import com.hazelcast.cp.exception.LeaderDemotedException;
 import com.hazelcast.cp.exception.NotLeaderException;
 import com.hazelcast.cp.exception.StaleAppendRequestException;
-import com.hazelcast.cp.lock.exception.LockAcquireLimitExceededException;
+import com.hazelcast.cp.lock.exception.LockAcquireLimitReachedException;
 import com.hazelcast.cp.lock.exception.LockOwnershipLostException;
 import com.hazelcast.cp.internal.datastructures.exception.WaitKeyCancelledException;
 import com.hazelcast.cp.internal.session.SessionExpiredException;
@@ -209,7 +209,7 @@ public class ClientExceptions {
         register(ClientProtocolErrorCodes.CONSISTENCY_LOST_EXCEPTION, ConsistencyLostException.class);
         register(ClientProtocolErrorCodes.SESSION_EXPIRED_EXCEPTION, SessionExpiredException.class);
         register(ClientProtocolErrorCodes.WAIT_KEY_CANCELLED_EXCEPTION, WaitKeyCancelledException.class);
-        register(ClientProtocolErrorCodes.LOCK_ACQUIRE_LIMIT_EXCEEDED_EXCEPTION, LockAcquireLimitExceededException.class);
+        register(ClientProtocolErrorCodes.LOCK_ACQUIRE_LIMIT_REACHED_EXCEPTION, LockAcquireLimitReachedException.class);
         register(ClientProtocolErrorCodes.LOCK_OWNERSHIP_LOST_EXCEPTION, LockOwnershipLostException.class);
         register(ClientProtocolErrorCodes.CP_GROUP_DESTROYED_EXCEPTION, CPGroupDestroyedException.class);
         register(ClientProtocolErrorCodes.CANNOT_REPLICATE_EXCEPTION, CannotReplicateException.class);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientProtocolErrorCodes.java
@@ -113,7 +113,7 @@ public final class ClientProtocolErrorCodes {
     public static final int CONSISTENCY_LOST_EXCEPTION = 88;
     public static final int SESSION_EXPIRED_EXCEPTION = 89;
     public static final int WAIT_KEY_CANCELLED_EXCEPTION = 90;
-    public static final int LOCK_ACQUIRE_LIMIT_EXCEEDED_EXCEPTION = 91;
+    public static final int LOCK_ACQUIRE_LIMIT_REACHED_EXCEPTION = 91;
     public static final int LOCK_OWNERSHIP_LOST_EXCEPTION = 92;
     public static final int CP_GROUP_DESTROYED_EXCEPTION = 93;
     public static final int CANNOT_REPLICATE_EXCEPTION = 94;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/proxy/AbstractRaftFencedLockProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/proxy/AbstractRaftFencedLockProxy.java
@@ -24,7 +24,7 @@ import com.hazelcast.cp.internal.session.AbstractProxySessionManager;
 import com.hazelcast.cp.internal.session.SessionAwareProxy;
 import com.hazelcast.cp.internal.session.SessionExpiredException;
 import com.hazelcast.cp.lock.FencedLock;
-import com.hazelcast.cp.lock.exception.LockAcquireLimitExceededException;
+import com.hazelcast.cp.lock.exception.LockAcquireLimitReachedException;
 import com.hazelcast.cp.lock.exception.LockOwnershipLostException;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.util.Clock;
@@ -92,7 +92,7 @@ public abstract class AbstractRaftFencedLockProxy extends SessionAwareProxy impl
                     return;
                 }
 
-                throw new LockAcquireLimitExceededException("Lock[" + proxyName + "] reentrant lock limit exceeded!");
+                throw new LockAcquireLimitReachedException("Lock[" + proxyName + "] reentrant lock limit is already reached!");
             } catch (SessionExpiredException e) {
                 invalidateSession(sessionId);
                 verifyNoLockedSessionIdPresent(threadId);
@@ -125,7 +125,7 @@ public abstract class AbstractRaftFencedLockProxy extends SessionAwareProxy impl
                     return fence;
                 }
 
-                throw new LockAcquireLimitExceededException("Lock[" + proxyName + "] reentrant lock limit exceeded!");
+                throw new LockAcquireLimitReachedException("Lock[" + proxyName + "] reentrant lock limit is already reached!");
             } catch (SessionExpiredException e) {
                 invalidateSession(sessionId);
                 verifyNoLockedSessionIdPresent(threadId);

--- a/hazelcast/src/main/java/com/hazelcast/cp/lock/FencedLock.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/lock/FencedLock.java
@@ -21,7 +21,7 @@ import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.CPSubsystem;
-import com.hazelcast.cp.lock.exception.LockAcquireLimitExceededException;
+import com.hazelcast.cp.lock.exception.LockAcquireLimitReachedException;
 import com.hazelcast.cp.lock.exception.LockOwnershipLostException;
 import com.hazelcast.cp.session.CPSession;
 import com.hazelcast.cp.session.CPSessionManagementService;
@@ -48,9 +48,9 @@ import java.util.concurrent.locks.Lock;
  * in a linearizable manner. You can configure the reentrancy behaviour via
  * {@link FencedLockConfig}. For instance, reentrancy can be disabled and
  * {@link FencedLock} can work as a non-reentrant mutex. One can also set
- * a custom reentrancy limit. When the reentrancy limit is exceeded,
+ * a custom reentrancy limit. When the reentrancy limit is reached,
  * {@link FencedLock} does not block a lock call. Instead, it fails with
- * {@link LockAcquireLimitExceededException} or a specified return value.
+ * {@link LockAcquireLimitReachedException} or a specified return value.
  * Please check the locking methods to see details about the behaviour.
  * <p>
  * Distributed locks are unfortunately NOT EQUIVALENT to single-node mutexes
@@ -123,7 +123,7 @@ import java.util.concurrent.locks.Lock;
  * @see CPSessionManagementService
  * @see CPSession
  * @see LockOwnershipLostException
- * @see LockAcquireLimitExceededException
+ * @see LockAcquireLimitReachedException
  */
 public interface FencedLock extends Lock, DistributedObject {
 
@@ -138,8 +138,9 @@ public interface FencedLock extends Lock, DistributedObject {
      * <p>
      * When the caller already holds the lock and the current lock() call is
      * reentrant, the call can fail with
-     * {@link LockAcquireLimitExceededException} if the lock acquire limit is
-     * exceeded. Please see {@link FencedLockConfig} for more information.
+     * {@link LockAcquireLimitReachedException} if the lock acquire limit is
+     * already reached. Please see {@link FencedLockConfig} for more
+     * information.
      * <p>
      * If the lock is not available then the current thread becomes disabled
      * for thread scheduling purposes and lies dormant until the lock has been
@@ -168,8 +169,8 @@ public interface FencedLock extends Lock, DistributedObject {
      *
      * @throws LockOwnershipLostException if the underlying CP session is
      *         closed while locking reentrantly
-     * @throws LockAcquireLimitExceededException if the lock call is reentrant
-     *         and the configured lock acquire limit is exceeded.
+     * @throws LockAcquireLimitReachedException if the lock call is reentrant
+     *         and the configured lock acquire limit is already reached.
      */
     void lock();
 
@@ -179,8 +180,9 @@ public interface FencedLock extends Lock, DistributedObject {
      * <p>
      * When the caller already holds the lock and the current lock() call is
      * reentrant, the call can fail with
-     * {@link LockAcquireLimitExceededException} if the lock acquire limit is
-     * exceeded. Please see {@link FencedLockConfig} for more information.
+     * {@link LockAcquireLimitReachedException} if the lock acquire limit is
+     * already reached. Please see {@link FencedLockConfig} for more
+     * information.
      * <p>
      * If the lock is not available then the current thread becomes disabled
      * for thread scheduling purposes and lies dormant until the lock has been
@@ -220,8 +222,8 @@ public interface FencedLock extends Lock, DistributedObject {
      *
      * @throws LockOwnershipLostException if the underlying CP session is
      *         closed while locking reentrantly
-     * @throws LockAcquireLimitExceededException if the lock call is reentrant
-     *         and the configured lock acquire limit is exceeded.
+     * @throws LockAcquireLimitReachedException if the lock call is reentrant
+     *         and the configured lock acquire limit is already reached.
      */
     void lockInterruptibly() throws InterruptedException;
 
@@ -229,8 +231,9 @@ public interface FencedLock extends Lock, DistributedObject {
      * Acquires the lock and returns the fencing token assigned to the current
      * thread for this lock acquire. If the lock is acquired reentrantly,
      * the same fencing token is returned, or the lock() call can fail with
-     * {@link LockAcquireLimitExceededException} if the lock acquire limit is
-     * exceeded. Please see {@link FencedLockConfig} for more information.
+     * {@link LockAcquireLimitReachedException} if the lock acquire limit is
+     * already reached. Please see {@link FencedLockConfig} for more
+     * information.
      * <p>
      * If the lock is not available then the current thread becomes disabled
      * for thread scheduling purposes and lies dormant until the lock has been
@@ -293,8 +296,8 @@ public interface FencedLock extends Lock, DistributedObject {
      *
      * @throws LockOwnershipLostException if the underlying CP session is
      *         closed while locking reentrantly
-     * @throws LockAcquireLimitExceededException if the lock call is reentrant
-     *         and the configured lock acquire limit is exceeded.
+     * @throws LockAcquireLimitReachedException if the lock call is reentrant
+     *         and the configured lock acquire limit is already reached.
      */
     long lockAndGetFence();
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/lock/exception/LockAcquireLimitReachedException.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/lock/exception/LockAcquireLimitReachedException.java
@@ -28,12 +28,12 @@ import com.hazelcast.cp.lock.FencedLock;
  * @see FencedLockConfig
  * @see FencedLock
  */
-public class LockAcquireLimitExceededException extends HazelcastException {
+public class LockAcquireLimitReachedException extends HazelcastException {
 
-    public LockAcquireLimitExceededException() {
+    public LockAcquireLimitReachedException() {
     }
 
-    public LockAcquireLimitExceededException(String message) {
+    public LockAcquireLimitReachedException(String message) {
         super(message);
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/BoundedReentrantFencedLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/BoundedReentrantFencedLockTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.lock.FencedLock;
-import com.hazelcast.cp.lock.exception.LockAcquireLimitExceededException;
+import com.hazelcast.cp.lock.exception.LockAcquireLimitReachedException;
 import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -156,7 +156,7 @@ public class BoundedReentrantFencedLockTest extends HazelcastRaftTestSupport {
         lock.lock();
         lock.lock();
 
-        expectedException.expect(LockAcquireLimitExceededException.class);
+        expectedException.expect(LockAcquireLimitReachedException.class);
         lock.lock();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/NonReentrantFencedLockTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/lock/NonReentrantFencedLockTest.java
@@ -20,7 +20,7 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.cp.lock.FencedLock;
-import com.hazelcast.cp.lock.exception.LockAcquireLimitExceededException;
+import com.hazelcast.cp.lock.exception.LockAcquireLimitReachedException;
 import com.hazelcast.cp.internal.HazelcastRaftTestSupport;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -134,7 +134,7 @@ public class NonReentrantFencedLockTest extends HazelcastRaftTestSupport {
     public void testReentrantLockFails() {
         lock.lock();
 
-        expectedException.expect(LockAcquireLimitExceededException.class);
+        expectedException.expect(LockAcquireLimitReachedException.class);
         lock.lock();
     }
 


### PR DESCRIPTION
LockAcquireLimitExceededException is a bit misleading because it is
thrown from a new `lock()` call after the FencedLock reentrant acquire limit is
reached. So the lock acquire limit is not really exceeded.