### PR TITLE
Changes application/javascript to application/json in Rest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpCommand.java
@@ -47,7 +47,7 @@ public abstract class HttpCommand extends AbstractTextCommand {
     public static final byte[] CONTENT_TYPE = stringToBytes("Content-Type: ");
     public static final byte[] CONTENT_LENGTH = stringToBytes("Content-Length: ");
     public static final byte[] CONTENT_TYPE_PLAIN_TEXT = stringToBytes("text/plain");
-    public static final byte[] CONTENT_TYPE_JSON = stringToBytes("application/javascript");
+    public static final byte[] CONTENT_TYPE_JSON = stringToBytes("application/json");
     public static final byte[] CONTENT_TYPE_BINARY = stringToBytes("application/binary");
 
     protected final String uri;


### PR DESCRIPTION
Rest API used `application/javascript` "Content-Type" header to respond with json documents. This mime-type is reserved for "runnable" javascript documents(http://www.rfc-editor.org/rfc/rfc4329.txt). Instead, we must use "application/json" which is reserved for data exchange in json format(https://www.ietf.org/rfc/rfc4627.txt). Hazelcast codebase does not depend on this Content-Type header. I also checked cluster.sh file. It does not rely on Content-Type either. This should be considered a breaking change however I don't think it will have any impact on existing customers.

This change is done to correctly support Json over Rest without having multiple mime types served for json documents.