### PR TITLE
Improve test progress tracker

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/test/DefaultTaskProgress.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/DefaultTaskProgress.java
@@ -20,13 +20,13 @@ public class DefaultTaskProgress implements TaskProgress {
     private final long timestamp = System.currentTimeMillis();
     private final int total;
     private final int done;
-    private final float progress;
+    private final double progress;
     private final boolean completed;
 
     public DefaultTaskProgress(int total, int done) {
         this.total = total;
         this.done = done;
-        this.progress = ((float) done) / total;
+        this.progress = ((double) done) / total;
         this.completed = total == done;
     }
 
@@ -36,7 +36,7 @@ public class DefaultTaskProgress implements TaskProgress {
     }
 
     @Override
-    public float progress() {
+    public double progress() {
         return progress;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/TaskProgress.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TaskProgress.java
@@ -38,7 +38,7 @@ public interface TaskProgress {
      *
      * @return the progress
      */
-    float progress();
+    double progress();
 
     /**
      * Returns the timestamp when this progress snapshot was taken


### PR DESCRIPTION
- Use doubles instead of floats, so even big ints can be represented and
compared correctly when checking if we should record progress
- Report stall exceeded only if stall exceeded AND no progress was made
- Introduce configurable stall tolerance with default 20s

Follow-up on #14255 
Needed for: https://github.com/hazelcast/hazelcast-enterprise/pull/2639