### PR TITLE
Include complete commitId in BuildInfo

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfo.java
@@ -38,34 +38,36 @@ public class BuildInfo {
     private final byte serializationVersion;
     private final BuildInfo upstreamBuildInfo;
     private final JetBuildInfo jetBuildInfo;
+    private final String commitId;
 
     public BuildInfo(String version, String build, String revision, int buildNumber, boolean enterprise,
-                     byte serializationVersion) {
-        this(version, build, revision, buildNumber, enterprise, serializationVersion, null);
+                     byte serializationVersion, String commitId) {
+        this(version, build, revision, buildNumber, enterprise, serializationVersion, commitId, null);
     }
 
     public BuildInfo(String version, String build, String revision, int buildNumber, boolean enterprise,
-                     byte serializationVersion, BuildInfo upstreamBuildInfo) {
-        this(version, build, revision, buildNumber, enterprise, serializationVersion, upstreamBuildInfo,
-                null);
+                     byte serializationVersion, String commitId, BuildInfo upstreamBuildInfo) {
+        this(version, build, revision, buildNumber, enterprise, serializationVersion, commitId,
+                upstreamBuildInfo, null);
     }
 
     private BuildInfo(String version, String build, String revision, int buildNumber, boolean enterprise,
-                     byte serializationVersion, BuildInfo upstreamBuildInfo, JetBuildInfo jetBuildInfo) {
+                     byte serializationVersion, String commitId, BuildInfo upstreamBuildInfo, JetBuildInfo jetBuildInfo) {
         this.version = version;
         this.build = build;
         this.revision = revision;
         this.buildNumber = buildNumber;
         this.enterprise = enterprise;
         this.serializationVersion = serializationVersion;
+        this.commitId = commitId;
         this.upstreamBuildInfo = upstreamBuildInfo;
         this.jetBuildInfo = jetBuildInfo;
     }
 
     private BuildInfo(BuildInfo buildInfo, JetBuildInfo jetBuildInfo) {
         this(buildInfo.getVersion(), buildInfo.getBuild(), buildInfo.getRevision(), buildInfo.getBuildNumber(),
-                buildInfo.isEnterprise(), buildInfo.getSerializationVersion(), buildInfo.getUpstreamBuildInfo(),
-                jetBuildInfo);
+                buildInfo.isEnterprise(), buildInfo.getSerializationVersion(), buildInfo.getCommitId(),
+                buildInfo.getUpstreamBuildInfo(), jetBuildInfo);
     }
 
     public String getRevision() {
@@ -94,6 +96,10 @@ public class BuildInfo {
 
     public BuildInfo getUpstreamBuildInfo() {
         return upstreamBuildInfo;
+    }
+
+    public String getCommitId() {
+        return commitId;
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/BuildInfoProvider.java
@@ -120,16 +120,17 @@ public final class BuildInfoProvider {
         String build = readStaticStringField(clazz, "BUILD");
         String revision = readStaticStringField(clazz, "REVISION");
         String distribution = readStaticStringField(clazz, "DISTRIBUTION");
+        String commitId = readStaticStringField(clazz, "COMMIT_ID");
 
-        if (!revision.isEmpty() && revision.equals("${git.commit.id.abbrev}")) {
-            revision = "";
-        }
+        revision = checkMissingExpressionValue(revision, "${git.commit.id.abbrev}");
+        commitId = checkMissingExpressionValue(commitId, "${git.commit.id}");
+
         int buildNumber = Integer.parseInt(build);
         boolean enterprise = !"Hazelcast".equals(distribution);
 
         String serialVersionString = readStaticStringField(clazz, "SERIALIZATION_VERSION");
         byte serialVersion = Byte.parseByte(serialVersionString);
-        return overrides.apply(version, build, revision, buildNumber, enterprise, serialVersion, upstreamBuildInfo);
+        return overrides.apply(version, build, revision, buildNumber, enterprise, serialVersion, commitId, upstreamBuildInfo);
     }
 
     //todo: move elsewhere
@@ -141,6 +142,14 @@ public final class BuildInfoProvider {
             throw new HazelcastException(e);
         } catch (IllegalAccessException e) {
             throw new HazelcastException(e);
+        }
+    }
+
+    private static String checkMissingExpressionValue(String value, String expression) {
+        if (!value.isEmpty() && value.equals(expression)) {
+            return "";
+        } else {
+            return value;
         }
     }
 
@@ -158,7 +167,7 @@ public final class BuildInfoProvider {
         }
 
         private BuildInfo apply(String version, String build, String revision, int buildNumber,
-                                boolean enterprise, byte serialVersion, BuildInfo upstreamBuildInfo) {
+                                boolean enterprise, byte serialVersion, String commitId, BuildInfo upstreamBuildInfo) {
             if (buildNo != -1) {
                 build = String.valueOf(buildNo);
                 buildNumber = buildNo;
@@ -171,7 +180,8 @@ public final class BuildInfoProvider {
                 LOGGER.info("Overriding hazelcast enterprise flag with system property value " + this.enterprise);
                 enterprise = this.enterprise;
             }
-            return new BuildInfo(version, build, revision, buildNumber, enterprise, serialVersion, upstreamBuildInfo);
+            return new BuildInfo(version, build, revision, buildNumber, enterprise, serialVersion,
+                    commitId, upstreamBuildInfo);
 
         }
 

--- a/hazelcast/src/main/template/com/hazelcast/instance/GeneratedBuildProperties.java
+++ b/hazelcast/src/main/template/com/hazelcast/instance/GeneratedBuildProperties.java
@@ -35,6 +35,7 @@ public final class GeneratedBuildProperties {
     public static final String VERSION = "${project.version}";
     public static final String BUILD = "${timestamp}";
     public static final String REVISION = "${git.commit.id.abbrev}";
+    public static final String COMMIT_ID = "${git.commit.id}";
     public static final String DISTRIBUTION = "${hazelcast.distribution}";
     public static final String SERIALIZATION_VERSION = "${hazelcast.serialization.version}";
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/BuildInfoProviderTest.java
@@ -113,4 +113,12 @@ public class BuildInfoProviderTest extends HazelcastTestSupport {
         BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
         assertFalse(buildInfo.isEnterprise());
     }
+
+    @Test
+    public void testCommitId() {
+        BuildInfo buildInfo = BuildInfoProvider.getBuildInfo();
+        String revision = buildInfo.getRevision();
+        String commitId = buildInfo.getCommitId();
+        assertTrue(commitId.startsWith(revision));
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/impl/OperationExecutorImpl_AbstractTest.java
@@ -71,7 +71,7 @@ public abstract class OperationExecutorImpl_AbstractTest extends HazelcastTestSu
 
     @Before
     public void setup() throws Exception {
-        loggingService = new LoggingServiceImpl("foo", "jdk", new BuildInfo("1", "1", "1", 1, false, (byte) 1));
+        loggingService = new LoggingServiceImpl("foo", "jdk", new BuildInfo("1", "1", "1", 1, false, (byte) 1, "1"));
 
         serializationService = new DefaultSerializationServiceBuilder().build();
         config = smallInstanceConfig();


### PR DESCRIPTION
Some tests are fragile when using the abbreviated commit ID, so
the complete commit ID needs to be included in `BuildInfo`.
Since the `BuildInfo.revision` field may be used in other contexts,
a new field is added in BuildInfo to access the full commit ID.

EE counterpart: https://github.com/hazelcast/hazelcast-enterprise/pull/2924