### PR TITLE
Publish only expired events in case of eviction

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/console/ClientConsoleApp.java
@@ -184,7 +184,6 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
     /**
      * A line reader
      */
-
     static class DefaultLineReader implements LineReader {
 
         BufferedReader in = new BufferedReader(new InputStreamReader(System.in, Charset.forName("UTF-8")));
@@ -1343,6 +1342,11 @@ public class ClientConsoleApp implements EntryListener, ItemListener, MessageLis
 
     @Override
     public void entryEvicted(EntryEvent event) {
+        println(event);
+    }
+
+    @Override
+    public void entryExpired(EntryEvent event) {
         println(event);
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -23,7 +23,7 @@ import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.map.BasicMapTest;
 import com.hazelcast.map.MapInterceptor;
-import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.monitor.LocalMapStats;
 import com.hazelcast.query.PagingPredicate;
 import com.hazelcast.query.Predicate;
@@ -49,8 +49,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -408,11 +408,7 @@ public class ClientMapBasicTest extends AbstractClientMapTest {
         String key = "Key";
         String value = "Val";
         final CountDownLatch latch = new CountDownLatch(1);
-        map.addEntryListener(new EntryEvictedListener<String, String>() {
-            public void entryEvicted(EntryEvent<String, String> event) {
-                latch.countDown();
-            }
-        }, true);
+        map.addEntryListener((EntryExpiredListener<String, String>) event -> latch.countDown(), true);
 
         Future<Void> result = map.setAsync(key, value, 1, TimeUnit.SECONDS);
         result.get();
@@ -427,11 +423,7 @@ public class ClientMapBasicTest extends AbstractClientMapTest {
         String oldValue = "oldValue";
         String newValue = "Val";
         final CountDownLatch latch = new CountDownLatch(1);
-        map.addEntryListener(new EntryEvictedListener<String, String>() {
-            public void entryEvicted(EntryEvent<String, String> event) {
-                latch.countDown();
-            }
-        }, true);
+        map.addEntryListener((EntryExpiredListener<String, String>) event -> latch.countDown(), true);
 
         map.set(key, oldValue);
         Future<Void> result = map.setAsync(key, newValue, 1, TimeUnit.SECONDS);
@@ -1417,6 +1409,11 @@ public class ClientMapBasicTest extends AbstractClientMapTest {
         }
 
         public void mapCleared(MapEvent event) {
+        }
+
+        @Override
+        public void entryExpired(EntryEvent<String, String> event) {
+
         }
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/MapPreconditionsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/MapPreconditionsTest.java
@@ -628,6 +628,7 @@ public class MapPreconditionsTest extends HazelcastTestSupport {
 
         int entryAddedCalled;
         int entryEvictedCalled;
+        int entryExpiredCalled;
         int entryRemovedCalled;
         int entryUpdatedCalled;
         int mapClearedCalled;
@@ -641,6 +642,11 @@ public class MapPreconditionsTest extends HazelcastTestSupport {
         @Override
         public void entryEvicted(EntryEvent event) {
             entryEvictedCalled++;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            entryExpiredCalled++;
         }
 
         @Override

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheEventHandlingTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/impl/querycache/ClientQueryCacheEventHandlingTest.java
@@ -25,7 +25,6 @@ import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.query.Predicate;
 import com.hazelcast.query.TruePredicate;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -77,27 +76,17 @@ public class ClientQueryCacheEventHandlingTest extends HazelcastTestSupport {
         int value = 1;
 
         final CountDownLatch latch = new CountDownLatch(1);
-        queryCache.addEntryListener(new EntryAddedListener() {
-            @Override
-            public void entryAdded(EntryEvent event) {
-                latch.countDown();
-            }
-        }, true);
+        queryCache.addEntryListener((EntryAddedListener) event -> latch.countDown(), true);
 
         map.put(key, value, 1, SECONDS);
 
         latch.await();
-        sleepSeconds(1);
+        sleepAtLeastMillis(1100);
 
         // map#get creates EXPIRED event
         map.get(key);
 
-        assertTrueEventually(new AssertTask() {
-            @Override
-            public void run() throws Exception {
-                assertEquals(0, queryCache.size());
-            }
-        });
+        assertTrueEventually(() -> assertEquals(0, queryCache.size()));
     }
 
     @Test

--- a/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapListenerTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/replicatedmap/ClientReplicatedMapListenerTest.java
@@ -239,6 +239,11 @@ public class ClientReplicatedMapListenerTest extends HazelcastTestSupport {
         }
 
         @Override
+        public void entryExpired(EntryEvent<Object, Object> event) {
+            throw new UnsupportedOperationException("Expired event is not published by replicated map");
+        }
+
+        @Override
         public void mapEvicted(MapEvent event) {
             mapEvictCount.incrementAndGet();
         }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyEntryListener.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyEntryListener.java
@@ -43,6 +43,11 @@ public class DummyEntryListener implements EntryListener {
     }
 
     @Override
+    public void entryExpired(EntryEvent event) {
+        //System.err.println("Expired: " + event);
+    }
+
+    @Override
     public void mapEvicted(MapEvent event) {
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/AbstractReplicatedMapAddEntryListenerMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/replicatedmap/AbstractReplicatedMapAddEntryListenerMessageTask.java
@@ -153,6 +153,11 @@ public abstract class AbstractReplicatedMapAddEntryListenerMessageTask<Parameter
     }
 
     @Override
+    public void entryExpired(EntryEvent<Object, Object> event) {
+        handleEvent(event);
+    }
+
+    @Override
     public void mapEvicted(MapEvent event) {
         // TODO handle this event
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/EntryListenerConfig.java
@@ -23,6 +23,7 @@ import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.MapEvent;
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.map.listener.EntryUpdatedListener;
 import com.hazelcast.map.listener.MapClearedListener;
@@ -154,6 +155,13 @@ public class EntryListenerConfig extends ListenerConfig {
         public void entryEvicted(EntryEvent event) {
             if (mapListener instanceof EntryEvictedListener) {
                 ((EntryEvictedListener) mapListener).entryEvicted(event);
+            }
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            if (mapListener instanceof EntryExpiredListener) {
+                ((EntryExpiredListener) mapListener).entryExpired(event);
             }
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
+++ b/hazelcast/src/main/java/com/hazelcast/console/ConsoleApp.java
@@ -1347,6 +1347,11 @@ public class ConsoleApp implements EntryListener<Object, Object>, ItemListener<O
     }
 
     @Override
+    public void entryExpired(EntryEvent<Object, Object> event) {
+        println(event);
+    }
+
+    @Override
     public void mapEvicted(MapEvent event) {
         println(event);
     }

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryAdapter.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryAdapter.java
@@ -47,6 +47,11 @@ public class EntryAdapter<K, V> implements EntryListener<K, V> {
     }
 
     @Override
+    public void entryExpired(EntryEvent<K, V> event) {
+        onEntryEvent(event);
+    }
+
+    @Override
     public void mapEvicted(MapEvent event) {
         onMapEvent(event);
     }

--- a/hazelcast/src/main/java/com/hazelcast/core/EntryListener.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/EntryListener.java
@@ -18,6 +18,7 @@ package com.hazelcast.core;
 
 import com.hazelcast.map.listener.EntryAddedListener;
 import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.map.listener.EntryRemovedListener;
 import com.hazelcast.map.listener.EntryUpdatedListener;
 import com.hazelcast.map.listener.MapClearedListener;
@@ -39,6 +40,6 @@ import com.hazelcast.map.listener.MapEvictedListener;
  */
 public interface EntryListener<K, V>
         extends EntryAddedListener<K, V>, EntryUpdatedListener<K, V>, EntryRemovedListener<K, V>,
-        EntryEvictedListener<K, V>, MapClearedListener, MapEvictedListener {
+        EntryEvictedListener<K, V>, EntryExpiredListener<K, V>, MapClearedListener, MapEvictedListener {
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheEventPublisher.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/event/QueryCacheEventPublisher.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.Collections;
 
 import static com.hazelcast.core.EntryEventType.ADDED;
-import static com.hazelcast.core.EntryEventType.EXPIRED;
 import static com.hazelcast.core.EntryEventType.REMOVED;
 import static com.hazelcast.core.EntryEventType.UPDATED;
 import static com.hazelcast.map.impl.event.MapEventPublisherImpl.isIncludeValue;
@@ -65,12 +64,6 @@ public class QueryCacheEventPublisher {
 
         String mapName = ((EventData) eventData).getMapName();
         int eventType = ((EventData) eventData).getEventType();
-
-        // in case of expiration, IMap publishes both EVICTED and EXPIRED events for a key
-        // only handling EVICTED event for that key is sufficient
-        if (EXPIRED.getType() == eventType) {
-            return;
-        }
 
         // this collection contains all defined query-caches on an IMap
         Collection<PartitionAccumulatorRegistry> partitionAccumulatorRegistries = getPartitionAccumulatorRegistries(mapName);

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
@@ -17,15 +17,18 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.MapInterceptor;
+import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.operationservice.AbstractNamedOperation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
 import java.io.IOException;
 
-public class AddInterceptorOperation extends MapOperation
+public class AddInterceptorOperation extends AbstractNamedOperation
         implements MutatingOperation {
 
     private String id;
@@ -48,8 +51,14 @@ public class AddInterceptorOperation extends MapOperation
     }
 
     @Override
-    protected void runInternal() {
-        mapContainer.getInterceptorRegistry().register(id, mapInterceptor);
+    public void run() {
+        getMapContainer().getInterceptorRegistry().register(id, mapInterceptor);
+    }
+
+    private MapContainer getMapContainer() {
+        MapService mapService = getService();
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        return mapServiceContext.getMapContainer(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
@@ -16,14 +16,18 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
+import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.impl.operationservice.AbstractNamedOperation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
 import java.io.IOException;
 
-public class RemoveInterceptorOperation extends MapOperation
+public class RemoveInterceptorOperation extends AbstractNamedOperation
         implements MutatingOperation {
 
     private String id;
@@ -38,8 +42,19 @@ public class RemoveInterceptorOperation extends MapOperation
     }
 
     @Override
-    protected void runInternal() {
-        interceptorRemoved = mapContainer.getInterceptorRegistry().deregister(id);
+    public void run() {
+        interceptorRemoved = getMapContainer().getInterceptorRegistry().deregister(id);
+    }
+
+    @Override
+    public String getServiceName() {
+        return MapService.SERVICE_NAME;
+    }
+
+    private MapContainer getMapContainer() {
+        MapService mapService = getService();
+        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
+        return mapServiceContext.getMapContainer(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/querycache/subscriber/SubscriberAccumulatorHandler.java
@@ -99,6 +99,7 @@ class SubscriberAccumulatorHandler implements AccumulatorHandler<QueryCacheEvent
                 break;
             case REMOVED:
             case EVICTED:
+            case EXPIRED:
                 queryCache.delete(keyData, entryEventType);
                 break;
             case CLEAR_ALL:

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/AbstractEvictableRecordStore.java
@@ -294,30 +294,19 @@ public abstract class AbstractEvictableRecordStore extends AbstractRecordStore {
 
     @Override
     public void doPostEvictionOperations(Record record) {
-        // Fire EVICTED event also in case of expiration because historically eviction-listener
-        // listens all kind of eviction and expiration events and by firing EVICTED event we are preserving
-        // this behavior.
+        boolean hasEventRegistration = eventService.hasEventRegistration(SERVICE_NAME, name);
 
         Data key = record.getKey();
         Object value = record.getValue();
-
-        boolean hasEventRegistration = eventService.hasEventRegistration(SERVICE_NAME, name);
-        if (hasEventRegistration) {
-            mapEventPublisher.publishEvent(thisAddress, name, EVICTED, key, value, null);
-        }
 
         long now = getNow();
         boolean idleExpired = isIdleExpired(record, now, false);
         boolean ttlExpired = isTTLExpired(record, now, false);
         boolean expired = idleExpired || ttlExpired;
 
-        if (expired && hasEventRegistration) {
-            // We will be in this if in two cases:
-            // 1. In case of TTL or max-idle-seconds expiration.
-            // 2. When evicting due to the size-based eviction, we are also firing an EXPIRED event
-            //    because there is a possibility that evicted entry may be also an expired one. Trying to catch
-            //    as much as possible expired entries.
-            mapEventPublisher.publishEvent(thisAddress, name, EXPIRED, key, value, null);
+        if (hasEventRegistration) {
+            mapEventPublisher.publishEvent(thisAddress, name,
+                    expired ? EXPIRED : EVICTED, key, value, null);
         }
 
         if (!ttlExpired && idleExpired) {

--- a/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigBouncingTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/dynamicconfig/DynamicConfigBouncingTest.java
@@ -187,6 +187,11 @@ public class DynamicConfigBouncingTest extends HazelcastTestSupport {
         }
 
         @Override
+        public void entryExpired(EntryEvent event) {
+
+        }
+
+        @Override
         public int hashCode() {
             return getClass().hashCode();
         }

--- a/hazelcast/src/test/java/com/hazelcast/map/AsyncTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AsyncTest.java
@@ -16,10 +16,9 @@
 
 package com.hazelcast.map;
 
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
-import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelJVMTest;
@@ -78,11 +77,7 @@ public class AsyncTest extends HazelcastTestSupport {
         IMap<String, String> map = instance.getMap(randomString());
 
         final CountDownLatch latch = new CountDownLatch(1);
-        map.addEntryListener(new EntryEvictedListener<String, String>() {
-            public void entryEvicted(EntryEvent<String, String> event) {
-                latch.countDown();
-            }
-        }, true);
+        map.addEntryListener((EntryExpiredListener<String, String>) event -> latch.countDown(), true);
 
         Future<String> f1 = map.putAsync(key, value1, 3, TimeUnit.SECONDS);
         String f1Val = f1.get();
@@ -119,11 +114,7 @@ public class AsyncTest extends HazelcastTestSupport {
         IMap<String, String> map = instance.getMap(randomString());
 
         final CountDownLatch latch = new CountDownLatch(1);
-        map.addEntryListener(new EntryEvictedListener<String, String>() {
-            public void entryEvicted(EntryEvent<String, String> event) {
-                latch.countDown();
-            }
-        }, true);
+        map.addEntryListener((EntryExpiredListener<String, String>) event -> latch.countDown(), true);
 
         Future<Void> f1 = map.setAsync(key, value1, 3, TimeUnit.SECONDS);
         f1.get();

--- a/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/EvictionTest.java
@@ -32,6 +32,7 @@ import com.hazelcast.partition.Partition;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.recordstore.RecordStore;
 import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.spi.properties.GroupProperty;
 import com.hazelcast.test.AssertTask;
@@ -637,7 +638,7 @@ public class EvictionTest extends HazelcastTestSupport {
         EntryListenerConfig entryListenerConfig = new EntryListenerConfig()
                 .setLocal(true)
                 .setImplementation(new EntryAdapter() {
-                    public void entryEvicted(EntryEvent event) {
+                    public void entryExpired(EntryEvent event) {
                         entryEvictedEventCount.incrementAndGet();
                     }
                 });
@@ -827,13 +828,7 @@ public class EvictionTest extends HazelcastTestSupport {
         IMap<Integer, Integer> map = instances[0].getMap(mapName);
 
         final CountDownLatch latch = new CountDownLatch(entryCount);
-        map.addEntryListener(new EntryAdapter<Integer, Integer>() {
-            @Override
-            public void entryEvicted(EntryEvent<Integer, Integer> event) {
-                super.entryEvicted(event);
-                latch.countDown();
-            }
-        }, false);
+        map.addEntryListener((EntryExpiredListener<Integer, Integer>) event -> latch.countDown(), false);
 
         // put some sample data
         for (int i = 0; i < entryCount; i++) {
@@ -1111,12 +1106,7 @@ public class EvictionTest extends HazelcastTestSupport {
         IMap<String, Integer> map = initialNode.getMap(mapName);
 
         final CountDownLatch evictedEntryCounterLatch = new CountDownLatch(1);
-        map.addEntryListener(new EntryAdapter<String, Integer>() {
-            @Override
-            public void entryEvicted(EntryEvent<String, Integer> event) {
-                evictedEntryCounterLatch.countDown();
-            }
-        }, false);
+        map.addEntryListener((EntryExpiredListener<String, Integer>) event -> evictedEntryCounterLatch.countDown(), false);
 
         String key = getClass().getCanonicalName();
 

--- a/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/ListenerTest.java
@@ -443,7 +443,8 @@ public class ListenerTest extends HazelcastTestSupport {
         final CountDownLatch latch = new CountDownLatch(1);
 
         map.addEntryListener(new EntryAdapter<String, String>() {
-            public void entryEvicted(EntryEvent<String, String> event) {
+            @Override
+            public void entryExpired(EntryEvent<String, String> event) {
                 value[0] = event.getValue();
                 oldValue[0] = event.getOldValue();
                 latch.countDown();
@@ -747,6 +748,11 @@ public class ListenerTest extends HazelcastTestSupport {
         }
 
         @Override
+        public void entryExpired(EntryEvent<Integer, String> event) {
+
+        }
+
+        @Override
         public void entryRemoved(EntryEvent<Integer, String> event) {
         }
 
@@ -769,6 +775,7 @@ public class ListenerTest extends HazelcastTestSupport {
         final AtomicLong removeCount = new AtomicLong();
         final AtomicLong updateCount = new AtomicLong();
         final AtomicLong evictCount = new AtomicLong();
+        final AtomicLong expiryCount = new AtomicLong();
 
         public CounterEntryListener() {
         }
@@ -791,6 +798,11 @@ public class ListenerTest extends HazelcastTestSupport {
         @Override
         public void entryEvicted(EntryEvent<Object, Object> objectObjectEntryEvent) {
             evictCount.incrementAndGet();
+        }
+
+        @Override
+        public void entryExpired(EntryEvent<Object, Object> event) {
+            expiryCount.incrementAndGet();
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/MapPreconditionsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/MapPreconditionsTest.java
@@ -630,6 +630,7 @@ public class MapPreconditionsTest extends HazelcastTestSupport {
 
         int entryAddedCalled;
         int entryEvictedCalled;
+        int entryExpiredCalled;
         int entryRemovedCalled;
         int entryUpdatedCalled;
         int mapClearedCalled;
@@ -643,6 +644,11 @@ public class MapPreconditionsTest extends HazelcastTestSupport {
         @Override
         public void entryEvicted(EntryEvent event) {
             entryEvictedCalled++;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            entryExpiredCalled++;
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/TestEntryListener.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/TestEntryListener.java
@@ -37,6 +37,11 @@ class TestEntryListener implements EntryListener, HazelcastInstanceAware {
     }
 
     @Override
+    public void entryExpired(EntryEvent event) {
+
+    }
+
+    @Override
     public void entryRemoved(EntryEvent event) {
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/EntryListenerAdaptorsTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/EntryListenerAdaptorsTest.java
@@ -66,6 +66,7 @@ public class EntryListenerAdaptorsTest {
 
         int entryAddedCalled;
         int entryEvictedCalled;
+        int entryExpiredCalled;
         int entryRemovedCalled;
         int entryUpdatedCalled;
         int mapClearedCalled;
@@ -79,6 +80,11 @@ public class EntryListenerAdaptorsTest {
         @Override
         public void entryEvicted(EntryEvent event) {
             entryEvictedCalled++;
+        }
+
+        @Override
+        public void entryExpired(EntryEvent event) {
+            entryExpiredCalled++;
         }
 
         @Override

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTest.java
@@ -705,7 +705,7 @@ public class NearCacheTest extends NearCacheTestSupport {
         IMap<Integer, Integer> map = instance.getMap(mapName);
 
         CountDownLatch latch = new CountDownLatch(mapSize);
-        addEntryEvictedListener(map, latch);
+        addEntryExpiredListener(map, latch);
 
         populateMapWithExpirableEntries(map, mapSize, 3, TimeUnit.SECONDS);
         populateNearCache(map, mapSize);

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/nearcache/NearCacheTestSupport.java
@@ -22,7 +22,6 @@ import com.hazelcast.config.EvictionPolicy;
 import com.hazelcast.config.MapConfig;
 import com.hazelcast.config.MapStoreConfig;
 import com.hazelcast.config.NearCacheConfig;
-import com.hazelcast.core.EntryEvent;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapStoreAdapter;
@@ -32,7 +31,7 @@ import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.map.impl.proxy.NearCachedMapProxyImpl;
-import com.hazelcast.map.listener.EntryEvictedListener;
+import com.hazelcast.map.listener.EntryExpiredListener;
 import com.hazelcast.monitor.NearCacheStats;
 import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.spi.impl.NodeEngineImpl;
@@ -224,13 +223,8 @@ public class NearCacheTestSupport extends HazelcastTestSupport {
         assertOpenEventually(latch);
     }
 
-    protected void addEntryEvictedListener(IMap<Integer, Integer> map, final CountDownLatch latch) {
-        map.addLocalEntryListener(new EntryEvictedListener<Integer, Integer>() {
-            @Override
-            public void entryEvicted(EntryEvent<Integer, Integer> event) {
-                latch.countDown();
-            }
-        });
+    protected void addEntryExpiredListener(IMap<Integer, Integer> map, final CountDownLatch latch) {
+        map.addLocalEntryListener((EntryExpiredListener<Integer, Integer>) event -> latch.countDown());
     }
 
     protected void populateMapWithExpirableEntries(IMap<Integer, Integer> map, int mapSize, long ttl, TimeUnit timeunit) {

--- a/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/impl/query/QueryAdvancedTest.java
@@ -123,7 +123,7 @@ public class QueryAdvancedTest extends HazelcastTestSupport {
         final CountDownLatch latch = new CountDownLatch(allEmployees);
         map.addEntryListener(new EntryAdapter() {
             @Override
-            public void entryEvicted(EntryEvent event) {
+            public void entryExpired(EntryEvent event) {
                 latch.countDown();
             }
         }, false);

--- a/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/multimap/MultiMapSplitBrainTest.java
@@ -502,5 +502,10 @@ public class MultiMapSplitBrainTest extends SplitBrainTestSupport {
         public void entryAdded(EntryEvent<K, V> event) {
 
         }
+
+        @Override
+        public void entryExpired(EntryEvent<K, V> event) {
+
+        }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapListenerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/replicatedmap/ReplicatedMapListenerTest.java
@@ -237,6 +237,11 @@ public class ReplicatedMapListenerTest extends HazelcastTestSupport {
         }
 
         @Override
+        public void entryExpired(EntryEvent<Object, Object> event) {
+            throw new UnsupportedOperationException("Expired event is not published by replicated map");
+        }
+
+        @Override
         public void mapEvicted(MapEvent event) {
             mapEvictCount.incrementAndGet();
         }


### PR DESCRIPTION
For 3.x series, we were firing both expired and evicted events when an evicted entry
is also expired. The reason for this was to keep backward compatible behavior.


closes https://github.com/hazelcast/hazelcast/issues/14712