### PR TITLE
Shutdown memcached client to prevent reconnect

### DIFF
--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/InvalidEndpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/InvalidEndpointTest.java
@@ -115,6 +115,8 @@ public class InvalidEndpointTest {
         } catch (ExecutionException e) {
             ignore(e);
         }
+
+        client.shutdown();
     }
 
     protected Config createRestEndpointConfig() {


### PR DESCRIPTION
Shutdown is required to stop memcached client otherwise it stays alive and keeps trying to connect as long as the test suite.