### PR TITLE
Disable migrations while mastership claim is in progress

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -634,6 +634,9 @@ public class MembershipManager {
         // Make sure that all pending join requests are cancelled temporarily.
         clusterJoinManager.setMastershipClaimInProgress();
 
+        // pause migrations until mastership claim process completes
+        node.getPartitionService().pauseMigration();
+
         clusterService.setMasterAddress(node.getThisAddress());
         return true;
     }
@@ -1239,6 +1242,8 @@ public class MembershipManager {
                 sendMemberListToOthers();
                 logger.info("Mastership is claimed with: " + newMembersView);
             } finally {
+                // Resume migrations, they are disabled when mastership claim is started
+                node.getPartitionService().resumeMigration();
                 clusterServiceLock.unlock();
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionServiceImpl.java
@@ -294,8 +294,10 @@ public class InternalPartitionServiceImpl implements InternalPartitionService,
                 @Override
                 public void onResponse(PartitionRuntimeState partitionState) {
                     resetMasterTriggeredFlag();
-                    partitionState.setMaster(masterAddress);
-                    processPartitionRuntimeState(partitionState);
+                    if (partitionState != null) {
+                        partitionState.setMaster(masterAddress);
+                        processPartitionRuntimeState(partitionState);
+                    }
                 }
 
                 @Override


### PR DESCRIPTION
Otherwise, when master candidate, the member claiming the mastership,
starts to shutdown, it can create & submit migrations before its claim
is approved by all final cluster members.
This can break safety when claim is partially accepted
by some of the members and they process the migration operations.