### PR TITLE
Set socket connection timeout to 10s down from infinite

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelOptions.java
@@ -93,9 +93,9 @@ final class NioChannelOptions implements ChannelOptions {
             } else if (option.equals(SO_TIMEOUT)) {
                 socket.setSoTimeout((Integer) value);
             } else if (option.equals(SO_LINGER)) {
-                int soLonger = (Integer) value;
-                if (soLonger > 0) {
-                    socket.setSoLinger(true, soLonger);
+                int soLinger = (Integer) value;
+                if (soLinger >= 0) {
+                    socket.setSoLinger(true, soLinger);
                 }
             } else {
                 values.put(option.name(), value);

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -371,9 +371,9 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.socket.client.buffer.direct", false);
 
     public static final HazelcastProperty SOCKET_LINGER_SECONDS
-            = new HazelcastProperty("hazelcast.socket.linger.seconds", 0, SECONDS);
+            = new HazelcastProperty("hazelcast.socket.linger.seconds", -1, SECONDS);
     public static final HazelcastProperty SOCKET_CONNECT_TIMEOUT_SECONDS
-            = new HazelcastProperty("hazelcast.socket.connect.timeout.seconds", 0, SECONDS);
+            = new HazelcastProperty("hazelcast.socket.connect.timeout.seconds", 10, SECONDS);
     public static final HazelcastProperty SOCKET_KEEP_ALIVE
             = new HazelcastProperty("hazelcast.socket.keep.alive", true);
     public static final HazelcastProperty SOCKET_NO_DELAY


### PR DESCRIPTION
Set `hazelcast.socket.connect.timeout.seconds` to 10 seconds. It was 0
before which means a connection attempt will wait indefinitely until
connection succeeds or a fails with an IO error.

Reason of this change is, in some cases while restarting a pod on Kubernetes,
we found that connection attempts to former pod takes too much time
until it fails with an IO error.

Additionally, usage of `SO_LINGER` socket option in Hazelcast was wrong.
Its default value was `0` but it was used as if it's disabled. It was enabled
only when a positive value is given. But in fact, enabling `SO_LINGER` with 0
timeout is a valid option too. See https://docs.oracle.com/javase/8/docs/technotes/guides/net/articles/connection_release.html
for more info.