### PR TITLE
Fix for partition table update on the client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/ClientPartitionServiceImpl.java
@@ -48,15 +48,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.hazelcast.util.EmptyStatement.ignore;
 
 /**
  * The {@link ClientPartitionService} implementation.
  */
-public final class ClientPartitionServiceImpl
-        extends ClientAddPartitionListenerCodec.AbstractEventHandler
-        implements EventHandler<ClientMessage>, ClientPartitionService {
+public final class ClientPartitionServiceImpl implements ClientPartitionService {
 
     private static final long PERIOD = 10;
     private static final long INITIAL_DELAY = 10;
@@ -65,11 +64,9 @@ public final class ClientPartitionServiceImpl
     private final ClientExecutionServiceImpl clientExecutionService;
     private final HazelcastClientInstanceImpl client;
     private final ILogger logger;
-    private volatile Map<Integer, Address> partitions = Collections.emptyMap();
     private volatile int partitionCount;
-    private volatile int lastPartitionStateVersion = -1;
-    private volatile Connection ownerConnection;
-    private final Object lock = new Object();
+    private AtomicReference<PartitionTable> partitionTable =
+            new AtomicReference<PartitionTable>(new PartitionTable(null, -1, Collections.<Integer, Address>emptyMap()));
 
     public ClientPartitionServiceImpl(HazelcastClientInstanceImpl client) {
         this.client = client;
@@ -82,15 +79,31 @@ public final class ClientPartitionServiceImpl
         clientExecutionService.scheduleWithRepetition(new RefreshTask(), INITIAL_DELAY, PERIOD, TimeUnit.SECONDS);
     }
 
+    private static class PartitionTable {
+        final Connection connection;
+        final int partitionSateVersion;
+        final Map<Integer, Address> partitions;
+
+        PartitionTable(Connection connection, int partitionSateVersion, Map<Integer, Address> partitions) {
+            this.connection = connection;
+            this.partitionSateVersion = partitionSateVersion;
+            this.partitions = partitions;
+        }
+    }
+
     public void listenPartitionTable(Connection ownerConnection) throws Exception {
         //when we connect to cluster back we need to reset partition state version
-        lastPartitionStateVersion = -1;
-        this.ownerConnection = ownerConnection;
+        //we are keeping the partition map as is because, user may want its operations run on connected members even if
+        //owner connection is gone, and partition table is missing.
+        // See @{link com.hazelcast.client.spi.properties.ClientProperty#ALLOW_INVOCATIONS_WHEN_DISCONNECTED}
+        Map<Integer, Address> partitions = getPartitions();
+        partitionTable.set(new PartitionTable(ownerConnection, -1, partitions));
+
         if (((ClientConnection) ownerConnection).getConnectedServerVersion() >= BuildInfo.calculateVersion("3.9")) {
             //Servers after 3.9 supports listeners
             ClientMessage clientMessage = ClientAddPartitionListenerCodec.encodeRequest();
             ClientInvocation invocation = new ClientInvocation(client, clientMessage, null, ownerConnection);
-            invocation.setEventHandler(this);
+            invocation.setEventHandler(new PartitionEventHandler(ownerConnection));
             invocation.invokeUrgent().get();
         }
     }
@@ -104,26 +117,11 @@ public final class ClientPartitionServiceImpl
         }
     }
 
-    @Override
-    public void handlePartitionsEventV15(Collection<Map.Entry<Address, List<Integer>>> collection, int partitionStateVersion) {
-        processPartitionResponse(collection, partitionStateVersion, true);
-    }
-
-    @Override
-    public void beforeListenerRegister() {
-
-    }
-
-    @Override
-    public void onListenerRegister() {
-
-    }
-
     private void waitForPartitionsFetchedOnce() {
-        while (partitions.isEmpty() && client.getConnectionManager().isAlive()) {
+        while (getPartitions().isEmpty() && client.getConnectionManager().isAlive()) {
             ClientClusterService clusterService = client.getClientClusterService();
             Collection<Member> memberList = clusterService.getMemberList();
-            Connection currentOwnerConnection = this.ownerConnection;
+            Connection currentOwnerConnection = this.partitionTable.get().connection;
             //if member list is empty or owner is null, we will sleep and retry
             if (memberList.isEmpty() || currentOwnerConnection == null) {
                 sleepBeforeNextTry();
@@ -144,15 +142,7 @@ public final class ClientPartitionServiceImpl
                 ClientGetPartitionsCodec.ResponseParameters response =
                         ClientGetPartitionsCodec.decodeResponse(responseMessage);
                 Connection connection = responseMessage.getConnection();
-                if (!currentOwnerConnection.equals(ownerConnection)) {
-                    if (logger.isFinestEnabled()) {
-                        logger.finest(" We will not apply the response, since response come from an old connection  " + connection
-                                + ". Current connection " + this.ownerConnection + " state version:"
-                                + (response.partitionStateVersionExist ? response.partitionStateVersion : "NotAvailable"));
-                    }
-                    continue;
-                }
-                processPartitionResponse(response.partitions,
+                processPartitionResponse(connection, response.partitions,
                         response.partitionStateVersion, response.partitionStateVersionExist);
             } catch (Exception e) {
                 if (client.getLifecycleService().isRunning()) {
@@ -179,33 +169,68 @@ public final class ClientPartitionServiceImpl
      * The partitions can be empty on the response, client will not apply the empty partition table,
      * see {@link ClientPartitionListenerService#getPartitions(PartitionTableView)}
      */
-    private void processPartitionResponse(Collection<Map.Entry<Address, List<Integer>>> partitions,
+    private void processPartitionResponse(Connection connection, Collection<Map.Entry<Address, List<Integer>>> partitions,
                                           int partitionStateVersion,
                                           boolean partitionStateVersionExist) {
-        if (partitions.isEmpty()) {
-            if (logger.isFinestEnabled()) {
-                logger.finest("Partition response is empty, state version:"
-                        + (partitionStateVersionExist ? partitionStateVersion : "NotAvailable"));
-            }
-            return;
-        }
 
-        synchronized (lock) {
-            if (!partitionStateVersionExist || partitionStateVersion > lastPartitionStateVersion) {
-                Map<Integer, Address> partitionToAddressMap = convertToPartitionToAddressMap(partitions);
-                this.partitions = Collections.unmodifiableMap(partitionToAddressMap);
+        while (true) {
+            PartitionTable current = this.partitionTable.get();
+            if (!shouldBeApplied(connection, partitions, partitionStateVersion, partitionStateVersionExist, current)) {
+                return;
+            }
+            Map<Integer, Address> newPartitions = Collections.unmodifiableMap(convertToPartitionToAddressMap(partitions));
+            PartitionTable newMetaData = new PartitionTable(connection, partitionStateVersion, newPartitions);
+            if (this.partitionTable.compareAndSet(current, newMetaData)) {
+                // partition count is set once at the start. Even if we reset the partition table when switching cluster
+                //we want to remember the partition count. That is why it is a different field.
                 if (partitionCount == 0) {
-                    partitionCount = this.partitions.size();
+                    partitionCount = newPartitions.size();
                 }
-                lastPartitionStateVersion = partitionStateVersion;
                 if (logger.isFinestEnabled()) {
                     logger.finest("Processed partition response. partitionStateVersion : "
                             + (partitionStateVersionExist ? partitionStateVersion : "NotAvailable")
-                            + ", partitionCount :" + this.partitions.size());
+                            + ", partitionCount :" + newPartitions.size() + ", connection : " + connection);
                 }
-
+                return;
             }
+
         }
+    }
+
+    private boolean shouldBeApplied(Connection connection, Collection<Map.Entry<Address, List<Integer>>> partitions,
+                                    int partitionStateVersion, boolean partitionStateVersionExist, PartitionTable current) {
+        if (partitions.isEmpty()) {
+            if (logger.isFinestEnabled()) {
+                logFailure(connection, partitionStateVersion, partitionStateVersionExist, current,
+                        "response is empty");
+            }
+            return false;
+        }
+        if (!current.connection.equals(connection)) {
+            if (logger.isFinestEnabled()) {
+                logFailure(connection, partitionStateVersion, partitionStateVersionExist, current,
+                        "response is from old connection");
+            }
+            return false;
+        }
+        if (partitionStateVersionExist && partitionStateVersion <= current.partitionSateVersion) {
+            if (logger.isFinestEnabled()) {
+                logFailure(connection, partitionStateVersion, partitionStateVersionExist, current,
+                        "response state version is old");
+            }
+            return false;
+        }
+        return true;
+    }
+
+    private void logFailure(Connection connection, int partitionStateVersion,
+                            boolean partitionStateVersionExist, PartitionTable current, String cause) {
+
+        logger.finest(" We will not apply the response, since " + cause + " . Response is from " + connection
+                + ". Current connection " + current.connection
+                + " response state version:"
+                + (partitionStateVersionExist ? partitionStateVersion : "NotAvailable"
+                + ". Current state version: " + current.partitionSateVersion));
     }
 
     private Map<Integer, Address> convertToPartitionToAddressMap(Collection<Map.Entry<Address, List<Integer>>> partitions) {
@@ -220,12 +245,17 @@ public final class ClientPartitionServiceImpl
     }
 
     public void reset() {
-        partitions = Collections.emptyMap();
+        partitionTable.set(new PartitionTable(null, -1,
+                Collections.<Integer, Address>emptyMap()));
     }
 
     @Override
     public Address getPartitionOwner(int partitionId) {
-        return partitions.get(partitionId);
+        return getPartitions().get(partitionId);
+    }
+
+    private Map<Integer, Address> getPartitions() {
+        return partitionTable.get().partitions;
     }
 
     @Override
@@ -285,6 +315,31 @@ public final class ClientPartitionServiceImpl
         }
     }
 
+    private final class PartitionEventHandler extends ClientAddPartitionListenerCodec.AbstractEventHandler
+            implements EventHandler<ClientMessage> {
+
+        private final Connection clientConnection;
+
+        private PartitionEventHandler(Connection clientConnection) {
+            this.clientConnection = clientConnection;
+        }
+
+        @Override
+        public void handlePartitionsEventV15(Collection<Map.Entry<Address, List<Integer>>> response, int stateVersion) {
+            processPartitionResponse(clientConnection, response, stateVersion, true);
+        }
+
+        @Override
+        public void beforeListenerRegister() {
+
+        }
+
+        @Override
+        public void onListenerRegister() {
+
+        }
+    }
+
     private final class RefreshTask implements Runnable {
 
         private RefreshTask() {
@@ -316,8 +371,10 @@ public final class ClientPartitionServiceImpl
             if (responseMessage == null) {
                 return;
             }
+            Connection connection = responseMessage.getConnection();
             ClientGetPartitionsCodec.ResponseParameters response = ClientGetPartitionsCodec.decodeResponse(responseMessage);
-            processPartitionResponse(response.partitions, response.partitionStateVersion, response.partitionStateVersionExist);
+            processPartitionResponse(connection, response.partitions,
+                    response.partitionStateVersion, response.partitionStateVersionExist);
         }
 
         @Override


### PR DESCRIPTION
Client partition table can be updated from 4 different paths
1. When partition table is not create yet and user tries to access it
for the first time
2. 10 second periodic updates
3. When member list changes
4. Via listener for server version 3.9 and after

We realized that we are applying the partition table from old connection
and messing the partition version. To keep it consistent, it should
be updated from only one connection.
https://github.com/hazelcast/hazelcast/pull/14792 was fixing only
first item. With this pr, all paths are checked for version
and connection.

fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2854