### PR TITLE
Enable DOTALL flag to match line termination characters for LIKE pred…

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/ILikePredicate.java
@@ -40,7 +40,7 @@ public class ILikePredicate extends LikePredicate {
 
     @Override
     protected int getFlags() {
-        return Pattern.CASE_INSENSITIVE;
+        return super.getFlags() | Pattern.CASE_INSENSITIVE;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/LikePredicate.java
@@ -48,28 +48,32 @@ public class LikePredicate extends AbstractPredicate {
         String attributeValueString = (String) attributeValue;
         if (attributeValueString == null) {
             return (expression == null);
-        } else if (expression == null) {
-            return false;
-        } else {
-            if (pattern == null) {
-                // we quote the input string then escape then replace % and _
-                // at the end we have a regex pattern look like: \QSOME_STRING\E.*\QSOME_OTHER_STRING\E
-                final String quotedExpression = Pattern.quote(expression);
-                String regex = quotedExpression
-                        //escaped %
-                        .replaceAll("(?<!\\\\)[%]", "\\\\E.*\\\\Q")
-                                //escaped _
-                        .replaceAll("(?<!\\\\)[_]", "\\\\E.\\\\Q")
-                                //non escaped %
-                        .replaceAll("\\\\%", "%")
-                                //non escaped _
-                        .replaceAll("\\\\_", "_");
-                int flags = getFlags();
-                pattern = Pattern.compile(regex, flags);
-            }
-            Matcher m = pattern.matcher(attributeValueString);
-            return m.matches();
         }
+
+        if (expression == null) {
+            return false;
+        }
+
+        pattern = pattern != null ? pattern : createPattern(expression);
+        Matcher m = pattern.matcher(attributeValueString);
+        return m.matches();
+    }
+
+    private Pattern createPattern(String expression) {
+        // we quote the input string then escape then replace % and _
+        // at the end we have a regex pattern look like: \QSOME_STRING\E.*\QSOME_OTHER_STRING\E
+        final String quotedExpression = Pattern.quote(expression);
+        String regex = quotedExpression
+                //escaped %
+                .replaceAll("(?<!\\\\)[%]", "\\\\E.*\\\\Q")
+                //escaped _
+                .replaceAll("(?<!\\\\)[_]", "\\\\E.\\\\Q")
+                //non escaped %
+                .replaceAll("\\\\%", "%")
+                //non escaped _
+                .replaceAll("\\\\_", "_");
+        int flags = getFlags();
+        return Pattern.compile(regex, flags);
     }
 
     @Override
@@ -84,10 +88,8 @@ public class LikePredicate extends AbstractPredicate {
         expression = in.readUTF();
     }
 
-
     protected int getFlags() {
-        //no addFlag
-        return 0;
+        return Pattern.DOTALL;
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -243,6 +243,7 @@ public class PredicatesTest extends HazelcastTestSupport {
         assertPredicateTrue(like(ATTRIBUTE, "J.-*.*\\%"), "J.-*.*%");
         assertPredicateTrue(like(ATTRIBUTE, "J\\_"), "J_");
         assertPredicateTrue(like(ATTRIBUTE, "J%"), "Java");
+        assertPredicateTrue(like(ATTRIBUTE, "J%"), "Java\n");
     }
 
     @Test
@@ -252,6 +253,7 @@ public class PredicatesTest extends HazelcastTestSupport {
         assertPredicateTrue(ilike(ATTRIBUTE, "java%ld"), "Java World");
         assertPredicateTrue(ilike(ATTRIBUTE, "%world"), "Java World");
         assertPredicateFalse(ilike(ATTRIBUTE, "Java_World"), "gava World");
+        assertPredicateTrue(ilike(ATTRIBUTE, "J%"), "java\nworld");
     }
 
     @Test


### PR DESCRIPTION
…icate

closes #14751 

`like` predicate doesn't match with line terminators as `\n`. This PR enables `java.util.regex.Pattern.DOTALL` flag to fix this for LIKE and ILIKE. So `%` will match `any character`.