### PR TITLE
Prevent registering a closed connection when processing bind response

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/BindHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/BindHandler.java
@@ -191,7 +191,7 @@ final class BindHandler {
         }
         boolean returnValue = tcpIpEndpointManager.registerConnection(remoteEndpoint, connection);
 
-        if (remoteAddressAliases != null) {
+        if (remoteAddressAliases != null && returnValue) {
             for (Address remoteAddressAlias : remoteAddressAliases) {
                 if (logger.isLoggable(Level.FINEST)) {
                     logger.finest("Registering connection " + connection + " to address alias " + remoteAddressAlias);


### PR DESCRIPTION
In some cases, the bind response is processed after the connections map
is cleared during split brain process. The connection is closed at that
point but it was added to the connections map regardless. Further
connections to the same address fail because there is already a
connection in the map. The commit prevents adding closed connections
into the map.

Fixes: https://github.com/hazelcast/hazelcast/issues/14737