### PR TITLE
Performs client->member address translation after decode

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.client.impl.protocol;
 
-import com.hazelcast.client.impl.ClientEngine;
 import com.hazelcast.client.impl.protocol.exception.MaxMessageSizeExceeded;
 import com.hazelcast.client.impl.protocol.util.BufferBuilder;
 import com.hazelcast.client.impl.protocol.util.ClientProtocolBuffer;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/ClientMessage.java
@@ -113,7 +113,6 @@ public class ClientMessage
     private transient boolean isRetryable;
     private transient boolean acquiresResource;
     private transient String operationName;
-    private transient ClientEngine clientEngine;
     private Connection connection;
 
     protected ClientMessage() {
@@ -125,14 +124,6 @@ public class ClientMessage
 
     public void setConnection(Connection connection) {
         this.connection = connection;
-    }
-
-    public void setClientEngine(ClientEngine clientEngine) {
-        this.clientEngine = clientEngine;
-    }
-
-    public ClientEngine getClientEngine() {
-        return clientEngine;
     }
 
     protected void wrapForEncode(ClientProtocolBuffer buffer, int offset) {

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTask.java
@@ -91,10 +91,6 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
         return new ClientEndpointImpl(clientEngine, nodeEngine, connection);
     }
 
-    protected void postDecodeParameters() {
-
-    }
-
     protected abstract P decodeClientMessage(ClientMessage clientMessage);
 
     protected abstract ClientMessage encodeResponse(Object response);
@@ -126,9 +122,6 @@ public abstract class AbstractMessageTask<P> implements MessageTask, SecureReque
             throw new HazelcastInstanceNotActiveException("Hazelcast instance is not ready yet!");
         }
         parameters = decodeClientMessage(clientMessage);
-        // todo: inline postDecodeParameters to avoid an additional virtual call
-        //  write assertion to ensure all Address parameters are decoded
-        postDecodeParameters();
         assert addressesDecodedWithTranslation() : formatWrongAddressInDecodedMessage();
         Credentials credentials = endpoint.getCredentials();
         interceptBefore(credentials);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxyMessageTask.java
@@ -50,12 +50,9 @@ public class CreateProxyMessageTask extends AbstractInvocationMessageTask<Client
 
     @Override
     protected ClientCreateProxyCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ClientCreateProxyCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ClientCreateProxyCodec.decodeRequest(clientMessage);
         parameters.target = clientEngine.memberAddressOf(parameters.target);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/CreateProxyMessageTask.java
@@ -54,6 +54,11 @@ public class CreateProxyMessageTask extends AbstractInvocationMessageTask<Client
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.target = clientEngine.memberAddressOf(parameters.target);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return ClientCreateProxyCodec.encodeResponse();
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheFetchNearCacheInvalidationMetadataTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheFetchNearCacheInvalidationMetadataTask.java
@@ -49,12 +49,9 @@ public class CacheFetchNearCacheInvalidationMetadataTask
 
     @Override
     protected CacheFetchNearCacheInvalidationMetadataCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return CacheFetchNearCacheInvalidationMetadataCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = CacheFetchNearCacheInvalidationMetadataCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheFetchNearCacheInvalidationMetadataTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheFetchNearCacheInvalidationMetadataTask.java
@@ -53,6 +53,11 @@ public class CacheFetchNearCacheInvalidationMetadataTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         CacheGetInvalidationMetaDataOperation.MetaDataResponse metaDataResponse =
                 (CacheGetInvalidationMetaDataOperation.MetaDataResponse) response;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheListenerRegistrationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheListenerRegistrationMessageTask.java
@@ -50,12 +50,9 @@ public class CacheListenerRegistrationMessageTask
 
     @Override
     protected CacheListenerRegistrationCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return CacheListenerRegistrationCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = CacheListenerRegistrationCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheListenerRegistrationMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheListenerRegistrationMessageTask.java
@@ -54,6 +54,11 @@ public class CacheListenerRegistrationMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return CacheListenerRegistrationCodec.encodeResponse();
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
@@ -48,12 +48,9 @@ public class CacheManagementConfigMessageTask
 
     @Override
     protected CacheManagementConfigCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return CacheManagementConfigCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = CacheManagementConfigCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/CacheManagementConfigMessageTask.java
@@ -52,6 +52,11 @@ public class CacheManagementConfigMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return CacheManagementConfigCodec.encodeResponse();
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/crdt/pncounter/PNCounterAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/crdt/pncounter/PNCounterAddMessageTask.java
@@ -71,6 +71,11 @@ public class PNCounterAddMessageTask extends AbstractAddressMessageTask<RequestP
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.targetReplica = clientEngine.memberAddressOf(parameters.targetReplica);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         final CRDTTimestampedLong resp = (CRDTTimestampedLong) response;
         final PNCounterConfig counterConfig = nodeEngine.getConfig().findPNCounterConfig(parameters.name);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/crdt/pncounter/PNCounterAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/crdt/pncounter/PNCounterAddMessageTask.java
@@ -67,12 +67,9 @@ public class PNCounterAddMessageTask extends AbstractAddressMessageTask<RequestP
 
     @Override
     protected PNCounterAddCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return PNCounterAddCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = PNCounterAddCodec.decodeRequest(clientMessage);
         parameters.targetReplica = clientEngine.memberAddressOf(parameters.targetReplica);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/crdt/pncounter/PNCounterGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/crdt/pncounter/PNCounterGetMessageTask.java
@@ -69,6 +69,11 @@ public class PNCounterGetMessageTask extends AbstractAddressMessageTask<RequestP
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.targetReplica = clientEngine.memberAddressOf(parameters.targetReplica);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         final CRDTTimestampedLong resp = (CRDTTimestampedLong) response;
         final PNCounterConfig counterConfig = nodeEngine.getConfig().findPNCounterConfig(parameters.name);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/crdt/pncounter/PNCounterGetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/crdt/pncounter/PNCounterGetMessageTask.java
@@ -65,12 +65,9 @@ public class PNCounterGetMessageTask extends AbstractAddressMessageTask<RequestP
 
     @Override
     protected PNCounterGetCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return PNCounterGetCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = PNCounterGetCodec.decodeRequest(clientMessage);
         parameters.targetReplica = clientEngine.memberAddressOf(parameters.targetReplica);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnAddressMessageTask.java
@@ -45,12 +45,9 @@ public class ExecutorServiceCancelOnAddressMessageTask
 
     @Override
     protected ExecutorServiceCancelOnAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ExecutorServiceCancelOnAddressCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ExecutorServiceCancelOnAddressCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceCancelOnAddressMessageTask.java
@@ -49,6 +49,11 @@ public class ExecutorServiceCancelOnAddressMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return ExecutorServiceCancelOnAddressCodec.encodeResponse((Boolean) response);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
@@ -66,12 +66,9 @@ public class ExecutorServiceSubmitToAddressMessageTask
 
     @Override
     protected ExecutorServiceSubmitToAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ExecutorServiceSubmitToAddressCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ExecutorServiceSubmitToAddressCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
@@ -70,6 +70,11 @@ public class ExecutorServiceSubmitToAddressMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         Data data = serializationService.toData(response);
         return ExecutorServiceSubmitToAddressCodec.encodeResponse(data);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapClearNearCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapClearNearCacheMessageTask.java
@@ -54,12 +54,9 @@ public class MapClearNearCacheMessageTask extends AbstractInvocationMessageTask<
 
     @Override
     protected MapClearNearCacheCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return MapClearNearCacheCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = MapClearNearCacheCodec.decodeRequest(clientMessage);
         parameters.target = clientEngine.memberAddressOf(parameters.target);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapClearNearCacheMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapClearNearCacheMessageTask.java
@@ -58,6 +58,11 @@ public class MapClearNearCacheMessageTask extends AbstractInvocationMessageTask<
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.target = clientEngine.memberAddressOf(parameters.target);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return MapClearNearCacheCodec.encodeResponse();
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchNearCacheInvalidationMetadataTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchNearCacheInvalidationMetadataTask.java
@@ -53,6 +53,11 @@ public class MapFetchNearCacheInvalidationMetadataTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         MapGetInvalidationMetaDataOperation.MetaDataResponse metaDataResponse =
                 (MapGetInvalidationMetaDataOperation.MetaDataResponse) response;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchNearCacheInvalidationMetadataTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapFetchNearCacheInvalidationMetadataTask.java
@@ -49,12 +49,9 @@ public class MapFetchNearCacheInvalidationMetadataTask
 
     @Override
     protected MapFetchNearCacheInvalidationMetadataCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return MapFetchNearCacheInvalidationMetadataCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = MapFetchNearCacheInvalidationMetadataCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorShutdownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorShutdownMessageTask.java
@@ -57,6 +57,11 @@ public class ScheduledExecutorShutdownMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return ScheduledExecutorShutdownCodec.encodeResponse();
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorShutdownMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorShutdownMessageTask.java
@@ -53,12 +53,9 @@ public class ScheduledExecutorShutdownMessageTask
 
     @Override
     protected ScheduledExecutorShutdownCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ScheduledExecutorShutdownCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ScheduledExecutorShutdownCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorSubmitToAddressMessageTask.java
@@ -56,12 +56,9 @@ public class ScheduledExecutorSubmitToAddressMessageTask
 
     @Override
     protected ScheduledExecutorSubmitToAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ScheduledExecutorSubmitToAddressCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ScheduledExecutorSubmitToAddressCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorSubmitToAddressMessageTask.java
@@ -60,6 +60,11 @@ public class ScheduledExecutorSubmitToAddressMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return ScheduledExecutorSubmitToAddressCodec.encodeResponse();
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskCancelFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskCancelFromAddressMessageTask.java
@@ -54,12 +54,9 @@ public class ScheduledExecutorTaskCancelFromAddressMessageTask
 
     @Override
     protected ScheduledExecutorCancelFromAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ScheduledExecutorCancelFromAddressCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ScheduledExecutorCancelFromAddressCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskCancelFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskCancelFromAddressMessageTask.java
@@ -58,6 +58,11 @@ public class ScheduledExecutorTaskCancelFromAddressMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return ScheduledExecutorCancelFromAddressCodec.encodeResponse((Boolean) response);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskDisposeFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskDisposeFromAddressMessageTask.java
@@ -58,6 +58,11 @@ public class ScheduledExecutorTaskDisposeFromAddressMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return ScheduledExecutorDisposeFromAddressCodec.encodeResponse();
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskDisposeFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskDisposeFromAddressMessageTask.java
@@ -54,12 +54,9 @@ public class ScheduledExecutorTaskDisposeFromAddressMessageTask
 
     @Override
     protected ScheduledExecutorDisposeFromAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ScheduledExecutorDisposeFromAddressCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ScheduledExecutorDisposeFromAddressCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetDelayFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetDelayFromAddressMessageTask.java
@@ -55,12 +55,9 @@ public class ScheduledExecutorTaskGetDelayFromAddressMessageTask
 
     @Override
     protected ScheduledExecutorGetDelayFromAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ScheduledExecutorGetDelayFromAddressCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ScheduledExecutorGetDelayFromAddressCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetDelayFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetDelayFromAddressMessageTask.java
@@ -59,6 +59,11 @@ public class ScheduledExecutorTaskGetDelayFromAddressMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return ScheduledExecutorGetDelayFromAddressCodec.encodeResponse((Long) response);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetResultFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetResultFromAddressMessageTask.java
@@ -57,12 +57,9 @@ public class ScheduledExecutorTaskGetResultFromAddressMessageTask
 
     @Override
     protected ScheduledExecutorGetResultFromAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ScheduledExecutorGetResultFromAddressCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ScheduledExecutorGetResultFromAddressCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetResultFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetResultFromAddressMessageTask.java
@@ -61,6 +61,11 @@ public class ScheduledExecutorTaskGetResultFromAddressMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         Data data = nodeEngine.getSerializationService().toData(response);
         return ScheduledExecutorGetResultFromAddressCodec.encodeResponse(data);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetStatisticsFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetStatisticsFromAddressMessageTask.java
@@ -57,12 +57,9 @@ public class ScheduledExecutorTaskGetStatisticsFromAddressMessageTask
 
     @Override
     protected ScheduledExecutorGetStatsFromAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ScheduledExecutorGetStatsFromAddressCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ScheduledExecutorGetStatsFromAddressCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetStatisticsFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskGetStatisticsFromAddressMessageTask.java
@@ -61,6 +61,11 @@ public class ScheduledExecutorTaskGetStatisticsFromAddressMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         ScheduledTaskStatistics stats = (ScheduledTaskStatistics) response;
         return ScheduledExecutorGetStatsFromAddressCodec.encodeResponse(stats.getLastIdleTime(TimeUnit.NANOSECONDS),

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsCancelledFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsCancelledFromAddressMessageTask.java
@@ -54,12 +54,9 @@ public class ScheduledExecutorTaskIsCancelledFromAddressMessageTask
 
     @Override
     protected ScheduledExecutorIsCancelledFromAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ScheduledExecutorIsCancelledFromAddressCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ScheduledExecutorIsCancelledFromAddressCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsCancelledFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsCancelledFromAddressMessageTask.java
@@ -58,6 +58,11 @@ public class ScheduledExecutorTaskIsCancelledFromAddressMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return ScheduledExecutorIsCancelledFromAddressCodec.encodeResponse((Boolean) response);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsDoneFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsDoneFromAddressMessageTask.java
@@ -54,12 +54,9 @@ public class ScheduledExecutorTaskIsDoneFromAddressMessageTask
 
     @Override
     protected ScheduledExecutorIsDoneFromAddressCodec.RequestParameters decodeClientMessage(ClientMessage clientMessage) {
-        return ScheduledExecutorIsDoneFromAddressCodec.decodeRequest(clientMessage);
-    }
-
-    @Override
-    protected void postDecodeParameters() {
+        parameters = ScheduledExecutorIsDoneFromAddressCodec.decodeRequest(clientMessage);
         parameters.address = clientEngine.memberAddressOf(parameters.address);
+        return parameters;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsDoneFromAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/scheduledexecutor/ScheduledExecutorTaskIsDoneFromAddressMessageTask.java
@@ -58,6 +58,11 @@ public class ScheduledExecutorTaskIsDoneFromAddressMessageTask
     }
 
     @Override
+    protected void postDecodeParameters() {
+        parameters.address = clientEngine.memberAddressOf(parameters.address);
+    }
+
+    @Override
     protected ClientMessage encodeResponse(Object response) {
         return ScheduledExecutorIsDoneFromAddressCodec.encodeResponse((Boolean) response);
     }

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTaskTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/protocol/task/AbstractMessageTaskTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task;
+
+import com.hazelcast.client.impl.protocol.codec.ClientCreateProxyCodec;
+import com.hazelcast.config.Config;
+import com.hazelcast.instance.Node;
+import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.nio.Address;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.powermock.reflect.Whitebox;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class AbstractMessageTaskTest {
+
+    final Collection<Address> memberAddresses = new ArrayList<Address>();
+    final Config config = new Config();
+    final ClientCreateProxyCodec.RequestParameters parameters = new ClientCreateProxyCodec.RequestParameters();
+    AbstractMessageTask messageTask;
+
+    @Before
+    public void setup() {
+        Node node = mock(Node.class);
+        when(node.getConfig()).thenReturn(config);
+
+        ClusterServiceImpl clusterService = mock(ClusterServiceImpl.class);
+        when(clusterService.getMemberAddresses()).thenReturn(memberAddresses);
+
+        messageTask = mock(AbstractMessageTask.class);
+        when(messageTask.addressesDecodedWithTranslation()).thenCallRealMethod();
+
+        Whitebox.setInternalState(node, "clusterService", clusterService);
+        Whitebox.setInternalState(messageTask, "node", node);
+
+        // setup common fields of parameters object
+        parameters.name = "test";
+        parameters.serviceName = MapService.SERVICE_NAME;
+        Whitebox.setInternalState(messageTask, "parameters", parameters);
+    }
+
+    @Test
+    public void assertionFalse_whenUnknownAddressesInDecodedMessage() throws UnknownHostException {
+        config.getAdvancedNetworkConfig().setEnabled(true);
+        memberAddresses.add(new Address("127.0.0.1", 5701));
+        parameters.target = new Address("127.0.0.1", 65000);
+
+        assertFalse(messageTask.addressesDecodedWithTranslation());
+    }
+
+    @Test
+    public void assertionTrue_whenKnownAddressesInDecodedMessage() throws UnknownHostException {
+        config.getAdvancedNetworkConfig().setEnabled(true);
+        memberAddresses.add(new Address("127.0.0.1", 5701));
+        parameters.target = new Address("127.0.0.1", 5701);
+
+        assertTrue(messageTask.addressesDecodedWithTranslation());
+    }
+
+    @Test
+    public void assertionTrue_whenAdvancedNetworkDisabled() throws UnknownHostException {
+        config.getAdvancedNetworkConfig().setEnabled(false);
+        memberAddresses.add(new Address("127.0.0.1", 5701));
+        parameters.target = new Address("127.0.0.1", 65000);
+
+        assertTrue(messageTask.addressesDecodedWithTranslation());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.8.0-6</client.protocol.version>
+        <client.protocol.version>1.8.0-7</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>6</jdk.version>


### PR DESCRIPTION
This used to be executed in AddressCodec in 3.12-BETA for every
Address received & decoded by a member, which is a nice way to do the
translation in a single point for all Addresses but that solution
required that ClientMessage depends on ClientEngine which a rather
hacky solution. This is being reverted in
https://github.com/hazelcast/hazelcast-client-protocol/pull/178
and address translation is now required in each message task that
receives Addresses from clients.

Requires a new client protocol version to be released (incorporating https://github.com/hazelcast/hazelcast-client-protocol/pull/178) before this PR can be reviewed & merged