### PR TITLE
Fix for Client.applySelector race

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientSelectorRaceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/ClientSelectorRaceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.bluegreen;
+
+
+import com.hazelcast.client.impl.ClientEndpoint;
+import com.hazelcast.client.impl.ClientEngineImpl;
+import com.hazelcast.client.impl.ClientSelectors;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.AssertTask;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientSelectorRaceTest extends HazelcastTestSupport {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @After
+    public void cleanup() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Test
+    public void testConcurrency() throws InterruptedException {
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance();
+
+        final ClientEngineImpl clientEngineImpl = getClientEngineImpl(instance);
+
+        LinkedList<Thread> threads = new LinkedList<Thread>();
+        int numberOfClients = 100;
+        for (int i = 0; i < numberOfClients; i++) {
+            Thread thread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    hazelcastFactory.newHazelcastClient();
+                }
+            });
+            thread.start();
+            threads.add(thread);
+
+        }
+
+        Thread.sleep(10);
+        clientEngineImpl.applySelector(ClientSelectors.none());
+
+        for (Thread thread : threads) {
+            thread.join();
+        }
+
+        assertTrueEventually(new AssertTask() {
+            @Override
+            public void run() throws Exception {
+                Collection<ClientEndpoint> endpoints = clientEngineImpl.getEndpointManager().getEndpoints();
+                assertEquals(0, endpoints.size());
+            }
+        });
+
+
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/test/TestClientRegistry.java
@@ -223,6 +223,9 @@ class TestClientRegistry {
 
         @Override
         public boolean write(final OutboundFrame frame) {
+            if (!isAlive()) {
+                return false;
+            }
             final Node node = serverNodeEngine.getNode();
             if (node.getState() == NodeState.SHUT_DOWN) {
                 return false;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngine.java
@@ -40,7 +40,19 @@ import java.util.Map;
  */
 public interface ClientEngine extends Consumer<ClientMessage> {
 
-    void bind(ClientEndpoint endpoint);
+    /**
+     * Registers client endpoint to endpointManager.
+     * Only authenticated endpoints should be registered here.
+     * bind can be called twice for same connection, as long as client is allowed to be registered all calls to this
+     * method returns true
+     *
+     * A selector could prevent endpoint to be registered
+     * see {@link #applySelector}
+     *
+     * @param endpoint to be registered to client engine
+     * @return false if client is not allowed to join because of a selector, true otherwise
+     */
+    boolean bind(ClientEndpoint endpoint);
 
     Collection<Client> getClients();
 
@@ -57,8 +69,8 @@ public interface ClientEngine extends Consumer<ClientMessage> {
     ILogger getLogger(Class clazz);
 
     /**
-     * @return  the address of this member that listens for CLIENT protocol connections. When advanced network config
-     *          is in use, it will be different from the MEMBER listening address reported eg by {@code Node.getThisAddress()}
+     * @return the address of this member that listens for CLIENT protocol connections. When advanced network config
+     * is in use, it will be different from the MEMBER listening address reported eg by {@code Node.getThisAddress()}
      */
     Address getThisAddress();
 
@@ -79,7 +91,7 @@ public interface ClientEngine extends Consumer<ClientMessage> {
      *
      * The returned map can be used to get information about connected clients to the cluster.
      *
-     * @return Map<ClientType , Integer> .
+     * @return Map<ClientType, Integer> .
      */
     Map<ClientType, Integer> getConnectedClientStats();
 
@@ -176,7 +188,7 @@ public interface ClientEngine extends Consumer<ClientMessage> {
      * provided client address can be located.
      *
      * @param clientAddress the client address of the member
-     * @return              the member address of the member
+     * @return the member address of the member
      */
     Address memberAddressOf(Address clientAddress);
 
@@ -185,7 +197,7 @@ public interface ClientEngine extends Consumer<ClientMessage> {
      * of {@link #memberAddressOf(Address)}.
      *
      * @param memberAddress the member address of the member
-     * @return              the client address of the member
+     * @return the client address of the member
      */
     Address clientAddressOf(Address memberAddress);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/NoOpClientEngine.java
@@ -39,7 +39,8 @@ import static java.util.Collections.emptyMap;
 public class NoOpClientEngine implements ClientEngine {
 
     @Override
-    public void bind(ClientEndpoint endpoint) {
+    public boolean bind(ClientEndpoint endpoint) {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
Selectors are the API used by ManagementCenterService to blacklist
clients for blue/green feature.

Because of a race between applying a selector and registering/removing
endpoints, there were cases that some clients are never closed after
applying a selector to remove them.
This fix checks the selector again after registering endpoint to catch
concurrent changes.

fixes https://github.com/hazelcast/hazelcast/issues/14732
