### PR TITLE
Set owner connection address null when post actions fail

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/connection/nio/ClusterConnector.java
@@ -139,6 +139,7 @@ class ClusterConnector {
             fireConnectionEvent(LifecycleEvent.LifecycleState.CLIENT_CONNECTED);
             connectionStrategy.onConnectToCluster();
         } catch (Exception e) {
+            setOwnerConnectionAddress(null);
             logger.warning("Exception during initial connection to " + address + ", exception " + e);
             if (null != connection) {
                 connection.close("Could not connect to " + address + " as owner", e);


### PR DESCRIPTION
Owner connection address should be set to null when a owner connection
is established but post actions are could not completed.
When not set back to null the user calls can not see owner as
disconnected while the single threaded cluster connector
thread is searching for a new owner connection

fixes https://github.com/hazelcast/hazelcast/issues/14807