### PR TITLE
Ignore all Exception types in PhoneHomes (Workaround for Weblogic 12.1 NPE)

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/PhoneHome.java
@@ -208,7 +208,7 @@ public class PhoneHome {
             conn.setConnectTimeout(TIMEOUT * 2);
             conn.setReadTimeout(TIMEOUT * 2);
             in = new BufferedInputStream(conn.getInputStream());
-        } catch (IOException ignored) {
+        } catch (Exception ignored) {
             ignore(ignored);
         } finally {
             closeResource(in);


### PR DESCRIPTION
NPE in WebLogic 12c was reported during a Hazelcast phone home call. This PR as an workaround extends the phone-home catch block to ignore other Exception types and not only the `IOException`.

```
Exception in thread "hz._hzInstance_1.thread-1" java.lang.NullPointerException
                at weblogic.net.http.HttpURLConnection.getInputStream(HttpURLConnection.java:445)
                at weblogic.net.http.SOAPHttpURLConnection.getInputStream(SOAPHttpURLConnection.java:37)
                at com.hazelcast.util.PhoneHome.fetchWebService(PhoneHome.java:194)
                at com.hazelcast.util.PhoneHome.phoneHome(PhoneHome.java:181)
                at com.hazelcast.util.PhoneHome$1.run(PhoneHome.java:81)
                at com.hazelcast.spi.impl.executionservice.impl.DelegateAndSkipOnConcurrentExecutionDecorator$DelegateDecorator.run(DelegateAndSkipOnConcurrentExecutionDecorator.java:66)
                at com.hazelcast.util.executor.CachedExecutorServiceDelegate$Worker.run(CachedExecutorServiceDelegate.java:228)
                at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
                at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
                at java.lang.Thread.run(Thread.java:745)
                at com.hazelcast.util.executor.HazelcastManagedThread.executeRun(HazelcastManagedThread.java:64)
                at com.hazelcast.util.executor.HazelcastManagedThread.run(HazelcastManagedThread.java:80)
```