### PR TITLE
Remove Versioned tag from classes in cluster/partition packages

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -23,7 +23,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.version.MemberVersion;
 
 import java.io.IOException;
@@ -38,7 +37,7 @@ import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeM
 import static com.hazelcast.util.MapUtil.createHashMap;
 import static java.util.Collections.singletonMap;
 
-public class MemberInfo implements IdentifiedDataSerializable, Versioned {
+public class MemberInfo implements IdentifiedDataSerializable {
 
     private Address address;
     private String uuid;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterJoinManager.java
@@ -748,14 +748,13 @@ public class ClusterJoinManager {
     }
 
     private OnJoinOp preparePostJoinOp() {
-        Operation[] postJoinOps = nodeEngine.getPostJoinOperations();
-        boolean createPostJoinOperation = (postJoinOps != null && postJoinOps.length > 0);
-        return (createPostJoinOperation ? new OnJoinOp(postJoinOps) : null);
+        Collection<Operation> postJoinOps = nodeEngine.getPostJoinOperations();
+        return (postJoinOps != null && !postJoinOps.isEmpty()) ? new OnJoinOp(postJoinOps) : null;
     }
 
     private OnJoinOp preparePreJoinOps() {
-        Operation[] preJoinOps = nodeEngine.getPreJoinOperations();
-        return (preJoinOps != null && preJoinOps.length > 0) ? new OnJoinOp(preJoinOps) : null;
+        Collection<Operation> preJoinOps = nodeEngine.getPreJoinOperations();
+        return (preJoinOps != null && !preJoinOps.isEmpty()) ? new OnJoinOp(preJoinOps) : null;
     }
 
     private Future invokeClusterOp(Operation op, Address target) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterStateTransactionLogRecord.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.cluster.impl.operations.RollbackClusterStateOp;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.transaction.impl.TargetAwareTransactionLogRecord;
 import com.hazelcast.util.Preconditions;
@@ -36,7 +35,7 @@ import java.io.IOException;
  * @see ClusterState
  * @see com.hazelcast.core.Cluster#changeClusterState(ClusterState, com.hazelcast.transaction.TransactionOptions)
  */
-public class ClusterStateTransactionLogRecord implements TargetAwareTransactionLogRecord, Versioned {
+public class ClusterStateTransactionLogRecord implements TargetAwareTransactionLogRecord {
 
     ClusterStateChange stateChange;
     Address initiator;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/SplitBrainJoinMessage.java
@@ -19,7 +19,6 @@ package com.hazelcast.internal.cluster.impl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.version.MemberVersion;
 import com.hazelcast.version.Version;
 
@@ -30,7 +29,7 @@ import java.util.Collection;
  * A {@code JoinMessage} issued by the master node of a subcluster to the master of another subcluster
  * while searching for other clusters for split brain recovery.
  */
-public class SplitBrainJoinMessage extends JoinMessage implements Versioned {
+public class SplitBrainJoinMessage extends JoinMessage {
 
     public enum SplitBrainMergeCheckResult {
         /**

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/FinalizeJoinOp.java
@@ -139,9 +139,9 @@ public class FinalizeJoinOp extends MembersUpdateOp implements TargetAware {
 
         // Post join operations must be lock free; means no locks at all;
         // no partition locks, no key-based locks, no service level locks!
-        final Operation[] postJoinOperations = nodeEngine.getPostJoinOperations();
+        Collection<Operation> postJoinOperations = nodeEngine.getPostJoinOperations();
 
-        if (postJoinOperations != null && postJoinOperations.length > 0) {
+        if (postJoinOperations != null && !postJoinOperations.isEmpty()) {
             final OperationService operationService = nodeEngine.getOperationService();
             final Collection<Member> members = clusterService.getMembers();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/HeartbeatOp.java
@@ -22,12 +22,11 @@ import com.hazelcast.internal.cluster.impl.ClusterServiceImpl;
 import com.hazelcast.internal.cluster.impl.MembersViewMetadata;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 
 /** A heartbeat sent from one cluster member to another. The sent timestamp is the cluster clock time of the sending member */
-public final class HeartbeatOp extends AbstractClusterOperation implements Versioned {
+public final class HeartbeatOp extends AbstractClusterOperation {
 
     private MembersViewMetadata senderMembersViewMetadata;
     private String targetUuid;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/LockClusterStateOp.java
@@ -26,7 +26,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.UrgentSystemOperation;
@@ -37,7 +36,7 @@ import com.hazelcast.transaction.TransactionException;
 import java.io.IOException;
 
 public class LockClusterStateOp  extends Operation implements AllowedDuringPassiveState, UrgentSystemOperation,
-        IdentifiedDataSerializable, Versioned {
+        IdentifiedDataSerializable {
 
     private ClusterStateChange stateChange;
     private Address initiator;

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MembersUpdateOp.java
@@ -26,18 +26,18 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.util.Clock;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
+import static com.hazelcast.internal.serialization.impl.SerializationUtil.readList;
+import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 
-public class MembersUpdateOp extends AbstractClusterOperation implements Versioned {
+public class MembersUpdateOp extends AbstractClusterOperation {
     /** The master cluster clock time. */
     long masterTime = Clock.currentTimeMillis();
     /** The updated member info collection. */
@@ -111,12 +111,7 @@ public class MembersUpdateOp extends AbstractClusterOperation implements Version
     protected void readInternalImpl(ObjectDataInput in) throws IOException {
         targetUuid = in.readUTF();
         masterTime = in.readLong();
-        int size = in.readInt();
-        memberInfos = new ArrayList<>(size);
-        while (size-- > 0) {
-            MemberInfo memberInfo = in.readObject();
-            memberInfos.add(memberInfo);
-        }
+        memberInfos = readList(in);
         partitionRuntimeState = in.readObject();
         returnResponse = in.readBoolean();
     }
@@ -130,10 +125,7 @@ public class MembersUpdateOp extends AbstractClusterOperation implements Version
     protected void writeInternalImpl(ObjectDataOutput out) throws IOException {
         out.writeUTF(targetUuid);
         out.writeLong(masterTime);
-        out.writeInt(memberInfos.size());
-        for (MemberInfo memberInfo : memberInfos) {
-            out.writeObject(memberInfo);
-        }
+        writeList(memberInfos, out);
         out.writeObject(partitionRuntimeState);
         out.writeBoolean(returnResponse);
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/MigrationInfo.java
@@ -21,7 +21,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.util.UuidUtil;
 
 import java.io.DataInput;
@@ -29,7 +28,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class MigrationInfo implements IdentifiedDataSerializable, Versioned {
+public class MigrationInfo implements IdentifiedDataSerializable {
 
     public enum MigrationStatus {
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationCommitOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationCommitOperation.java
@@ -25,7 +25,6 @@ import com.hazelcast.internal.partition.impl.InternalPartitionServiceImpl;
 import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.spi.exception.TargetNotMemberException;
@@ -36,7 +35,7 @@ import java.io.IOException;
  * Sent by the master node to commit a migration on the migration destination.
  * It updates the partition table on the migration destination and finalizes the migration.
  */
-public class MigrationCommitOperation extends AbstractPartitionOperation implements MigrationCycleOperation, Versioned {
+public class MigrationCommitOperation extends AbstractPartitionOperation implements MigrationCycleOperation {
 
     private MigrationInfo migration;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/MigrationOperation.java
@@ -27,7 +27,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.MigrationAwareService;
 import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.OperationAccessor;
@@ -52,7 +51,7 @@ import java.util.logging.Level;
  * Sent by the partition owner to the migration destination to start the migration process on the destination.
  * Contains the operations which will be executed on the destination node to migrate the data and the replica versions to be set.
  */
-public class MigrationOperation extends BaseMigrationOperation implements TargetAware, Versioned {
+public class MigrationOperation extends BaseMigrationOperation implements TargetAware {
 
     private static final OperationResponseHandler ERROR_RESPONSE_HANDLER = (op, obj) -> {
         throw new HazelcastException("Migration operations can not send response!");

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionBackupReplicaAntiEntropyOperation.java
@@ -23,7 +23,6 @@ import com.hazelcast.internal.partition.impl.PartitionReplicaManager;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ServiceNamespace;
 import com.hazelcast.spi.impl.AllowedDuringPassiveState;
@@ -39,7 +38,7 @@ import static com.hazelcast.internal.partition.impl.PartitionDataSerializerHook.
 // should not be an urgent operation. required to be in order with backup operations on target node
 public final class PartitionBackupReplicaAntiEntropyOperation
         extends AbstractPartitionOperation
-        implements PartitionAwareOperation, AllowedDuringPassiveState, Versioned {
+        implements PartitionAwareOperation, AllowedDuringPassiveState {
 
     private Map<ServiceNamespace, Long> versions;
     private boolean returnResponse;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRetryResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionReplicaSyncRetryResponse.java
@@ -24,15 +24,16 @@ import com.hazelcast.internal.partition.impl.PartitionDataSerializerHook;
 import com.hazelcast.internal.partition.impl.PartitionReplicaManager;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
 import com.hazelcast.spi.ServiceNamespace;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+
+import static com.hazelcast.internal.serialization.impl.SerializationUtil.readCollection;
+import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeCollection;
 
 /**
  * The response to a {@link PartitionReplicaSyncRequest} that the replica should retry. This will reset the current ongoing
@@ -40,7 +41,7 @@ import java.util.Collections;
  */
 public class PartitionReplicaSyncRetryResponse
         extends AbstractPartitionOperation
-        implements PartitionAwareOperation, BackupOperation, MigrationCycleOperation, Versioned {
+        implements PartitionAwareOperation, BackupOperation, MigrationCycleOperation {
 
     private Collection<ServiceNamespace> namespaces;
 
@@ -86,20 +87,12 @@ public class PartitionReplicaSyncRetryResponse
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
-        out.writeInt(namespaces.size());
-        for (ServiceNamespace namespace : namespaces) {
-            out.writeObject(namespace);
-        }
+        writeCollection(namespaces, out);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
-        int len = in.readInt();
-        namespaces = new ArrayList<>(len);
-        for (int i = 0; i < len; i++) {
-            ServiceNamespace ns = in.readObject();
-            namespaces.add(ns);
-        }
+        namespaces = readCollection(in);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionStateOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PartitionStateOperation.java
@@ -26,7 +26,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 
@@ -37,7 +36,7 @@ import java.io.IOException;
  * @see InternalPartitionServiceImpl#syncPartitionRuntimeState
  */
 public final class PartitionStateOperation extends AbstractPartitionOperation
-        implements MigrationCycleOperation, JoinOperation, Versioned {
+        implements MigrationCycleOperation, JoinOperation {
 
     private PartitionRuntimeState partitionState;
     private boolean sync;

--- a/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PublishCompletedMigrationsOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/partition/operation/PublishCompletedMigrationsOperation.java
@@ -28,8 +28,10 @@ import com.hazelcast.spi.ExceptionAction;
 import com.hazelcast.spi.exception.TargetNotMemberException;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
+
+import static com.hazelcast.internal.serialization.impl.SerializationUtil.readCollection;
+import static com.hazelcast.internal.serialization.impl.SerializationUtil.writeCollection;
 
 /**
  * Sent by master member to other cluster members to publish completed migrations
@@ -78,22 +80,13 @@ public class PublishCompletedMigrationsOperation extends AbstractPartitionOperat
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        int len = in.readInt();
-        completedMigrations = new ArrayList<>(len);
-        for (int i = 0; i < len; i++) {
-            MigrationInfo migrationInfo = in.readObject();
-            completedMigrations.add(migrationInfo);
-        }
+        completedMigrations = readCollection(in);
     }
 
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        int len = completedMigrations.size();
-        out.writeInt(len);
-        for (MigrationInfo migrationInfo : completedMigrations) {
-            out.writeObject(migrationInfo);
-        }
+        writeCollection(completedMigrations, out);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/serialization/impl/SerializationUtil.java
@@ -145,52 +145,6 @@ public final class SerializationUtil {
     }
 
     /**
-     * Write items from a list into a ObjectDataOutput. The list can be null.
-     * It has to be deserialized via {@link #readNullableList(ObjectDataInput)}
-     *
-     * @param list list to write into the output
-     * @param out the output to use
-     * @param <T> type of the list
-     * @throws IOException
-     */
-    public static <T> void writeNullableList(List<T> list, ObjectDataOutput out) throws IOException {
-        if (list == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            out.writeInt(list.size());
-            for (T item : list) {
-                out.writeObject(item);
-            }
-        }
-    }
-
-    /**
-     * Read a list written by {@link #writeNullableList(List, ObjectDataOutput)}
-     *
-     * It does not guarantee to use the same implementation of a list as was written
-     * into the stream.
-     *
-     * @param in data input to read from
-     * @param <T> type of items
-     * @return list with all items or null
-     * @throws IOException
-     */
-    public static <T> List<T> readNullableList(ObjectDataInput in) throws IOException {
-        boolean notNull = in.readBoolean();
-        List<T> list = null;
-        if (notNull) {
-            int size = in.readInt();
-            list = new ArrayList<T>(size);
-            for (int i = 0; i < size; i++) {
-                T item = in.readObject();
-                list.add(item);
-            }
-        }
-        return list;
-    }
-
-    /**
      * Writes a map to given {@code ObjectDataOutput}.
      *
      * @param map           the map to serialize, can be {@code null}
@@ -249,18 +203,97 @@ public final class SerializationUtil {
     /**
      * Writes a collection to an {@link ObjectDataOutput}. The collection's size is written
      * to the data output, then each object in the collection is serialized.
+     * The collection is allowed to be null.
+     *
+     * @param items collection of items to be serialized
+     * @param out   data output to write to
+     * @param <T>   type of items
+     * @throws IOException when an error occurs while writing to the output
+     */
+    public static <T> void writeNullableCollection(Collection<T> items, ObjectDataOutput out) throws IOException {
+        // write true when the collection is NOT null
+        out.writeBoolean(items != null);
+        if (items == null) {
+            return;
+        }
+        writeCollection(items, out);
+    }
+
+    /**
+     * Writes a list to an {@link ObjectDataOutput}. The list's size is written
+     * to the data output, then each object in the list is serialized.
+     * The list is allowed to be null.
+     *
+     * @param items list of items to be serialized
+     * @param out   data output to write to
+     * @param <T>   type of items
+     * @throws IOException when an error occurs while writing to the output
+     */
+    public static <T> void writeNullableList(List<T> items, ObjectDataOutput out) throws IOException {
+        writeNullableCollection(items, out);
+    }
+
+    /**
+     * Writes a collection to an {@link ObjectDataOutput}. The collection's size is written
+     * to the data output, then each object in the collection is serialized.
      *
      * @param items collection of items to be serialized
      * @param out   data output to write to
      * @param <T>   type of items
      * @throws NullPointerException if {@code items} or {@code out} is {@code null}
-     * @throws IOException
+     * @throws IOException when an error occurs while writing to the output
      */
     public static <T> void writeCollection(Collection<T> items, ObjectDataOutput out) throws IOException {
         out.writeInt(items.size());
         for (T item : items) {
             out.writeObject(item);
         }
+    }
+
+    /**
+     * Writes a list to an {@link ObjectDataOutput}. The list's size is written
+     * to the data output, then each object in the list is serialized.
+     *
+     * @param items list of items to be serialized
+     * @param out   data output to write to
+     * @param <T>   type of items
+     * @throws NullPointerException if {@code items} or {@code out} is {@code null}
+     * @throws IOException when an error occurs while writing to the output
+     */
+    public static <T> void writeList(List<T> items, ObjectDataOutput out) throws IOException {
+        writeCollection(items, out);
+    }
+
+    /**
+     * Reads a collection from the given {@link ObjectDataInput}. It is expected that
+     * the next int read from the data input is the collection's size, then that
+     * many objects are read from the data input and returned as a collection.
+     *
+     * @param in    data input to read from
+     * @param <T>   type of items
+     * @return      collection of items read from data input or null
+     * @throws IOException when an error occurs while reading from the input
+     */
+    public static <T> Collection<T> readNullableCollection(ObjectDataInput in) throws IOException {
+        return readNullableList(in);
+    }
+
+    /**
+     * Reads a list from the given {@link ObjectDataInput}. It is expected that
+     * the next int read from the data input is the list's size, then that
+     * many objects are read from the data input and returned as a list.
+     *
+     * @param in    data input to read from
+     * @param <T>   type of items
+     * @return      list of items read from data input or null
+     * @throws IOException when an error occurs while reading from the input
+     */
+    public static <T> List<T> readNullableList(ObjectDataInput in) throws IOException {
+        boolean isNull = !in.readBoolean();
+        if (isNull) {
+            return null;
+        }
+        return readList(in);
     }
 
     /**
@@ -271,18 +304,32 @@ public final class SerializationUtil {
      * @param in    data input to read from
      * @param <T>   type of items
      * @return      collection of items read from data input
-     * @throws IOException
+     * @throws IOException  when an error occurs while reading from the input
      */
     public static <T> Collection<T> readCollection(ObjectDataInput in) throws IOException {
+        return readList(in);
+    }
+
+    /**
+     * Reads a list from the given {@link ObjectDataInput}. It is expected that
+     * the next int read from the data input is the list's size, then that
+     * many objects are read from the data input and returned as a list.
+     *
+     * @param in    data input to read from
+     * @param <T>   type of items
+     * @return      list of items read from data input
+     * @throws IOException  when an error occurs while reading from the input
+     */
+    public static <T> List<T> readList(ObjectDataInput in) throws IOException {
         int size = in.readInt();
         if (size == 0) {
             return Collections.emptyList();
         }
-        Collection<T> collection = new ArrayList<T>(size);
+        List<T> list = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
             T item = in.readObject();
-            collection.add(item);
+            list.add(item);
         }
-        return collection;
+        return list;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/NodeEngineImpl.java
@@ -427,8 +427,8 @@ public class NodeEngineImpl implements NodeEngine {
      *
      * @return the operations to be executed at the end of a finalized join
      */
-    public Operation[] getPostJoinOperations() {
-        Collection<Operation> postJoinOps = new LinkedList<Operation>();
+    public Collection<Operation> getPostJoinOperations() {
+        Collection<Operation> postJoinOps = new LinkedList<>();
         Collection<PostJoinAwareService> services = getServices(PostJoinAwareService.class);
         for (PostJoinAwareService service : services) {
             Operation postJoinOperation = service.getPostJoinOperation();
@@ -442,11 +442,11 @@ public class NodeEngineImpl implements NodeEngine {
                 postJoinOps.add(postJoinOperation);
             }
         }
-        return postJoinOps.isEmpty() ? null : postJoinOps.toArray(new Operation[0]);
+        return postJoinOps;
     }
 
-    public Operation[] getPreJoinOperations() {
-        Collection<Operation> preJoinOps = new LinkedList<Operation>();
+    public Collection<Operation> getPreJoinOperations() {
+        Collection<Operation> preJoinOps = new LinkedList<>();
         Collection<PreJoinAwareService> services = getServices(PreJoinAwareService.class);
         for (PreJoinAwareService service : services) {
             Operation preJoinOperation = service.getPreJoinOperation();
@@ -460,7 +460,7 @@ public class NodeEngineImpl implements NodeEngine {
                 preJoinOps.add(preJoinOperation);
             }
         }
-        return preJoinOps.isEmpty() ? null : preJoinOps.toArray(new Operation[0]);
+        return preJoinOps;
     }
 
     public void reset() {


### PR DESCRIPTION
Additionally replaced manual collection serializations with
`SerializationUtil` methods.