### PR TITLE
Let Client handle restarted members with same uuid different address

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientClusterRestartEventTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.MemberAttributeEvent;
+import com.hazelcast.core.MembershipEvent;
+import com.hazelcast.core.MembershipListener;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.hazelcast.test.HazelcastTestSupport.assertContains;
+import static com.hazelcast.test.HazelcastTestSupport.assertOpenEventually;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class ClientClusterRestartEventTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.shutdownAll();
+    }
+
+    protected Config newConfig() {
+        return new Config();
+    }
+
+    private ClientConfig newClientConfig() {
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.getNetworkConfig().setConnectionAttemptLimit(Integer.MAX_VALUE);
+        return clientConfig;
+    }
+
+    @Test
+    public void testSingleMemberRestart() {
+        HazelcastInstance instance = hazelcastFactory.newHazelcastInstance(newConfig());
+        Member oldMember = instance.getCluster().getLocalMember();
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient();
+
+        final CountDownLatch memberAdded = new CountDownLatch(1);
+        final CountDownLatch memberRemoved = new CountDownLatch(1);
+        final AtomicReference<Member> addedMemberReference = new AtomicReference<Member>();
+        final AtomicReference<Member> removedMemberReference = new AtomicReference<Member>();
+        client.getCluster().addMembershipListener(new MembershipListener() {
+            @Override
+            public void memberAdded(MembershipEvent membershipEvent) {
+                addedMemberReference.set(membershipEvent.getMember());
+                memberAdded.countDown();
+            }
+
+            @Override
+            public void memberRemoved(MembershipEvent membershipEvent) {
+                removedMemberReference.set(membershipEvent.getMember());
+                memberRemoved.countDown();
+            }
+
+            @Override
+            public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
+
+            }
+        });
+
+        instance.shutdown();
+        instance = hazelcastFactory.newHazelcastInstance(newConfig());
+        Member newMember = instance.getCluster().getLocalMember();
+
+        assertOpenEventually(memberRemoved);
+        assertEquals(oldMember, removedMemberReference.get());
+
+        assertOpenEventually(memberAdded);
+        assertEquals(newMember, addedMemberReference.get());
+
+        Set<Member> members = client.getCluster().getMembers();
+        assertContains(members, newMember);
+        assertEquals(1, members.size());
+    }
+
+    @Test
+    public void testMultiMemberRestart() {
+        HazelcastInstance instance1 = hazelcastFactory.newHazelcastInstance(newConfig());
+        HazelcastInstance instance2 = hazelcastFactory.newHazelcastInstance(newConfig());
+        HazelcastInstance client = hazelcastFactory.newHazelcastClient(newClientConfig());
+        Member oldMember1 = instance1.getCluster().getLocalMember();
+        Member oldMember2 = instance2.getCluster().getLocalMember();
+
+        final CountDownLatch memberAdded = new CountDownLatch(2);
+        final Set<Member> addedMembers = Collections.newSetFromMap(new ConcurrentHashMap<Member, Boolean>());
+        final CountDownLatch memberRemoved = new CountDownLatch(2);
+        final Set<Member> removedMembers = Collections.newSetFromMap(new ConcurrentHashMap<Member, Boolean>());
+        client.getCluster().addMembershipListener(new MembershipListener() {
+            @Override
+            public void memberAdded(MembershipEvent membershipEvent) {
+                addedMembers.add(membershipEvent.getMember());
+                memberAdded.countDown();
+            }
+
+            @Override
+            public void memberRemoved(MembershipEvent membershipEvent) {
+                removedMembers.add(membershipEvent.getMember());
+                memberRemoved.countDown();
+
+            }
+
+            @Override
+            public void memberAttributeChanged(MemberAttributeEvent memberAttributeEvent) {
+
+            }
+        });
+
+        instance1.shutdown();
+        instance2.shutdown();
+
+        instance1 = hazelcastFactory.newHazelcastInstance(newConfig());
+        instance2 = hazelcastFactory.newHazelcastInstance(newConfig());
+
+        Member newMember1 = instance1.getCluster().getLocalMember();
+        Member newMember2 = instance2.getCluster().getLocalMember();
+
+        assertOpenEventually(memberRemoved);
+        assertEquals(2, removedMembers.size());
+        assertContains(removedMembers, oldMember1);
+        assertContains(removedMembers, oldMember2);
+
+        assertOpenEventually(memberAdded);
+        assertEquals(2, addedMembers.size());
+        assertContains(addedMembers, newMember1);
+        assertContains(addedMembers, newMember2);
+
+        Set<Member> members = client.getCluster().getMembers();
+        assertContains(members, newMember1);
+        assertContains(members, newMember2);
+        assertEquals(2, members.size());
+
+    }
+}


### PR DESCRIPTION
In hotrestart feature, members will preserve their uuid's, but can
start with different addresses. Client was relying on only uuid,
and when a member restarted, it was assuming nothing has changed.
When it does not change its local membership view in this case, it
is trying to continue with old address which is wrong.

Also for these cases, we were not firing any member
removed,added events. With this fix, for a restarted member
with different address we will wire removed,added events.

Note that, if member comes back with same address and uuid, from
client point of view there is no way to detect the restart. So
no events will be fired in that case.

fixes https://github.com/hazelcast/hazelcast/issues/14839

(cherry picked from commit b639fd350efa0d22d3aa44129ee2a1f00bee7ea3)