### PR TITLE
Fix regression in declarative config file resolution

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigLocator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientConfigLocator.java
@@ -24,9 +24,17 @@ import com.hazelcast.config.AbstractConfigLocator;
  */
 public class XmlClientConfigLocator extends AbstractConfigLocator {
 
+    public XmlClientConfigLocator() {
+        super(false);
+    }
+
+    public XmlClientConfigLocator(boolean failIfSysPropWithNotExpectedSuffix) {
+        super(failIfSysPropWithNotExpectedSuffix);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
-        return loadFromSystemProperty("hazelcast.client.config", "xml");
+        return loadFromSystemProperty("hazelcast.client.config");
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigLocator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigLocator.java
@@ -24,9 +24,17 @@ import com.hazelcast.config.AbstractConfigLocator;
  */
 public class XmlClientFailoverConfigLocator extends AbstractConfigLocator {
 
+    public XmlClientFailoverConfigLocator() {
+        super(false);
+    }
+
+    public XmlClientFailoverConfigLocator(boolean failIfSysPropWithNotExpectedSuffix) {
+        super(failIfSysPropWithNotExpectedSuffix);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
-        return loadFromSystemProperty("hazelcast.client.failover.config", "xml");
+        return loadFromSystemProperty("hazelcast.client.failover.config");
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientConfigBuilder.java
@@ -98,7 +98,7 @@ public class YamlClientConfigBuilder extends AbstractYamlConfigBuilder {
      */
     public YamlClientConfigBuilder(YamlClientConfigLocator locator) {
         if (locator == null) {
-            locator = new YamlClientConfigLocator();
+            locator = new YamlClientConfigLocator(true);
             locator.locateEverywhere();
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientConfigLocator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientConfigLocator.java
@@ -24,6 +24,14 @@ import com.hazelcast.config.AbstractConfigLocator;
  */
 public class YamlClientConfigLocator extends AbstractConfigLocator {
 
+    public YamlClientConfigLocator() {
+        super(false);
+    }
+
+    public YamlClientConfigLocator(boolean failIfSysPropWithNotExpectedSuffix) {
+        super(failIfSysPropWithNotExpectedSuffix);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
         return loadFromSystemProperty("hazelcast.client.config", "yaml", "yml");

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilder.java
@@ -101,7 +101,7 @@ public class YamlClientFailoverConfigBuilder extends AbstractYamlConfigBuilder {
      */
     public YamlClientFailoverConfigBuilder(YamlClientFailoverConfigLocator locator) {
         if (locator == null) {
-            locator = new YamlClientFailoverConfigLocator();
+            locator = new YamlClientFailoverConfigLocator(true);
             locator.locateEverywhere();
         }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigLocator.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/YamlClientFailoverConfigLocator.java
@@ -24,9 +24,17 @@ import com.hazelcast.config.AbstractConfigLocator;
  */
 public class YamlClientFailoverConfigLocator extends AbstractConfigLocator {
 
+    public YamlClientFailoverConfigLocator() {
+        super(false);
+    }
+
+    public YamlClientFailoverConfigLocator(boolean failIfSysPropWithNotExpectedSuffix) {
+        super(failIfSysPropWithNotExpectedSuffix);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
-        return loadFromSystemProperty("hazelcast.client.failover.config", "yaml");
+        return loadFromSystemProperty("hazelcast.client.failover.config", "yaml", "yml");
     }
 
     @Override

--- a/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/impl/clientside/FailoverClientConfigSupport.java
@@ -98,13 +98,13 @@ public final class FailoverClientConfigSupport {
         XmlClientFailoverConfigLocator xmlConfigLocator = new XmlClientFailoverConfigLocator();
         YamlClientFailoverConfigLocator yamlConfigLocator = new YamlClientFailoverConfigLocator();
 
-        if (xmlConfigLocator.locateFromSystemProperty()) {
-            // 1. Try loading config if provided in system property and it is an XML file
-            config = new XmlClientFailoverConfigBuilder(xmlConfigLocator).build();
-
-        } else if (yamlConfigLocator.locateFromSystemProperty()) {
-            // 2. Try loading config if provided in system property and it is an YAML file
+        if (yamlConfigLocator.locateFromSystemProperty()) {
+            // 1. Try loading config if provided in system property and it is an YAML file
             config = new YamlClientFailoverConfigBuilder(yamlConfigLocator).build();
+
+        } else if (xmlConfigLocator.locateFromSystemProperty()) {
+            // 2. Try loading config if provided in system property and it is an XML file
+            config = new XmlClientFailoverConfigBuilder(xmlConfigLocator).build();
 
         } else if (xmlConfigLocator.locateInWorkDirOrOnClasspath()) {
             // 3. Try loading XML config from the working directory or from the classpath
@@ -125,13 +125,13 @@ public final class FailoverClientConfigSupport {
         XmlClientConfigLocator xmlConfigLocator = new XmlClientConfigLocator();
         YamlClientConfigLocator yamlConfigLocator = new YamlClientConfigLocator();
 
-        if (xmlConfigLocator.locateFromSystemProperty()) {
-            // 1. Try loading config if provided in system property and it is an XML file
-            config = new XmlClientConfigBuilder(xmlConfigLocator).build();
-
-        } else if (yamlConfigLocator.locateFromSystemProperty()) {
-            // 2. Try loading config if provided in system property and it is an YAML file
+        if (yamlConfigLocator.locateFromSystemProperty()) {
+            // 1. Try loading config if provided in system property and it is an YAML file
             config = new YamlClientConfigBuilder(yamlConfigLocator).build();
+
+        } else if (xmlConfigLocator.locateFromSystemProperty()) {
+            // 2. Try loading config if provided in system property and it is an XML file
+            config = new XmlClientConfigBuilder(xmlConfigLocator).build();
 
         } else if (xmlConfigLocator.locateInWorkDirOrOnClasspath()) {
             // 3. Try loading XML config from the working directory or from the classpath

--- a/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientConfigResolutionTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HazelcastClientConfigResolutionTest {
+
+    private static final String SYSPROP_NAME = "hazelcast.client.config";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private HazelcastInstance instance;
+    private DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
+
+    @Before
+    public void setUp() {
+        System.clearProperty(SYSPROP_NAME);
+    }
+
+    @After
+    public void tearDown() {
+        if (instance != null) {
+            instance.shutdown();
+        }
+        System.clearProperty(SYSPROP_NAME);
+        helper.ensureTestConfigDeleted();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_xml_loadedAsXml() throws Exception {
+        File file = helper.givenXmlClientConfigFileInWorkDir("foo.xml", "cluster-xml");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-xml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_xml_loadedAsXml() throws Exception {
+        helper.givenXmlClientConfigFileOnClasspath("foo.xml", "cluster-xml");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.xml");
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-xml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_yaml_loadedAsYaml() throws Exception {
+        File file = helper.givenYamlClientConfigFileInWorkDir("foo.yaml", "cluster-yaml");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_yaml_loadedAsYaml() throws Exception {
+        helper.givenYamlClientConfigFileOnClasspath("foo.yaml", "cluster-yaml");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_yml_loadedAsYaml() throws Exception {
+        File file = helper.givenYamlClientConfigFileInWorkDir("foo.yml", "cluster-yaml");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_yml_loadedAsYaml() throws Exception {
+        helper.givenYamlClientConfigFileOnClasspath("foo.yml", "cluster-yaml");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yml");
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_bar_loadedAsXml() throws Exception {
+        File file = helper.givenXmlClientConfigFileInWorkDir("foo.bar", "cluster-bar");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-bar", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_bar_loadedAsXml() throws Exception {
+        helper.givenXmlClientConfigFileOnClasspath("foo.bar", "cluster-bar");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-bar", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.xml");
+
+        instance = HazelcastClient.newHazelcastClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.xml");
+
+        instance = HazelcastClient.newHazelcastClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.yaml");
+
+        instance = HazelcastClient.newHazelcastClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.yaml");
+
+        instance = HazelcastClient.newHazelcastClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentYml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.yml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.yml");
+
+        instance = HazelcastClient.newHazelcastClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentYml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.yml");
+
+        instance = HazelcastClient.newHazelcastClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentBar_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.bar");
+
+        instance = HazelcastClient.newHazelcastClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentBar_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.bar");
+
+        instance = HazelcastClient.newHazelcastClient();
+    }
+
+    @Test
+    public void testResolveWorkDir_xml() throws Exception {
+        helper.givenXmlClientConfigFileInWorkDir("cluster-xml");
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-xml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveClasspath_xml() throws Exception {
+        helper.givenXmlClientConfigFileOnClasspath("cluster-xml");
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-xml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveWorkDir_yaml() throws Exception {
+        helper.givenYamlClientConfigFileInWorkDir("cluster-yaml");
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveClasspath_yaml() throws Exception {
+        helper.givenYamlClientConfigFileOnClasspath("cluster-yaml");
+
+        instance = HazelcastClient.newHazelcastClient();
+        ClientConfig config = getClientConfig(instance);
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveDefault_xml() {
+        // needed for the client
+        HazelcastInstance member = HazelcastInstanceFactory.newHazelcastInstance(null);
+
+        try {
+            getClass().getClassLoader().getResource("hazelcast-client-default.xml");
+
+            instance = HazelcastClient.newHazelcastClient();
+            ClientConfig config = getClientConfig(instance);
+
+            assertEquals("dev", config.getGroupConfig().getName());
+        } finally {
+            member.shutdown();
+        }
+    }
+
+    private ClientConfig getClientConfig(HazelcastInstance instance) {
+        return ((HazelcastClientProxy) instance).getClientConfig();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientFailoverConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientFailoverConfigResolutionTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client;
+
+import com.hazelcast.client.config.ClientFailoverConfig;
+import com.hazelcast.client.impl.clientside.HazelcastClientProxy;
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HazelcastClientFailoverConfigResolutionTest {
+
+    private static final String SYSPROP_NAME = "hazelcast.client.failover.config";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private HazelcastInstance instance;
+    private DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
+
+    @Before
+    public void setUp() {
+        System.clearProperty(SYSPROP_NAME);
+    }
+
+    @After
+    public void tearDown() {
+        if (instance != null) {
+            instance.shutdown();
+        }
+        System.clearProperty(SYSPROP_NAME);
+        helper.ensureTestConfigDeleted();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_xml_loadedAsXml() throws Exception {
+        File file = helper.givenXmlClientFailoverConfigFileInWorkDir("foo.xml", 42);
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_xml_loadedAsXml() throws Exception {
+        helper.givenXmlClientFailoverConfigFileOnClasspath("foo.xml", 42);
+        System.setProperty(SYSPROP_NAME, "classpath:foo.xml");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_yaml_loadedAsYaml() throws Exception {
+        File file = helper.givenYamlClientFailoverConfigFileInWorkDir("foo.yaml", 42);
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_yaml_loadedAsYaml() throws Exception {
+        helper.givenYamlClientFailoverConfigFileOnClasspath("foo.yaml", 42);
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_yml_loadedAsYaml() throws Exception {
+        File file = helper.givenYamlClientFailoverConfigFileInWorkDir("foo.yml", 42);
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_yml_loadedAsYaml() throws Exception {
+        helper.givenYamlClientFailoverConfigFileOnClasspath("foo.yml", 42);
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yml");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_bar_loadedAsXml() throws Exception {
+        File file = helper.givenXmlClientFailoverConfigFileInWorkDir("foo.bar", 42);
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_bar_loadedAsXml() throws Exception {
+        helper.givenXmlClientFailoverConfigFileOnClasspath("foo.bar", 42);
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.xml");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.xml");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.yaml");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.yaml");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentYml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.yml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.yml");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentYml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.yml");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentBar_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.bar");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentBar_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.bar");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+    }
+
+    @Test
+    public void testResolveWorkDir_xml() throws Exception {
+        helper.givenXmlClientFailoverConfigFileInWorkDir(42);
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveClasspath_xml() throws Exception {
+        helper.givenXmlClientFailoverConfigFileOnClasspath(42);
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveWorkDir_yaml() throws Exception {
+        helper.givenYamlClientFailoverConfigFileInWorkDir(42);
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveClasspath_yaml() throws Exception {
+        helper.givenYamlClientFailoverConfigFileOnClasspath(42);
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+        ClientFailoverConfig config = getClientConfig(instance);
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveDefault_xml() {
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("Failed to load ClientFailoverConfig");
+
+        instance = HazelcastClient.newHazelcastFailoverClient();
+    }
+
+    private ClientFailoverConfig getClientConfig(HazelcastInstance instance) {
+        return ((HazelcastClientProxy) instance).client.getFailoverConfig();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderResolutionTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class XmlClientConfigBuilderResolutionTest {
+
+    private static final String SYSPROP_NAME = "hazelcast.client.config";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private final DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
+
+    @Before
+    @After
+    public void beforeAndAfter() {
+        System.clearProperty(SYSPROP_NAME);
+        helper.ensureTestConfigDeleted();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_xml() throws Exception {
+        helper.givenXmlClientConfigFileInWorkDir("foo.xml", "cluster-xml-file");
+        System.setProperty(SYSPROP_NAME, "foo.xml");
+
+        ClientConfig config = new XmlClientConfigBuilder().build();
+        assertEquals("cluster-xml-file", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_xml() throws Exception {
+        helper.givenXmlClientConfigFileOnClasspath("foo.xml", "cluster-xml-classpath");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.xml");
+
+        ClientConfig config = new XmlClientConfigBuilder().build();
+        assertEquals("cluster-xml-classpath", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.xml");
+
+        new XmlClientConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "idontexist.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("idontexist.xml");
+
+        new XmlClientConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonXml_loadedAsXml() throws Exception {
+        File file = helper.givenXmlClientConfigFileInWorkDir("foo.bar", "cluster-bar-file");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        ClientConfig config = new XmlClientConfigBuilder().build();
+
+        assertEquals("cluster-bar-file", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonXml_loadedAsXml() throws Exception {
+        helper.givenXmlClientConfigFileOnClasspath("foo.bar", "cluster-bar-classpath");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        ClientConfig config = new XmlClientConfigBuilder().build();
+        assertEquals("cluster-bar-classpath", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentNonXml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.bar");
+
+        new XmlClientConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentNonXml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.bar");
+
+        new XmlClientConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveFromWorkDir() throws Exception {
+        helper.givenXmlClientConfigFileInWorkDir("cluster-xml-workdir");
+
+        ClientConfig config = new XmlClientConfigBuilder().build();
+
+        assertEquals("cluster-xml-workdir", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveFromClasspath() throws Exception {
+        helper.givenXmlClientConfigFileOnClasspath("cluster-xml-classpath");
+
+        ClientConfig config = new XmlClientConfigBuilder().build();
+
+        assertEquals("cluster-xml-classpath", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveDefault() {
+        ClientConfig config = new XmlClientConfigBuilder().build();
+        assertEquals("dev", config.getGroupConfig().getName());
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderTest.java
@@ -144,7 +144,7 @@ public class XmlClientConfigBuilderTest extends AbstractClientConfigBuilderTest 
 
         XmlClientConfigBuilder configBuilder = new XmlClientConfigBuilder();
         ClientConfig config = configBuilder.build();
-        assertEquals("foobar", config.getGroupConfig().getName());
+        assertEquals("foobar-xml", config.getGroupConfig().getName());
         assertEquals("com.hazelcast.nio.ssl.BasicSSLContextFactory", config.getNetworkConfig().getSSLConfig().getFactoryClassName());
         assertEquals(128, config.getNetworkConfig().getSocketOptions().getBufferSize());
         assertFalse(config.getNetworkConfig().getSocketOptions().isKeepAlive());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderConfigResolutionTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class XmlClientFailoverConfigBuilderConfigResolutionTest {
+
+    private static final String SYSPROP_NAME = "hazelcast.client.failover.config";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private final DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
+
+    @Before
+    @After
+    public void beforeAndAfter() {
+        System.clearProperty(SYSPROP_NAME);
+        helper.ensureTestConfigDeleted();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_xml() throws Exception {
+        helper.givenXmlClientFailoverConfigFileInWorkDir("foo.xml", 42);
+        System.setProperty(SYSPROP_NAME, "foo.xml");
+
+        ClientFailoverConfig config = new XmlClientFailoverConfigBuilder().build();
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_xml() throws Exception {
+        helper.givenXmlClientFailoverConfigFileOnClasspath("foo.xml", 42);
+        System.setProperty(SYSPROP_NAME, "classpath:foo.xml");
+
+        ClientFailoverConfig config = new XmlClientFailoverConfigBuilder().build();
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.xml");
+
+        new XmlClientFailoverConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "idontexist.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("idontexist.xml");
+
+        new XmlClientFailoverConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonXml_loadedAsXml() throws Exception {
+        File file = helper.givenXmlClientFailoverConfigFileInWorkDir("foo.bar", 42);
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        ClientFailoverConfig config = new XmlClientFailoverConfigBuilder().build();
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonXml_loadedAsXml() throws Exception {
+        helper.givenXmlClientFailoverConfigFileOnClasspath("foo.bar", 42);
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        ClientFailoverConfig config = new XmlClientFailoverConfigBuilder().build();
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentNonXml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.bar");
+
+        new XmlClientFailoverConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentNonXml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.bar");
+
+        new XmlClientFailoverConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveFromWorkDir() throws Exception {
+        helper.givenXmlClientFailoverConfigFileInWorkDir(42);
+
+        ClientFailoverConfig config = new XmlClientFailoverConfigBuilder().build();
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveFromClasspath() throws Exception {
+        helper.givenXmlClientFailoverConfigFileOnClasspath(42);
+
+        ClientFailoverConfig config = new XmlClientFailoverConfigBuilder().build();
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveDefault() {
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("Failed to load ClientFailoverConfig");
+
+        new XmlClientFailoverConfigBuilder().build();
+    }
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderResolutionTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class YamlClientConfigBuilderResolutionTest {
+
+    private static final String SYSPROP_NAME = "hazelcast.client.config";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
+
+    @Before
+    @After
+    public void beforeAndAfter() {
+        System.clearProperty(SYSPROP_NAME);
+        helper.ensureTestConfigDeleted();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_yaml() throws Exception {
+        helper.givenYamlClientConfigFileInWorkDir("foo.yaml", "cluster-yaml-file");
+        System.setProperty(SYSPROP_NAME, "foo.yaml");
+
+        ClientConfig config = new YamlClientConfigBuilder().build();
+        assertEquals("cluster-yaml-file", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_yaml() throws Exception {
+        helper.givenYamlClientConfigFileOnClasspath("foo.yaml", "cluster-yaml-classpath");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
+
+        ClientConfig config = new YamlClientConfigBuilder().build();
+        assertEquals("cluster-yaml-classpath", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.yaml");
+
+        new YamlClientConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "idontexist.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("idontexist.yaml");
+
+        new YamlClientConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonYaml_throws() throws Exception {
+        File file = helper.givenYamlClientConfigFileInWorkDir("foo.bar", "irrelevant");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("suffix");
+        expectedException.expectMessage("foo.bar");
+
+        new YamlClientConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonYaml_throws() throws Exception {
+        helper.givenYamlClientConfigFileOnClasspath("foo.bar", "irrelevant");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("suffix");
+        expectedException.expectMessage("foo.bar");
+
+        new YamlClientConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentNonYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.bar");
+
+        new YamlClientConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentNonYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.bar");
+
+        new YamlClientConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveFromWorkDir() throws Exception {
+        helper.givenYamlClientConfigFileInWorkDir("cluster-yaml-workdir");
+
+        ClientConfig config = new YamlClientConfigBuilder().build();
+
+        assertEquals("cluster-yaml-workdir", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveFromClasspath() throws Exception {
+        helper.givenYamlClientConfigFileOnClasspath("cluster-yaml-classpath");
+
+        ClientConfig config = new YamlClientConfigBuilder().build();
+
+        assertEquals("cluster-yaml-classpath", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveDefault() {
+        ClientConfig config = new YamlClientConfigBuilder().build();
+        assertEquals("dev", config.getGroupConfig().getName());
+    }
+
+}

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderTest.java
@@ -135,7 +135,7 @@ public class YamlClientConfigBuilderTest extends AbstractClientConfigBuilderTest
 
         YamlClientConfigBuilder configBuilder = new YamlClientConfigBuilder();
         ClientConfig config = configBuilder.build();
-        assertEquals("foobar", config.getGroupConfig().getName());
+        assertEquals("foobar-yaml", config.getGroupConfig().getName());
         assertEquals("com.hazelcast.nio.ssl.BasicSSLContextFactory",
                 config.getNetworkConfig().getSSLConfig().getFactoryClassName());
         assertEquals(128, config.getNetworkConfig().getSocketOptions().getBufferSize());

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilderConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilderConfigResolutionTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class YamlClientFailoverConfigBuilderConfigResolutionTest {
+
+    private static final String SYSPROP_NAME = "hazelcast.client.failover.config";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
+
+    @Before
+    @After
+    public void beforeAndAfter() {
+        System.clearProperty(SYSPROP_NAME);
+        helper.ensureTestConfigDeleted();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_yaml() throws Exception {
+        helper.givenYamlClientFailoverConfigFileInWorkDir("foo.yaml", 42);
+        System.setProperty(SYSPROP_NAME, "foo.yaml");
+
+        ClientFailoverConfig config = new YamlClientFailoverConfigBuilder().build();
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_yaml() throws Exception {
+        helper.givenYamlClientFailoverConfigFileOnClasspath("foo.yaml", 42);
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
+
+        ClientFailoverConfig config = new YamlClientFailoverConfigBuilder().build();
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.yaml");
+
+        new YamlClientFailoverConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "idontexist.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("idontexist.yaml");
+
+        new YamlClientFailoverConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonYaml_throws() throws Exception {
+        File file = helper.givenYamlClientFailoverConfigFileInWorkDir("foo.bar", 42);
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("suffix");
+        expectedException.expectMessage("foo.bar");
+
+        new YamlClientFailoverConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonYaml_throws() throws Exception {
+        helper.givenYamlClientFailoverConfigFileOnClasspath("foo.bar", 42);
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("suffix");
+        expectedException.expectMessage("foo.bar");
+
+        new YamlClientFailoverConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentNonYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.bar");
+
+        new YamlClientFailoverConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentNonYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.bar");
+
+        new YamlClientFailoverConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveFromWorkDir() throws Exception {
+        helper.givenYamlClientFailoverConfigFileInWorkDir(42);
+
+        ClientFailoverConfig config = new YamlClientFailoverConfigBuilder().build();
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveFromClasspath() throws Exception {
+        helper.givenYamlClientFailoverConfigFileOnClasspath(42);
+
+        ClientFailoverConfig config = new YamlClientFailoverConfigBuilder().build();
+
+        assertEquals(42, config.getTryCount());
+    }
+
+    @Test
+    public void testResolveDefault() {
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("Failed to load ClientFailoverConfig");
+
+        new YamlClientFailoverConfigBuilder().build();
+    }
+
+}

--- a/hazelcast-client/src/test/resources/hazelcast-client-c1.foobar
+++ b/hazelcast-client/src/test/resources/hazelcast-client-c1.foobar
@@ -21,7 +21,7 @@
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
 
     <group>
-        <name>cluster1</name>
+        <name>cluster1-foobar</name>
         <password>cluster1pass</password>
     </group>
 
@@ -30,9 +30,5 @@
             <address>127.0.0.1:5701</address>
         </cluster-members>
     </network>
-
-    <connection-strategy async-start="true" reconnect-mode="OFF">
-        <connection-retry enabled="false"/>
-    </connection-strategy>
 
 </hazelcast-client>

--- a/hazelcast-client/src/test/resources/hazelcast-client-c1.yaml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-c1.yaml
@@ -20,3 +20,9 @@ hazelcast-client:
   network:
     cluster-members:
       - 127.0.0.1:5701
+
+  connection-strategy:
+    async-start: true
+    reconnect-mode: OFF
+    connection-retry:
+      enabled: false

--- a/hazelcast-client/src/test/resources/hazelcast-client-c2.foobar
+++ b/hazelcast-client/src/test/resources/hazelcast-client-c2.foobar
@@ -21,18 +21,14 @@
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
 
     <group>
-        <name>cluster1</name>
-        <password>cluster1pass</password>
+        <name>cluster2-foobar</name>
+        <password>cluster2pass</password>
     </group>
 
     <network>
         <cluster-members>
-            <address>127.0.0.1:5701</address>
+            <address>127.0.0.1:5702</address>
         </cluster-members>
     </network>
-
-    <connection-strategy async-start="true" reconnect-mode="OFF">
-        <connection-retry enabled="false"/>
-    </connection-strategy>
 
 </hazelcast-client>

--- a/hazelcast-client/src/test/resources/hazelcast-client-failover-sample.foobar
+++ b/hazelcast-client/src/test/resources/hazelcast-client-failover-sample.foobar
@@ -1,0 +1,7 @@
+<hazelcast-client-failover>
+    <try-count>4</try-count>
+    <clients>
+        <client>hazelcast-client-c1.foobar</client>
+        <client>hazelcast-client-c2.foobar</client>
+    </clients>
+</hazelcast-client-failover>

--- a/hazelcast/src/main/java/com/hazelcast/config/XmlConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/XmlConfigLocator.java
@@ -27,9 +27,13 @@ package com.hazelcast.config;
  */
 public class XmlConfigLocator extends AbstractConfigLocator {
 
+    public XmlConfigLocator() {
+        super(false);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
-        return loadFromSystemProperty("hazelcast.config", "xml");
+        return loadFromSystemProperty("hazelcast.config");
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -107,7 +107,7 @@ public class YamlConfigBuilder extends AbstractYamlConfigBuilder implements Conf
      */
     public YamlConfigBuilder(YamlConfigLocator locator) {
         if (locator == null) {
-            locator = new YamlConfigLocator();
+            locator = new YamlConfigLocator(true);
             locator.locateEverywhere();
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigLocator.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigLocator.java
@@ -27,6 +27,14 @@ package com.hazelcast.config;
  */
 public class YamlConfigLocator extends AbstractConfigLocator {
 
+    public YamlConfigLocator() {
+        this(false);
+    }
+
+    public YamlConfigLocator(boolean failIfSysPropWithNotExpectedSuffix) {
+        super(failIfSysPropWithNotExpectedSuffix);
+    }
+
     @Override
     public boolean locateFromSystemProperty() {
         return loadFromSystemProperty("hazelcast.config", "yaml", "yml");

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceFactory.java
@@ -131,13 +131,13 @@ public final class HazelcastInstanceFactory {
             XmlConfigLocator xmlConfigLocator = new XmlConfigLocator();
             YamlConfigLocator yamlConfigLocator = new YamlConfigLocator();
 
-            if (xmlConfigLocator.locateFromSystemProperty()) {
-                // 1. Try loading XML config if provided in system property
-                config = new XmlConfigBuilder(xmlConfigLocator).build();
-
-            } else if (yamlConfigLocator.locateFromSystemProperty()) {
-                // 2. Try loading YAML config if provided in system property
+            if (yamlConfigLocator.locateFromSystemProperty()) {
+                // 1. Try loading YAML config if provided in system property with .yaml or .yml extension
                 config = new YamlConfigBuilder(yamlConfigLocator).build();
+
+            } else if (xmlConfigLocator.locateFromSystemProperty()) {
+                // 2. Try loading XML config if provided in system property with any extension
+                config = new XmlConfigBuilder(xmlConfigLocator).build();
 
             } else if (xmlConfigLocator.locateInWorkDirOrOnClasspath()) {
                 // 3. Try loading XML config from the working directory or from the classpath

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigWithSystemPropertyTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigWithSystemPropertyTest.java
@@ -17,6 +17,8 @@
 package com.hazelcast.config;
 
 import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.instance.HazelcastInstanceFactory;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
 import org.junit.After;
@@ -104,6 +106,26 @@ public class XMLConfigWithSystemPropertyTest {
 
         XmlConfigBuilder configBuilder = new XmlConfigBuilder();
         Config config = configBuilder.build();
-        assertEquals("foobar", config.getGroupConfig().getName());
+        assertEquals("foobar-xml", config.getGroupConfig().getName());
+    }
+
+    @Test
+    public void loadingThroughSystemProperty_nonXmlSuffix() {
+        System.setProperty("hazelcast.config", "classpath:test-hazelcast.foobar");
+
+        XmlConfigBuilder configBuilder = new XmlConfigBuilder();
+        Config config = configBuilder.build();
+        assertEquals("foobar-foobar", config.getGroupConfig().getName());
+    }
+
+    @Test
+    public void loadingThroughSystemPropertyViaLocator_nonXmlSuffix() {
+        System.setProperty("hazelcast.config", "classpath:test-hazelcast.foobar");
+
+        HazelcastInstance instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+        instance.shutdown();
+
+        assertEquals("foobar-foobar", config.getGroupConfig().getName());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigBuilderConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigBuilderConfigResolutionTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class XmlConfigBuilderConfigResolutionTest {
+
+    private static final String SYSPROP_NAME = "hazelcast.config";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private final DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
+
+    @Before
+    @After
+    public void beforeAndAfter() {
+        System.clearProperty(SYSPROP_NAME);
+        helper.ensureTestConfigDeleted();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_xml() throws Exception {
+        helper.givenXmlConfigFileInWorkDir("foo.xml", "cluster-xml-file");
+        System.setProperty(SYSPROP_NAME, "foo.xml");
+
+        Config config = new XmlConfigBuilder().build();
+        assertEquals("cluster-xml-file", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_xml() throws Exception {
+        helper.givenXmlConfigFileOnClasspath("foo.xml", "cluster-xml-classpath");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.xml");
+
+        Config config = new XmlConfigBuilder().build();
+        assertEquals("cluster-xml-classpath", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.xml");
+
+        new XmlConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "idontexist.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("idontexist.xml");
+
+        new XmlConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonXml_loadedAsXml() throws Exception {
+        File file = helper.givenXmlConfigFileInWorkDir("foo.bar", "cluster-bar-file");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        Config config = new XmlConfigBuilder().build();
+
+        assertEquals("cluster-bar-file", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonXml_loadedAsXml() throws Exception {
+        helper.givenXmlConfigFileOnClasspath("foo.bar", "cluster-bar-classpath");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        Config config = new XmlConfigBuilder().build();
+        assertEquals("cluster-bar-classpath", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentNonXml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.bar");
+
+        new XmlConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentNonXml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.bar");
+
+        new XmlConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveFromWorkDir() throws Exception {
+        helper.givenXmlConfigFileInWorkDir("cluster-xml-workdir");
+
+        Config config = new XmlConfigBuilder().build();
+
+        assertEquals("cluster-xml-workdir", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveFromClasspath() throws Exception {
+        helper.givenXmlConfigFileOnClasspath("cluster-xml-classpath");
+
+        Config config = new XmlConfigBuilder().build();
+
+        assertEquals("cluster-xml-classpath", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveDefault() {
+        Config config = new XmlConfigBuilder().build();
+        assertEquals("dev", config.getGroupConfig().getName());
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigImportVariableReplacementTest.java
@@ -386,7 +386,7 @@ public class XmlConfigImportVariableReplacementTest extends AbstractConfigImport
                 + HAZELCAST_END_TAG;
         Config config = buildConfig(xml, null);
         GroupConfig groupConfig = config.getGroupConfig();
-        assertEquals("foobar", groupConfig.getName());
+        assertEquals("foobar-xml", groupConfig.getName());
         assertEquals("dev-pass", groupConfig.getPassword());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderConfigResolutionTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config;
+
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class YamlConfigBuilderConfigResolutionTest {
+
+    private static final String SYSPROP_NAME = "hazelcast.config";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
+
+    @Before
+    @After
+    public void beforeAndAfter() {
+        System.clearProperty(SYSPROP_NAME);
+        helper.ensureTestConfigDeleted();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_yaml() throws Exception {
+        helper.givenYamlConfigFileInWorkDir("foo.yaml", "cluster-yaml-file");
+        System.setProperty(SYSPROP_NAME, "foo.yaml");
+
+        Config config = new YamlConfigBuilder().build();
+        assertEquals("cluster-yaml-file", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_yaml() throws Exception {
+        helper.givenYamlConfigFileOnClasspath("foo.yaml", "cluster-yaml-classpath");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
+
+        Config config = new YamlConfigBuilder().build();
+        assertEquals("cluster-yaml-classpath", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.yaml");
+
+        new YamlConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "idontexist.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("idontexist.yaml");
+
+        new YamlConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonYaml_throws() throws Exception {
+        File file = helper.givenYamlConfigFileInWorkDir("foo.bar", "irrelevant");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("suffix");
+        expectedException.expectMessage("foo.bar");
+
+        new YamlConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonYaml_throws() throws Exception {
+        helper.givenYamlConfigFileOnClasspath("foo.bar", "irrelevant");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("suffix");
+        expectedException.expectMessage("foo.bar");
+
+        new YamlConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentNonYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.bar");
+
+        new YamlConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentNonYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:idontexist.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("idontexist.bar");
+
+        new YamlConfigBuilder().build();
+    }
+
+    @Test
+    public void testResolveFromWorkDir() throws Exception {
+        helper.givenYamlConfigFileInWorkDir("cluster-yaml-workdir");
+
+        Config config = new YamlConfigBuilder().build();
+
+        assertEquals("cluster-yaml-workdir", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveFromClasspath() throws Exception {
+        helper.givenYamlConfigFileOnClasspath("cluster-yaml-classpath");
+
+        Config config = new YamlConfigBuilder().build();
+
+        assertEquals("cluster-yaml-classpath", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveDefault() {
+        Config config = new YamlConfigBuilder().build();
+        assertEquals("dev", config.getGroupConfig().getName());
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigImportVariableReplacementTest.java
@@ -385,7 +385,7 @@ public class YamlConfigImportVariableReplacementTest extends AbstractConfigImpor
                 + "    - classpath:test-hazelcast.yaml";
         Config config = buildConfig(yaml, null);
         GroupConfig groupConfig = config.getGroupConfig();
-        assertEquals("foobar", groupConfig.getName());
+        assertEquals("foobar-yaml", groupConfig.getName());
         assertEquals("dev-pass", groupConfig.getPassword());
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.config.helpers;
+
+import com.hazelcast.config.Config;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.net.URL;
+
+public class DeclarativeConfigFileHelper {
+    private static final String HAZELCAST_START_TAG = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n";
+    private static final String HAZELCAST_END_TAG = "</hazelcast>\n";
+    private static final String HAZELCAST_CLIENT_START_TAG =
+            "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n";
+    private static final String HAZELCAST_CLIENT_END_TAG = "</hazelcast-client>";
+
+    private String testConfigPath;
+
+    // MEMBER
+
+    public File givenXmlConfigFileInWorkDir(String instanceName) throws Exception {
+        return givenXmlConfigFileInWorkDir("hazelcast.xml", instanceName);
+    }
+
+    public File givenXmlConfigFileInWorkDir(String filename, String instanceName) throws Exception {
+        String xml = xmlConfig(instanceName);
+        return givenConfigFileInWorkDir(filename, xml);
+    }
+
+    public File givenYamlConfigFileInWorkDir(String instanceName) throws Exception {
+        return givenYamlConfigFileInWorkDir("hazelcast.yaml", instanceName);
+    }
+
+    public File givenYamlConfigFileInWorkDir(String filename, String instanceName) throws Exception {
+        String xml = yamlConfig(instanceName);
+        return givenConfigFileInWorkDir(filename, xml);
+    }
+
+    public URL givenXmlConfigFileOnClasspath(String instanceName) throws Exception {
+        return givenXmlConfigFileOnClasspath("hazelcast.xml", instanceName);
+    }
+
+    public URL givenXmlConfigFileOnClasspath(String filename, String instanceName) throws Exception {
+        String xml = xmlConfig(instanceName);
+        return givenConfigFileOnClasspath(filename, xml);
+    }
+
+    public URL givenYamlConfigFileOnClasspath(String instanceName) throws Exception {
+        return givenYamlConfigFileOnClasspath("hazelcast.yaml", instanceName);
+    }
+
+    public URL givenYamlConfigFileOnClasspath(String filename, String instanceName) throws Exception {
+        String yaml = yamlConfig(instanceName);
+        return givenConfigFileOnClasspath(filename, yaml);
+    }
+
+    // CLIENT
+
+    public File givenXmlClientConfigFileInWorkDir(String instanceName) throws Exception {
+        return givenXmlClientConfigFileInWorkDir("hazelcast-client.xml", instanceName);
+    }
+
+    public File givenXmlClientConfigFileInWorkDir(String filename, String instanceName) throws Exception {
+        String xml = xmlClientConfig(instanceName);
+        return givenConfigFileInWorkDir(filename, xml);
+    }
+
+    public URL givenXmlClientConfigFileOnClasspath(String instanceName) throws Exception {
+        return givenXmlClientConfigFileOnClasspath("hazelcast-client.xml", instanceName);
+    }
+
+    public URL givenXmlClientConfigFileOnClasspath(String filename, String instanceName) throws Exception {
+        String xml = xmlClientConfig(instanceName);
+        return givenConfigFileOnClasspath(filename, xml);
+    }
+
+    public File givenYamlClientConfigFileInWorkDir(String instanceName) throws Exception {
+        return givenYamlClientConfigFileInWorkDir("hazelcast-client.yaml", instanceName);
+    }
+
+    public File givenYamlClientConfigFileInWorkDir(String filename, String instanceName) throws Exception {
+        String xml = yamlClientConfig(instanceName);
+        return givenConfigFileInWorkDir(filename, xml);
+    }
+
+    public URL givenYamlClientConfigFileOnClasspath(String instanceName) throws Exception {
+        return givenYamlClientConfigFileOnClasspath("hazelcast-client.yaml", instanceName);
+    }
+
+    public URL givenYamlClientConfigFileOnClasspath(String filename, String instanceName) throws Exception {
+        String yaml = yamlClientConfig(instanceName);
+        return givenConfigFileOnClasspath(filename, yaml);
+    }
+
+    // CLIENT-FAILOVER
+
+    public File givenXmlClientFailoverConfigFileInWorkDir(int tryCount) throws Exception {
+        return givenXmlClientFailoverConfigFileInWorkDir("hazelcast-client-failover.xml", tryCount);
+    }
+
+    public File givenXmlClientFailoverConfigFileInWorkDir(String filename, int tryCount) throws Exception {
+        String xml = xmlFailoverClientConfig(tryCount);
+        return givenConfigFileInWorkDir(filename, xml);
+    }
+
+    public URL givenXmlClientFailoverConfigFileOnClasspath(int tryCount) throws Exception {
+        return givenXmlClientFailoverConfigFileOnClasspath("hazelcast-client-failover.xml", tryCount);
+    }
+
+    public URL givenXmlClientFailoverConfigFileOnClasspath(String filename, int tryCount) throws Exception {
+        String xml = xmlFailoverClientConfig(tryCount);
+        return givenConfigFileOnClasspath(filename, xml);
+    }
+
+    public File givenYamlClientFailoverConfigFileInWorkDir(int tryCount) throws Exception {
+        return givenYamlClientFailoverConfigFileInWorkDir("hazelcast-client-failover.yaml", tryCount);
+    }
+
+    public File givenYamlClientFailoverConfigFileInWorkDir(String filename, int tryCount) throws Exception {
+        String xml = yamlFailoverClientConfig(tryCount);
+        return givenConfigFileInWorkDir(filename, xml);
+    }
+
+    public URL givenYamlClientFailoverConfigFileOnClasspath(int tryCount) throws Exception {
+        return givenYamlClientFailoverConfigFileOnClasspath("hazelcast-client-failover.yaml", tryCount);
+    }
+
+    public URL givenYamlClientFailoverConfigFileOnClasspath(String filename, int tryCount) throws Exception {
+        String yaml = yamlFailoverClientConfig(tryCount);
+        return givenConfigFileOnClasspath(filename, yaml);
+    }
+
+    public File givenConfigFileInWorkDir(String filename, String content) throws Exception {
+        File file = new File(filename);
+        PrintWriter writer = new PrintWriter(file, "UTF-8");
+        writer.println(content);
+        writer.close();
+
+        testConfigPath = file.getAbsolutePath();
+
+        return file;
+    }
+
+    public URL givenConfigFileOnClasspath(String filename, String content) throws Exception {
+        URL classPathConfigUrl = Config.class.getClassLoader().getResource(".");
+        String configFilePath = classPathConfigUrl.getFile() + "/" + filename;
+        File file = new File(configFilePath);
+        PrintWriter writer = new PrintWriter(file, "UTF-8");
+        writer.println(content);
+        writer.close();
+
+        testConfigPath = file.getAbsolutePath();
+
+        return getClass().getClassLoader().getResource(filename);
+    }
+
+    private String xmlConfig(String instanceName) {
+        return ""
+                + HAZELCAST_START_TAG
+                + "  <instance-name>" + instanceName + "</instance-name>"
+                + HAZELCAST_END_TAG;
+    }
+
+    private String xmlClientConfig(String instanceName) {
+        return ""
+                + HAZELCAST_CLIENT_START_TAG
+                + "  <instance-name>" + instanceName + "</instance-name>"
+                + "  <connection-strategy async-start=\"true\" reconnect-mode=\"OFF\">"
+                + "    <connection-retry enabled=\"false\" />"
+                + "  </connection-strategy>"
+                + HAZELCAST_CLIENT_END_TAG;
+    }
+
+    private String xmlFailoverClientConfig(int tryCount) {
+        return ""
+                + "<hazelcast-client-failover>"
+                + "  <try-count>" + tryCount + "</try-count>"
+                + "  <clients>"
+                + "    <client>hazelcast-client-c1.xml</client>"
+                + "  </clients>"
+                + "</hazelcast-client-failover>";
+    }
+
+    private String yamlConfig(String instanceName) {
+        return ""
+                + "hazelcast:\n"
+                + "  instance-name: " + instanceName;
+    }
+
+    private String yamlClientConfig(String instanceName) {
+        return ""
+                + "hazelcast-client:\n"
+                + "  instance-name: " + instanceName + "\n"
+                + "  connection-strategy:\n"
+                + "    async-start: true\n"
+                + "    reconnect-mode: OFF\n"
+                + "    connection-retry:\n"
+                + "      enabled: false";
+    }
+
+    private String yamlFailoverClientConfig(int tryCount) {
+        return ""
+                + "hazelcast-client-failover:\n"
+                + "  try-count: " + tryCount + "\n"
+                + "  clients:\n"
+                + "    - hazelcast-client-c1.yaml";
+    }
+
+    public void ensureTestConfigDeleted() {
+        if (testConfigPath != null) {
+            File file = new File(testConfigPath);
+            file.delete();
+        }
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryConfigResolutionTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.instance;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
+import com.hazelcast.core.HazelcastException;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category(QuickTest.class)
+public class HazelcastInstanceFactoryConfigResolutionTest {
+
+    private static final String SYSPROP_NAME = "hazelcast.config";
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private HazelcastInstance instance;
+    private DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
+
+    @Before
+    public void setUp() {
+        System.clearProperty(SYSPROP_NAME);
+    }
+
+    @After
+    public void tearDown() {
+        if (instance != null) {
+            instance.shutdown();
+        }
+        System.clearProperty(SYSPROP_NAME);
+        helper.ensureTestConfigDeleted();
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_xml_loadedAsXml() throws Exception {
+        File file = helper.givenXmlConfigFileInWorkDir("foo.xml", "cluster-xml");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-xml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_xml_loadedAsXml() throws Exception {
+        helper.givenXmlConfigFileOnClasspath("foo.xml", "cluster-xml");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.xml");
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-xml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_yaml_loadedAsYaml() throws Exception {
+        File file = helper.givenYamlConfigFileInWorkDir("foo.yaml", "cluster-yaml");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_yaml_loadedAsYaml() throws Exception {
+        helper.givenYamlConfigFileOnClasspath("foo.yaml", "cluster-yaml");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_yml_loadedAsYaml() throws Exception {
+        File file = helper.givenYamlConfigFileInWorkDir("foo.yml", "cluster-yaml");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_yml_loadedAsYaml() throws Exception {
+        helper.givenYamlConfigFileOnClasspath("foo.yml", "cluster-yaml");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yml");
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_bar_loadedAsXml() throws Exception {
+        File file = helper.givenXmlConfigFileInWorkDir("foo.bar", "cluster-bar");
+        System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-bar", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_bar_loadedAsXml() throws Exception {
+        helper.givenXmlConfigFileOnClasspath("foo.bar", "cluster-bar");
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-bar", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.xml");
+
+        HazelcastInstanceFactory.newHazelcastInstance(null);
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentXml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.xml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.xml");
+
+        HazelcastInstanceFactory.newHazelcastInstance(null);
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.yaml");
+
+        HazelcastInstanceFactory.newHazelcastInstance(null);
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentYaml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.yaml");
+
+        HazelcastInstanceFactory.newHazelcastInstance(null);
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentYml_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.yml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.yml");
+
+        HazelcastInstanceFactory.newHazelcastInstance(null);
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentYml_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.yml");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.yml");
+
+        HazelcastInstanceFactory.newHazelcastInstance(null);
+    }
+
+    @Test
+    public void testResolveSystemProperty_file_nonExistentBar_throws() {
+        System.setProperty(SYSPROP_NAME, "foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("foo.bar");
+
+        HazelcastInstanceFactory.newHazelcastInstance(null);
+    }
+
+    @Test
+    public void testResolveSystemProperty_classpath_nonExistentBar_throws() {
+        System.setProperty(SYSPROP_NAME, "classpath:foo.bar");
+
+        expectedException.expect(HazelcastException.class);
+        expectedException.expectMessage("classpath");
+        expectedException.expectMessage("foo.bar");
+
+        HazelcastInstanceFactory.newHazelcastInstance(null);
+    }
+
+    @Test
+    public void testResolveWorkDir_xml() throws Exception {
+        helper.givenXmlConfigFileInWorkDir("cluster-xml");
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-xml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveClasspath_xml() throws Exception {
+        helper.givenXmlConfigFileOnClasspath("cluster-xml");
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-xml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveWorkDir_yaml() throws Exception {
+        helper.givenYamlConfigFileInWorkDir("cluster-yaml");
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveClasspath_yaml() throws Exception {
+        helper.givenYamlConfigFileOnClasspath("cluster-yaml");
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("cluster-yaml", config.getInstanceName());
+    }
+
+    @Test
+    public void testResolveDefault_xml() {
+        getClass().getClassLoader().getResource("hazelcast-default.xml");
+
+        instance = HazelcastInstanceFactory.newHazelcastInstance(null);
+        Config config = instance.getConfig();
+
+        assertEquals("dev", config.getGroupConfig().getName());
+    }
+}

--- a/hazelcast/src/test/resources/test-hazelcast-client.foobar
+++ b/hazelcast/src/test/resources/test-hazelcast-client.foobar
@@ -21,18 +21,19 @@
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
 
     <group>
-        <name>cluster1</name>
-        <password>cluster1pass</password>
+        <name>foobar-foobar</name>
+        <password>dev-pass</password>
     </group>
-
     <network>
-        <cluster-members>
-            <address>127.0.0.1:5701</address>
-        </cluster-members>
+        <ssl enabled="true">
+            <factory-class-name>com.hazelcast.nio.ssl.BasicSSLContextFactory</factory-class-name>
+        </ssl>
+        <socket-options>
+            <buffer-size>128</buffer-size>
+            <keep-alive>false</keep-alive>
+            <tcp-no-delay>false</tcp-no-delay>
+            <reuse-address>false</reuse-address>
+            <linger-seconds>3</linger-seconds>
+        </socket-options>
     </network>
-
-    <connection-strategy async-start="true" reconnect-mode="OFF">
-        <connection-retry enabled="false"/>
-    </connection-strategy>
-
 </hazelcast-client>

--- a/hazelcast/src/test/resources/test-hazelcast-client.xml
+++ b/hazelcast/src/test/resources/test-hazelcast-client.xml
@@ -21,7 +21,7 @@
                   http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
 
     <group>
-        <name>foobar</name>
+        <name>foobar-xml</name>
         <password>dev-pass</password>
     </group>
     <network>

--- a/hazelcast/src/test/resources/test-hazelcast-client.yaml
+++ b/hazelcast/src/test/resources/test-hazelcast-client.yaml
@@ -14,7 +14,7 @@
 
 hazelcast-client:
   group:
-    name: foobar
+    name: foobar-yaml
     password: dev-pass
   network:
     ssl:

--- a/hazelcast/src/test/resources/test-hazelcast.foobar
+++ b/hazelcast/src/test/resources/test-hazelcast.foobar
@@ -15,24 +15,14 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
-                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://www.hazelcast.com/schema/config
+           http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
 
     <group>
-        <name>cluster1</name>
-        <password>cluster1pass</password>
+        <name>foobar-foobar</name>
+        <password>dev-pass</password>
     </group>
 
-    <network>
-        <cluster-members>
-            <address>127.0.0.1:5701</address>
-        </cluster-members>
-    </network>
-
-    <connection-strategy async-start="true" reconnect-mode="OFF">
-        <connection-retry enabled="false"/>
-    </connection-strategy>
-
-</hazelcast-client>
+</hazelcast>

--- a/hazelcast/src/test/resources/test-hazelcast.xml
+++ b/hazelcast/src/test/resources/test-hazelcast.xml
@@ -21,7 +21,7 @@
            http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd">
 
     <group>
-        <name>foobar</name>
+        <name>foobar-xml</name>
         <password>dev-pass</password>
     </group>
 

--- a/hazelcast/src/test/resources/test-hazelcast.yaml
+++ b/hazelcast/src/test/resources/test-hazelcast.yaml
@@ -14,5 +14,5 @@
 
 hazelcast:
   group:
-    name: foobar
+    name: foobar-yaml
     password: dev-pass


### PR DESCRIPTION
3.12 introduced a regression that configuration files with suffixes not
in [xml,yaml,yml] passed in system property are ignored silently and
the config resolution continues following the resolution priority, most
likely resolving the default XML configuration shipped with the jar. The
expected behavior is:
- if the system property is set we fail fast if we can't load the config
from the referenced resource/file
- if the file in the system property has a suffix [yaml,yml], we treat it
as YAML config
- if the file in the system property has any other suffix (or don't have
suffix), we treat it as XML config

Note that in 4.0 the fix will be different, we enforce the config files
to have suffix from the [xml,yaml,yml] list.

This commit fixes this behavior in member, client and client-failover
config resolution, with additional tests verifying the resolution logic.

Fixes #14924