### PR TITLE
Mastership-claim and graceful-shutdown tasks should use distinct executors

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -67,7 +67,6 @@ import com.hazelcast.partition.PartitionLostListener;
 import com.hazelcast.security.Credentials;
 import com.hazelcast.security.SecurityContext;
 import com.hazelcast.security.SecurityService;
-import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.GracefulShutdownAwareService;
 import com.hazelcast.spi.annotation.PrivateApi;
 import com.hazelcast.spi.discovery.SimpleDiscoveryNode;
@@ -125,6 +124,7 @@ import static java.security.AccessController.doPrivileged;
 public class Node {
 
     private static final int THREAD_SLEEP_DURATION_MS = 500;
+    private static final String GRACEFUL_SHUTDOWN_EXECUTOR_NAME = "hz:graceful-shutdown";
 
     public final HazelcastInstanceImpl hazelcastInstance;
 
@@ -477,7 +477,7 @@ public class Node {
     }
 
     private boolean callGracefulShutdownAwareServices(final int maxWaitSeconds) {
-        ExecutorService executor = nodeEngine.getExecutionService().getExecutor(ExecutionService.SYSTEM_EXECUTOR);
+        ExecutorService executor = nodeEngine.getExecutionService().getExecutor(GRACEFUL_SHUTDOWN_EXECUTOR_NAME);
         Collection<GracefulShutdownAwareService> services = nodeEngine.getServices(GracefulShutdownAwareService.class);
         Collection<Future> futures = new ArrayList<Future>(services.size());
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.logging.Level;
 
-import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.EXECUTOR_NAME;
+import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.CLUSTER_EXECUTOR_NAME;
 import static com.hazelcast.util.EmptyStatement.ignore;
 import static com.hazelcast.util.StringUtil.timeToString;
 import static java.lang.String.format;
@@ -216,7 +216,7 @@ public class ClusterHeartbeatManager {
     void init() {
         ExecutionService executionService = nodeEngine.getExecutionService();
 
-        executionService.scheduleWithRepetition(EXECUTOR_NAME, new Runnable() {
+        executionService.scheduleWithRepetition(CLUSTER_EXECUTOR_NAME, new Runnable() {
             public void run() {
                 heartbeat();
             }
@@ -587,7 +587,7 @@ public class ClusterHeartbeatManager {
     }
 
     private void startPeriodicPinger() {
-        nodeEngine.getExecutionService().scheduleWithRepetition(EXECUTOR_NAME, new Runnable() {
+        nodeEngine.getExecutionService().scheduleWithRepetition(CLUSTER_EXECUTOR_NAME, new Runnable() {
             public void run() {
                 Collection<Member> members = clusterService.getMembers(MemberSelectors.NON_LOCAL_MEMBER_SELECTOR);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -57,6 +57,7 @@ import com.hazelcast.spi.OperationService;
 import com.hazelcast.spi.TransactionalService;
 import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
+import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalObject;
@@ -87,12 +88,12 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         EventPublishingService<MembershipEvent, MembershipListener>, TransactionalService {
 
     public static final String SERVICE_NAME = "hz:core:clusterService";
+    public static final String SPLIT_BRAIN_HANDLER_EXECUTOR_NAME = "hz:cluster:splitbrain";
 
-    static final String EXECUTOR_NAME = "hz:cluster";
+    static final String CLUSTER_EXECUTOR_NAME = "hz:cluster";
     static final String MEMBERSHIP_EVENT_EXECUTOR_NAME = "hz:cluster:event";
 
     private static final int DEFAULT_MERGE_RUN_DELAY_MILLIS = 100;
-    private static final int CLUSTER_EXECUTOR_QUEUE_CAPACITY = 1000;
     private static final long CLUSTER_SHUTDOWN_SLEEP_DURATION_IN_MILLIS = 1000;
     private static final boolean ASSERTION_ENABLED = ClusterServiceImpl.class.desiredAssertionStatus();
 
@@ -141,8 +142,11 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         clusterHeartbeatManager = new ClusterHeartbeatManager(node, this, lock);
 
         node.connectionManager.addConnectionListener(this);
+        InternalExecutionService executionService = nodeEngine.getExecutionService();
+        executionService.register(CLUSTER_EXECUTOR_NAME, 2, Integer.MAX_VALUE, ExecutorType.CACHED);
+        executionService.register(SPLIT_BRAIN_HANDLER_EXECUTOR_NAME, 2, Integer.MAX_VALUE, ExecutorType.CACHED);
         //MEMBERSHIP_EVENT_EXECUTOR is a single threaded executor to ensure that events are executed in correct order.
-        nodeEngine.getExecutionService().register(MEMBERSHIP_EVENT_EXECUTOR_NAME, 1, Integer.MAX_VALUE, ExecutorType.CACHED);
+        executionService.register(MEMBERSHIP_EVENT_EXECUTOR_NAME, 1, Integer.MAX_VALUE, ExecutorType.CACHED);
         registerMetrics();
     }
 
@@ -157,14 +161,12 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
     public void init(NodeEngine nodeEngine, Properties properties) {
         long mergeFirstRunDelayMs = node.getProperties().getPositiveMillisOrDefault(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS,
                 DEFAULT_MERGE_RUN_DELAY_MILLIS);
-
-        ExecutionService executionService = nodeEngine.getExecutionService();
-        executionService.register(EXECUTOR_NAME, 2, CLUSTER_EXECUTOR_QUEUE_CAPACITY, ExecutorType.CACHED);
-
         long mergeNextRunDelayMs = node.getProperties().getPositiveMillisOrDefault(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS,
                 DEFAULT_MERGE_RUN_DELAY_MILLIS);
-        executionService.scheduleWithRepetition(EXECUTOR_NAME, new SplitBrainHandler(node), mergeFirstRunDelayMs,
-                mergeNextRunDelayMs, TimeUnit.MILLISECONDS);
+
+        ExecutionService executionService = nodeEngine.getExecutionService();
+        executionService.scheduleWithRepetition(SPLIT_BRAIN_HANDLER_EXECUTOR_NAME, new SplitBrainHandler(node),
+                mergeFirstRunDelayMs, mergeNextRunDelayMs, TimeUnit.MILLISECONDS);
 
         membershipManager.init();
         clusterHeartbeatManager.init();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MergeClustersOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MergeClustersOp.java
@@ -23,10 +23,11 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.ExecutionService;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 
 import java.io.IOException;
+
+import static com.hazelcast.internal.cluster.impl.ClusterServiceImpl.SPLIT_BRAIN_HANDLER_EXECUTOR_NAME;
 
 public class MergeClustersOp extends AbstractClusterOperation {
 
@@ -57,7 +58,7 @@ public class MergeClustersOp extends AbstractClusterOperation {
         logger.warning(node.getThisAddress() + " is merging to " + newTargetAddress
                 + ", because: instructed by master " + masterAddress);
 
-        nodeEngine.getExecutionService().execute(ExecutionService.SYSTEM_EXECUTOR, new Runnable() {
+        nodeEngine.getExecutionService().execute(SPLIT_BRAIN_HANDLER_EXECUTOR_NAME, new Runnable() {
             @Override
             public void run() {
                 clusterService.merge(newTargetAddress);

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/ExecutionServiceImpl.java
@@ -144,7 +144,7 @@ public final class ExecutionServiceImpl implements InternalExecutionService {
                 singleExecutorThreadFactory,
                 nodeEngine.getProperties().getBoolean(GroupProperty.TASK_SCHEDULER_REMOVE_ON_CANCEL));
 
-        int coreSize = RuntimeAvailableProcessors.get();
+        int coreSize = Math.max(RuntimeAvailableProcessors.get(), 2);
         // default executors
         register(SYSTEM_EXECUTOR, coreSize, Integer.MAX_VALUE, ExecutorType.CACHED);
         register(SCHEDULED_EXECUTOR, coreSize * POOL_MULTIPLIER, coreSize * QUEUE_MULTIPLIER, ExecutorType.CACHED);

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/SingleProcessorMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/SingleProcessorMemberTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.cluster.impl;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.OverridePropertyRule;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import com.hazelcast.test.environment.RuntimeAvailableProcessorsRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.concurrent.Future;
+
+import static com.hazelcast.spi.properties.GroupProperty.GRACEFUL_SHUTDOWN_MAX_WAIT;
+import static com.hazelcast.test.OverridePropertyRule.clear;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class SingleProcessorMemberTest extends HazelcastTestSupport {
+
+    @Rule
+    public RuntimeAvailableProcessorsRule runtimeAvailableProcessorsRule = new RuntimeAvailableProcessorsRule(1);
+
+    @Rule
+    public OverridePropertyRule gracefulShutdownTimeoutRule = clear(GRACEFUL_SHUTDOWN_MAX_WAIT.getName());
+
+    @Test
+    public void shutdownMembersConcurrently() throws Exception {
+        shutdownMembersConcurrently(true);
+    }
+
+    @Test
+    public void shutdownMembersConcurrently_withoutPartitionsInitialized() throws Exception {
+        shutdownMembersConcurrently(false);
+    }
+
+    private void shutdownMembersConcurrently(boolean initializePartitions) throws Exception {
+        // setting a very graceful shutdown high timeout value
+        // to guarantee instance.shutdown() not to timeout
+        gracefulShutdownTimeoutRule.setOrClearProperty(Integer.toString(Integer.MAX_VALUE));
+
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        final HazelcastInstance[] instances = factory.newInstances(new Config(), 4);
+        assertClusterSizeEventually(4, instances);
+        if (initializePartitions) {
+            warmUpPartitions(instances);
+        }
+
+        ArrayList<Future> futures = new ArrayList<Future>();
+        for (final HazelcastInstance instance : instances) {
+            Future future = spawn(new Runnable() {
+                @Override
+                public void run() {
+                    instance.shutdown();
+                }
+            });
+            futures.add(future);
+        }
+
+        for (Future future : futures) {
+            assertCompletesEventually(future);
+            future.get();
+        }
+    }
+}


### PR DESCRIPTION
Graceful-shutdown tasks may depend on mastership-claim task if multiple members
are being shutdown, including current master and the next master candidate.
If mastership-claim cannot be completed, graceful-shutdown tasks will be
blocked too.

Currently both task groups are using the `SYSTEM_EXECUTOR` which has the core size equal to
the number of cpu cores in the system (reported by JVM process).
If `SYSTEM_EXECUTOR` does not have enough cores to execute both graceful-shutdown tasks
and mastership-claim task, mastership-claim task may not be executed
and shutdown process will hang.

This can happen easily when number of cpu cores is 1.

Additionally, increased minimum number of cores of default executors
(such as `ASYNC_EXECUTOR`, `SYSTEM_EXECUTOR` etc) to 2, to avoid
similar issues in future.

Backport of https://github.com/hazelcast/hazelcast/pull/14752