### PR TITLE
Adds a check on the send/receive buffer configuration

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelOptions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannelOptions.java
@@ -18,13 +18,15 @@ package com.hazelcast.internal.networking.nio;
 
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.internal.networking.Channel;
-import com.hazelcast.internal.networking.ChannelOptions;
 import com.hazelcast.internal.networking.ChannelOption;
+import com.hazelcast.internal.networking.ChannelOptions;
+import com.hazelcast.logging.Logger;
 
 import java.net.Socket;
 import java.net.SocketException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.hazelcast.internal.networking.ChannelOption.DIRECT_BUF;
 import static com.hazelcast.internal.networking.ChannelOption.SO_KEEPALIVE;
@@ -35,12 +37,15 @@ import static com.hazelcast.internal.networking.ChannelOption.SO_SNDBUF;
 import static com.hazelcast.internal.networking.ChannelOption.SO_TIMEOUT;
 import static com.hazelcast.internal.networking.ChannelOption.TCP_NODELAY;
 import static com.hazelcast.util.Preconditions.checkNotNull;
+import static java.util.logging.Level.WARNING;
 
 /**
  * Contains the configuration for a {@link Channel}.
  */
 final class NioChannelOptions implements ChannelOptions {
 
+    private static final AtomicBoolean SEND_BUFFER_WARNING = new AtomicBoolean();
+    private static final AtomicBoolean RECEIVE_BUFFER_WARNING = new AtomicBoolean();
     private final Map<String, Object> values = new ConcurrentHashMap<String, Object>();
     private final Socket socket;
 
@@ -83,9 +88,13 @@ final class NioChannelOptions implements ChannelOptions {
             if (option.equals(TCP_NODELAY)) {
                 socket.setTcpNoDelay((Boolean) value);
             } else if (option.equals(SO_RCVBUF)) {
-                socket.setReceiveBufferSize((Integer) value);
+                int receiveBufferSize = (Integer) value;
+                socket.setReceiveBufferSize(receiveBufferSize);
+                verifyReceiveBufferSize(receiveBufferSize);
             } else if (option.equals(SO_SNDBUF)) {
-                socket.setSendBufferSize((Integer) value);
+                int sendBufferSize = (Integer) value;
+                socket.setSendBufferSize(sendBufferSize);
+                verifySendBufferSize(sendBufferSize);
             } else if (option.equals(SO_KEEPALIVE)) {
                 socket.setKeepAlive((Boolean) value);
             } else if (option.equals(SO_REUSEADDR)) {
@@ -105,5 +114,38 @@ final class NioChannelOptions implements ChannelOptions {
         }
 
         return this;
+    }
+
+    private void verifySendBufferSize(int sendBufferSize) throws SocketException {
+        if (socket.getSendBufferSize() == sendBufferSize) {
+            return;
+        }
+
+        if (SEND_BUFFER_WARNING.compareAndSet(false, true)) {
+            Logger.getLogger(NioChannelOptions.class).log(WARNING,
+                    "The configured tcp send buffer size conflicts with the value actually being used "
+                            + "by the socket and can lead to sub-optimal performance. "
+                            + "Configured " + sendBufferSize + " bytes, "
+                            + "actual " + socket.getSendBufferSize() + " bytes. "
+                            + "On Linux look for kernel parameters 'net.ipv4.tcp_wmem' and 'net.core.wmem_max'."
+                            + "This warning will only be shown once.");
+        }
+
+    }
+
+    private void verifyReceiveBufferSize(int receiveBufferSize) throws SocketException {
+        if (socket.getReceiveBufferSize() == receiveBufferSize) {
+            return;
+        }
+
+        if (RECEIVE_BUFFER_WARNING.compareAndSet(false, true)) {
+            Logger.getLogger(NioChannelOptions.class).log(WARNING,
+                    "The configured tcp receive buffer size conflicts with the value actually being used "
+                            + "by the socket and can lead to sub-optimal performance. "
+                            + "Configured " + receiveBufferSize + " bytes, "
+                            + "actual " + socket.getReceiveBufferSize() + " bytes. "
+                            + "On Linux look for kernel parameters 'net.ipv4.tcp_rmem' and 'net.core.rmem_max'."
+                            + "This warning will only be shown once.");
+        }
     }
 }


### PR DESCRIPTION
The value that is set on the socket is just a hint and
the OS isn't obligated to use the configured value.

This can lead to sub-optimal performance. E.g. when the
socket buffer is too small, the system will not be able
to utilize the full network bandwidth (see BDP for more
info).

The warning will only be shown once to prevent flooding the 
log with too many warnings.

fixes https://github.com/hazelcast/hazelcast/issues/14197