### PR TITLE
Fix Java 6 compilation error in DelegatingAddressPicker

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java
@@ -127,11 +127,11 @@ final class DelegatingAddressPicker
         InetSocketAddress publicAddress;
         ServerSocketChannel serverSocketChannel;
 
-        for (EndpointConfig config : config.getAdvancedNetworkConfig().getEndpointConfigs().values()) {
-            if (!(config instanceof ServerSocketEndpointConfig)) {
+        for (EndpointConfig ec : config.getAdvancedNetworkConfig().getEndpointConfigs().values()) {
+            if (!(ec instanceof ServerSocketEndpointConfig)) {
                 continue;
             }
-            ServerSocketEndpointConfig endpointConfig = (ServerSocketEndpointConfig) config;
+            ServerSocketEndpointConfig endpointConfig = (ServerSocketEndpointConfig) ec;
             EndpointQualifier qualifier = endpointConfig.getQualifier();
 
             bindAddress = memberAddressProvider.getBindAddress(qualifier);
@@ -140,7 +140,7 @@ final class DelegatingAddressPicker
 
             if (!bindAddresses.values().contains(bindAddress)) {
                 // bind new server socket
-                serverSocketChannel = createServerSocketChannel(logger, config, bindAddress.getAddress(),
+                serverSocketChannel = createServerSocketChannel(logger, ec, bindAddress.getAddress(),
                         bindAddress.getPort() == 0 ? endpointConfig.getPort() : bindAddress.getPort(),
                         endpointConfig.getPortCount(), endpointConfig.isPortAutoIncrement(),
                         endpointConfig.isReuseAddress(), false);


### PR DESCRIPTION
Fix for Java 6 compilation error:

```
$ mvn -version
Apache Maven 3.2.5 (12a6b3acb947671f09b81f49094c53f426d8cea1; 2014-12-14T18:29:23+01:00)
Maven home: /path/to/apache-maven-3.2.5
Java version: 1.6.0-107, vendor: Azul Systems, Inc.
Java home: /path/to/zulu6.20.0.1-jdk6.0.107-linux_x64/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "4.15.0-47-generic", arch: "amd64", family: "unix"

$ mvn -Pjdk-pre-8 clean install -DskipTests
...
[ERROR] /tmp/hz/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java:[130,43] cannot find symbol
symbol  : method getAdvancedNetworkConfig()
location: class com.hazelcast.config.EndpointConfig
```