### PR TITLE
Make AssertTask an interface

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/partition/PartitionCorrectnessTestSupport.java
@@ -377,7 +377,7 @@ public abstract class PartitionCorrectnessTestSupport extends HazelcastTestSuppo
         return config;
     }
 
-    private class AssertSizeAndDataTask extends AssertTask {
+    private class AssertSizeAndDataTask implements AssertTask {
         private final boolean allowDirty;
 
         AssertSizeAndDataTask(boolean allowDirty) {

--- a/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/scheduledexecutor/ScheduledExecutorServiceTestSupport.java
@@ -371,7 +371,7 @@ public class ScheduledExecutorServiceTestSupport extends HazelcastTestSupport {
         }
     }
 
-    public static class AllTasksRunningWithinNumOfNodes extends AssertTask {
+    public static class AllTasksRunningWithinNumOfNodes implements AssertTask {
 
         private final IScheduledExecutorService scheduler;
         private final int expectedNodesWithTasks;

--- a/hazelcast/src/test/java/com/hazelcast/test/AssertTask.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/AssertTask.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.test;
 
-public abstract class AssertTask {
+public interface AssertTask {
 
-    public abstract void run() throws Exception;
+    void run() throws Exception;
 }


### PR DESCRIPTION
This way, lambdas can be used in assert-eventually methods.

EE: https://github.com/hazelcast/hazelcast-enterprise/pull/2922