### PR TITLE
Restored NioNetworking metrics.

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/networking/nio/NioNetworking.java
@@ -126,6 +126,7 @@ public final class NioNetworking implements Networking {
         this.selectorMode = ctx.selectorMode;
         this.selectorWorkaroundTest = ctx.selectorWorkaroundTest;
         this.idleStrategy = ctx.idleStrategy;
+        metricsRegistry.scanAndRegister(this, "tcp");
     }
 
     @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "used only for testing")


### PR DESCRIPTION
Someone by accident has removed this line and therefor
we don't get NioNetworking level metrics.

https://github.com/hazelcast/hazelcast/pull/14755