### PR TITLE
Increased assert timeout for lock lease test

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/concurrent/lock/LockBasicTest.java
@@ -403,7 +403,7 @@ public abstract class LockBasicTest extends HazelcastTestSupport {
             public void run() throws Exception {
                 assertFalse(lock.isLocked());
             }
-        }, 5);
+        }, 20);
     }
 
     @Test(expected = NullPointerException.class, timeout = 60000)


### PR DESCRIPTION
5 seconds timeout is too short when there are some pauses : 

http://jenkins.hazelcast.com/view/Official%20Builds/job/Hazelcast-3.maintenance-IbmJDK7/26/testReport/com.hazelcast.concurrent.lock/LockBasicDistributedTest/testTryLockLeaseTime_whenLockAcquiredTwice/

