### PR TITLE
MetricsRegistry unregister fix.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -230,6 +230,7 @@ public final class NioNetworking implements Networking {
         shutdown(outputThreads);
         outputThreads = null;
         closeListenerExecutor.shutdown();
+        metricsRegistry.deregister(ioBalancer);
     }
 
     private void shutdown(NioThread[] threads) {
@@ -238,6 +239,7 @@ public final class NioNetworking implements Networking {
         }
         for (NioThread thread : threads) {
             thread.shutdown();
+            metricsRegistry.deregister(thread);
         }
     }
 


### PR DESCRIPTION
NioNetworking can be stopped and started. When this happens, the
IOThreads get re-registered and will overwrite the old probes. This
causes logging noise.

This PR fixes this problem by deregistering the IOThreads when NioNetworking
is shutdown.

(cherry picked from commit 4d9c28e741d3d77ba39021ab06c30191bf52297b)

1:1 backport of https://github.com/hazelcast/hazelcast/pull/14823