### PR TITLE
[3.11.z] Move client authentication out of generic threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -23,8 +23,6 @@ import com.hazelcast.client.impl.operations.OnJoinClientOperation;
 import com.hazelcast.client.impl.protocol.ClientExceptions;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.MessageTaskFactory;
-import com.hazelcast.client.impl.protocol.task.AuthenticationCustomCredentialsMessageTask;
-import com.hazelcast.client.impl.protocol.task.AuthenticationMessageTask;
 import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.client.impl.protocol.task.GetPartitionsMessageTask;
 import com.hazelcast.client.impl.protocol.task.MessageTask;
@@ -255,8 +253,6 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
         Class clazz = messageTask.getClass();
         return clazz == PingMessageTask.class
                 || clazz == GetPartitionsMessageTask.class
-                || clazz == AuthenticationMessageTask.class
-                || clazz == AuthenticationCustomCredentialsMessageTask.class
                 ;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/ClientEngineImpl.java
@@ -25,6 +25,7 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.MessageTaskFactory;
 import com.hazelcast.client.impl.protocol.task.AuthenticationCustomCredentialsMessageTask;
 import com.hazelcast.client.impl.protocol.task.AuthenticationMessageTask;
+import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.client.impl.protocol.task.GetPartitionsMessageTask;
 import com.hazelcast.client.impl.protocol.task.MessageTask;
 import com.hazelcast.client.impl.protocol.task.PingMessageTask;
@@ -104,6 +105,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
     public static final String SERVICE_NAME = "hz:core:clientEngine";
 
     private static final int EXECUTOR_QUEUE_CAPACITY_PER_CORE = 100000;
+    private static final int BLOCKING_THREADS_PER_CORE = 5;
     private static final int THREADS_PER_CORE = 20;
     private static final int QUERY_THREADS_PER_CORE = 1;
     private static final ConstructorFunction<String, AtomicLong> LAST_AUTH_CORRELATION_ID_CONSTRUCTOR_FUNC =
@@ -116,6 +118,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
     private final Node node;
     private final NodeEngineImpl nodeEngine;
     private final Executor executor;
+    private final Executor blockingExecutor;
     private final ExecutorService clientManagementExecutor;
     private final Executor queryExecutor;
 
@@ -143,6 +146,7 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
         this.endpointManager = new ClientEndpointManagerImpl(nodeEngine);
         this.executor = newClientExecutor();
         this.queryExecutor = newClientQueryExecutor();
+        this.blockingExecutor = newBlockingExecutor();
         this.clientManagementExecutor = newClientsManagementExecutor();
         this.messageTaskFactory = new CompositeMessageTaskFactory(nodeEngine);
         this.clientExceptions = initClientExceptionFactory();
@@ -195,6 +199,22 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
                 ExecutorType.CONCRETE);
     }
 
+    private Executor newBlockingExecutor() {
+        final ExecutionService executionService = nodeEngine.getExecutionService();
+        int coreSize = Runtime.getRuntime().availableProcessors();
+
+        int threadCount = node.getProperties().getInteger(GroupProperty.CLIENT_ENGINE_BLOCKING_THREAD_COUNT);
+        if (threadCount <= 0) {
+            threadCount = coreSize * BLOCKING_THREADS_PER_CORE;
+        }
+
+        logger.finest("Creating new client executor for blocking tasks with threadCount=" + threadCount);
+
+        return executionService.register(ExecutionService.CLIENT_BLOCKING_EXECUTOR,
+                threadCount, coreSize * EXECUTOR_QUEUE_CAPACITY_PER_CORE,
+                ExecutorType.CONCRETE);
+    }
+
     //needed for testing purposes
     public ConnectionListener getConnectionListener() {
         return connectionListener;
@@ -221,6 +241,8 @@ public class ClientEngineImpl implements ClientEngine, CoreService, PreJoinAware
                 operationService.execute(new PriorityPartitionSpecificRunnable(messageTask));
             } else if (isQuery(messageTask)) {
                 queryExecutor.execute(messageTask);
+            } else if (messageTask instanceof BlockingMessageTask) {
+                blockingExecutor.execute(messageTask);
             } else {
                 executor.execute(messageTask);
             }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -44,7 +44,8 @@ import java.util.List;
 /**
  * Base authentication task
  */
-public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClusterMessageTask<P> {
+public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClusterMessageTask<P>
+        implements BlockingMessageTask {
 
     protected transient ClientPrincipal principal;
     protected transient Credentials credentials;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/BlockingMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/BlockingMessageTask.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.task;
+
+/**
+ * Marker interface for tasks that are blocking the running thread by doing remote operation
+ * and waiting the result.
+ *
+ * Even-tough Query, Listener, and Transactional Tasks are also BlockingMessageTasks
+ * They are marked with different interfaces, they are not implementing this interface
+ */
+public interface BlockingMessageTask {
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/HealthMonitor.java
@@ -196,6 +196,10 @@ public class HealthMonitor {
                 = metricRegistry.newLongGauge("executor.hz:async.queueSize");
         final LongGauge executorClientQueueSize
                 = metricRegistry.newLongGauge("executor.hz:client.queueSize");
+        final LongGauge executorQueryClientQueueSize
+                = metricRegistry.newLongGauge("executor.hz:client.query.queueSize");
+        final LongGauge executorBlockingClientQueueSize
+                = metricRegistry.newLongGauge("executor.hz:client.blocking.queueSize");
         final LongGauge executorClusterQueueSize
                 = metricRegistry.newLongGauge("executor.hz:cluster.queueSize");
         final LongGauge executorScheduledQueueSize
@@ -467,6 +471,10 @@ public class HealthMonitor {
                     .append(executorAsyncQueueSize.read()).append(", ");
             sb.append("executor.q.client.size=")
                     .append(executorClientQueueSize.read()).append(", ");
+            sb.append("executor.q.client.query.size=")
+                    .append(executorQueryClientQueueSize.read()).append(", ");
+            sb.append("executor.q.client.blocking.size=")
+                    .append(executorBlockingClientQueueSize.read()).append(", ");
             sb.append("executor.q.query.size=")
                     .append(executorQueryQueueSize.read()).append(", ");
             sb.append("executor.q.scheduled.size=")

--- a/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/jmx/InstanceMBean.java
@@ -60,6 +60,8 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
     private ManagedExecutorServiceMBean asyncExecutorMBean;
     private ManagedExecutorServiceMBean scheduledExecutorMBean;
     private ManagedExecutorServiceMBean clientExecutorMBean;
+    private ManagedExecutorServiceMBean clientQueryExecutorMBean;
+    private ManagedExecutorServiceMBean clientBlockingExecutorMBean;
     private ManagedExecutorServiceMBean queryExecutorMBean;
     private ManagedExecutorServiceMBean ioExecutorMBean;
     private ManagedExecutorServiceMBean offloadableExecutorMBean;
@@ -117,6 +119,10 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
                 hazelcastInstance, executionService.getExecutor(ExecutionService.SCHEDULED_EXECUTOR), service);
         this.clientExecutorMBean = new ManagedExecutorServiceMBean(
                 hazelcastInstance, executionService.getExecutor(ExecutionService.CLIENT_EXECUTOR), service);
+        this.clientQueryExecutorMBean = new ManagedExecutorServiceMBean(
+                hazelcastInstance, executionService.getExecutor(ExecutionService.CLIENT_QUERY_EXECUTOR), service);
+        this.clientBlockingExecutorMBean = new ManagedExecutorServiceMBean(
+                hazelcastInstance, executionService.getExecutor(ExecutionService.CLIENT_BLOCKING_EXECUTOR), service);
         this.queryExecutorMBean = new ManagedExecutorServiceMBean(
                 hazelcastInstance, executionService.getExecutor(ExecutionService.QUERY_EXECUTOR), service);
         this.ioExecutorMBean = new ManagedExecutorServiceMBean(
@@ -137,6 +143,8 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
         register(asyncExecutorMBean);
         register(scheduledExecutorMBean);
         register(clientExecutorMBean);
+        register(clientQueryExecutorMBean);
+        register(clientBlockingExecutorMBean);
         register(queryExecutorMBean);
         register(ioExecutorMBean);
         register(offloadableExecutorMBean);
@@ -168,6 +176,14 @@ public class InstanceMBean extends HazelcastMBean<HazelcastInstanceImpl> {
 
     public ManagedExecutorServiceMBean getClientExecutorMBean() {
         return clientExecutorMBean;
+    }
+
+    public ManagedExecutorServiceMBean getClientQueryExecutorMBean() {
+        return clientQueryExecutorMBean;
+    }
+
+    public ManagedExecutorServiceMBean getClientBlockingExecutorMBean() {
+        return clientBlockingExecutorMBean;
     }
 
     public ManagedExecutorServiceMBean getQueryExecutorMBean() {

--- a/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/ExecutionService.java
@@ -63,6 +63,11 @@ public interface ExecutionService {
     String CLIENT_MANAGEMENT_EXECUTOR = "hz:client-management";
 
     /**
+     * Name of the client transaction executor.
+     */
+    String CLIENT_BLOCKING_EXECUTOR = "hz:client-blocking-tasks";
+
+    /**
      * Name of the query executor.
      */
     String QUERY_EXECUTOR = "hz:query";

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -116,12 +116,26 @@ public final class GroupProperty {
      * partition-specific operation thread, but there are also requests that can't be executed on a partition-specific operation
      * thread, such as {@code multimap.containsValue(value)}, because they need to access all partitions on a given
      * member.
+     *
+     * When not set it is set as core-size * 20
      */
     public static final HazelcastProperty CLIENT_ENGINE_THREAD_COUNT
             = new HazelcastProperty("hazelcast.clientengine.thread.count", -1);
 
+    /**
+     * The number of threads that the client engine has available for processing requests that are related to transactions;
+     * When not set it is set as core-size.
+     */
     public static final HazelcastProperty CLIENT_ENGINE_QUERY_THREAD_COUNT
             = new HazelcastProperty("hazelcast.clientengine.query.thread.count", -1);
+
+    /**
+     * The number of threads that the client engine has available for processing requests that are blocking
+     * (in 3.11.z it's only used for client authentication);
+     * When not set it is set as core-size * 5.
+     */
+    public static final HazelcastProperty CLIENT_ENGINE_BLOCKING_THREAD_COUNT
+            = new HazelcastProperty("hazelcast.clientengine.blocking.thread.count", -1);
 
     /**
      * Time after which client connection is removed or owner node of a client is removed from the cluster.

--- a/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/TestAwareInstanceFactory.java
@@ -118,8 +118,16 @@ public class TestAwareInstanceFactory {
     protected void shutdownInstances(List<HazelcastInstance> listToRemove) {
         if (listToRemove != null) {
             for (HazelcastInstance hz : listToRemove) {
-                ManagementService.shutdown(hz.getName());
-                hz.getLifecycleService().terminate();
+                try {
+                    ManagementService.shutdown(hz.getName());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                try {
+                    hz.getLifecycleService().terminate();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
     }


### PR DESCRIPTION
This PR backports the `blockingExecutor` part of #13887 and uses the executor just for client authentications.