### PR TITLE
Don't apply partition response coming from old connection

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -123,9 +123,9 @@ public final class ClientPartitionServiceImpl
         while (partitions.isEmpty() && client.getConnectionManager().isAlive()) {
             ClientClusterService clusterService = client.getClientClusterService();
             Collection<Member> memberList = clusterService.getMemberList();
-            Connection ownerConnection = this.ownerConnection;
+            Connection currentOwnerConnection = this.ownerConnection;
             //if member list is empty or owner is null, we will sleep and retry
-            if (memberList.isEmpty() || ownerConnection == null) {
+            if (memberList.isEmpty() || currentOwnerConnection == null) {
                 sleepBeforeNextTry();
                 continue;
             }
@@ -138,11 +138,20 @@ public final class ClientPartitionServiceImpl
             // invocation should go to owner connection because the listener is added to owner connection
             // and partition state version should be fetched from one member to keep it consistent
             ClientInvocationFuture future =
-                    new ClientInvocation(client, requestMessage, null, ownerConnection).invokeUrgent();
+                    new ClientInvocation(client, requestMessage, null, currentOwnerConnection).invokeUrgent();
             try {
                 ClientMessage responseMessage = future.get();
                 ClientGetPartitionsCodec.ResponseParameters response =
                         ClientGetPartitionsCodec.decodeResponse(responseMessage);
+                Connection connection = responseMessage.getConnection();
+                if (!currentOwnerConnection.equals(ownerConnection)) {
+                    if (logger.isFinestEnabled()) {
+                        logger.finest(" We will not apply the response, since response come from an old connection  " + connection
+                                + ". Current connection " + this.ownerConnection + " state version:"
+                                + (response.partitionStateVersionExist ? response.partitionStateVersion : "NotAvailable"));
+                    }
+                    continue;
+                }
                 processPartitionResponse(response.partitions,
                         response.partitionStateVersion, response.partitionStateVersionExist);
             } catch (Exception e) {


### PR DESCRIPTION
https://github.com/hazelcast/hazelcast/pull/14730
In the fix below, we changed the fetching partitions so that we get
from owner connection only. This fix checks the connection that response
comes from to see if should be applied or not. If connection is
changed, response should not be applied in order not to mess with
partition state.
We saw the problem in following issue:
related to https://github.com/hazelcast/hazelcast-enterprise/issues/2854