### PR TITLE
Optimise WAN objects serialized format and remove compatibility hacks

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/MapEventPublisherImpl.java
@@ -45,7 +45,6 @@ import java.util.LinkedList;
 
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.map.impl.event.AbstractFilteringStrategy.FILTER_DOES_NOT_MATCH;
-import static com.hazelcast.util.Clock.currentTimeMillis;
 import static com.hazelcast.util.CollectionUtil.isEmpty;
 
 public class MapEventPublisherImpl implements MapEventPublisher {
@@ -110,7 +109,7 @@ public class MapEventPublisherImpl implements MapEventPublisher {
             return;
         }
 
-        MapReplicationRemove event = new MapReplicationRemove(mapName, key, currentTimeMillis());
+        MapReplicationRemove event = new MapReplicationRemove(mapName, key);
         publishWanEvent(mapName, event);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/DeleteOperation.java
@@ -16,16 +16,14 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 
-public class DeleteOperation extends BaseRemoveOperation implements Versioned {
+public class DeleteOperation extends BaseRemoveOperation {
     private boolean success;
 
     public DeleteOperation(String name, Data dataKey) {
@@ -74,20 +72,12 @@ public class DeleteOperation extends BaseRemoveOperation implements Versioned {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-
-        // RU_COMPAT_3_10
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
-            out.writeBoolean(disableWanReplicationEvent);
-        }
+        out.writeBoolean(disableWanReplicationEvent);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-
-        // RU_COMPAT_3_10
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
-            disableWanReplicationEvent = in.readBoolean();
-        }
+        disableWanReplicationEvent = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllBackupOperation.java
@@ -16,7 +16,6 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapEntries;
 import com.hazelcast.map.impl.record.Record;
@@ -24,7 +23,6 @@ import com.hazelcast.map.impl.record.RecordInfo;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.Versioned;
 import com.hazelcast.spi.BackupOperation;
 import com.hazelcast.spi.PartitionAwareOperation;
 
@@ -35,7 +33,7 @@ import java.util.List;
 import static com.hazelcast.map.impl.record.Records.applyRecordInfo;
 
 public class PutAllBackupOperation extends MapOperation
-        implements PartitionAwareOperation, BackupOperation, Versioned {
+        implements PartitionAwareOperation, BackupOperation {
 
     private MapEntries entries;
     private List<RecordInfo> recordInfos;
@@ -77,11 +75,7 @@ public class PutAllBackupOperation extends MapOperation
         for (RecordInfo recordInfo : recordInfos) {
             recordInfo.writeData(out);
         }
-
-        // RU_COMPAT_3_10
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
-            out.writeBoolean(disableWanReplicationEvent);
-        }
+        out.writeBoolean(disableWanReplicationEvent);
     }
 
     @Override
@@ -97,11 +91,7 @@ public class PutAllBackupOperation extends MapOperation
             recordInfo.readData(in);
             recordInfos.add(recordInfo);
         }
-
-        // RU_COMPAT_3_10
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
-            disableWanReplicationEvent = in.readBoolean();
-        }
+        disableWanReplicationEvent = in.readBoolean();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveOperation.java
@@ -16,16 +16,14 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
-import com.hazelcast.nio.serialization.impl.Versioned;
 
 import java.io.IOException;
 
-public class RemoveOperation extends BaseRemoveOperation implements Versioned {
+public class RemoveOperation extends BaseRemoveOperation {
 
     protected boolean successful;
 
@@ -62,20 +60,12 @@ public class RemoveOperation extends BaseRemoveOperation implements Versioned {
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-
-        // RU_COMPAT_3_10
-        if (out.getVersion().isGreaterOrEqual(Versions.V3_11)) {
-            out.writeBoolean(disableWanReplicationEvent);
-        }
+        out.writeBoolean(disableWanReplicationEvent);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-
-        // RU_COMPAT_3_10
-        if (in.getVersion().isGreaterOrEqual(Versions.V3_11)) {
-            disableWanReplicationEvent = in.readBoolean();
-        }
+        disableWanReplicationEvent = in.readBoolean();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationRemove.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationRemove.java
@@ -29,12 +29,10 @@ import java.io.IOException;
 public class MapReplicationRemove implements ReplicationEventObject, IdentifiedDataSerializable {
     private String mapName;
     private Data key;
-    private long removeTime;
 
-    public MapReplicationRemove(String mapName, Data key, long removeTime) {
+    public MapReplicationRemove(String mapName, Data key) {
         this.mapName = mapName;
         this.key = key;
-        this.removeTime = removeTime;
     }
 
     public MapReplicationRemove() {
@@ -57,25 +55,15 @@ public class MapReplicationRemove implements ReplicationEventObject, IdentifiedD
         this.key = key;
     }
 
-    public long getRemoveTime() {
-        return removeTime;
-    }
-
-    public void setRemoveTime(long removeTime) {
-        this.removeTime = removeTime;
-    }
-
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
         out.writeUTF(mapName);
-        out.writeLong(removeTime);
         out.writeData(key);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
         mapName = in.readUTF();
-        removeTime = in.readLong();
         key = in.readData();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/MapReplicationUpdate.java
@@ -87,13 +87,7 @@ public class MapReplicationUpdate implements ReplicationEventObject, IdentifiedD
     public void readData(ObjectDataInput in) throws IOException {
         mapName = in.readUTF();
         mergePolicy = in.readObject();
-        EntryView<Data, Data> entryView = in.readObject();
-
-        if (entryView instanceof WanMapEntryView) {
-            this.entryView = (WanMapEntryView<Data, Data>) entryView;
-        } else {
-            this.entryView = new WanMapEntryView<>(entryView);
-        }
+        entryView = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/wan/WanMapEntryView.java
@@ -17,36 +17,36 @@
 package com.hazelcast.map.impl.wan;
 
 import com.hazelcast.core.EntryView;
-import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.nio.IOUtil;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
+import com.hazelcast.wan.impl.WanDataSerializerHook;
 
 import java.io.IOException;
 
 /**
- * WAN heap based implementation of {@link EntryView} for keeping
- * compatibility when sending to older (3.8+) clusters.
+ * WAN heap based implementation of {@link EntryView}.
  *
  * @param <K> the type of key.
  * @param <V> the type of value.
  */
-@BinaryInterface
 public class WanMapEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSerializable {
 
-    private final K key;
-    private final V value;
-    private final long cost;
-    private final long creationTime;
-    private final long expirationTime;
-    private final long hits;
-    private final long lastAccessTime;
-    private final long lastStoredTime;
-    private final long lastUpdateTime;
-    private final long version;
-    private final long ttl;
+    private K key;
+    private V value;
+    private long cost;
+    private long creationTime;
+    private long expirationTime;
+    private long hits;
+    private long lastAccessTime;
+    private long lastStoredTime;
+    private long lastUpdateTime;
+    private long version;
+    private long ttl;
+
+    public WanMapEntryView() {
+    }
 
     public WanMapEntryView(EntryView<K, V> entryView) {
         this.key = entryView.getKey();
@@ -124,7 +124,6 @@ public class WanMapEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        // the serialized format must match the serialized format for a 3.8 SimpleEntryView
         IOUtil.writeObject(out, key);
         IOUtil.writeObject(out, value);
         out.writeLong(cost);
@@ -135,27 +134,32 @@ public class WanMapEntryView<K, V> implements EntryView<K, V>, IdentifiedDataSer
         out.writeLong(lastStoredTime);
         out.writeLong(lastUpdateTime);
         out.writeLong(version);
-        out.writeLong(0);
         out.writeLong(ttl);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        throw new UnsupportedOperationException(getClass().getName() + " should not be deserialized!");
+        key = IOUtil.readObject(in);
+        value = IOUtil.readObject(in);
+        cost = in.readLong();
+        creationTime = in.readLong();
+        expirationTime = in.readLong();
+        hits = in.readLong();
+        lastAccessTime = in.readLong();
+        lastStoredTime = in.readLong();
+        lastUpdateTime = in.readLong();
+        version = in.readLong();
+        ttl = in.readLong();
     }
 
     @Override
     public int getFactoryId() {
-        // needs to have same factoryId and ID as SimpleEntryView
-        // for backwards compatibility when sending to a 3.8+ cluster
-        return MapDataSerializerHook.F_ID;
+        return WanDataSerializerHook.F_ID;
     }
 
     @Override
     public int getId() {
-        // needs to have same factoryId and ID as SimpleEntryView
-        // for backwards compatibility when sending to a 3.8+ cluster
-        return MapDataSerializerHook.ENTRY_VIEW;
+        return WanDataSerializerHook.WAN_MAP_ENTRY_VIEW;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/wan/impl/WanDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/wan/impl/WanDataSerializerHook.java
@@ -20,6 +20,7 @@ import com.hazelcast.internal.serialization.DataSerializerHook;
 import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.map.impl.wan.MapReplicationRemove;
 import com.hazelcast.map.impl.wan.MapReplicationUpdate;
+import com.hazelcast.map.impl.wan.WanMapEntryView;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.wan.WanReplicationEvent;
 
@@ -33,20 +34,10 @@ public class WanDataSerializerHook implements DataSerializerHook {
 
     public static final int F_ID = FactoryIdHelper.getFactoryId(WAN_REPLICATION_DS_FACTORY, WAN_REPLICATION_DS_FACTORY_ID);
 
-    /**
-     * ID of {@link com.hazelcast.wan.WanReplicationEvent}
-     */
     public static final int WAN_REPLICATION_EVENT = 0;
-
-    /**
-     * ID of {@link com.hazelcast.map.impl.wan.MapReplicationUpdate}
-     */
     public static final int MAP_REPLICATION_UPDATE = 1;
-
-    /**
-     * ID of {@link com.hazelcast.map.impl.wan.MapReplicationRemove}
-     */
     public static final int MAP_REPLICATION_REMOVE = 2;
+    public static final int WAN_MAP_ENTRY_VIEW = 3;
 
     @Override
     public int getFactoryId() {
@@ -63,6 +54,8 @@ public class WanDataSerializerHook implements DataSerializerHook {
                     return new MapReplicationUpdate();
                 case MAP_REPLICATION_REMOVE:
                     return new MapReplicationRemove();
+                case WAN_MAP_ENTRY_VIEW:
+                    return new WanMapEntryView<>();
                 default:
                     throw new IllegalArgumentException("Unknown type-id: " + typeId);
             }


### PR DESCRIPTION
- removed hacks for fixing issues in 3.x WAN classes
- removed RU code for 3.11
- removed usage of java serialization when serializing some collections
- further separated WAN specific map and cache entry views
- removed unused fields
- used out.writeObject/in.readObject instead of readData/writeData to
    avoid future serialization issues

Fixes:
https://github.com/hazelcast/hazelcast-enterprise/issues/1885
https://github.com/hazelcast/hazelcast-enterprise/issues/1750

Part of:
https://github.com/hazelcast/hazelcast/issues/14909

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2920