### PR TITLE
Fix LocalQueryTest

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/TestRaftMember.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/TestRaftMember.java
@@ -18,6 +18,7 @@ package com.hazelcast.cp.internal.raft.impl.testing;
 
 import com.hazelcast.core.Endpoint;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
 public class TestRaftMember implements Endpoint {
@@ -38,7 +39,7 @@ public class TestRaftMember implements Endpoint {
 
     @Override
     public SocketAddress getSocketAddress() {
-        return null;
+        return new InetSocketAddress(port);
     }
 
     public int getPort() {


### PR DESCRIPTION
Reading the latest value from a random follower is not guaranteed.
But in a 3 node Raft group, at least one of the followers must return
the latest value.

Fixes #14774