### PR TITLE
Config format: better support for whitespace in enumerations

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-config-4.0.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-config-4.0.xsd
@@ -273,7 +273,7 @@
     <xs:complexType name="load-balancer">
         <xs:attribute name="type" use="required">
             <xs:simpleType>
-                <xs:restriction base="xs:string">
+                <xs:restriction base="non-space-string">
                     <xs:enumeration value="random"/>
                     <xs:enumeration value="round-robin"/>
                 </xs:restriction>
@@ -485,7 +485,7 @@
     </xs:complexType>
 
     <xs:simpleType name="eviction-policy">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="NONE"/>
             <xs:enumeration value="LRU"/>
             <xs:enumeration value="LFU"/>
@@ -494,7 +494,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="max-size-policy">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="ENTRY_COUNT"/>
             <xs:enumeration value="USED_NATIVE_MEMORY_SIZE"/>
             <xs:enumeration value="USED_NATIVE_MEMORY_PERCENTAGE"/>
@@ -527,9 +527,11 @@
 
     <xs:simpleType name="non-space-string">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\S.*"/>
+            <xs:whiteSpace value="collapse"/>
+            <xs:pattern value="\S+"/>
         </xs:restriction>
     </xs:simpleType>
+
     <xs:complexType name="serialization">
         <xs:all>
             <xs:element name="portable-version" type="xs:unsignedInt" minOccurs="0" maxOccurs="1"/>
@@ -700,7 +702,7 @@
     </xs:complexType>
 
     <xs:simpleType name="memory-unit">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="BYTES"/>
             <xs:enumeration value="KILOBYTES"/>
             <xs:enumeration value="MEGABYTES"/>
@@ -709,7 +711,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="memory-allocator-type">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="STANDARD"/>
             <xs:enumeration value="POOLED"/>
         </xs:restriction>
@@ -826,7 +828,7 @@
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
-                    <xs:restriction base="xs:string">
+                    <xs:restriction base="non-space-string">
                         <xs:enumeration value="DISCARD_OLDEST"/>
                         <xs:enumeration value="DISCARD_NEWEST"/>
                         <xs:enumeration value="BLOCK"/>

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/AbstractClientConfigBuilderTest.java
@@ -452,4 +452,7 @@ public abstract class AbstractClientConfigBuilderTest extends HazelcastTestSuppo
 
     @Test
     public abstract void testLoadBalancerRoundRobin();
+
+    @Test
+    public abstract void testWhitespaceInNonSpaceStrings();
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/InvalidConfigurationClientTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/InvalidConfigurationClientTest.java
@@ -95,21 +95,23 @@ public class InvalidConfigurationClientTest {
     @Test
     public void WhenValid_CredentialsClassName() {
         buildConfig("credentials-class-name", "com.hazelcast.client.config.Credentials");
+        buildConfig("credentials-class-name", " com.hazelcast.client.config.Credentials");
     }
 
     @Test(expected = InvalidConfigurationException.class)
     public void WhenInvalid_CredentialsClassName() {
-        buildConfig("credentials-class-name", " com.hazelcast.client.config.Credentials");
+        buildConfig("credentials-class-name", "com hazelcast.client.config.Credentials");
     }
 
     @Test
     public void WhenValid_ListenerClassName() {
         buildConfig("listener-class-name", "com.hazelcast.client.config.Listener");
+        buildConfig("listener-class-name", " com.hazelcast.client.config.Listener");
     }
 
     @Test(expected = InvalidConfigurationException.class)
     public void WhenInvalid_ListenerClassName() {
-        buildConfig("listener-class-name", " com.hazelcast.client.config.Listener");
+        buildConfig("listener-class-name", "com hazelcast.client.config.Listener");
     }
 
     @Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -355,6 +355,14 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
         assertInstanceOf(RoundRobinLB.class, config.getLoadBalancer());
     }
 
+    @Override
+    public void testWhitespaceInNonSpaceStrings() {
+        String xml = HAZELCAST_CLIENT_START_TAG
+                + "<load-balancer type=' \n random \n'/>"
+                + HAZELCAST_CLIENT_END_TAG;
+        buildConfig(xml);
+    }
+
     static ClientConfig buildConfig(String xml, Properties properties) {
         ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
         XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder(bis);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -356,6 +356,15 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
         buildConfig(yaml);
     }
 
+    @Override
+    public void testWhitespaceInNonSpaceStrings() {
+        String yaml = ""
+                + "hazelcast-client:\n"
+                + "  load-balancer:\n"
+                + "    type:   random   \n";
+
+        buildConfig(yaml);
+    }
 
     public static ClientConfig buildConfig(String yaml) {
         ByteArrayInputStream bis = new ByteArrayInputStream(yaml.getBytes());

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -2580,7 +2580,7 @@
     </xs:complexType>
 
     <xs:simpleType name="propertyNameEnum">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="hazelcast.merge.first.run.delay.seconds"/>
             <xs:enumeration value="hazelcast.merge.next.run.delay.seconds"/>
             <xs:enumeration value="hazelcast.redo.wait.millis"/>
@@ -2654,7 +2654,7 @@
         <xs:restriction base="non-space-string"/>
     </xs:simpleType>
     <xs:simpleType name="attributeTypeEnum">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="boolean"/>
             <xs:enumeration value="byte"/>
             <xs:enumeration value="double"/>
@@ -2814,7 +2814,8 @@
 
     <xs:simpleType name="non-space-string">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\S.*"/>
+            <xs:whiteSpace value="collapse"/>
+            <xs:pattern value="\S+"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -3139,7 +3140,7 @@
             <xs:simpleType>
                 <xs:union>
                     <xs:simpleType>
-                        <xs:restriction base="xs:string">
+                        <xs:restriction base="non-space-string">
                             <xs:enumeration value="REQUIRED"/>
                             <xs:enumeration value="OPTIONAL"/>
                             <xs:enumeration value="REQUISITE"/>
@@ -3210,7 +3211,7 @@
                 <xs:simpleType>
                     <xs:union>
                         <xs:simpleType>
-                            <xs:restriction base="xs:string">
+                            <xs:restriction base="non-space-string">
                                 <xs:enumeration value="all"/>
                                 <xs:enumeration value="create"/>
                                 <xs:enumeration value="destroy"/>
@@ -3444,7 +3445,7 @@
     <xs:complexType name="load-balancer">
         <xs:attribute name="type" use="required">
             <xs:simpleType>
-                <xs:restriction base="xs:string">
+                <xs:restriction base="non-space-string">
                     <xs:enumeration value="random"/>
                     <xs:enumeration value="round-robin"/>
                 </xs:restriction>
@@ -3764,7 +3765,7 @@
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
-                    <xs:restriction base="xs:string">
+                    <xs:restriction base="non-space-string">
                         <xs:enumeration value="DISCARD_OLDEST"/>
                         <xs:enumeration value="DISCARD_NEWEST"/>
                         <xs:enumeration value="BLOCK"/>
@@ -3850,7 +3851,7 @@
         </xs:simpleContent>
     </xs:complexType>
     <xs:simpleType name="eviction-policy-enum">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="NONE"/>
             <xs:enumeration value="LRU"/>
             <xs:enumeration value="LFU"/>
@@ -3862,7 +3863,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="in-memory-format-enum">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="BINARY"/>
             <xs:enumeration value="OBJECT"/>
             <xs:enumeration value="NATIVE"/>
@@ -3874,14 +3875,14 @@
     </xs:simpleType>
 
     <xs:simpleType name="local-update-policy-enum">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="INVALIDATE"/>
             <xs:enumeration value="CACHE_ON_UPDATE"/>
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="topic-overload-policy-enum">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="DISCARD_OLDEST"/>
             <xs:enumeration value="DISCARD_NEWEST"/>
             <xs:enumeration value="BLOCK"/>
@@ -3928,14 +3929,14 @@
     </xs:simpleType>
 
     <xs:simpleType name="topology-changed-strategy">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="CANCEL_RUNNING_OPERATION"/>
             <xs:enumeration value="DISCARD_AND_RESTART"/>
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="max-size-policy">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="ENTRY_COUNT"/>
             <xs:enumeration value="USED_NATIVE_MEMORY_SIZE"/>
             <xs:enumeration value="USED_NATIVE_MEMORY_PERCENTAGE"/>
@@ -4039,7 +4040,7 @@
         <xs:attribute name="unit" type="memory-unit" default="MEGABYTES"/>
     </xs:complexType>
     <xs:simpleType name="memory-unit">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="BYTES"/>
             <xs:enumeration value="KILOBYTES"/>
             <xs:enumeration value="MEGABYTES"/>
@@ -4047,7 +4048,7 @@
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="memory-allocator-type">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="STANDARD"/>
             <xs:enumeration value="POOLED"/>
         </xs:restriction>
@@ -4124,7 +4125,7 @@
     </xs:element>
 
     <xs:simpleType name="quorum-type">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="READ"/>
             <xs:enumeration value="WRITE"/>
             <xs:enumeration value="READ_WRITE"/>
@@ -4149,15 +4150,8 @@
         </xs:sequence>
     </xs:complexType>
 
-    <xs:simpleType name="wan-ack-type-format-enum">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="ACK_ON_RECEIPT"/>
-            <xs:enumeration value="ACK_ON_OPERATION_COMPLETE"/>
-        </xs:restriction>
-    </xs:simpleType>
-
     <xs:simpleType name="wan-queue-full-behavior-format-enum">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="DISCARD_AFTER_MUTATION"/>
             <xs:enumeration value="THROW_EXCEPTION"/>
             <xs:enumeration value="THROW_EXCEPTION_ONLY_IF_REPLICATION_ACTIVE"/>
@@ -4165,7 +4159,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="initial-publisher-state-format-enum">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="REPLICATING"/>
             <xs:enumeration value="PAUSED"/>
             <xs:enumeration value="STOPPED"/>
@@ -4173,14 +4167,10 @@
     </xs:simpleType>
 
     <xs:simpleType name="consistency-check-strategy-format-enum">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="NONE"/>
             <xs:enumeration value="MERKLE_TREES"/>
         </xs:restriction>
-    </xs:simpleType>
-
-    <xs:simpleType name="wan-ack-type">
-        <xs:union memberTypes="wan-ack-type-format-enum non-space-string"/>
     </xs:simpleType>
 
     <xs:simpleType name="wan-queue-full-behavior">

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -2829,7 +2829,7 @@
         <xs:attribute name="class-name" type="non-space-string" use="required"/>
         <xs:attribute name="usage" use="optional" default="REQUIRED">
             <xs:simpleType>
-                <xs:restriction base="xs:string">
+                <xs:restriction base="non-space-string">
                     <xs:enumeration value="REQUIRED"/>
                     <xs:enumeration value="OPTIONAL"/>
                     <xs:enumeration value="REQUISITE"/>
@@ -2927,7 +2927,7 @@
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
-                    <xs:restriction base="xs:string">
+                    <xs:restriction base="non-space-string">
                         <xs:enumeration value="all"/>
                         <xs:enumeration value="create"/>
                         <xs:enumeration value="destroy"/>
@@ -3129,9 +3129,11 @@
 
     <xs:simpleType name="non-space-string">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\S.*"/>
+            <xs:whiteSpace value="collapse"/>
+            <xs:pattern value="\S+"/>
         </xs:restriction>
     </xs:simpleType>
+
     <xs:complexType name="serialization">
         <xs:all>
             <xs:element name="portable-version" type="xs:unsignedInt" minOccurs="0" maxOccurs="1">
@@ -3378,7 +3380,7 @@
     </xs:complexType>
 
     <xs:simpleType name="memory-unit">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="BYTES"/>
             <xs:enumeration value="KILOBYTES"/>
             <xs:enumeration value="MEGABYTES"/>
@@ -3387,7 +3389,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="topic-overload-policy">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="DISCARD_OLDEST"/>
             <xs:enumeration value="DISCARD_NEWEST"/>
             <xs:enumeration value="BLOCK"/>
@@ -3395,7 +3397,7 @@
         </xs:restriction>
     </xs:simpleType>
     <xs:simpleType name="memory-allocator-type">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="STANDARD"/>
             <xs:enumeration value="POOLED"/>
         </xs:restriction>
@@ -3435,7 +3437,7 @@
         <xs:restriction base="non-space-string"/>
     </xs:simpleType>
     <xs:simpleType name="attributeTypeEnum">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="boolean"/>
             <xs:enumeration value="byte"/>
             <xs:enumeration value="double"/>
@@ -3462,14 +3464,14 @@
     </xs:complexType>
 
     <xs:simpleType name="topology-changed-strategy">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="CANCEL_RUNNING_OPERATION"/>
             <xs:enumeration value="DISCARD_AND_RESTART"/>
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="eviction-policy">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="NONE"/>
             <xs:enumeration value="LRU"/>
             <xs:enumeration value="LFU"/>
@@ -3478,7 +3480,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="max-size-policy">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="ENTRY_COUNT"/>
             <xs:enumeration value="USED_NATIVE_MEMORY_SIZE"/>
             <xs:enumeration value="USED_NATIVE_MEMORY_PERCENTAGE"/>
@@ -3652,7 +3654,7 @@
     </xs:element>
 
     <xs:simpleType name="quorum-type">
-        <xs:restriction base="xs:string">
+        <xs:restriction base="non-space-string">
             <xs:enumeration value="READ"/>
             <xs:enumeration value="WRITE"/>
             <xs:enumeration value="READ_WRITE"/>
@@ -4022,13 +4024,6 @@
             <xs:element name="filter-impl" type="xs:string" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
-
-    <xs:simpleType name="wan-ack-type">
-        <xs:restriction base="non-space-string">
-            <xs:enumeration value="ACK_ON_RECEIPT"/>
-            <xs:enumeration value="ACK_ON_OPERATION_COMPLETE"/>
-        </xs:restriction>
-    </xs:simpleType>
 
     <xs:simpleType name="wan-queue-full-behavior">
         <xs:restriction base="non-space-string">

--- a/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/AbstractConfigBuilderTest.java
@@ -462,6 +462,9 @@ public abstract class AbstractConfigBuilderTest extends HazelcastTestSupport {
     public abstract void testMultipleMemberEndpointConfigs_throwsException();
 
     @Test
+    public abstract void testWhitespaceInNonSpaceStrings();
+
+    @Test
     public void testCompleteAdvancedNetworkConfig() {
         Config config = buildCompleteAdvancedNetworkConfig();
 

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3329,6 +3329,14 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     }
 
     @Override
+    public void testWhitespaceInNonSpaceStrings() {
+        String xml = HAZELCAST_START_TAG
+                + "<quorum enabled='true' name='q'><quorum-type> \n WRITE \n </quorum-type></quorum>"
+                + HAZELCAST_END_TAG;
+        buildConfig(xml);
+    }
+
+    @Override
     protected Config buildCompleteAdvancedNetworkConfig() {
         String xml = HAZELCAST_START_TAG
                 + "<advanced-network enabled=\"true\">"

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3529,4 +3529,17 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         assertEquals(1, lockConfig1.getLockAcquireLimit());
         assertEquals(2, lockConfig2.getLockAcquireLimit());
     }
+
+    @Override
+    public void testWhitespaceInNonSpaceStrings() {
+        String yaml = ""
+                + "hazelcast:\n"
+                + "  quorum:\n"
+                + "    enabled: true\n"
+                + "    name: q\n"
+                + "    quorum-type:   WRITE   \n";
+
+        buildConfig(yaml);
+    }
+
 }


### PR DESCRIPTION
Changed the 'non-space-string' XSD type to collapse all
whitespace, and made sure that all enumerated types
extend from this type (some were extending xs:string).

Fixes https://github.com/hazelcast/hazelcast/issues/14919