### PR TITLE
Support Java 8 optionals in queries

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractMultiValueGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/AbstractMultiValueGetter.java
@@ -24,8 +24,10 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Member;
 import java.util.Collection;
 
+import static com.hazelcast.query.impl.predicates.PredicateUtils.unwrapIfOptional;
 
 public abstract class AbstractMultiValueGetter extends Getter {
+
     public static final String REDUCER_ANY_TOKEN = "any";
 
     public static final int DO_NOT_REDUCE = -1;
@@ -63,12 +65,12 @@ public abstract class AbstractMultiValueGetter extends Getter {
             return extractFromMultiResult((MultiResult) parentObject);
         }
 
-        Object o = extractFrom(parentObject);
+        Object o = unwrapIfOptional(extractFrom(parentObject));
         if (modifier == DO_NOT_REDUCE) {
             return o;
         }
         if (modifier == REDUCE_EVERYTHING) {
-            MultiResult collector = new MultiResult();
+            MultiResult<Object> collector = new MultiResult<>();
             reduceInto(collector, o);
             return collector;
         }
@@ -94,21 +96,21 @@ public abstract class AbstractMultiValueGetter extends Getter {
         }
 
         if (!inputType.isArray()) {
-            throw new IllegalArgumentException("Cannot infer a return type with modifier "
-                    + modifier + " on type " + inputType.getName());
+            throw new IllegalArgumentException(
+                    "Cannot infer a return type with modifier " + modifier + " on type " + inputType.getName());
         }
 
         //ok, it must be an array. let's return array type
         return inputType.getComponentType();
     }
 
-    private void collectResult(MultiResult collector, Object parentObject)
-            throws IllegalAccessException, InvocationTargetException {
+    private void collectResult(MultiResult<Object> collector, Object parentObject) throws IllegalAccessException,
+            InvocationTargetException {
         // re-add nulls from parent extraction without extracting further down the path
         if (parentObject == null) {
             collector.add(null);
         } else {
-            Object currentObject = extractFrom(parentObject);
+            Object currentObject = unwrapIfOptional(extractFrom(parentObject));
             if (shouldReduce()) {
                 reduceInto(collector, currentObject);
             } else {
@@ -119,11 +121,10 @@ public abstract class AbstractMultiValueGetter extends Getter {
 
     private Object extractFromMultiResult(MultiResult parentMultiResult) throws IllegalAccessException,
             InvocationTargetException {
-        MultiResult collector = new MultiResult();
+        MultiResult<Object> collector = new MultiResult<>();
         collector.setNullOrEmptyTarget(parentMultiResult.isNullEmptyTarget());
-        int size = parentMultiResult.getResults().size();
-        for (int i = 0; i < size; i++) {
-            collectResult(collector, parentMultiResult.getResults().get(i));
+        for (Object result : parentMultiResult.getResults()) {
+            collectResult(collector, result);
         }
 
         return collector;
@@ -140,12 +141,11 @@ public abstract class AbstractMultiValueGetter extends Getter {
         return parseModifier(modifierSuffix);
     }
 
-
     private Object getItemAtPositionOrNull(Object object, int position) {
         if (object == null) {
             return null;
         } else if (object instanceof Collection) {
-            return CollectionUtil.getItemAtPositionOrNull((Collection) object, position);
+            return CollectionUtil.getItemAtPositionOrNull((Collection<?>) object, position);
         } else if (object instanceof Object[]) {
             return ArrayUtils.getItemAtPositionOrNull((Object[]) object, position);
         } else if (object.getClass().isArray()) {
@@ -155,23 +155,21 @@ public abstract class AbstractMultiValueGetter extends Getter {
                 + " Collections and Arrays are supported only");
     }
 
-
     private Object getParentObject(Object obj) throws Exception {
         return parent != null ? parent.getValue(obj) : obj;
     }
 
-    private void reduceArrayInto(MultiResult collector, Object[] currentObject) {
-        Object[] array = currentObject;
+    private void reduceArrayInto(MultiResult<Object> collector, Object[] array) {
         if (array.length == 0) {
             collector.addNullOrEmptyTarget();
         } else {
-            for (int i = 0; i < array.length; i++) {
-                collector.add(array[i]);
+            for (Object o : array) {
+                collector.add(o);
             }
         }
     }
 
-    private void reducePrimitiveArrayInto(MultiResult collector, Object primitiveArray) {
+    private void reducePrimitiveArrayInto(MultiResult<Object> collector, Object primitiveArray) {
         int length = Array.getLength(primitiveArray);
         if (length == 0) {
             collector.addNullOrEmptyTarget();
@@ -182,8 +180,7 @@ public abstract class AbstractMultiValueGetter extends Getter {
         }
     }
 
-    protected void reduceCollectionInto(MultiResult collector, Collection currentObject) {
-        Collection collection = currentObject;
+    protected void reduceCollectionInto(MultiResult<Object> collector, Collection collection) {
         if (collection.isEmpty()) {
             collector.addNullOrEmptyTarget();
         } else {
@@ -193,7 +190,7 @@ public abstract class AbstractMultiValueGetter extends Getter {
         }
     }
 
-    protected void reduceInto(MultiResult collector, Object currentObject) {
+    protected void reduceInto(MultiResult<Object> collector, Object currentObject) {
         if (modifier != REDUCE_EVERYTHING) {
             Object item = getItemAtPositionOrNull(currentObject, modifier);
             collector.add(item);
@@ -213,7 +210,6 @@ public abstract class AbstractMultiValueGetter extends Getter {
                     + " Only Collections and Arrays are supported.");
         }
     }
-
 
     private static int parseModifier(String modifier) {
         String stringValue = modifier.substring(1, modifier.length() - 1);

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/FieldGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/FieldGetter.java
@@ -16,14 +16,19 @@
 
 package com.hazelcast.query.impl.getters;
 
-
 import java.lang.reflect.Field;
 
-public class FieldGetter extends AbstractMultiValueGetter {
+public final class FieldGetter extends AbstractMultiValueGetter {
+
     private final Field field;
 
-    public FieldGetter(Getter parent, Field field, String modifierSuffix, Class resultType) {
-        super(parent, modifierSuffix, field.getType(), resultType);
+    // for testing purposes only
+    public FieldGetter(Getter parent, Field field, String modifier, Class elementType) {
+        this(parent, field, modifier, field.getType(), elementType);
+    }
+
+    public FieldGetter(Getter parent, Field field, String modifier, Class type, Class elementType) {
+        super(parent, modifier, type, elementType);
         this.field = field;
     }
 
@@ -45,4 +50,5 @@ public class FieldGetter extends AbstractMultiValueGetter {
     public String toString() {
         return "FieldGetter [parent=" + parent + ", field=" + field + ", modifier = " + getModifier() + "]";
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterFactory.java
@@ -21,124 +21,119 @@ import com.hazelcast.util.CollectionUtil;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collection;
+import java.util.Optional;
 
 import static com.hazelcast.query.impl.getters.AbstractMultiValueGetter.validateModifier;
 import static com.hazelcast.query.impl.getters.NullGetter.NULL_GETTER;
 import static com.hazelcast.query.impl.getters.NullMultiValueGetter.NULL_MULTIVALUE_GETTER;
+import static com.hazelcast.query.impl.predicates.PredicateUtils.unwrapIfOptional;
 
 public final class GetterFactory {
 
-    private static final String ANY_POSTFIX = "[any]";
+    private static final String ANY = "[any]";
 
     private GetterFactory() {
     }
 
-    public static Getter newFieldGetter(Object object, Getter parentGetter, Field field, String modifierSuffix)
-            throws Exception {
-        Class<?> fieldType = field.getType();
-        Class<?> returnType = null;
-        if (isExtractingFromCollection(fieldType, modifierSuffix)) {
-            validateModifier(modifierSuffix);
-            Object currentObject = getCurrentObject(object, parentGetter);
-            if (currentObject == null) {
-                return NULL_GETTER;
-            }
-            if (currentObject instanceof MultiResult) {
-                MultiResult multiResult = (MultiResult) currentObject;
-                returnType = extractTypeFromMultiResult(field, multiResult);
-            } else {
-                Collection collection = (Collection) field.get(currentObject);
-                returnType = getCollectionType(collection);
-            }
-            if (returnType == null) {
-                if (modifierSuffix.equals(ANY_POSTFIX)) {
-                    return NULL_MULTIVALUE_GETTER;
-                }
-                return NULL_GETTER;
-            }
-        } else if (isExtractingFromArray(fieldType, modifierSuffix)) {
-            validateModifier(modifierSuffix);
-            Object currentObject = getCurrentObject(object, parentGetter);
-            if (currentObject == null) {
-                return NULL_GETTER;
-            }
-        }
-        return new FieldGetter(parentGetter, field, modifierSuffix, returnType);
+    public static Getter newFieldGetter(Object object, Getter parent, Field field, String modifier) throws Exception {
+        return newGetter(object, parent, modifier, field.getType(), field::get,
+                (t, et) -> new FieldGetter(parent, field, modifier, t, et));
     }
 
-    private static Class<?> extractTypeFromMultiResult(Field field, MultiResult multiResult) throws Exception {
-        Class<?> returnType = null;
-        for (Object o : multiResult.getResults()) {
-            if (o == null) {
-                continue;
-            }
-            Collection collection = (Collection) field.get(o);
-            returnType = getCollectionType(collection);
-            if (returnType != null) {
-                break;
-            }
-        }
-        return returnType;
-    }
-
-    public static Getter newMethodGetter(Object object, Getter parentGetter, Method method, String modifierSuffix)
-            throws Exception {
-        Class<?> methodReturnType = method.getReturnType();
-        Class<?> returnType = null;
-        if (isExtractingFromCollection(methodReturnType, modifierSuffix)) {
-            validateModifier(modifierSuffix);
-            Object currentObject = getCurrentObject(object, parentGetter);
-            if (currentObject == null) {
-                return NULL_GETTER;
-            }
-            if (currentObject instanceof MultiResult) {
-                MultiResult multiResult = (MultiResult) currentObject;
-                returnType = extractTypeFromMultiResult(method, multiResult);
-            } else {
-                Collection collection = (Collection) method.invoke(currentObject);
-                returnType = getCollectionType(collection);
-            }
-            if (returnType == null) {
-                if (modifierSuffix.equals(ANY_POSTFIX)) {
-                    return NULL_MULTIVALUE_GETTER;
-                }
-                return NULL_GETTER;
-            }
-        } else if (isExtractingFromArray(methodReturnType, modifierSuffix)) {
-            validateModifier(modifierSuffix);
-            Object currentObject = getCurrentObject(object, parentGetter);
-            if (currentObject == null) {
-                return NULL_GETTER;
-            }
-        }
-        return new MethodGetter(parentGetter, method, modifierSuffix, returnType);
-    }
-
-    private static Class<?> extractTypeFromMultiResult(Method method, MultiResult multiResult) throws Exception {
-        Class<?> returnType = null;
-        for (Object o : multiResult.getResults()) {
-            if (o == null) {
-                continue;
-            }
-            Collection collection = (Collection) method.invoke(o);
-            returnType = getCollectionType(collection);
-            if (returnType != null) {
-                break;
-            }
-        }
-        return returnType;
+    public static Getter newMethodGetter(Object object, Getter parent, Method method, String modifier) throws Exception {
+        return newGetter(object, parent, modifier, method.getReturnType(), o -> method.invoke(o),
+                (t, et) -> new MethodGetter(parent, method, modifier, t, et));
     }
 
     public static Getter newThisGetter(Getter parent, Object object) {
         return new ThisGetter(parent, object);
     }
 
-    private static Class<?> getCollectionType(Collection collection) throws Exception {
+    private static Getter newGetter(Object object, Getter parent, String modifier, Class type, Reader reader,
+                                    Constructor constructor) throws Exception {
+        Object currentObject = getCurrentObject(object, parent);
+        if (type == Optional.class) {
+            type = deduceOptionalType(currentObject, reader);
+            if (type == null) {
+                return ANY.equals(modifier) ? NULL_MULTIVALUE_GETTER : NULL_GETTER;
+            }
+        }
+
+        Class elementType = null;
+        if (isExtractingFromCollection(type, modifier)) {
+            validateModifier(modifier);
+            if (currentObject == null) {
+                return NULL_GETTER;
+            }
+            if (currentObject instanceof MultiResult) {
+                MultiResult multiResult = (MultiResult) currentObject;
+                elementType = deduceElementType(multiResult, reader);
+            } else {
+                Collection collection = unwrapIfOptional(reader.read(currentObject));
+                elementType = deduceElementType(collection);
+            }
+            if (elementType == null) {
+                if (modifier.equals(ANY)) {
+                    return NULL_MULTIVALUE_GETTER;
+                }
+                return NULL_GETTER;
+            }
+        } else if (isExtractingFromArray(type, modifier)) {
+            validateModifier(modifier);
+            if (currentObject == null) {
+                return NULL_GETTER;
+            }
+        }
+        return constructor.construct(type, elementType);
+    }
+
+    private static Class deduceOptionalType(Object object, Reader reader) throws Exception {
+        if (object instanceof MultiResult) {
+            for (Object result : ((MultiResult) object).getResults()) {
+                if (result == null) {
+                    continue;
+                }
+                Class deducedType = deduceOptionalType(reader.read(result));
+                if (deducedType != null) {
+                    return deducedType;
+                }
+            }
+            return null;
+        } else {
+            return object == null ? null : deduceOptionalType(reader.read(object));
+        }
+    }
+
+    private static Class deduceOptionalType(Object value) {
+        assert value == null || value instanceof Optional;
+
+        if (value == null) {
+            return null;
+        }
+        Optional optional = (Optional) value;
+        return optional.isPresent() ? optional.get().getClass() : null;
+    }
+
+    private static Class deduceElementType(MultiResult multiResult, Reader reader) throws Exception {
+        for (Object result : multiResult.getResults()) {
+            if (result == null) {
+                continue;
+            }
+            Collection collection = unwrapIfOptional(reader.read(result));
+            Class elementType = deduceElementType(collection);
+            if (elementType != null) {
+                break;
+            }
+        }
+        return null;
+    }
+
+    private static Class deduceElementType(Collection<?> collection) {
         if (collection == null || collection.isEmpty()) {
             return null;
         }
-        Object targetObject = CollectionUtil.getItemAtPositionOrNull(collection, 0);
-        if (targetObject == null) {
+        Object item = CollectionUtil.getItemAtPositionOrNull(collection, 0);
+        if (item == null) {
             for (Object object : collection) {
                 if (object != null) {
                     return object.getClass();
@@ -146,19 +141,33 @@ public final class GetterFactory {
             }
             return null;
         }
-        return targetObject.getClass();
+        return item.getClass();
     }
 
-    private static boolean isExtractingFromCollection(Class<?> type, String modifierSuffix) {
-        return modifierSuffix != null && Collection.class.isAssignableFrom(type);
+    private static boolean isExtractingFromCollection(Class type, String modifier) {
+        return modifier != null && Collection.class.isAssignableFrom(type);
     }
 
-    private static boolean isExtractingFromArray(Class<?> type, String modifierSuffix) {
-        return modifierSuffix != null && type.isArray();
+    private static boolean isExtractingFromArray(Class type, String modifier) {
+        return modifier != null && type.isArray();
     }
 
-    private static Object getCurrentObject(Object obj, Getter parent) throws Exception {
-        return parent == null ? obj : parent.getValue(obj);
+    private static Object getCurrentObject(Object object, Getter parent) throws Exception {
+        return parent == null ? object : parent.getValue(object);
+    }
+
+    @FunctionalInterface
+    private interface Reader {
+
+        Object read(Object object) throws Exception;
+
+    }
+
+    @FunctionalInterface
+    private interface Constructor {
+
+        Getter construct(Class type, Class elementType);
+
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/GetterFactory.java
@@ -122,7 +122,7 @@ public final class GetterFactory {
             Collection collection = unwrapIfOptional(reader.read(result));
             Class elementType = deduceElementType(collection);
             if (elementType != null) {
-                break;
+                return elementType;
             }
         }
         return null;

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/getters/MethodGetter.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/getters/MethodGetter.java
@@ -16,15 +16,20 @@
 
 package com.hazelcast.query.impl.getters;
 
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-final class MethodGetter extends AbstractMultiValueGetter {
+public final class MethodGetter extends AbstractMultiValueGetter {
+
     private final Method method;
 
-    MethodGetter(Getter parent, Method method, String modifierSuffix, Class resultType) {
-        super(parent, modifierSuffix, method.getReturnType(), resultType);
+    // for testing purposes only
+    public MethodGetter(Getter parent, Method method, String modifier, Class elementType) {
+        this(parent, method, modifier, method.getReturnType(), elementType);
+    }
+
+    public MethodGetter(Getter parent, Method method, String modifier, Class type, Class elementType) {
+        super(parent, modifier, type, elementType);
         this.method = method;
     }
 
@@ -46,4 +51,5 @@ final class MethodGetter extends AbstractMultiValueGetter {
     public String toString() {
         return "MethodGetter [parent=" + parent + ", method=" + method.getName() + ", modifier = " + getModifier() + "]";
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
+++ b/hazelcast/src/main/java/com/hazelcast/query/impl/predicates/PredicateUtils.java
@@ -22,6 +22,7 @@ import com.hazelcast.query.impl.QueryableEntry;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -64,6 +65,18 @@ public final class PredicateUtils {
      */
     public static boolean isNull(Comparable value) {
         return value == null || value == NULL;
+    }
+
+    /**
+     * Unwraps the given potentially {@link Optional optional} value.
+     *
+     * @param value the potentially optional value to unwrap.
+     * @return an unwrapped value, if the given value is optional; the
+     * original given value, if it's not optional.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T unwrapIfOptional(Object value) {
+        return value instanceof Optional ? ((Optional<T>) value).orElse(null) : (T) value;
     }
 
     /**

--- a/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/aggregation/AggregatorsSpecTest.java
@@ -42,7 +42,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -52,6 +52,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(HazelcastParametersRunnerFactory.class)
@@ -60,6 +61,7 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
     public static final int PERSONS_COUNT = 999;
 
+    @SuppressWarnings("DefaultAnnotationParam")
     @Parameter(0)
     public InMemoryFormat inMemoryFormat;
 
@@ -99,135 +101,117 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
     public static void assertMinAggregators(IMap<Integer, Person> map, String p) {
         assertNoDataMissing(map, PERSONS_COUNT);
-        assertEquals(Double.valueOf(1), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleMin("doubleValue" + p)));
-        assertEquals(Long.valueOf(1), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longMin("longValue" + p)));
-        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerMin("intValue" + p)));
-        assertEquals(BigDecimal.valueOf(1), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalMin(
-                "bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(1), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerMin(
-                "bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(1), map.aggregate(Aggregators.doubleMin("doubleValue" + p)));
+        assertEquals(Long.valueOf(1), map.aggregate(Aggregators.longMin("longValue" + p)));
+        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.integerMin("intValue" + p)));
+        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.integerMin("optionalIntValue" + p)));
+        assertEquals(BigDecimal.valueOf(1), map.aggregate(Aggregators.bigDecimalMin("bigDecimalValue" + p)));
+        assertEquals(BigInteger.valueOf(1), map.aggregate(Aggregators.bigIntegerMin("bigIntegerValue" + p)));
 
-        assertEquals(Double.valueOf(1), map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Double>comparableMin(
-                "doubleValue" + p)));
-        assertEquals(Long.valueOf(1), map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Long>comparableMin(
-                "longValue" + p)));
-        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Integer>comparableMin(
-                "intValue" + p)));
-        assertEquals(BigDecimal.valueOf(1), map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigDecimal>comparableMin(
-                "bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(1), map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigInteger>comparableMin(
-                "bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(1), map.aggregate(Aggregators.comparableMin("doubleValue" + p)));
+        assertEquals(Long.valueOf(1), map.aggregate(Aggregators.comparableMin("longValue" + p)));
+        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.comparableMin("intValue" + p)));
+        assertEquals(Integer.valueOf(1), map.aggregate(Aggregators.comparableMin("optionalIntValue" + p)));
+        assertEquals(BigDecimal.valueOf(1), map.aggregate(Aggregators.comparableMin("bigDecimalValue" + p)));
+        assertEquals(BigInteger.valueOf(1), map.aggregate(Aggregators.comparableMin("bigIntegerValue" + p)));
 
-        assertEquals("1", map.aggregate(Aggregators.<Map.Entry<Integer, Person>, String>comparableMin("comparableValue" + p)));
+        assertEquals("1", map.aggregate(Aggregators.comparableMin("comparableValue" + p)));
+        assertEquals("1", map.aggregate(Aggregators.comparableMin("optionalComparableValue" + p)));
     }
 
     public static void assertMaxAggregators(IMap<Integer, Person> map, String p) {
         assertNoDataMissing(map, PERSONS_COUNT);
-        assertEquals(Double.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleMax("doubleValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longMax("longValue" + p)));
-        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerMax("intValue" + p)));
-        assertEquals(BigDecimal.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalMax(
-                "bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerMax(
-                "bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(999), map.aggregate(Aggregators.doubleMax("doubleValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.longMax("longValue" + p)));
+        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.integerMax("intValue" + p)));
+        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.integerMax("optionalIntValue" + p)));
+        assertEquals(BigDecimal.valueOf(999), map.aggregate(Aggregators.bigDecimalMax("bigDecimalValue" + p)));
+        assertEquals(BigInteger.valueOf(999), map.aggregate(Aggregators.bigIntegerMax("bigIntegerValue" + p)));
 
-        assertEquals(Double.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Double>comparableMax(
-                "doubleValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Long>comparableMax(
-                "longValue" + p)));
-        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Integer>comparableMax(
-                "intValue" + p)));
-        assertEquals(BigDecimal.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigDecimal>comparableMax(
-                "bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigInteger>comparableMax(
-                "bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(999), map.aggregate(Aggregators.comparableMax("doubleValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.comparableMax("longValue" + p)));
+        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.comparableMax("intValue" + p)));
+        assertEquals(Integer.valueOf(999), map.aggregate(Aggregators.comparableMax("optionalIntValue" + p)));
+        assertEquals(BigDecimal.valueOf(999), map.aggregate(Aggregators.comparableMax("bigDecimalValue" + p)));
+        assertEquals(BigInteger.valueOf(999), map.aggregate(Aggregators.comparableMax("bigIntegerValue" + p)));
 
-        assertEquals("999", map.aggregate(Aggregators.<Map.Entry<Integer, Person>, String>comparableMax("comparableValue" + p)));
+        assertEquals("999", map.aggregate(Aggregators.comparableMax("comparableValue" + p)));
+        assertEquals("999", map.aggregate(Aggregators.comparableMax("optionalComparableValue" + p)));
     }
 
     public static void assertSumAggregators(IMap<Integer, Person> map, String p) {
         assertNoDataMissing(map, PERSONS_COUNT);
-        assertEquals(Double.valueOf(499500.0d), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleSum(
-                "doubleValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longSum("longValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerSum("intValue" + p)));
-        assertEquals(BigDecimal.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalSum(
-                "bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerSum(
-                "bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(499500.0d), map.aggregate(Aggregators.doubleSum("doubleValue" + p)));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.longSum("longValue" + p)));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.integerSum("intValue" + p)));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.integerSum("optionalIntValue" + p)));
+        assertEquals(BigDecimal.valueOf(499500), map.aggregate(Aggregators.bigDecimalSum("bigDecimalValue" + p)));
+        assertEquals(BigInteger.valueOf(499500), map.aggregate(Aggregators.bigIntegerSum("bigIntegerValue" + p)));
 
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum(
-                "doubleValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum("longValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum("intValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum(
-                "bigIntegerValue" + p)));
-        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum(
-                "bigDecimalValue" + p)));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("doubleValue" + p)));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("longValue" + p)));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("intValue" + p)));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("optionalIntValue" + p)));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("bigIntegerValue" + p)));
+        assertEquals(Long.valueOf(499500), map.aggregate(Aggregators.fixedPointSum("bigDecimalValue" + p)));
 
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum(
-                "doubleValue" + p)));
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum(
-                "longValue" + p)));
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum(
-                "intValue" + p)));
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum(
-                "bigIntegerValue" + p)));
-        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum(
-                "bigDecimalValue" + p)));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("doubleValue" + p)));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("longValue" + p)));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("intValue" + p)));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("optionalIntValue" + p)));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(499500), map.aggregate(Aggregators.floatingPointSum("bigDecimalValue" + p)));
     }
 
     public static void assertAverageAggregators(IMap<Integer, Person> map, String p) {
         assertNoDataMissing(map, PERSONS_COUNT);
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleAvg("doubleValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longAvg("longValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerAvg("intValue" + p)));
-        assertEquals(BigDecimal.valueOf(500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalAvg(
-                "bigDecimalValue" + p)));
-        assertEquals(BigDecimal.valueOf(500), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerAvg(
-                "bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.doubleAvg("doubleValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.longAvg("longValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.integerAvg("intValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.integerAvg("optionalIntValue" + p)));
+        assertEquals(BigDecimal.valueOf(500), map.aggregate(Aggregators.bigDecimalAvg("bigDecimalValue" + p)));
+        assertEquals(BigDecimal.valueOf(500), map.aggregate(Aggregators.bigIntegerAvg("bigIntegerValue" + p)));
 
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("doubleValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("longValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("intValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg(
-                "bigDecimalValue" + p)));
-        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg(
-                "bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("doubleValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("longValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("intValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("optionalIntValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("bigDecimalValue" + p)));
+        assertEquals(Double.valueOf(500.0d), map.aggregate(Aggregators.numberAvg("bigIntegerValue" + p)));
     }
 
     public static void assertCountAggregators(IMap<Integer, Person> map, String p) {
         assertNoDataMissing(map, PERSONS_COUNT);
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("doubleValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("longValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("intValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("bigDecimalValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("bigIntegerValue" + p)));
-        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("comparableValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("doubleValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("longValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("intValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("optionalIntValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("bigDecimalValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("bigIntegerValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("comparableValue" + p)));
+        assertEquals(Long.valueOf(999), map.aggregate(Aggregators.count("optionalComparableValue" + p)));
     }
 
     public static void assertDistinctAggregators(IMap<Integer, Person> map, String p) {
         // projections do not support [any] but we have one element only so here we go.
         assertNoDataMissing(map, PERSONS_COUNT);
         String projection = p.contains("[any]") ? "[0]" : "";
-        assertCollectionEquals(map.project(Projections.<Map.Entry<Integer, Person>, Double>singleAttribute(
-                "doubleValue" + projection)),
-                map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Double>distinct("doubleValue" + p)));
-        assertCollectionEquals(map.project(Projections.<Map.Entry<Integer, Person>, Long>singleAttribute(
-                "longValue" + projection)),
-                map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Long>distinct("longValue" + p)));
-        assertCollectionEquals(map.project(Projections.<Map.Entry<Integer, Person>, Integer>singleAttribute(
-                "intValue" + projection)),
-                map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Integer>distinct("intValue" + p)));
-        assertCollectionEquals(map.project(Projections.<Map.Entry<Integer, Person>, BigDecimal>singleAttribute(
-                "bigDecimalValue" + projection)),
-                map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigDecimal>distinct("bigDecimalValue" + p)));
-        assertCollectionEquals(map.project(Projections.<Map.Entry<Integer, Person>, BigInteger>singleAttribute(
-                "bigIntegerValue" + projection)),
-                map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigInteger>distinct("bigIntegerValue" + p)));
-        assertCollectionEquals(map.project(Projections.<Map.Entry<Integer, Person>, Comparable>singleAttribute(
-                "comparableValue" + projection)),
-                map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Comparable>distinct("comparableValue" + p)));
+        assertCollectionEquals(map.project(Projections.singleAttribute("doubleValue" + projection)),
+                map.aggregate(Aggregators.distinct("doubleValue" + p)));
+        assertCollectionEquals(map.project(Projections.singleAttribute("longValue" + projection)),
+                map.aggregate(Aggregators.distinct("longValue" + p)));
+        assertCollectionEquals(map.project(Projections.singleAttribute("intValue" + projection)),
+                map.aggregate(Aggregators.distinct("intValue" + p)));
+        assertCollectionEquals(map.project(Projections.singleAttribute("optionalIntValue" + projection)),
+                map.aggregate(Aggregators.distinct("optionalIntValue" + p)));
+        assertCollectionEquals(map.project(Projections.singleAttribute("bigDecimalValue" + projection)),
+                map.aggregate(Aggregators.distinct("bigDecimalValue" + p)));
+        assertCollectionEquals(map.project(Projections.singleAttribute("bigIntegerValue" + projection)),
+                map.aggregate(Aggregators.distinct("bigIntegerValue" + p)));
+        assertCollectionEquals(map.project(Projections.singleAttribute("comparableValue" + projection)),
+                map.aggregate(Aggregators.distinct("comparableValue" + p)));
+        assertCollectionEquals(map.project(Projections.singleAttribute("optionalComparableValue" + projection)),
+                map.aggregate(Aggregators.distinct("optionalComparableValue" + p)));
     }
 
     @Test
@@ -247,7 +231,7 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
             assertMaxAggregatorsAnyCornerCase(map, postfix);
             // sum and avg do not accept null values, thus skipped
             assertCountAggregatorsAnyCornerCase(map, postfix, 1);
-            HashSet expected = new HashSet();
+            HashSet<?> expected = new HashSet<>();
             expected.add(null);
             assertDistinctAggregatorsAnyCornerCase(map, postfix, expected);
         }
@@ -270,103 +254,107 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
 
     private void assertMinAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
         assertNoDataMissing(map, 1);
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleMin("doubleValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longMin("longValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerMin("intValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalMin("bigDecimalValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerMin("bigIntegerValue" + p)));
+        assertNull(map.aggregate(Aggregators.doubleMin("doubleValue" + p)));
+        assertNull(map.aggregate(Aggregators.longMin("longValue" + p)));
+        assertNull(map.aggregate(Aggregators.integerMin("intValue" + p)));
+        assertNull(map.aggregate(Aggregators.integerMin("optionalIntValue" + p)));
+        assertNull(map.aggregate(Aggregators.bigDecimalMin("bigDecimalValue" + p)));
+        assertNull(map.aggregate(Aggregators.bigIntegerMin("bigIntegerValue" + p)));
 
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Double>comparableMin("doubleValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Long>comparableMin("longValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Integer>comparableMin("intValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigDecimal>comparableMin(
-                "bigDecimalValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigInteger>comparableMin(
-                "bigIntegerValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMin("doubleValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMin("longValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMin("intValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMin("optionalIntValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMin("bigDecimalValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMin("bigIntegerValue" + p)));
 
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, String>comparableMin("comparableValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMin("comparableValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMin("optionalComparableValue" + p)));
     }
 
     public static void assertMaxAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
         assertNoDataMissing(map, 1);
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleMax("doubleValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longMax("longValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerMax("intValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalMax("bigDecimalValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerMax("bigIntegerValue" + p)));
+        assertNull(map.aggregate(Aggregators.doubleMax("doubleValue" + p)));
+        assertNull(map.aggregate(Aggregators.longMax("longValue" + p)));
+        assertNull(map.aggregate(Aggregators.integerMax("intValue" + p)));
+        assertNull(map.aggregate(Aggregators.integerMax("optionalIntValue" + p)));
+        assertNull(map.aggregate(Aggregators.bigDecimalMax("bigDecimalValue" + p)));
+        assertNull(map.aggregate(Aggregators.bigIntegerMax("bigIntegerValue" + p)));
 
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Double>comparableMax("doubleValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Long>comparableMax("longValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Integer>comparableMax("intValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigDecimal>comparableMax(
-                "bigDecimalValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigInteger>comparableMax(
-                "bigIntegerValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMax("doubleValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMax("longValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMax("intValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMax("optionalIntValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMax("bigDecimalValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMax("bigIntegerValue" + p)));
 
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, String>comparableMax("comparableValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMax("comparableValue" + p)));
+        assertNull(map.aggregate(Aggregators.comparableMax("optionalComparableValue" + p)));
     }
 
     public static void assertSumAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
         assertNoDataMissing(map, 1);
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleSum("doubleValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longSum("longValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerSum("intValue" + p)));
-        assertEquals(BigDecimal.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalSum(
-                "bigDecimalValue" + p)));
-        assertEquals(BigInteger.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerSum(
-                "bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.doubleSum("doubleValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.longSum("longValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.integerSum("intValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.integerSum("optionalIntValue" + p)));
+        assertEquals(BigDecimal.valueOf(0), map.aggregate(Aggregators.bigDecimalSum("bigDecimalValue" + p)));
+        assertEquals(BigInteger.valueOf(0), map.aggregate(Aggregators.bigIntegerSum("bigIntegerValue" + p)));
 
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum("doubleValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum("longValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum("intValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum(
-                "bigIntegerValue" + p)));
-        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>fixedPointSum(
-                "bigDecimalValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("doubleValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("longValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("intValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("optionalIntValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("bigIntegerValue" + p)));
+        assertEquals(Long.valueOf(0), map.aggregate(Aggregators.fixedPointSum("bigDecimalValue" + p)));
 
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum(
-                "doubleValue" + p)));
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum("longValue" + p)));
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum("intValue" + p)));
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum(
-                "bigIntegerValue" + p)));
-        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>floatingPointSum(
-                "bigDecimalValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("doubleValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("longValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("intValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("optionalIntValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("bigIntegerValue" + p)));
+        assertEquals(Double.valueOf(0), map.aggregate(Aggregators.floatingPointSum("bigDecimalValue" + p)));
     }
 
     public static void assertAverageAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p) {
         assertNoDataMissing(map, 1);
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>doubleAvg("doubleValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>longAvg("longValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>integerAvg("intValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigDecimalAvg("bigDecimalValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>bigIntegerAvg("bigIntegerValue" + p)));
+        assertNull(map.aggregate(Aggregators.doubleAvg("doubleValue" + p)));
+        assertNull(map.aggregate(Aggregators.longAvg("longValue" + p)));
+        assertNull(map.aggregate(Aggregators.integerAvg("intValue" + p)));
+        assertNull(map.aggregate(Aggregators.integerAvg("optionalIntValue" + p)));
+        assertNull(map.aggregate(Aggregators.bigDecimalAvg("bigDecimalValue" + p)));
+        assertNull(map.aggregate(Aggregators.bigIntegerAvg("bigIntegerValue" + p)));
 
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("doubleValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("longValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("intValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("bigDecimalValue" + p)));
-        assertEquals(null, map.aggregate(Aggregators.<Map.Entry<Integer, Person>>numberAvg("bigIntegerValue" + p)));
+        assertNull(map.aggregate(Aggregators.numberAvg("doubleValue" + p)));
+        assertNull(map.aggregate(Aggregators.numberAvg("longValue" + p)));
+        assertNull(map.aggregate(Aggregators.numberAvg("intValue" + p)));
+        assertNull(map.aggregate(Aggregators.numberAvg("optionalIntValue" + p)));
+        assertNull(map.aggregate(Aggregators.numberAvg("bigDecimalValue" + p)));
+        assertNull(map.aggregate(Aggregators.numberAvg("bigIntegerValue" + p)));
     }
 
     public static void assertCountAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, long value) {
         assertNoDataMissing(map, 1);
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("doubleValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("longValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("intValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("bigDecimalValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("bigIntegerValue" + p)));
-        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.<Map.Entry<Integer, Person>>count("comparableValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("doubleValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("longValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("intValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("optionalIntValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("bigDecimalValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("bigIntegerValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("comparableValue" + p)));
+        assertEquals(Long.valueOf(value), map.aggregate(Aggregators.count("optionalComparableValue" + p)));
     }
 
     public static void assertDistinctAggregatorsAnyCornerCase(IMap<Integer, Person> map, String p, Set result) {
         assertNoDataMissing(map, 1);
-        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Double>distinct("doubleValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Long>distinct("longValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Integer>distinct("intValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigDecimal>distinct("bigDecimalValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, BigInteger>distinct("bigIntegerValue" + p)));
-        assertEquals(result, map.aggregate(Aggregators.<Map.Entry<Integer, Person>, Comparable>distinct("comparableValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.distinct("doubleValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.distinct("longValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.distinct("intValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.distinct("optionalIntValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.distinct("bigDecimalValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.distinct("bigIntegerValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.distinct("comparableValue" + p)));
+        assertEquals(result, map.aggregate(Aggregators.distinct("optionalComparableValue" + p)));
     }
 
     protected <K, V> IMap<K, V> getMapWithNodeCount(int nodeCount, boolean parallelAccumulation) {
@@ -388,9 +376,9 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
         return instance.getMap("aggr");
     }
 
-    private static void assertCollectionEquals(Collection a, Collection b) {
-        TreeSet aSorted = new TreeSet(a);
-        TreeSet bSorted = new TreeSet(b);
+    private static void assertCollectionEquals(Collection<?> a, Collection<?> b) {
+        TreeSet<?> aSorted = new TreeSet<>(a);
+        TreeSet<?> bSorted = new TreeSet<>(b);
         assertEquals(aSorted, bSorted);
     }
 
@@ -426,6 +414,17 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
             this.bigIntegerValue = BigInteger.valueOf(numberValue);
             this.comparableValue = String.valueOf(numberValue);
         }
+
+        @SuppressWarnings("unused")
+        public Optional getOptionalIntValue() {
+            return Optional.ofNullable(intValue);
+        }
+
+        @SuppressWarnings("unused")
+        public Optional getOptionalComparableValue() {
+            return Optional.ofNullable(comparableValue);
+        }
+
     }
 
     @SuppressWarnings("WeakerAccess")
@@ -450,19 +449,31 @@ public class AggregatorsSpecTest extends HazelcastTestSupport {
             this.comparableValue = singletonList(String.valueOf(numberValue));
         }
 
+        @Override
+        public Optional getOptionalIntValue() {
+            return Optional.ofNullable(intValue);
+        }
+
+        @Override
+        public Optional getOptionalComparableValue() {
+            return Optional.ofNullable(comparableValue);
+        }
+
         public static PersonAny empty() {
             PersonAny person = new PersonAny();
             person.intValue = new int[]{};
             person.doubleValue = new double[]{};
             person.longValue = new long[]{};
-            person.bigDecimalValue = new ArrayList<BigDecimal>();
-            person.bigIntegerValue = new ArrayList<BigInteger>();
-            person.comparableValue = new ArrayList<String>();
+            person.bigDecimalValue = new ArrayList<>();
+            person.bigIntegerValue = new ArrayList<>();
+            person.comparableValue = new ArrayList<>();
             return person;
         }
 
         public static PersonAny nulls() {
             return new PersonAny();
         }
+
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/OptionalsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/OptionalsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util;
+
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Optional;
+
+import static com.hazelcast.query.impl.predicates.PredicateUtils.unwrapIfOptional;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+@Category({QuickTest.class, ParallelTest.class})
+public class OptionalsTest {
+
+    @SuppressWarnings("ConstantConditions")
+    @Test
+    public void testUnwrapping() {
+        Object value = new Object();
+        assertSame(value, unwrapIfOptional(value));
+
+        assertNull(unwrapIfOptional(null));
+
+        assertSame(value, unwrapIfOptional(Optional.of(value)));
+
+        assertNull(unwrapIfOptional(Optional.empty()));
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/projection/impl/MultiAttributeProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/impl/MultiAttributeProjectionTest.java
@@ -41,6 +41,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
@@ -56,22 +57,22 @@ public class MultiAttributeProjectionTest extends HazelcastTestSupport {
 
     @Test(expected = IllegalArgumentException.class)
     public void multiAttribute_attributeNull() {
-        Projections.<Map.Entry<String, Person>>multiAttribute(null);
+        Projections.multiAttribute((String) null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void multiAttribute_attributeEmpty() {
-        Projections.<Map.Entry<String, Person>>multiAttribute("");
+        Projections.multiAttribute("");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void multiAttribute_attributeNullWithOther() {
-        Projections.<Map.Entry<String, Person>>multiAttribute("age", null, "height");
+        Projections.multiAttribute("age", null, "height");
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void multiAttribute_attributeEmptyWithOther() {
-        Projections.<Map.Entry<String, Person>>multiAttribute("age", "", "height");
+        Projections.multiAttribute("age", "", "height");
     }
 
     @Test
@@ -79,7 +80,7 @@ public class MultiAttributeProjectionTest extends HazelcastTestSupport {
         IMap<String, Person> map = getMapWithNodeCount();
         populateMapWithPersons(map);
 
-        Collection<Object[]> result = map.project(Projections.<Map.Entry<String, Person>>multiAttribute("age", "height"));
+        Collection<Object[]> result = map.project(Projections.multiAttribute("age", "height"));
         assertThat(result, containsInAnyOrder(new Object[]{1.0d, 190}, new Object[]{4.0d, 123}));
     }
 
@@ -87,7 +88,7 @@ public class MultiAttributeProjectionTest extends HazelcastTestSupport {
     public void multiAttribute_emptyMap() {
         IMap<String, Person> map = getMapWithNodeCount();
 
-        Collection<Object[]> result = map.project(Projections.<Map.Entry<String, Person>>multiAttribute("age", "height"));
+        Collection<Object[]> result = map.project(Projections.multiAttribute("age", "height"));
 
         assertEquals(0, result.size());
     }
@@ -97,7 +98,7 @@ public class MultiAttributeProjectionTest extends HazelcastTestSupport {
         IMap<String, Person> map = getMapWithNodeCount();
         populateMapWithPersons(map);
 
-        Collection<Object[]> result = map.project(Projections.<Map.Entry<String, Person>>multiAttribute("__key"));
+        Collection<Object[]> result = map.project(Projections.multiAttribute("__key"));
 
         assertThat(result, containsInAnyOrder(new Object[]{"key1"}, new Object[]{"key2"}));
     }
@@ -108,7 +109,7 @@ public class MultiAttributeProjectionTest extends HazelcastTestSupport {
         map.put("key1", 1);
         map.put("key2", 2);
 
-        Collection<Object[]> result = map.project(Projections.<Map.Entry<String, Integer>>multiAttribute("this"));
+        Collection<Object[]> result = map.project(Projections.multiAttribute("this"));
 
         assertThat(result, containsInAnyOrder(new Object[]{1}, new Object[]{2}));
     }
@@ -119,7 +120,18 @@ public class MultiAttributeProjectionTest extends HazelcastTestSupport {
         map.put("key1", new Person(1.0d, null));
         map.put("007", new Person(null, 144));
 
-        Collection<Object[]> result = map.project(Projections.<Map.Entry<String, Person>>multiAttribute("age", "height"));
+        Collection<Object[]> result = map.project(Projections.multiAttribute("age", "height"));
+
+        assertThat(result, containsInAnyOrder(new Object[]{1.0d, null}, new Object[]{null, 144}));
+    }
+
+    @Test
+    public void multiAttribute_optional() {
+        IMap<String, Person> map = getMapWithNodeCount();
+        map.put("key1", new Person(1.0d, null));
+        map.put("007", new Person(null, 144));
+
+        Collection<Object[]> result = map.project(Projections.multiAttribute("optionalAge", "optionalHeight"));
 
         assertThat(result, containsInAnyOrder(new Object[]{1.0d, null}, new Object[]{null, 144}));
     }
@@ -179,5 +191,17 @@ public class MultiAttributeProjectionTest extends HazelcastTestSupport {
             age = in.readObject();
             height = in.readObject();
         }
+
+        @SuppressWarnings("unused")
+        public Optional<Double> optionalAge() {
+            return Optional.ofNullable(age);
+        }
+
+        @SuppressWarnings("unused")
+        public Optional<Integer> optionalHeight() {
+            return Optional.ofNullable(height);
+        }
+
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/projection/impl/SingleAttributeProjectionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/projection/impl/SingleAttributeProjectionTest.java
@@ -41,6 +41,7 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.hazelcast.spi.properties.GroupProperty.PARTITION_COUNT;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
@@ -69,7 +70,7 @@ public class SingleAttributeProjectionTest extends HazelcastTestSupport {
         IMap<String, Person> map = getMapWithNodeCount();
         populateMapWithPersons(map);
 
-        Collection<Double> result = map.project(Projections.<Map.Entry<String, Person>, Double>singleAttribute("age"));
+        Collection<Double> result = map.project(Projections.singleAttribute("age"));
 
         assertThat(result, containsInAnyOrder(1.0d, 4.0d, 7.0d));
     }
@@ -79,7 +80,7 @@ public class SingleAttributeProjectionTest extends HazelcastTestSupport {
         IMap<String, Person> map = getMapWithNodeCount();
         populateMapWithPersons(map);
 
-        Collection<String> result = map.project(Projections.<Map.Entry<String, Person>, String>singleAttribute("__key"));
+        Collection<String> result = map.project(Projections.singleAttribute("__key"));
 
         assertThat(result, containsInAnyOrder("key1", "key2", "key3"));
     }
@@ -90,7 +91,7 @@ public class SingleAttributeProjectionTest extends HazelcastTestSupport {
         map.put("key1", 1);
         map.put("key2", 2);
 
-        Collection<Integer> result = map.project(Projections.<Map.Entry<String, Integer>, Integer>singleAttribute("this"));
+        Collection<Integer> result = map.project(Projections.singleAttribute("this"));
 
         assertThat(result, containsInAnyOrder(1, 2));
     }
@@ -99,7 +100,7 @@ public class SingleAttributeProjectionTest extends HazelcastTestSupport {
     public void singleAttribute_emptyMap() {
         IMap<String, Person> map = getMapWithNodeCount();
 
-        Collection<Double> result = map.project(Projections.<Map.Entry<String, Person>, Double>singleAttribute("age"));
+        Collection<Double> result = map.project(Projections.singleAttribute("age"));
 
         assertEquals(0, result.size());
     }
@@ -110,7 +111,18 @@ public class SingleAttributeProjectionTest extends HazelcastTestSupport {
         map.put("key1", new Person(1.0d));
         map.put("007", new Person(null));
 
-        Collection<Double> result = map.project(Projections.<Map.Entry<String, Person>, Double>singleAttribute("age"));
+        Collection<Double> result = map.project(Projections.singleAttribute("age"));
+
+        assertThat(result, containsInAnyOrder(null, 1.0d));
+    }
+
+    @Test
+    public void singleAttribute_optional() {
+        IMap<String, Person> map = getMapWithNodeCount();
+        map.put("key1", new Person(1.0d));
+        map.put("007", new Person(null));
+
+        Collection<Double> result = map.project(Projections.singleAttribute("optionalAge"));
 
         assertThat(result, containsInAnyOrder(null, 1.0d));
     }
@@ -167,5 +179,12 @@ public class SingleAttributeProjectionTest extends HazelcastTestSupport {
         public void readData(ObjectDataInput in) throws IOException {
             age = in.readObject();
         }
+
+        @SuppressWarnings("unused")
+        public Optional<Double> optionalAge() {
+            return Optional.ofNullable(age);
+        }
+
     }
+
 }

--- a/hazelcast/src/test/java/com/hazelcast/query/SampleTestObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/query/SampleTestObjects.java
@@ -26,6 +26,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
 
 public final class SampleTestObjects {
@@ -557,4 +558,17 @@ public final class SampleTestObjects {
             return attribute;
         }
     }
+
+    public static class ObjectWithOptional<T> implements Serializable {
+        private T attribute;
+
+        public ObjectWithOptional(T attribute) {
+            this.attribute = attribute;
+        }
+
+        public Optional<T> getAttribute() {
+            return Optional.ofNullable(attribute);
+        }
+    }
+
 }


### PR DESCRIPTION
The most important changes are in `GetterFactory` and `AbstractMultiValueGetter`, the rest is mostly tests and Java 6 to Java 8 migration.

Fixes: https://github.com/hazelcast/hazelcast/issues/13300