### PR TITLE
Updated partition package to Java 8 and removed 3.11 RU paths

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/metrics/metricsets/ClassLoadingMetricSet.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.metrics.metricsets;
 
-import com.hazelcast.internal.metrics.LongProbeFunction;
 import com.hazelcast.internal.metrics.MetricsRegistry;
 
 import java.lang.management.ClassLoadingMXBean;
@@ -43,16 +42,11 @@ public final class ClassLoadingMetricSet {
 
         ClassLoadingMXBean mxBean = ManagementFactory.getClassLoadingMXBean();
 
-        metricsRegistry.register(mxBean, "classloading.loadedClassesCount", MANDATORY,
-                (LongProbeFunction<ClassLoadingMXBean>) classLoadingMXBean -> classLoadingMXBean.getLoadedClassCount()
-        );
+        metricsRegistry.register(mxBean, "classloading.loadedClassesCount", MANDATORY, ClassLoadingMXBean::getLoadedClassCount);
 
         metricsRegistry.register(mxBean, "classloading.totalLoadedClassesCount", MANDATORY,
-                (LongProbeFunction<ClassLoadingMXBean>) classLoadingMXBean -> classLoadingMXBean.getTotalLoadedClassCount()
-        );
+                ClassLoadingMXBean::getTotalLoadedClassCount);
 
-        metricsRegistry.register(mxBean, "classloading.unloadedClassCount", MANDATORY,
-                (LongProbeFunction<ClassLoadingMXBean>) classLoadingMXBean -> classLoadingMXBean.getUnloadedClassCount()
-        );
+        metricsRegistry.register(mxBean, "classloading.unloadedClassCount", MANDATORY, ClassLoadingMXBean::getUnloadedClassCount);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/NonFragmentedServiceNamespace.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/NonFragmentedServiceNamespace.java
@@ -22,8 +22,6 @@ import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.ServiceNamespace;
 
-import java.io.IOException;
-
 /**
  * Internal {@link ServiceNamespace} implementation used by partitioning system to identify
  * non-fragmented service structures. All partition replica data belonging to service which do not implement
@@ -56,11 +54,11 @@ public final class NonFragmentedServiceNamespace implements ServiceNamespace, Id
     }
 
     @Override
-    public void writeData(ObjectDataOutput out) throws IOException {
+    public void writeData(ObjectDataOutput out) {
     }
 
     @Override
-    public void readData(ObjectDataInput in) throws IOException {
+    public void readData(ObjectDataInput in) {
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionReplica.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionReplica.java
@@ -42,9 +42,6 @@ import java.io.IOException;
  */
 public final class PartitionReplica implements IdentifiedDataSerializable {
 
-    // RU_COMPAT_3_11
-    public static final String UNKNOWN_UID = "<unknown-uuid>";
-
     private Address address;
 
     private String uuid;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/PartitionServiceProxy.java
@@ -66,7 +66,7 @@ public class PartitionServiceProxy implements PartitionService {
 
         int partitionCount = partitionService.getPartitionCount();
         Map<Integer, Partition> map = createHashMap(partitionCount);
-        Set<Partition> set = new TreeSet<Partition>();
+        Set<Partition> set = new TreeSet<>();
         for (int i = 0; i < partitionCount; i++) {
             Partition partition = new PartitionProxy(i);
             set.add(partition);
@@ -121,7 +121,7 @@ public class PartitionServiceProxy implements PartitionService {
             return true;
         }
 
-        final Collection<Future<Boolean>> futures = new ArrayList<Future<Boolean>>(members.size());
+        final Collection<Future<Boolean>> futures = new ArrayList<>(members.size());
         for (Member member : members) {
             final Address target = member.getAddress();
             final Operation operation = new SafeStateCheckOperation();
@@ -229,10 +229,7 @@ public class PartitionServiceProxy implements PartitionService {
         @Override
         public int compareTo(Object o) {
             PartitionProxy partition = (PartitionProxy) o;
-            int otherPartitionId = partition.partitionId;
-            return (partitionId < otherPartitionId)
-                    ? -1
-                    : ((partitionId == otherPartitionId) ? 0 : 1);
+            return Integer.compare(partitionId, partition.partitionId);
         }
 
         @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/ReplicaFragmentMigrationState.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/ReplicaFragmentMigrationState.java
@@ -85,14 +85,14 @@ public class ReplicaFragmentMigrationState implements IdentifiedDataSerializable
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         int namespaceSize = in.readInt();
-        namespaces = new HashMap<ServiceNamespace, long[]>(namespaceSize);
+        namespaces = new HashMap<>(namespaceSize);
         for (int i = 0; i < namespaceSize; i++) {
             ServiceNamespace namespace = in.readObject();
             long[] replicaVersions = in.readLongArray();
             namespaces.put(namespace, replicaVersions);
         }
         int migrationOperationSize = in.readInt();
-        migrationOperations = new ArrayList<Operation>(migrationOperationSize);
+        migrationOperations = new ArrayList<>(migrationOperationSize);
         for (int i = 0; i < migrationOperationSize; i++) {
             Operation migrationOperation = in.readObject();
             migrationOperations.add(migrationOperation);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/AbstractPartitionPrimaryReplicaAntiEntropyTask.java
@@ -67,7 +67,7 @@ public abstract class AbstractPartitionPrimaryReplicaAntiEntropyTask
         PartitionReplicationEvent event = new PartitionReplicationEvent(partitionId, 0);
         Collection<FragmentedMigrationAwareService> services = nodeEngine.getServices(FragmentedMigrationAwareService.class);
 
-        Set<ServiceNamespace> namespaces = new HashSet<ServiceNamespace>();
+        Set<ServiceNamespace> namespaces = new HashSet<>();
         for (FragmentedMigrationAwareService service : services) {
             Collection<ServiceNamespace> serviceNamespaces = service.getAllServiceNamespaces(event);
             if (serviceNamespaces != null) {
@@ -88,7 +88,7 @@ public abstract class AbstractPartitionPrimaryReplicaAntiEntropyTask
         }
 
         PartitionReplicaManager replicaManager = partitionService.getReplicaManager();
-        Map<ServiceNamespace, Long> versionMap = new HashMap<ServiceNamespace, Long>();
+        Map<ServiceNamespace, Long> versionMap = new HashMap<>();
         for (ServiceNamespace ns : namespaces) {
             long[] versions = replicaManager.getPartitionReplicaVersions(partitionId, ns);
             long currentReplicaVersion = versions[replicaIndex - 1];

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationPlanner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationPlanner.java
@@ -51,8 +51,7 @@ class MigrationPlanner {
 
     private final ILogger logger;
     private final PartitionReplica[] state = new PartitionReplica[InternalPartition.MAX_REPLICA_COUNT];
-    private final Set<PartitionReplica> verificationSet = ASSERTION_ENABLED
-            ? new HashSet<PartitionReplica>() : Collections.<PartitionReplica>emptySet();
+    private final Set<PartitionReplica> verificationSet = ASSERTION_ENABLED ? new HashSet<>() : Collections.emptySet();
 
     MigrationPlanner() {
         logger = Logger.getLogger(getClass());

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/MigrationQueue.java
@@ -34,7 +34,7 @@ class MigrationQueue {
 
     private final AtomicInteger migrateTaskCount = new AtomicInteger();
 
-    private final BlockingQueue<MigrationRunnable> queue = new LinkedBlockingQueue<MigrationRunnable>();
+    private final BlockingQueue<MigrationRunnable> queue = new LinkedBlockingQueue<>();
 
     @SuppressFBWarnings(value = "RV_RETURN_VALUE_IGNORED",
             justification = "offer will always be successful since queue is unbounded")
@@ -49,7 +49,7 @@ class MigrationQueue {
     }
 
     public void clear() {
-        List<MigrationRunnable> sink = new ArrayList<MigrationRunnable>();
+        List<MigrationRunnable> sink = new ArrayList<>();
         queue.drainTo(sink);
 
         for (MigrationRunnable task : sink) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionDataSerializerHook.java
@@ -85,116 +85,27 @@ public final class PartitionDataSerializerHook implements DataSerializerHook {
     public DataSerializableFactory createFactory() {
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[LEN];
 
-        constructors[PARTITION_RUNTIME_STATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PartitionRuntimeState();
-            }
-        };
-        constructors[ASSIGN_PARTITIONS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new AssignPartitions();
-            }
-        };
-        constructors[PARTITION_BACKUP_REPLICA_ANTI_ENTROPY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PartitionBackupReplicaAntiEntropyOperation();
-            }
-        };
-        constructors[FETCH_PARTITION_STATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new FetchPartitionStateOperation();
-            }
-        };
-        constructors[HAS_ONGOING_MIGRATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new HasOngoingMigration();
-            }
-        };
-        constructors[MIGRATION_COMMIT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MigrationCommitOperation();
-            }
-        };
-        constructors[PARTITION_STATE_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PartitionStateOperation();
-            }
-        };
-        constructors[PROMOTION_COMMIT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PromotionCommitOperation();
-            }
-        };
-        constructors[REPLICA_SYNC_REQUEST] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PartitionReplicaSyncRequest();
-            }
-        };
-        constructors[REPLICA_SYNC_RESPONSE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PartitionReplicaSyncResponse();
-            }
-        };
-        constructors[REPLICA_SYNC_RETRY_RESPONSE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PartitionReplicaSyncRetryResponse();
-            }
-        };
-        constructors[SAFE_STATE_CHECK] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new SafeStateCheckOperation();
-            }
-        };
-        constructors[SHUTDOWN_REQUEST] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ShutdownRequestOperation();
-            }
-        };
-        constructors[SHUTDOWN_RESPONSE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ShutdownResponseOperation();
-            }
-        };
-        constructors[REPLICA_FRAGMENT_MIGRATION_STATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ReplicaFragmentMigrationState();
-            }
-        };
-        constructors[MIGRATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MigrationOperation();
-            }
-        };
-        constructors[MIGRATION_REQUEST] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MigrationRequestOperation();
-            }
-        };
-        constructors[NON_FRAGMENTED_SERVICE_NAMESPACE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return NonFragmentedServiceNamespace.INSTANCE;
-            }
-        };
-        constructors[PARTITION_REPLICA] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PartitionReplica();
-            }
-        };
-        constructors[PUBLISH_COMPLETED_MIGRATIONS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PublishCompletedMigrationsOperation();
-            }
-        };
-        constructors[PARTITION_STATE_VERSION_CHECK_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PartitionStateVersionCheckOperation();
-            }
-        };
+        constructors[PARTITION_RUNTIME_STATE] = arg -> new PartitionRuntimeState();
+        constructors[ASSIGN_PARTITIONS] = arg -> new AssignPartitions();
+        constructors[PARTITION_BACKUP_REPLICA_ANTI_ENTROPY] = arg -> new PartitionBackupReplicaAntiEntropyOperation();
+        constructors[FETCH_PARTITION_STATE] = arg -> new FetchPartitionStateOperation();
+        constructors[HAS_ONGOING_MIGRATION] = arg -> new HasOngoingMigration();
+        constructors[MIGRATION_COMMIT] = arg -> new MigrationCommitOperation();
+        constructors[PARTITION_STATE_OP] = arg -> new PartitionStateOperation();
+        constructors[PROMOTION_COMMIT] = arg -> new PromotionCommitOperation();
+        constructors[REPLICA_SYNC_REQUEST] = arg -> new PartitionReplicaSyncRequest();
+        constructors[REPLICA_SYNC_RESPONSE] = arg -> new PartitionReplicaSyncResponse();
+        constructors[REPLICA_SYNC_RETRY_RESPONSE] = arg -> new PartitionReplicaSyncRetryResponse();
+        constructors[SAFE_STATE_CHECK] = arg -> new SafeStateCheckOperation();
+        constructors[SHUTDOWN_REQUEST] = arg -> new ShutdownRequestOperation();
+        constructors[SHUTDOWN_RESPONSE] = arg -> new ShutdownResponseOperation();
+        constructors[REPLICA_FRAGMENT_MIGRATION_STATE] = arg -> new ReplicaFragmentMigrationState();
+        constructors[MIGRATION] = arg -> new MigrationOperation();
+        constructors[MIGRATION_REQUEST] = arg -> new MigrationRequestOperation();
+        constructors[NON_FRAGMENTED_SERVICE_NAMESPACE] = arg -> NonFragmentedServiceNamespace.INSTANCE;
+        constructors[PARTITION_REPLICA] = arg -> new PartitionReplica();
+        constructors[PUBLISH_COMPLETED_MIGRATIONS] = arg -> new PublishCompletedMigrationsOperation();
+        constructors[PARTITION_STATE_VERSION_CHECK_OP] = arg -> new PartitionStateVersionCheckOperation();
         return new ArrayDataSerializableFactory(constructors);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaManager.java
@@ -112,7 +112,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
         replicaSyncTimeoutScheduler = EntryTaskSchedulerFactory.newScheduler(globalScheduler,
                 new ReplicaSyncTimeoutProcessor(), ScheduleType.POSTPONE);
 
-        replicaSyncRequests = newSetFromMap(new ConcurrentHashMap<ReplicaFragmentSyncInfo, Boolean>(partitionCount));
+        replicaSyncRequests = newSetFromMap(new ConcurrentHashMap<>(partitionCount));
     }
 
     /**
@@ -233,7 +233,7 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
     private List<ServiceNamespace> registerSyncInfoForNamespaces(int partitionId,
             Collection<ServiceNamespace> requestedNamespaces, int replicaIndex, PartitionReplica target, int permits) {
 
-        List<ServiceNamespace> namespaces = new ArrayList<ServiceNamespace>(permits);
+        List<ServiceNamespace> namespaces = new ArrayList<>(permits);
         for (ServiceNamespace namespace : requestedNamespaces) {
             if (namespaces.size() == permits) {
                 if (logger.isFinestEnabled()) {
@@ -427,15 +427,14 @@ public class PartitionReplicaManager implements PartitionReplicaVersionManager {
      * @return copy of ongoing replica-sync operations
      */
     List<ReplicaFragmentSyncInfo> getOngoingReplicaSyncRequests() {
-        return new ArrayList<ReplicaFragmentSyncInfo>(replicaSyncRequests);
+        return new ArrayList<>(replicaSyncRequests);
     }
 
     /**
      * @return copy of scheduled replica-sync requests
      */
     List<ScheduledEntry<ReplicaFragmentSyncInfo, Void>> getScheduledReplicaSyncRequests() {
-        final List<ScheduledEntry<ReplicaFragmentSyncInfo, Void>>
-                entries = new ArrayList<ScheduledEntry<ReplicaFragmentSyncInfo, Void>>();
+        final List<ScheduledEntry<ReplicaFragmentSyncInfo, Void>> entries = new ArrayList<>();
         for (ReplicaFragmentSyncInfo syncInfo : replicaSyncRequests) {
             ScheduledEntry<ReplicaFragmentSyncInfo, Void> entry = replicaSyncTimeoutScheduler.get(syncInfo);
             if (entry != null) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionReplicaVersions.java
@@ -27,8 +27,7 @@ import java.util.Set;
 final class PartitionReplicaVersions {
     private final int partitionId;
 
-    private final Map<ServiceNamespace, PartitionReplicaFragmentVersions> fragmentVersionsMap
-            = new HashMap<ServiceNamespace, PartitionReplicaFragmentVersions>();
+    private final Map<ServiceNamespace, PartitionReplicaFragmentVersions> fragmentVersionsMap = new HashMap<>();
 
     PartitionReplicaVersions(int partitionId) {
         this.partitionId = partitionId;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateGeneratorImpl.java
@@ -136,9 +136,9 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
             }
 
             // groups having partitions under average
-            Queue<NodeGroup> underLoadedGroups = new LinkedList<NodeGroup>();
+            Queue<NodeGroup> underLoadedGroups = new LinkedList<>();
             // groups having partitions over average
-            List<NodeGroup> overLoadedGroups = new LinkedList<NodeGroup>();
+            List<NodeGroup> overLoadedGroups = new LinkedList<>();
             // number of groups should have (average + 1) partitions
             int plusOneGroupCount = partitionCount - avgPartitionPerGroup * groupSize;
             // determine under-loaded and over-loaded groups
@@ -268,12 +268,7 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
                     // all (avg + 1) partitions owned groups are found
                     // if there is any group has avg number of partitions in under-loaded queue
                     // remove it.
-                    Iterator<NodeGroup> underLoaded = underLoadedGroups.iterator();
-                    while (underLoaded.hasNext()) {
-                        if (underLoaded.next().getPartitionCount(index) >= avgPartitionPerGroup) {
-                            underLoaded.remove();
-                        }
-                    }
+                    underLoadedGroups.removeIf(nodeGroup -> nodeGroup.getPartitionCount(index) >= avgPartitionPerGroup);
                 }
             } else if ((plusOneGroupCount > 0 && count < maxPartitionPerGroup)
                     || (count < avgPartitionPerGroup)) {
@@ -296,7 +291,7 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
     }
 
     private Queue<Integer> getUnownedPartitions(PartitionReplica[][] state, int replicaIndex) {
-        LinkedList<Integer> freePartitions = new LinkedList<Integer>();
+        LinkedList<Integer> freePartitions = new LinkedList<>();
         // if owner of a partition can not be found then add partition to free partitions queue.
         for (int partitionId = 0; partitionId < state.length; partitionId++) {
             PartitionReplica[] replicas = state[partitionId];
@@ -353,7 +348,7 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
     }
 
     private Queue<NodeGroup> createNodeGroups(Collection<MemberGroup> memberGroups) {
-        Queue<NodeGroup> nodeGroups = new LinkedList<NodeGroup>();
+        Queue<NodeGroup> nodeGroups = new LinkedList<>();
         if (memberGroups == null || memberGroups.isEmpty()) {
             return nodeGroups;
         }
@@ -429,8 +424,8 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
 
     private static class DefaultNodeGroup implements NodeGroup {
         final PartitionTable groupPartitionTable = new PartitionTable();
-        final Map<PartitionReplica, PartitionTable> nodePartitionTables = new HashMap<PartitionReplica, PartitionTable>();
-        final LinkedList<Integer> partitionQ = new LinkedList<Integer>();
+        final Map<PartitionReplica, PartitionTable> nodePartitionTables = new HashMap<>();
+        final LinkedList<Integer> partitionQ = new LinkedList<>();
 
         @Override
         public void addNode(PartitionReplica replica) {
@@ -540,7 +535,7 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
                     table.add(index, partitionQ.poll());
                 }
             } else {
-                List<PartitionTable> underLoadedStates = new LinkedList<PartitionTable>();
+                List<PartitionTable> underLoadedStates = new LinkedList<>();
                 int avgCount = slimDownNodesToAvgPartitionTableSize(index, underLoadedStates);
                 if (!partitionQ.isEmpty()) {
                     for (PartitionTable table : underLoadedStates) {
@@ -676,7 +671,7 @@ final class PartitionStateGeneratorImpl implements PartitionStateGenerator {
             check(index);
             Set<Integer> set = partitions[index];
             if (set == null) {
-                set = new LinkedHashSet<Integer>();
+                set = new LinkedHashSet<>();
                 partitions[index] = set;
             }
             return set;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PartitionStateManager.java
@@ -98,12 +98,7 @@ public class PartitionStateManager {
     }
 
     private Collection<MemberGroup> createMemberGroups(final Set<Member> excludedMembers) {
-        MemberSelector exclude = new MemberSelector() {
-            @Override
-            public boolean select(Member member) {
-                return !excludedMembers.contains(member);
-            }
-        };
+        MemberSelector exclude = member -> !excludedMembers.contains(member);
         final MemberSelector selector = MemberSelectors.and(DATA_MEMBER_SELECTOR, exclude);
         final Collection<Member> members = node.getClusterService().getMembers(selector);
         return memberGroupFactory.createMemberGroups(members);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/impl/PublishPartitionRuntimeStateTask.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.partition.impl;
 
 import com.hazelcast.instance.Node;
 import com.hazelcast.instance.NodeState;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.logging.ILogger;
 
@@ -51,12 +50,7 @@ class PublishPartitionRuntimeStateTask implements Runnable {
                 logger.info("Remaining migration tasks in queue => " + partitionService.getMigrationQueueSize()
                     + ". (" + migrationManager.getStats().formatToString(logger.isFineEnabled()) + ")");
             } else if (node.getState() == NodeState.ACTIVE) {
-                if (node.getClusterService().getClusterVersion().isGreaterOrEqual(Versions.V3_12)) {
-                    partitionService.checkClusterPartitionRuntimeStates();
-                } else {
-                    // RU_COMPAT_3_11
-                    partitionService.publishPartitionRuntimeState();
-                }
+                partitionService.checkClusterPartitionRuntimeStates();
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/AbstractPartitionOperation.java
@@ -49,7 +49,7 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
     }
 
     private Collection<Operation> createReplicationOperations(PartitionReplicationEvent event, boolean nonFragmentedOnly) {
-        Collection<Operation> operations = new ArrayList<Operation>();
+        Collection<Operation> operations = new ArrayList<>();
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
         Collection<ServiceInfo> services = nodeEngine.getServiceInfos(MigrationAwareService.class);
 
@@ -117,7 +117,7 @@ abstract class AbstractPartitionOperation extends Operation implements Identifie
             // generally a namespace belongs to a single service only
             operations = singleton(op);
         } else if (operations.size() == 1) {
-            operations = new ArrayList<Operation>(operations);
+            operations = new ArrayList<>(operations);
             operations.add(op);
         } else {
             operations.add(op);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BaseMigrationOperation.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.partition.operation;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartition;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
@@ -45,7 +44,6 @@ import com.hazelcast.spi.exception.RetryableHazelcastException;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.ExceptionUtil;
-import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -77,11 +75,9 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
      * the cluster should be in {@link ClusterState#ACTIVE} and the node started and the partition state version from
      * the sender should match the local partition state version.
      *
-     * @throws IllegalStateException                  if the UUIDs don't match or if the cluster and node state are not
-     * @throws PartitionStateVersionMismatchException if the partition versions don't match and this node is not the master node
      */
     @Override
-    public final void beforeRun() throws Exception {
+    public final void beforeRun() {
 
         try {
             onMigrationStart();
@@ -108,8 +104,7 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
     }
 
     private void applyCompletedMigrations() {
-        // RU_COMPAT_3_11 : completedMigrations is null when cluster is 3.11
-        if (completedMigrations == null || completedMigrations.isEmpty()) {
+        if (completedMigrations.isEmpty()) {
             return;
         }
         InternalPartitionServiceImpl partitionService = getService();
@@ -313,48 +308,27 @@ abstract class BaseMigrationOperation extends AbstractPartitionOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        Version version = out.getVersion();
-        // RU_COMPAT_3_11
-        if (version.isGreaterOrEqual(Versions.V3_12)) {
-            out.writeObject(migrationInfo);
-        } else {
-            migrationInfo.writeData(out);
-        }
-
+        out.writeObject(migrationInfo);
         out.writeInt(partitionStateVersion);
 
-        // RU_COMPAT_3_11
-        if (version.isGreaterOrEqual(Versions.V3_12)) {
-            int len = completedMigrations.size();
-            out.writeInt(len);
-            for (MigrationInfo migrationInfo : completedMigrations) {
-                out.writeObject(migrationInfo);
-            }
+        int len = completedMigrations.size();
+        out.writeInt(len);
+        for (MigrationInfo migrationInfo : completedMigrations) {
+            out.writeObject(migrationInfo);
         }
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        Version version = in.getVersion();
-        // RU_COMPAT_3_11
-        if (version.isGreaterOrEqual(Versions.V3_12)) {
-            migrationInfo = in.readObject();
-        } else {
-            migrationInfo = new MigrationInfo();
-            migrationInfo.readData(in);
-        }
-
+        migrationInfo = in.readObject();
         partitionStateVersion = in.readInt();
 
-        // RU_COMPAT_3_11
-        if (version.isGreaterOrEqual(Versions.V3_12)) {
-            int len = in.readInt();
-            completedMigrations = new ArrayList<MigrationInfo>(len);
-            for (int i = 0; i < len; i++) {
-                MigrationInfo migrationInfo = in.readObject();
-                completedMigrations.add(migrationInfo);
-            }
+        int len = in.readInt();
+        completedMigrations = new ArrayList<>(len);
+        for (int i = 0; i < len; i++) {
+            MigrationInfo migrationInfo = in.readObject();
+            completedMigrations.add(migrationInfo);
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/BeforePromotionOperation.java
@@ -49,7 +49,7 @@ final class BeforePromotionOperation extends AbstractPromotionOperation {
     }
 
     @Override
-    public void beforeRun() throws Exception {
+    public void beforeRun() {
         sendMigrationEvent(STARTED);
 
         InternalPartitionServiceImpl service = getService();
@@ -61,7 +61,7 @@ final class BeforePromotionOperation extends AbstractPromotionOperation {
     }
 
     @Override
-    public void run() throws Exception {
+    public void run() {
         ILogger logger = getLogger();
         if (logger.isFinestEnabled()) {
             logger.finest("Running before promotion for " + getPartitionMigrationEvent());
@@ -78,7 +78,7 @@ final class BeforePromotionOperation extends AbstractPromotionOperation {
     }
 
     @Override
-    public void afterRun() throws Exception {
+    public void afterRun() {
         if (beforePromotionsCallback != null) {
             beforePromotionsCallback.run();
         }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizeMigrationOperation.java
@@ -87,7 +87,7 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
         }
 
         NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
-        notifyServices(nodeEngine);
+        notifyServices();
 
         if (endpoint == MigrationEndpoint.SOURCE && success) {
             commitSource();
@@ -106,7 +106,7 @@ public final class FinalizeMigrationOperation extends AbstractPartitionOperation
      * rollback logic. If this node was the source and backup replica for a partition, the services will first be notified that
      * the migration is starting.
      */
-    private void notifyServices(NodeEngineImpl nodeEngine) {
+    private void notifyServices() {
         PartitionMigrationEvent event = getPartitionMigrationEvent();
 
         Collection<MigrationAwareService> migrationAwareServices = getMigrationAwareServices();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/FinalizePromotionOperation.java
@@ -61,12 +61,12 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
     }
 
     @Override
-    public void beforeRun() throws Exception {
+    public void beforeRun() {
         logger = getLogger();
     }
 
     @Override
-    public void run() throws Exception {
+    public void run() {
         if (logger.isFinestEnabled()) {
             logger.finest("Running finalize promotion for " + getPartitionMigrationEvent() + ", result: " + success);
         }
@@ -80,7 +80,7 @@ final class FinalizePromotionOperation extends AbstractPromotionOperation {
     }
 
     @Override
-    public void afterRun() throws Exception {
+    public void afterRun() {
         InternalPartitionServiceImpl service = getService();
         PartitionStateManager partitionStateManager = service.getPartitionStateManager();
         partitionStateManager.clearMigratingFlag(getPartitionId());

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/HasOngoingMigration.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/HasOngoingMigration.java
@@ -30,7 +30,7 @@ public final class HasOngoingMigration extends AbstractPartitionOperation
     private Object response;
 
     @Override
-    public void run() throws Exception {
+    public void run() {
         InternalPartitionServiceImpl service = getService();
         response = service.hasOnGoingMigrationLocal();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationCommitOperation.java
@@ -18,11 +18,9 @@ package com.hazelcast.internal.partition.operation;
 
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.MigrationInfo;
-import com.hazelcast.internal.partition.PartitionRuntimeState;
 import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
@@ -40,9 +38,6 @@ import java.io.IOException;
  */
 public class MigrationCommitOperation extends AbstractPartitionOperation implements MigrationCycleOperation, Versioned {
 
-    // RU_COMPAT_3_11
-    private PartitionRuntimeState partitionState;
-
     private MigrationInfo migration;
 
     private String expectedMemberUuid;
@@ -50,12 +45,6 @@ public class MigrationCommitOperation extends AbstractPartitionOperation impleme
     private transient boolean success;
 
     public MigrationCommitOperation() {
-    }
-
-    // RU_COMPAT_3_11
-    public MigrationCommitOperation(PartitionRuntimeState partitionState, String expectedMemberUuid) {
-        this.partitionState = partitionState;
-        this.expectedMemberUuid = expectedMemberUuid;
     }
 
     public MigrationCommitOperation(MigrationInfo migration, String expectedMemberUuid) {
@@ -74,14 +63,7 @@ public class MigrationCommitOperation extends AbstractPartitionOperation impleme
         }
 
         InternalPartitionServiceImpl service = getService();
-
-        if (nodeEngine.getClusterService().getClusterVersion().isGreaterOrEqual(Versions.V3_12)) {
-            success = service.commitMigrationOnDestination(migration, getCallerAddress());
-        } else {
-            // RU_COMPAT_3_11
-            partitionState.setMaster(getCallerAddress());
-            success = service.processPartitionRuntimeState(partitionState);
-        }
+        success = service.commitMigrationOnDestination(migration, getCallerAddress());
     }
 
     @Override
@@ -107,27 +89,14 @@ public class MigrationCommitOperation extends AbstractPartitionOperation impleme
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         expectedMemberUuid = in.readUTF();
-
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_12)) {
-            migration = in.readObject();
-        } else {
-            // RU_COMPAT_3_11
-            partitionState = new PartitionRuntimeState();
-            partitionState.readData(in);
-        }
+        migration = in.readObject();
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(expectedMemberUuid);
-
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_12)) {
-            out.writeObject(migration);
-        } else {
-            // RU_COMPAT_3_11
-            partitionState.writeData(out);
-        }
+        out.writeObject(migration);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.partition.operation;
 
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.MigrationInfo;
 import com.hazelcast.internal.partition.ReplicaFragmentMigrationState;
 import com.hazelcast.internal.partition.impl.InternalMigrationListener.MigrationParticipant;
@@ -37,7 +36,6 @@ import com.hazelcast.spi.PartitionMigrationEvent;
 import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.impl.operationservice.TargetAware;
 import com.hazelcast.spi.partition.MigrationEndpoint;
-import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -56,11 +54,8 @@ import java.util.logging.Level;
  */
 public class MigrationOperation extends BaseMigrationOperation implements TargetAware, Versioned {
 
-    private static final OperationResponseHandler ERROR_RESPONSE_HANDLER = new OperationResponseHandler() {
-        @Override
-        public void sendResponse(Operation op, Object obj) {
-            throw new HazelcastException("Migration operations can not send response!");
-        }
+    private static final OperationResponseHandler ERROR_RESPONSE_HANDLER = (op, obj) -> {
+        throw new HazelcastException("Migration operations can not send response!");
     };
 
     private ReplicaFragmentMigrationState fragmentMigrationState;
@@ -247,13 +242,7 @@ public class MigrationOperation extends BaseMigrationOperation implements Target
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        // RU_COMPAT_3_11
-        Version version = out.getVersion();
-        if (version.isGreaterOrEqual(Versions.V3_12)) {
-            out.writeObject(fragmentMigrationState);
-        } else {
-            fragmentMigrationState.writeData(out);
-        }
+        out.writeObject(fragmentMigrationState);
         out.writeBoolean(firstFragment);
         out.writeBoolean(lastFragment);
     }
@@ -261,14 +250,7 @@ public class MigrationOperation extends BaseMigrationOperation implements Target
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        // RU_COMPAT_3_11
-        Version version = in.getVersion();
-        if (version.isGreaterOrEqual(Versions.V3_12)) {
-            fragmentMigrationState = in.readObject();
-        } else {
-            fragmentMigrationState = new ReplicaFragmentMigrationState();
-            fragmentMigrationState.readData(in);
-        }
+        fragmentMigrationState = in.readObject();
         firstFragment = in.readBoolean();
         lastFragment = in.readBoolean();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationRequestOperation.java
@@ -139,13 +139,13 @@ public class MigrationRequestOperation extends BaseMigrationOperation {
     private void invokeMigrationOperation(ReplicaFragmentMigrationState migrationState, boolean firstFragment) {
         boolean lastFragment = !fragmentedMigrationEnabled || !namespacesContext.hasNext();
         Operation operation = new MigrationOperation(migrationInfo,
-                firstFragment ? completedMigrations : Collections.<MigrationInfo>emptyList(),
+                firstFragment ? completedMigrations : Collections.emptyList(),
                 partitionStateVersion, migrationState, firstFragment, lastFragment);
 
         ILogger logger = getLogger();
         if (logger.isFinestEnabled()) {
             Set<ServiceNamespace> namespaces = migrationState != null
-                    ? migrationState.getNamespaceVersionMap().keySet() : Collections.<ServiceNamespace>emptySet();
+                    ? migrationState.getNamespaceVersionMap().keySet() : Collections.emptySet();
             logger.finest("Invoking MigrationOperation for namespaces " + namespaces + " and " + migrationInfo
                     + ", lastFragment: " + lastFragment);
         }
@@ -209,7 +209,7 @@ public class MigrationRequestOperation extends BaseMigrationOperation {
         PartitionReplicationEvent event = getPartitionReplicationEvent();
         Collection<Operation> operations = createNonFragmentedReplicationOperations(event);
         Collection<ServiceNamespace> namespaces =
-                Collections.<ServiceNamespace>singleton(NonFragmentedServiceNamespace.INSTANCE);
+                Collections.singleton(NonFragmentedServiceNamespace.INSTANCE);
         return createReplicaFragmentMigrationState(namespaces, operations);
     }
 
@@ -232,7 +232,7 @@ public class MigrationRequestOperation extends BaseMigrationOperation {
 
         InternalPartitionService partitionService = getService();
         PartitionReplicaVersionManager versionManager = partitionService.getPartitionReplicaVersionManager();
-        Map<ServiceNamespace, long[]> versions = new HashMap<ServiceNamespace, long[]>(namespaces.size());
+        Map<ServiceNamespace, long[]> versions = new HashMap<>(namespaces.size());
         for (ServiceNamespace namespace : namespaces) {
             long[] v = versionManager.getPartitionReplicaVersions(getPartitionId(), namespace);
             versions.put(namespace, v);
@@ -346,8 +346,8 @@ public class MigrationRequestOperation extends BaseMigrationOperation {
     }
 
     private static class ServiceNamespacesContext {
-        final Collection<ServiceNamespace> allNamespaces = new HashSet<ServiceNamespace>();
-        final Map<ServiceNamespace, Collection<String>> namespaceToServices = new HashMap<ServiceNamespace, Collection<String>>();
+        final Collection<ServiceNamespace> allNamespaces = new HashSet<>();
+        final Map<ServiceNamespace, Collection<String>> namespaceToServices = new HashMap<>();
 
         final Iterator<ServiceNamespace> namespaceIterator;
 
@@ -375,7 +375,7 @@ public class MigrationRequestOperation extends BaseMigrationOperation {
                     // generally a namespace belongs to a single service only
                     namespaceToServices.put(ns, singleton(serviceName));
                 } else if (serviceNames.size() == 1) {
-                    serviceNames = new HashSet<String>(serviceNames);
+                    serviceNames = new HashSet<>(serviceNames);
                     serviceNames.add(serviceName);
                     namespaceToServices.put(ns, serviceNames);
                 } else {

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.PARTITION_BACKUP_REPLICA_ANTI_ENTROPY;
 
 // should not be an urgent operation. required to be in order with backup operations on target node
-// RU_COMPAT_39: Do not remove Versioned interface! Version info is needed on 3.9 members while deserializing the operation.
 public final class PartitionBackupReplicaAntiEntropyOperation
         extends AbstractPartitionOperation
         implements PartitionAwareOperation, AllowedDuringPassiveState, Versioned {
@@ -55,7 +54,7 @@ public final class PartitionBackupReplicaAntiEntropyOperation
     }
 
     @Override
-    public void run() throws Exception {
+    public void run() {
         if (!isNodeStartCompleted()) {
             response = false;
             return;
@@ -150,7 +149,7 @@ public final class PartitionBackupReplicaAntiEntropyOperation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int len = in.readInt();
-        versions = new HashMap<ServiceNamespace, Long>(len);
+        versions = new HashMap<>(len);
         for (int i = 0; i < len; i++) {
             ServiceNamespace ns = in.readObject();
             long v = in.readLong();

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRequest.java
@@ -56,8 +56,6 @@ import java.util.List;
  * </ul>
  * An empty response can be sent if the current replica version is 0.
  */
-// RU_COMPAT_39: Do not remove Versioned interface!
-// Version info is needed on 3.9 members while deserializing the operation.
 public final class PartitionReplicaSyncRequest extends AbstractPartitionOperation
         implements PartitionAwareOperation, MigrationCycleOperation, Versioned {
 
@@ -264,7 +262,7 @@ public final class PartitionReplicaSyncRequest extends AbstractPartitionOperatio
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int len = in.readInt();
-        namespaces = new ArrayList<ServiceNamespace>(len);
+        namespaces = new ArrayList<>(len);
         for (int i = 0; i < len; i++) {
             ServiceNamespace ns = in.readObject();
             namespaces.add(ns);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncResponse.java
@@ -61,8 +61,6 @@ import static com.hazelcast.spi.impl.OperationResponseHandlerFactory.createError
  * <li>if the node is not a replica anymore it will clear the replica versions for the partition</li>
  * </ul>
  */
-// RU_COMPAT_39: Do not remove Versioned interface!
-// Version info is needed on 3.9 members while deserializing the operation.
 @SuppressFBWarnings("EI_EXPOSE_REP")
 public class PartitionReplicaSyncResponse extends AbstractPartitionOperation
         implements PartitionAwareOperation, BackupOperation, UrgentSystemOperation,
@@ -281,7 +279,7 @@ public class PartitionReplicaSyncResponse extends AbstractPartitionOperation
 
         int size = in.readInt();
         if (size > 0) {
-            operations = new ArrayList<Operation>(size);
+            operations = new ArrayList<>(size);
             for (int i = 0; i < size; i++) {
                 Operation op = in.readObject();
                 operations.add(op);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRetryResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRetryResponse.java
@@ -38,8 +38,6 @@ import java.util.Collections;
  * The response to a {@link PartitionReplicaSyncRequest} that the replica should retry. This will reset the current ongoing
  * synchronization request state and retry the request if this node is still a replica of this partition.
  */
-// RU_COMPAT_39: Do not remove Versioned interface!
-// Version info is needed on 3.9 members while deserializing the operation.
 public class PartitionReplicaSyncRetryResponse
         extends AbstractPartitionOperation
         implements PartitionAwareOperation, BackupOperation, MigrationCycleOperation, Versioned {
@@ -97,7 +95,7 @@ public class PartitionReplicaSyncRetryResponse
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         int len = in.readInt();
-        namespaces = new ArrayList<ServiceNamespace>(len);
+        namespaces = new ArrayList<>(len);
         for (int i = 0; i < len; i++) {
             ServiceNamespace ns = in.readObject();
             namespaces.add(ns);

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionStateOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.internal.partition.operation;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.operations.JoinOperation;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
@@ -28,7 +27,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.impl.Versioned;
-import com.hazelcast.version.Version;
 
 import java.io.IOException;
 
@@ -86,27 +84,14 @@ public final class PartitionStateOperation extends AbstractPartitionOperation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        // RU_COMPAT_3_11
-        Version version = in.getVersion();
-        if (version.isGreaterOrEqual(Versions.V3_12)) {
-            partitionState = in.readObject();
-        } else {
-            partitionState = new PartitionRuntimeState();
-            partitionState.readData(in);
-        }
+        partitionState = in.readObject();
         sync = in.readBoolean();
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        // RU_COMPAT_3_11
-        Version version = out.getVersion();
-        if (version.isGreaterOrEqual(Versions.V3_12)) {
-            out.writeObject(partitionState);
-        } else {
-            partitionState.writeData(out);
-        }
+        out.writeObject(partitionState);
         out.writeBoolean(sync);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PromotionCommitOperation.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.partition.operation;
 
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.partition.InternalPartitionService;
 import com.hazelcast.internal.partition.MigrationCycleOperation;
 import com.hazelcast.internal.partition.MigrationInfo;
@@ -40,7 +39,6 @@ import com.hazelcast.spi.exception.TargetNotMemberException;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.Preconditions;
-import com.hazelcast.version.Version;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -251,28 +249,13 @@ public class PromotionCommitOperation extends AbstractPartitionOperation impleme
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         expectedMemberUuid = in.readUTF();
-
-        Version version = in.getVersion();
-        // RU_COMPAT_3_11
-        if (version.isGreaterOrEqual(Versions.V3_12)) {
-            partitionState = in.readObject();
-        } else {
-            partitionState = new PartitionRuntimeState();
-            partitionState.readData(in);
-        }
+        partitionState = in.readObject();
 
         int len = in.readInt();
         if (len > 0) {
-            promotions = new ArrayList<MigrationInfo>(len);
+            promotions = new ArrayList<>(len);
             for (int i = 0; i < len; i++) {
-                MigrationInfo migrationInfo;
-                // RU_COMPAT_3_11
-                if (version.isGreaterOrEqual(Versions.V3_12)) {
-                    migrationInfo = in.readObject();
-                } else {
-                    migrationInfo = new MigrationInfo();
-                    migrationInfo.readData(in);
-                }
+                MigrationInfo migrationInfo = in.readObject();
                 promotions.add(migrationInfo);
             }
         }
@@ -282,24 +265,12 @@ public class PromotionCommitOperation extends AbstractPartitionOperation impleme
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeUTF(expectedMemberUuid);
-
-        Version version = out.getVersion();
-        // RU_COMPAT_3_11
-        if (version.isGreaterOrEqual(Versions.V3_12)) {
-            out.writeObject(partitionState);
-        } else {
-            partitionState.writeData(out);
-        }
+        out.writeObject(partitionState);
 
         int len = promotions.size();
         out.writeInt(len);
         for (MigrationInfo migrationInfo : promotions) {
-            // RU_COMPAT_3_11
-            if (version.isGreaterOrEqual(Versions.V3_12)) {
-                out.writeObject(migrationInfo);
-            } else {
-                migrationInfo.writeData(out);
-            }
+            out.writeObject(migrationInfo);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PublishCompletedMigrationsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PublishCompletedMigrationsOperation.java
@@ -79,7 +79,7 @@ public class PublishCompletedMigrationsOperation extends AbstractPartitionOperat
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         int len = in.readInt();
-        completedMigrations = new ArrayList<MigrationInfo>(len);
+        completedMigrations = new ArrayList<>(len);
         for (int i = 0; i < len; i++) {
             MigrationInfo migrationInfo = in.readObject();
             completedMigrations.add(migrationInfo);

--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/impl/MigrationCommitServiceTest.java
@@ -345,7 +345,10 @@ public class MigrationCommitServiceTest extends HazelcastTestSupport {
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() {
-                assertTrue(partitionService.syncPartitionRuntimeState());
+                partitionService.checkClusterPartitionRuntimeStates();
+                for (HazelcastInstance instance : instances) {
+                    assertEquals(partitionService.getPartitionStateVersion(), getPartitionService(instance).getPartitionStateVersion());
+                }
             }
         });
 


### PR DESCRIPTION
Additionally replaced `dataserializable.readObject(in)/writeObject(out)` with `dataserializable = in.readObject() / out.writeObject(dataserializable)`.

Part of #14896