### PR TITLE
Replace readData/writeData with readObject/writeObject

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheNearCacheStateHolder.java
@@ -49,7 +49,7 @@ public class CacheNearCacheStateHolder implements IdentifiedDataSerializable {
     public CacheNearCacheStateHolder() {
     }
 
-    public CacheNearCacheStateHolder(CacheReplicationOperation cacheReplicationOperation) {
+    public void setCacheReplicationOperation(CacheReplicationOperation cacheReplicationOperation) {
         this.cacheReplicationOperation = cacheReplicationOperation;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/cache/impl/operation/CacheReplicationOperation.java
@@ -63,9 +63,11 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
 
     private final List<CacheConfig> configs = new ArrayList<CacheConfig>();
     private final Map<String, Map<Data, CacheRecord>> data = new HashMap<String, Map<Data, CacheRecord>>();
-    private final CacheNearCacheStateHolder nearCacheStateHolder = new CacheNearCacheStateHolder(this);
+    private CacheNearCacheStateHolder nearCacheStateHolder;
 
     public CacheReplicationOperation() {
+        nearCacheStateHolder = new CacheNearCacheStateHolder();
+        nearCacheStateHolder.setCacheReplicationOperation(this);
     }
 
     public final void prepare(CachePartitionSegment segment, Collection<ServiceNamespace> namespaces,
@@ -178,7 +180,7 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
             IOUtil.writeData(out, null);
         }
 
-        nearCacheStateHolder.writeData(out);
+        out.writeObject(nearCacheStateHolder);
     }
 
     @Override
@@ -211,7 +213,8 @@ public class CacheReplicationOperation extends Operation implements IdentifiedDa
             }
         }
 
-        nearCacheStateHolder.readData(in);
+        nearCacheStateHolder = in.readObject();
+        nearCacheStateHolder.setCacheReplicationOperation(this);
     }
 
     public boolean isEmpty() {

--- a/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/cluster/impl/AbstractMember.java
@@ -156,8 +156,7 @@ public abstract class AbstractMember implements Member {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        address = new Address();
-        address.readData(in);
+        address = in.readObject();
         uuid = UUIDSerializationUtil.readUUID(in);
         liteMember = in.readBoolean();
         version = in.readObject();
@@ -172,7 +171,7 @@ public abstract class AbstractMember implements Member {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        address.writeData(out);
+        out.writeObject(address);
         UUIDSerializationUtil.writeUUID(out, uuid);
         out.writeBoolean(liteMember);
         out.writeObject(version);

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/operations/CollectionReplicationOperation.java
@@ -60,7 +60,7 @@ public abstract class CollectionReplicationOperation extends Operation implement
         for (Map.Entry<String, CollectionContainer> entry : migrationData.entrySet()) {
             out.writeUTF(entry.getKey());
             CollectionContainer container = entry.getValue();
-            container.writeData(out);
+            out.writeObject(container);
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListReplicationOperation.java
@@ -19,7 +19,6 @@ package com.hazelcast.collection.impl.list.operations;
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.operations.CollectionReplicationOperation;
-import com.hazelcast.collection.impl.list.ListContainer;
 import com.hazelcast.nio.ObjectDataInput;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/list/operations/ListReplicationOperation.java
@@ -47,9 +47,7 @@ public class ListReplicationOperation extends CollectionReplicationOperation {
         migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
-            ListContainer container = new ListContainer();
-            container.readData(in);
-            migrationData.put(name, container);
+            migrationData.put(name, in.readObject());
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueContainer.java
@@ -92,20 +92,13 @@ public class QueueContainer implements IdentifiedDataSerializable {
     // to avoid reloading same items
     private long lastIdLoaded;
 
-    /**
-     * The default no-args constructor is only meant for factory usage.
-     */
     public QueueContainer() {
     }
 
-    public QueueContainer(String name) {
+    public QueueContainer(String name, QueueConfig config, NodeEngine nodeEngine, QueueService service) {
         this.name = name;
         this.pollWaitNotifyKey = new QueueWaitNotifyKey(name, "poll");
         this.offerWaitNotifyKey = new QueueWaitNotifyKey(name, "offer");
-    }
-
-    public QueueContainer(String name, QueueConfig config, NodeEngine nodeEngine, QueueService service) {
-        this(name);
         setConfig(config, nodeEngine, service);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueDataSerializerHook.java
@@ -135,239 +135,51 @@ public final class QueueDataSerializerHook implements DataSerializerHook {
 
         //noinspection unchecked
         ConstructorFunction<Integer, IdentifiedDataSerializable>[] constructors = new ConstructorFunction[MERGE_BACKUP + 1];
-        constructors[OFFER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new OfferOperation();
-            }
-        };
-
-        constructors[OFFER_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new OfferBackupOperation();
-            }
-        };
-        constructors[POLL] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PollOperation();
-            }
-        };
-        constructors[POLL_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PollBackupOperation();
-            }
-        };
-        constructors[PEEK] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new PeekOperation();
-            }
-        };
-        constructors[ADD_ALL_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new AddAllBackupOperation();
-            }
-        };
-        constructors[ADD_ALL] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new AddAllOperation();
-            }
-        };
-        constructors[CLEAR_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ClearBackupOperation();
-            }
-        };
-        constructors[CLEAR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ClearOperation();
-            }
-        };
-        constructors[COMPARE_AND_REMOVE_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new CompareAndRemoveBackupOperation();
-            }
-        };
-        constructors[COMPARE_AND_REMOVE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new CompareAndRemoveOperation();
-            }
-        };
-        constructors[CONTAINS] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new ContainsOperation();
-            }
-        };
-        constructors[DRAIN_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new DrainBackupOperation();
-            }
-        };
-        constructors[DRAIN] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new DrainOperation();
-            }
-        };
-        constructors[ITERATOR] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new IteratorOperation();
-            }
-        };
-        constructors[QUEUE_EVENT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new QueueEvent();
-            }
-        };
-        constructors[QUEUE_EVENT_FILTER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new QueueEventFilter();
-            }
-        };
-        constructors[QUEUE_ITEM] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new QueueItem();
-            }
-        };
-        constructors[QUEUE_REPLICATION] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new QueueReplicationOperation();
-            }
-        };
-        constructors[REMOVE_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new RemoveBackupOperation();
-            }
-        };
-        constructors[REMOVE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new RemoveOperation();
-            }
-        };
-        constructors[SIZE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new SizeOperation();
-            }
-        };
-        constructors[TXN_OFFER_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnOfferBackupOperation();
-            }
-        };
-        constructors[TXN_OFFER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnOfferOperation();
-            }
-        };
-        constructors[TXN_POLL_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnPollBackupOperation();
-            }
-        };
-        constructors[TXN_POLL] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnPollOperation();
-            }
-        };
-        constructors[TXN_PREPARE_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnPrepareBackupOperation();
-            }
-        };
-        constructors[TXN_PREPARE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnPrepareOperation();
-            }
-        };
-        constructors[TXN_RESERVE_OFFER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnReserveOfferOperation();
-            }
-        };
-        constructors[TXN_RESERVE_OFFER_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnReserveOfferBackupOperation();
-            }
-        };
-        constructors[TXN_RESERVE_POLL] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnReservePollOperation();
-            }
-        };
-        constructors[TXN_RESERVE_POLL_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnReservePollBackupOperation();
-            }
-        };
-        constructors[TXN_ROLLBACK_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnRollbackBackupOperation();
-            }
-        };
-        constructors[TXN_ROLLBACK] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnRollbackOperation();
-            }
-        };
-        constructors[CHECK_EVICT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new CheckAndEvictOperation();
-            }
-        };
-        constructors[QUEUE_CONTAINER] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new QueueContainer(null);
-            }
-        };
-        constructors[TRANSACTION_ROLLBACK] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new QueueTransactionRollbackOperation();
-            }
-        };
-        constructors[TX_QUEUE_ITEM] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxQueueItem();
-            }
-        };
-        constructors[TXN_PEEK] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnPeekOperation();
-            }
-        };
-        constructors[IS_EMPTY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new IsEmptyOperation();
-            }
-        };
-        constructors[REMAINING_CAPACITY] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new RemainingCapacityOperation();
-            }
-        };
-        constructors[TXN_COMMIT] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnCommitOperation();
-            }
-        };
-        constructors[TXN_COMMIT_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new TxnCommitBackupOperation();
-            }
-        };
-        constructors[MERGE] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new QueueMergeOperation();
-            }
-        };
-        constructors[MERGE_BACKUP] = new ConstructorFunction<Integer, IdentifiedDataSerializable>() {
-            @Override
-            public IdentifiedDataSerializable createNew(Integer arg) {
-                return new QueueMergeBackupOperation();
-            }
-        };
+        constructors[OFFER] = arg -> new OfferOperation();
+        constructors[OFFER_BACKUP] = arg -> new OfferBackupOperation();
+        constructors[POLL] = arg -> new PollOperation();
+        constructors[POLL_BACKUP] = arg -> new PollBackupOperation();
+        constructors[PEEK] = arg -> new PeekOperation();
+        constructors[ADD_ALL_BACKUP] = arg -> new AddAllBackupOperation();
+        constructors[ADD_ALL] = arg -> new AddAllOperation();
+        constructors[CLEAR_BACKUP] = arg -> new ClearBackupOperation();
+        constructors[CLEAR] = arg -> new ClearOperation();
+        constructors[COMPARE_AND_REMOVE_BACKUP] = arg -> new CompareAndRemoveBackupOperation();
+        constructors[COMPARE_AND_REMOVE] = arg -> new CompareAndRemoveOperation();
+        constructors[CONTAINS] = arg -> new ContainsOperation();
+        constructors[DRAIN_BACKUP] = arg -> new DrainBackupOperation();
+        constructors[DRAIN] = arg -> new DrainOperation();
+        constructors[ITERATOR] = arg -> new IteratorOperation();
+        constructors[QUEUE_EVENT] = arg -> new QueueEvent();
+        constructors[QUEUE_EVENT_FILTER] = arg -> new QueueEventFilter();
+        constructors[QUEUE_ITEM] = arg -> new QueueItem();
+        constructors[QUEUE_REPLICATION] = arg -> new QueueReplicationOperation();
+        constructors[REMOVE_BACKUP] = arg -> new RemoveBackupOperation();
+        constructors[REMOVE] = arg -> new RemoveOperation();
+        constructors[SIZE] = arg -> new SizeOperation();
+        constructors[TXN_OFFER_BACKUP] = arg -> new TxnOfferBackupOperation();
+        constructors[TXN_OFFER] = arg -> new TxnOfferOperation();
+        constructors[TXN_POLL_BACKUP] = arg -> new TxnPollBackupOperation();
+        constructors[TXN_POLL] = arg -> new TxnPollOperation();
+        constructors[TXN_PREPARE_BACKUP] = arg -> new TxnPrepareBackupOperation();
+        constructors[TXN_PREPARE] = arg -> new TxnPrepareOperation();
+        constructors[TXN_RESERVE_OFFER] = arg -> new TxnReserveOfferOperation();
+        constructors[TXN_RESERVE_OFFER_BACKUP] = arg -> new TxnReserveOfferBackupOperation();
+        constructors[TXN_RESERVE_POLL] = arg -> new TxnReservePollOperation();
+        constructors[TXN_RESERVE_POLL_BACKUP] = arg -> new TxnReservePollBackupOperation();
+        constructors[TXN_ROLLBACK_BACKUP] = arg -> new TxnRollbackBackupOperation();
+        constructors[TXN_ROLLBACK] = arg -> new TxnRollbackOperation();
+        constructors[CHECK_EVICT] = arg -> new CheckAndEvictOperation();
+        constructors[QUEUE_CONTAINER] = arg -> new QueueContainer();
+        constructors[TRANSACTION_ROLLBACK] = arg -> new QueueTransactionRollbackOperation();
+        constructors[TX_QUEUE_ITEM] = arg -> new TxQueueItem();
+        constructors[TXN_PEEK] = arg -> new TxnPeekOperation();
+        constructors[IS_EMPTY] = arg -> new IsEmptyOperation();
+        constructors[REMAINING_CAPACITY] = arg -> new RemainingCapacityOperation();
+        constructors[TXN_COMMIT] = arg -> new TxnCommitOperation();
+        constructors[TXN_COMMIT_BACKUP] = arg -> new TxnCommitBackupOperation();
+        constructors[MERGE] = arg -> new QueueMergeOperation();
+        constructors[MERGE_BACKUP] = arg -> new QueueMergeBackupOperation();
 
         return new ArrayDataSerializableFactory(constructors);
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/operations/QueueReplicationOperation.java
@@ -83,7 +83,7 @@ public class QueueReplicationOperation extends Operation implements IdentifiedDa
         for (Map.Entry<String, QueueContainer> entry : migrationData.entrySet()) {
             out.writeUTF(entry.getKey());
             QueueContainer container = entry.getValue();
-            container.writeData(out);
+            out.writeObject(container);
         }
     }
 
@@ -93,9 +93,7 @@ public class QueueReplicationOperation extends Operation implements IdentifiedDa
         migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
-            QueueContainer container = new QueueContainer(name);
-            container.readData(in);
-            migrationData.put(name, container);
+            migrationData.put(name, in.readObject());
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/set/operations/SetReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/set/operations/SetReplicationOperation.java
@@ -19,7 +19,6 @@ package com.hazelcast.collection.impl.set.operations;
 import com.hazelcast.collection.impl.collection.CollectionContainer;
 import com.hazelcast.collection.impl.collection.CollectionDataSerializerHook;
 import com.hazelcast.collection.impl.collection.operations.CollectionReplicationOperation;
-import com.hazelcast.collection.impl.set.SetContainer;
 import com.hazelcast.nio.ObjectDataInput;
 
 import java.io.IOException;
@@ -42,9 +41,7 @@ public class SetReplicationOperation extends CollectionReplicationOperation {
         migrationData = createHashMap(mapSize);
         for (int i = 0; i < mapSize; i++) {
             String name = in.readUTF();
-            SetContainer container = new SetContainer();
-            container.readData(in);
-            migrationData.put(name, container);
+            migrationData.put(name, in.readObject());
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockStoreImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/locksupport/LockStoreImpl.java
@@ -300,7 +300,7 @@ public final class LockStoreImpl implements IdentifiedDataSerializable, LockStor
         if (len > 0) {
             for (LockResourceImpl lock : locks.values()) {
                 if (!lock.isLocal()) {
-                    lock.writeData(out);
+                    out.writeObject(lock);
                 }
             }
         }
@@ -314,8 +314,7 @@ public final class LockStoreImpl implements IdentifiedDataSerializable, LockStor
         int len = in.readInt();
         if (len > 0) {
             for (int i = 0; i < len; i++) {
-                LockResourceImpl lock = new LockResourceImpl();
-                lock.readData(in);
+                LockResourceImpl lock = in.readObject();
                 lock.setLockStore(this);
                 locks.put(lock.getKey(), lock);
             }

--- a/hazelcast/src/main/java/com/hazelcast/internal/locksupport/operations/LockReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/locksupport/operations/LockReplicationOperation.java
@@ -96,7 +96,7 @@ public class LockReplicationOperation extends Operation
         out.writeInt(len);
         if (len > 0) {
             for (LockStoreImpl ls : locks) {
-                ls.writeData(out);
+                out.writeObject(ls);
             }
         }
     }
@@ -107,9 +107,7 @@ public class LockReplicationOperation extends Operation
         int len = in.readInt();
         if (len > 0) {
             for (int i = 0; i < len; i++) {
-                LockStoreImpl ls = new LockStoreImpl();
-                ls.readData(in);
-                locks.add(ls);
+                locks.add(in.readObject());
             }
         }
     }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapNearCacheStateHolder.java
@@ -56,7 +56,7 @@ public class MapNearCacheStateHolder implements IdentifiedDataSerializable {
     public MapNearCacheStateHolder() {
     }
 
-    public MapNearCacheStateHolder(MapReplicationOperation mapReplicationOperation) {
+    public void setMapReplicationOperation(MapReplicationOperation mapReplicationOperation) {
         this.mapReplicationOperation = mapReplicationOperation;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationOperation.java
@@ -134,8 +134,11 @@ public class MapReplicationOperation extends Operation
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         mapReplicationStateHolder = in.readObject();
+        mapReplicationStateHolder.setOperation(this);
         writeBehindStateHolder = in.readObject();
+        writeBehindStateHolder.setMapReplicationOperation(this);
         mapNearCacheStateHolder = in.readObject();
+        mapNearCacheStateHolder.setMapReplicationOperation(this);
     }
 
     RecordStore getRecordStore(String mapName) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/MapReplicationStateHolder.java
@@ -85,7 +85,7 @@ public class MapReplicationStateHolder implements IdentifiedDataSerializable {
     public MapReplicationStateHolder() {
     }
 
-    public MapReplicationStateHolder(MapReplicationOperation operation) {
+    public void setOperation(MapReplicationOperation operation) {
         this.operation = operation;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PostJoinMapOperation.java
@@ -174,7 +174,7 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
 
         out.writeInt(interceptorInfoList.size());
         for (InterceptorInfo interceptorInfo : interceptorInfoList) {
-            interceptorInfo.writeData(out);
+            out.writeObject(interceptorInfo);
         }
         int size = infoList.size();
         out.writeInt(size);
@@ -189,9 +189,7 @@ public class PostJoinMapOperation extends Operation implements IdentifiedDataSer
 
         int interceptorsCount = in.readInt();
         for (int i = 0; i < interceptorsCount; i++) {
-            InterceptorInfo info = new InterceptorInfo();
-            info.readData(in);
-            interceptorInfoList.add(info);
+            interceptorInfoList.add(in.readObject());
         }
         int accumulatorsCount = in.readInt();
         if (accumulatorsCount < 1) {

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PutAllOperation.java
@@ -210,14 +210,13 @@ public class PutAllOperation extends MapOperation
     @Override
     protected void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        mapEntries.writeData(out);
+        out.writeObject(mapEntries);
     }
 
     @Override
     protected void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        mapEntries = new MapEntries();
-        mapEntries.readData(in);
+        mapEntries = in.readObject();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WriteBehindStateHolder.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/WriteBehindStateHolder.java
@@ -73,7 +73,7 @@ public class WriteBehindStateHolder implements IdentifiedDataSerializable {
     public WriteBehindStateHolder() {
     }
 
-    public WriteBehindStateHolder(MapReplicationOperation mapReplicationOperation) {
+    public void setMapReplicationOperation(MapReplicationOperation mapReplicationOperation) {
         this.mapReplicationOperation = mapReplicationOperation;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
@@ -109,7 +109,7 @@ public class Registration implements EventRegistration {
         UUIDSerializationUtil.writeUUID(out, id);
         out.writeUTF(serviceName);
         out.writeUTF(topic);
-        subscriber.writeData(out);
+        out.writeObject(subscriber);
         out.writeObject(filter);
     }
 
@@ -118,8 +118,7 @@ public class Registration implements EventRegistration {
         id = UUIDSerializationUtil.readUUID(in);
         serviceName = in.readUTF();
         topic = in.readUTF();
-        subscriber = new Address();
-        subscriber.readData(in);
+        subscriber = in.readObject();
         filter = in.readObject();
     }
 


### PR DESCRIPTION
Replaces usage of obj.writeData(out) and obj.readData(in) with
in.readObject/out.writeObject. This reduces the probability of errors in
case the Versioned interface is introduced mistakenly on the object
being serialized but not the object performing the writeData/readData
call.

This PR does not cover all places where this is present, though. Using
writeObject/readObject will write two more ints per object in the
serialized format. In some cases (e.g. serialising many entries), this
may increase the size of the serialized format too much.

I'm open to suggestions and discussion here.

Fixes: https://github.com/hazelcast/hazelcast/pull/14909 
Depends on: https://github.com/hazelcast/hazelcast/pull/14936