### PR TITLE
Fixes misinterpreting failover request failure

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClientConnectionManagerImpl.java
@@ -39,6 +39,7 @@ import com.hazelcast.client.spi.impl.ClientInvocationFuture;
 import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.instance.BuildInfo;
 import com.hazelcast.instance.BuildInfoProvider;
 import com.hazelcast.internal.networking.Channel;
 import com.hazelcast.internal.networking.ChannelErrorHandler;
@@ -672,9 +673,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             AuthenticationStatus authenticationStatus = AuthenticationStatus.getById(result.status);
             switch (authenticationStatus) {
                 case AUTHENTICATED:
-                    if (!checkFailoverSupportIfNeeded()) {
-                        onFailure(new IllegalStateException("Cluster does not support failover. "
-                                + "This feature is available in Hazelcast Enterprise"));
+                    if (!checkFailoverSupportIfNeeded(result)) {
                         return;
                     }
                     handleSuccessResult(result);
@@ -713,7 +712,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             }
         }
 
-        private boolean checkFailoverSupportIfNeeded() {
+        private boolean checkFailoverSupportIfNeeded(ClientAuthenticationCodec.ResponseParameters result) {
             if (!asOwner) {
                 return true;
             }
@@ -721,9 +720,31 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
             if (!isFailoverAskedToCluster) {
                 return true;
             }
+
+            if (!result.serverHazelcastVersionExist
+                    || BuildInfo.calculateVersion(result.serverHazelcastVersion) < BuildInfo.calculateVersion("3.12")) {
+                //this means that server is too old and failover not supported
+                //IllegalStateException will cause client to give up trying on this cluster
+                onFailure(new ClientNotAllowedInClusterException("Cluster does not support failover. "
+                        + "This feature is available in Hazelcast Enterprise with version 3.12 and after"));
+                return false;
+            }
+
             try {
-                return ClientIsFailoverSupportedCodec.decodeResponse(isFailoverFuture.get()).response;
+                boolean isAllowed = ClientIsFailoverSupportedCodec.decodeResponse(isFailoverFuture.get()).response;
+                if (!isAllowed) {
+                    //in this path server is new but not enterprise.
+                    //IllegalStateException will cause client to give up trying on this cluster
+                    onFailure(new ClientNotAllowedInClusterException("Cluster does not support failover. "
+                            + "This feature is available in Hazelcast Enterprise"));
+                    return false;
+                }
+                return true;
             } catch (Exception e) {
+                //server version is 3.12 or newer, but an exception occured while getting the isFailover supported info
+                //Exception is delegated without wrapping `IllegalStateException` to so that we will continue
+                // trying same connection
+                onFailure(e);
                 return false;
             }
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnectorServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnectorServiceImpl.java
@@ -214,7 +214,11 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
 
     private void beforeClusterSwitch(CandidateClusterContext context) {
         //reset near caches, clears all near cache data
-        client.getNearCacheManager().clearAllNearCaches();
+        try {
+            client.getNearCacheManager().clearAllNearCaches();
+        } catch (Throwable e) {
+            logger.warning("Error when clearing near caches before cluster switch ", e);
+        }
         //clear the member list
         client.getClientClusterService().reset();
         //clear the partition table
@@ -270,7 +274,7 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
             public Void call() {
                 try {
                     connectToClusterInternal();
-                } catch (Exception e) {
+                } catch (Throwable e) {
                     logger.warning("Could not connect to any cluster, shutting down the client: " + e.getMessage());
                     new Thread(new Runnable() {
                         @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnectorServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnectorServiceImpl.java
@@ -156,12 +156,6 @@ public class ClusterConnectorServiceImpl implements ClusterConnectorService, Con
                 connection.close("Could not connect to " + address + " as owner", e);
             }
             throw rethrow(e);
-        } catch (IllegalStateException e) {
-            logger.warning("Exception during initial connection to " + address + ": " + e);
-            if (null != connection) {
-                connection.close("Could not connect to " + address + " as owner", e);
-            }
-            throw e;
         } catch (ClientNotAllowedInClusterException e) {
             logger.warning("Exception during initial connection to " + address + ": " + e);
             if (null != connection) {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/FailoverTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/bluegreen/FailoverTest.java
@@ -74,7 +74,7 @@ public class FailoverTest extends ClientTestSupport {
         networkConfig2.setAddresses(Collections.singletonList(address2.getHost() + ":" + address2.getPort()));
 
         ClientFailoverConfig clientFailoverConfig = new ClientFailoverConfig();
-        clientFailoverConfig.addClientConfig(clientConfig).addClientConfig(clientConfig2);
+        clientFailoverConfig.addClientConfig(clientConfig).addClientConfig(clientConfig2).setTryCount(1);
 
         HazelcastClient.newHazelcastFailoverClient(clientFailoverConfig);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/NoSuchMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/NoSuchMessageTask.java
@@ -47,6 +47,11 @@ public class NoSuchMessageTask extends AbstractMessageTask<ClientMessage> {
     }
 
     @Override
+    protected boolean requiresAuthentication() {
+        return false;
+    }
+
+    @Override
     public String getServiceName() {
         return null;
     }


### PR DESCRIPTION
We were skipping retrying same cluster when a failover request failure.
With this fix, we will differentiate the cases in more detail

Failover request can fail when a connection problem occurs:
In this case, authentication will fail, but we will try new connections
on same cluster.

Failover request can fail when server is old:
In this case, authentication will fail, and we should not retry same
cluster.

Failover request can fail when server is open source:
In this case, client will get OperationNotSupportedException as cause,
and we should not retry same cluster.

fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2820