### PR TITLE
Fix for partition table update on the client

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientInstanceImpl.java
@@ -957,7 +957,7 @@ public class HazelcastClientInstanceImpl implements HazelcastInstance, Serializa
         proxyManager.destroy();
         connectionManager.shutdown();
         clusterService.shutdown();
-        partitionService.stop();
+        partitionService.reset();
         transactionManager.shutdown();
         invocationService.shutdown();
         executionService.shutdown();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionServiceLiteMemberTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/partitionservice/ClientPartitionServiceLiteMemberTest.java
@@ -31,7 +31,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static com.hazelcast.client.impl.clientside.ClientTestUtil.getHazelcastClientInstanceImpl;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelTest.class})
@@ -55,7 +57,8 @@ public class ClientPartitionServiceLiteMemberTest {
 
         final HazelcastInstance client = factory.newHazelcastClient();
         final ClientPartitionService clientPartitionService = getClientPartitionService(client);
-        clientPartitionService.getPartitionOwner(0);
+        assertNull(clientPartitionService.getPartitionOwner(0));
+        clientPartitionService.getPartitionCount();
     }
 
     @Test
@@ -65,6 +68,7 @@ public class ClientPartitionServiceLiteMemberTest {
 
         final HazelcastInstance client = factory.newHazelcastClient();
         final ClientPartitionService clientPartitionService = getClientPartitionService(client);
+        assertNotEquals(0, clientPartitionService.getPartitionCount());
         assertNotNull(clientPartitionService.getPartitionOwner(0));
     }
 


### PR DESCRIPTION
Client partition table can be updated from 4 different paths
1. When partition table is not create yet and user tries to access it
for the first time
2. 10 second periodic updates
3. When member list changes
4. Via listener for server version 3.9 and after

We realized that we are applying the partition table from old connection
and messing the partition version. To keep it consistent, it should
be updated from only one connection.
https://github.com/hazelcast/hazelcast/pull/14792 was fixing only
first item. With this pr, all paths are checked for version
and connection.

fixes https://github.com/hazelcast/hazelcast-enterprise/issues/2854

(cherry picked from commit bb4c54e1e5587a4432f3cf27313f6f7cdc264d96)