### PR TITLE
Clears lefotver durable executor containers after destroy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DistributedDurableExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DistributedDurableExecutorService.java
@@ -106,6 +106,7 @@ public class DistributedDurableExecutorService implements ManagedService, Remote
     public void destroyDistributedObject(String name) {
         shutdownExecutors.remove(name);
         nodeEngine.getExecutionService().shutdownDurableExecutor(name);
+        removeAllContainers(name);
         quorumConfigCache.remove(name);
     }
 
@@ -159,4 +160,9 @@ public class DistributedDurableExecutorService implements ManagedService, Remote
         return quorumName == NULL_OBJECT ? null : (String) quorumName;
     }
 
+    private void removeAllContainers(String name) {
+        for (int i = 0; i < partitionContainers.length; i++) {
+            getPartitionContainer(i).removeContainer(name);
+        }
+    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorPartitionContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorPartitionContainer.java
@@ -83,6 +83,15 @@ public class DurableExecutorPartitionContainer {
         }
     }
 
+    public void removeContainer(String name) {
+        executorContainerMap.remove(name);
+    }
+
+    // for testing
+    DurableExecutorContainer getExistingExecutorContainer(String name) {
+        return executorContainerMap.get(name);
+    }
+
     private DurableExecutorContainer createExecutorContainer(String name) {
         DurableExecutorConfig durableExecutorConfig = nodeEngine.getConfig().findDurableExecutorConfig(name);
         int durability = durableExecutorConfig.getDurability();

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/impl/DurableExecutorServiceHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/impl/DurableExecutorServiceHelper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.durableexecutor.impl;
+
+public class DurableExecutorServiceHelper {
+
+    public static DurableExecutorContainer getDurableExecutorContainer(DistributedDurableExecutorService service, int partitionId, String name) {
+        return service.getPartitionContainer(partitionId).getExistingExecutorContainer(name);
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -150,6 +150,14 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         }
     }
 
+    public static class DummyCallable implements Callable<String>, Serializable {
+
+        @Override
+        public String call() throws Exception {
+            return "Completed";
+        }
+    }
+
     public static class SleepingTask implements Callable<Boolean>, Serializable, PartitionAware {
 
         long sleepSeconds;


### PR DESCRIPTION
DistributedDurableExecutorService did not clean containers removed via DurableExecutorService#destroy() call. This caused a leak.

fixes https://github.com/hazelcast/hazelcast/issues/14087