### PR TITLE
[BACKPORT 3.12] Update hazelcast-wm dependency to the latest one

### DIFF
--- a/hazelcast-all/pom.xml
+++ b/hazelcast-all/pom.xml
@@ -184,7 +184,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-wm</artifactId>
-            <version>3.8.1</version>
+            <version>3.8.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Backport of: #14822

The `hazelcast-all` artifact is built with an old `hazelcast-wm` dependency (shaded).

Feel free to close this PR if it's too risky for 3.12, there is another one #14828 for maintenance-3.x (3.12.1)