### PR TITLE
Round up <1ms latencies to 1ms in local IMap stats

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTest.java
@@ -873,6 +873,10 @@ public class ClientMapTest extends HazelcastTestSupport {
         assertTrue("set latency", 0 < localMapStats.getTotalSetLatency());
         assertTrue("get latency", 0 < localMapStats.getTotalGetLatency());
         assertTrue("remove latency", 0 < localMapStats.getTotalRemoveLatency());
+        assertTrue("max put latency", 0 < localMapStats.getMaxPutLatency());
+        assertTrue("max set latency", 0 < localMapStats.getMaxSetLatency());
+        assertTrue("max get latency", 0 < localMapStats.getMaxGetLatency());
+        assertTrue("max remove latency", 0 < localMapStats.getMaxRemoveLatency());
     }
 
     @Test
@@ -891,10 +895,9 @@ public class ClientMapTest extends HazelcastTestSupport {
         assertEquals("set count", operationCount, localMapStats.getSetOperationCount());
         assertEquals("get count", 0, localMapStats.getGetOperationCount());
         assertEquals("remove count", operationCount, localMapStats.getRemoveOperationCount());
-        assertEquals("put latency", 0, localMapStats.getTotalPutLatency());
+
         assertTrue("set latency", localMapStats.getTotalSetLatency() > 0);
-        assertEquals("get latency", 0, localMapStats.getTotalGetLatency());
-        assertTrue("remove latency", localMapStats.getTotalRemoveLatency() > 0);
+        assertTrue("max set latency", localMapStats.getMaxSetLatency() > 0);
     }
 
     @Test
@@ -913,10 +916,9 @@ public class ClientMapTest extends HazelcastTestSupport {
         assertEquals("set count", operationCount, localMapStats.getSetOperationCount());
         assertEquals("get count", 0, localMapStats.getGetOperationCount());
         assertEquals("remove count", operationCount, localMapStats.getRemoveOperationCount());
-        assertEquals("put latency", 0, localMapStats.getTotalPutLatency());
+
         assertTrue("set latency", localMapStats.getTotalSetLatency() > 0);
-        assertEquals("get latency", 0, localMapStats.getTotalGetLatency());
-        assertTrue("remove latency", localMapStats.getTotalRemoveLatency() > 0);
+        assertTrue("max set latency", localMapStats.getMaxSetLatency() > 0);
     }
 
     @Test
@@ -938,10 +940,9 @@ public class ClientMapTest extends HazelcastTestSupport {
                 assertEquals("set count", operationCount, localMapStats.getSetOperationCount());
                 assertEquals("get count", 0, localMapStats.getGetOperationCount());
                 assertEquals("remove count", operationCount, localMapStats.getRemoveOperationCount());
-                assertEquals("put latency", 0, localMapStats.getTotalPutLatency());
+
                 assertTrue("set latency", localMapStats.getTotalSetLatency() > 0);
-                assertEquals("get latency", 0, localMapStats.getTotalGetLatency());
-                assertTrue("remove latency", localMapStats.getTotalRemoveLatency() > 0);
+                assertTrue("max set latency", localMapStats.getMaxSetLatency() > 0);
             }
         });
     }
@@ -965,10 +966,9 @@ public class ClientMapTest extends HazelcastTestSupport {
                 assertEquals("set count", operationCount, localMapStats.getSetOperationCount());
                 assertEquals("get count", 0, localMapStats.getGetOperationCount());
                 assertEquals("remove count", operationCount, localMapStats.getRemoveOperationCount());
-                assertEquals("put latency", 0, localMapStats.getTotalPutLatency());
+
                 assertTrue("set latency", localMapStats.getTotalSetLatency() > 0);
-                assertEquals("get latency", 0, localMapStats.getTotalGetLatency());
-                assertTrue("remove latency", localMapStats.getTotalRemoveLatency() > 0);
+                assertTrue("max set latency", localMapStats.getMaxSetLatency() > 0);
             }
         });
     }
@@ -992,10 +992,9 @@ public class ClientMapTest extends HazelcastTestSupport {
                 assertEquals("set count", operationCount, localMapStats.getSetOperationCount());
                 assertEquals("get count", 0, localMapStats.getGetOperationCount());
                 assertEquals("remove count", operationCount, localMapStats.getRemoveOperationCount());
-                assertEquals("put latency", 0, localMapStats.getTotalPutLatency());
+
                 assertTrue("set latency", localMapStats.getTotalSetLatency() > 0);
-                assertEquals("get latency", 0, localMapStats.getTotalGetLatency());
-                assertTrue("remove latency", localMapStats.getTotalRemoveLatency() > 0);
+                assertTrue("max set latency", localMapStats.getMaxSetLatency() > 0);
             }
         });
     }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -266,49 +266,49 @@ public class LocalMapStatsImpl implements LocalMapStats {
     @Probe
     @Override
     public long getTotalPutLatency() {
-        return NANOSECONDS.toMillis(totalPutLatenciesNanos);
+        return convertNanosToMillis(totalPutLatenciesNanos);
     }
 
     @Probe
     @Override
     public long getTotalSetLatency() {
-        return NANOSECONDS.toMillis(totalSetLatenciesNanos);
+        return convertNanosToMillis(totalSetLatenciesNanos);
     }
 
     @Probe
     @Override
     public long getTotalGetLatency() {
-        return NANOSECONDS.toMillis(totalGetLatenciesNanos);
+        return convertNanosToMillis(totalGetLatenciesNanos);
     }
 
     @Probe
     @Override
     public long getTotalRemoveLatency() {
-        return NANOSECONDS.toMillis(totalRemoveLatenciesNanos);
+        return convertNanosToMillis(totalRemoveLatenciesNanos);
     }
 
     @Probe
     @Override
     public long getMaxPutLatency() {
-        return NANOSECONDS.toMillis(maxPutLatency);
+        return convertNanosToMillis(maxPutLatency);
     }
 
     @Probe
     @Override
     public long getMaxSetLatency() {
-        return NANOSECONDS.toMillis(maxSetLatency);
+        return convertNanosToMillis(maxSetLatency);
     }
 
     @Probe
     @Override
     public long getMaxGetLatency() {
-        return NANOSECONDS.toMillis(maxGetLatency);
+        return convertNanosToMillis(maxGetLatency);
     }
 
     @Probe
     @Override
     public long getMaxRemoveLatency() {
-        return NANOSECONDS.toMillis(maxRemoveLatency);
+        return convertNanosToMillis(maxRemoveLatency);
     }
 
     @Override
@@ -484,14 +484,14 @@ public class LocalMapStatsImpl implements LocalMapStats {
         root.add("dirtyEntryCount", dirtyEntryCount);
 
         // keep the contract as milliseconds for latencies sent using Json
-        root.add("totalGetLatencies", NANOSECONDS.toMillis(totalGetLatenciesNanos));
-        root.add("totalPutLatencies", NANOSECONDS.toMillis(totalPutLatenciesNanos));
-        root.add("totalSetLatencies", NANOSECONDS.toMillis(totalSetLatenciesNanos));
-        root.add("totalRemoveLatencies", NANOSECONDS.toMillis(totalRemoveLatenciesNanos));
-        root.add("maxGetLatency", NANOSECONDS.toMillis(maxGetLatency));
-        root.add("maxPutLatency", NANOSECONDS.toMillis(maxPutLatency));
-        root.add("maxSetLatency", NANOSECONDS.toMillis(maxSetLatency));
-        root.add("maxRemoveLatency", NANOSECONDS.toMillis(maxRemoveLatency));
+        root.add("totalGetLatencies", convertNanosToMillis(totalGetLatenciesNanos));
+        root.add("totalPutLatencies", convertNanosToMillis(totalPutLatenciesNanos));
+        root.add("totalSetLatencies", convertNanosToMillis(totalSetLatenciesNanos));
+        root.add("totalRemoveLatencies", convertNanosToMillis(totalRemoveLatenciesNanos));
+        root.add("maxGetLatency", convertNanosToMillis(maxGetLatency));
+        root.add("maxPutLatency", convertNanosToMillis(maxPutLatency));
+        root.add("maxSetLatency", convertNanosToMillis(maxSetLatency));
+        root.add("maxRemoveLatency", convertNanosToMillis(maxRemoveLatency));
 
         root.add("heapCost", heapCost);
         root.add("merkleTreesCost", merkleTreesCost);
@@ -525,14 +525,14 @@ public class LocalMapStatsImpl implements LocalMapStats {
         lastUpdateTime = getLong(json, "lastUpdateTime", -1L);
 
         // Json uses milliseconds but we keep latencies in nanoseconds internally
-        totalGetLatenciesNanos = MILLISECONDS.toNanos(getLong(json, "totalGetLatencies", -1L));
-        totalPutLatenciesNanos = MILLISECONDS.toNanos(getLong(json, "totalPutLatencies", -1L));
-        totalSetLatenciesNanos = MILLISECONDS.toNanos(getLong(json, "totalSetLatencies", -1L));
-        totalRemoveLatenciesNanos = MILLISECONDS.toNanos(getLong(json, "totalRemoveLatencies", -1L));
-        maxGetLatency = MILLISECONDS.toNanos(getLong(json, "maxGetLatency", -1L));
-        maxPutLatency = MILLISECONDS.toNanos(getLong(json, "maxPutLatency", -1L));
-        maxSetLatency = MILLISECONDS.toNanos(getLong(json, "maxSetLatency", -1L));
-        maxRemoveLatency = MILLISECONDS.toNanos(getLong(json, "maxRemoveLatency", -1L));
+        totalGetLatenciesNanos = convertMillisToNanos(getLong(json, "totalGetLatencies", -1L));
+        totalPutLatenciesNanos = convertMillisToNanos(getLong(json, "totalPutLatencies", -1L));
+        totalSetLatenciesNanos = convertMillisToNanos(getLong(json, "totalSetLatencies", -1L));
+        totalRemoveLatenciesNanos = convertMillisToNanos(getLong(json, "totalRemoveLatencies", -1L));
+        maxGetLatency = convertMillisToNanos(getLong(json, "maxGetLatency", -1L));
+        maxPutLatency = convertMillisToNanos(getLong(json, "maxPutLatency", -1L));
+        maxSetLatency = convertMillisToNanos(getLong(json, "maxSetLatency", -1L));
+        maxRemoveLatency = convertMillisToNanos(getLong(json, "maxRemoveLatency", -1L));
 
         hits = getLong(json, "hits", -1L);
         ownedEntryCount = getLong(json, "ownedEntryCount", -1L);
@@ -579,14 +579,14 @@ public class LocalMapStatsImpl implements LocalMapStats {
                 + ", putCount=" + putCount
                 + ", setCount=" + setCount
                 + ", removeCount=" + removeCount
-                + ", totalGetLatencies=" + NANOSECONDS.toMillis(totalGetLatenciesNanos)
-                + ", totalPutLatencies=" + NANOSECONDS.toMillis(totalPutLatenciesNanos)
-                + ", totalSetLatencies=" + NANOSECONDS.toMillis(totalSetLatenciesNanos)
-                + ", totalRemoveLatencies=" + NANOSECONDS.toMillis(totalRemoveLatenciesNanos)
-                + ", maxGetLatency=" + NANOSECONDS.toMillis(maxGetLatency)
-                + ", maxPutLatency=" + NANOSECONDS.toMillis(maxPutLatency)
-                + ", maxSetLatency=" + NANOSECONDS.toMillis(maxSetLatency)
-                + ", maxRemoveLatency=" + NANOSECONDS.toMillis(maxRemoveLatency)
+                + ", totalGetLatencies=" + convertNanosToMillis(totalGetLatenciesNanos)
+                + ", totalPutLatencies=" + convertNanosToMillis(totalPutLatenciesNanos)
+                + ", totalSetLatencies=" + convertNanosToMillis(totalSetLatenciesNanos)
+                + ", totalRemoveLatencies=" + convertNanosToMillis(totalRemoveLatenciesNanos)
+                + ", maxGetLatency=" + convertNanosToMillis(maxGetLatency)
+                + ", maxPutLatency=" + convertNanosToMillis(maxPutLatency)
+                + ", maxSetLatency=" + convertNanosToMillis(maxSetLatency)
+                + ", maxRemoveLatency=" + convertNanosToMillis(maxRemoveLatency)
                 + ", ownedEntryCount=" + ownedEntryCount
                 + ", backupEntryCount=" + backupEntryCount
                 + ", backupCount=" + backupCount
@@ -602,5 +602,23 @@ public class LocalMapStatsImpl implements LocalMapStats {
                 + ", indexedQueryCount=" + indexedQueryCount
                 + ", indexStats=" + indexStats
                 + '}';
+    }
+
+    /**
+     * Converts the value in nanoseconds to milliseconds representation. The value in range 0-999999ns will be counted as 1 ms.
+     * This is done to differ an empty zero value from a value that less than our current resolution which is 1 ms.
+     * @param nanos the value in nanoseconds that will be converted to milliseconds.
+     * @return value in milliseconds.
+     */
+    private static long convertNanosToMillis(long nanos) {
+        long millis = NANOSECONDS.toMillis(nanos);
+        if (millis == 0 && nanos > 0) {
+            millis = 1;
+        }
+        return millis;
+    }
+
+    private static long convertMillisToNanos(long millis) {
+       return MILLISECONDS.toNanos(millis);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/LocalMapStatsImpl.java
@@ -36,6 +36,7 @@ import static com.hazelcast.util.ConcurrencyUtil.setMax;
 import static com.hazelcast.util.JsonUtil.getInt;
 import static com.hazelcast.util.JsonUtil.getLong;
 import static com.hazelcast.util.JsonUtil.getObject;
+import static com.hazelcast.util.TimeUtil.timeInMsOrOneIfResultIsZero;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.atomic.AtomicLongFieldUpdater.newUpdater;
@@ -604,18 +605,8 @@ public class LocalMapStatsImpl implements LocalMapStats {
                 + '}';
     }
 
-    /**
-     * Converts the value in nanoseconds to milliseconds representation. The value in range 0-999999ns will be counted as 1 ms.
-     * This is done to differ an empty zero value from a value that less than our current resolution which is 1 ms.
-     * @param nanos the value in nanoseconds that will be converted to milliseconds.
-     * @return value in milliseconds.
-     */
     private static long convertNanosToMillis(long nanos) {
-        long millis = NANOSECONDS.toMillis(nanos);
-        if (millis == 0 && nanos > 0) {
-            millis = 1;
-        }
-        return millis;
+        return timeInMsOrOneIfResultIsZero(nanos, NANOSECONDS);
     }
 
     private static long convertMillisToNanos(long millis) {

--- a/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/LocalMapStatsTest.java
@@ -195,8 +195,8 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         assertEquals(0, localMapStats.getPutOperationCount());
         assertEquals(100, localMapStats.getSetOperationCount());
         assertEquals(0, localMapStats.getHits());
-        assertGreaterOrEquals("totalSetLatency should be >= 0", localMapStats.getTotalSetLatency(), 0);
-        assertGreaterOrEquals("maxSetLatency should be >= 0", localMapStats.getMaxSetLatency(), 0);
+        assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+        assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
     }
 
     @Test
@@ -210,8 +210,8 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         assertEquals(0, localMapStats.getPutOperationCount());
         assertEquals(200, localMapStats.getSetOperationCount());
         assertEquals(100, localMapStats.getHits());
-        assertGreaterOrEquals("totalSetLatency should be >= 0", localMapStats.getTotalSetLatency(), 0);
-        assertGreaterOrEquals("maxSetLatency should be >= 0", localMapStats.getMaxSetLatency(), 0);
+        assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+        assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
     }
 
     @Test
@@ -225,8 +225,8 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         assertEquals(0, localMapStats.getPutOperationCount());
         assertEquals(200, localMapStats.getSetOperationCount());
         assertEquals(100, localMapStats.getHits());
-        assertGreaterOrEquals("totalSetLatency should be >= 0", localMapStats.getTotalSetLatency(), 0);
-        assertGreaterOrEquals("maxSetLatency should be >= 0", localMapStats.getMaxSetLatency(), 0);
+        assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+        assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
     }
 
     @Test
@@ -240,8 +240,8 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
         assertEquals(0, localMapStats.getPutOperationCount());
         assertEquals(200, localMapStats.getSetOperationCount());
         assertEquals(100, localMapStats.getHits());
-        assertGreaterOrEquals("totalSetLatency should be >= 0", localMapStats.getTotalSetLatency(), 0);
-        assertGreaterOrEquals("maxSetLatency should be >= 0", localMapStats.getMaxSetLatency(), 0);
+        assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+        assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
     }
 
     @Test
@@ -259,8 +259,8 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
                 assertEquals(0, localMapStats.getPutOperationCount());
                 assertEquals(260, localMapStats.getSetOperationCount());
                 assertEquals(130, localMapStats.getHits());
-                assertGreaterOrEquals("totalSetLatency should be >= 0", localMapStats.getTotalSetLatency(), 0);
-                assertGreaterOrEquals("maxSetLatency should be >= 0", localMapStats.getMaxSetLatency(), 0);
+                assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+                assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
             }
         });
     }
@@ -280,8 +280,8 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
                 assertEquals(0, localMapStats.getPutOperationCount());
                 assertEquals(114, localMapStats.getSetOperationCount());
                 assertEquals(57, localMapStats.getHits());
-                assertGreaterOrEquals("totalSetLatency should be >= 0", localMapStats.getTotalSetLatency(), 0);
-                assertGreaterOrEquals("maxSetLatency should be >= 0", localMapStats.getMaxSetLatency(), 0);
+                assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+                assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
             }
         });
     }
@@ -301,12 +301,11 @@ public class LocalMapStatsTest extends HazelcastTestSupport {
                 assertEquals(0, localMapStats.getPutOperationCount());
                 assertEquals(200, localMapStats.getSetOperationCount());
                 assertEquals(100, localMapStats.getHits());
-                assertGreaterOrEquals("totalSetLatency should be >= 0", localMapStats.getTotalSetLatency(), 0);
-                assertGreaterOrEquals("maxSetLatency should be >= 0", localMapStats.getMaxSetLatency(), 0);
+                assertGreaterOrEquals("totalSetLatency should be > 0", localMapStats.getTotalSetLatency(), 1);
+                assertGreaterOrEquals("maxSetLatency should be > 0", localMapStats.getMaxSetLatency(), 1);
             }
         });
     }
-
 
     @Test
     public void testRemove() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMapStatsImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/monitor/impl/LocalMapStatsImplTest.java
@@ -204,4 +204,40 @@ public class LocalMapStatsImplTest {
         assertTrue(printed.contains("indexedQueryCount=5"));
         assertTrue(printed.contains("indexStats"));
     }
+
+    @Test
+    public void lowLatenciesRoundedToOneMillisecond() {
+        LocalMapStatsImpl stats = new LocalMapStatsImpl();
+        stats.incrementGetLatencyNanos(1);
+        stats.incrementPutLatencyNanos(1000);
+        stats.incrementSetLatencyNanos(10000);
+        stats.incrementRemoveLatencyNanos(MILLISECONDS.toNanos(1) + 100);
+
+        assertEquals(1, stats.getTotalGetLatency());
+        assertEquals(1, stats.getMaxGetLatency());
+        assertEquals(1, stats.getTotalPutLatency());
+        assertEquals(1, stats.getMaxPutLatency());
+        assertEquals(1, stats.getTotalSetLatency());
+        assertEquals(1, stats.getMaxSetLatency());
+        assertEquals(1, stats.getTotalRemoveLatency());
+        assertEquals(1, stats.getMaxRemoveLatency());
+    }
+
+    @Test
+    public void zeroLatenciesRemainZeroAfterConversion() {
+        LocalMapStatsImpl stats = new LocalMapStatsImpl();
+        stats.incrementGetLatencyNanos(0);
+        stats.incrementPutLatencyNanos(0);
+        stats.incrementSetLatencyNanos(0);
+        stats.incrementRemoveLatencyNanos(0);
+
+        assertEquals(0, stats.getTotalGetLatency());
+        assertEquals(0, stats.getMaxGetLatency());
+        assertEquals(0, stats.getTotalPutLatency());
+        assertEquals(0, stats.getMaxPutLatency());
+        assertEquals(0, stats.getTotalSetLatency());
+        assertEquals(0, stats.getMaxSetLatency());
+        assertEquals(0, stats.getTotalRemoveLatency());
+        assertEquals(0, stats.getMaxRemoveLatency());
+    }
 }


### PR DESCRIPTION
Fixes: hazelcast/hazelcast#14851

To distinguish between zero value of latency and a value that less than
current resolution (milliseconds) we round up the 0-999999ns latencies
to 1ms.