### PR TITLE
Overload close() in IOUtil

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
@@ -38,6 +38,7 @@ import java.io.OutputStream;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -362,6 +363,38 @@ public final class IOUtil {
         }
         try {
             serverSocket.close();
+        } catch (IOException e) {
+            Logger.getLogger(IOUtil.class).finest("closeResource failed", e);
+        }
+    }
+
+    /**
+     * Quietly attempts to close a {@link Socket}, swallowing any exception.
+     *
+     * @param socket socket to close. If {@code null}, no action is taken.
+     */
+    public static void close(Socket socket) {
+        if (socket == null) {
+            return;
+        }
+        try {
+            socket.close();
+        } catch (IOException e) {
+            Logger.getLogger(IOUtil.class).finest("closeResource failed", e);
+        }
+    }
+
+    /**
+     * Quietly attempts to close a {@link Closeable}, swallowing any exception.
+     *
+     * @param closeable closeable to close. If {@code null}, no action is taken.
+     */
+    public static void close(Closeable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
         } catch (IOException e) {
             Logger.getLogger(IOUtil.class).finest("closeResource failed", e);
         }

--- a/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/IOUtil.java
@@ -385,22 +385,6 @@ public final class IOUtil {
     }
 
     /**
-     * Quietly attempts to close a {@link Closeable}, swallowing any exception.
-     *
-     * @param closeable closeable to close. If {@code null}, no action is taken.
-     */
-    public static void close(Closeable closeable) {
-        if (closeable == null) {
-            return;
-        }
-        try {
-            closeable.close();
-        } catch (IOException e) {
-            Logger.getLogger(IOUtil.class).finest("closeResource failed", e);
-        }
-    }
-
-    /**
      * Ensures that the file described by the supplied parameter does not exist
      * after the method returns. If the file didn't exist, returns silently.
      * If the file could not be deleted, returns silently.


### PR DESCRIPTION
Besides the existing `close(ServerSocket)`, `close(Socket)` and `close(Closeable)` methods are added. We need the first two to keep backward compatibility with JDK6 in which version `ServerSocket` and `Socket` were not `Closeable`.