### PR TITLE
Upgrade checkstyle version

### DIFF
--- a/checkstyle/ClassHeader.txt
+++ b/checkstyle/ClassHeader.txt
@@ -13,4 +13,3 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -107,9 +107,6 @@
     </module>
 
     <module name="TreeWalker">
-        <!-- Activate comment suppression filters -->
-        <module name="FileContentsHolder"/>
-
         <!-- Needed for SuppressWarningsFilter to work -->
         <module name="SuppressWarningsHolder"/>
 
@@ -215,7 +212,8 @@
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->
         <module name="ModifierOrder"/>
-        <module name="RedundantModifier"/>
+        <!-- TODO add me back -->
+        <!--<module name="RedundantModifier"/>-->
 
         <!-- Checks for blocks. You know, those {}'s         -->
         <!-- See http://checkstyle.sf.net/config_blocks.html -->
@@ -252,6 +250,7 @@
         <module name="InnerAssignment"/>
         <module name="ReturnCount">
             <property name="max" value="8"/>
+            <property name="maxForVoid" value="8"/>
         </module>
         <module name="NestedIfDepth">
             <property name="max" value="2"/>
@@ -292,14 +291,20 @@
             <property name="max" value="15"/>
         </module>
         <module name="ClassFanOutComplexity">
-            <property name="max" value="40"/>
+            <!-- TODO figure out why this needed an increase -->
+            <property name="max" value="42"/>
         </module>
         <module name="CyclomaticComplexity">
             <property name="severity" value="error"/>
             <property name="max" value="12"/>
         </module>
         <module name="NPathComplexity">
-            <property name="max" value="50"/>
+            <!-- TODO Agree on the value
+                 Checkstyle 7.7 improved the NPath algorithm further that leads to higher NPath counts.
+                 7.6 passes with max 50, 7.7 needs it to be set to at least 216
+                 the default threshold is 200
+            -->
+            <property name="max" value="250"/>
         </module>
 
         <!-- Miscellaneous other checks.                   -->

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -290,8 +290,7 @@
             <property name="max" value="15"/>
         </module>
         <module name="ClassFanOutComplexity">
-            <!-- TODO figure out why this needed an increase -->
-            <property name="max" value="42"/>
+            <property name="max" value="40"/>
         </module>
         <module name="CyclomaticComplexity">
             <property name="severity" value="error"/>

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -212,8 +212,7 @@
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->
         <module name="ModifierOrder"/>
-        <!-- TODO add me back -->
-        <!--<module name="RedundantModifier"/>-->
+        <module name="RedundantModifier"/>
 
         <!-- Checks for blocks. You know, those {}'s         -->
         <!-- See http://checkstyle.sf.net/config_blocks.html -->

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -269,8 +269,6 @@
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]recordstore[\\/]RecordStore"/>
     <suppress checks="MethodCount"
               files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]recordstore[\\/]AbstractEvictableRecordStore"/>
-    <suppress checks="MethodCount|ClassFanOutComplexity"
-              files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]recordstore[\\/]DefaultRecordStore"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]recordstore[\\/]AbstractRecordStore"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]proxy[\\/]MapProxyImpl"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]proxy[\\/]MapProxySupport"/>
@@ -297,12 +295,6 @@
     <suppress checks="NPathComplexity|CyclomaticComplexity"
               files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]querycache[\\/]event[\\/]DefaultQueryCacheEventData"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]query[\\/]MapQueryEngineImpl"/>
-
-    <!--TransacionalMap-->
-    <suppress checks="ClassFanOutComplexity" files="com[\\/]hazelcast[\\/]replicatedmap[\\/]impl[\\/]ReplicatedMapService"/>
-
-    <!--CP subsystem-->
-    <suppress checks="ClassFanOutComplexity" files="com[\\/]hazelcast[\\/]cp[\\/]internal[\\/]MetadataRaftGroupManager"/>
 
     <!-- PhoneHome -->
     <suppress checks="NPathComplexity" files="com[\\/]hazelcast[\\/]util[\\/]PhoneHome"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -269,7 +269,8 @@
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]recordstore[\\/]RecordStore"/>
     <suppress checks="MethodCount"
               files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]recordstore[\\/]AbstractEvictableRecordStore"/>
-    <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]recordstore[\\/]DefaultRecordStore"/>
+    <suppress checks="MethodCount|ClassFanOutComplexity"
+              files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]recordstore[\\/]DefaultRecordStore"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]recordstore[\\/]AbstractRecordStore"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]proxy[\\/]MapProxyImpl"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]proxy[\\/]MapProxySupport"/>
@@ -296,6 +297,12 @@
     <suppress checks="NPathComplexity|CyclomaticComplexity"
               files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]querycache[\\/]event[\\/]DefaultQueryCacheEventData"/>
     <suppress checks="MethodCount" files="com[\\/]hazelcast[\\/]map[\\/]impl[\\/]query[\\/]MapQueryEngineImpl"/>
+
+    <!--TransacionalMap-->
+    <suppress checks="ClassFanOutComplexity" files="com[\\/]hazelcast[\\/]replicatedmap[\\/]impl[\\/]ReplicatedMapService"/>
+
+    <!--CP subsystem-->
+    <suppress checks="ClassFanOutComplexity" files="com[\\/]hazelcast[\\/]cp[\\/]internal[\\/]MetadataRaftGroupManager"/>
 
     <!-- PhoneHome -->
     <suppress checks="NPathComplexity" files="com[\\/]hazelcast[\\/]util[\\/]PhoneHome"/>

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/HazelcastManifestTransformer.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/HazelcastManifestTransformer.java
@@ -124,41 +124,32 @@ public class HazelcastManifestTransformer extends ManifestResourceTransformer {
         close(inputStream);
     }
 
-    // TODO remove the explanatory comments
-    // How the calculation is done: http://checkstyle.sourceforge.net/config_metrics.html#NPathComplexity
-    // NP: 2 * 4 * 3 * 3 * 3 * 1 = 216
     private PackageDefinition findStrongerDefinition(PackageDefinition packageDefinition,
                                                      PackageDefinition oldPackageDefinition) {
         // if the override is a remove instruction skip all other tests
-        // NP: 1 + 1 + 0 = 2
         if (packageDefinition.removeImport) {
             return packageDefinition;
         }
 
         // if no old definition or new definition is required import we take the new one
-        // NP: 1 + 1 + 2 = 4
         if (oldPackageDefinition == null
                 || oldPackageDefinition.resolutionOptional && !packageDefinition.resolutionOptional) {
             return packageDefinition;
         }
 
         // if old definition was required import but new isn't we take the old one
-        // NP: 1 + 1 + 1 = 3
         if (!oldPackageDefinition.resolutionOptional && packageDefinition.resolutionOptional) {
             return oldPackageDefinition;
         }
 
-        // NP: 1 + 1 + 1 = 3
         if (oldPackageDefinition.version == null && packageDefinition.version != null) {
             return packageDefinition;
         }
 
-        // NP: 1 + 1 + 1 = 3
         if (oldPackageDefinition.version != null && packageDefinition.version == null) {
             return oldPackageDefinition;
         }
 
-        // NP: 1
         return oldPackageDefinition;
     }
 

--- a/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/HazelcastManifestTransformer.java
+++ b/hazelcast-build-utils/src/main/java/com/hazelcast/buildutils/HazelcastManifestTransformer.java
@@ -124,32 +124,41 @@ public class HazelcastManifestTransformer extends ManifestResourceTransformer {
         close(inputStream);
     }
 
+    // TODO remove the explanatory comments
+    // How the calculation is done: http://checkstyle.sourceforge.net/config_metrics.html#NPathComplexity
+    // NP: 2 * 4 * 3 * 3 * 3 * 1 = 216
     private PackageDefinition findStrongerDefinition(PackageDefinition packageDefinition,
                                                      PackageDefinition oldPackageDefinition) {
         // if the override is a remove instruction skip all other tests
+        // NP: 1 + 1 + 0 = 2
         if (packageDefinition.removeImport) {
             return packageDefinition;
         }
 
         // if no old definition or new definition is required import we take the new one
+        // NP: 1 + 1 + 2 = 4
         if (oldPackageDefinition == null
                 || oldPackageDefinition.resolutionOptional && !packageDefinition.resolutionOptional) {
             return packageDefinition;
         }
 
         // if old definition was required import but new isn't we take the old one
+        // NP: 1 + 1 + 1 = 3
         if (!oldPackageDefinition.resolutionOptional && packageDefinition.resolutionOptional) {
             return oldPackageDefinition;
         }
 
+        // NP: 1 + 1 + 1 = 3
         if (oldPackageDefinition.version == null && packageDefinition.version != null) {
             return packageDefinition;
         }
 
+        // NP: 1 + 1 + 1 = 3
         if (oldPackageDefinition.version != null && packageDefinition.version == null) {
             return oldPackageDefinition;
         }
 
+        // NP: 1
         return oldPackageDefinition;
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientManagedContext.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/HazelcastClientManagedContext.java
@@ -26,7 +26,7 @@ final class HazelcastClientManagedContext implements ManagedContext {
     private final ManagedContext externalContext;
     private final boolean hasExternalContext;
 
-    public HazelcastClientManagedContext(HazelcastClientInstanceImpl instance, ManagedContext externalContext) {
+    HazelcastClientManagedContext(HazelcastClientInstanceImpl instance, ManagedContext externalContext) {
         this.instance = instance;
         this.externalContext = externalContext;
         this.hasExternalContext = externalContext != null;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/querycache/subscriber/ClientQueryCacheEventService.java
@@ -292,8 +292,8 @@ public class ClientQueryCacheEventService implements QueryCacheEventService {
         private final long timeoutMs;
         private final SerializationService serializationService;
 
-        public EventDispatcher(Object event, ListenerInfo listenerInfo, int orderKey,
-                               SerializationService serializationService, long timeoutMs) {
+        EventDispatcher(Object event, ListenerInfo listenerInfo, int orderKey,
+                        SerializationService serializationService, long timeoutMs) {
             this.event = event;
             this.listenerInfo = listenerInfo;
             this.orderKey = orderKey;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientDurableExecutorServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientDurableExecutorServiceProxy.java
@@ -251,10 +251,10 @@ public final class ClientDurableExecutorServiceProxy extends ClientProxy impleme
 
         private final long taskId;
 
-        public ClientDurableExecutorServiceDelegatingFuture(ClientInvocationFuture clientInvocationFuture,
-                                                            SerializationService serializationService,
-                                                            ClientMessageDecoder clientMessageDecoder,
-                                                            T defaultValue, long taskId) {
+        ClientDurableExecutorServiceDelegatingFuture(ClientInvocationFuture clientInvocationFuture,
+                                                     SerializationService serializationService,
+                                                     ClientMessageDecoder clientMessageDecoder,
+                                                     T defaultValue, long taskId) {
             super(clientInvocationFuture, serializationService, clientMessageDecoder, defaultValue);
             this.taskId = taskId;
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
@@ -326,7 +326,7 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
 
         private final ItemListener<E> listener;
 
-        public ItemEventHandler(ItemListener<E> listener) {
+        ItemEventHandler(ItemListener<E> listener) {
             this.listener = listener;
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapReduceProxy.java
@@ -116,7 +116,7 @@ public class ClientMapReduceProxy
     private class ClientJob<KeyIn, ValueIn>
             extends AbstractJob<KeyIn, ValueIn> {
 
-        public ClientJob(String name, KeyValueSource<KeyIn, ValueIn> keyValueSource) {
+        ClientJob(String name, KeyValueSource<KeyIn, ValueIn> keyValueSource) {
             super(name, ClientMapReduceProxy.this, keyValueSource);
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMultiMapProxy.java
@@ -490,7 +490,7 @@ public class ClientMultiMapProxy<K, V> extends ClientProxy implements MultiMap<K
 
         private final ListenerAdapter listenerAdapter;
 
-        public ClientMultiMapEventHandler(ListenerAdapter listenerAdapter) {
+        ClientMultiMapEventHandler(ListenerAdapter listenerAdapter) {
             this.listenerAdapter = listenerAdapter;
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
@@ -110,7 +110,7 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
         private final boolean includeValue;
         private final ItemListener<E> listener;
 
-        public ItemEventHandler(boolean includeValue, ItemListener<E> listener) {
+        ItemEventHandler(boolean includeValue, ItemListener<E> listener) {
             this.includeValue = includeValue;
             this.listener = listener;
         }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
@@ -223,7 +223,7 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
 
         private final ItemListener<E> listener;
 
-        public ItemEventHandler(ItemListener<E> listener) {
+        ItemEventHandler(ItemListener<E> listener) {
             this.listener = listener;
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionServiceProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/PartitionServiceProxy.java
@@ -142,7 +142,7 @@ public final class PartitionServiceProxy implements PartitionService {
 
         private PartitionLostListener listener;
 
-        public ClientPartitionLostEventHandler(PartitionLostListener listener) {
+        ClientPartitionLostEventHandler(PartitionLostListener listener) {
             this.listener = listener;
         }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientMaxAllowedInvocationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientMaxAllowedInvocationTest.java
@@ -236,7 +236,7 @@ public class ClientMaxAllowedInvocationTest extends ClientTestSupport {
         final ILogger logger = Logger.getLogger(getClass());
         final CountDownLatch countDownLatch;
 
-        public SleepyCallback(CountDownLatch countDownLatch) {
+        SleepyCallback(CountDownLatch countDownLatch) {
             this.countDownLatch = countDownLatch;
         }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientRegressionWithMockNetworkTest.java
@@ -456,11 +456,11 @@ public class ClientRegressionWithMockNetworkTest extends HazelcastTestSupport {
 
         public int a;
 
-        public SamplePortable(int a) {
+        SamplePortable(int a) {
             this.a = a;
         }
 
-        public SamplePortable() {
+        SamplePortable() {
         }
 
         public int getFactoryId() {

--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientServiceTest.java
@@ -360,7 +360,7 @@ public class ClientServiceTest extends ClientTestSupport {
 
     static class ClientConnectedListenerLatch extends CountDownLatch implements ClientListener {
 
-        public ClientConnectedListenerLatch(int count) {
+        ClientConnectedListenerLatch(int count) {
             super(count);
         }
 
@@ -376,7 +376,7 @@ public class ClientServiceTest extends ClientTestSupport {
 
     static class ClientDisconnectedListenerLatch extends CountDownLatch implements ClientListener {
 
-        public ClientDisconnectedListenerLatch(int count) {
+        ClientDisconnectedListenerLatch(int count) {
             super(count);
         }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionLostListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/cache/ClientCachePartitionLostListenerTest.java
@@ -211,7 +211,7 @@ public class ClientCachePartitionLostListenerTest extends HazelcastTestSupport {
         private final List<CachePartitionLostEvent> events
                 = Collections.synchronizedList(new LinkedList<CachePartitionLostEvent>());
 
-        public EventCollectingCachePartitionLostListener() {
+        EventCollectingCachePartitionLostListener() {
         }
 
         @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutorServiceTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/durable/ClientDurableExecutorServiceTest.java
@@ -307,7 +307,7 @@ public class ClientDurableExecutorServiceTest {
 
         int counter;
 
-        public SerializedCounterCallable() {
+        SerializedCounterCallable() {
         }
 
         @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientConcurrentLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/lock/ClientConcurrentLockTest.java
@@ -87,7 +87,7 @@ public class ClientConcurrentLockTest {
     }
 
     static class TryLockThread extends LockTestThread {
-        public TryLockThread(ILock lock, AtomicInteger upTotal, AtomicInteger downTotal) {
+        TryLockThread(ILock lock, AtomicInteger upTotal, AtomicInteger downTotal) {
             super(lock, upTotal, downTotal);
         }
 
@@ -100,7 +100,7 @@ public class ClientConcurrentLockTest {
     }
 
     static class TryLockWithTimeOutThread extends LockTestThread {
-        public TryLockWithTimeOutThread(ILock lock, AtomicInteger upTotal, AtomicInteger downTotal) {
+        TryLockWithTimeOutThread(ILock lock, AtomicInteger upTotal, AtomicInteger downTotal) {
             super(lock, upTotal, downTotal);
         }
 
@@ -122,7 +122,7 @@ public class ClientConcurrentLockTest {
         protected final AtomicInteger upTotal;
         protected final AtomicInteger downTotal;
 
-        public LockTestThread(ILock lock, AtomicInteger upTotal, AtomicInteger downTotal) {
+        LockTestThread(ILock lock, AtomicInteger upTotal, AtomicInteger downTotal) {
             this.lock = lock;
             this.upTotal = upTotal;
             this.downTotal = downTotal;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryLoadedListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientEntryLoadedListenerTest.java
@@ -325,7 +325,7 @@ public class ClientEntryLoadedListenerTest extends HazelcastTestSupport {
         private final AtomicInteger loadEventCount;
         private final AtomicInteger addEventCount;
 
-        public LoadAndAddListener(AtomicInteger loadEventCount, AtomicInteger addEventCount) {
+        LoadAndAddListener(AtomicInteger loadEventCount, AtomicInteger addEventCount) {
             this.loadEventCount = loadEventCount;
             this.addEventCount = addEventCount;
         }
@@ -347,7 +347,7 @@ public class ClientEntryLoadedListenerTest extends HazelcastTestSupport {
         private final AtomicInteger loadEventCount;
         private final AtomicInteger updateEventCount;
 
-        public LoadAndUpdateListener(AtomicInteger loadEventCount, AtomicInteger updateEventCount) {
+        LoadAndUpdateListener(AtomicInteger loadEventCount, AtomicInteger updateEventCount) {
             this.loadEventCount = loadEventCount;
             this.updateEventCount = updateEventCount;
         }
@@ -367,7 +367,7 @@ public class ClientEntryLoadedListenerTest extends HazelcastTestSupport {
 
         private final AtomicInteger addEventCount;
 
-        public AddListener(AtomicInteger addEventCount) {
+        AddListener(AtomicInteger addEventCount) {
             this.addEventCount = addEventCount;
         }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapLockTest.java
@@ -655,7 +655,7 @@ public class ClientMapLockTest {
 
         public final String payload;
 
-        public LockEntryProcessor(String payload) {
+        LockEntryProcessor(String payload) {
             this.payload = payload;
         }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapProjectSerializationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapProjectSerializationTest.java
@@ -89,10 +89,10 @@ public class ClientMapProjectSerializationTest extends HazelcastTestSupport {
 
         private static AtomicInteger readCalled = new AtomicInteger(0);
 
-        public OnlyDeserializedTwiceObject() {
+        OnlyDeserializedTwiceObject() {
         }
 
-        public OnlyDeserializedTwiceObject(String value) {
+        OnlyDeserializedTwiceObject(String value) {
             this.value = value;
         }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTryLockConcurrentTests.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapTryLockConcurrentTests.java
@@ -96,7 +96,7 @@ public class ClientMapTryLockConcurrentTests {
 
     static class MapTryLockThread extends TestHelper {
 
-        public MapTryLockThread(IMap map, String upKey, String downKey) {
+        MapTryLockThread(IMap map, String upKey, String downKey) {
             super(map, upKey, downKey);
         }
 
@@ -119,7 +119,7 @@ public class ClientMapTryLockConcurrentTests {
 
     static class MapTryLockTimeOutThread extends TestHelper {
 
-        public MapTryLockTimeOutThread(IMap map, String upKey, String downKey) {
+        MapTryLockTimeOutThread(IMap map, String upKey, String downKey) {
             super(map, upKey, downKey);
         }
 
@@ -149,7 +149,7 @@ public class ClientMapTryLockConcurrentTests {
         protected final String upKey;
         protected final String downKey;
 
-        public TestHelper(IMap map, String upKey, String downKey) {
+        TestHelper(IMap map, String upKey, String downKey) {
             this.map = map;
             this.upKey = upKey;
             this.downKey = downKey;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPagingPredicateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPagingPredicateTest.java
@@ -498,10 +498,10 @@ public class ClientPagingPredicateTest extends HazelcastTestSupport {
         protected boolean active;
         protected double salary;
 
-        public BaseEmployee() {
+        BaseEmployee() {
         }
 
-        public BaseEmployee(int id) {
+        BaseEmployee(int id) {
             this.id = id;
             setAtributesRandomly();
         }
@@ -560,10 +560,10 @@ public class ClientPagingPredicateTest extends HazelcastTestSupport {
 
     private static class Employee extends BaseEmployee implements Comparable<Employee> {
 
-        public Employee() {
+        Employee() {
         }
 
-        public Employee(int id) {
+        Employee(int id) {
             super(id);
         }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPartitionPredicateTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientPartitionPredicateTest.java
@@ -209,7 +209,7 @@ public class ClientPartitionPredicateTest extends HazelcastTestSupport {
 
     static class MyProcessor extends AbstractEntryProcessor<String, Integer> {
 
-        public MyProcessor() {
+        MyProcessor() {
         }
 
         @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/listener/ClientExpirationListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/listener/ClientExpirationListenerTest.java
@@ -81,7 +81,7 @@ public class ClientExpirationListenerTest extends HazelcastTestSupport {
 
         private final CountDownLatch expirationEventCount;
 
-        public ExpirationListener(CountDownLatch expirationEventCount) {
+        ExpirationListener(CountDownLatch expirationEventCount) {
             this.expirationEventCount = expirationEventCount;
         }
 
@@ -122,7 +122,7 @@ public class ClientExpirationListenerTest extends HazelcastTestSupport {
         private final CountDownLatch expirationEventArrivalCount;
         private final CountDownLatch evictionEventArrivalCount;
 
-        public ExpirationAndEvictionListener(CountDownLatch expirationEventArrivalCount, CountDownLatch evictionEventArrivalCount) {
+        ExpirationAndEvictionListener(CountDownLatch expirationEventArrivalCount, CountDownLatch evictionEventArrivalCount) {
             this.expirationEventArrivalCount = expirationEventArrivalCount;
             this.evictionEventArrivalCount = evictionEventArrivalCount;
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenersTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapListenersTest.java
@@ -324,7 +324,7 @@ public class ClientMultiMapListenersTest {
         public final CountDownLatch evictLatch;
         public final CountDownLatch clearLatch;
 
-        public MyEntryListener(int latchCount) {
+        MyEntryListener(int latchCount) {
             addLatch = new CountDownLatch(latchCount);
             removeLatch = new CountDownLatch(latchCount);
             updateLatch = new CountDownLatch(1);
@@ -332,7 +332,7 @@ public class ClientMultiMapListenersTest {
             clearLatch = new CountDownLatch(1);
         }
 
-        public MyEntryListener(int addlatchCount, int removeLatchCount) {
+        MyEntryListener(int addlatchCount, int removeLatchCount) {
             addLatch = new CountDownLatch(addlatchCount);
             removeLatch = new CountDownLatch(removeLatchCount);
             updateLatch = new CountDownLatch(1);
@@ -343,11 +343,11 @@ public class ClientMultiMapListenersTest {
 
     static class CountDownValueNotNullListener extends MyEntryListener {
 
-        public CountDownValueNotNullListener(int latchCount) {
+        CountDownValueNotNullListener(int latchCount) {
             super(latchCount);
         }
 
-        public CountDownValueNotNullListener(int addlatchCount, int removeLatchCount) {
+        CountDownValueNotNullListener(int addlatchCount, int removeLatchCount) {
             super(addlatchCount, removeLatchCount);
         }
 
@@ -387,11 +387,11 @@ public class ClientMultiMapListenersTest {
 
     static class CountDownValueNullListener extends MyEntryListener {
 
-        public CountDownValueNullListener(int latchCount) {
+        CountDownValueNullListener(int latchCount) {
             super(latchCount);
         }
 
-        public CountDownValueNullListener(int addlatchCount, int removeLatchCount) {
+        CountDownValueNullListener(int addlatchCount, int removeLatchCount) {
             super(addlatchCount, removeLatchCount);
         }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapLockTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/multimap/ClientMultiMapLockTest.java
@@ -130,7 +130,7 @@ public class ClientMultiMapLockTest extends HazelcastTestSupport {
         public MultiMap mm = null;
         public Object key = null;
 
-        public UnLockThread(MultiMap mm, Object key) {
+        UnLockThread(MultiMap mm, Object key) {
             this.mm = mm;
             this.key = key;
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapPutSerializationTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapPutSerializationTest.java
@@ -70,7 +70,7 @@ public class ClientReplicatedMapPutSerializationTest extends HazelcastTestSuppor
 
     static class SerializationCountingData implements DataSerializable {
 
-        public SerializationCountingData() {
+        SerializationCountingData() {
         }
 
         @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/semaphore/ClientSemaphoreThreadedTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/semaphore/ClientSemaphoreThreadedTest.java
@@ -94,7 +94,7 @@ public class ClientSemaphoreThreadedTest {
     }
 
     static class TrySemaphoreThread extends SemaphoreTestThread {
-        public TrySemaphoreThread(ISemaphore semaphore, AtomicInteger upTotal, AtomicInteger downTotal) {
+        TrySemaphoreThread(ISemaphore semaphore, AtomicInteger upTotal, AtomicInteger downTotal) {
             super(semaphore, upTotal, downTotal);
         }
 
@@ -107,7 +107,7 @@ public class ClientSemaphoreThreadedTest {
     }
 
     static class TrySemaphoreTimeOutThread extends SemaphoreTestThread {
-        public TrySemaphoreTimeOutThread(ISemaphore semaphore, AtomicInteger upTotal, AtomicInteger downTotal) {
+        TrySemaphoreTimeOutThread(ISemaphore semaphore, AtomicInteger upTotal, AtomicInteger downTotal) {
             super(semaphore, upTotal, downTotal);
         }
 
@@ -131,7 +131,7 @@ public class ClientSemaphoreThreadedTest {
 
         private final Random random = new Random();
 
-        public SemaphoreTestThread(ISemaphore semaphore, AtomicInteger upTotal, AtomicInteger downTotal) {
+        SemaphoreTestThread(ISemaphore semaphore, AtomicInteger upTotal, AtomicInteger downTotal) {
             this.semaphore = semaphore;
             this.upTotal = upTotal;
             this.downTotal = downTotal;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -602,8 +602,8 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         private final List<DiscoveryNode> discoveryNodes;
         private final DiscoveryNode discoveryNode;
 
-        public CollectingDiscoveryStrategy(DiscoveryNode discoveryNode, List<DiscoveryNode> discoveryNodes, ILogger logger,
-                                           Map<String, Comparable> properties) {
+        CollectingDiscoveryStrategy(DiscoveryNode discoveryNode, List<DiscoveryNode> discoveryNodes, ILogger logger,
+                                    Map<String, Comparable> properties) {
             super(logger, properties);
             this.discoveryNodes = discoveryNodes;
             this.discoveryNode = discoveryNode;
@@ -668,9 +668,9 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         private final List<DiscoveryNode> discoveryNodes;
         private final DiscoveryNode discoveryNode;
 
-        public LifecycleDiscoveryStrategy(CountDownLatch startLatch, CountDownLatch stopLatch,
-                                          DiscoveryNode discoveryNode, List<DiscoveryNode> discoveryNodes,
-                                          ILogger logger, Map<String, Comparable> properties) {
+        LifecycleDiscoveryStrategy(CountDownLatch startLatch, CountDownLatch stopLatch,
+                                   DiscoveryNode discoveryNode, List<DiscoveryNode> discoveryNodes,
+                                   ILogger logger, Map<String, Comparable> properties) {
             super(logger, properties);
             this.startLatch = startLatch;
             this.stopLatch = stopLatch;
@@ -716,7 +716,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
     }
 
     private static class NoMemberDiscoveryStrategy extends AbstractDiscoveryStrategy {
-        public NoMemberDiscoveryStrategy(ILogger logger, Map<String, Comparable> properties) {
+        NoMemberDiscoveryStrategy(ILogger logger, Map<String, Comparable> properties) {
             super(logger, properties);
         }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/topic/Issue7317Test.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/topic/Issue7317Test.java
@@ -81,7 +81,7 @@ public class Issue7317Test extends HazelcastTestSupport {
         private final CountDownLatch cdl;
         private long seq;
 
-        public Issue7317MessageListener(List<String> messages, CountDownLatch cdl) {
+        Issue7317MessageListener(List<String> messages, CountDownLatch cdl) {
             this.messages = messages;
             this.cdl = cdl;
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXAStressTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/ClientXAStressTest.java
@@ -100,7 +100,7 @@ public class ClientXAStressTest extends HazelcastTestSupport {
 
         int i;
 
-        public XATransactionRunnable(HazelcastXAResource xaResource, String name,
+        XATransactionRunnable(HazelcastXAResource xaResource, String name,
                                      ExecutorService executorServiceForCommit, int i) {
             this.xaResource = xaResource;
             this.name = name;

--- a/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/SampleIdentified.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/txn/serialization/SampleIdentified.java
@@ -29,10 +29,10 @@ class SampleIdentified implements IdentifiedDataSerializable {
 
     private int amount;
 
-    public SampleIdentified() {
+    SampleIdentified() {
     }
 
-    public SampleIdentified(int amount) {
+    SampleIdentified(int amount) {
         this.amount = amount;
     }
 

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/HazelcastConfigBeanDefinitionParser.java
@@ -115,12 +115,12 @@ import com.hazelcast.config.WanPublisherConfig;
 import com.hazelcast.config.WanReplicationConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.config.WanSyncConfig;
-import com.hazelcast.instance.EndpointQualifier;
-import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.config.cp.CPSemaphoreConfig;
 import com.hazelcast.config.cp.CPSubsystemConfig;
 import com.hazelcast.config.cp.FencedLockConfig;
 import com.hazelcast.config.cp.RaftAlgorithmConfig;
+import com.hazelcast.instance.EndpointQualifier;
+import com.hazelcast.instance.ProtocolType;
 import com.hazelcast.map.eviction.MapEvictionPolicy;
 import com.hazelcast.memory.MemorySize;
 import com.hazelcast.memory.MemoryUnit;
@@ -228,7 +228,7 @@ public class HazelcastConfigBeanDefinitionParser extends AbstractHazelcastBeanDe
         private boolean hasNetwork;
         private boolean hasAdvancedNetworkEnabled;
 
-        public SpringXmlConfigBuilder(ParserContext parserContext) {
+        SpringXmlConfigBuilder(ParserContext parserContext) {
             this.parserContext = parserContext;
             this.configBuilder = BeanDefinitionBuilder.rootBeanDefinition(Config.class);
             this.mapConfigManagedMap = createManagedMap("mapConfigs");

--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/TransactionContextHolder.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/TransactionContextHolder.java
@@ -31,7 +31,7 @@ class TransactionContextHolder {
     private final TransactionContext transactionContext;
     private boolean transactionActive;
 
-    public TransactionContextHolder(TransactionContext transactionContext) {
+    TransactionContextHolder(TransactionContext transactionContext) {
         this.transactionContext = transactionContext;
     }
 

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheNoReadTimeoutTest.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/cache/HazelcastCacheNoReadTimeoutTest.java
@@ -89,7 +89,7 @@ public class HazelcastCacheNoReadTimeoutTest extends HazelcastTestSupport {
 
         private final int delay;
 
-        public DelayIMapGetInterceptor(int delay) {
+        DelayIMapGetInterceptor(int delay) {
             this.delay = delay;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryCountResolver.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/CacheEntryCountResolver.java
@@ -31,7 +31,7 @@ public abstract class CacheEntryCountResolver {
 
         private final CacheContext cacheContext;
 
-        public CacheContextBackedEntryCountResolver(CacheContext cacheContext) {
+        CacheContextBackedEntryCountResolver(CacheContext cacheContext) {
             this.cacheContext = cacheContext;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/DeferredValue.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/DeferredValue.java
@@ -168,7 +168,7 @@ public final class DeferredValue<V> {
         private final SerializationService serializationService;
         private final Set<DeferredValue<V>> delegate;
 
-        public DeferredValueSet(SerializationService serializationService, Set<DeferredValue<V>> delegate) {
+        DeferredValueSet(SerializationService serializationService, Set<DeferredValue<V>> delegate) {
             this.serializationService = serializationService;
             this.delegate = delegate;
         }
@@ -210,7 +210,7 @@ public final class DeferredValue<V> {
         private final SerializationService serializationService;
         private final Iterator<DeferredValue<V>> iterator;
 
-        public DeferredValueIterator(SerializationService serializationService, Iterator<DeferredValue<V>> iterator) {
+        DeferredValueIterator(SerializationService serializationService, Iterator<DeferredValue<V>> iterator) {
             this.serializationService = serializationService;
             this.iterator = iterator;
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheCreateConfigOperation.java
@@ -134,7 +134,7 @@ public class CacheCreateConfigOperation
         final AtomicInteger counter;
         final CacheCreateConfigOperation operation;
 
-        public CacheConfigCreateCallback(CacheCreateConfigOperation op, int count) {
+        CacheConfigCreateCallback(CacheCreateConfigOperation op, int count) {
             this.operation = op;
             this.counter = new AtomicInteger(count);
         }

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/record/CacheRecordHashMap.java
@@ -124,7 +124,7 @@ public class CacheRecordHashMap
             extends SamplingEntry<Data, CacheRecord>
             implements EvictionCandidate, CacheEntryView {
 
-        public CacheEvictableSamplingEntry(Data key, CacheRecord value) {
+        CacheEvictableSamplingEntry(Data key, CacheRecord value) {
             super(key, value);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -731,7 +731,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
 
         private final MessageTask task;
 
-        public PriorityPartitionSpecificRunnable(MessageTask task) {
+        PriorityPartitionSpecificRunnable(MessageTask task) {
             this.task = task;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddMembershipListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AddMembershipListenerMessageTask.java
@@ -93,7 +93,7 @@ public class AddMembershipListenerMessageTask
         private final ClientEndpoint endpoint;
         private final boolean advancedNetworkConfigEnabled;
 
-        public MembershipListenerImpl(ClientEndpoint endpoint, boolean advancedNetworkConfigEnabled) {
+        MembershipListenerImpl(ClientEndpoint endpoint, boolean advancedNetworkConfigEnabled) {
             this.endpoint = endpoint;
             this.advancedNetworkConfigEnabled = advancedNetworkConfigEnabled;
         }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheAllPartitionsTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/cache/AbstractCacheAllPartitionsTask.java
@@ -34,7 +34,7 @@ import java.security.Permission;
 abstract class AbstractCacheAllPartitionsTask<P>
         extends AbstractAllPartitionsMessageTask<P> {
 
-    public AbstractCacheAllPartitionsTask(ClientMessage clientMessage, Node node, Connection connection) {
+    AbstractCacheAllPartitionsTask(ClientMessage clientMessage, Node node, Connection connection) {
         super(clientMessage, node, connection);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/AndMemberSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/AndMemberSelector.java
@@ -27,7 +27,7 @@ class AndMemberSelector
 
     private final MemberSelector[] selectors;
 
-    public AndMemberSelector(MemberSelector... selectors) {
+    AndMemberSelector(MemberSelector... selectors) {
         this.selectors = selectors;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/OrMemberSelector.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/memberselector/OrMemberSelector.java
@@ -26,7 +26,7 @@ class OrMemberSelector implements MemberSelector {
 
     private final MemberSelector[] selectors;
 
-    public OrMemberSelector(MemberSelector... selectors) {
+    OrMemberSelector(MemberSelector... selectors) {
         this.selectors = selectors;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionLogRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionLogRecordKey.java
@@ -22,7 +22,7 @@ class TransactionLogRecordKey {
 
     private final String name;
 
-    public TransactionLogRecordKey(long itemId, String name) {
+    TransactionLogRecordKey(long itemId, String name) {
         this.itemId = itemId;
         this.name = name;
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/BackupAwareCountDownLatchOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/countdownlatch/operations/BackupAwareCountDownLatchOperation.java
@@ -27,7 +27,7 @@ abstract class BackupAwareCountDownLatchOperation extends AbstractCountDownLatch
     protected BackupAwareCountDownLatchOperation() {
     }
 
-    public BackupAwareCountDownLatchOperation(String name) {
+    protected BackupAwareCountDownLatchOperation(String name) {
         super(name);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/ConditionImpl.java
@@ -43,7 +43,7 @@ final class ConditionImpl implements ICondition {
     private final ObjectNamespace namespace;
     private final String conditionId;
 
-    public ConditionImpl(LockProxy lockProxy, String id) {
+    ConditionImpl(LockProxy lockProxy, String id) {
         this.lockProxy = lockProxy;
         this.partitionId = lockProxy.getPartitionId();
         this.namespace = lockProxy.getNamespace();

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/LockResourceImpl.java
@@ -59,10 +59,10 @@ final class LockResourceImpl implements IdentifiedDataSerializable, LockResource
     // and incremented by 1 for each lock and extendLease operation
     private transient int version;
 
-    public LockResourceImpl() {
+    LockResourceImpl() {
     }
 
-    public LockResourceImpl(Data key, LockStoreImpl lockStore) {
+    LockResourceImpl(Data key, LockStoreImpl lockStore) {
         this.key = key;
         this.lockStore = lockStore;
     }

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/WaitersInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/WaitersInfo.java
@@ -34,10 +34,10 @@ final class WaitersInfo implements IdentifiedDataSerializable {
     private String conditionId;
     private Set<ConditionWaiter> waiters = SetUtil.createHashSet(INITIAL_WAITER_SIZE);
 
-    public WaitersInfo() {
+    WaitersInfo() {
     }
 
-    public WaitersInfo(String conditionId) {
+    WaitersInfo(String conditionId) {
         this.conditionId = conditionId;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseSignalOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/concurrent/lock/operations/BaseSignalOperation.java
@@ -30,10 +30,10 @@ abstract class BaseSignalOperation extends AbstractLockOperation {
     protected String conditionId;
     protected transient int awaitCount;
 
-    public BaseSignalOperation() {
+    BaseSignalOperation() {
     }
 
-    public BaseSignalOperation(ObjectNamespace namespace, Data key, long threadId, String conditionId, boolean all) {
+    BaseSignalOperation(ObjectNamespace namespace, Data key, long threadId, String conditionId, boolean all) {
         super(namespace, key, threadId);
         this.conditionId = conditionId;
         this.all = all;

--- a/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/NearCachePreloaderConfig.java
@@ -193,7 +193,7 @@ public class NearCachePreloaderConfig implements IdentifiedDataSerializable, Ser
     private static class NearCachePreloaderConfigReadOnly extends NearCachePreloaderConfig {
 
         @SuppressWarnings("unused")
-        public NearCachePreloaderConfigReadOnly() {
+        NearCachePreloaderConfigReadOnly() {
         }
 
         NearCachePreloaderConfigReadOnly(NearCachePreloaderConfig nearCachePreloaderConfig) {

--- a/hazelcast/src/main/java/com/hazelcast/config/PredicateConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/PredicateConfigReadOnly.java
@@ -26,7 +26,7 @@ import com.hazelcast.query.Predicate;
  */
 class PredicateConfigReadOnly extends PredicateConfig {
 
-    public PredicateConfigReadOnly(PredicateConfig config) {
+    PredicateConfigReadOnly(PredicateConfig config) {
         super(config);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/QueryCacheConfigReadOnly.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 class QueryCacheConfigReadOnly extends QueryCacheConfig {
 
-    public QueryCacheConfigReadOnly(QueryCacheConfig other) {
+    QueryCacheConfigReadOnly(QueryCacheConfig other) {
         super(other);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/ReplicatedMapConfigReadOnly.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ScheduledExecutorService;
  */
 class ReplicatedMapConfigReadOnly extends ReplicatedMapConfig {
 
-    public ReplicatedMapConfigReadOnly(ReplicatedMapConfig replicatedMapConfig) {
+    ReplicatedMapConfigReadOnly(ReplicatedMapConfig replicatedMapConfig) {
         super(replicatedMapConfig);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/RestEndpointGroup.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/RestEndpointGroup.java
@@ -52,7 +52,7 @@ public enum RestEndpointGroup {
 
     private final boolean enabledByDefault;
 
-    private RestEndpointGroup(boolean enabledByDefault) {
+    RestEndpointGroup(boolean enabledByDefault) {
         this.enabledByDefault = enabledByDefault;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/core/ItemEventType.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/ItemEventType.java
@@ -32,7 +32,7 @@ public enum ItemEventType {
 
     private int type;
 
-    private ItemEventType(final int type) {
+    ItemEventType(final int type) {
         this.type = type;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/MetadataRaftGroupManager.java
@@ -81,7 +81,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * Maintains the CP subsystem metadata, such as CP groups, active CP members,
  * leaving and joining CP members, etc.
  */
-@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classdataabstractioncoupling"})
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classdataabstractioncoupling", "checkstyle:classfanoutcomplexity"})
 public class MetadataRaftGroupManager implements SnapshotAwareService<MetadataRaftGroupSnapshot>  {
 
     public static final RaftGroupId INITIAL_METADATA_GROUP_ID = new RaftGroupId(METADATA_CP_GROUP_NAME, 0, 0);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/operation/AbstractSemaphoreOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/operation/AbstractSemaphoreOp.java
@@ -40,7 +40,7 @@ abstract class AbstractSemaphoreOp extends RaftOp implements IdentifiedDataSeria
     protected long threadId;
     protected UUID invocationUid;
 
-    public AbstractSemaphoreOp() {
+    AbstractSemaphoreOp() {
     }
 
     AbstractSemaphoreOp(String name, long sessionId, long threadId, UUID invocationUid) {

--- a/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/durableexecutor/impl/DurableExecutorServiceProxy.java
@@ -295,9 +295,9 @@ public class DurableExecutorServiceProxy extends AbstractDistributedObject<Distr
 
         final long taskId;
 
-        public DurableExecutorServiceDelegateFuture(InternalCompletableFuture future,
-                                                    SerializationService serializationService,
-                                                    T defaultValue, long taskId) {
+        DurableExecutorServiceDelegateFuture(InternalCompletableFuture future,
+                                             SerializationService serializationService,
+                                             T defaultValue, long taskId) {
             super(future, serializationService, defaultValue);
             this.taskId = taskId;
         }

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/operations/AbstractCallableTaskOperation.java
@@ -38,10 +38,10 @@ abstract class AbstractCallableTaskOperation extends Operation implements NamedO
     protected String uuid;
     private Data callableData;
 
-    public AbstractCallableTaskOperation() {
+    AbstractCallableTaskOperation() {
     }
 
-    public AbstractCallableTaskOperation(String name, String uuid, Data callableData) {
+    AbstractCallableTaskOperation(String name, String uuid, Data callableData) {
         this.name = name;
         this.uuid = uuid;
         this.callableData = callableData;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainHandler.java
@@ -27,7 +27,7 @@ final class SplitBrainHandler implements Runnable {
     private final Node node;
     private final AtomicBoolean inProgress = new AtomicBoolean(false);
 
-    public SplitBrainHandler(Node node) {
+    SplitBrainHandler(Node node) {
         this.node = node;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/ConfigSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/ConfigSupplier.java
@@ -40,7 +40,7 @@ public interface ConfigSupplier<T extends IdentifiedDataSerializable> {
      * @return configuration if found, or <code>null</code>
      */
     @Nullable
-    T getDynamicConfig(@Nonnull final ConfigurationService configurationService, @Nonnull final String name);
+    T getDynamicConfig(@Nonnull ConfigurationService configurationService, @Nonnull String name);
 
     /**
      * Get static configuration for the given name
@@ -50,12 +50,12 @@ public interface ConfigSupplier<T extends IdentifiedDataSerializable> {
      * @return configuration if found, or <code>null</code>
      */
     @Nullable
-    T getStaticConfig(@Nonnull final Config staticConfig, @Nonnull final String name);
+    T getStaticConfig(@Nonnull Config staticConfig, @Nonnull String name);
 
     /**
      * Get all static configs for the given config type.
      * @param staticConfig static config
      * @return name-to-config map
      */
-    Map<String, T> getStaticConfigs(@Nonnull final Config staticConfig);
+    Map<String, T> getStaticConfigs(@Nonnull Config staticConfig);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/Searcher.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/dynamicconfig/search/Searcher.java
@@ -36,5 +36,5 @@ public interface Searcher<T extends IdentifiedDataSerializable> {
      * @return configuration for <code>name</code> or fallback config for <code>fallbackName</code>. If neither is
      * found, <code>null</code> is returned.
      */
-    T getConfig(@Nonnull final String name, final String fallbackName, @Nonnull final ConfigSupplier<T> configSupplier);
+    T getConfig(@Nonnull String name, String fallbackName, @Nonnull ConfigSupplier<T> configSupplier);
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/eviction/CompositeEvictionChecker.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/eviction/CompositeEvictionChecker.java
@@ -34,7 +34,7 @@ public abstract class CompositeEvictionChecker
     /**
      * Operator for composing results of given {@link EvictionChecker} instances.
      */
-    public static enum CompositionOperator {
+    public enum CompositionOperator {
 
         /**
          * Result is <tt>true</tt> if results of <b>all</b> given {@link EvictionChecker} instances

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/HazelcastMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/HazelcastMBean.java
@@ -194,7 +194,7 @@ public abstract class HazelcastMBean<T> implements DynamicMBean, MBeanRegistrati
         final String description;
         transient Method method;
 
-        public BeanInfo(String name, String description, Method method) {
+        BeanInfo(String name, String description, Method method) {
             this.name = name;
             this.description = description;
             this.method = method;

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ConsoleCommandHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ConsoleCommandHandler.java
@@ -72,7 +72,7 @@ public class ConsoleCommandHandler {
      * Wrapper for {@link com.hazelcast.console.ConsoleApp}
      */
     private class ConsoleHandlerApp extends ConsoleApp {
-        public ConsoleHandlerApp(HazelcastInstance hazelcast) {
+        ConsoleHandlerApp(HazelcastInstance hazelcast) {
             super(hazelcast);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -734,7 +734,7 @@ public class ManagementCenterService {
             private final int taskId;
             private final ConsoleRequest task;
 
-            public AsyncConsoleRequestTask(int taskId, ConsoleRequest task) {
+            AsyncConsoleRequestTask(int taskId, ConsoleRequest task) {
                 this.taskId = taskId;
                 this.task = task;
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/FieldProbe.java
@@ -85,7 +85,7 @@ abstract class FieldProbe implements ProbeFunction {
 
     static class LongFieldProbe<S> extends FieldProbe implements LongProbeFunction<S> {
 
-        public LongFieldProbe(Field field, Probe probe, int type) {
+        LongFieldProbe(Field field, Probe probe, int type) {
             super(field, probe, type);
         }
 
@@ -117,7 +117,7 @@ abstract class FieldProbe implements ProbeFunction {
 
     static class DoubleFieldProbe<S> extends FieldProbe implements DoubleProbeFunction<S> {
 
-        public DoubleFieldProbe(Field field, Probe probe, int type) {
+        DoubleFieldProbe(Field field, Probe probe, int type) {
             super(field, probe, type);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MethodProbe.java
@@ -96,7 +96,7 @@ abstract class MethodProbe implements ProbeFunction {
 
     static class LongMethodProbe<S> extends MethodProbe implements LongProbeFunction<S> {
 
-        public LongMethodProbe(Method method, Probe probe, int type) {
+        LongMethodProbe(Method method, Probe probe, int type) {
             super(method, probe, type);
         }
 
@@ -128,7 +128,7 @@ abstract class MethodProbe implements ProbeFunction {
 
     static class DoubleMethodProbe<S> extends MethodProbe implements DoubleProbeFunction<S> {
 
-        public DoubleMethodProbe(Method method, Probe probe, int type) {
+        DoubleMethodProbe(Method method, Probe probe, int type) {
             super(method, probe, type);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/DefaultNearCacheManager.java
@@ -199,7 +199,7 @@ public class DefaultNearCacheManager implements NearCacheManager {
         private final long started = System.currentTimeMillis();
         private final NearCachePreloaderConfig preloaderConfig;
 
-        public StorageTask(NearCachePreloaderConfig preloaderConfig) {
+        StorageTask(NearCachePreloaderConfig preloaderConfig) {
             this.preloaderConfig = preloaderConfig;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationListenerAdapter.java
@@ -28,7 +28,7 @@ class MigrationListenerAdapter implements PartitionEventListener<MigrationEvent>
 
     private final MigrationListener migrationListener;
 
-    public MigrationListenerAdapter(MigrationListener migrationListener) {
+    MigrationListenerAdapter(MigrationListener migrationListener) {
         this.migrationListener = migrationListener;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionLostListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionLostListenerAdapter.java
@@ -26,7 +26,7 @@ class PartitionLostListenerAdapter implements PartitionEventListener<PartitionLo
 
     private final PartitionLostListener listener;
 
-    public PartitionLostListenerAdapter(PartitionLostListener listener) {
+    PartitionLostListenerAdapter(PartitionLostListener listener) {
         this.listener = listener;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
@@ -39,7 +39,7 @@ final class BeforePromotionOperation extends AbstractPromotionOperation {
      * This constructor should not be used to obtain an instance of this class; it exists to fulfill IdentifiedDataSerializable
      * coding conventions.
      */
-    public BeforePromotionOperation() {
+    BeforePromotionOperation() {
         super(null);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
@@ -50,7 +50,7 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
      * This constructor should not be used to obtain an instance of this class; it exists to fulfill IdentifiedDataSerializable
      * coding conventions.
      */
-    public FinalizePromotionOperation() {
+    FinalizePromotionOperation() {
         super(null);
         success = false;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayInputOutputFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayInputOutputFactory.java
@@ -28,7 +28,7 @@ final class ByteArrayInputOutputFactory implements InputOutputFactory {
 
     private final ByteOrder byteOrder;
 
-    public ByteArrayInputOutputFactory(ByteOrder byteOrder) {
+    ByteArrayInputOutputFactory(ByteOrder byteOrder) {
         this.byteOrder = byteOrder;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataOutput.java
@@ -409,7 +409,7 @@ class ByteArrayObjectDataOutput extends VersionedObjectDataOutput implements Buf
     }
 
     @Override
-    public byte toByteArray()[] {
+    public byte[] toByteArray() {
         return toByteArray(0);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/ByteArraySerializerAdapter.java
@@ -29,7 +29,7 @@ class ByteArraySerializerAdapter implements SerializerAdapter {
 
     protected final ByteArraySerializer serializer;
 
-    public ByteArraySerializerAdapter(ByteArraySerializer serializer) {
+    ByteArraySerializerAdapter(ByteArraySerializer serializer) {
         this.serializer = serializer;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/StreamSerializerAdapter.java
@@ -32,7 +32,7 @@ class StreamSerializerAdapter implements SerializerAdapter {
     protected final InternalSerializationService service;
     protected final StreamSerializer serializer;
 
-    public StreamSerializerAdapter(InternalSerializationService service, StreamSerializer serializer) {
+    StreamSerializerAdapter(InternalSerializationService service, StreamSerializer serializer) {
         this.service = service;
         this.serializer = serializer;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/AmbigiousInstantiationException.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/AmbigiousInstantiationException.java
@@ -23,7 +23,7 @@ import com.hazelcast.core.HazelcastException;
  *
  */
 final class AmbigiousInstantiationException extends HazelcastException {
-    public AmbigiousInstantiationException(String message) {
+    AmbigiousInstantiationException(String message) {
         super(message);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/logging/StandardLoggerFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/logging/StandardLoggerFactory.java
@@ -31,7 +31,7 @@ public class StandardLoggerFactory extends LoggerFactorySupport implements Logge
     static class StandardLogger extends AbstractLogger {
         private final Logger logger;
 
-        public StandardLogger(Logger logger) {
+        StandardLogger(Logger logger) {
             this.logger = logger;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/DefaultMapServiceFactory.java
@@ -41,7 +41,7 @@ class DefaultMapServiceFactory extends AbstractMapServiceFactory {
     private final NodeEngine nodeEngine;
     private final MapServiceContext mapServiceContext;
 
-    public DefaultMapServiceFactory(NodeEngine nodeEngine, MapServiceContext mapServiceContext) {
+    DefaultMapServiceFactory(NodeEngine nodeEngine, MapServiceContext mapServiceContext) {
         this.nodeEngine = checkNotNull(nodeEngine, "nodeEngine should not be null");
         this.mapServiceContext = checkNotNull(mapServiceContext, "mapServiceContext should not be null");
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/InternalMapPartitionLostListenerAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/InternalMapPartitionLostListenerAdapter.java
@@ -31,7 +31,7 @@ class InternalMapPartitionLostListenerAdapter
 
     private final MapPartitionLostListener partitionLostListener;
 
-    public InternalMapPartitionLostListenerAdapter(MapPartitionLostListener partitionLostListener) {
+    InternalMapPartitionLostListenerAdapter(MapPartitionLostListener partitionLostListener) {
         this.partitionLostListener = partitionLostListener;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyEntryView.java
@@ -49,10 +49,10 @@ class LazyEntryView<K, V> implements EntryView<K, V> {
     private SerializationService serializationService;
     private MapMergePolicy mergePolicy;
 
-    public LazyEntryView() {
+    LazyEntryView() {
     }
 
-    public LazyEntryView(K key, V value, SerializationService serializationService, MapMergePolicy mergePolicy) {
+    LazyEntryView(K key, V value, SerializationService serializationService, MapMergePolicy mergePolicy) {
         this.value = value;
         this.key = key;
         this.serializationService = serializationService;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapClientAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapClientAwareService.java
@@ -30,7 +30,7 @@ class MapClientAwareService implements ClientAwareService {
 
     private final MapServiceContext mapServiceContext;
 
-    public MapClientAwareService(MapServiceContext mapServiceContext) {
+    MapClientAwareService(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapKeyLoaderUtil.java
@@ -163,7 +163,7 @@ public final class MapKeyLoaderUtil {
     private static class DataToEntry implements IFunction<Data, Entry<Integer, Data>> {
         private final IPartitionService partitionService;
 
-        public DataToEntry(IPartitionService partitionService) {
+        DataToEntry(IPartitionService partitionService) {
             this.partitionService = partitionService;
         }
 
@@ -172,7 +172,7 @@ public final class MapKeyLoaderUtil {
             // Null-pointer here, in case of null key loaded by MapLoader
             checkNotNull(input, "Key loaded by a MapLoader cannot be null.");
             Integer partition = partitionService.getPartitionId(input);
-            return new MapEntrySimple<Integer, Data>(partition, input);
+            return new MapEntrySimple<>(partition, input);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapPartitionAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapPartitionAwareService.java
@@ -38,7 +38,7 @@ class MapPartitionAwareService implements PartitionAwareService {
     private final NodeEngine nodeEngine;
     private final ProxyService proxyService;
 
-    public MapPartitionAwareService(MapServiceContext mapServiceContext) {
+    MapPartitionAwareService(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
         this.nodeEngine = mapServiceContext.getNodeEngine();
         this.proxyService = this.nodeEngine.getProxyService();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapPostJoinAwareService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapPostJoinAwareService.java
@@ -34,7 +34,7 @@ class MapPostJoinAwareService implements PostJoinAwareService {
 
     private final MapServiceContext mapServiceContext;
 
-    public MapPostJoinAwareService(MapServiceContext mapServiceContext) {
+    MapPostJoinAwareService(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
     }
 
@@ -52,7 +52,7 @@ class MapPostJoinAwareService implements PostJoinAwareService {
     }
 
     private List<AccumulatorInfo> getAccumulatorInfoList() {
-        List<AccumulatorInfo> infoList = new ArrayList<AccumulatorInfo>();
+        List<AccumulatorInfo> infoList = new ArrayList<>();
 
         PublisherContext publisherContext = mapServiceContext.getQueryCacheContext().getPublisherContext();
         MapPublisherRegistry mapPublisherRegistry = publisherContext.getMapPublisherRegistry();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapTransactionalService.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapTransactionalService.java
@@ -31,7 +31,7 @@ class MapTransactionalService implements TransactionalService {
     private final MapServiceContext mapServiceContext;
     private final NodeEngine nodeEngine;
 
-    public MapTransactionalService(MapServiceContext mapServiceContext) {
+    MapTransactionalService(MapServiceContext mapServiceContext) {
         this.mapServiceContext = mapServiceContext;
         this.nodeEngine = mapServiceContext.getNodeEngine();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/AbstractEventData.java
@@ -34,10 +34,10 @@ abstract class AbstractEventData implements EventData {
     protected Address caller;
     protected int eventType;
 
-    public AbstractEventData() {
+    AbstractEventData() {
     }
 
-    public AbstractEventData(String source, String mapName, Address caller, int eventType) {
+    AbstractEventData(String source, String mapName, Address caller, int eventType) {
         this.source = source;
         this.mapName = mapName;
         this.caller = caller;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CyclicWriteBehindQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/CyclicWriteBehindQueue.java
@@ -54,7 +54,7 @@ class CyclicWriteBehindQueue implements WriteBehindQueue<DelayedEntry> {
      */
     private final Map<Data, MutableInteger> index;
 
-    public CyclicWriteBehindQueue() {
+    CyclicWriteBehindQueue() {
         this.deque = new ArrayDeque<DelayedEntry>();
         this.index = new HashMap<Data, MutableInteger>();
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/AddedDelayedEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/AddedDelayedEntry.java
@@ -30,8 +30,7 @@ class AddedDelayedEntry<K, V> implements DelayedEntry<K, V> {
     private long storeTime;
     private long sequence;
 
-
-    public AddedDelayedEntry(K key, V value, long storeTime, int partitionId) {
+    AddedDelayedEntry(K key, V value, long storeTime, int partitionId) {
         this.key = key;
         this.storeTime = storeTime;
         this.partitionId = partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/DeletedDelayedEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/DeletedDelayedEntry.java
@@ -30,7 +30,7 @@ class DeletedDelayedEntry<K, V> implements DelayedEntry<K, V> {
     private long storeTime;
     private long sequence;
 
-    public DeletedDelayedEntry(K key, long storeTime, int partitionId) {
+    DeletedDelayedEntry(K key, long storeTime, int partitionId) {
         this.key = key;
         this.storeTime = storeTime;
         this.partitionId = partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/NullValueDelayedEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/mapstore/writebehind/entry/NullValueDelayedEntry.java
@@ -31,7 +31,7 @@ class NullValueDelayedEntry<K, V> implements DelayedEntry<K, V> {
 
     private final K key;
 
-    public NullValueDelayedEntry(K key) {
+    NullValueDelayedEntry(K key) {
         this.key = key;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AbstractMultipleEntryBackupOperation.java
@@ -28,10 +28,10 @@ abstract class AbstractMultipleEntryBackupOperation extends MapOperation impleme
 
     EntryBackupProcessor backupProcessor;
 
-    public AbstractMultipleEntryBackupOperation() {
+    AbstractMultipleEntryBackupOperation() {
     }
 
-    public AbstractMultipleEntryBackupOperation(String name, EntryBackupProcessor backupProcessor) {
+    AbstractMultipleEntryBackupOperation(String name, EntryBackupProcessor backupProcessor) {
         super(name);
         this.backupProcessor = backupProcessor;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AbstractAccumulator.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/accumulator/AbstractAccumulator.java
@@ -35,7 +35,7 @@ abstract class AbstractAccumulator<E extends Sequenced> implements Accumulator<E
     protected final CyclicBuffer<E> buffer;
     protected final PartitionSequencer partitionSequencer;
 
-    public AbstractAccumulator(QueryCacheContext context, AccumulatorInfo info) {
+    AbstractAccumulator(QueryCacheContext context, AccumulatorInfo info) {
         this.context = context;
         this.info = info;
         this.partitionSequencer = new DefaultPartitionSequencer();

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/AbstractInternalQueryCache.java
@@ -65,8 +65,8 @@ abstract class AbstractInternalQueryCache<K, V> implements InternalQueryCache<K,
      */
     protected volatile String publisherListenerId;
 
-    public AbstractInternalQueryCache(String cacheId, String cacheName, QueryCacheConfig queryCacheConfig,
-                                      IMap delegate, QueryCacheContext context) {
+    AbstractInternalQueryCache(String cacheId, String cacheName, QueryCacheConfig queryCacheConfig,
+                               IMap delegate, QueryCacheContext context) {
         this.cacheId = cacheId;
         this.cacheName = cacheName;
         this.queryCacheConfig = queryCacheConfig;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCache.java
@@ -75,8 +75,8 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 @SuppressWarnings("checkstyle:methodcount")
 class DefaultQueryCache<K, V> extends AbstractInternalQueryCache<K, V> {
 
-    public DefaultQueryCache(String cacheId, String cacheName, QueryCacheConfig queryCacheConfig,
-                             IMap delegate, QueryCacheContext context) {
+    DefaultQueryCache(String cacheId, String cacheName, QueryCacheConfig queryCacheConfig,
+                      IMap delegate, QueryCacheContext context) {
         super(cacheId, cacheName, queryCacheConfig, delegate, context);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/DefaultQueryCacheRecordStore.java
@@ -51,10 +51,10 @@ class DefaultQueryCacheRecordStore implements QueryCacheRecordStore {
     private final InternalSerializationService serializationService;
     private final Extractors extractors;
 
-    public DefaultQueryCacheRecordStore(InternalSerializationService serializationService,
-                                        Indexes indexes,
-                                        QueryCacheConfig config, EvictionListener listener,
-                                        Extractors extractors) {
+    DefaultQueryCacheRecordStore(InternalSerializationService serializationService,
+                                 Indexes indexes,
+                                 QueryCacheConfig config, EvictionListener listener,
+                                 Extractors extractors) {
         this.cache = new QueryCacheRecordHashMap(serializationService, DEFAULT_CACHE_CAPACITY);
         this.serializationService = serializationService;
         this.recordFactory = getRecordFactory(config.getInMemoryFormat());

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
@@ -47,7 +47,7 @@ class SubscriberAccumulatorHandler implements AccumulatorHandler<QueryCacheEvent
     private final AtomicReferenceArray<Queue<Integer>> clearAllRemovedCountHolders;
     private final AtomicReferenceArray<Queue<Integer>> evictAllRemovedCountHolders;
 
-    public SubscriberAccumulatorHandler(boolean includeValue, InternalQueryCache queryCache,
+    SubscriberAccumulatorHandler(boolean includeValue, InternalQueryCache queryCache,
                                         InternalSerializationService serializationService) {
         this.includeValue = includeValue;
         this.queryCache = queryCache;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/DataQueryCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/DataQueryCacheRecord.java
@@ -28,7 +28,7 @@ class DataQueryCacheRecord extends AbstractQueryCacheRecord {
 
     private final SerializationService serializationService;
 
-    public DataQueryCacheRecord(Data valueData, SerializationService serializationService) {
+    DataQueryCacheRecord(Data valueData, SerializationService serializationService) {
         this.valueData = valueData;
         this.serializationService = serializationService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/ObjectQueryCacheRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/record/ObjectQueryCacheRecord.java
@@ -26,7 +26,7 @@ class ObjectQueryCacheRecord extends AbstractQueryCacheRecord {
 
     private final Object value;
 
-    public ObjectQueryCacheRecord(Data valueData, SerializationService serializationService) {
+    ObjectQueryCacheRecord(Data valueData, SerializationService serializationService) {
         this.value = serializationService.toObject(valueData);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -84,6 +84,7 @@ import static java.util.Collections.emptyList;
 /**
  * Default implementation of record-store.
  */
+@SuppressWarnings({"checkstyle:methodcount", "checkstyle:classfanoutcomplexity"})
 public class DefaultRecordStore extends AbstractEvictableRecordStore {
 
     protected final ILogger logger;

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/aggregation/impl/SimpleEntry.java
@@ -33,7 +33,7 @@ final class SimpleEntry<K, V> extends QueryableEntry<K, V> {
     private K key;
     private V value;
 
-    public SimpleEntry() {
+    SimpleEntry() {
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceSimpleEntry.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/MapReduceSimpleEntry.java
@@ -33,11 +33,11 @@ class MapReduceSimpleEntry<K, V>
     private K key;
     private V value;
 
-    public MapReduceSimpleEntry() {
+    MapReduceSimpleEntry() {
         this(null, null);
     }
 
-    public MapReduceSimpleEntry(K key, V value) {
+    MapReduceSimpleEntry(K key, V value) {
         this.key = key;
         this.value = value;
     }

--- a/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
+++ b/hazelcast/src/main/java/com/hazelcast/mapreduce/impl/task/JobSupervisor.java
@@ -479,8 +479,8 @@ public class JobSupervisor {
         private final JobSupervisor jobSupervisor;
         private final TrackableJobFuture future;
 
-        public GetResultsRunnable(NodeEngine nodeEngine, GetResultOperationFactory operationFactory, String jobId,
-                                  JobSupervisor jobSupervisor, TrackableJobFuture future) {
+        GetResultsRunnable(NodeEngine nodeEngine, GetResultOperationFactory operationFactory, String jobId,
+                           JobSupervisor jobSupervisor, TrackableJobFuture future) {
             this.nodeEngine = nodeEngine;
             this.operationFactory = operationFactory;
             this.jobId = jobId;

--- a/hazelcast/src/main/java/com/hazelcast/monitor/impl/PartitionPerIndexStats.java
+++ b/hazelcast/src/main/java/com/hazelcast/monitor/impl/PartitionPerIndexStats.java
@@ -258,7 +258,7 @@ public class PartitionPerIndexStats implements PerIndexStats {
 
         private final MemoryAllocator delegate;
 
-        public MemoryAllocatorWithStats(MemoryAllocator delegate) {
+        MemoryAllocatorWithStats(MemoryAllocator delegate) {
             this.delegate = delegate;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionRecordKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/multimap/impl/txn/TransactionRecordKey.java
@@ -23,7 +23,7 @@ class TransactionRecordKey {
     final String name;
     final Data key;
 
-    public TransactionRecordKey(String name, Data key) {
+    TransactionRecordKey(String name, Data key) {
         this.name = name;
         this.key = key;
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
@@ -434,7 +434,8 @@ public final class ClassLoaderUtil {
         /**
          * Works as a marker for irresolvable constructors.
          */
-        IrresolvableConstructor() {
+        @SuppressWarnings("checkstyle:RedundantModifier")
+        public IrresolvableConstructor() {
             throw new UnsupportedOperationException("Irresolvable constructor should never be instantiated.");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/ClassLoaderUtil.java
@@ -434,7 +434,7 @@ public final class ClassLoaderUtil {
         /**
          * Works as a marker for irresolvable constructors.
          */
-        public IrresolvableConstructor() {
+        IrresolvableConstructor() {
             throw new UnsupportedOperationException("Irresolvable constructor should never be instantiated.");
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiInstanceImpl.java
@@ -74,8 +74,8 @@ class HazelcastOSGiInstanceImpl
     private final HazelcastInstance delegatedInstance;
     private final HazelcastOSGiService ownerService;
 
-    public HazelcastOSGiInstanceImpl(HazelcastInstance delegatedInstance,
-                                     HazelcastOSGiService ownerService) {
+    HazelcastOSGiInstanceImpl(HazelcastInstance delegatedInstance,
+                              HazelcastOSGiService ownerService) {
         this.delegatedInstance = delegatedInstance;
         this.ownerService = ownerService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/HazelcastOSGiServiceImpl.java
@@ -65,11 +65,11 @@ class HazelcastOSGiServiceImpl
     // it can be read from any thread without `synchronized` blocks and without `volatile` they may seen invalid value.
     private volatile HazelcastOSGiInstance hazelcastInstance;
 
-    public HazelcastOSGiServiceImpl(Bundle ownerBundle) {
+    HazelcastOSGiServiceImpl(Bundle ownerBundle) {
         this(ownerBundle, DEFAULT_ID);
     }
 
-    public HazelcastOSGiServiceImpl(Bundle ownerBundle, String id) {
+    HazelcastOSGiServiceImpl(Bundle ownerBundle, String id) {
         this.ownerBundle = ownerBundle;
         this.ownerBundleContext = ownerBundle.getBundleContext();
         this.id = id;

--- a/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngine.java
+++ b/hazelcast/src/main/java/com/hazelcast/osgi/impl/OSGiScriptEngine.java
@@ -36,7 +36,7 @@ class OSGiScriptEngine implements ScriptEngine {
     private ScriptEngine engine;
     private OSGiScriptEngineFactory factory;
 
-    public OSGiScriptEngine(ScriptEngine engine, OSGiScriptEngineFactory factory) {
+    OSGiScriptEngine(ScriptEngine engine, OSGiScriptEngineFactory factory) {
         this.engine = engine;
         this.factory = factory;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/Parser.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/Parser.java
@@ -79,7 +79,7 @@ class Parser {
     private static final String IN_UPPER = " IN ";
     private static final String IN_UPPER_P = " IN(";
 
-    public Parser() {
+    Parser() {
     }
 
     public List<String> toPrefix(String in) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/AttributeIndexRegistry.java
@@ -172,7 +172,7 @@ public class AttributeIndexRegistry {
 
         private final int width;
 
-        public FirstComponentDecorator(InternalIndex delegate) {
+        FirstComponentDecorator(InternalIndex delegate) {
             assert delegate.getComponents() != null;
             assert delegate.isOrdered();
             this.delegate = delegate;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/ConverterCache.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/ConverterCache.java
@@ -172,7 +172,7 @@ public final class ConverterCache {
         final InternalIndex index;
         final int component;
 
-        public UnresolvedConverter(InternalIndex index, int component) {
+        UnresolvedConverter(InternalIndex index, int component) {
             this.index = index;
             this.component = component;
         }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Getter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/Getter.java
@@ -23,7 +23,7 @@ package com.hazelcast.query.impl.getters;
 abstract class Getter {
     protected final Getter parent;
 
-    public Getter(final Getter parent) {
+    Getter(final Getter parent) {
         this.parent = parent;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/PortableGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/PortableGetter.java
@@ -28,7 +28,7 @@ final class PortableGetter extends Getter {
 
     private final InternalSerializationService serializationService;
 
-    public PortableGetter(InternalSerializationService serializationService) {
+    PortableGetter(InternalSerializationService serializationService) {
         super(null);
         this.serializationService = serializationService;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ThisGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/ThisGetter.java
@@ -19,7 +19,7 @@ package com.hazelcast.query.impl.getters;
 final class ThisGetter extends Getter {
     private final Object object;
 
-    public ThisGetter(final Getter parent, Object object) {
+    ThisGetter(final Getter parent, Object object) {
         super(parent);
         this.object = object;
     }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeIndexVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeIndexVisitor.java
@@ -396,7 +396,7 @@ public class CompositeIndexVisitor extends AbstractVisitor {
 
         private boolean requiresGeneration;
 
-        public Output(int capacity) {
+        Output(int capacity) {
             super(capacity);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RangeVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RangeVisitor.java
@@ -150,7 +150,7 @@ public class RangeVisitor extends AbstractVisitor {
 
         private int reduction;
 
-        public Ranges(int predicateCount) {
+        Ranges(int predicateCount) {
             super(predicateCount);
             this.rangesByPredicateIndex = new Range[predicateCount];
         }
@@ -235,7 +235,7 @@ public class RangeVisitor extends AbstractVisitor {
         private boolean intersected;
         private boolean generated;
 
-        public Range(RangePredicate predicate, TypeConverter converter) {
+        Range(RangePredicate predicate, TypeConverter converter) {
             this.attribute = predicate.getAttribute();
             this.converter = converter;
 

--- a/hazelcast/src/main/java/com/hazelcast/quorum/impl/MemberCountQuorumFunction.java
+++ b/hazelcast/src/main/java/com/hazelcast/quorum/impl/MemberCountQuorumFunction.java
@@ -25,7 +25,7 @@ class MemberCountQuorumFunction implements QuorumFunction {
 
     private final int quorumSize;
 
-    public MemberCountQuorumFunction(int quorumSize) {
+    MemberCountQuorumFunction(int quorumSize) {
         this.quorumSize = quorumSize;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapProxy.java
@@ -444,6 +444,11 @@ public class ReplicatedMapProxy<K, V> extends AbstractDistributedObject<Replicat
     }
 
     @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
     public String toString() {
         return getClass().getSimpleName() + " -> " + name;
     }

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/ReplicatedMapService.java
@@ -82,6 +82,7 @@ import static java.lang.Math.max;
  * This is the main service implementation to handle proxy creation, event publishing, migration, anti-entropy and
  * manages the backing {@link PartitionContainer}s that actually hold the data
  */
+@SuppressWarnings("checkstyle:classfanoutcomplexity")
 public class ReplicatedMapService implements ManagedService, RemoteService, EventPublishingService<Object, Object>,
         MigrationAwareService, SplitBrainHandlerService, StatisticsAwareService<LocalReplicatedMapStats>, QuorumAwareService {
 

--- a/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazyCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/replicatedmap/impl/record/LazyCollection.java
@@ -31,7 +31,7 @@ class LazyCollection<K, V> implements Collection<V> {
     private final IteratorFactory<K, V, V> iteratorFactory;
     private final Collection<ReplicatedRecord<K, V>> values;
 
-    public LazyCollection(IteratorFactory<K, V, V> iteratorFactory, InternalReplicatedMapStorage<K, V> storage) {
+    LazyCollection(IteratorFactory<K, V, V> iteratorFactory, InternalReplicatedMapStorage<K, V> storage) {
         this.iteratorFactory = iteratorFactory;
         this.values = storage.values();
         this.storage = storage;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/AbstractCompletableFuture.java
@@ -330,7 +330,7 @@ public abstract class AbstractCompletableFuture<V> implements ICompletableFuture
         private final ExecutionCallback<V> callback;
         private final ILogger logger;
 
-        public ExecutionCallbackRunnable(Class<?> caller, Object result, ExecutionCallback<V> callback, ILogger logger) {
+        ExecutionCallbackRunnable(Class<?> caller, Object result, ExecutionCallback<V> callback, ILogger logger) {
             this.caller = caller;
             this.result = result;
             this.callback = callback;

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/UnmodifiableLazyList.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/UnmodifiableLazyList.java
@@ -128,7 +128,7 @@ public class UnmodifiableLazyList<E> extends AbstractList<E> implements Identifi
 
         ListIterator listIterator;
 
-        public UnmodifiableLazyListIterator(ListIterator listIterator) {
+        UnmodifiableLazyListIterator(ListIterator listIterator) {
             this.listIterator = listIterator;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingCallableTaskDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingCallableTaskDecorator.java
@@ -38,7 +38,7 @@ class DelegatingCallableTaskDecorator<V>
      * @param callable Task to be executed
      * @param executor ExecutorService the task to be delegated to
      */
-    public DelegatingCallableTaskDecorator(Callable<V> callable, ExecutorService executor) {
+    DelegatingCallableTaskDecorator(Callable<V> callable, ExecutorService executor) {
         this.executor = executor;
         this.callable = callable;
     }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingTaskDecorator.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/executionservice/impl/DelegatingTaskDecorator.java
@@ -33,7 +33,7 @@ class DelegatingTaskDecorator implements Runnable {
      * @param runnable Task to be executed
      * @param executor Executor the task to be delegated to
      */
-    public DelegatingTaskDecorator(Runnable runnable, Executor executor) {
+    DelegatingTaskDecorator(Runnable runnable, Executor executor) {
         this.executor = executor;
         this.runnable = runnable;
     }

--- a/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
+++ b/hazelcast/src/main/java/com/hazelcast/topic/impl/TopicEvent.java
@@ -32,7 +32,7 @@ class TopicEvent implements IdentifiedDataSerializable {
     Address publisherAddress;
     Data data;
 
-    public TopicEvent() {
+    TopicEvent() {
     }
 
     TopicEvent(String name, Data data, Address publisherAddress) {

--- a/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/AddressUtil.java
@@ -593,7 +593,7 @@ public final class AddressUtil {
 
     static class Ip4AddressMatcher extends AddressMatcher {
 
-        public Ip4AddressMatcher() {
+        Ip4AddressMatcher() {
             // d.d.d.d
             super(new String[IPV4_LENGTH]);
         }
@@ -638,7 +638,7 @@ public final class AddressUtil {
 
     static class Ip6AddressMatcher extends AddressMatcher {
 
-        public Ip6AddressMatcher() {
+        Ip6AddressMatcher() {
             // x:x:x:x:x:x:x:x%s
             super(new String[IPV6_LENGTH]);
         }

--- a/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/SampleableConcurrentHashMap.java
@@ -136,6 +136,9 @@ public class SampleableConcurrentHashMap<K, V> extends ConcurrentReferenceHashMa
 
     /**
      * Entry to define keys and values for sampling.
+     *
+     * @param <K> type of key
+     * @param <V> type of value
      */
     public static class SamplingEntry<K, V> {
 

--- a/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/ServiceLoader.java
@@ -199,7 +199,7 @@ public final class ServiceLoader {
         private final String className;
         private final ClassLoader classLoader;
 
-        public ServiceDefinition(String className, ClassLoader classLoader) {
+        ServiceDefinition(String className, ClassLoader classLoader) {
             this.className = isNotNull(className, "className");
             this.classLoader = isNotNull(classLoader, "classLoader");
         }

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
@@ -466,8 +466,7 @@ public class Long2LongHashMap implements Map<Long, Long> {
     @SuppressFBWarnings(value = "PZ_DONT_REUSE_ENTRY_OBJECTS_IN_ITERATORS",
             justification = "deliberate, documented choice")
     private final class EntryIterator
-            extends AbstractIterator implements Iterator<Entry<Long, Long>>, Entry<Long, Long>
-    {
+            extends AbstractIterator implements Iterator<Entry<Long, Long>>, Entry<Long, Long> {
         private long key;
         private long value;
 

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/Long2LongHashMap.java
@@ -341,7 +341,7 @@ public class Long2LongHashMap implements Map<Long, Long> {
     private static class IteratorSupplier implements Supplier<Iterator<Long>> {
         private final LongIterator keyIterator;
 
-        public IteratorSupplier(LongIterator keyIterator) {
+        IteratorSupplier(LongIterator keyIterator) {
             this.keyIterator = keyIterator;
         }
 
@@ -354,7 +354,7 @@ public class Long2LongHashMap implements Map<Long, Long> {
     private static class EntryIteratorSupplier implements Supplier<Iterator<Entry<Long, Long>>> {
         private final EntryIterator entryIterator;
 
-        public EntryIteratorSupplier(EntryIterator entryIterator) {
+        EntryIteratorSupplier(EntryIterator entryIterator) {
             this.entryIterator = entryIterator;
         }
 
@@ -367,7 +367,7 @@ public class Long2LongHashMap implements Map<Long, Long> {
     private static class UnboxingBiConsumer implements LongLongConsumer {
         private final BiConsumer<? super Long, ? super Long> action;
 
-        public UnboxingBiConsumer(BiConsumer<? super Long, ? super Long> action) {
+        UnboxingBiConsumer(BiConsumer<? super Long, ? super Long> action) {
             this.action = action;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/util/collection/OAHashSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/collection/OAHashSet.java
@@ -351,6 +351,11 @@ public class OAHashSet<E> extends AbstractSet<E> {
         return hashCode;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
     private void increaseCapacity() {
         final int newCapacity = capacity << 1;
         if (newCapacity < 0) {

--- a/hazelcast/src/main/java/com/hazelcast/util/executor/SingleExecutorThreadFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/executor/SingleExecutorThreadFactory.java
@@ -32,7 +32,7 @@ public final class SingleExecutorThreadFactory extends AbstractExecutorThreadFac
 
     private class ManagedThread extends HazelcastManagedThread {
 
-        public ManagedThread(Runnable target) {
+        ManagedThread(Runnable target) {
             super(target, threadName);
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/util/scheduler/CompositeKey.java
+++ b/hazelcast/src/main/java/com/hazelcast/util/scheduler/CompositeKey.java
@@ -26,7 +26,7 @@ final class CompositeKey {
     private final Object key;
     private final long id;
 
-    public CompositeKey(Object key, long id) {
+    CompositeKey(Object key, long id) {
         this.key = key;
         this.id = id;
     }

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationPublisherDelegate.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanReplicationPublisherDelegate.java
@@ -30,7 +30,7 @@ final class WanReplicationPublisherDelegate
     final String name;
     final WanReplicationEndpoint[] endpoints;
 
-    public WanReplicationPublisherDelegate(String name, WanReplicationEndpoint[] endpoints) {
+    WanReplicationPublisherDelegate(String name, WanReplicationEndpoint[] endpoints) {
         this.name = name;
         this.endpoints = endpoints;
     }

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsPortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsPortableTest.java
@@ -139,7 +139,7 @@ public class AggregatorsPortableTest extends HazelcastTestSupport {
     private static class TestAggregator extends AbstractAggregator<Map.Entry<Integer, Car>, String, List<String>> {
         private List<String> accumulated = new ArrayList<String>();
 
-        public TestAggregator(String attribute) {
+        TestAggregator(String attribute) {
             super(attribute);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsTest.java
@@ -150,7 +150,7 @@ public class AggregatorsTest extends HazelcastTestSupport {
     private static class TestAggregator extends AbstractAggregator<Map.Entry<Integer, Car>, Long, List<Long>> {
         private List<Long> accumulated = new ArrayList<Long>();
 
-        public TestAggregator(String attribute) {
+        TestAggregator(String attribute) {
             super(attribute);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheEventListenerSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cache/merge/CacheEventListenerSplitBrainTest.java
@@ -181,7 +181,7 @@ public class CacheEventListenerSplitBrainTest extends SplitBrainTestSupport {
 
         public AtomicInteger updated = new AtomicInteger();
 
-        public TestCacheEntryUpdatedListener() {
+        TestCacheEntryUpdatedListener() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cardinality/CardinalityEstimatorAbstractTest.java
@@ -68,7 +68,7 @@ public abstract class CardinalityEstimatorAbstractTest extends HazelcastTestSupp
         estimator = local.getCardinalityEstimator(name);
     }
 
-    protected abstract HazelcastInstance[] newInstances(final Config config);
+    protected abstract HazelcastInstance[] newInstances(Config config);
 
     @Test
     public void estimate() {

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/operations/OperationFactoryWrapperTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/operations/OperationFactoryWrapperTest.java
@@ -65,7 +65,7 @@ public class OperationFactoryWrapperTest extends HazelcastTestSupport {
 
     private class GetCallersUUIDOperationFactory implements OperationFactory {
 
-        public GetCallersUUIDOperationFactory() {
+        GetCallersUUIDOperationFactory() {
         }
 
         @Override
@@ -96,7 +96,7 @@ public class OperationFactoryWrapperTest extends HazelcastTestSupport {
 
     private class GetCallersUUIDOperation extends Operation {
 
-        public GetCallersUUIDOperation() {
+        GetCallersUUIDOperation() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedDataSerializableFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/IdentifiedDataSerializableFactory.java
@@ -47,7 +47,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
 
     class SampleFailingTask implements Callable, IdentifiedDataSerializable {
 
-        public SampleFailingTask() {
+        SampleFailingTask() {
         }
 
         public int getFactoryId() {
@@ -73,7 +73,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
 
         private String name;
 
-        public SampleRunnableTask() {
+        SampleRunnableTask() {
         }
 
         public void run() {
@@ -101,7 +101,7 @@ public class IdentifiedDataSerializableFactory implements DataSerializableFactor
 
         private String param;
 
-        public SampleCallableTask() {
+        SampleCallableTask() {
         }
 
         public Object call() throws Exception {

--- a/hazelcast/src/test/java/com/hazelcast/client/test/PortableFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/test/PortableFactory.java
@@ -36,7 +36,7 @@ public class PortableFactory implements com.hazelcast.nio.serialization.Portable
 
         private String name;
 
-        public SampleRunnableTask() {
+        SampleRunnableTask() {
         }
 
         public void run() {

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/idgen/IdGeneratorStressTest.java
@@ -106,7 +106,7 @@ public class IdGeneratorStressTest extends HazelcastTestSupport {
 
         IdGenerator idGenerator;
 
-        public IdGeneratorCallable(IdGenerator idGenerator) {
+        IdGeneratorCallable(IdGenerator idGenerator) {
             this.idGenerator = idGenerator;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockAdvancedTest.java
@@ -545,10 +545,10 @@ public class LockAdvancedTest extends HazelcastTestSupport {
         ObjectNamespace ns;
         long sleepMillis;
 
-        public SlowLockOperation() {
+        SlowLockOperation() {
         }
 
-        public SlowLockOperation(String name, Data key, long sleepMillis) {
+        SlowLockOperation(String name, Data key, long sleepMillis) {
             this.key = key;
             this.ns = new InternalLockNamespace(name);
             this.sleepMillis = sleepMillis;

--- a/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableExecutorServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/durableexecutor/DurableExecutorServiceTest.java
@@ -580,10 +580,10 @@ public class DurableExecutorServiceTest extends ExecutorServiceTestSupport {
 
         String instanceName;
 
-        public InstanceAsserterRunnable() {
+        InstanceAsserterRunnable() {
         }
 
-        public InstanceAsserterRunnable(String instanceName) {
+        InstanceAsserterRunnable(String instanceName) {
             this.instanceName = instanceName;
         }
 
@@ -645,7 +645,7 @@ public class DurableExecutorServiceTest extends ExecutorServiceTestSupport {
 
         private HazelcastInstance instance;
 
-        public ICountDownLatchAwaitCallable(String name) {
+        ICountDownLatchAwaitCallable(String name) {
             this.name = name;
         }
 
@@ -666,7 +666,7 @@ public class DurableExecutorServiceTest extends ExecutorServiceTestSupport {
         static CountDownLatch startLatch;
         static CountDownLatch sleepLatch;
 
-        public SleepLatchRunnable() {
+        SleepLatchRunnable() {
             startLatch = new CountDownLatch(1);
             sleepLatch = new CountDownLatch(1);
         }

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCancelTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceCancelTest.java
@@ -159,7 +159,7 @@ public class ExecutorServiceCancelTest extends ExecutorServiceTestSupport {
         private long sleepSeconds;
         private HazelcastInstance hz;
 
-        public SleepingTask(long sleepSeconds, String taskStartedLatchName) {
+        SleepingTask(long sleepSeconds, String taskStartedLatchName) {
             this.sleepSeconds = sleepSeconds;
             this.taskStartedLatchName = taskStartedLatchName;
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/EventQueuePluginTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/diagnostics/EventQueuePluginTest.java
@@ -340,7 +340,7 @@ public class EventQueuePluginTest extends AbstractDiagnosticsPluginTest {
     private final class TestCacheListener
             implements CacheEntryCreatedListener<Integer, Integer>, CacheEntryRemovedListener<Integer, Integer>, Serializable {
 
-        public TestCacheListener() {
+        TestCacheListener() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSlowPreJoinBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigSlowPreJoinBouncingTest.java
@@ -43,7 +43,7 @@ public class DynamicConfigSlowPreJoinBouncingTest extends DynamicConfigBouncingT
 
         static final String SERVICE_NAME = "delaying-pre-join-op-prep-service";
 
-        public DelaysPreparingPreJoinOpService() {
+        DelaysPreparingPreJoinOpService() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/AbstractExpirationBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/AbstractExpirationBouncingMemberTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractExpirationBouncingMemberTest extends HazelcastTest
         private final AtomicInteger totalUnexpired = new AtomicInteger();
         private final AtomicReference<String> msgUnexpired = new AtomicReference();
 
-        public RemainingCacheSize(CountDownLatch latch) {
+        RemainingCacheSize(CountDownLatch latch) {
             this.latch = latch;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/CacheExpirationBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/CacheExpirationBouncingMemberTest.java
@@ -115,7 +115,7 @@ public class CacheExpirationBouncingMemberTest extends AbstractExpirationBouncin
 
         private final Cache<Integer, Integer> cache;
 
-        public Get(Cache cache) {
+        Get(Cache cache) {
             this.cache = cache;
         }
 
@@ -131,7 +131,7 @@ public class CacheExpirationBouncingMemberTest extends AbstractExpirationBouncin
 
         private final Cache<Integer, Integer> cache;
 
-        public Set(Cache cache) {
+        Set(Cache cache) {
             this.cache = cache;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/eviction/MapExpirationBouncingMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/eviction/MapExpirationBouncingMemberTest.java
@@ -109,7 +109,7 @@ public class MapExpirationBouncingMemberTest extends AbstractExpirationBouncingM
 
         private final IMap map;
 
-        public Get(IMap map) {
+        Get(IMap map) {
             this.map = map;
         }
 
@@ -125,7 +125,7 @@ public class MapExpirationBouncingMemberTest extends AbstractExpirationBouncingM
 
         private final IMap map;
 
-        public Set(IMap map) {
+        Set(IMap map) {
             this.map = map;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/jmx/LocalStatsDelegateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/jmx/LocalStatsDelegateTest.java
@@ -120,7 +120,7 @@ public class LocalStatsDelegateTest extends HazelcastTestSupport {
         private IMap map;
         private AtomicBoolean done;
 
-        public MapPutThread(IMap map, AtomicBoolean done) {
+        MapPutThread(IMap map, AtomicBoolean done) {
             this.map = map;
             this.done = done;
         }
@@ -144,13 +144,13 @@ public class LocalStatsDelegateTest extends HazelcastTestSupport {
 
         private int sleepMs;
 
-        public MapStatsThread(LocalStatsDelegate localMapStatsDelegate, AtomicBoolean done, int sleepMs) {
+        MapStatsThread(LocalStatsDelegate localMapStatsDelegate, AtomicBoolean done, int sleepMs) {
             this.localStatsDelegate = localMapStatsDelegate;
             this.done = done;
             this.sleepMs = sleepMs;
         }
 
-        public MapStatsThread(LocalStatsDelegate localMapStatsDelegate, AtomicBoolean done, boolean stress, int sleepMs) {
+        MapStatsThread(LocalStatsDelegate localMapStatsDelegate, AtomicBoolean done, boolean stress, int sleepMs) {
             this.localStatsDelegate = localMapStatsDelegate;
             this.done = done;
             this.stress = stress;

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalMigrationListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/InternalMigrationListenerTest.java
@@ -105,12 +105,12 @@ public class InternalMigrationListenerTest extends HazelcastTestSupport {
 
         final boolean success;
 
-        public MigrationProgressNotification(MigrationProgressEvent event, MigrationParticipant participant,
+        MigrationProgressNotification(MigrationProgressEvent event, MigrationParticipant participant,
                                              MigrationInfo migrationInfo) {
             this(event, participant, migrationInfo, true);
         }
 
-        public MigrationProgressNotification(MigrationProgressEvent event, MigrationParticipant participant,
+        MigrationProgressNotification(MigrationProgressEvent event, MigrationParticipant participant,
                                              MigrationInfo migrationInfo, boolean success) {
             this.event = event;
             this.participant = participant;

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitTest.java
@@ -786,7 +786,7 @@ public class MigrationCommitTest extends HazelcastTestSupport {
         private volatile boolean commit;
         private volatile HazelcastInstance instance;
 
-        public CollectMigrationTaskOnCommit(CountDownLatch migrationStartLatch) {
+        CollectMigrationTaskOnCommit(CountDownLatch migrationStartLatch) {
             this.migrationStartLatch = migrationStartLatch;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionListenerTest.java
@@ -138,7 +138,7 @@ public class PartitionListenerTest extends HazelcastTestSupport {
     private static class EventCountingPartitionListener implements PartitionListener {
         private final AtomicInteger count;
 
-        public EventCountingPartitionListener(AtomicInteger count) {
+        EventCountingPartitionListener(AtomicInteger count) {
             this.count = count;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateCheckerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/PartitionReplicaStateCheckerTest.java
@@ -256,7 +256,7 @@ public class PartitionReplicaStateCheckerTest extends HazelcastTestSupport {
 
     private static class TestPutOperationWithAsyncBackup extends TestPutOperation {
 
-        public TestPutOperationWithAsyncBackup() {
+        TestPutOperationWithAsyncBackup() {
         }
 
         TestPutOperationWithAsyncBackup(int i) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/AbstractSerializationServiceTest.java
@@ -419,7 +419,7 @@ public class AbstractSerializationServiceTest {
         int typeId = 100000;
         private boolean fail;
 
-        public StringBufferSerializer(boolean fail) {
+        StringBufferSerializer(boolean fail) {
             this.fail = fail;
         }
 
@@ -453,7 +453,7 @@ public class AbstractSerializationServiceTest {
 
     private class TheOtherGlobalSerializer extends StringBufferSerializer {
 
-        public TheOtherGlobalSerializer(boolean fail) {
+        TheOtherGlobalSerializer(boolean fail) {
             super(fail);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ByteArrayObjectDataInputIntegrationTest.java
@@ -60,10 +60,10 @@ public class ByteArrayObjectDataInputIntegrationTest {
         private Data data;
         private Object o;
 
-        public MyObject() {
+        MyObject() {
         }
 
-        public MyObject(Data data) {
+        MyObject(Data data) {
             this.data = data;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/serialization/impl/ObjectDataInputStreamFinalMethodsTest.java
@@ -344,7 +344,7 @@ public class ObjectDataInputStreamFinalMethodsTest {
 
     private class InitableByteArrayInputStream extends ByteArrayInputStream {
 
-        public InitableByteArrayInputStream(byte[] buf) {
+        InitableByteArrayInputStream(byte[] buf) {
             super(buf);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/logging/CustomLoggerFactorySingularityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/logging/CustomLoggerFactorySingularityTest.java
@@ -91,7 +91,7 @@ public class CustomLoggerFactorySingularityTest extends HazelcastTestSupport {
 
         public static volatile boolean singularityCheckFailed = false;
 
-        public CustomLoggerFactory() {
+        CustomLoggerFactory() {
             final long count = INSTANCE_COUNT.incrementAndGet();
 
             // XXX: All exceptions during factory construction are inhibited in Logger.tryCreateLoggerFactory(), so we use a flag

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -23,11 +23,11 @@ import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.core.IBiFunction;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.internal.json.Json;
-import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.test.AssertTask;
@@ -1359,7 +1359,7 @@ public class BasicMapTest extends HazelcastTestSupport {
 
     private static class TestPagingPredicate extends PagingPredicate {
 
-        public TestPagingPredicate(int pageSize) {
+        TestPagingPredicate(int pageSize) {
             super(pageSize);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerCompatibleModeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerCompatibleModeTest.java
@@ -93,7 +93,7 @@ public class EntryLoadedListenerCompatibleModeTest extends HazelcastTestSupport 
 
         private final AtomicInteger addEventCount;
 
-        public AddListener(AtomicInteger addEventCount) {
+        AddListener(AtomicInteger addEventCount) {
             this.addEventCount = addEventCount;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryLoadedListenerTest.java
@@ -315,7 +315,7 @@ public class EntryLoadedListenerTest extends HazelcastTestSupport {
         private final AtomicInteger loadEventCount;
         private final AtomicInteger addEventCount;
 
-        public LoadAndAddListener(AtomicInteger loadEventCount, AtomicInteger addEventCount) {
+        LoadAndAddListener(AtomicInteger loadEventCount, AtomicInteger addEventCount) {
             this.loadEventCount = loadEventCount;
             this.addEventCount = addEventCount;
         }
@@ -337,7 +337,7 @@ public class EntryLoadedListenerTest extends HazelcastTestSupport {
         private final AtomicInteger loadEventCount;
         private final AtomicInteger updateEventCount;
 
-        public LoadAndUpdateListener(AtomicInteger loadEventCount, AtomicInteger updateEventCount) {
+        LoadAndUpdateListener(AtomicInteger loadEventCount, AtomicInteger updateEventCount) {
             this.loadEventCount = loadEventCount;
             this.updateEventCount = updateEventCount;
         }
@@ -357,7 +357,7 @@ public class EntryLoadedListenerTest extends HazelcastTestSupport {
 
         private final AtomicInteger addEventCount;
 
-        public AddListener(AtomicInteger addEventCount) {
+        AddListener(AtomicInteger addEventCount) {
             this.addEventCount = addEventCount;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorBouncingNodesTest.java
@@ -182,7 +182,7 @@ public class EntryProcessorBouncingNodesTest extends HazelcastTestSupport {
         private List<Integer> list = new ArrayList<Integer>();
         private int size;
 
-        public ListHolder() {
+        ListHolder() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorOffloadableTest.java
@@ -485,7 +485,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
 
         private final Object value;
 
-        public EntryAdderOffloadable(Object value) {
+        EntryAdderOffloadable(Object value) {
             this.value = value;
         }
 
@@ -545,7 +545,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
         private final CountDownLatch start;
         private final CountDownLatch stop;
 
-        public EntryLatchModifying(CountDownLatch start, CountDownLatch stop) {
+        EntryLatchModifying(CountDownLatch start, CountDownLatch stop) {
             this.start = start;
             this.stop = stop;
         }
@@ -586,7 +586,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
         private final CountDownLatch otherStopped;
         private final int valueToSet;
 
-        public EntryLatchVerifying(CountDownLatch otherStarted, CountDownLatch otherStopped, final int value) {
+        EntryLatchVerifying(CountDownLatch otherStarted, CountDownLatch otherStopped, final int value) {
             this.otherStarted = otherStarted;
             this.otherStopped = otherStopped;
             this.valueToSet = value;
@@ -657,7 +657,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
         private final CountDownLatch stop;
         private final CountDownLatch waitToProceed;
 
-        public EntryLatchModifyingOtherReading(CountDownLatch start, CountDownLatch waitToProceed, CountDownLatch stop) {
+        EntryLatchModifyingOtherReading(CountDownLatch start, CountDownLatch waitToProceed, CountDownLatch stop) {
             this.start = start;
             this.stop = stop;
             this.waitToProceed = waitToProceed;
@@ -703,7 +703,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
         private final CountDownLatch otherWaitingToProceed;
         private final CountDownLatch otherStopped;
 
-        public EntryLatchReadOnlyVerifyingWhileOtherWriting(CountDownLatch otherStarted, CountDownLatch otherWaitingToProceed,
+        EntryLatchReadOnlyVerifyingWhileOtherWriting(CountDownLatch otherStarted, CountDownLatch otherWaitingToProceed,
                                                             CountDownLatch otherStopped) {
             this.otherStarted = otherStarted;
             this.otherWaitingToProceed = otherWaitingToProceed;
@@ -877,7 +877,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
         private final CountDownLatch mayStart;
         private final CountDownLatch stop;
 
-        public EntryLatchAwaitingModifying(CountDownLatch mayStart, CountDownLatch stop) {
+        EntryLatchAwaitingModifying(CountDownLatch mayStart, CountDownLatch stop) {
             this.mayStart = mayStart;
             this.stop = stop;
         }
@@ -918,7 +918,7 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
 
         private final CountDownLatch otherStopped;
 
-        public EntryOtherStoppedVerifying(CountDownLatch otherStopped) {
+        EntryOtherStoppedVerifying(CountDownLatch otherStopped) {
             this.otherStopped = otherStopped;
         }
 
@@ -1081,11 +1081,11 @@ public class EntryProcessorOffloadableTest extends HazelcastTestSupport {
         private long processStart;
         private long processEnd;
 
-        public TimestampedSimpleValue() {
+        TimestampedSimpleValue() {
             super();
         }
 
-        public TimestampedSimpleValue(int i) {
+        TimestampedSimpleValue(int i) {
             super(i);
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EntryProcessorTest.java
@@ -1061,7 +1061,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
 
             private final String value;
 
-            public UpdatingEntryProcessor(String value) {
+            UpdatingEntryProcessor(String value) {
                 this.value = value;
             }
 
@@ -2010,7 +2010,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
     static class MyData implements Serializable {
         private long lastValue;
 
-        public MyData(long lastValue) {
+        MyData(long lastValue) {
             this.lastValue = lastValue;
         }
 
@@ -2025,7 +2025,7 @@ public class EntryProcessorTest extends HazelcastTestSupport {
 
     static class MyProcessor extends AbstractEntryProcessor<Long, MyData> {
 
-        public MyProcessor() {
+        MyProcessor() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/MapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapListenerTest.java
@@ -134,7 +134,7 @@ public class MapListenerTest extends HazelcastTestSupport {
         final AtomicInteger entriesObserved;
         final AtomicInteger exitsObserved;
 
-        public AllListener() {
+        AllListener() {
             entries = new AtomicInteger();
             exits = new AtomicInteger();
             entriesObserved = new AtomicInteger();
@@ -168,12 +168,12 @@ public class MapListenerTest extends HazelcastTestSupport {
         private int age;
         private String name;
 
-        public Person(int age, String name) {
+        Person(int age, String name) {
             this.age = age;
             this.name = name;
         }
 
-        public Person(Person p) {
+        Person(Person p) {
             this.name = p.name;
             this.age = p.age;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapMergePolicySerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapMergePolicySerializationTest.java
@@ -77,7 +77,7 @@ public class MapMergePolicySerializationTest extends HazelcastTestSupport {
         static int serializedCount = 0;
         static int deserializedCount = 0;
 
-        public MyObject() {
+        MyObject() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/MapQueryEventFilterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapQueryEventFilterTest.java
@@ -101,7 +101,7 @@ public class MapQueryEventFilterTest extends HazelcastTestSupport {
     static final class Employee implements Serializable {
         int age;
 
-        public Employee(int age) {
+        Employee(int age) {
             this.age = age;
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapRemoveFailingBackupTest.java
@@ -116,7 +116,7 @@ public class MapRemoveFailingBackupTest extends HazelcastTestSupport {
             super(name, dataKey);
         }
 
-        public RemoveOperation() {
+        RemoveOperation() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/LazyMapEntryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/LazyMapEntryTest.java
@@ -127,7 +127,7 @@ public class LazyMapEntryTest extends HazelcastTestSupport {
         int serializedCount = 0;
         int deserializedCount = 0;
 
-        public MyObject() {
+        MyObject() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindFailAndRetryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindFailAndRetryTest.java
@@ -197,7 +197,7 @@ public class WriteBehindFailAndRetryTest extends HazelcastTestSupport {
 
     private static class TemporaryMapStoreException extends RuntimeException {
 
-        public TemporaryMapStoreException() {
+        TemporaryMapStoreException() {
             super("Test exception");
         }
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindWithEntryProcessorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/mapstore/writebehind/WriteBehindWithEntryProcessorTest.java
@@ -196,7 +196,7 @@ public class WriteBehindWithEntryProcessorTest extends HazelcastTestSupport {
         int serializedCount = 0;
         int deserializedCount = 0;
 
-        public TestObject() {
+        TestObject() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/operation/PostJoinMapOperationTest.java
@@ -56,7 +56,7 @@ public class PostJoinMapOperationTest extends HazelcastTestSupport {
         private final int age;
         private final String name;
 
-        public Person(String name, int age) {
+        Person(String name, int age) {
             this.age = age;
             this.name = name;
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/CompositeIndexQueriesTest.java
@@ -274,7 +274,7 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
         private final Integer key;
         private final Person value;
 
-        public ExtractableAdapter(Map.Entry<Integer, Person> entry) {
+        ExtractableAdapter(Map.Entry<Integer, Person> entry) {
             this.key = entry.getKey();
             this.value = entry.getValue();
         }
@@ -321,7 +321,7 @@ public class CompositeIndexQueriesTest extends HazelcastTestSupport {
 
         private Predicate delegate;
 
-        public NoIndexPredicate(Predicate delegate) {
+        NoIndexPredicate(Predicate delegate) {
             this.delegate = delegate;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMapLoaderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/querycache/QueryCacheMapLoaderTest.java
@@ -114,7 +114,7 @@ public class QueryCacheMapLoaderTest extends HazelcastTestSupport {
 
         private final ConcurrentMap<Integer, Integer> map = new ConcurrentHashMap<Integer, Integer>();
 
-        public TestMapLoader() {
+        TestMapLoader() {
             map.put(1, 1);
             map.put(2, 2);
             map.put(3, 4);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/tx/MapTransactionTest.java
@@ -1382,7 +1382,7 @@ public class MapTransactionTest extends HazelcastTestSupport {
 
         private final MapOperationProvider operationProvider;
 
-        public WaitTimeoutSetterMapOperationProvider(MapOperationProvider operationProvider) {
+        WaitTimeoutSetterMapOperationProvider(MapOperationProvider operationProvider) {
             this.operationProvider = operationProvider;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/merge/NoIndexLossAfterSplitBrainHealTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/merge/NoIndexLossAfterSplitBrainHealTest.java
@@ -108,10 +108,10 @@ public class NoIndexLossAfterSplitBrainHealTest extends SplitBrainTestSupport {
         private Long id;
         private String value;
 
-        public TestObject() {
+        TestObject() {
         }
 
-        public TestObject(Long id, String value) {
+        TestObject(Long id, String value) {
             this.id = id;
             this.value = value;
         }

--- a/hazelcast/src/test/java/com/hazelcast/mock/MockUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/mock/MockUtil.java
@@ -52,7 +52,7 @@ public class MockUtil {
 
         private Object delegated;
 
-        public DelegatingAnswer(Object delegated) {
+        DelegatingAnswer(Object delegated) {
             this.delegated = delegated;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/ascii/RestApiConfigTestBase.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ascii/RestApiConfigTestBase.java
@@ -163,7 +163,7 @@ public abstract class RestApiConfigTestBase extends AbstractTextProtocolsTestBas
         final String requestUri;
         final String expectedSubstring;
 
-        public TestUrl(RestEndpointGroup restEndpointGroup, String httpMethod, String requestUri, String expectedSubstring) {
+        TestUrl(RestEndpointGroup restEndpointGroup, String httpMethod, String requestUri, String expectedSubstring) {
             this.restEndpointGroup = restEndpointGroup;
             this.method = httpMethod;
             this.requestUri = requestUri;

--- a/hazelcast/src/test/java/com/hazelcast/nio/ascii/TextProtocolClient.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/ascii/TextProtocolClient.java
@@ -216,7 +216,7 @@ public class TextProtocolClient implements Closeable {
         private final ByteArrayOutputStream os = new ByteArrayOutputStream();
         private volatile IOException exception;
 
-        public InputStreamConsumerThread(InputStream is) {
+        InputStreamConsumerThread(InputStream is) {
             this.is = is;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/PortableTest.java
@@ -498,10 +498,10 @@ public class PortableTest {
 
         private Portable[] portables;
 
-        public TestObject1() {
+        TestObject1() {
         }
 
-        public TestObject1(Portable[] p) {
+        TestObject1(Portable[] p) {
             portables = p;
         }
 
@@ -530,7 +530,7 @@ public class PortableTest {
 
         private String shortString;
 
-        public TestObject2() {
+        TestObject2() {
             shortString = "Hello World";
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/SerializationTest.java
@@ -352,7 +352,7 @@ public class SerializationTest extends HazelcastTestSupport {
     private static class Foo implements Serializable {
         public Bar bar;
 
-        public Foo() {
+         Foo() {
             this.bar = new Bar();
         }
 
@@ -407,10 +407,10 @@ public class SerializationTest extends HazelcastTestSupport {
 
         String value;
 
-        public ExternalizableString() {
+        ExternalizableString() {
         }
 
-        public ExternalizableString(String value) {
+        ExternalizableString(String value) {
             this.value = value;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderQuickTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/serialization/impl/DefaultPortableReaderQuickTest.java
@@ -435,7 +435,7 @@ public class DefaultPortableReaderQuickTest extends HazelcastTestSupport {
 
         public String[] model;
 
-        public CarPortable() {
+        CarPortable() {
         }
 
         CarPortable(String name, EnginePortable engine, WheelPortable... wheels) {
@@ -505,7 +505,7 @@ public class DefaultPortableReaderQuickTest extends HazelcastTestSupport {
         Integer power;
         ChipPortable chip;
 
-        public EnginePortable() {
+        EnginePortable() {
             this.chip = new ChipPortable();
         }
 
@@ -567,7 +567,7 @@ public class DefaultPortableReaderQuickTest extends HazelcastTestSupport {
 
         Integer power;
 
-        public ChipPortable() {
+        ChipPortable() {
             this.power = 15;
         }
 
@@ -631,7 +631,7 @@ public class DefaultPortableReaderQuickTest extends HazelcastTestSupport {
         Portable[] nullChips;
         int[] serial;
 
-        public WheelPortable() {
+        WheelPortable() {
         }
 
         WheelPortable(String name, boolean nonNull) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/ConverterResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/ConverterResolutionTest.java
@@ -186,7 +186,7 @@ public class ConverterResolutionTest {
         private final int key;
         private final Value value;
 
-        public Entry(int key, Long value) {
+        Entry(int key, Long value) {
             this.serializationService = ConverterResolutionTest.this.serializationService;
             this.extractors = ConverterResolutionTest.this.extractors;
             this.key = key;

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexFirstComponentDecoratorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexFirstComponentDecoratorTest.java
@@ -142,7 +142,7 @@ public class IndexFirstComponentDecoratorTest {
         private final int key;
         private final long value;
 
-        public Entry(int key, long value) {
+        Entry(int key, long value) {
             this.key = key;
             this.value = value;
         }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexIntegrationTest.java
@@ -338,7 +338,7 @@ public class IndexIntegrationTest extends HazelcastTestSupport {
 
         String currency;
 
-        public DummyLoader(long amount, String currency) {
+        DummyLoader(long amount, String currency) {
             this.amount = amount;
             this.currency = currency;
         }

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/IndexSplitBrainTest.java
@@ -113,7 +113,7 @@ public class IndexSplitBrainTest extends SplitBrainTestSupport {
 
         private String id;
 
-        public ValueObject() {
+        ValueObject() {
         }
 
         ValueObject(String id) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/getters/AbstractJsonGetterTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/getters/AbstractJsonGetterTest.java
@@ -145,7 +145,7 @@ public class AbstractJsonGetterTest {
         private boolean isFailed;
         private Throwable exception;
 
-        public GetterRunner(AtomicBoolean running) {
+        GetterRunner(AtomicBoolean running) {
             this.running = running;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AttributeCanonicalizationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/AttributeCanonicalizationTest.java
@@ -111,7 +111,7 @@ public class AttributeCanonicalizationTest {
 
     private static class TestPredicate extends AbstractPredicate {
 
-        public TestPredicate(String attribute) {
+        TestPredicate(String attribute) {
             super(attribute);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BoundedRangePredicateQueriesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/BoundedRangePredicateQueriesTest.java
@@ -199,7 +199,7 @@ public class BoundedRangePredicateQueriesTest extends HazelcastTestSupport {
 
         private final com.hazelcast.util.function.Predicate<Integer> predicate;
 
-        public PersonPredicate(com.hazelcast.util.function.Predicate<Integer> predicate) {
+        PersonPredicate(com.hazelcast.util.function.Predicate<Integer> predicate) {
             this.predicate = predicate;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NestedPredicateWithExtractorTest.java
@@ -162,7 +162,7 @@ public class NestedPredicateWithExtractorTest extends HazelcastTestSupport {
 
     private static final class CustomPredicate extends AbstractPredicate {
 
-        public CustomPredicate() {
+        CustomPredicate() {
             super("limbname");
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/VisitorTestSupport.java
@@ -256,7 +256,7 @@ public abstract class VisitorTestSupport {
 
         private final int referentIndex;
 
-        public ReferencePredicate(int referentIndex) {
+        ReferencePredicate(int referentIndex) {
             this.referentIndex = referentIndex;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapAntiEntropyTest.java
@@ -113,7 +113,7 @@ public class ReplicatedMapAntiEntropyTest extends ReplicatedMapAbstractTest {
 
     class PutOperationWithNoReplication extends PutOperation {
 
-        public PutOperationWithNoReplication() {
+        PutOperationWithNoReplication() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapPutSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapPutSerializationTest.java
@@ -63,7 +63,7 @@ public class ReplicatedMapPutSerializationTest extends HazelcastTestSupport {
 
     static class SerializationCountingData implements DataSerializable {
 
-        public SerializationCountingData() {
+        SerializationCountingData() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddAllReadManyStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddAllReadManyStressTest.java
@@ -141,7 +141,7 @@ public class RingbufferAddAllReadManyStressTest extends HazelcastTestSupport {
 
         private volatile long produced;
 
-        public ProduceThread() {
+        ProduceThread() {
             super("ProduceThread");
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddReadOneStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAddReadOneStressTest.java
@@ -112,7 +112,7 @@ public class RingbufferAddReadOneStressTest extends HazelcastTestSupport {
     class ProduceThread extends TestThread {
         private volatile long produced;
 
-        public ProduceThread() {
+        ProduceThread() {
             super("ProduceThread");
         }
 
@@ -143,7 +143,7 @@ public class RingbufferAddReadOneStressTest extends HazelcastTestSupport {
     class ConsumeThread extends TestThread {
         volatile long seq;
 
-        public ConsumeThread(int id) {
+        ConsumeThread(int id) {
             super("ConsumeThread-" + id);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAsyncAddWithBackoffStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferAsyncAddWithBackoffStressTest.java
@@ -107,7 +107,7 @@ public class RingbufferAsyncAddWithBackoffStressTest extends HazelcastTestSuppor
     class ProduceThread extends TestThread {
         private volatile long produced;
 
-        public ProduceThread() {
+        ProduceThread() {
             super("ProduceThread");
         }
 
@@ -149,7 +149,7 @@ public class RingbufferAsyncAddWithBackoffStressTest extends HazelcastTestSuppor
     class ConsumeThread extends TestThread {
         volatile long seq;
 
-        public ConsumeThread(int id) {
+        ConsumeThread(int id) {
             super("ConsumeThread-" + id);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/ringbuffer/impl/RingbufferStoreTest.java
@@ -374,7 +374,7 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
     static class ExceptionThrowingRingbufferStore<T> implements RingbufferStore<T> {
         private final boolean getLargestSequenceThrowsException;
 
-        public ExceptionThrowingRingbufferStore() {
+        ExceptionThrowingRingbufferStore() {
             this(false);
         }
 
@@ -416,7 +416,7 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
         final CountDownLatch latchStoreAll;
         final CountDownLatch latchLoad;
 
-        public TestRingbufferStore() {
+        TestRingbufferStore() {
             this(0, 0, 0);
         }
 
@@ -475,7 +475,7 @@ public class RingbufferStoreTest extends HazelcastTestSupport {
         final Map<Long, T> store = new LinkedHashMap<Long, T>();
 
 
-        public WriteOnlyRingbufferStore() {
+        WriteOnlyRingbufferStore() {
         }
 
         Map<Long, T> getStore() {

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
@@ -238,7 +238,7 @@ public class OperationSerializationTest extends HazelcastTestSupport {
 
     private static class DummyOperation extends Operation {
 
-        public DummyOperation() {
+        DummyOperation() {
         }
 
         @Override
@@ -249,7 +249,7 @@ public class OperationSerializationTest extends HazelcastTestSupport {
 
     private static class OperationWithServiceNameOverride extends Operation {
 
-        public OperationWithServiceNameOverride() {
+        OperationWithServiceNameOverride() {
         }
 
         @Override
@@ -264,7 +264,7 @@ public class OperationSerializationTest extends HazelcastTestSupport {
 
     private static class OperationWithExplicitServiceNameAndOverride extends Operation {
 
-        public OperationWithExplicitServiceNameAndOverride() {
+        OperationWithExplicitServiceNameAndOverride() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/OperationSerializationTest.java
@@ -238,7 +238,8 @@ public class OperationSerializationTest extends HazelcastTestSupport {
 
     private static class DummyOperation extends Operation {
 
-        DummyOperation() {
+        @SuppressWarnings("checkstyle:RedundantModifier")
+        public DummyOperation() {
         }
 
         @Override
@@ -249,7 +250,8 @@ public class OperationSerializationTest extends HazelcastTestSupport {
 
     private static class OperationWithServiceNameOverride extends Operation {
 
-        OperationWithServiceNameOverride() {
+        @SuppressWarnings("checkstyle:RedundantModifier")
+        public OperationWithServiceNameOverride() {
         }
 
         @Override
@@ -264,7 +266,8 @@ public class OperationSerializationTest extends HazelcastTestSupport {
 
     private static class OperationWithExplicitServiceNameAndOverride extends Operation {
 
-        OperationWithExplicitServiceNameAndOverride() {
+        @SuppressWarnings("checkstyle:RedundantModifier")
+        public OperationWithExplicitServiceNameAndOverride() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/AbstractInvocationFuture_AbstractTest.java
@@ -45,11 +45,11 @@ public abstract class AbstractInvocationFuture_AbstractTest extends HazelcastTes
     class TestFuture extends AbstractInvocationFuture {
         volatile boolean interruptDetected;
 
-        public TestFuture() {
+        TestFuture() {
             super(AbstractInvocationFuture_AbstractTest.this.executor, AbstractInvocationFuture_AbstractTest.this.logger);
         }
 
-        public TestFuture(Executor executor, ILogger logger) {
+        TestFuture(Executor executor, ILogger logger) {
             super(executor, logger);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFutureTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/executionservice/impl/BasicCompletableFutureTest.java
@@ -279,7 +279,7 @@ public class BasicCompletableFutureTest {
     }
 
     private static class TestCurrentThreadExecutor extends ThreadPoolExecutor implements ManagedExecutorService {
-        public TestCurrentThreadExecutor() {
+        TestCurrentThreadExecutor() {
             super(1, 1, 1, TimeUnit.MINUTES, new LinkedBlockingQueue<>());
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_BasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_BasicTest.java
@@ -78,7 +78,7 @@ public class OperationExecutorImpl_BasicTest extends OperationExecutorImpl_Abstr
     class LongRunningOperation extends Operation {
         private CountDownLatch completionLatch;
 
-        public LongRunningOperation(int partitionId, CountDownLatch completionLatch) {
+        LongRunningOperation(int partitionId, CountDownLatch completionLatch) {
             this.completionLatch = completionLatch;
             setPartitionId(partitionId);
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueueImplStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationQueueImplStressTest.java
@@ -63,7 +63,7 @@ public class OperationQueueImplStressTest extends HazelcastTestSupport {
     private class ProducerThread extends TestThread {
         private volatile long produced;
 
-        public ProducerThread() {
+        ProducerThread() {
             super("ProducerThread");
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetectorBasicTest.java
@@ -294,7 +294,7 @@ public class SlowOperationDetectorBasicTest extends SlowOperationDetectorAbstrac
         private final int recursionDepth;
         private final int sleepSeconds;
 
-        public SlowRecursiveOperation(int partitionId, int recursionDepth, int sleepSeconds) {
+        SlowRecursiveOperation(int partitionId, int recursionDepth, int sleepSeconds) {
             this.recursionDepth = recursionDepth;
             this.sleepSeconds = sleepSeconds;
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/OperationParkerImplTest.java
@@ -64,7 +64,7 @@ public class OperationParkerImplTest extends HazelcastTestSupport {
         private final int keyCount;
         private final CountDownLatch latch;
 
-        public LockWaitAndUnlockTask(HazelcastInstance hz, int keyCount, CountDownLatch latch) {
+        LockWaitAndUnlockTask(HazelcastInstance hz, int keyCount, CountDownLatch latch) {
             this.hz = hz;
             this.keyCount = keyCount;
             this.latch = latch;

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/WaitSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationparker/impl/WaitSetTest.java
@@ -267,7 +267,7 @@ public class WaitSetTest {
         private final String serviceName;
         private final String objectName;
 
-        public WaitNotifyKeyImpl(String serviceName, String objectName) {
+        WaitNotifyKeyImpl(String serviceName, String objectName) {
             this.serviceName = serviceName;
             this.objectName = objectName;
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorStressTest.java
@@ -220,7 +220,7 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
         public int runDelayMs = 1;
         public int backupRunDelayMs = 0;
 
-        public StressThread() {
+        StressThread() {
             super("StressThread-" + THREAD_ID_GENERATOR.incrementAndGet());
         }
 
@@ -318,10 +318,10 @@ public class BackpressureRegulatorStressTest extends HazelcastTestSupport {
         int runDelayMs = 1;
         int backupRunDelayMs = 0;
 
-        public DummyOperation() {
+        DummyOperation() {
         }
 
-        public DummyOperation(long result) {
+        DummyOperation(long result) {
             this.result = result;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/BackpressureRegulatorTest.java
@@ -216,7 +216,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
 
     private class PartitionSpecificOperation extends Operation implements PartitionAwareOperation, BackupAwareOperation {
 
-        public PartitionSpecificOperation(int partitionId) {
+        PartitionSpecificOperation(int partitionId) {
             setPartitionId(partitionId);
         }
 
@@ -247,7 +247,7 @@ public class BackpressureRegulatorTest extends HazelcastTestSupport {
 
     private class GenericOperation extends Operation implements BackupAwareOperation {
 
-        public GenericOperation() {
+        GenericOperation() {
             setPartitionId(-1);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/DummyBackupOperation.java
@@ -28,10 +28,10 @@ class DummyBackupOperation extends Operation implements BackupOperation {
 
     private String backupKey;
 
-    public DummyBackupOperation() {
+    DummyBackupOperation() {
     }
 
-    public DummyBackupOperation(String backupKey) {
+    DummyBackupOperation(String backupKey) {
         this.backupKey = backupKey;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NestedAbstractTest.java
@@ -45,10 +45,10 @@ abstract class Invocation_NestedAbstractTest extends HazelcastTestSupport {
         public Object result;
 
         @SuppressWarnings("unused")
-        public OuterOperation() {
+        OuterOperation() {
         }
 
-        public OuterOperation(Operation innerOperation, int partitionId) {
+        OuterOperation(Operation innerOperation, int partitionId) {
             this.innerOperation = innerOperation;
             setPartitionId(partitionId);
         }
@@ -89,10 +89,10 @@ abstract class Invocation_NestedAbstractTest extends HazelcastTestSupport {
         public Object value;
 
         @SuppressWarnings("unused")
-        public InnerOperation() {
+        InnerOperation() {
         }
 
-        public InnerOperation(Object value, int partitionId) {
+        InnerOperation(Object value, int partitionId) {
             this.value = value;
 
             setPartitionId(partitionId);

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnBackupLeftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_OnBackupLeftTest.java
@@ -127,10 +127,10 @@ public class Invocation_OnBackupLeftTest extends HazelcastTestSupport {
         private String backupId;
         private int primaryResponseDelaySeconds;
 
-        public PrimaryOperation() {
+        PrimaryOperation() {
         }
 
-        public PrimaryOperation(String backupId) {
+        PrimaryOperation(String backupId) {
             this.backupId = backupId;
         }
 
@@ -188,10 +188,10 @@ public class Invocation_OnBackupLeftTest extends HazelcastTestSupport {
     static class SlowBackupOperation extends Operation {
         private String backupId;
 
-        public SlowBackupOperation() {
+        SlowBackupOperation() {
         }
 
-        public SlowBackupOperation(String backupId) {
+        SlowBackupOperation(String backupId) {
             this.backupId = backupId;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_RetryTest.java
@@ -262,7 +262,7 @@ public class Invocation_RetryTest extends HazelcastTestSupport {
 
         private long sleepMillis;
 
-        public SleepingOperation() {
+        SleepingOperation() {
         }
 
         SleepingOperation(long sleepMillis) {

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationOutOfOrderBackupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationOutOfOrderBackupTest.java
@@ -141,10 +141,10 @@ public class OperationOutOfOrderBackupTest extends HazelcastTestSupport {
 
         long value;
 
-        public SampleBackupAwareOperation() {
+        SampleBackupAwareOperation() {
         }
 
-        public SampleBackupAwareOperation(long value) {
+        SampleBackupAwareOperation(long value) {
             this.value = value;
         }
 
@@ -194,10 +194,10 @@ public class OperationOutOfOrderBackupTest extends HazelcastTestSupport {
 
         long value;
 
-        public SampleBackupOperation() {
+        SampleBackupOperation() {
         }
 
-        public SampleBackupOperation(long value) {
+        SampleBackupOperation(long value) {
             this.value = value;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OperationServiceImpl_invokeOnPartitionsTest.java
@@ -350,11 +350,11 @@ public class OperationServiceImpl_invokeOnPartitionsTest extends HazelcastTestSu
     }
 
     private static class PartitionAwareOperationFactoryImpl extends PartitionAwareOperationFactory {
-        public PartitionAwareOperationFactoryImpl(int[] partitions) {
+        PartitionAwareOperationFactoryImpl(int[] partitions) {
             this.partitions = partitions;
         }
 
-        public PartitionAwareOperationFactoryImpl() {
+         PartitionAwareOperationFactoryImpl() {
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/OutboundResponseHandlerTest.java
@@ -245,10 +245,10 @@ public class OutboundResponseHandlerTest {
 
         private int no;
 
-        public PortableAddress() {
+        PortableAddress() {
         }
 
-        public PortableAddress(String street, int no) {
+        PortableAddress(String street, int no) {
             this.street = street;
             this.no = no;
         }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/SlowOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/SlowOperation.java
@@ -28,14 +28,14 @@ class SlowOperation extends Operation {
     long durationMs;
 
     @SuppressWarnings("unused")
-    public SlowOperation() {
+    SlowOperation() {
     }
 
-    public SlowOperation(long durationMs) {
+    SlowOperation(long durationMs) {
         this.durationMs = durationMs;
     }
 
-    public SlowOperation(long durationMs, Object response) {
+    SlowOperation(long durationMs, Object response) {
         this.durationMs = durationMs;
         this.response = response;
     }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/VoidOperation.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/VoidOperation.java
@@ -33,10 +33,10 @@ class VoidOperation extends Operation implements PartitionAwareOperation {
 
     private long durationMs;
 
-    public VoidOperation() {
+    VoidOperation() {
     }
 
-    public VoidOperation(long durationMs) {
+    VoidOperation(long durationMs) {
         this.durationMs = durationMs;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/TestJavaSerializationUtils.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestJavaSerializationUtils.java
@@ -55,7 +55,7 @@ public final class TestJavaSerializationUtils {
 
         private final int id;
 
-        public SerializableObject(int id) {
+        SerializableObject(int id) {
             this.id = id;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/bounce/BounceMemberRule.java
@@ -295,7 +295,7 @@ public class BounceMemberRule implements TestRule {
     private class BouncingClusterStatement extends Statement {
         private final Statement statement;
 
-        public BouncingClusterStatement(Statement statement) {
+        BouncingClusterStatement(Statement statement) {
             this.statement = statement;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/transaction/impl/MockTransactionLogRecord.java
+++ b/hazelcast/src/test/java/com/hazelcast/transaction/impl/MockTransactionLogRecord.java
@@ -133,10 +133,10 @@ public class MockTransactionLogRecord implements TransactionLogRecord {
     static class MockOperation extends Operation {
         private boolean fail;
 
-        public MockOperation() {
+        MockOperation() {
         }
 
-        public MockOperation(boolean fail) {
+        MockOperation(boolean fail) {
             setPartitionId(0);
             this.fail = fail;
         }

--- a/hazelcast/src/test/java/com/hazelcast/util/CollectionTxnUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/CollectionTxnUtilTest.java
@@ -141,10 +141,10 @@ public class CollectionTxnUtilTest extends HazelcastTestSupport {
 
         transient boolean afterCalled;
 
-        public TestOperation() {
+        TestOperation() {
         }
 
-        public TestOperation(int i) {
+        TestOperation(int i) {
             this.i = i;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/FutureUtilTest.java
@@ -302,7 +302,7 @@ public class FutureUtilTest extends HazelcastTestSupport {
 
     private static class UncancellableFuture<V> extends AbstractCompletableFuture<V> {
 
-        public UncancellableFuture() {
+        UncancellableFuture() {
             super((Executor) null, null);
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/util/JumpingSystemClock.java
+++ b/hazelcast/src/test/java/com/hazelcast/util/JumpingSystemClock.java
@@ -25,7 +25,7 @@ class JumpingSystemClock extends Clock.ClockImpl {
     private final long jumpAfter;
     private final long jumpOffset;
 
-    public JumpingSystemClock() {
+    JumpingSystemClock() {
         String clockOffset = System.getProperty(ClockProperties.HAZELCAST_CLOCK_OFFSET);
         String jumpAfterSeconds = System.getProperty(JUMP_AFTER_SECONDS_PROPERTY);
         try {

--- a/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXAStressTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/xa/HazelcastXAStressTest.java
@@ -80,7 +80,7 @@ public class HazelcastXAStressTest extends HazelcastTestSupport {
 
         int i;
 
-        public XATransactionRunnable(HazelcastXAResource xaResource, String name,
+        XATransactionRunnable(HazelcastXAResource xaResource, String name,
                                      ExecutorService executorServiceForCommit, int i) {
             this.xaResource = xaResource;
             this.name = name;

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <maven.git.commit.id.plugin.version>2.1.10</maven.git.commit.id.plugin.version>
 
         <maven.surefire.plugin.version>2.21.0</maven.surefire.plugin.version>
-        <maven.checkstyle.plugin.version>2.15</maven.checkstyle.plugin.version>
+        <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <maven.spotbugs.plugin.version>3.1.6</maven.spotbugs.plugin.version>
         <maven.sonar.plugin.version>3.3.0.603</maven.sonar.plugin.version>
         <maven.jacoco.plugin.version>0.8.2</maven.jacoco.plugin.version>
@@ -100,6 +100,8 @@
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.language>java</sonar.language>
         <sonar.verbose>true</sonar.verbose>
+
+        <checkstyle.version>8.19</checkstyle.version>
 
         <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
 
@@ -869,6 +871,13 @@
                             <enableRulesSummary>true</enableRulesSummary>
                             <propertyExpansion>main.basedir=${main.basedir}</propertyExpansion>
                         </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.puppycrawl.tools</groupId>
+                                <artifactId>checkstyle</artifactId>
+                                <version>${checkstyle.version}</version>
+                            </dependency>
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
Upgrade checkstyle version to the latest 8.19, to enable working properly with Java8 and using checkstyle IDE plugin. Since the metrics and checks got improved since the version we've been using until now, some modifications had to be done to the sources as well. 

In terms of the number of touched classes, the most significant change is removing redundant modifiers. This change includes mostly removing `public` modifiers from the constructors of `private` internal classes, and other classes with `non-public` visibility.  This is done in a separate commit, where the modifiers are simply removed instead of repeating the inherited visibility. No hard preference on this, we can repeat the visibility. This change is done in a separate commit to ease reviewing.

The other point to highlight is suppressing the `ClassFanOutComplexity` for 3 classes, instead of raising the threshold. Again no strong preference on this, since the classes are above the threshold by 1 and 2.  Also in a separate commit.

EE PR: https://github.com/hazelcast/hazelcast-enterprise/pull/2913