### PR TITLE
Config XML/YAML: support for reliable topic executors

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientDomConfigProcessor.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientDomConfigProcessor.java
@@ -317,6 +317,9 @@ class ClientDomConfigProcessor extends AbstractDomConfigProcessor {
                 config.setTopicOverloadPolicy(TopicOverloadPolicy.valueOf(value));
             } else if ("read-batch-size".equalsIgnoreCase(nodeName)) {
                 config.setReadBatchSize(Integer.parseInt(value));
+            } else if ("executor".equals(nodeName)) {
+                String className = getAttribute(child, "class-name");
+                config.setExecutorClassName(className);
             }
         }
         clientConfig.addReliableTopicConfig(config);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientReliableTopicConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/ClientReliableTopicConfig.java
@@ -41,6 +41,7 @@ public class ClientReliableTopicConfig {
     public static final TopicOverloadPolicy DEFAULT_TOPIC_OVERLOAD_POLICY = BLOCK;
 
     private Executor executor;
+    private String executorClassName;
     private int readBatchSize = DEFAULT_READ_BATCH_SIZE;
     private String name;
     private TopicOverloadPolicy topicOverloadPolicy = DEFAULT_TOPIC_OVERLOAD_POLICY;
@@ -64,6 +65,7 @@ public class ClientReliableTopicConfig {
      */
     public ClientReliableTopicConfig(ClientReliableTopicConfig reliableTopicConfig) {
         this.executor = reliableTopicConfig.executor;
+        this.executorClassName = reliableTopicConfig.executorClassName;
         this.readBatchSize = reliableTopicConfig.readBatchSize;
         this.name = reliableTopicConfig.name;
         this.topicOverloadPolicy = reliableTopicConfig.topicOverloadPolicy;
@@ -111,10 +113,17 @@ public class ClientReliableTopicConfig {
     /**
      * Gets the Executor that is going to process the events.
      *
-     * If no Executor is selected, then the {@link com.hazelcast.spi.ExecutionService#ASYNC_EXECUTOR} is used.
+     * The reliable topic selects the Executor as follows:
+     * <ul>
+     *     <li>the Executor returned by {@link #getExecutor()}, if not null;</li>
+     *     <li>a new instance of the Executor class as returned by {@link #getExecutorClassName()}, if not null; otherwise</li>
+     *     <li>{@link com.hazelcast.spi.ExecutionService#ASYNC_EXECUTOR}</li>
+     * </ul>
      *
      * @return the Executor used to process events.
      * @see #setExecutor(Executor)
+     * @see #setExecutorClassName(String)
+     * @see #getExecutorClassName()
      */
     public Executor getExecutor() {
         return executor;
@@ -129,12 +138,55 @@ public class ClientReliableTopicConfig {
      * A single Executor can be shared between multiple Reliable topics, although it could take more time to process a message.
      * If a single Executor is not shared with other reliable topics, then the Executor only needs to have a single thread.
      *
-     * @param executor the Executor. if the executor is null, the {@link com.hazelcast.spi.ExecutionService#ASYNC_EXECUTOR} will
+     * @param executor the Executor. If the executor is null, the Executor class as returned by {@link #getExecutorClassName()}
+     *                 will be used. If the class is null, the {@link com.hazelcast.spi.ExecutionService#ASYNC_EXECUTOR} will
      *                 be used to process the event.
      * @return the updated config.
+     * @see #setExecutorClassName(String)
+     * @see #getExecutorClassName()
      */
     public ClientReliableTopicConfig setExecutor(Executor executor) {
         this.executor = executor;
+        return this;
+    }
+
+    /**
+     * Gets the class name of the Executor that is going to process the events.
+     *
+     * The reliable topic selects the Executor as follows:
+     * <ul>
+     *     <li>the Executor returned by {@link #getExecutor()}, if not null;</li>
+     *     <li>a new instance of the Executor class as returned by {@link #getExecutorClassName()}, if not null; otherwise</li>
+     *     <li>{@link com.hazelcast.spi.ExecutionService#ASYNC_EXECUTOR}</li>
+     * </ul>
+     *
+     * @return the Executor class name used to process events.
+     * @see #setExecutorClassName(String)
+     * @see #setExecutor(Executor)
+     * @see #getExecutor()
+     */
+    public String getExecutorClassName() {
+        return executorClassName;
+    }
+
+    /**
+     * Sets the class name of the Executor that is going to process the event.
+     *
+     * In some cases it is desirable to set a specific Executor. For example, you may want to isolate a certain topic from other
+     * topics because it contains long running messages or very high priority messages.
+     *
+     * An Executor specified using a class name cannot be shared between multiple Reliable topics (each Reliable topic will create
+     * a new instance of the Executor class).
+     *
+     * @param executorClassName the Executor class name. If {@link #getExecutor()} returns null, then the Executor class name will
+     *                          be used. If the class is null, the {@link com.hazelcast.spi.ExecutionService#ASYNC_EXECUTOR} will
+     *                          be used to process the event.
+     * @return the updated config.
+     * @see #setExecutor(Executor)
+     * @see #getExecutor()
+     */
+    public ClientReliableTopicConfig setExecutorClassName(String executorClassName) {
+        this.executorClassName = executorClassName;
         return this;
     }
 
@@ -184,6 +236,7 @@ public class ClientReliableTopicConfig {
                 + "name='" + name + '\''
                 + ", topicOverloadPolicy=" + topicOverloadPolicy
                 + ", executor=" + executor
+                + ", executorClassName=" + executorClassName
                 + ", readBatchSize=" + readBatchSize
                 + '}';
     }
@@ -206,6 +259,9 @@ public class ClientReliableTopicConfig {
         if (executor != null ? !executor.equals(that.executor) : that.executor != null) {
             return false;
         }
+        if (executorClassName != null ? !executorClassName.equals(that.executorClassName) : that.executorClassName != null) {
+            return false;
+        }
         if (name != null ? !name.equals(that.name) : that.name != null) {
             return false;
         }
@@ -215,6 +271,7 @@ public class ClientReliableTopicConfig {
     @Override
     public int hashCode() {
         int result = executor != null ? executor.hashCode() : 0;
+        result = 31 * result + (executorClassName != null ? executorClassName.hashCode() : 0);
         result = 31 * result + readBatchSize;
         result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (topicOverloadPolicy != null ? topicOverloadPolicy.hashCode() : 0);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/ClientDynamicClusterConfig.java
@@ -290,7 +290,7 @@ public class ClientDynamicClusterConfig extends Config {
         Data executorData = serializationService.toData(config.getExecutor());
         ClientMessage request = DynamicConfigAddReliableTopicConfigCodec.encodeRequest(config.getName(),
                 listenerConfigHolders, config.getReadBatchSize(), config.isStatisticsEnabled(),
-                config.getTopicOverloadPolicy().name(), executorData);
+                config.getTopicOverloadPolicy().name(), executorData, config.getExecutorClassName());
         invoke(request);
         return this;
     }

--- a/hazelcast-client/src/main/resources/hazelcast-client-config-4.0.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-4.0.xsd
@@ -841,6 +841,18 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="executor" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The fully qualified class name of the java.util.concurrent.Executor
+                                implementation.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
         </xs:all>
         <xs:attribute name="name" use="required">
             <xs:annotation>

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.xml
@@ -294,6 +294,7 @@
     <reliable-topic name="rel-topic">
         <read-batch-size>100</read-batch-size>
         <topic-overload-policy>DISCARD_NEWEST</topic-overload-policy>
+        <executor class-name="com.hazelcast.examples.Executor"/>
     </reliable-topic>
 
     <user-code-deployment enabled="true">

--- a/hazelcast-client/src/main/resources/hazelcast-client-full.yaml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full.yaml
@@ -283,6 +283,8 @@ hazelcast-client:
     rel-topic:
       read-batch-size: 100
       topic-overload-policy: DISCARD_NEWEST
+      executor:
+        class-name: com.hazelcast.examples.Executor
 
   user-code-deployment:
     enabled: true

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastClientBeanDefinitionParser.java
@@ -361,9 +361,23 @@ public class HazelcastClientBeanDefinitionParser extends AbstractHazelcastBeanDe
 
         private void handleReliableTopic(Node node) {
             BeanDefinitionBuilder configBuilder = createBeanBuilder(ClientReliableTopicConfig.class);
-            String name = getAttribute(node, "name");
-            fillValues(node, configBuilder);
-            reliableTopicConfigMap.put(name, configBuilder.getBeanDefinition());
+            for (Node child : childElements(node)) {
+                String nodeName = cleanNodeName(child);
+                if ("executor".equals(nodeName)) {
+                    String className = getAttribute(child, "class-name");
+                    if (className != null) {
+                        configBuilder.addPropertyValue("executorClassName", className);
+                    }
+                    String impl = getAttribute(child, "implementation");
+                    if (impl != null) {
+                        configBuilder.addPropertyReference("executor", impl);
+                    }
+                } else  {
+                    String value = getTextContent(child);
+                    configBuilder.addPropertyValue(xmlToJavaName(nodeName), value);
+                }
+            }
+            reliableTopicConfigMap.put(getAttribute(node, "name"), configBuilder.getBeanDefinition());
         }
 
         private void handleEvictionConfig(Node node, BeanDefinitionBuilder configBuilder) {

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -115,12 +115,12 @@ import com.hazelcast.config.WanPublisherConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanSyncConfig;
-import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.config.cp.CPSemaphoreConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.map.eviction.MapEvictionPolicy;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
@@ -1069,9 +1069,19 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
             BeanDefinitionBuilder builder = createBeanBuilder(ReliableTopicConfig.class);
             fillAttributeValues(node, builder);
             for (Node childNode : childElements(node)) {
-                if ("message-listeners".equals(cleanNodeName(childNode))) {
+                String name = cleanNodeName(childNode);
+                if ("message-listeners".equals(name)) {
                     ManagedList listeners = parseListeners(childNode, ListenerConfig.class);
                     builder.addPropertyValue("messageListenerConfigs", listeners);
+                } else if ("executor".equals(name)) {
+                    String className = getAttribute(childNode, "class-name");
+                    if (className != null) {
+                        builder.addPropertyValue("executorClassName", className);
+                    }
+                    String impl = getAttribute(childNode, "implementation");
+                    if (impl != null) {
+                        builder.addPropertyReference("executor", impl);
+                    }
                 }
             }
             reliableTopicManagedMap.put(getAttribute(node, "name"), builder.getBeanDefinition());

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -533,6 +533,17 @@
                                             </xs:sequence>
                                         </xs:complexType>
                                     </xs:element>
+                                    <xs:element name="executor" minOccurs="0" maxOccurs="1">
+                                        <xs:complexType>
+                                            <xs:attributeGroup ref="class-or-bean-name">
+                                                <xs:annotation>
+                                                    <xs:documentation>
+                                                        Name of the class or bean implementing java.util.concurrent.Executor.
+                                                    </xs:documentation>
+                                                </xs:annotation>
+                                            </xs:attributeGroup>
+                                        </xs:complexType>
+                                    </xs:element>
                                 </xs:sequence>
                                 <xs:attribute name="name" use="required" type="xs:string"/>
                                 <xs:attribute name="statistics-enabled" type="parameterized-boolean" use="optional"
@@ -3800,6 +3811,17 @@
                         a thread, but can be processed in parallel.
                     </xs:documentation>
                 </xs:annotation>
+            </xs:element>
+            <xs:element name="executor" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attributeGroup ref="class-or-bean-name">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Name of the class or bean implementing java.util.concurrent.Executor.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attributeGroup>
+                </xs:complexType>
             </xs:element>
         </xs:all>
         <xs:attribute name="name" use="required">

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyExecutor.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyExecutor.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.spring;
+
+import java.util.concurrent.Executor;
+
+public class DummyExecutor implements Executor {
+
+    @Override
+    public void execute(Runnable command) {
+    }
+}

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestClientApplicationContext.java
@@ -80,6 +80,7 @@ import static com.hazelcast.test.HazelcastTestSupport.assertContains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
@@ -463,6 +464,9 @@ public class TestClientApplicationContext {
         ClientReliableTopicConfig topicConfig = clientConfig.getReliableTopicConfig("rel-topic");
         assertEquals(100, topicConfig.getReadBatchSize());
         assertEquals(TopicOverloadPolicy.DISCARD_NEWEST, topicConfig.getTopicOverloadPolicy());
+        assertNotNull(topicConfig.getExecutor());
+        assertSame(DummyExecutor.class, topicConfig.getExecutor().getClass());
+        assertEquals("com.hazelcast.spring.DummyExecutor", topicConfig.getExecutorClassName());
     }
 
     private static QueryCacheConfig getQueryCacheConfig(ClientConfig config) {

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -183,6 +183,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -647,6 +648,9 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
         assertEquals("com.hazelcast.spring.DummyMessageListener", listenerConfig.getClassName());
         assertEquals(10, testReliableTopic.getReadBatchSize());
         assertEquals(TopicOverloadPolicy.BLOCK, testReliableTopic.getTopicOverloadPolicy());
+        assertNotNull(testReliableTopic.getExecutor());
+        assertSame(DummyExecutor.class, testReliableTopic.getExecutor().getClass());
+        assertEquals("com.hazelcast.spring.DummyExecutor", testReliableTopic.getExecutorClassName());
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
@@ -21,7 +21,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -24,7 +24,7 @@
         http://www.hazelcast.com/schema/sample
         hazelcast-sample-service.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
@@ -373,6 +373,7 @@
                 <hz:message-listeners>
                     <hz:message-listener class-name="com.hazelcast.spring.DummyMessageListener"/>
                 </hz:message-listeners>
+                <hz:executor implementation="dummyExecutor" class-name="com.hazelcast.spring.DummyExecutor"/>
             </hz:reliable-topic>
 
             <hz:map name="testMap"
@@ -915,5 +916,6 @@
     <bean id="dummyDiscoveryServiceProvider" class="com.hazelcast.spring.DummyDiscoveryServiceProvider"/>
     <bean id="dummyService" class="com.hazelcast.spring.MyService"/>
     <bean id="wanConsumer" class="com.hazelcast.spring.DummyWanConsumer"/>
+    <bean id="dummyExecutor" class="com.hazelcast.spring.DummyExecutor"/>
 
 </beans>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
@@ -331,6 +331,7 @@
         <hz:reliable-topic name="rel-topic">
             <hz:topic-overload-policy>DISCARD_NEWEST</hz:topic-overload-policy>
             <hz:read-batch-size>100</hz:read-batch-size>
+            <hz:executor implementation="dummyExecutor" class-name="com.hazelcast.spring.DummyExecutor"/>
         </hz:reliable-topic>
     </hz:client>
 
@@ -385,4 +386,5 @@
 
     <bean id="dummyMembershipListener" class="com.hazelcast.spring.DummyMembershipListener"/>
     <bean id="dummyCredentialsFactory" class="com.hazelcast.spring.security.DummyCredentialsFactory"/>
+    <bean id="dummyExecutor" class="com.hazelcast.spring.DummyExecutor"/>
 </beans>

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -564,6 +564,10 @@ public class ConfigXmlGenerator {
                 }
                 gen.close();
             }
+
+            if (t.getExecutor() != null) {
+                gen.open("executor", "class-name", t.getExecutor().getClass().getName()).close();
+            }
             gen.close();
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ConfigXmlGenerator.java
@@ -565,8 +565,9 @@ public class ConfigXmlGenerator {
                 gen.close();
             }
 
-            if (t.getExecutor() != null) {
-                gen.open("executor", "class-name", t.getExecutor().getClass().getName()).close();
+            String executorClassName = t.getExecutor() == null ? t.getExecutorClassName() : t.getExecutor().getClass().getName();
+            if (executorClassName != null) {
+                gen.open("executor", "class-name", executorClassName).close();
             }
             gen.close();
         }

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -45,6 +45,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.AliasedDiscoveryConfigUtils.getConfigByTag;
@@ -2325,6 +2326,14 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                         return null;
                     }
                 });
+            } else if ("executor".equals(nodeName)) {
+                String className = checkHasText(getAttribute(n, "class-name"), "class-name cannot be empty");
+                try {
+                    Executor executor = ClassLoaderUtil.newInstance(config.getClassLoader(), className);
+                    topicConfig.setExecutor(executor);
+                } catch (Exception e) {
+                    throw ExceptionUtil.rethrow(e);
+                }
             }
         }
         config.addReliableTopicConfig(topicConfig);

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -45,7 +45,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.config.AliasedDiscoveryConfigUtils.getConfigByTag;
@@ -2328,12 +2327,7 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
                 });
             } else if ("executor".equals(nodeName)) {
                 String className = checkHasText(getAttribute(n, "class-name"), "class-name cannot be empty");
-                try {
-                    Executor executor = ClassLoaderUtil.newInstance(config.getClassLoader(), className);
-                    topicConfig.setExecutor(executor);
-                } catch (Exception e) {
-                    throw ExceptionUtil.rethrow(e);
-                }
+                topicConfig.setExecutorClassName(className);
             }
         }
         config.addReliableTopicConfig(topicConfig);

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/reliable/ReliableTopicProxy.java
@@ -144,10 +144,18 @@ public class ReliableTopicProxy<E> extends AbstractDistributedObject<ReliableTop
 
     private Executor initExecutor(NodeEngine nodeEngine, ReliableTopicConfig topicConfig) {
         Executor executor = topicConfig.getExecutor();
-        if (executor == null) {
-            executor = nodeEngine.getExecutionService().getExecutor(ASYNC_EXECUTOR);
+        if (executor != null) {
+            return executor;
         }
-        return executor;
+        String className = topicConfig.getExecutorClassName();
+        if (className != null) {
+            try {
+                return ClassLoaderUtil.newInstance(nodeEngine.getConfigClassLoader(), className);
+            } catch (Exception e) {
+                throw ExceptionUtil.rethrow(e);
+            }
+        }
+        return nodeEngine.getExecutionService().getExecutor(ASYNC_EXECUTOR);
     }
 
     @Override

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -1233,6 +1233,18 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="executor" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:attribute name="class-name" use="required">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The fully qualified class name of the java.util.concurrent.Executor
+                                implementation.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
         </xs:all>
         <xs:attribute name="name" use="optional" default="default">
             <xs:annotation>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1786,6 +1786,8 @@
                 The publish call fails immediately.
         * <message-listeners>:
             Adds listeners (listener classes) for the Reliable Topic messages using its sub-element <message-listener>.
+        * <executor>:
+            Sets the java.util.concurrent.Executor implementation to use with the topic.
     -->
     <reliable-topic name="default">
         <statistics-enabled>true</statistics-enabled>
@@ -1794,6 +1796,7 @@
         <message-listeners>
             <message-listener>com.hazelcast.examples.MessageListener</message-listener>
         </message-listeners>
+        <executor class-name="com.hazelcast.examples.Executor"/>
     </reliable-topic>
     <!--
         ===== HAZELCAST MAPREDUCE JOBTRACKER CONFIGURATION =====

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -1791,6 +1791,8 @@ hazelcast:
   #         The publish call fails immediately.
   # * "message-listeners":
   #     Adds listeners (listener classes) for the Reliable Topic messages.
+  # * "executor":
+  #     Sets the java.util.concurrent.Executor implementation to use with the topic.
   #
   reliable-topic:
     default:
@@ -1799,6 +1801,8 @@ hazelcast:
       read-batch-size: 10
       message-listeners:
         - com.hazelcast.examples.MessageListener
+      executor:
+        class-name: com.hazelcast.examples.Executor
   #
   # ===== HAZELCAST MAPREDUCE JOBTRACKER CONFIGURATION =====
   #

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -26,6 +26,7 @@ import com.hazelcast.config.ConfigCompatibilityChecker.QuorumConfigChecker;
 import com.hazelcast.config.cp.CPSemaphoreConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
+import com.hazelcast.config.helpers.DummyExecutor;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.quorum.QuorumType;
@@ -1256,7 +1257,8 @@ public class ConfigXmlGeneratorTest {
                 .setReadBatchSize(10)
                 .setTopicOverloadPolicy(TopicOverloadPolicy.BLOCK)
                 .setStatisticsEnabled(true)
-                .setMessageListenerConfigs(singletonList(new ListenerConfig("foo.bar.Listener")));
+                .setMessageListenerConfigs(singletonList(new ListenerConfig("foo.bar.Listener")))
+                .setExecutor(new DummyExecutor());
 
         cfg.addReliableTopicConfig(expectedConfig);
 

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigXmlGeneratorTest.java
@@ -62,6 +62,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -1258,13 +1259,18 @@ public class ConfigXmlGeneratorTest {
                 .setTopicOverloadPolicy(TopicOverloadPolicy.BLOCK)
                 .setStatisticsEnabled(true)
                 .setMessageListenerConfigs(singletonList(new ListenerConfig("foo.bar.Listener")))
-                .setExecutor(new DummyExecutor());
+                .setExecutorClassName("foo.bar.Executor");
 
         cfg.addReliableTopicConfig(expectedConfig);
 
         ReliableTopicConfig actualConfig = getNewConfigViaXMLGenerator(cfg).getReliableTopicConfig(testTopic);
 
         assertEquals(expectedConfig, actualConfig);
+
+        expectedConfig.setExecutor(new DummyExecutor());
+        actualConfig = getNewConfigViaXMLGenerator(cfg).getReliableTopicConfig(testTopic);
+        assertNull(actualConfig.getExecutor());
+        assertEquals(DummyExecutor.class.getName(), actualConfig.getExecutorClassName());
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ReliableTopicConfigTest.java
@@ -49,6 +49,7 @@ public class ReliableTopicConfigTest {
         ReliableTopicConfig config = new ReliableTopicConfig("foo");
 
         assertNull(config.getExecutor());
+        assertNull(config.getExecutorClassName());
         assertEquals(DEFAULT_READ_BATCH_SIZE, config.getReadBatchSize());
         assertEquals("foo", config.getName());
         assertEquals(DEFAULT_TOPIC_OVERLOAD_POLICY, config.getTopicOverloadPolicy());
@@ -60,6 +61,7 @@ public class ReliableTopicConfigTest {
         ReliableTopicConfig original = new ReliableTopicConfig("original")
                 .setTopicOverloadPolicy(TopicOverloadPolicy.ERROR)
                 .setExecutor(mock(Executor.class))
+                .setExecutorClassName("com.hazelcast.example.Executor")
                 .setReadBatchSize(1)
                 .setStatisticsEnabled(!DEFAULT_STATISTICS_ENABLED);
 
@@ -67,6 +69,7 @@ public class ReliableTopicConfigTest {
 
         assertEquals("copy", copy.getName());
         assertSame(original.getExecutor(), copy.getExecutor());
+        assertEquals(original.getExecutorClassName(), copy.getExecutorClassName());
         assertEquals(original.getReadBatchSize(), copy.getReadBatchSize());
         assertEquals(original.isStatisticsEnabled(), copy.isStatisticsEnabled());
         assertEquals(original.getTopicOverloadPolicy(), copy.getTopicOverloadPolicy());
@@ -77,6 +80,7 @@ public class ReliableTopicConfigTest {
         ReliableTopicConfig original = new ReliableTopicConfig("original")
                 .setTopicOverloadPolicy(TopicOverloadPolicy.ERROR)
                 .setExecutor(mock(Executor.class))
+                .setExecutorClassName("com.hazelcast.example.Executor")
                 .setReadBatchSize(1)
                 .setStatisticsEnabled(!DEFAULT_STATISTICS_ENABLED);
 
@@ -84,6 +88,7 @@ public class ReliableTopicConfigTest {
 
         assertEquals(original.getName(), copy.getName());
         assertSame(original.getExecutor(), copy.getExecutor());
+        assertEquals(original.getExecutorClassName(), copy.getExecutorClassName());
         assertEquals(original.getReadBatchSize(), copy.getReadBatchSize());
         assertEquals(original.isStatisticsEnabled(), copy.isStatisticsEnabled());
         assertEquals(original.getTopicOverloadPolicy(), copy.getTopicOverloadPolicy());
@@ -169,11 +174,25 @@ public class ReliableTopicConfigTest {
     }
 
     @Test
+    public void setExecutorClassName() {
+        ReliableTopicConfig config = new ReliableTopicConfig("foo");
+
+        config.setExecutorClassName("com.hazelcast.example.Executor");
+
+        assertEquals("com.hazelcast.example.Executor", config.getExecutorClassName());
+
+        config.setExecutorClassName(null);
+
+        assertNull(config.getExecutorClassName());
+    }
+
+    @Test
     public void testReadonly() {
         Executor executor = mock(Executor.class);
         ReliableTopicConfig config = new ReliableTopicConfig("foo")
                 .setReadBatchSize(201)
                 .setExecutor(executor)
+                .setExecutorClassName("com.hazelcast.example.Executor")
                 .setTopicOverloadPolicy(TopicOverloadPolicy.ERROR)
                 .addMessageListenerConfig(new ListenerConfig("Foobar"));
 
@@ -188,6 +207,12 @@ public class ReliableTopicConfigTest {
 
         try {
             readOnly.setExecutor(null);
+            fail();
+        } catch (UnsupportedOperationException e) {
+        }
+
+        try {
+            readOnly.setExecutorClassName(null);
             fail();
         } catch (UnsupportedOperationException e) {
         }
@@ -224,7 +249,7 @@ public class ReliableTopicConfigTest {
         String s = config.toString();
 
         assertEquals("ReliableTopicConfig{name='foo', topicOverloadPolicy=BLOCK, executor=null,"
-                + " readBatchSize=10, statisticsEnabled=true, listenerConfigs=[]}", s);
+                + " executorClassName=null, readBatchSize=10, statisticsEnabled=true, listenerConfigs=[]}", s);
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.config.cp.CPSemaphoreConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
+import com.hazelcast.config.helpers.DummyExecutor;
 import com.hazelcast.config.helpers.DummyMapStore;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
@@ -725,6 +726,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "           <message-listeners>"
                 + "               <message-listener>MessageListenerImpl</message-listener>"
                 + "           </message-listeners>"
+                + "           <executor class-name='" + DummyExecutor.class.getName() + "'/>"
                 + "    </reliable-topic>"
                 + HAZELCAST_END_TAG;
 

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.config.cp.CPSemaphoreConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
+import com.hazelcast.config.helpers.DummyExecutor;
 import com.hazelcast.config.helpers.DummyMapStore;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
@@ -709,6 +710,8 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
                 + "      message-listeners:\n"
                 + "        - MessageListenerImpl\n"
                 + "        - MessageListenerImpl2\n"
+                + "      executor:\n"
+                + "        class-name: " + DummyExecutor.class.getName() + "\n"
                 + "    default:\n"
                 + "      read-batch-size: 42\n";
 

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/DummyExecutor.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/DummyExecutor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.helpers;
+
+import java.io.Serializable;
+import java.util.concurrent.Executor;
+
+public final class DummyExecutor implements Executor, Serializable {
+
+    @Override
+    public void execute(Runnable command) {
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof DummyExecutor;
+    }
+
+}

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-advanced-network-config.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-advanced-network-config.xml
@@ -36,7 +36,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
     <import resource="hazelcast-fullconfig-without-network.xml"/>
 

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -39,7 +39,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
     <group>
         <name>dev</name>
@@ -464,6 +464,7 @@
         <message-listeners>
             <message-listener>com.hazelcast.examples.MessageListener</message-listener>
         </message-listeners>
+        <executor class-name="com.hazelcast.examples.Executor"/>
     </reliable-topic>
 
     <semaphore name="default">

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -456,6 +456,8 @@ hazelcast:
       read-batch-size: 10
       message-listeners:
         - com.hazelcast.examples.MessageListener
+      executor:
+        class-name: com.hazelcast.examples.Executor
 
   semaphore:
     default:

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -36,7 +36,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
     <import resource="hazelcast-fullconfig-without-network.xml"/>
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <main.basedir>${project.basedir}</main.basedir>
-        <client.protocol.version>1.8.0-7</client.protocol.version>
+        <client.protocol.version>1.8.0-8</client.protocol.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdk.version>8</jdk.version>


### PR DESCRIPTION
Added a new child element `executor` to the `reliable-topic` element
in the configuration schema. A `java.util.concurrent.Executor`
implementation can be provided by specifying the fully qualified
class name in the `class-name` attribute:

```
<reliable-topic name="topic">
  ...
  <executor class-name="org.example.MyExecutor"/>
  ...
</reliable-topic>
```

Equivalent YAML:

```
reliable-topic:
  topic:
    ...
    executor:
      class-name: org.example.MyExecutor
    ...
```

Fixes: https://github.com/hazelcast/hazelcast-enterprise/issues/569