### PR TITLE
Networking restart cleanup

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -216,7 +216,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     }
 
     protected void startNetworking() {
-        networking.start();
+        networking.restart();
     }
 
     public synchronized void shutdown() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/MetricsRegistry.java
@@ -19,6 +19,7 @@ package com.hazelcast.internal.metrics;
 import com.hazelcast.internal.metrics.renderers.ProbeRenderer;
 
 import java.util.Set;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -171,8 +172,9 @@ public interface MetricsRegistry {
      * @param probeLevel the ProbeLevel publisher it publishing on. This is needed to prevent scheduling
      *                   publishers if their probe level isn't sufficient.
      * @throws NullPointerException if publisher or timeUnit is null.
+     * @return the ScheduledFuture that can be used to cancel the task, or null if nothing got scheduled.
      */
-    void scheduleAtFixedRate(Runnable publisher, long period, TimeUnit timeUnit, ProbeLevel probeLevel);
+    ScheduledFuture<?> scheduleAtFixedRate(Runnable publisher, long period, TimeUnit timeUnit, ProbeLevel probeLevel);
 
     /**
      * Renders the content of the MetricsRegistry.

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsRegistryImpl.java
@@ -40,6 +40,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -329,11 +330,11 @@ public class MetricsRegistryImpl implements MetricsRegistry {
     }
 
     @Override
-    public void scheduleAtFixedRate(Runnable publisher, long period, TimeUnit timeUnit, ProbeLevel probeLevel) {
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable publisher, long period, TimeUnit timeUnit, ProbeLevel probeLevel) {
         if (!probeLevel.isEnabled(minimumLevel)) {
-            return;
+            return null;
         }
-        scheduler.scheduleAtFixedRate(publisher, 0, period, timeUnit);
+        return scheduler.scheduleAtFixedRate(publisher, 0, period, timeUnit);
     }
 
     public void shutdown() {

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/Networking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/Networking.java
@@ -53,18 +53,34 @@ public interface Networking {
      * @return the created Channel
      * @throws IOException when something failed while registering the
      *                     socketChannel
+     * @throws IllegalStateException if Networking isn't running.
      */
-    Channel register(EndpointQualifier endpointQualifier, ChannelInitializerProvider channelInitializerProvider,
+    Channel register(EndpointQualifier endpointQualifier,
+                     ChannelInitializerProvider channelInitializerProvider,
                      SocketChannel socketChannel,
                      boolean clientMode) throws IOException;
 
     /**
-     * Starts Networking.
+     * Restarts Networking.
+     *
+     * This method can be called when the NioNetworking is started for the first time.
+     *
+     * But can also be called after {@link #shutdown()} has been completed. This is useful if you
+     * temporarily want to disable networking (e.g. dealing with merging). You should not call this
+     * method when the Networking is still running; first you need to call {@link #shutdown()}.
+     *
+     * @throws IllegalStateException if Networking already is running.
      */
-    void start();
+    void restart();
 
     /**
-     * Shuts down Networking.
+     * Shuts down Networking and closes all registered channels.
+     *
+     * Shutting down doesn't need to be a permanent state. It could be that for e.g. cluster merge, the
+     * networking is temporarily shutdown and later restarted.
+     *
+     * Shutdown can safely be called multiple times. The first time the Networking will be shutdown and the
+     * rest of the calls it will be ignored.
      */
     void shutdown();
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioChannel.java
@@ -131,7 +131,13 @@ public final class NioChannel extends AbstractChannel {
         if (Thread.currentThread() instanceof NioThread) {
             // we don't want to do any tasks on an io thread; we offload it instead
             try {
-                closeListenerExecutor.execute(new NotifyCloseListenersTask());
+                closeListenerExecutor.execute(() -> {
+                    try {
+                        notifyCloseListeners();
+                    } catch (Exception e) {
+                        logger.warning(e.getMessage(), e);
+                    }
+                });
             } catch (RejectedExecutionException e) {
                 // if the task gets rejected, the networking must be shutting down.
                 logger.fine(e);
@@ -164,16 +170,5 @@ public final class NioChannel extends AbstractChannel {
 
     private String getPort(SocketAddress socketAddress) {
         return socketAddress == null ? "*missing*" : Integer.toString(((InetSocketAddress) socketAddress).getPort());
-    }
-
-    private class NotifyCloseListenersTask implements Runnable {
-        @Override
-        public void run() {
-            try {
-                notifyCloseListeners();
-            } catch (Exception e) {
-                logger.warning(e.getMessage(), e);
-            }
-        }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -40,13 +40,14 @@ import java.nio.channels.SocketChannel;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT;
 import static com.hazelcast.internal.networking.nio.SelectorMode.SELECT_NOW_STRING;
+import static com.hazelcast.nio.IOUtil.closeResource;
 import static com.hazelcast.util.HashUtil.hashToIndex;
 import static com.hazelcast.util.ThreadUtil.createThreadPoolName;
 import static com.hazelcast.util.concurrent.BackoffIdleStrategy.createBackoffIdleStrategy;
@@ -82,18 +83,18 @@ import static java.util.logging.Level.FINE;
  */
 public final class NioNetworking implements Networking {
 
+    private final AtomicBoolean started = new AtomicBoolean();
     private final AtomicInteger nextInputThreadIndex = new AtomicInteger();
     private final AtomicInteger nextOutputThreadIndex = new AtomicInteger();
     private final ILogger logger;
     private final MetricsRegistry metricsRegistry;
-    private final AtomicBoolean metricsRegistryScheduled = new AtomicBoolean(false);
     private final LoggingService loggingService;
     private final String threadNamePrefix;
     private final ChannelErrorHandler errorHandler;
     private final int balancerIntervalSeconds;
     private final int inputThreadCount;
     private final int outputThreadCount;
-    private final Set<NioChannel> channels = newSetFromMap(new ConcurrentHashMap<NioChannel, Boolean>());
+    private final Set<NioChannel> channels = newSetFromMap(new ConcurrentHashMap<>());
     private final ChannelCloseListener channelCloseListener = new ChannelCloseListenerImpl();
     private final SelectorMode selectorMode;
     private final BackoffIdleStrategy idleStrategy;
@@ -104,8 +105,9 @@ public final class NioNetworking implements Networking {
     private volatile IOBalancer ioBalancer;
     private volatile NioThread[] inputThreads;
     private volatile NioThread[] outputThreads;
+    private volatile ScheduledFuture publishFuture;
 
-    // Currently this is a course grained aggregation of the bytes/send reveived.
+    // Currently this is a course grained aggregation of the bytes/send received.
     // In the future you probably want to split this up in member and client and potentially
     // wan specific.
     @Probe
@@ -154,7 +156,11 @@ public final class NioNetworking implements Networking {
     }
 
     @Override
-    public void start() {
+    public void restart() {
+        if (!started.compareAndSet(false, true)) {
+            throw new IllegalStateException("Can't (re)start an already running NioNetworking");
+        }
+
         if (logger.isFineEnabled()) {
             logger.fine("TcpIpConnectionManager configured with Non Blocking IO-threading model: "
                     + inputThreadCount + " input threads and "
@@ -164,17 +170,12 @@ public final class NioNetworking implements Networking {
 
         logger.log(selectorMode != SELECT ? Level.INFO : FINE, "IO threads selector mode is " + selectorMode);
 
-        if (metricsRegistryScheduled.compareAndSet(false, true) && metricsRegistry.minimumLevel().isEnabled(ProbeLevel.DEBUG)) {
-            metricsRegistry.scheduleAtFixedRate(new PublishAllTask(), 1, SECONDS, ProbeLevel.INFO);
-        }
+        publishFuture = metricsRegistry.scheduleAtFixedRate(new PublishAllTask(), 1, SECONDS, ProbeLevel.INFO);
 
-        this.closeListenerExecutor = newSingleThreadExecutor(new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setName(threadNamePrefix + "-NioNetworking-closeListenerExecutor");
-                return t;
-            }
+        this.closeListenerExecutor = newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r);
+            t.setName(threadNamePrefix + "-NioNetworking-closeListenerExecutor");
+            return t;
         });
 
         NioThread[] inThreads = new NioThread[inputThreadCount];
@@ -220,6 +221,24 @@ public final class NioNetworking implements Networking {
 
     @Override
     public void shutdown() {
+        if (!started.compareAndSet(true, false)) {
+            return;
+        }
+
+        // if there are any channels left, we close them.
+        for (Channel channel : channels) {
+            if (!channel.isClosed()) {
+                closeResource(channel);
+            }
+        }
+        //and clear them to prevent memory leaks.
+        channels.clear();
+
+        // we unregister the publish future to prevent memory leaks.
+        if (publishFuture != null) {
+            publishFuture.cancel(false);
+            publishFuture = null;
+        }
         ioBalancer.stop();
 
         if (logger.isFinestEnabled()) {
@@ -231,6 +250,7 @@ public final class NioNetworking implements Networking {
         shutdown(outputThreads);
         outputThreads = null;
         closeListenerExecutor.shutdown();
+        closeListenerExecutor = null;
         metricsRegistry.deregister(ioBalancer);
     }
 
@@ -245,8 +265,14 @@ public final class NioNetworking implements Networking {
     }
 
     @Override
-    public Channel register(EndpointQualifier endpointQualifier, ChannelInitializerProvider channelInitializerProvider,
-                            SocketChannel socketChannel, boolean clientMode) throws IOException {
+    public Channel register(EndpointQualifier endpointQualifier,
+                            ChannelInitializerProvider channelInitializerProvider,
+                            SocketChannel socketChannel,
+                            boolean clientMode) throws IOException {
+        if (!started.get()) {
+            throw new IllegalArgumentException("Can't register a channel when networking isn't started");
+        }
+
         ChannelInitializer initializer = channelInitializerProvider.provide(endpointQualifier);
         assert initializer != null : "Found NULL channel initializer for endpoint-qualifier " + endpointQualifier;
         NioChannel channel = new NioChannel(socketChannel, clientMode, initializer, metricsRegistry, closeListenerExecutor);
@@ -302,11 +328,8 @@ public final class NioNetworking implements Networking {
         @Override
         public void onClose(Channel channel) {
             NioChannel nioChannel = (NioChannel) channel;
-
             channels.remove(channel);
-
             ioBalancer.channelRemoved(nioChannel.inboundPipeline(), nioChannel.outboundPipeline());
-
             metricsRegistry.deregister(nioChannel.inboundPipeline());
             metricsRegistry.deregister(nioChannel.outboundPipeline());
         }
@@ -317,26 +340,16 @@ public final class NioNetworking implements Networking {
         @Override
         public void run() {
             for (NioChannel channel : channels) {
-                final NioInboundPipeline inboundPipeline = channel.inboundPipeline;
+                NioInboundPipeline inboundPipeline = channel.inboundPipeline;
                 NioThread inputThread = inboundPipeline.owner();
                 if (inputThread != null) {
-                    inputThread.addTaskAndWakeup(new Runnable() {
-                        @Override
-                        public void run() {
-                            inboundPipeline.publishMetrics();
-                        }
-                    });
+                    inputThread.addTaskAndWakeup(inboundPipeline::publishMetrics);
                 }
 
-                final NioOutboundPipeline outboundPipeline = channel.outboundPipeline;
+                NioOutboundPipeline outboundPipeline = channel.outboundPipeline;
                 NioThread outputThread = outboundPipeline.owner();
                 if (outputThread != null) {
-                    outputThread.addTaskAndWakeup(new Runnable() {
-                        @Override
-                        public void run() {
-                            outboundPipeline.publishMetrics();
-                        }
-                    });
+                    outputThread.addTaskAndWakeup(outboundPipeline::publishMetrics);
                 }
             }
 

--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpNetworkingService.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpNetworkingService.java
@@ -173,7 +173,7 @@ public class TcpIpNetworkingService
         live = true;
         logger.finest("Starting Networking Service and IO selectors.");
 
-        networking.start();
+        networking.restart();
         startAcceptor();
     }
 


### PR DESCRIPTION
Networking.start has been renamed to restart to make it obvious
that it can be used for restarting an already shutdown Networking
instance.

Added a flag to prevent starting an already started NioNetworking instance.

Added documentation to the NioNetworking about its abilities to deal
with restarting.

The publish all task (source of OOME) now cancels the scheduled future
when the networking is restarted. So instead of keeping the same task
registered, we unschedule the task and then reschedule it when networking
restarts. So now this unscheduling/rescheduling is in line with the
other components that get shutdown/restarted.