### PR TITLE
Ensure migrations resumed during cluster merge

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -1217,6 +1217,17 @@ public class MembershipManager {
 
         @Override
         public void run() {
+            try {
+                innerRun();
+            } catch (Throwable e) {
+                logger.warning("Exception thrown while running DecideNewMembersViewTask", e);
+            } finally {
+                // Resume migrations, they are disabled when mastership claim is started
+                node.getPartitionService().resumeMigration();
+            }
+        }
+
+        private void innerRun() {
             MembersView newMembersView = decideNewMembersView(localMemberMap, membersToAsk);
             clusterServiceLock.lock();
             try {
@@ -1245,8 +1256,6 @@ public class MembershipManager {
                 sendMemberListToOthers();
                 logger.info("Mastership is claimed with: " + newMembersView);
             } finally {
-                // Resume migrations, they are disabled when mastership claim is started
-                node.getPartitionService().resumeMigration();
                 clusterServiceLock.unlock();
             }
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationManager.java
@@ -607,6 +607,8 @@ public class MigrationManager {
         migrationQueue.clear();
         activeMigrationInfo = null;
         completedMigrations.clear();
+        shutdownRequestedMembers.clear();
+        migrationTasksAllowed.set(true);
     }
 
     void start() {


### PR DESCRIPTION
One of the members on merging side can start mastership claim
while merging to another cluster after master leaves.
But `DecideNewMembersViewTask` can fail because mastership claiming
member also starts the merge process, it resets all internal state.

After merge, migration-allowed flag should be set back
if it's disabled during mastership claim.

Also `MigrationManager` should reset `migrationTasksAllowed` flag
when `reset()` is called.

This bug was introduced by: https://github.com/hazelcast/hazelcast/pull/14744

Fixes #14767