### PR TITLE
Fix MemberToMemberDiscoveryTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/multicast/MemberToMemberDiscoveryTest.java
@@ -44,6 +44,10 @@ public class MemberToMemberDiscoveryTest extends HazelcastTestSupport {
     @Rule
     public final OverridePropertyRule overrideJoinWaitSecondsRule = set("hazelcast.wait.seconds.before.join", "10");
     @Rule
+    public final OverridePropertyRule overrideMergeFirstRunDelayRule = set("hazelcast.merge.first.run.delay.seconds", "5");
+    @Rule
+    public final OverridePropertyRule overrideMergeNextRunDelayRule = set("hazelcast.merge.next.run.delay.seconds", "5");
+    @Rule
     public final OverridePropertyRule overridePreferIpv4Rule = set("java.net.preferIPv4Stack", "true");
     @Rule
     public final OverridePropertyRule overrideHazelcastLocalAddressRule = clear("hazelcast.local.localAddress");


### PR DESCRIPTION
If the two nodes configured in this test can't form a cluster initially due to hiccups or any multicasting problem the two nodes form two single-member cluster, then the test waits for the configured eventual timeout and then it fails, because no merging attempt is made. This is because default `hazelcast.merge.first.run.delay.seconds` is 300 seconds, which is greater then the timeout 120 seconds. This commit decreases this setting to 5 seconds and also decreases `hazelcast.merge.next.run.delay.seconds` to 5 seconds from 120 seconds giving the two nodes a chance to discover each other even if there is a hiccup during the initial join.

Fixes #13942