### PR TITLE
Return result of interceptor remove call

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -768,9 +768,10 @@ public class ClientMapProxy<K, V> extends ClientProxy
     }
 
     @Override
-    public void removeInterceptor(String id) {
+    public boolean removeInterceptor(String id) {
         ClientMessage request = MapRemoveInterceptorCodec.encodeRequest(name, id);
-        invoke(request);
+        ClientMessage response = invoke(request);
+        return MapRemoveInterceptorCodec.decodeResponse(response).response;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddInterceptorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapAddInterceptorMessageTask.java
@@ -16,7 +16,7 @@
 
 package com.hazelcast.client.impl.protocol.task.map;
 
-import com.hazelcast.client.impl.AddInterceptorOperationSupplier;
+import com.hazelcast.map.impl.operation.AddInterceptorOperationSupplier;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapAddInterceptorCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractMultiTargetMessageTask;
@@ -50,7 +50,7 @@ public class MapAddInterceptorMessageTask
         final MapServiceContext mapServiceContext = mapService.getMapServiceContext();
         final MapInterceptor mapInterceptor = serializationService.toObject(parameters.interceptor);
         id = mapServiceContext.generateInterceptorId(parameters.name, mapInterceptor);
-        return new AddInterceptorOperationSupplier(id, parameters.name, mapInterceptor);
+        return new AddInterceptorOperationSupplier(parameters.name, id, mapInterceptor);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveInterceptorMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapRemoveInterceptorMessageTask.java
@@ -16,13 +16,13 @@
 
 package com.hazelcast.client.impl.protocol.task.map;
 
-import com.hazelcast.client.impl.RemoveInterceptorOperationSupplier;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.MapRemoveInterceptorCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractMultiTargetMessageTask;
 import com.hazelcast.cluster.Member;
 import com.hazelcast.instance.Node;
 import com.hazelcast.map.impl.MapService;
+import com.hazelcast.map.impl.operation.RemoveInterceptorOperationSupplier;
 import com.hazelcast.nio.Connection;
 import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.MapPermission;
@@ -42,17 +42,23 @@ public class MapRemoveInterceptorMessageTask
 
     @Override
     protected Supplier<Operation> createOperationSupplier() {
-        return new RemoveInterceptorOperationSupplier(parameters.id, parameters.name);
+        return new RemoveInterceptorOperationSupplier(parameters.name, parameters.id);
     }
 
     @Override
     protected Object reduce(Map<Member, Object> map) throws Throwable {
+        boolean interceptorRemoved = false;
         for (Object result : map.values()) {
             if (result instanceof Throwable) {
                 throw (Throwable) result;
             }
+
+            if ((Boolean) result) {
+                interceptorRemoved = true;
+            }
+
         }
-        return true;
+        return interceptorRemoved;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -2001,11 +2001,13 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
     String addInterceptor(MapInterceptor interceptor);
 
     /**
-     * Removes the given interceptor for this map, so it will not intercept operations anymore.
+     * Removes the given interceptor for this map,
+     * so it will not intercept operations anymore.
      *
      * @param id registration ID of the map interceptor
+     * @return {@code true} if registration is removed, {@code false} otherwise
      */
-    void removeInterceptor(String id);
+    boolean removeInterceptor(String id);
 
     /**
      * Adds a {@link MapListener} for this map.

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/InvocationUtil.java
@@ -66,7 +66,7 @@ public final class InvocationUtil {
 
         ClusterService clusterService = nodeEngine.getClusterService();
         if (!clusterService.isJoined()) {
-            return new CompletedFuture<Object>(null, null, new CallerRunsExecutor());
+            return new CompletedFuture(null, null, new CallerRunsExecutor());
         }
 
         RestartingMemberIterator memberIterator = new RestartingMemberIterator(clusterService, maxRetries);
@@ -83,7 +83,7 @@ public final class InvocationUtil {
         // ChainingFuture uses the iterator to start invocations
         // it invokes on another member only when the previous invocation is completed (so invocations are serial)
         // the future itself completes only when the last invocation completes (or if there is an error)
-        return new ChainingFuture<Object>(invocationIterator, executor, memberIterator, logger);
+        return new ChainingFuture(invocationIterator, executor, memberIterator, logger);
     }
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/InterceptorRegistry.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/InterceptorRegistry.java
@@ -32,9 +32,12 @@ import static java.util.Collections.unmodifiableMap;
 /**
  * Registry for {@code IMap} interceptors
  *
- * Interceptors are read mostly and this registry keeps all registered interceptor in an array to easily iterate on them.
- * Other than that, synchronized blocks are used to prevent leaks when concurrently registering/de-registering interceptors.
- * Keep in mind that all registration/de-registration operations are done in generic-operation-threads, in other words,
+ * Interceptors are read mostly and this registry keeps all
+ * registered interceptor in an array to easily iterate on them.
+ * Other than that, synchronized blocks are used to prevent leaks
+ * when concurrently registering/de-registering interceptors.
+ * Keep in mind that all registration/de-registration operations
+ * are done in generic-operation-threads, in other words,
  * synchronized methods are not used in partition-threads.
  *
  * This registry is created per map.
@@ -98,12 +101,15 @@ public class InterceptorRegistry {
      * when de-registering via {@link com.hazelcast.map.impl.operation.RemoveInterceptorOperation}
      *
      * @param id ID of the interceptor
+     * @return {@code true} when de-registration is successful
+     * otherwise returns {@code false} to indicate there is no
+     * matching registration for the provided registration id
      */
-    public synchronized void deregister(String id) {
+    public synchronized boolean deregister(String id) {
         assert !(Thread.currentThread() instanceof PartitionOperationThread);
 
         if (!id2InterceptorMap.containsKey(id)) {
-            return;
+            return false;
         }
 
         Map<String, MapInterceptor> tmpMap = new HashMap<>(id2InterceptorMap);
@@ -115,5 +121,7 @@ public class InterceptorRegistry {
         tmpInterceptors.remove(removedInterceptor);
 
         interceptors = unmodifiableList(tmpInterceptors);
+
+        return true;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextImpl.java
@@ -648,9 +648,9 @@ class MapServiceContextImpl implements MapServiceContext {
     }
 
     @Override
-    public void removeInterceptor(String mapName, String id) {
+    public boolean removeInterceptor(String mapName, String id) {
         MapContainer mapContainer = getMapContainer(mapName);
-        mapContainer.getInterceptorRegistry().deregister(id);
+        return mapContainer.getInterceptorRegistry().deregister(id);
     }
 
     // TODO: interceptors should get a wrapped object which includes the serialized version

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextInterceptorSupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MapServiceContextInterceptorSupport.java
@@ -37,7 +37,7 @@ public interface MapServiceContextInterceptorSupport {
 
     void addInterceptor(String id, String mapName, MapInterceptor interceptor);
 
-    void removeInterceptor(String mapName, String id);
+    boolean removeInterceptor(String mapName, String id);
 
     Object interceptGet(String mapName, Object value);
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperation.java
@@ -17,32 +17,29 @@
 package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.MapInterceptor;
-import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.impl.operationservice.NamedOperation;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
 import java.io.IOException;
 
-public class AddInterceptorOperation extends Operation implements MutatingOperation, NamedOperation, IdentifiedDataSerializable {
+public class AddInterceptorOperation extends MapOperation
+        implements MutatingOperation {
 
-    private MapService mapService;
     private String id;
     private MapInterceptor mapInterceptor;
-    private String mapName;
 
     public AddInterceptorOperation() {
     }
 
-    public AddInterceptorOperation(String id, MapInterceptor mapInterceptor, String mapName) {
+    public AddInterceptorOperation(String mapName,
+                                   String id,
+                                   MapInterceptor mapInterceptor) {
+        super(mapName);
         this.id = id;
         this.mapInterceptor = mapInterceptor;
-        this.mapName = mapName;
     }
 
     @Override
@@ -51,9 +48,7 @@ public class AddInterceptorOperation extends Operation implements MutatingOperat
     }
 
     @Override
-    public void run() {
-        mapService = getService();
-        MapContainer mapContainer = mapService.getMapServiceContext().getMapContainer(mapName);
+    protected void runInternal() {
         mapContainer.getInterceptorRegistry().register(id, mapInterceptor);
     }
 
@@ -65,7 +60,6 @@ public class AddInterceptorOperation extends Operation implements MutatingOperat
     @Override
     public void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        mapName = in.readUTF();
         id = in.readUTF();
         mapInterceptor = in.readObject();
     }
@@ -73,7 +67,6 @@ public class AddInterceptorOperation extends Operation implements MutatingOperat
     @Override
     public void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(mapName);
         out.writeUTF(id);
         out.writeObject(mapInterceptor);
     }
@@ -82,12 +75,7 @@ public class AddInterceptorOperation extends Operation implements MutatingOperat
     protected void toString(StringBuilder sb) {
         super.toString(sb);
 
-        sb.append(", name=").append(mapName);
-    }
-
-    @Override
-    public String getName() {
-        return mapName;
+        sb.append(", name=").append(name);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/AddInterceptorOperationSupplier.java
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-package com.hazelcast.client.impl;
+package com.hazelcast.map.impl.operation;
 
 import com.hazelcast.map.MapInterceptor;
-import com.hazelcast.map.impl.operation.AddInterceptorOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.function.Supplier;
@@ -28,14 +27,14 @@ public class AddInterceptorOperationSupplier implements Supplier<Operation> {
     private final String name;
     private final MapInterceptor mapInterceptor;
 
-    public AddInterceptorOperationSupplier(String id, String name, MapInterceptor mapInterceptor) {
-        this.id = id;
+    public AddInterceptorOperationSupplier(String name, String id, MapInterceptor mapInterceptor) {
         this.name = name;
+        this.id = id;
         this.mapInterceptor = mapInterceptor;
     }
 
     @Override
     public Operation get() {
-        return new AddInterceptorOperation(id, mapInterceptor, name);
+        return new AddInterceptorOperation(name, id, mapInterceptor);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperation.java
@@ -16,71 +16,53 @@
 
 package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.map.impl.MapContainer;
 import com.hazelcast.map.impl.MapDataSerializerHook;
-import com.hazelcast.map.impl.MapService;
-import com.hazelcast.map.impl.MapServiceContext;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.spi.impl.operationservice.NamedOperation;
-import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.MutatingOperation;
 
 import java.io.IOException;
 
-public class RemoveInterceptorOperation extends Operation implements MutatingOperation, NamedOperation,
-                                                                     IdentifiedDataSerializable {
+public class RemoveInterceptorOperation extends MapOperation
+        implements MutatingOperation {
 
-    private MapService mapService;
-    private String mapName;
     private String id;
+    private boolean interceptorRemoved;
 
     public RemoveInterceptorOperation() {
     }
 
     public RemoveInterceptorOperation(String mapName, String id) {
-        this.mapName = mapName;
+        super(mapName);
         this.id = id;
     }
 
     @Override
-    public void run() {
-        mapService = getService();
-        MapServiceContext mapServiceContext = mapService.getMapServiceContext();
-        MapContainer mapContainer = mapServiceContext.getMapContainer(mapName);
-        mapContainer.getInterceptorRegistry().deregister(id);
+    protected void runInternal() {
+        interceptorRemoved = mapContainer.getInterceptorRegistry().deregister(id);
     }
 
     @Override
     public Object getResponse() {
-        return true;
+        return interceptorRemoved;
     }
 
     @Override
     public void readInternal(ObjectDataInput in) throws IOException {
         super.readInternal(in);
-        mapName = in.readUTF();
         id = in.readUTF();
     }
 
     @Override
     public void writeInternal(ObjectDataOutput out) throws IOException {
         super.writeInternal(out);
-        out.writeUTF(mapName);
         out.writeUTF(id);
-    }
-
-    @Override
-    public String getName() {
-        return mapName;
     }
 
     @Override
     protected void toString(StringBuilder sb) {
         super.toString(sb);
 
-        sb.append(", mapName=").append(mapName);
         sb.append(", id=").append(id);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperationSupplier.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/RemoveInterceptorOperationSupplier.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package com.hazelcast.client.impl;
+package com.hazelcast.map.impl.operation;
 
-import com.hazelcast.map.impl.operation.RemoveInterceptorOperation;
 import com.hazelcast.spi.impl.operationservice.Operation;
 
 import java.util.function.Supplier;
@@ -26,9 +25,9 @@ public class RemoveInterceptorOperationSupplier implements Supplier<Operation> {
     private final String id;
     private final String name;
 
-    public RemoveInterceptorOperationSupplier(String id, String name) {
-        this.id = id;
+    public RemoveInterceptorOperationSupplier(String name, String id) {
         this.name = name;
+        this.id = id;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -456,10 +456,10 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     @Override
-    public void removeInterceptor(String id) {
+    public boolean removeInterceptor(String id) {
         checkNotNull(id, "Interceptor ID should not be null!");
 
-        removeMapInterceptorInternal(id);
+        return removeMapInterceptorInternal(id);
     }
 
     @Override


### PR DESCRIPTION
closes https://github.com/hazelcast/hazelcast/issues/9430

- `(Add|Remove)InterceptorOperation` extends MapOperation, this is to reduce code duplication.
- `IMap#removeInterceptor` returns `true|false`