### PR TITLE
Separate equal and not equal predicate impls

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeIndexVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/CompositeIndexVisitor.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import static com.hazelcast.query.impl.AbstractIndex.NULL;
 import static com.hazelcast.query.impl.CompositeValue.NEGATIVE_INFINITY;
 import static com.hazelcast.query.impl.CompositeValue.POSITIVE_INFINITY;
-import static com.hazelcast.query.impl.predicates.PredicateUtils.isEqualPredicate;
-import static com.hazelcast.query.impl.predicates.PredicateUtils.isRangePredicate;
 
 /**
  * Optimizes single-attribute predicates into composite index predicates.
@@ -64,7 +62,7 @@ public class CompositeIndexVisitor extends AbstractVisitor {
         Map<String, RangePredicate> comparisons = null;
         Output output = null;
         for (Predicate predicate : andPredicate.predicates) {
-            if (isEqualPredicate(predicate)) {
+            if (predicate instanceof EqualPredicate) {
                 EqualPredicate equalPredicate = (EqualPredicate) predicate;
                 prefixes = obtainHashMap(prefixes, originalSize);
 
@@ -85,7 +83,7 @@ public class CompositeIndexVisitor extends AbstractVisitor {
                 continue;
             }
 
-            if (isRangePredicate(predicate)) {
+            if (predicate instanceof RangePredicate) {
                 RangePredicate rangePredicate = (RangePredicate) predicate;
                 comparisons = obtainHashMap(comparisons, originalSize);
 
@@ -385,7 +383,7 @@ public class CompositeIndexVisitor extends AbstractVisitor {
     }
 
     private static <K, V> Map<K, V> obtainHashMap(Map<K, V> map, int capacity) {
-        return map == null ? new HashMap<K, V>(capacity) : map;
+        return map == null ? new HashMap<>(capacity) : map;
     }
 
     private static Output obtainOutput(Output output, int capacity) {

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/EqualPredicate.java
@@ -26,6 +26,7 @@ import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.hazelcast.query.impl.predicates.PredicateUtils.isNull;
@@ -38,7 +39,7 @@ public class EqualPredicate extends AbstractIndexAwarePredicate implements Negat
 
     private static final long serialVersionUID = 1L;
 
-    protected Comparable value;
+    Comparable value;
 
     public EqualPredicate() {
     }
@@ -96,7 +97,7 @@ public class EqualPredicate extends AbstractIndexAwarePredicate implements Negat
             return false;
         }
 
-        return value != null ? value.equals(that.value) : that.value == null;
+        return Objects.equals(value, that.value);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.query.Predicate;
 import com.hazelcast.query.impl.AndResultSet;
 import com.hazelcast.query.impl.OrResultSet;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -68,24 +67,6 @@ public final class PredicateUtils {
     }
 
     /**
-     * @return {@code true} if the given predicate is a {@link RangePredicate},
-     * {@code false} otherwise.
-     */
-    public static boolean isRangePredicate(Predicate predicate) {
-        // XXX: NotEqualPredicate is a subclass of EqualPredicate
-        return predicate instanceof RangePredicate && !(predicate instanceof NotEqualPredicate);
-    }
-
-    /**
-     * @return {@code true} if the given predicate is an {@link EqualPredicate},
-     * {@code false} otherwise.
-     */
-    public static boolean isEqualPredicate(Predicate predicate) {
-        // XXX: NotEqualPredicate is a subclass of EqualPredicate
-        return predicate instanceof EqualPredicate && !(predicate instanceof NotEqualPredicate);
-    }
-
-    /**
      * Produces canonical attribute representation by stripping an unnecessary
      * "this." qualifier from the passed attribute, if any.
      *
@@ -123,7 +104,7 @@ public final class PredicateUtils {
             throw new IllegalArgumentException("Too many composite index attributes: " + name);
         }
 
-        Set<String> seenComponents = new HashSet<String>(components.length);
+        Set<String> seenComponents = new HashSet<>(components.length);
         for (int i = 0; i < components.length; ++i) {
             String component = PredicateUtils.canonicalizeAttribute(components[i]);
             components[i] = component;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RangeVisitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/RangeVisitor.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 
 import static com.hazelcast.query.impl.AbstractIndex.NULL;
 import static com.hazelcast.query.impl.predicates.PredicateUtils.isNull;
-import static com.hazelcast.query.impl.predicates.PredicateUtils.isRangePredicate;
 
 /**
  * Performs range predicates optimization.
@@ -88,7 +87,7 @@ public class RangeVisitor extends AbstractVisitor {
 
         if (predicate instanceof FalsePredicate) {
             return Ranges.UNSATISFIABLE;
-        } else if (!isRangePredicate(predicate)) {
+        } else if (!(predicate instanceof RangePredicate)) {
             return ranges;
         }
 

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotEqualPredicateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/NotEqualPredicateTest.java
@@ -16,8 +16,6 @@
 
 package com.hazelcast.query.impl.predicates;
 
-import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryableEntry;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
@@ -28,17 +26,13 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import java.util.Set;
-
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastParallelClassRunner.class)
@@ -91,18 +85,6 @@ public class NotEqualPredicateTest {
     }
 
     @Test
-    public void isIndexed_givenAttributeNameIsFoo_whenTheFooFieldIsIndexed_returnFalse() {
-        // see https://github.com/hazelcast/hazelcast/pull/5847
-        String fieldName = "name";
-
-        NotEqualPredicate name = new NotEqualPredicate(fieldName, "foo");
-        QueryContext queryContext = newMockContextWithIndex(fieldName);
-
-        boolean indexed = name.isIndexed(queryContext);
-        assertFalse(indexed);
-    }
-
-    @Test
     public void toString_containsAttributeName() {
         String fieldName = "name";
         NotEqualPredicate predicate = new NotEqualPredicate(fieldName, "foo");
@@ -121,33 +103,12 @@ public class NotEqualPredicateTest {
     }
 
     @Test
-    public void filter_givenAttributeNameIsFoo_whenTheFooFieldIsIndex_thenReturnsNullAndDoesNotTouchQueryContext() {
-        /** see {@link #isIndexed_givenAttributeNameIsFoo_whenTheFooFieldIsIndexed_returnFalse()} */
-        String fieldName = "foo";
-        NotEqualPredicate predicate = new NotEqualPredicate(fieldName, "foo");
-
-        QueryContext queryContext = newMockContextWithIndex(fieldName);
-        Set<QueryableEntry> filter = predicate.filter(queryContext);
-
-        assertNull(filter);
-        verifyZeroInteractions(queryContext);
-    }
-
-    @Test
     public void testEqualsAndHashCode() {
         EqualsVerifier.forClass(NotEqualPredicate.class)
             .suppress(Warning.NONFINAL_FIELDS, Warning.STRICT_INHERITANCE)
             .withRedefinedSuperclass()
             .allFieldsShouldBeUsed()
             .verify();
-    }
-
-    private QueryContext newMockContextWithIndex(String indexedFieldName) {
-        QueryContext queryContext = mock(QueryContext.class);
-        Index mockIndex = mock(Index.class);
-        when(queryContext.getIndex(indexedFieldName)).thenReturn(mockIndex);
-
-        return queryContext;
     }
 
     private QueryableEntry newMockEntry(Object attributeValue) {

--- a/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/impl/predicates/PredicatesTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.internal.serialization.impl.DefaultSerializationServiceBuilder;
-import com.hazelcast.monitor.impl.PerIndexStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.query.EntryObject;
 import com.hazelcast.query.IndexAwarePredicate;
@@ -30,8 +29,6 @@ import com.hazelcast.query.Predicates;
 import com.hazelcast.query.QueryException;
 import com.hazelcast.query.SampleTestObjects.Employee;
 import com.hazelcast.query.SampleTestObjects.Value;
-import com.hazelcast.query.impl.Index;
-import com.hazelcast.query.impl.IndexImpl;
 import com.hazelcast.query.impl.QueryContext;
 import com.hazelcast.query.impl.QueryEntry;
 import com.hazelcast.query.impl.QueryableEntry;
@@ -64,7 +61,6 @@ import static com.hazelcast.query.Predicates.like;
 import static com.hazelcast.query.Predicates.notEqual;
 import static com.hazelcast.query.Predicates.or;
 import static com.hazelcast.query.Predicates.regex;
-import static com.hazelcast.query.impl.IndexCopyBehavior.COPY_ON_READ;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static org.hamcrest.Matchers.allOf;
@@ -72,9 +68,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
@@ -309,19 +302,6 @@ public class PredicatesTest extends HazelcastTestSupport {
     @Test(expected = NullPointerException.class)
     public void testInNullWithNullArray() {
         Predicates.in(ATTRIBUTE, null);
-    }
-
-    @Test
-    public void testNotEqualsPredicateDoesNotUseIndex() {
-        Index dummyIndex =
-                new IndexImpl("foo", null, false, ss, Extractors.newBuilder(ss).build(), COPY_ON_READ, PerIndexStats.EMPTY);
-        QueryContext mockQueryContext = mock(QueryContext.class);
-        when(mockQueryContext.getIndex(anyString())).thenReturn(dummyIndex);
-
-        NotEqualPredicate p = new NotEqualPredicate("foo", "bar");
-
-        boolean indexed = p.isIndexed(mockQueryContext);
-        assertFalse(indexed);
     }
 
     private class DummyEntry extends QueryEntry {


### PR DESCRIPTION
This makes `instanceof` checks less error prone and also removes unneeded/defunct conformances to `IndexAwarePredicate` and `RangePredicate` from `NotEqualPredicate`.