### PR TITLE
Fix TCP window scale for Advanced Network

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -18,6 +18,7 @@ package com.hazelcast.instance;
 
 import com.hazelcast.cluster.impl.TcpIpJoiner;
 import com.hazelcast.config.Config;
+import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.config.InterfacesConfig;
 import com.hazelcast.config.TcpIpConfig;
 import com.hazelcast.logging.ILogger;
@@ -134,7 +135,11 @@ class DefaultAddressPicker
         boolean bindAny = hazelcastProperties.getBoolean(GroupProperty.SOCKET_SERVER_BIND_ANY);
         AddressDefinition bindAddressDef = pickAddressDef();
 
-        serverSocketChannel = createServerSocketChannel(logger, endpointQualifier, bindAddressDef.inetAddress,
+        EndpointConfig endpoint = config.getAdvancedNetworkConfig().isEnabled()
+                ? config.getAdvancedNetworkConfig().getEndpointConfigs().get(endpointQualifier)
+                : null;
+
+        serverSocketChannel = createServerSocketChannel(logger, endpoint, bindAddressDef.inetAddress,
                 bindAddressDef.port == 0 ? port : bindAddressDef.port, portCount, isPortAutoIncrement, isReuseAddress, bindAny);
 
         int port = serverSocketChannel.socket().getLocalPort();

--- a/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java
@@ -102,7 +102,7 @@ final class DelegatingAddressPicker
         publicAddress = memberAddressProvider.getPublicAddress();
         validatePublicAddress(publicAddress);
 
-        serverSocketChannel = createServerSocketChannel(logger, MEMBER, bindAddress.getAddress(),
+        serverSocketChannel = createServerSocketChannel(logger, null, bindAddress.getAddress(),
                 bindAddress.getPort() == 0 ? networkConfig.getPort() : bindAddress.getPort(), networkConfig.getPortCount(),
                 networkConfig.isPortAutoIncrement(), networkConfig.isReuseAddress(), false);
 
@@ -140,7 +140,7 @@ final class DelegatingAddressPicker
 
             if (!bindAddresses.values().contains(bindAddress)) {
                 // bind new server socket
-                serverSocketChannel = createServerSocketChannel(logger, qualifier, bindAddress.getAddress(),
+                serverSocketChannel = createServerSocketChannel(logger, config, bindAddress.getAddress(),
                         bindAddress.getPort() == 0 ? endpointConfig.getPort() : bindAddress.getPort(),
                         endpointConfig.getPortCount(), endpointConfig.isPortAutoIncrement(),
                         endpointConfig.isReuseAddress(), false);

--- a/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ascii/TextChannelInitializer.java
@@ -35,11 +35,8 @@ public class TextChannelInitializer
         this.rest = rest;
     }
 
-
     @Override
     public void initChannel(Channel channel) {
-        super.initChannel(channel);
-
         TcpIpConnection connection = (TcpIpConnection) channel.attributeMap().get(TcpIpConnection.class);
         TextEncoder encoder = new TextEncoder(connection);
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/AbstractChannelInitializer.java
@@ -17,18 +17,15 @@
 package com.hazelcast.nio.tcp;
 
 import com.hazelcast.config.EndpointConfig;
-import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelInitializer;
 import com.hazelcast.nio.IOService;
-
-import static com.hazelcast.nio.IOUtil.setChannelOptions;
 
 /**
  * A {@link ChannelInitializer} that runs on a member and used for unencrypted
  * channels. It will deal with the exchange of protocols and based on that it
  * will set up the appropriate handlers in the pipeline.
  */
-public class AbstractChannelInitializer
+public abstract class AbstractChannelInitializer
         implements ChannelInitializer {
 
     protected final IOService ioService;
@@ -39,8 +36,4 @@ public class AbstractChannelInitializer
         this.ioService = ioService;
     }
 
-    @Override
-    public void initChannel(Channel channel) {
-        setChannelOptions(channel, config);
-    }
 }

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/ClientChannelInitializer.java
@@ -33,8 +33,6 @@ public class ClientChannelInitializer
 
     @Override
     public void initChannel(Channel channel) {
-        super.initChannel(channel);
-
         TcpIpConnection connection = (TcpIpConnection) channel.attributeMap().get(TcpIpConnection.class);
         SingleProtocolDecoder protocolDecoder = new SingleProtocolDecoder(CLIENT,
                 new ClientMessageDecoder(connection, ioService.getClientEngine()));

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/MemberChannelInitializer.java
@@ -33,8 +33,6 @@ public class MemberChannelInitializer
 
     @Override
     public void initChannel(Channel channel) {
-        super.initChannel(channel);
-
         TcpIpConnection connection = (TcpIpConnection) channel.attributeMap().get(TcpIpConnection.class);
         OutboundHandler[] outboundHandlers = ioService.createOutboundHandlers(EndpointQualifier.MEMBER, connection);
         InboundHandler[] inboundHandlers = ioService.createInboundHandlers(EndpointQualifier.MEMBER, connection);

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpNetworkingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpNetworkingService.java
@@ -128,7 +128,7 @@ public class TcpIpNetworkingService
         } else {
             for (EndpointConfig endpointConfig : config.getAdvancedNetworkConfig().getEndpointConfigs().values()) {
                 EndpointQualifier qualifier = endpointConfig.getQualifier();
-                EndpointManager em = newEndpointManager(ioService, qualifier, channelInitializerProvider,
+                EndpointManager em = newEndpointManager(ioService, endpointConfig, channelInitializerProvider,
                         loggingService, metricsRegistry, properties, singleton(endpointConfig.getProtocolType()));
                 endpointManagers.put(qualifier, em);
             }
@@ -136,13 +136,13 @@ public class TcpIpNetworkingService
     }
 
     private EndpointManager<TcpIpConnection> newEndpointManager(IOService ioService,
-                                                                EndpointQualifier qualifier,
+                                                                EndpointConfig endpointConfig,
                                                                 ChannelInitializerProvider channelInitializerProvider,
                                                                 LoggingService loggingService,
                                                                 MetricsRegistry metricsRegistry,
                                                                 HazelcastProperties properties,
                                                                 Set<ProtocolType> supportedProtocolTypes) {
-        return new TcpIpEndpointManager(this, qualifier, channelInitializerProvider, ioService, loggingService,
+        return new TcpIpEndpointManager(this, endpointConfig, channelInitializerProvider, ioService, loggingService,
                 metricsRegistry, properties, supportedProtocolTypes);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpUnifiedEndpointManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpUnifiedEndpointManager.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.nio.tcp;
 
-import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.config.EndpointConfig;
 import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 import com.hazelcast.internal.metrics.Probe;
@@ -37,11 +37,11 @@ import static com.hazelcast.nio.ConnectionType.REST_CLIENT;
 class TcpIpUnifiedEndpointManager
         extends TcpIpEndpointManager {
 
-    TcpIpUnifiedEndpointManager(NetworkingService root, EndpointQualifier qualifier,
+    TcpIpUnifiedEndpointManager(NetworkingService root, EndpointConfig endpointConfig,
                                 ChannelInitializerProvider channelInitializerProvider,
                                 IOService ioService, LoggingService loggingService, MetricsRegistry metricsRegistry,
                                 HazelcastProperties properties) {
-        super(root, qualifier, channelInitializerProvider, ioService, loggingService,
+        super(root, endpointConfig, channelInitializerProvider, ioService, loggingService,
                 metricsRegistry, properties, ProtocolType.valuesAsSet());
     }
 


### PR DESCRIPTION
Set`SO_RCVBUF`  before Server Socket binding and socket connection, to allow TCP Window Scale to take effect.
Fixes https://github.com/hazelcast/hazelcast/issues/12519

Verified with TCP capturing

**Initial SYN attempt from client with setting 20MB**
![image](https://user-images.githubusercontent.com/3369598/55036993-2ca3a180-5014-11e9-9a89-eca137d33fa4.png)

**SYN-ACK from server with the setting of 50MB**
![image](https://user-images.githubusercontent.com/3369598/55037023-48a74300-5014-11e9-92d6-ee6e1fd4ae4b.png)

---

Notice the window size is set to its max value 65kb, and the multiplier (Window scale) is set to 512 for the 20MB client setting, and to 1024 for the 50MB server setting.

The multiplier is resolved to 512 after the SYN completes, and the window size value holds appropriate values respecting that multiplier.

![image](https://user-images.githubusercontent.com/3369598/55037154-b05d8e00-5014-11e9-8894-7feaf8213ca2.png)

---

The changes affect Advanced Network use-cases and it is per Endpoint Configuration and Server Socket. Legacy Network configuration is not affected by it.