### PR TITLE
Updated cluster package to Java 8 and removed 3.11 RU paths

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -22,7 +22,6 @@ import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.VersionAware;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.version.MemberVersion;
@@ -32,11 +31,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.hazelcast.instance.BuildInfoProvider.getBuildInfo;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static com.hazelcast.instance.MemberImpl.NA_MEMBER_LIST_JOIN_VERSION;
-import static com.hazelcast.internal.cluster.Versions.V3_10;
-import static com.hazelcast.internal.cluster.Versions.V3_12;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readMap;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeMap;
 import static com.hazelcast.util.MapUtil.createHashMap;
@@ -57,8 +53,7 @@ public class MemberInfo implements IdentifiedDataSerializable, Versioned {
     }
 
     public MemberInfo(Address address, String uuid, Map<String, Object> attributes, MemberVersion version) {
-        this(address, uuid, attributes, false, version, NA_MEMBER_LIST_JOIN_VERSION,
-                Collections.<EndpointQualifier, Address>emptyMap());
+        this(address, uuid, attributes, false, version, NA_MEMBER_LIST_JOIN_VERSION, Collections.emptyMap());
     }
 
     public MemberInfo(Address address, String uuid, Map<String, Object> attributes, boolean liteMember, MemberVersion version,
@@ -70,8 +65,7 @@ public class MemberInfo implements IdentifiedDataSerializable, Versioned {
                       int memberListJoinVersion, Map<EndpointQualifier, Address> addressMap) {
         this.address = address;
         this.uuid = uuid;
-        this.attributes = attributes == null || attributes.isEmpty()
-                ? Collections.<String, Object>emptyMap() : new HashMap<String, Object>(attributes);
+        this.attributes = attributes == null || attributes.isEmpty() ? Collections.emptyMap() : new HashMap<>(attributes);
         this.liteMember = liteMember;
         this.version = version;
         this.memberListJoinVersion = memberListJoinVersion;
@@ -123,11 +117,8 @@ public class MemberInfo implements IdentifiedDataSerializable, Versioned {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        address = new Address();
-        address.readData(in);
-        if (in.readBoolean()) {
-            uuid = in.readUTF();
-        }
+        address = in.readObject();
+        uuid = in.readUTF();
         liteMember = in.readBoolean();
         int size = in.readInt();
         if (size > 0) {
@@ -139,31 +130,14 @@ public class MemberInfo implements IdentifiedDataSerializable, Versioned {
             attributes.put(key, value);
         }
         version = in.readObject();
-        // RU_COMPAT_3_10
-        // MemberInfo we read may originate:
-        // - from OS/EE 3.11 member -> memberListJoinversion is available
-        // - from EE 3.10:
-        //   - FinalizeJoinOp / MembersUpdateOp: in this case, memberListJoinVersion is available because container
-        //   operations are Versioned themselves
-        //   - as a MembersView response within a NormalResponse from FetchMembersViewOp which is expected to not contain
-        //   memberListJoinVersion because the container object (MembersView) was not Versioned (-> in.getVersion
-        //   is UNKNOWN)
-        if (mustReadMemberListJoinVersion(in)) {
-            memberListJoinVersion = in.readInt();
-        }
-        if (in.getVersion().isGreaterOrEqual(V3_12)) {
-            addressMap = readMap(in);
-        }
+        memberListJoinVersion = in.readInt();
+        addressMap = readMap(in);
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        address.writeData(out);
-        boolean hasUuid = uuid != null;
-        out.writeBoolean(hasUuid);
-        if (hasUuid) {
-            out.writeUTF(uuid);
-        }
+        out.writeObject(address);
+        out.writeUTF(uuid);
         out.writeBoolean(liteMember);
         out.writeInt(attributes == null ? 0 : attributes.size());
         if (attributes != null) {
@@ -173,13 +147,8 @@ public class MemberInfo implements IdentifiedDataSerializable, Versioned {
             }
         }
         out.writeObject(version);
-        // MemberInfo always serializes memberListJoinVersion. The output stream will include the
-        // cluster version, since all containing objects are Versioned (including MembersView)
-        // -> a 3.10 member will be able to deserialize it.
         out.writeInt(memberListJoinVersion);
-        if (out.getVersion().isGreaterOrEqual(V3_12)) {
-            writeMap(addressMap, out);
-        }
+        writeMap(addressMap, out);
     }
 
     @Override
@@ -203,13 +172,10 @@ public class MemberInfo implements IdentifiedDataSerializable, Versioned {
         }
         MemberInfo other = (MemberInfo) obj;
         if (address == null) {
-            if (other.address != null) {
-                return false;
-            }
-        } else if (!address.equals(other.address)) {
-            return false;
+            return other.address == null;
+        } else {
+            return address.equals(other.address);
         }
-        return true;
     }
 
     @Override
@@ -230,13 +196,5 @@ public class MemberInfo implements IdentifiedDataSerializable, Versioned {
     @Override
     public int getId() {
         return ClusterDataSerializerHook.MEMBER_INFO;
-    }
-
-    // memberListJoinVersion must be read when:
-    // - open source or
-    // - enterprise && stream version >= 3.10
-    private boolean mustReadMemberListJoinVersion(VersionAware versionAware) {
-        return (!getBuildInfo().isEnterprise()
-                || versionAware.getVersion().isGreaterOrEqual(V3_10));
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/DeadlineClusterFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/DeadlineClusterFailureDetector.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentMap;
 public class DeadlineClusterFailureDetector implements ClusterFailureDetector {
 
     private final long maxNoHeartbeatMillis;
-    private final ConcurrentMap<Member, Long> heartbeatTimes = new ConcurrentHashMap<Member, Long>();
+    private final ConcurrentMap<Member, Long> heartbeatTimes = new ConcurrentHashMap<>();
 
     public DeadlineClusterFailureDetector(long maxNoHeartbeatMillis) {
         this.maxNoHeartbeatMillis = maxNoHeartbeatMillis;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PhiAccrualFailureDetector.java
@@ -190,7 +190,7 @@ public class PhiAccrualFailureDetector implements FailureDetector {
      */
     private static class HeartbeatHistory {
         private final int maxSampleSize;
-        private final LinkedList<Long> intervals = new LinkedList<Long>();
+        private final LinkedList<Long> intervals = new LinkedList<>();
         private long intervalSum;
         private long squaredIntervalSum;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PingFailureDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/fd/PingFailureDetector.java
@@ -29,7 +29,7 @@ public class PingFailureDetector<E> {
 
     private final int maxPingAttempts;
 
-    private final ConcurrentMap<E, AtomicInteger> pingAttempts = new ConcurrentHashMap<E, AtomicInteger>();
+    private final ConcurrentMap<E, AtomicInteger> pingAttempts = new ConcurrentHashMap<>();
 
     public PingFailureDetector(int maxPingAttempts) {
         this.maxPingAttempts = maxPingAttempts;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/AbstractJoiner.java
@@ -70,7 +70,7 @@ public abstract class AbstractJoiner
     protected final ILogger logger;
 
     // map blacklisted endpoints. Boolean value represents if blacklist is temporary or permanent
-    protected final ConcurrentMap<Address, Boolean> blacklistedAddresses = new ConcurrentHashMap<Address, Boolean>();
+    protected final ConcurrentMap<Address, Boolean> blacklistedAddresses = new ConcurrentHashMap<>();
     protected final ClusterJoinManager clusterJoinManager;
 
     private final AtomicLong joinStartTime = new AtomicLong(Clock.currentTimeMillis());
@@ -285,7 +285,7 @@ public abstract class AbstractJoiner
 
         OperationService operationService = node.nodeEngine.getOperationService();
         Collection<Member> memberList = clusterService.getMembers();
-        Collection<Future> futures = new ArrayList<Future>(memberList.size());
+        Collection<Future> futures = new ArrayList<>(memberList.size());
         for (Member member : memberList) {
             if (!member.localMember()) {
                 Operation op = new MergeClustersOp(targetAddress);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/BindMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/BindMessage.java
@@ -62,24 +62,15 @@ public class BindMessage implements IdentifiedDataSerializable {
 
     @Override
     public void readData(final ObjectDataInput in) throws IOException {
-        localAddress = new Address();
-        localAddress.readData(in);
-        boolean hasTarget = in.readBoolean();
-        if (hasTarget) {
-            targetAddress = new Address();
-            targetAddress.readData(in);
-        }
+        localAddress = in.readObject();
+        targetAddress = in.readObject();
         reply = in.readBoolean();
     }
 
     @Override
     public void writeData(final ObjectDataOutput out) throws IOException {
-        localAddress.writeData(out);
-        boolean hasTarget = targetAddress != null;
-        out.writeBoolean(hasTarget);
-        if (hasTarget) {
-            targetAddress.writeData(out);
-        }
+        out.writeObject(localAddress);
+        out.writeObject(targetAddress);
         out.writeBoolean(reply);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializerHook.java
@@ -119,233 +119,50 @@ public final class ClusterDataSerializerHook implements DataSerializerHook {
     public DataSerializableFactory createFactory() {
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[LEN];
 
-        constructors[AUTH_FAILURE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new AuthenticationFailureOp();
-            }
-        };
-        constructors[ADDRESS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new Address();
-            }
-        };
-        constructors[MEMBER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MemberImpl();
-            }
-        };
-        constructors[HEARTBEAT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new HeartbeatOp();
-            }
-        };
-        constructors[CONFIG_CHECK] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ConfigCheck();
-            }
-        };
-        constructors[BIND_MESSAGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new BindMessage();
-            }
-        };
-        constructors[MEMBER_INFO_UPDATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MembersUpdateOp();
-            }
-        };
-        constructors[FINALIZE_JOIN] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new FinalizeJoinOp();
-            }
-        };
-        constructors[AUTHORIZATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new AuthorizationOp();
-            }
-        };
-        constructors[BEFORE_JOIN_CHECK_FAILURE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new BeforeJoinCheckFailureOp();
-            }
-        };
-        constructors[CHANGE_CLUSTER_STATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new CommitClusterStateOp();
-            }
-        };
-        constructors[CONFIG_MISMATCH] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ConfigMismatchOp();
-            }
-        };
-        constructors[GROUP_MISMATCH] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new GroupMismatchOp();
-            }
-        };
-        constructors[SPLIT_BRAIN_MERGE_VALIDATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new SplitBrainMergeValidationOp();
-            }
-        };
-        constructors[JOIN_REQUEST_OP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new JoinRequestOp();
-            }
-        };
-        constructors[LOCK_CLUSTER_STATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new LockClusterStateOp();
-            }
-        };
-        constructors[MASTER_CLAIM] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new JoinMastershipClaimOp();
-            }
-        };
-        constructors[WHOIS_MASTER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new WhoisMasterOp();
-            }
-        };
-        constructors[MEMBER_ATTR_CHANGED] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MemberAttributeChangedOp();
-            }
-        };
-        constructors[MERGE_CLUSTERS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MergeClustersOp();
-            }
-        };
-        constructors[POST_JOIN] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new OnJoinOp();
-            }
-        };
-        constructors[ROLLBACK_CLUSTER_STATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new RollbackClusterStateOp();
-            }
-        };
-        constructors[MASTER_RESPONSE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MasterResponseOp();
-            }
-        };
-        constructors[SHUTDOWN_NODE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ShutdownNodeOp();
-            }
-        };
-        constructors[TRIGGER_MEMBER_LIST_PUBLISH] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TriggerMemberListPublishOp();
-            }
-        };
-        constructors[CLUSTER_STATE_TRANSACTION_LOG_RECORD] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ClusterStateTransactionLogRecord();
-            }
-        };
-        constructors[MEMBER_INFO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MemberInfo();
-            }
-        };
-        constructors[JOIN_MESSAGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new JoinMessage();
-            }
-        };
-        constructors[JOIN_REQUEST] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new JoinRequest();
-            }
-        };
-        constructors[MIGRATION_INFO] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MigrationInfo();
-            }
-        };
-        constructors[MEMBER_VERSION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MemberVersion();
-            }
-        };
-        constructors[CLUSTER_STATE_CHANGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ClusterStateChange();
-            }
-        };
-        constructors[SPLIT_BRAIN_JOIN_MESSAGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new SplitBrainJoinMessage();
-            }
-        };
-        constructors[VERSION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new Version();
-            }
-        };
-
-        constructors[FETCH_MEMBER_LIST_STATE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new FetchMembersViewOp();
-            }
-        };
-        constructors[EXPLICIT_SUSPICION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ExplicitSuspicionOp();
-            }
-        };
-        constructors[MEMBERS_VIEW] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MembersView();
-            }
-        };
-        constructors[TRIGGER_EXPLICIT_SUSPICION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TriggerExplicitSuspicionOp();
-            }
-        };
-        constructors[MEMBERS_VIEW_METADATA] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new MembersViewMetadata();
-            }
-        };
-        constructors[HEARTBEAT_COMPLAINT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new HeartbeatComplaintOp();
-            }
-        };
-        constructors[PROMOTE_LITE_MEMBER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PromoteLiteMemberOp();
-            }
-        };
-        constructors[VECTOR_CLOCK] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new VectorClock();
-            }
-        };
-        constructors[EXTENDED_BIND_MESSAGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ExtendedBindMessage();
-            }
-        };
-        constructors[ENDPOINT_QUALIFIER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new EndpointQualifier();
-            }
-        };
+        constructors[AUTH_FAILURE] = arg -> new AuthenticationFailureOp();
+        constructors[ADDRESS] = arg -> new Address();
+        constructors[MEMBER] = arg -> new MemberImpl();
+        constructors[HEARTBEAT] = arg -> new HeartbeatOp();
+        constructors[CONFIG_CHECK] = arg -> new ConfigCheck();
+        constructors[BIND_MESSAGE] = arg -> new BindMessage();
+        constructors[MEMBER_INFO_UPDATE] = arg -> new MembersUpdateOp();
+        constructors[FINALIZE_JOIN] = arg -> new FinalizeJoinOp();
+        constructors[AUTHORIZATION] = arg -> new AuthorizationOp();
+        constructors[BEFORE_JOIN_CHECK_FAILURE] = arg -> new BeforeJoinCheckFailureOp();
+        constructors[CHANGE_CLUSTER_STATE] = arg -> new CommitClusterStateOp();
+        constructors[CONFIG_MISMATCH] = arg -> new ConfigMismatchOp();
+        constructors[GROUP_MISMATCH] = arg -> new GroupMismatchOp();
+        constructors[SPLIT_BRAIN_MERGE_VALIDATION] = arg -> new SplitBrainMergeValidationOp();
+        constructors[JOIN_REQUEST_OP] = arg -> new JoinRequestOp();
+        constructors[LOCK_CLUSTER_STATE] = arg -> new LockClusterStateOp();
+        constructors[MASTER_CLAIM] = arg -> new JoinMastershipClaimOp();
+        constructors[WHOIS_MASTER] = arg -> new WhoisMasterOp();
+        constructors[MEMBER_ATTR_CHANGED] = arg -> new MemberAttributeChangedOp();
+        constructors[MERGE_CLUSTERS] = arg -> new MergeClustersOp();
+        constructors[POST_JOIN] = arg -> new OnJoinOp();
+        constructors[ROLLBACK_CLUSTER_STATE] = arg -> new RollbackClusterStateOp();
+        constructors[MASTER_RESPONSE] = arg -> new MasterResponseOp();
+        constructors[SHUTDOWN_NODE] = arg -> new ShutdownNodeOp();
+        constructors[TRIGGER_MEMBER_LIST_PUBLISH] = arg -> new TriggerMemberListPublishOp();
+        constructors[CLUSTER_STATE_TRANSACTION_LOG_RECORD] = arg -> new ClusterStateTransactionLogRecord();
+        constructors[MEMBER_INFO] = arg -> new MemberInfo();
+        constructors[JOIN_MESSAGE] = arg -> new JoinMessage();
+        constructors[JOIN_REQUEST] = arg -> new JoinRequest();
+        constructors[MIGRATION_INFO] = arg -> new MigrationInfo();
+        constructors[MEMBER_VERSION] = arg -> new MemberVersion();
+        constructors[CLUSTER_STATE_CHANGE] = arg -> new ClusterStateChange();
+        constructors[SPLIT_BRAIN_JOIN_MESSAGE] = arg -> new SplitBrainJoinMessage();
+        constructors[VERSION] = arg -> new Version();
+        constructors[FETCH_MEMBER_LIST_STATE] = arg -> new FetchMembersViewOp();
+        constructors[EXPLICIT_SUSPICION] = arg -> new ExplicitSuspicionOp();
+        constructors[MEMBERS_VIEW] = arg -> new MembersView();
+        constructors[TRIGGER_EXPLICIT_SUSPICION] = arg -> new TriggerExplicitSuspicionOp();
+        constructors[MEMBERS_VIEW_METADATA] = arg -> new MembersViewMetadata();
+        constructors[HEARTBEAT_COMPLAINT] = arg -> new HeartbeatComplaintOp();
+        constructors[PROMOTE_LITE_MEMBER] = arg -> new PromoteLiteMemberOp();
+        constructors[VECTOR_CLOCK] = arg -> new VectorClock();
+        constructors[EXTENDED_BIND_MESSAGE] = arg -> new ExtendedBindMessage();
+        constructors[ENDPOINT_QUALIFIER] = arg -> new EndpointQualifier();
         return new ArrayDataSerializableFactory(constructors);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterHeartbeatManager.java
@@ -211,20 +211,14 @@ public class ClusterHeartbeatManager {
     }
 
     /**
-     * Initializes the {@link ClusterHeartbeatManager}. It will schedule the :
-     * <ul>
-     * <li>heartbeat operation to the {@link #getHeartbeatInterval(HazelcastProperties)} interval</li>
-     * <li>master confirmation to the {@link GroupProperty#MASTER_CONFIRMATION_INTERVAL_SECONDS} interval</li>
-     * </ul>
+     * Initializes the {@link ClusterHeartbeatManager}. It will schedule the
+     * heartbeat operation to the {@link #getHeartbeatInterval(HazelcastProperties)} interval.
      */
     void init() {
         ExecutionService executionService = nodeEngine.getExecutionService();
 
-        executionService.scheduleWithRepetition(CLUSTER_EXECUTOR_NAME, new Runnable() {
-            public void run() {
-                heartbeat();
-            }
-        }, heartbeatIntervalMillis, heartbeatIntervalMillis, TimeUnit.MILLISECONDS);
+        executionService.scheduleWithRepetition(CLUSTER_EXECUTOR_NAME, this::heartbeat,
+                heartbeatIntervalMillis, heartbeatIntervalMillis, TimeUnit.MILLISECONDS);
 
         if (icmpParallelMode) {
             startPeriodicPinger();
@@ -591,16 +585,14 @@ public class ClusterHeartbeatManager {
     }
 
     private void startPeriodicPinger() {
-        nodeEngine.getExecutionService().scheduleWithRepetition(CLUSTER_EXECUTOR_NAME, new Runnable() {
-            public void run() {
-                Collection<Member> members = clusterService.getMembers(MemberSelectors.NON_LOCAL_MEMBER_SELECTOR);
+        nodeEngine.getExecutionService().scheduleWithRepetition(CLUSTER_EXECUTOR_NAME, () -> {
+            Collection<Member> members = clusterService.getMembers(MemberSelectors.NON_LOCAL_MEMBER_SELECTOR);
 
-                for (Member member : members) {
-                    try {
-                        runPingTask(member);
-                    } catch (Throwable e) {
-                        logger.severe(e);
-                    }
+            for (Member member : members) {
+                try {
+                    runPingTask(member);
+                } catch (Throwable e) {
+                    logger.severe(e);
                 }
             }
         }, icmpIntervalMillis, icmpIntervalMillis, TimeUnit.MILLISECONDS);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterMergeTask.java
@@ -117,7 +117,7 @@ class ClusterMergeTask implements Runnable {
     private Collection<Runnable> collectMergeTasks(boolean coreServices) {
         // gather merge tasks from services
         Collection<SplitBrainHandlerService> services = node.nodeEngine.getServices(SplitBrainHandlerService.class);
-        Collection<Runnable> tasks = new LinkedList<Runnable>();
+        Collection<Runnable> tasks = new LinkedList<>();
         for (SplitBrainHandlerService service : services) {
             if (coreServices != isCoreService(service)) {
                 continue;
@@ -154,7 +154,7 @@ class ClusterMergeTask implements Runnable {
     }
 
     private void executeMergeTasks(Collection<Runnable> tasks) {
-        Collection<Future> futures = new LinkedList<Future>();
+        Collection<Future> futures = new LinkedList<>();
 
         for (Runnable task : tasks) {
             Future f = node.nodeEngine.getExecutionService().submit(MERGE_TASKS_EXECUTOR, task);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateManager.java
@@ -74,7 +74,7 @@ public class ClusterStateManager {
     private final Node node;
     private final ILogger logger;
     private final Lock clusterServiceLock;
-    private final AtomicReference<LockGuard> stateLockRef = new AtomicReference<LockGuard>(LockGuard.NOT_LOCKED);
+    private final AtomicReference<LockGuard> stateLockRef = new AtomicReference<>(LockGuard.NOT_LOCKED);
 
     private volatile ClusterState state = ClusterState.ACTIVE;
 
@@ -437,7 +437,7 @@ public class ClusterStateManager {
                                               String txnId, Collection<MemberImpl> members,
                                               int memberListVersion, int partitionStateVersion) {
 
-        Collection<Future> futures = new ArrayList<Future>(members.size());
+        Collection<Future> futures = new ArrayList<>(members.size());
 
         final Address thisAddress = node.getThisAddress();
         for (Member member : members) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -17,7 +17,6 @@
 package com.hazelcast.internal.cluster.impl;
 
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.operations.CommitClusterStateOp;
 import com.hazelcast.internal.cluster.impl.operations.LockClusterStateOp;
 import com.hazelcast.internal.cluster.impl.operations.RollbackClusterStateOp;
@@ -103,10 +102,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         out.writeLong(leaseTime);
         out.writeInt(partitionStateVersion);
         out.writeBoolean(isTransient);
-        // RU_COMPAT_V3_10
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
-            out.writeInt(memberListVersion);
-        }
+        out.writeInt(memberListVersion);
     }
 
     @Override
@@ -118,10 +114,7 @@ public class ClusterStateTransactionLogRecord implements TargetAwareTransactionL
         leaseTime = in.readLong();
         partitionStateVersion = in.readInt();
         isTransient = in.readBoolean();
-        // RU_COMPAT_V3_10
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
-            memberListVersion = in.readInt();
-        }
+        memberListVersion = in.readInt();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ConfigCheck.java
@@ -38,8 +38,6 @@ import static com.hazelcast.util.MapUtil.createHashMap;
  */
 public final class ConfigCheck implements IdentifiedDataSerializable {
 
-    private static final String EMPTY_PWD = "";
-
     private String groupName;
 
     private String joinerType;
@@ -106,10 +104,7 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
     }
 
     public boolean isSameGroup(ConfigCheck found) {
-        if (!equals(groupName, found.groupName)) {
-            return false;
-        }
-        return true;
+        return equals(groupName, found.groupName);
     }
 
     private void verifyApplicationValidationToken(ConfigCheck found) {
@@ -172,9 +167,6 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(groupName);
-
-        //TODO @tkountis remove in 4.0
-        out.writeUTF(EMPTY_PWD);
         out.writeUTF(joinerType);
         out.writeBoolean(partitionGroupEnabled);
         if (partitionGroupEnabled) {
@@ -203,8 +195,6 @@ public final class ConfigCheck implements IdentifiedDataSerializable {
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         groupName = in.readUTF();
-        //TODO groupPassword/ignored - @tkountis remove in 4.0
-        in.readUTF();
         joinerType = in.readUTF();
         partitionGroupEnabled = in.readBoolean();
         if (partitionGroupEnabled) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/DiscoveryJoiner.java
@@ -73,7 +73,7 @@ public class DiscoveryJoiner
         MemberImpl localMember = node.nodeEngine.getLocalMember();
         Address localAddress = localMember.getAddress();
 
-        Collection<Address> possibleMembers = new ArrayList<Address>();
+        Collection<Address> possibleMembers = new ArrayList<>();
         for (DiscoveryNode discoveryNode : discoveredNodes) {
             Address discoveredAddress = usePublicAddress ? discoveryNode.getPublicAddress() : discoveryNode.getPrivateAddress();
             if (localAddress.equals(discoveredAddress)) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ExtendedBindMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ExtendedBindMessage.java
@@ -57,7 +57,7 @@ public class ExtendedBindMessage implements IdentifiedDataSerializable {
     public ExtendedBindMessage(byte schemaVersion, Map<ProtocolType, Collection<Address>> localAddresses,
                                Address targetAddress, boolean reply) {
         this.schemaVersion = schemaVersion;
-        this.localAddresses = new EnumMap<ProtocolType, Collection<Address>>(localAddresses);
+        this.localAddresses = new EnumMap<>(localAddresses);
         this.targetAddress = targetAddress;
         this.reply = reply;
     }
@@ -114,8 +114,7 @@ public class ExtendedBindMessage implements IdentifiedDataSerializable {
             localAddresses = Collections.emptyMap();
             return;
         }
-        Map<ProtocolType, Collection<Address>> addressesPerProtocolType
-                = new EnumMap<ProtocolType, Collection<Address>>(ProtocolType.class);
+        Map<ProtocolType, Collection<Address>> addressesPerProtocolType = new EnumMap<>(ProtocolType.class);
         for (int i = 0; i < size; i++) {
             ProtocolType protocolType = ProtocolType.valueOf(in.readInt());
             Collection<Address> addresses = readCollection(in);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinMessage.java
@@ -49,8 +49,7 @@ public class JoinMessage implements IdentifiedDataSerializable {
 
     public JoinMessage(byte packetVersion, int buildNumber, MemberVersion memberVersion, Address address,
                        String uuid, boolean liteMember, ConfigCheck configCheck) {
-        this(packetVersion, buildNumber, memberVersion, address, uuid, liteMember, configCheck,
-                Collections.<Address>emptySet(), 0);
+        this(packetVersion, buildNumber, memberVersion, address, uuid, liteMember, configCheck, Collections.emptySet(), 0);
     }
 
     public JoinMessage(byte packetVersion, int buildNumber, MemberVersion memberVersion, Address address, String uuid,
@@ -99,7 +98,7 @@ public class JoinMessage implements IdentifiedDataSerializable {
     }
 
     public Collection<Address> getMemberAddresses() {
-        return memberAddresses != null ? memberAddresses : Collections.<Address>emptySet();
+        return memberAddresses != null ? memberAddresses : Collections.emptySet();
     }
 
     public int getDataMemberCount() {
@@ -111,19 +110,16 @@ public class JoinMessage implements IdentifiedDataSerializable {
         packetVersion = in.readByte();
         buildNumber = in.readInt();
         memberVersion = in.readObject();
-        address = new Address();
-        address.readData(in);
+        address = in.readObject();
         uuid = in.readUTF();
-        configCheck = new ConfigCheck();
-        configCheck.readData(in);
+        configCheck = in.readObject();
         liteMember = in.readBoolean();
 
         int memberCount = in.readInt();
-        memberAddresses = new ArrayList<Address>(memberCount);
+        memberAddresses = new ArrayList<>(memberCount);
         for (int i = 0; i < memberCount; i++) {
-            Address member = new Address();
-            member.readData(in);
-            memberAddresses.add(member);
+            Address address = in.readObject();
+            memberAddresses.add(address);
         }
         dataMemberCount = in.readInt();
     }
@@ -133,16 +129,16 @@ public class JoinMessage implements IdentifiedDataSerializable {
         out.writeByte(packetVersion);
         out.writeInt(buildNumber);
         out.writeObject(memberVersion);
-        address.writeData(out);
+        out.writeObject(address);
         out.writeUTF(uuid);
-        configCheck.writeData(out);
+        out.writeObject(configCheck);
         out.writeBoolean(liteMember);
 
         int memberCount = getMemberCount();
         out.writeInt(memberCount);
         if (memberCount > 0) {
-            for (Address member : memberAddresses) {
-                member.writeData(out);
+            for (Address address : memberAddresses) {
+                out.writeObject(address);
             }
         }
         out.writeInt(dataMemberCount);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
@@ -30,7 +30,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static com.hazelcast.internal.cluster.Versions.V3_12;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.readMap;
 import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeMap;
 import static com.hazelcast.util.MapUtil.createHashMap;
@@ -57,7 +56,7 @@ public class JoinRequest extends JoinMessage {
         this.credentials = credentials;
         this.attributes = attributes;
         if (excludedMemberUuids != null) {
-            this.excludedMemberUuids = unmodifiableSet(new HashSet<String>(excludedMemberUuids));
+            this.excludedMemberUuids = unmodifiableSet(new HashSet<>(excludedMemberUuids));
         }
         this.addresses = addresses;
     }
@@ -108,11 +107,7 @@ public class JoinRequest extends JoinMessage {
         }
 
         this.excludedMemberUuids = unmodifiableSet(excludedMemberUuids);
-
-        // starting with 3.12 member version, address map is part of the serialized form of JoinRequest
-        if (memberVersion.asVersion().isGreaterOrEqual(V3_12)) {
-            this.addresses = readMap(in);
-        }
+        this.addresses = readMap(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberMap.java
@@ -47,12 +47,12 @@ final class MemberMap {
 
     MemberMap(int version, Map<Address, MemberImpl> addressMap, Map<String, MemberImpl> uuidMap) {
         this.version = version;
-        assert new HashSet<MemberImpl>(addressMap.values()).equals(new HashSet<MemberImpl>(uuidMap.values()))
+        assert new HashSet<>(addressMap.values()).equals(new HashSet<>(uuidMap.values()))
                 : "Maps are different! AddressMap: " + addressMap + ", UuidMap: " + uuidMap;
 
         this.addressToMemberMap = addressMap;
         this.uuidToMemberMap = uuidMap;
-        this.members = Collections.unmodifiableSet(new LinkedHashSet<MemberImpl>(addressToMemberMap.values()));
+        this.members = Collections.unmodifiableSet(new LinkedHashSet<>(addressToMemberMap.values()));
     }
 
     /**
@@ -61,7 +61,7 @@ final class MemberMap {
      * @return empty {@code MemberMap}
      */
     static MemberMap empty() {
-        return new MemberMap(0, Collections.<Address, MemberImpl>emptyMap(), Collections.<String, MemberImpl>emptyMap());
+        return new MemberMap(0, Collections.emptyMap(), Collections.emptyMap());
     }
 
     /**
@@ -117,8 +117,8 @@ final class MemberMap {
             return source;
         }
 
-        Map<Address, MemberImpl> addressMap = new LinkedHashMap<Address, MemberImpl>(source.addressToMemberMap);
-        Map<String, MemberImpl> uuidMap = new LinkedHashMap<String, MemberImpl>(source.uuidToMemberMap);
+        Map<Address, MemberImpl> addressMap = new LinkedHashMap<>(source.addressToMemberMap);
+        Map<String, MemberImpl> uuidMap = new LinkedHashMap<>(source.uuidToMemberMap);
 
         for (MemberImpl member : excludeMembers) {
             MemberImpl removed = addressMap.remove(member.getAddress());
@@ -143,8 +143,8 @@ final class MemberMap {
      * @return clone map
      */
     static MemberMap cloneAdding(MemberMap source, MemberImpl... newMembers) {
-        Map<Address, MemberImpl> addressMap = new LinkedHashMap<Address, MemberImpl>(source.addressToMemberMap);
-        Map<String, MemberImpl> uuidMap = new LinkedHashMap<String, MemberImpl>(source.uuidToMemberMap);
+        Map<Address, MemberImpl> addressMap = new LinkedHashMap<>(source.addressToMemberMap);
+        Map<String, MemberImpl> uuidMap = new LinkedHashMap<>(source.uuidToMemberMap);
 
         for (MemberImpl member : newMembers) {
             putMember(addressMap, uuidMap, member);
@@ -220,7 +220,7 @@ final class MemberMap {
     Set<MemberImpl> tailMemberSet(MemberImpl member, boolean inclusive) {
         ensureMemberExist(member);
 
-        Set<MemberImpl> result = new LinkedHashSet<MemberImpl>();
+        Set<MemberImpl> result = new LinkedHashSet<>();
         boolean found = false;
         for (MemberImpl m : members) {
             if (!found && m.equals(member)) {
@@ -244,7 +244,7 @@ final class MemberMap {
     Set<MemberImpl> headMemberSet(Member member, boolean inclusive) {
         ensureMemberExist(member);
 
-        Set<MemberImpl> result = new LinkedHashSet<MemberImpl>();
+        Set<MemberImpl> result = new LinkedHashSet<>();
         for (MemberImpl m : members) {
             if (!m.equals(member)) {
                 result.add(m);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MemberSelectingCollection.java
@@ -83,7 +83,7 @@ public final class MemberSelectingCollection<M extends Member> implements Collec
 
     @Override
     public Object[] toArray() {
-        List<Object> result = new ArrayList<Object>();
+        List<Object> result = new ArrayList<>();
         for (M member : members) {
             if (selector.select(member)) {
                 result.add(member);
@@ -94,7 +94,7 @@ public final class MemberSelectingCollection<M extends Member> implements Collec
 
     @Override
     public <T> T[] toArray(T[] a) {
-        List<Object> result = new ArrayList<Object>();
+        List<Object> result = new ArrayList<>();
         for (M member : members) {
             if (selector.select(member)) {
                 result.add(member);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersView.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembersView.java
@@ -60,7 +60,7 @@ public final class MembersView implements IdentifiedDataSerializable, Versioned 
      * @return clone map
      */
     static MembersView cloneAdding(MembersView source, Collection<MemberInfo> newMembers) {
-        List<MemberInfo> list = new ArrayList<MemberInfo>(source.size() + newMembers.size());
+        List<MemberInfo> list = new ArrayList<>(source.size() + newMembers.size());
         list.addAll(source.getMembers());
         int newVersion = max(source.version, source.size());
         for (MemberInfo newMember : newMembers) {
@@ -80,7 +80,7 @@ public final class MembersView implements IdentifiedDataSerializable, Versioned 
      * @return a new {@code MemberMap}
      */
     public static MembersView createNew(int version, Collection<MemberImpl> members) {
-        List<MemberInfo> list = new ArrayList<MemberInfo>(members.size());
+        List<MemberInfo> list = new ArrayList<>(members.size());
 
         for (MemberImpl member : members) {
             list.add(new MemberInfo(member));
@@ -131,7 +131,7 @@ public final class MembersView implements IdentifiedDataSerializable, Versioned 
     }
 
     public Set<Address> getAddresses() {
-        Set<Address> addresses = new HashSet<Address>(members.size());
+        Set<Address> addresses = new HashSet<>(members.size());
         for (MemberInfo member : members) {
             addresses.add(member.getAddress());
         }
@@ -177,7 +177,7 @@ public final class MembersView implements IdentifiedDataSerializable, Versioned 
             throws IOException {
         version = in.readInt();
         int size = in.readInt();
-        List<MemberInfo> members = new ArrayList<MemberInfo>(size);
+        List<MemberInfo> members = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             MemberInfo member = new MemberInfo();
             member.readData(in);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastJoiner.java
@@ -44,7 +44,7 @@ public class MulticastJoiner extends AbstractJoiner {
 
     // this deque is used as a stack, the SplitBrainMulticastListener adds to its head and the periodic split brain handler job
     // also polls from its head.
-    private final BlockingDeque<SplitBrainJoinMessage> splitBrainJoinMessages = new LinkedBlockingDeque<SplitBrainJoinMessage>();
+    private final BlockingDeque<SplitBrainJoinMessage> splitBrainJoinMessages = new LinkedBlockingDeque<>();
 
     public MulticastJoiner(Node node) {
         super(node);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MulticastService.java
@@ -55,7 +55,7 @@ public final class MulticastService implements Runnable {
     private static final int SHUTDOWN_TIMEOUT_SECONDS = 5;
     private static final int JOIN_SERIALIZATION_ERROR_SUPPRESSION_MILLIS = 60000;
 
-    private final List<MulticastListener> listeners = new CopyOnWriteArrayList<MulticastListener>();
+    private final List<MulticastListener> listeners = new CopyOnWriteArrayList<>();
     private final Object sendLock = new Object();
     private final CountDownLatch stopLatch = new CountDownLatch(1);
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/NodeMulticastListener.java
@@ -109,7 +109,7 @@ public class NodeMulticastListener implements MulticastListener {
     }
 
     private boolean isJoinMessage(Object msg) {
-        return msg != null && msg instanceof JoinMessage && !(msg instanceof SplitBrainJoinMessage);
+        return msg instanceof JoinMessage && !(msg instanceof SplitBrainJoinMessage);
     }
 
     private boolean isValidJoinMessage(Object msg) {
@@ -124,10 +124,7 @@ public class NodeMulticastListener implements MulticastListener {
         }
 
         ConfigCheck theirConfig = joinMessage.getConfigCheck();
-        if (!ourConfig.isSameGroup(theirConfig)) {
-            return false;
-        }
-        return true;
+        return ourConfig.isSameGroup(theirConfig);
     }
 
     private boolean isMessageToSelf(JoinMessage joinMessage) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
@@ -30,8 +30,6 @@ import java.util.Collection;
  * A {@code JoinMessage} issued by the master node of a subcluster to the master of another subcluster
  * while searching for other clusters for split brain recovery.
  */
-// RU_COMPAT_39: Do not remove Versioned interface!
-// Version info is needed on 3.9 members while deserializing the operation.
 public class SplitBrainJoinMessage extends JoinMessage implements Versioned {
 
     public enum SplitBrainMergeCheckResult {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/CommitClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/CommitClusterStateOp.java
@@ -102,7 +102,7 @@ public class CommitClusterStateOp extends Operation implements AllowedDuringPass
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(stateChange);
-        initiator.writeData(out);
+        out.writeObject(initiator);
         out.writeUTF(txnId);
         out.writeBoolean(isTransient);
     }
@@ -111,8 +111,7 @@ public class CommitClusterStateOp extends Operation implements AllowedDuringPass
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         stateChange = in.readObject();
-        initiator = new Address();
-        initiator.readData(in);
+        initiator = in.readObject();
         txnId = in.readUTF();
         isTransient = in.readBoolean();
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
@@ -27,8 +27,6 @@ import com.hazelcast.nio.serialization.impl.Versioned;
 import java.io.IOException;
 
 /** A heartbeat sent from one cluster member to another. The sent timestamp is the cluster clock time of the sending member */
-// RU_COMPAT_39: Do not remove Versioned interface!
-// Version info is needed on 3.9 members while deserializing the operation.
 public final class HeartbeatOp extends AbstractClusterOperation implements Versioned {
 
     private MembersViewMetadata senderMembersViewMetadata;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinRequestOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/JoinRequestOp.java
@@ -47,13 +47,12 @@ public class JoinRequestOp extends AbstractClusterOperation {
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        request = new JoinRequest();
-        request.readData(in);
+        request = in.readObject();
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        request.writeData(out);
+        out.writeObject(request);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
@@ -18,7 +18,6 @@ package com.hazelcast.internal.cluster.impl.operations;
 
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.MemberLeftException;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.cluster.impl.ClusterDataSerializerHook;
 import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.ClusterStateChange;
@@ -109,29 +108,22 @@ public class LockClusterStateOp  extends Operation implements AllowedDuringPassi
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
         out.writeObject(stateChange);
-        initiator.writeData(out);
+        out.writeObject(initiator);
         out.writeUTF(txnId);
         out.writeLong(leaseTime);
         out.writeInt(partitionStateVersion);
-        // RU_COMPAT_V3_10
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
-            out.writeInt(memberListVersion);
-        }
+        out.writeInt(memberListVersion);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
         stateChange = in.readObject();
-        initiator = new Address();
-        initiator.readData(in);
+        initiator = in.readObject();
         txnId = in.readUTF();
         leaseTime = in.readLong();
         partitionStateVersion = in.readInt();
-        // RU_COMPAT_V3_10
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
-            memberListVersion = in.readInt();
-        }
+        memberListVersion = in.readInt();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterResponseOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MasterResponseOp.java
@@ -48,13 +48,12 @@ public class MasterResponseOp extends AbstractClusterOperation {
 
     @Override
     protected void readInternal(final ObjectDataInput in) throws IOException {
-        masterAddress = new Address();
-        masterAddress.readData(in);
+        masterAddress = in.readObject();
     }
 
     @Override
     protected void writeInternal(final ObjectDataOutput out) throws IOException {
-        masterAddress.writeData(out);
+        out.writeObject(masterAddress);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
@@ -37,8 +37,6 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 
-// RU_COMPAT_39: Do not remove Versioned interface!
-// Version info is needed on 3.9 members while deserializing the operation.
 public class MembersUpdateOp extends AbstractClusterOperation implements Versioned {
     /** The master cluster clock time. */
     long masterTime = Clock.currentTimeMillis();
@@ -114,13 +112,11 @@ public class MembersUpdateOp extends AbstractClusterOperation implements Version
         targetUuid = in.readUTF();
         masterTime = in.readLong();
         int size = in.readInt();
-        memberInfos = new ArrayList<MemberInfo>(size);
+        memberInfos = new ArrayList<>(size);
         while (size-- > 0) {
-            MemberInfo memberInfo = new MemberInfo();
-            memberInfo.readData(in);
+            MemberInfo memberInfo = in.readObject();
             memberInfos.add(memberInfo);
         }
-
         partitionRuntimeState = in.readObject();
         returnResponse = in.readBoolean();
     }
@@ -136,7 +132,7 @@ public class MembersUpdateOp extends AbstractClusterOperation implements Version
         out.writeLong(masterTime);
         out.writeInt(memberInfos.size());
         for (MemberInfo memberInfo : memberInfos) {
-            memberInfo.writeData(out);
+            out.writeObject(memberInfo);
         }
         out.writeObject(partitionRuntimeState);
         out.writeBoolean(returnResponse);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MergeClustersOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MergeClustersOp.java
@@ -58,12 +58,7 @@ public class MergeClustersOp extends AbstractClusterOperation {
         logger.warning(node.getThisAddress() + " is merging to " + newTargetAddress
                 + ", because: instructed by master " + masterAddress);
 
-        nodeEngine.getExecutionService().execute(SPLIT_BRAIN_HANDLER_EXECUTOR_NAME, new Runnable() {
-            @Override
-            public void run() {
-                clusterService.merge(newTargetAddress);
-            }
-        });
+        nodeEngine.getExecutionService().execute(SPLIT_BRAIN_HANDLER_EXECUTOR_NAME, () -> clusterService.merge(newTargetAddress));
     }
 
     @Override
@@ -73,13 +68,12 @@ public class MergeClustersOp extends AbstractClusterOperation {
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        newTargetAddress = new Address();
-        newTargetAddress.readData(in);
+        newTargetAddress = in.readObject();
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        newTargetAddress.writeData(out);
+        out.writeObject(newTargetAddress);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/RollbackClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/RollbackClusterStateOp.java
@@ -77,15 +77,14 @@ public class RollbackClusterStateOp extends Operation implements AllowedDuringPa
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        initiator.writeData(out);
+        out.writeObject(initiator);
         out.writeUTF(txnId);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        initiator = new Address();
-        initiator.readData(in);
+        initiator = in.readObject();
         txnId = in.readUTF();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ShutdownNodeOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/ShutdownNodeOp.java
@@ -36,15 +36,12 @@ public class ShutdownNodeOp extends AbstractClusterOperation implements AllowedD
         final ClusterState clusterState = clusterService.getClusterState();
 
         if (clusterState == ClusterState.PASSIVE) {
-            final NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
+            NodeEngineImpl nodeEngine = (NodeEngineImpl) getNodeEngine();
             if (nodeEngine.isRunning()) {
                 logger.info("Shutting down node in cluster passive state. Requested by: " + getCallerAddress());
-                new Thread(new Runnable() {
-                    @Override
-                    public void run() {
-                        final Node node = nodeEngine.getNode();
-                        node.hazelcastInstance.getLifecycleService().shutdown();
-                    }
+                new Thread(() -> {
+                    Node node = nodeEngine.getNode();
+                    node.hazelcastInstance.getLifecycleService().shutdown();
                 }, createThreadName(nodeEngine.getHazelcastInstance().getName(), ".clusterShutdown")).start();
             } else {
                 logger.info("Node is already shutting down. NodeState: " + nodeEngine.getNode().getState());

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SplitBrainMergeValidationOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/SplitBrainMergeValidationOp.java
@@ -178,13 +178,12 @@ public class SplitBrainMergeValidationOp extends AbstractJoinOperation {
 
     @Override
     protected void readInternal(final ObjectDataInput in) throws IOException {
-        request = new SplitBrainJoinMessage();
-        request.readData(in);
+        request = in.readObject();
     }
 
     @Override
     protected void writeInternal(final ObjectDataOutput out) throws IOException {
-        request.writeData(out);
+        out.writeObject(request);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/WhoisMasterOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/WhoisMasterOp.java
@@ -43,13 +43,12 @@ public class WhoisMasterOp extends AbstractClusterOperation {
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        joinMessage = new JoinMessage();
-        joinMessage.readData(in);
+        joinMessage = in.readObject();
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        joinMessage.writeData(out);
+        out.writeObject(joinMessage);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -427,23 +427,6 @@ public final class GroupProperty {
             = new HazelcastProperty("hazelcast.max.no.heartbeat.seconds", 60, SECONDS);
 
     /**
-     * The interval at which master confirmations are sent from non-master nodes to the master node
-     *
-     * @deprecated since 3.10
-     */
-    @Deprecated
-    public static final HazelcastProperty MASTER_CONFIRMATION_INTERVAL_SECONDS
-            = new HazelcastProperty("hazelcast.master.confirmation.interval.seconds", 30, SECONDS);
-    /**
-     * The timeout which defines when a cluster member is removed because it has not sent any master confirmations.
-     *
-     * @deprecated since 3.10
-     */
-    @Deprecated
-    public static final HazelcastProperty MAX_NO_MASTER_CONFIRMATION_SECONDS
-            = new HazelcastProperty("hazelcast.max.no.master.confirmation.seconds", 150, SECONDS);
-
-    /**
      * Heartbeat failure detector type. Available options are:
      * <ul>
      * <li><code>deadline</code>:  A deadline based failure detector uses an absolute timeout

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationservice/impl/Invocation_NetworkSplitTest.java
@@ -163,7 +163,6 @@ public class Invocation_NetworkSplitTest extends HazelcastTestSupport {
     private Config createConfig() {
         Config config = new Config();
         config.getGroupConfig().setName(generateRandomString(10));
-        config.setProperty(GroupProperty.MASTER_CONFIRMATION_INTERVAL_SECONDS.getName(), "1");
         config.setProperty(GroupProperty.MEMBER_LIST_PUBLISH_INTERVAL_SECONDS.getName(), "10");
         return config;
     }


### PR DESCRIPTION
Additionally replaced `dataserializable.readObject(in)/writeObject(out)` with `dataserializable = in.readObject() / out.writeObject(dataserializable)`.

Part of #14896
Part of #14909