### PR TITLE
Prevent migration operations running before previous finalization completes

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/InternalPartitionImpl.java
@@ -60,8 +60,23 @@ public class InternalPartitionImpl implements InternalPartition {
         return isMigrating;
     }
 
-    public void setMigrating(boolean isMigrating) {
-        this.isMigrating = isMigrating;
+    /**
+     * Sets migrating flag if it's not set already.
+     * @return true if migrating flag is updated, false otherwise
+     */
+    public boolean setMigrating() {
+        if (isMigrating) {
+            return false;
+        }
+        isMigrating = true;
+        return true;
+    }
+
+    /**
+     * Resets migrating flag.
+     */
+    public void resetMigrating() {
+        isMigrating = false;
     }
 
     @Override
@@ -234,7 +249,7 @@ public class InternalPartitionImpl implements InternalPartition {
         assert localReplica != null;
         this.replicas = new PartitionReplica[MAX_REPLICA_COUNT];
         this.localReplica = localReplica;
-        setMigrating(false);
+        resetMigrating();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -313,18 +313,22 @@ public class PartitionStateManager {
         return newState;
     }
 
-    public void setMigratingFlag(int partitionId) {
+    public boolean trySetMigratingFlag(int partitionId) {
         if (logger.isFinestEnabled()) {
             logger.finest("Setting partition-migrating flag. partitionId=" + partitionId);
         }
-        partitions[partitionId].setMigrating(true);
+        return partitions[partitionId].setMigrating();
     }
 
     public void clearMigratingFlag(int partitionId) {
         if (logger.isFinestEnabled()) {
             logger.finest("Clearing partition-migrating flag. partitionId=" + partitionId);
         }
-        partitions[partitionId].setMigrating(false);
+        partitions[partitionId].resetMigrating();
+    }
+
+    public boolean isMigrating(int partitionId) {
+        return partitions[partitionId].isMigrating();
     }
 
     /** Sets the replica members for the {@code partitionId}. */

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -216,7 +216,10 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
                     + ". Current active migration is " + currentActiveMigration);
         }
         PartitionStateManager partitionStateManager = partitionService.getPartitionStateManager();
-        partitionStateManager.setMigratingFlag(migrationInfo.getPartitionId());
+        if (!partitionStateManager.trySetMigratingFlag(migrationInfo.getPartitionId())) {
+            throw new RetryableHazelcastException("Cannot set migrating flag, "
+                    + "probably previous migration's finalization is not completed yet.");
+        }
     }
 
     void onMigrationStart() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
@@ -54,7 +54,10 @@ final class BeforePromotionOperation extends AbstractPromotionOperation {
 
         InternalPartitionServiceImpl service = getService();
         PartitionStateManager partitionStateManager = service.getPartitionStateManager();
-        partitionStateManager.setMigratingFlag(getPartitionId());
+        if (!partitionStateManager.trySetMigratingFlag(getPartitionId())) {
+            throw new IllegalStateException("Cannot set migrating flag, "
+                    + "probably previous migration's finalization is not completed yet.");
+        }
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
@@ -328,7 +328,7 @@ public abstract class LockBasicTest extends HazelcastTestSupport {
         final int leaseTime = 1000;
 
         lock.lock(leaseTime, TimeUnit.MILLISECONDS);
-        partition.setMigrating(true);
+        partition.setMigrating();
 
         spawn(new Runnable() {
             @Override
@@ -338,7 +338,7 @@ public abstract class LockBasicTest extends HazelcastTestSupport {
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
-                partition.setMigrating(false);
+                partition.resetMigrating();
             }
         });
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/StaleReadDuringMigrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/StaleReadDuringMigrationTest.java
@@ -77,7 +77,7 @@ public class StaleReadDuringMigrationTest extends HazelcastTestSupport {
         final int partitionId = 0;
         final InternalPartitionServiceImpl partitionService = (InternalPartitionServiceImpl) getPartitionService(instance);
         final InternalPartitionImpl partition = (InternalPartitionImpl) partitionService.getPartition(partitionId);
-        partition.setMigrating(true);
+        partition.setMigrating();
 
         final InternalOperationService operationService = getOperationService(instance);
         final InvocationBuilder invocationBuilder = operationService

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/InvocationUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/InvocationUtilTest.java
@@ -89,7 +89,7 @@ public class InvocationUtilTest extends HazelcastTestSupport {
         final InternalPartitionService partitionService = nodeEngineImpl.getPartitionService();
         final int randomPartitionId = (int) (Math.random() * partitionService.getPartitionCount());
         final InternalPartitionImpl partition = (InternalPartitionImpl) partitionService.getPartition(randomPartitionId);
-        partition.setMigrating(true);
+        partition.setMigrating();
 
         final String operationResponse = "operationResponse";
         final Operation operation = new LocalOperation(operationResponse)
@@ -104,7 +104,7 @@ public class InvocationUtilTest extends HazelcastTestSupport {
                 } catch (InterruptedException e) {
 
                 }
-                partition.setMigrating(false);
+                partition.resetMigrating();
             }
         });
 


### PR DESCRIPTION
Normally finalization is scheduled when either `PublishCompletedMigrationsOperation`
or a migration operation is executed.

But in a small window of time, a `MigrationOperation` can come and start just
after `PublishCompletedMigrationsOperation` starts executing.

In this case, if completed migrations include a previous migration which
belongs to the same partition with `MigrationOperation` and local member
was source of that migration and if `MigrationOperation` starts its execution
before the `FinalizeMigrationOperation` is put into the partition operation
threads queue, then `FinalizeMigrationOperation` can run after the `MigrationOperation`
and remove data replicated by it.

To fix that, `MigrationOperation` is retried if it cannot set `migrating` flag
of a partition. `migrating` flag is set by migration operations and cleared by
`FinalizeMigrationOperation`. So, if `migrating` flag is set while `MigrationOperation`
is executed, that means former `FinalizeMigrationOperation` is not executed yet.


Fixes #14809

Backport of https://github.com/hazelcast/hazelcast/pull/14832