### PR TITLE
NioNetworking input and out threads visibility problem

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -157,7 +157,7 @@ public final class NioNetworking implements Networking {
         });
 
         NioThread[] inThreads = new NioThread[inputThreadCount];
-        for (int i = 0; i < inputThreads.length; i++) {
+        for (int i = 0; i < inThreads.length; i++) {
             NioThread thread = new NioThread(
                     createThreadPoolName(threadNamePrefix, "IO") + "in-" + i,
                     loggingService.getLogger(NioThread.class),
@@ -173,7 +173,7 @@ public final class NioNetworking implements Networking {
         this.inputThreads = inThreads;
 
         NioThread[] outThreads = new NioThread[outputThreadCount];
-        for (int i = 0; i < outputThreads.length; i++) {
+        for (int i = 0; i < outThreads.length; i++) {
             NioThread thread = new NioThread(
                     createThreadPoolName(threadNamePrefix, "IO") + "out-" + i,
                     loggingService.getLogger(NioThread.class),

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -156,7 +156,7 @@ public final class NioNetworking implements Networking {
             }
         });
 
-        this.inputThreads = new NioThread[inputThreadCount];
+        NioThread[] inThreads = new NioThread[inputThreadCount];
         for (int i = 0; i < inputThreads.length; i++) {
             NioThread thread = new NioThread(
                     createThreadPoolName(threadNamePrefix, "IO") + "in-" + i,
@@ -166,12 +166,13 @@ public final class NioNetworking implements Networking {
                     idleStrategy);
             thread.id = i;
             thread.setSelectorWorkaroundTest(selectorWorkaroundTest);
-            inputThreads[i] = thread;
+            inThreads[i] = thread;
             metricsRegistry.scanAndRegister(thread, "tcp.inputThread[" + thread.getName() + "]");
             thread.start();
         }
+        this.inputThreads = inThreads;
 
-        this.outputThreads = new NioThread[outputThreadCount];
+        NioThread[] outThreads = new NioThread[outputThreadCount];
         for (int i = 0; i < outputThreads.length; i++) {
             NioThread thread = new NioThread(
                     createThreadPoolName(threadNamePrefix, "IO") + "out-" + i,
@@ -181,10 +182,11 @@ public final class NioNetworking implements Networking {
                     idleStrategy);
             thread.id = i;
             thread.setSelectorWorkaroundTest(selectorWorkaroundTest);
-            outputThreads[i] = thread;
+            outThreads[i] = thread;
             metricsRegistry.scanAndRegister(thread, "tcp.outputThread[" + thread.getName() + "]");
             thread.start();
         }
+        this.outputThreads = outThreads;
 
         startIOBalancer();
     }


### PR DESCRIPTION
Make the NioNetworking input and output threads visible only after they are ready. The start method can be called multiple times (on instance start + merge completions)