### PR TITLE
Simplifies member attributes

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/ClientMemberAttributeTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/ClientMemberAttributeTest.java
@@ -68,7 +68,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         final Member localMember = instance.getCluster().getLocalMember();
         for (int i = 0; i < count; i++) {
-            localMember.setStringAttribute("key" + i, HazelcastTestSupport.randomString());
+            localMember.setAttribute("key" + i, HazelcastTestSupport.randomString());
         }
 
         assertOpenEventually(countDownLatch);
@@ -81,15 +81,15 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         join.getTcpIpConfig().addMember("127.0.0.1").setEnabled(true);
         join.getMulticastConfig().setEnabled(false);
         MemberAttributeConfig memberAttributeConfig = c.getMemberAttributeConfig();
-        memberAttributeConfig.setIntAttribute("Test", 123);
+        memberAttributeConfig.setAttribute("Test", "123");
 
         HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(c);
         Member m1 = h1.getCluster().getLocalMember();
-        assertEquals(123, (int) m1.getIntAttribute("Test"));
+        assertEquals("123", m1.getAttribute("Test"));
 
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(c);
         Member m2 = h2.getCluster().getLocalMember();
-        assertEquals(123, (int) m2.getIntAttribute("Test"));
+        assertEquals("123", m2.getAttribute("Test"));
 
         assertClusterSize(2, h2);
 
@@ -103,13 +103,13 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m1, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         Collection<Member> members = client.getCluster().getMembers();
         for (Member m : members) {
-            assertEquals(123, (int) m.getIntAttribute("Test"));
+            assertEquals("123", m.getAttribute("Test"));
         }
     }
 
@@ -122,7 +122,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(c);
         Member m1 = h1.getCluster().getLocalMember();
-        m1.setIntAttribute("Test", 123);
+        m1.setAttribute("Test", "123");
 
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(c);
         assertClusterSize(2, h2);
@@ -137,15 +137,15 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m1, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         boolean found = false;
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
         Collection<Member> members = client.getCluster().getMembers();
         for (Member m : members) {
             if (m.equals(m1)) {
-                assertEquals(123, (int) m.getIntAttribute("Test"));
+                assertEquals("123", m.getAttribute("Test"));
                 found = true;
             }
         }
@@ -162,7 +162,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(c);
         Member m1 = h1.getCluster().getLocalMember();
-        m1.setIntAttribute("Test", 123);
+        m1.setAttribute("Test", "123");
 
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(c);
         assertClusterSize(2, h2);
@@ -177,8 +177,8 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m1, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
@@ -188,19 +188,19 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         h1.getCluster().addMembershipListener(listener);
         client.getCluster().addMembershipListener(listener);
 
-        m1.setIntAttribute("Test2", 321);
+        m1.setAttribute("Test2", "321");
 
         // Force sleep to distribute value
         assertOpenEventually(latch);
 
-        assertNotNull(member.getIntAttribute("Test2"));
-        assertEquals(321, (int) member.getIntAttribute("Test2"));
+        assertNotNull(member.getAttribute("Test2"));
+        assertEquals("321", member.getAttribute("Test2"));
 
         boolean found = false;
         Collection<Member> members = client.getCluster().getMembers();
         for (Member m : members) {
             if (m.equals(m1)) {
-                assertEquals(321, (int) m.getIntAttribute("Test2"));
+                assertEquals("321", m.getAttribute("Test2"));
                 found = true;
             }
         }
@@ -217,7 +217,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(c);
         Member m1 = h1.getCluster().getLocalMember();
-        m1.setIntAttribute("Test", 123);
+        m1.setAttribute("Test", "123");
 
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(c);
         assertClusterSize(2, h2);
@@ -232,8 +232,8 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m1, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
@@ -243,19 +243,19 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         h1.getCluster().addMembershipListener(listener);
         client.getCluster().addMembershipListener(listener);
 
-        m1.setIntAttribute("Test", 321);
+        m1.setAttribute("Test", "321");
 
         // Force sleep to distribute value
         assertOpenEventually(latch);
 
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(321, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("321", member.getAttribute("Test"));
 
         boolean found = false;
         Collection<Member> members = client.getCluster().getMembers();
         for (Member m : members) {
             if (m.equals(m1)) {
-                assertEquals(321, (int) m.getIntAttribute("Test"));
+                assertEquals("321", m.getAttribute("Test"));
                 found = true;
             }
         }
@@ -272,7 +272,7 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         HazelcastInstance h1 = hazelcastFactory.newHazelcastInstance(c);
         Member m1 = h1.getCluster().getLocalMember();
-        m1.setIntAttribute("Test", 123);
+        m1.setAttribute("Test", "123");
 
         HazelcastInstance h2 = hazelcastFactory.newHazelcastInstance(c);
         assertClusterSize(2, h2);
@@ -287,8 +287,8 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m1, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         HazelcastInstance client = hazelcastFactory.newHazelcastClient();
 
@@ -303,13 +303,13 @@ public class ClientMemberAttributeTest extends HazelcastTestSupport {
         // Force sleep to distribute value
         assertOpenEventually(latch);
 
-        assertNull(member.getIntAttribute("Test"));
+        assertNull(member.getAttribute("Test"));
 
         boolean found = false;
         Collection<Member> members = client.getCluster().getMembers();
         for (Member m : members) {
             if (m.equals(m1)) {
-                assertNull(m.getIntAttribute("Test"));
+                assertNull(m.getAttribute("Test"));
                 found = true;
             }
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/spi/impl/discovery/ClientDiscoverySpiTest.java
@@ -429,7 +429,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Map<String, Object> discoverLocalMetadata() {
+        public Map<String, String> discoverLocalMetadata() {
             return Collections.emptyMap();
         }
     }
@@ -497,7 +497,7 @@ public class ClientDiscoverySpiTest extends HazelcastTestSupport {
         }
 
         @Override
-        public Map<String, Object> discoverLocalMetadata() {
+        public Map<String, String> discoverLocalMetadata() {
             return Collections.emptyMap();
         }
     }

--- a/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
+++ b/hazelcast-spring/src/main/resources/hazelcast-spring-4.0.xsd
@@ -2653,24 +2653,10 @@
     <xs:simpleType name="attributeName">
         <xs:restriction base="non-space-string"/>
     </xs:simpleType>
-    <xs:simpleType name="attributeTypeEnum">
-        <xs:restriction base="non-space-string">
-            <xs:enumeration value="boolean"/>
-            <xs:enumeration value="byte"/>
-            <xs:enumeration value="double"/>
-            <xs:enumeration value="float"/>
-            <xs:enumeration value="int"/>
-            <xs:enumeration value="long"/>
-            <xs:enumeration value="short"/>
-            <xs:enumeration value="string"/>
-        </xs:restriction>
-    </xs:simpleType>
     <xs:complexType name="attribute">
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="name" use="required" type="attributeName"/>
-                <!--xs:attribute name="name" use="required" type="xs:ID"/-->
-                <xs:attribute name="type" use="optional" default="string" type="attributeTypeEnum"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyDiscoveryStrategy.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/DummyDiscoveryStrategy.java
@@ -44,7 +44,7 @@ public class DummyDiscoveryStrategy implements DiscoveryStrategy {
     }
 
     @Override
-    public Map<String, Object> discoverLocalMetadata() {
+    public Map<String, String> discoverLocalMetadata() {
         return Collections.emptyMap();
     }
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/TestFullApplicationContext.java
@@ -1131,14 +1131,7 @@ public class TestFullApplicationContext extends HazelcastTestSupport {
     public void testMemberAttributesConfig() {
         MemberAttributeConfig memberAttributeConfig = config.getMemberAttributeConfig();
         assertNotNull(memberAttributeConfig);
-        assertEquals("spring-group", memberAttributeConfig.getStringAttribute("cluster.group.name"));
-        assertEquals(new Integer(5700), memberAttributeConfig.getIntAttribute("cluster.port.int"));
-        assertEquals(new Long(5700), memberAttributeConfig.getLongAttribute("cluster.port.long"));
-        assertEquals(new Short("5700"), memberAttributeConfig.getShortAttribute("cluster.port.short"));
-        assertEquals(new Byte("111"), memberAttributeConfig.getByteAttribute("attribute.byte"));
-        assertTrue(memberAttributeConfig.getBooleanAttribute("attribute.boolean"));
-        assertEquals(0.0d, memberAttributeConfig.getDoubleAttribute("attribute.double"), 0.0001d);
-        assertEquals(1234.5678, memberAttributeConfig.getFloatAttribute("attribute.float"), 0.0001);
+        assertEquals("spring-group", memberAttributeConfig.getAttribute("cluster.group.name"));
     }
 
     @Test

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/advancedNetworkConfig-applicationContext-hazelcast.xml
@@ -21,7 +21,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
@@ -251,13 +251,6 @@
 
             <hz:member-attributes>
                 <hz:attribute name="cluster.group.name">spring-group</hz:attribute>
-                <hz:attribute name="cluster.port.int" type="int">5700</hz:attribute>
-                <hz:attribute name="cluster.port.long" type="long">5700</hz:attribute>
-                <hz:attribute name="cluster.port.short" type="short">5700</hz:attribute>
-                <hz:attribute name="attribute.byte" type="byte">111</hz:attribute>
-                <hz:attribute name="attribute.boolean" type="boolean">true</hz:attribute>
-                <hz:attribute name="attribute.double" type="double">0.0d</hz:attribute>
-                <hz:attribute name="attribute.float" type="float">1234.5678</hz:attribute>
             </hz:member-attributes>
 
         </hz:config>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/beans-applicationContext-hazelcast.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.11.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/client-network-defaults-context.xml
@@ -20,7 +20,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.11.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <hz:hazelcast id="instance"/>
 

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/clientNetworkConfig-applicationContext.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.11.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/fullConfig-applicationContext-hazelcast.xml
@@ -24,7 +24,7 @@
         http://www.hazelcast.com/schema/sample
         hazelcast-sample-service.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">
@@ -757,13 +757,6 @@
 
             <hz:member-attributes>
                 <hz:attribute name="cluster.group.name">spring-group</hz:attribute>
-                <hz:attribute name="cluster.port.int" type="int">5700</hz:attribute>
-                <hz:attribute name="cluster.port.long" type="long">5700</hz:attribute>
-                <hz:attribute name="cluster.port.short" type="short">5700</hz:attribute>
-                <hz:attribute name="attribute.byte" type="byte">111</hz:attribute>
-                <hz:attribute name="attribute.boolean" type="boolean">true</hz:attribute>
-                <hz:attribute name="attribute.double" type="double">0.0d</hz:attribute>
-                <hz:attribute name="attribute.float" type="float">1234.5678</hz:attribute>
             </hz:member-attributes>
 
             <hz:services>

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-failover-hazelcast.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/node-client-applicationContext-hazelcast.xml
@@ -22,7 +22,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.12.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <bean class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer"
           p:systemPropertiesModeName="SYSTEM_PROPERTIES_MODE_OVERRIDE">

--- a/hazelcast-spring/src/test/resources/com/hazelcast/spring/withoutconfig-applicationContext-hazelcast.xml
+++ b/hazelcast-spring/src/test/resources/com/hazelcast/spring/withoutconfig-applicationContext-hazelcast.xml
@@ -20,7 +20,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd
         http://www.hazelcast.com/schema/spring
-        http://www.hazelcast.com/schema/spring/hazelcast-spring-3.11.xsd">
+        http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd">
 
     <hz:hazelcast id="instance"/>
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/MemberImpl.java
@@ -23,7 +23,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.nio.serialization.SerializableByConvention;
 import com.hazelcast.version.MemberVersion;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Map;
 
@@ -55,11 +54,11 @@ public final class MemberImpl extends AbstractMember implements Member {
         super(singletonMap(MEMBER, address), version, uuid, null, false);
     }
 
-    public MemberImpl(Address address, String uuid, Map<String, Object> attributes, boolean liteMember) {
+    public MemberImpl(Address address, String uuid, Map<String, String> attributes, boolean liteMember) {
         super(singletonMap(MEMBER, address), MemberVersion.UNKNOWN, uuid, attributes, liteMember);
     }
 
-    public MemberImpl(Address address, MemberVersion version, String uuid, Map<String, Object> attributes, boolean liteMember) {
+    public MemberImpl(Address address, MemberVersion version, String uuid, Map<String, String> attributes, boolean liteMember) {
         super(singletonMap(MEMBER, address), version, uuid, attributes, liteMember);
     }
 
@@ -78,90 +77,7 @@ public final class MemberImpl extends AbstractMember implements Member {
     }
 
     @Override
-    public String getStringAttribute(String key) {
-        return (String) getAttribute(key);
-    }
-
-    @Override
-    public void setStringAttribute(String key, String value) {
-        throw notSupportedOnClient();
-    }
-
-    @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "null means 'missing'")
-    @Override
-    public Boolean getBooleanAttribute(String key) {
-        Object attribute = getAttribute(key);
-        return attribute != null ? Boolean.valueOf(attribute.toString()) : null;
-    }
-
-    @Override
-    public void setBooleanAttribute(String key, boolean value) {
-        throw notSupportedOnClient();
-    }
-
-    @Override
-    public Byte getByteAttribute(String key) {
-        Object attribute = getAttribute(key);
-        return attribute != null ? Byte.valueOf(attribute.toString()) : null;
-    }
-
-    @Override
-    public void setByteAttribute(String key, byte value) {
-        throw notSupportedOnClient();
-    }
-
-    @Override
-    public Short getShortAttribute(String key) {
-        Object attribute = getAttribute(key);
-        return attribute != null ? Short.valueOf(attribute.toString()) : null;
-    }
-
-    @Override
-    public void setShortAttribute(String key, short value) {
-        throw notSupportedOnClient();
-    }
-
-    @Override
-    public Integer getIntAttribute(String key) {
-        Object attribute = getAttribute(key);
-        return attribute != null ? Integer.valueOf(attribute.toString()) : null;
-    }
-
-    @Override
-    public void setIntAttribute(String key, int value) {
-        throw notSupportedOnClient();
-    }
-
-    @Override
-    public Long getLongAttribute(String key) {
-        Object attribute = getAttribute(key);
-        return attribute != null ? Long.valueOf(attribute.toString()) : null;
-    }
-
-    @Override
-    public void setLongAttribute(String key, long value) {
-        throw notSupportedOnClient();
-    }
-
-    @Override
-    public Float getFloatAttribute(String key) {
-        Object attribute = getAttribute(key);
-        return attribute != null ? Float.valueOf(attribute.toString()) : null;
-    }
-
-    @Override
-    public void setFloatAttribute(String key, float value) {
-        throw notSupportedOnClient();
-    }
-
-    @Override
-    public Double getDoubleAttribute(String key) {
-        Object attribute = getAttribute(key);
-        return attribute != null ? Double.valueOf(attribute.toString()) : null;
-    }
-
-    @Override
-    public void setDoubleAttribute(String key, double value) {
+    public void setAttribute(String key, String value) {
         throw notSupportedOnClient();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfig.java
@@ -25,7 +25,7 @@ import java.util.Map;
  */
 public class MemberAttributeConfig {
 
-    private final Map<String, Object> attributes = new HashMap<String, Object>();
+    private final Map<String, String> attributes = new HashMap<>();
 
     public MemberAttributeConfig() {
     }
@@ -34,79 +34,23 @@ public class MemberAttributeConfig {
         attributes.putAll(source.attributes);
     }
 
-    public Map<String, Object> getAttributes() {
+    public Map<String, String> getAttributes() {
         return attributes;
     }
 
-    public void setAttributes(Map<String, Object> attributes) {
+    public void setAttributes(Map<String, String> attributes) {
         this.attributes.clear();
         if (attributes != null) {
             this.attributes.putAll(attributes);
         }
     }
 
-    public String getStringAttribute(String key) {
-        return (String) getAttribute(key);
+    public String getAttribute(String key) {
+        return attributes.get(key);
     }
 
-    public void setStringAttribute(String key, String value) {
-        setAttribute(key, value);
-    }
-
-    public Boolean getBooleanAttribute(String key) {
-        return (Boolean) getAttribute(key);
-    }
-
-    public void setBooleanAttribute(String key, boolean value) {
-        setAttribute(key, value);
-    }
-
-    public Byte getByteAttribute(String key) {
-        return (Byte) getAttribute(key);
-    }
-
-    public void setByteAttribute(String key, byte value) {
-        setAttribute(key, value);
-    }
-
-    public Short getShortAttribute(String key) {
-        return (Short) getAttribute(key);
-    }
-
-    public void setShortAttribute(String key, short value) {
-        setAttribute(key, value);
-    }
-
-    public Integer getIntAttribute(String key) {
-        return (Integer) getAttribute(key);
-    }
-
-    public void setIntAttribute(String key, int value) {
-        setAttribute(key, value);
-    }
-
-    public Long getLongAttribute(String key) {
-        return (Long) getAttribute(key);
-    }
-
-    public void setLongAttribute(String key, long value) {
-        setAttribute(key, value);
-    }
-
-    public Float getFloatAttribute(String key) {
-        return (Float) getAttribute(key);
-    }
-
-    public void setFloatAttribute(String key, float value) {
-        setAttribute(key, value);
-    }
-
-    public Double getDoubleAttribute(String key) {
-        return (Double) getAttribute(key);
-    }
-
-    public void setDoubleAttribute(String key, double value) {
-        setAttribute(key, value);
+    public void setAttribute(String key, String value) {
+        this.attributes.put(key, value);
     }
 
     public void removeAttribute(String key) {
@@ -121,13 +65,5 @@ public class MemberAttributeConfig {
      */
     public MemberAttributeConfig asReadOnly() {
         return new MemberAttributeConfigReadOnly(this);
-    }
-
-    private Object getAttribute(String key) {
-        return attributes.get(key);
-    }
-
-    private void setAttribute(String key, Object value) {
-        attributes.put(key, value);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfigReadOnly.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberAttributeConfigReadOnly.java
@@ -31,42 +31,7 @@ public class MemberAttributeConfigReadOnly extends MemberAttributeConfig {
     }
 
     @Override
-    public void setStringAttribute(String key, String value) {
-        throw new UnsupportedOperationException("This config is read-only");
-    }
-
-    @Override
-    public void setBooleanAttribute(String key, boolean value) {
-        throw new UnsupportedOperationException("This config is read-only");
-    }
-
-    @Override
-    public void setByteAttribute(String key, byte value) {
-        throw new UnsupportedOperationException("This config is read-only");
-    }
-
-    @Override
-    public void setShortAttribute(String key, short value) {
-        throw new UnsupportedOperationException("This config is read-only");
-    }
-
-    @Override
-    public void setIntAttribute(String key, int value) {
-        throw new UnsupportedOperationException("This config is read-only");
-    }
-
-    @Override
-    public void setLongAttribute(String key, long value) {
-        throw new UnsupportedOperationException("This config is read-only");
-    }
-
-    @Override
-    public void setFloatAttribute(String key, float value) {
-        throw new UnsupportedOperationException("This config is read-only");
-    }
-
-    @Override
-    public void setDoubleAttribute(String key, double value) {
+    public void setAttribute(String key, String value) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
@@ -76,12 +41,12 @@ public class MemberAttributeConfigReadOnly extends MemberAttributeConfig {
     }
 
     @Override
-    public void setAttributes(Map<String, Object> attributes) {
+    public void setAttributes(Map<String, String> attributes) {
         throw new UnsupportedOperationException("This config is read-only");
     }
 
     @Override
-    public Map<String, Object> getAttributes() {
+    public Map<String, String> getAttributes() {
         return Collections.unmodifiableMap(super.getAttributes());
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/MemberDomConfigProcessor.java
@@ -2653,26 +2653,7 @@ class MemberDomConfigProcessor extends AbstractDomConfigProcessor {
     }
 
     void handleMemberAttributesNode(Node n, String attributeName, String value) {
-        String attributeType = getTextContent(n.getAttributes().getNamedItem("type"));
-        if ("string".equals(attributeType)) {
-            config.getMemberAttributeConfig().setStringAttribute(attributeName, value);
-        } else if ("boolean".equals(attributeType)) {
-            config.getMemberAttributeConfig().setBooleanAttribute(attributeName, parseBoolean(value));
-        } else if ("byte".equals(attributeType)) {
-            config.getMemberAttributeConfig().setByteAttribute(attributeName, Byte.parseByte(value));
-        } else if ("double".equals(attributeType)) {
-            config.getMemberAttributeConfig().setDoubleAttribute(attributeName, Double.parseDouble(value));
-        } else if ("float".equals(attributeType)) {
-            config.getMemberAttributeConfig().setFloatAttribute(attributeName, Float.parseFloat(value));
-        } else if ("int".equals(attributeType)) {
-            config.getMemberAttributeConfig().setIntAttribute(attributeName, parseInt(value));
-        } else if ("long".equals(attributeType)) {
-            config.getMemberAttributeConfig().setLongAttribute(attributeName, parseLong(value));
-        } else if ("short".equals(attributeType)) {
-            config.getMemberAttributeConfig().setShortAttribute(attributeName, Short.parseShort(value));
-        } else {
-            config.getMemberAttributeConfig().setStringAttribute(attributeName, value);
-        }
+        config.getMemberAttributeConfig().setAttribute(attributeName, value);
     }
 
     private void handleCredentialsFactory(Node node) {

--- a/hazelcast/src/main/java/com/hazelcast/config/UserCodeDeploymentConfig.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/UserCodeDeploymentConfig.java
@@ -127,7 +127,7 @@ public class UserCodeDeploymentConfig {
      * Default: {@code null}
      *
      * @return this instance of UserCodeDeploymentConfig for easy method-chaining
-     * @see com.hazelcast.core.Member#setStringAttribute(String, String)
+     * @see com.hazelcast.core.Member#setAttribute(String, String)
      */
     public UserCodeDeploymentConfig setProviderFilter(String providerFilter) {
         this.providerFilter = providerFilter;

--- a/hazelcast/src/main/java/com/hazelcast/core/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Member.java
@@ -103,9 +103,8 @@ public interface Member extends DataSerializable, Endpoint {
      * <b>This method might not be available on all native clients.</b>
      *
      * @return configured attributes for this member.
-     * @since 3.2
      */
-    Map<String, Object> getAttributes();
+    Map<String, String> getAttributes();
 
     /**
      * Returns the value of the specified key for this member or
@@ -113,9 +112,8 @@ public interface Member extends DataSerializable, Endpoint {
      *
      * @param key The key to lookup.
      * @return The value for this member key.
-     * @since 3.2
      */
-    String getStringAttribute(String key);
+    String getAttribute(String key);
 
     /**
      * Defines a key-value pair string attribute for this member available
@@ -123,149 +121,8 @@ public interface Member extends DataSerializable, Endpoint {
      *
      * @param key The key for this property.
      * @param value The value that corresponds to this attribute and this member.
-     * @since 3.2
      */
-    void setStringAttribute(String key, String value);
-
-    /**
-     * Returns the value of the specified key for this member, or
-     * null if the value is undefined.
-     *
-     * @param key The key to look up
-     * @return the value for this member key
-     * @since 3.2
-     */
-    Boolean getBooleanAttribute(String key);
-
-    /**
-     * Defines a key-value pair boolean attribute for this member that is available
-     * to other cluster members.
-     *
-     * @param key The key for this property.
-     * @param value The value that corresponds to this attribute and this member.
-     * @since 3.2
-     */
-    void setBooleanAttribute(String key, boolean value);
-
-    /**
-     * Returns the value of the specified key for this member or
-     * null if the value is undefined.
-     *
-     * @param key The key to look up.
-     * @return The value for this member key.
-     * @since 3.2
-     */
-    Byte getByteAttribute(String key);
-
-    /**
-     * Defines a key-value pair byte attribute for this member available
-     * to other cluster members.
-     *
-     * @param key The key for this property.
-     * @param value The value that corresponds to this attribute and this member.
-     * @since 3.2
-     */
-    void setByteAttribute(String key, byte value);
-
-    /**
-     * Returns the value of the specified key for this member or
-     * null if value is undefined.
-     *
-     * @param key The key to look up.
-     * @return The value for this member key.
-     * @since 3.2
-     */
-    Short getShortAttribute(String key);
-
-    /**
-     * Defines a key-value pair short attribute for this member available
-     * to other cluster members.
-     *
-     * @param key The key for this property.
-     * @param value The value that corresponds to this attribute and this member.
-     * @since 3.2
-     */
-    void setShortAttribute(String key, short value);
-
-    /**
-     * Returns the value of the specified key for this member or
-     * null if value is undefined.
-     *
-     * @param key The key to look up.
-     * @return The value for this members key.
-     * @since 3.2
-     */
-    Integer getIntAttribute(String key);
-
-    /**
-     * Defines a key-value pair int attribute for this member available
-     * to other cluster members.
-     *
-     * @param key The key for this property.
-     * @param value The value that corresponds to this attribute and this member.
-     * @since 3.2
-     */
-    void setIntAttribute(String key, int value);
-
-    /**
-     * Returns the value of the specified key for this member or
-     * null if value is undefined.
-     *
-     * @param key The key to look up.
-     * @return The value for this members key.
-     * @since 3.2
-     */
-    Long getLongAttribute(String key);
-
-    /**
-     * Defines a key-value pair long attribute for this member available
-     * to other cluster members.
-     *
-     * @param key The key for this property.
-     * @param value The value that corresponds to this attribute and this member.
-     * @since 3.2
-     */
-    void setLongAttribute(String key, long value);
-
-    /**
-     * Returns the value of the specified key for this member or
-     * null if value is undefined.
-     *
-     * @param key The key to look up.
-     * @return The value for this member key.
-     * @since 3.2
-     */
-    Float getFloatAttribute(String key);
-
-    /**
-     * Defines a key-value pair float attribute for this member available
-     * to other cluster members.
-     *
-     * @param key The key for this property.
-     * @param value The value that corresponds to this attribute and this member.
-     * @since 3.2
-     */
-    void setFloatAttribute(String key, float value);
-
-    /**
-     * Returns the value of the specified key for this member or
-     * null if value is undefined.
-     *
-     * @param key The key to look up.
-     * @return The value for this members key.
-     * @since 3.2
-     */
-    Double getDoubleAttribute(String key);
-
-    /**
-     * Defines a key-value pair double attribute for this member available
-     * to other cluster members.
-     *
-     * @param key The key for this property.
-     * @param value The value that corresponds to this attribute and this member.
-     * @since 3.2
-     */
-    void setDoubleAttribute(String key, double value);
+    void setAttribute(String key, String value);
 
     /**
      * Removes a key-value pair attribute for this member if given key was

--- a/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/MemberImpl.java
@@ -78,7 +78,7 @@ public final class MemberImpl
     }
 
     private MemberImpl(Map<EndpointQualifier, Address> addresses, MemberVersion version, boolean localMember,
-                       String uuid, Map<String, Object> attributes, boolean liteMember, int memberListJoinVersion,
+                       String uuid, Map<String, String> attributes, boolean liteMember, int memberListJoinVersion,
                        HazelcastInstanceImpl instance) {
         super(addresses, version, uuid, attributes, liteMember);
         this.memberListJoinVersion = memberListJoinVersion;
@@ -106,83 +106,8 @@ public final class MemberImpl
     }
 
     @Override
-    public String getStringAttribute(String key) {
-        return (String) getAttribute(key);
-    }
-
-    @Override
-    public void setStringAttribute(String key, String value) {
-        setAttribute(key, value);
-    }
-
-    @Override
-    public Boolean getBooleanAttribute(String key) {
-        return (Boolean) getAttribute(key);
-    }
-
-    @Override
-    public void setBooleanAttribute(String key, boolean value) {
-        setAttribute(key, value);
-    }
-
-    @Override
-    public Byte getByteAttribute(String key) {
-        return (Byte) getAttribute(key);
-    }
-
-    @Override
-    public void setByteAttribute(String key, byte value) {
-        setAttribute(key, value);
-    }
-
-    @Override
-    public Short getShortAttribute(String key) {
-        return (Short) getAttribute(key);
-    }
-
-    @Override
-    public void setShortAttribute(String key, short value) {
-        setAttribute(key, value);
-    }
-
-    @Override
-    public Integer getIntAttribute(String key) {
-        return (Integer) getAttribute(key);
-    }
-
-    @Override
-    public void setIntAttribute(String key, int value) {
-        setAttribute(key, value);
-    }
-
-    @Override
-    public Long getLongAttribute(String key) {
-        return (Long) getAttribute(key);
-    }
-
-    @Override
-    public void setLongAttribute(String key, long value) {
-        setAttribute(key, value);
-    }
-
-    @Override
-    public Float getFloatAttribute(String key) {
-        return (Float) getAttribute(key);
-    }
-
-    @Override
-    public void setFloatAttribute(String key, float value) {
-        setAttribute(key, value);
-    }
-
-    @Override
-    public Double getDoubleAttribute(String key) {
-        return (Double) getAttribute(key);
-    }
-
-    @Override
-    public void setDoubleAttribute(String key, double value) {
-        setAttribute(key, value);
+    public String getAttribute(String key) {
+        return attributes.get(key);
     }
 
     @Override
@@ -215,7 +140,8 @@ public final class MemberImpl
         }
     }
 
-    private void setAttribute(String key, Object value) {
+    @Override
+    public void setAttribute(String key, String value) {
         ensureLocalMember();
         isNotNull(key, "key");
         isNotNull(value, "value");
@@ -259,9 +185,9 @@ public final class MemberImpl
 
         private final MemberAttributeOperationType operationType;
         private final String key;
-        private final Object value;
+        private final String value;
 
-        MemberAttributeOperationSupplier(MemberAttributeOperationType operationType, String key, Object value) {
+        MemberAttributeOperationSupplier(MemberAttributeOperationType operationType, String key, String value) {
             this.operationType = operationType;
             this.key = key;
             this.value = value;
@@ -279,7 +205,7 @@ public final class MemberImpl
     public static class Builder {
         private final Map<EndpointQualifier, Address> addressMap;
 
-        private Map<String, Object> attributes;
+        private Map<String, String> attributes;
         private boolean localMember;
         private String uuid;
         private boolean liteMember;
@@ -313,7 +239,7 @@ public final class MemberImpl
             return this;
         }
 
-        public Builder attributes(Map<String, Object> attributes) {
+        public Builder attributes(Map<String, String> attributes) {
             this.attributes = attributes;
             return this;
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/Node.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/Node.java
@@ -221,7 +221,7 @@ public class Node {
             boolean liteMember = config.isLiteMember();
             address = addressPicker.getPublicAddress(MEMBER);
             nodeExtension = nodeContext.createNodeExtension(this);
-            final Map<String, Object> memberAttributes = findMemberAttributes(config.getMemberAttributeConfig().asReadOnly());
+            final Map<String, String> memberAttributes = findMemberAttributes(config.getMemberAttributeConfig().asReadOnly());
             MemberImpl localMember = new MemberImpl.Builder(addressPicker.getPublicAddressMap())
                     .version(version)
                     .localMember(true)
@@ -586,26 +586,10 @@ public class Node {
 
     private void mergeEnvironmentProvidedMemberMetadata() {
         MemberImpl localMember = getLocalMember();
-        Map<String, Object> metadata = discoveryService.discoverLocalMetadata();
-        for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+        Map<String, String> metadata = discoveryService.discoverLocalMetadata();
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
             Object value = entry.getValue();
-            if (value instanceof Byte) {
-                localMember.setByteAttribute(entry.getKey(), (Byte) value);
-            } else if (value instanceof Short) {
-                localMember.setShortAttribute(entry.getKey(), (Short) value);
-            } else if (value instanceof Integer) {
-                localMember.setIntAttribute(entry.getKey(), (Integer) value);
-            } else if (value instanceof Long) {
-                localMember.setLongAttribute(entry.getKey(), (Long) value);
-            } else if (value instanceof Float) {
-                localMember.setFloatAttribute(entry.getKey(), (Float) value);
-            } else if (value instanceof Double) {
-                localMember.setDoubleAttribute(entry.getKey(), (Double) value);
-            } else if (value instanceof Boolean) {
-                localMember.setBooleanAttribute(entry.getKey(), (Boolean) value);
-            } else {
-                localMember.setStringAttribute(entry.getKey(), value.toString());
-            }
+            localMember.setAttribute(entry.getKey(), value.toString());
         }
     }
 
@@ -913,8 +897,8 @@ public class Node {
         return buildInfo;
     }
 
-    private Map<String, Object> findMemberAttributes(MemberAttributeConfig attributeConfig) {
-        Map<String, Object> attributes = new HashMap<String, Object>(attributeConfig.getAttributes());
+    private Map<String, String> findMemberAttributes(MemberAttributeConfig attributeConfig) {
+        Map<String, String> attributes = new HashMap<>(attributeConfig.getAttributes());
         Properties properties = System.getProperties();
         for (String key : properties.stringPropertyNames()) {
             if (key.startsWith("hazelcast.member.attribute.")) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/MemberInfo.java
@@ -43,7 +43,7 @@ public class MemberInfo implements IdentifiedDataSerializable {
     private String uuid;
     private boolean liteMember;
     private MemberVersion version;
-    private Map<String, Object> attributes;
+    private Map<String, String> attributes;
     private int memberListJoinVersion = NA_MEMBER_LIST_JOIN_VERSION;
     // since 3.12
     private Map<EndpointQualifier, Address> addressMap;
@@ -51,16 +51,16 @@ public class MemberInfo implements IdentifiedDataSerializable {
     public MemberInfo() {
     }
 
-    public MemberInfo(Address address, String uuid, Map<String, Object> attributes, MemberVersion version) {
+    public MemberInfo(Address address, String uuid, Map<String, String> attributes, MemberVersion version) {
         this(address, uuid, attributes, false, version, NA_MEMBER_LIST_JOIN_VERSION, Collections.emptyMap());
     }
 
-    public MemberInfo(Address address, String uuid, Map<String, Object> attributes, boolean liteMember, MemberVersion version,
+    public MemberInfo(Address address, String uuid, Map<String, String> attributes, boolean liteMember, MemberVersion version,
                       Map<EndpointQualifier, Address> addressMap) {
         this(address, uuid, attributes, liteMember, version, NA_MEMBER_LIST_JOIN_VERSION, addressMap);
     }
 
-    public MemberInfo(Address address, String uuid, Map<String, Object> attributes, boolean liteMember, MemberVersion version,
+    public MemberInfo(Address address, String uuid, Map<String, String> attributes, boolean liteMember, MemberVersion version,
                       int memberListJoinVersion, Map<EndpointQualifier, Address> addressMap) {
         this.address = address;
         this.uuid = uuid;
@@ -88,7 +88,7 @@ public class MemberInfo implements IdentifiedDataSerializable {
         return uuid;
     }
 
-    public Map<String, Object> getAttributes() {
+    public Map<String, String> getAttributes() {
         return attributes;
     }
 
@@ -125,7 +125,7 @@ public class MemberInfo implements IdentifiedDataSerializable {
         }
         for (int i = 0; i < size; i++) {
             String key = in.readUTF();
-            Object value = in.readObject();
+            String value = in.readUTF();
             attributes.put(key, value);
         }
         version = in.readObject();
@@ -140,9 +140,9 @@ public class MemberInfo implements IdentifiedDataSerializable {
         out.writeBoolean(liteMember);
         out.writeInt(attributes == null ? 0 : attributes.size());
         if (attributes != null) {
-            for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+            for (Map.Entry<String, String> entry : attributes.entrySet()) {
                 out.writeUTF(entry.getKey());
-                out.writeObject(entry.getValue());
+                out.writeUTF(entry.getValue());
             }
         }
         out.writeObject(version);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/ClusterServiceImpl.java
@@ -490,7 +490,7 @@ public class ClusterServiceImpl implements ClusterService, ConnectionListener, M
         return true;
     }
 
-    public void updateMemberAttribute(String uuid, MemberAttributeOperationType operationType, String key, Object value) {
+    public void updateMemberAttribute(String uuid, MemberAttributeOperationType operationType, String key, String value) {
         lock.lock();
         try {
             MemberImpl member = membershipManager.getMember(uuid);

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/JoinRequest.java
@@ -40,7 +40,7 @@ public class JoinRequest extends JoinMessage {
 
     private Credentials credentials;
     private int tryCount;
-    private Map<String, Object> attributes;
+    private Map<String, String> attributes;
     private Set<String> excludedMemberUuids = Collections.emptySet();
     // see Member.getAddressMap
     private Map<EndpointQualifier, Address> addresses;
@@ -50,7 +50,7 @@ public class JoinRequest extends JoinMessage {
 
     @SuppressWarnings("checkstyle:parameternumber")
     public JoinRequest(byte packetVersion, int buildNumber, MemberVersion version, Address address, String uuid,
-                       boolean liteMember, ConfigCheck config, Credentials credentials, Map<String, Object> attributes,
+                       boolean liteMember, ConfigCheck config, Credentials credentials, Map<String, String> attributes,
                        Set<String> excludedMemberUuids, Map<EndpointQualifier, Address> addresses) {
         super(packetVersion, buildNumber, version, address, uuid, liteMember, config);
         this.credentials = credentials;
@@ -73,7 +73,7 @@ public class JoinRequest extends JoinMessage {
         this.tryCount = tryCount;
     }
 
-    public Map<String, Object> getAttributes() {
+    public Map<String, String> getAttributes() {
         return attributes;
     }
 
@@ -97,7 +97,7 @@ public class JoinRequest extends JoinMessage {
         attributes = createHashMap(size);
         for (int i = 0; i < size; i++) {
             String key = in.readUTF();
-            Object value = in.readObject();
+            String value = in.readUTF();
             attributes.put(key, value);
         }
         size = in.readInt();
@@ -116,9 +116,9 @@ public class JoinRequest extends JoinMessage {
         out.writeObject(credentials);
         out.writeInt(tryCount);
         out.writeInt(attributes.size());
-        for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+        for (Map.Entry<String, String> entry : attributes.entrySet()) {
             out.writeUTF(entry.getKey());
-            out.writeObject(entry.getValue());
+            out.writeUTF(entry.getValue());
         }
         out.writeInt(excludedMemberUuids.size());
         for (String uuid : excludedMemberUuids) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/MembershipManager.java
@@ -370,7 +370,7 @@ public class MembershipManager {
         return member;
     }
 
-    private MemberImpl createMember(MemberInfo memberInfo, Map<String, Object> attributes) {
+    private MemberImpl createMember(MemberInfo memberInfo, Map<String, String> attributes) {
         Address address = memberInfo.getAddress();
         Address thisAddress = node.getThisAddress();
         String ipV6ScopeId = thisAddress.getScopeId();

--- a/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberAttributeChangedOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/cluster/impl/operations/MemberAttributeChangedOp.java
@@ -30,12 +30,12 @@ public class MemberAttributeChangedOp extends AbstractClusterOperation {
 
     private MemberAttributeOperationType operationType;
     private String key;
-    private Object value;
+    private String value;
 
     public MemberAttributeChangedOp() {
     }
 
-    public MemberAttributeChangedOp(MemberAttributeOperationType operationType, String key, Object value) {
+    public MemberAttributeChangedOp(MemberAttributeOperationType operationType, String key, String value) {
         this.operationType = operationType;
         this.key = key;
         this.value = value;
@@ -52,7 +52,7 @@ public class MemberAttributeChangedOp extends AbstractClusterOperation {
         out.writeUTF(key);
         out.writeByte(operationType.getId());
         if (operationType == PUT) {
-            out.writeObject(value);
+            out.writeUTF(value);
         }
     }
 
@@ -61,7 +61,7 @@ public class MemberAttributeChangedOp extends AbstractClusterOperation {
         key = in.readUTF();
         operationType = MemberAttributeOperationType.getValue(in.readByte());
         if (operationType == PUT) {
-            value = in.readObject();
+            value = in.readUTF();
         }
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ZoneAwareMemberGroupFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/partition/membergroup/ZoneAwareMemberGroupFactory.java
@@ -39,9 +39,9 @@ public class ZoneAwareMemberGroupFactory extends BackupSafeMemberGroupFactory im
         Map<String, MemberGroup> groups = new HashMap<String, MemberGroup>();
         for (Member member : allMembers) {
 
-            final String zoneInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE);
-            final String rackInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK);
-            final String hostInfo = member.getStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST);
+            final String zoneInfo = member.getAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE);
+            final String rackInfo = member.getAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK);
+            final String hostInfo = member.getAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST);
 
             if (zoneInfo == null && rackInfo == null && hostInfo == null) {
                 throw new IllegalArgumentException("Not enough metadata information is provided. "

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/AbstractDiscoveryStrategy.java
@@ -57,7 +57,7 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
     }
 
     @Override
-    public Map<String, Object> discoverLocalMetadata() {
+    public Map<String, String> discoverLocalMetadata() {
         return Collections.emptyMap();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/DiscoveryStrategy.java
@@ -91,5 +91,5 @@ public interface DiscoveryStrategy {
      * @return a map of discovered metadata as provided by the runtime environment
      * @since 3.7
      */
-    Map<String, Object> discoverLocalMetadata();
+    Map<String, String> discoverLocalMetadata();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/SimpleDiscoveryNode.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/SimpleDiscoveryNode.java
@@ -44,7 +44,7 @@ public final class SimpleDiscoveryNode
      * @param privateAddress the discovered node's private address
      */
     public SimpleDiscoveryNode(Address privateAddress) {
-        this(privateAddress, privateAddress, Collections.<String, Object>emptyMap());
+        this(privateAddress, privateAddress, Collections.emptyMap());
     }
 
     /**
@@ -53,7 +53,7 @@ public final class SimpleDiscoveryNode
      * @param privateAddress the discovered node's private address
      * @param properties     the discovered node's additional properties
      */
-    public SimpleDiscoveryNode(Address privateAddress, Map<String, Object> properties) {
+    public SimpleDiscoveryNode(Address privateAddress, Map<String, String> properties) {
         this(privateAddress, privateAddress, properties);
     }
 
@@ -67,7 +67,7 @@ public final class SimpleDiscoveryNode
      * @param publicAddress  the discovered node's public address
      */
     public SimpleDiscoveryNode(Address privateAddress, Address publicAddress) {
-        this(privateAddress, publicAddress, Collections.<String, Object>emptyMap());
+        this(privateAddress, publicAddress, Collections.emptyMap());
     }
 
     /**
@@ -79,7 +79,7 @@ public final class SimpleDiscoveryNode
      * @param publicAddress  the discovered node's public address
      * @param properties     the discovered node's additional properties
      */
-    public SimpleDiscoveryNode(Address privateAddress, Address publicAddress, Map<String, Object> properties) {
+    public SimpleDiscoveryNode(Address privateAddress, Address publicAddress, Map<String, String> properties) {
         checkNotNull(privateAddress, "The private address cannot be null");
         checkNotNull(properties, "The properties cannot be null");
         this.privateAddress = privateAddress;

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/DefaultDiscoveryService.java
@@ -82,8 +82,8 @@ public class DefaultDiscoveryService
     }
 
     @Override
-    public Map<String, Object> discoverLocalMetadata() {
-        Map<String, Object> metadata = new HashMap<String, Object>();
+    public Map<String, String> discoverLocalMetadata() {
+        Map<String, String> metadata = new HashMap<>();
         for (DiscoveryStrategy discoveryStrategy : discoveryStrategies) {
             metadata.putAll(discoveryStrategy.discoverLocalMetadata());
         }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/PredefinedDiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/impl/PredefinedDiscoveryService.java
@@ -45,7 +45,7 @@ public class PredefinedDiscoveryService implements DiscoveryService {
     }
 
     @Override
-    public Map<String, Object> discoverLocalMetadata() {
+    public Map<String, String> discoverLocalMetadata() {
         return strategy.discoverLocalMetadata();
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/integration/DiscoveryService.java
@@ -71,9 +71,8 @@ public interface DiscoveryService {
      * may include, but are not limited, to location information like datacenter, rack, host or additional
      * tags to be used for custom purpose.
      * <p/>
-     * Information discovered from this method are shaded into the {@link com.hazelcast.core.Member}s
-     * attributes. Existing attributes will not be overridden, that way local attribute configuration
-     * overrides provided metadata.
+     * Information discovered from this method are copied into the {@link com.hazelcast.core.Member}s
+     * attributes. Existing attributes will be overridden.
      * <p/>
      * The default implementation provides an empty map with no further metadata configured. Returning
      * <tt>null</tt> is not permitted and will most probably result in an {@link NullPointerException}
@@ -82,5 +81,5 @@ public interface DiscoveryService {
      * @return a map of discovered metadata as provided by the runtime environment
      * @since 3.7
      */
-    Map<String, Object> discoverLocalMetadata();
+    Map<String, String> discoverLocalMetadata();
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/discovery/multicast/MulticastDiscoveryStrategy.java
@@ -33,7 +33,6 @@ import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
@@ -133,11 +132,6 @@ public class MulticastDiscoveryStrategy extends AbstractDiscoveryStrategy {
     @Override
     public PartitionGroupStrategy getPartitionGroupStrategy() {
         return null;
-    }
-
-    @Override
-    public Map<String, Object> discoverLocalMetadata() {
-        return new HashMap<String, Object>();
     }
 
     /**

--- a/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
+++ b/hazelcast/src/main/resources/hazelcast-config-4.0.xsd
@@ -3436,24 +3436,10 @@
     <xs:simpleType name="attributeName">
         <xs:restriction base="non-space-string"/>
     </xs:simpleType>
-    <xs:simpleType name="attributeTypeEnum">
-        <xs:restriction base="non-space-string">
-            <xs:enumeration value="boolean"/>
-            <xs:enumeration value="byte"/>
-            <xs:enumeration value="double"/>
-            <xs:enumeration value="float"/>
-            <xs:enumeration value="int"/>
-            <xs:enumeration value="long"/>
-            <xs:enumeration value="short"/>
-            <xs:enumeration value="string"/>
-        </xs:restriction>
-    </xs:simpleType>
     <xs:complexType name="attribute">
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="name" use="required" type="attributeName"/>
-                <!--xs:attribute name="name" use="required" type="xs:ID"/-->
-                <xs:attribute name="type" use="optional" default="string" type="attributeTypeEnum"/>
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -2389,8 +2389,8 @@
         name, type and value.
     -->
     <member-attributes>
-        <attribute name="CPU_CORE_COUNT" type="int">4</attribute>
-        <attribute name="CPU_CORE_FREQ" type="int">1033</attribute>
+        <attribute name="CPU_CORE_COUNT">4</attribute>
+        <attribute name="CPU_CORE_FREQ">1033</attribute>
     </member-attributes>
     <!--
         ===== HAZELCAST QUORUM CONFIGURATION =====

--- a/hazelcast/src/test/java/com/hazelcast/client/impl/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/impl/MemberImplTest.java
@@ -32,7 +32,6 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -76,16 +75,8 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withAttributes() throws Exception {
-        Map<String, Object> attributes = new HashMap<String, Object>();
+        Map<String, String> attributes = new HashMap<>();
         attributes.put("stringKey", "value");
-        attributes.put("booleanKeyTrue", true);
-        attributes.put("booleanKeyFalse", false);
-        attributes.put("byteKey", Byte.MAX_VALUE);
-        attributes.put("shortKey", Short.MAX_VALUE);
-        attributes.put("intKey", Integer.MAX_VALUE);
-        attributes.put("longKey", Long.MAX_VALUE);
-        attributes.put("floatKey", Float.MAX_VALUE);
-        attributes.put("doubleKey", Double.MAX_VALUE);
 
         MemberImpl member = new MemberImpl(address, VERSION, "uuid2342", attributes, true);
 
@@ -93,40 +84,8 @@ public class MemberImplTest extends HazelcastTestSupport {
         assertEquals("uuid2342", member.getUuid());
         assertTrue(member.isLiteMember());
 
-        assertEquals("value", member.getStringAttribute("stringKey"));
-        assertNull(member.getBooleanAttribute("booleanKey"));
-
-        Boolean booleanValueTrue = member.getBooleanAttribute("booleanKeyTrue");
-        assertNotNull(booleanValueTrue);
-        assertTrue(booleanValueTrue);
-
-        Boolean booleanValueFalse = member.getBooleanAttribute("booleanKeyFalse");
-        assertNotNull(booleanValueFalse);
-        assertFalse(booleanValueFalse);
-
-        Byte byteValue = member.getByteAttribute("byteKey");
-        assertNotNull(byteValue);
-        assertEquals(Byte.MAX_VALUE, byteValue.byteValue());
-
-        Short shortValue = member.getShortAttribute("shortKey");
-        assertNotNull(shortValue);
-        assertEquals(Short.MAX_VALUE, shortValue.shortValue());
-
-        Integer intValue = member.getIntAttribute("intKey");
-        assertNotNull(intValue);
-        assertEquals(Integer.MAX_VALUE, intValue.intValue());
-
-        Long longValue = member.getLongAttribute("longKey");
-        assertNotNull(longValue);
-        assertEquals(Long.MAX_VALUE, longValue.longValue());
-
-        Float floatValue = member.getFloatAttribute("floatKey");
-        assertNotNull(floatValue);
-        assertEquals(Float.MAX_VALUE, floatValue, 0.000001);
-
-        Double doubleValue = member.getDoubleAttribute("doubleKey");
-        assertNotNull(doubleValue);
-        assertEquals(Double.MAX_VALUE, doubleValue, 0.000001);
+        assertEquals("value", member.getAttribute("stringKey"));
+        assertNull(member.getAttribute("keydoesnotexist"));
     }
 
     @Test
@@ -137,51 +96,9 @@ public class MemberImplTest extends HazelcastTestSupport {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testSetStringAttribute() {
+    public void testSetAttribute() {
         MemberImpl member = new MemberImpl(address, VERSION);
-        member.setStringAttribute("stringKey", "stringValue");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetBooleanAttribute() {
-        MemberImpl member = new MemberImpl(address, VERSION);
-        member.setBooleanAttribute("booleanKeyTrue", true);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetByteAttribute() {
-        MemberImpl member = new MemberImpl(address, VERSION);
-        member.setByteAttribute("byteKey", Byte.MAX_VALUE);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetShortAttribute() {
-        MemberImpl member = new MemberImpl(address, VERSION);
-        member.setShortAttribute("shortKey", Short.MAX_VALUE);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetIntAttribute() {
-        MemberImpl member = new MemberImpl(address, VERSION);
-        member.setIntAttribute("intKey", Integer.MAX_VALUE);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetLongAttribute() {
-        MemberImpl member = new MemberImpl(address, VERSION);
-        member.setLongAttribute("longKey", Long.MAX_VALUE);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetFloatAttribute() {
-        MemberImpl member = new MemberImpl(address, VERSION);
-        member.setFloatAttribute("floatKey", Float.MAX_VALUE);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSetDoubleAttribute() {
-        MemberImpl member = new MemberImpl(address, VERSION);
-        member.setDoubleAttribute("doubleKey", Double.MAX_VALUE);
+        member.setAttribute("stringKey", "stringValue");
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
+++ b/hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility/ReferenceObjects.java
@@ -627,7 +627,7 @@ public class ReferenceObjects {
     }
 
     public static Member aMember = new MemberImpl(anAddress, MemberVersion.UNKNOWN, aString,
-            Collections.singletonMap(aString, (Object) aString), false);
+            Collections.singletonMap(aString, aString), false);
     public static Collection<Map.Entry<Address, List<Integer>>> aPartitionTable;
 
     static {

--- a/hazelcast/src/test/java/com/hazelcast/cluster/MemberAttributeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cluster/MemberAttributeTest.java
@@ -48,15 +48,15 @@ public class MemberAttributeTest extends HazelcastTestSupport {
         TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory(2);
 
         MemberAttributeConfig memberAttributeConfig = config.getMemberAttributeConfig();
-        memberAttributeConfig.setIntAttribute("Test", 123);
+        memberAttributeConfig.setAttribute("Test", "123");
 
         HazelcastInstance h1 = factory.newHazelcastInstance(config);
         Member m1 = h1.getCluster().getLocalMember();
-        assertEquals(123, (int) m1.getIntAttribute("Test"));
+        assertEquals("123", m1.getAttribute("Test"));
 
         HazelcastInstance h2 = factory.newHazelcastInstance(config);
         Member m2 = h2.getCluster().getLocalMember();
-        assertEquals(123, (int) m2.getIntAttribute("Test"));
+        assertEquals("123", m2.getAttribute("Test"));
 
         assertClusterSize(2, h1, h2);
 
@@ -70,8 +70,8 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m1, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         for (Member m : h1.getCluster().getMembers()) {
             if (m == h1.getCluster().getLocalMember()) {
@@ -82,8 +82,8 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m2, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         h1.shutdown();
         h2.shutdown();
@@ -95,7 +95,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         HazelcastInstance h1 = factory.newHazelcastInstance();
         Member m1 = h1.getCluster().getLocalMember();
-        m1.setIntAttribute("Test", 123);
+        m1.setAttribute("Test", "123");
 
         HazelcastInstance h2 = factory.newHazelcastInstance();
         assertClusterSize(2, h2);
@@ -110,8 +110,8 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m1, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         h1.shutdown();
         h2.shutdown();
@@ -123,7 +123,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         HazelcastInstance h1 = factory.newHazelcastInstance();
         Member m1 = h1.getCluster().getLocalMember();
-        m1.setIntAttribute("Test", 123);
+        m1.setAttribute("Test", "123");
 
         HazelcastInstance h2 = factory.newHazelcastInstance();
         assertClusterSize(2, h2);
@@ -138,21 +138,21 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m1, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         final CountDownLatch latch = new CountDownLatch(2);
         final MembershipListener listener = new LatchMembershipListener(latch);
         h2.getCluster().addMembershipListener(listener);
         h1.getCluster().addMembershipListener(listener);
 
-        m1.setIntAttribute("Test2", 321);
+        m1.setAttribute("Test2", "321");
 
         // Force sleep to distribute value
         assertOpenEventually(latch);
 
-        assertNotNull(member.getIntAttribute("Test2"));
-        assertEquals(321, (int) member.getIntAttribute("Test2"));
+        assertNotNull(member.getAttribute("Test2"));
+        assertEquals("321", member.getAttribute("Test2"));
 
         h1.shutdown();
         h2.shutdown();
@@ -164,7 +164,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         HazelcastInstance h1 = factory.newHazelcastInstance();
         Member m1 = h1.getCluster().getLocalMember();
-        m1.setIntAttribute("Test", 123);
+        m1.setAttribute("Test", "123");
 
         HazelcastInstance h2 = factory.newHazelcastInstance();
         assertClusterSize(2, h2);
@@ -179,21 +179,21 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m1, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         final CountDownLatch latch = new CountDownLatch(2);
         final MembershipListener listener = new LatchMembershipListener(latch);
         h2.getCluster().addMembershipListener(listener);
         h1.getCluster().addMembershipListener(listener);
 
-        m1.setIntAttribute("Test", 321);
+        m1.setAttribute("Test", "321");
 
         // Force sleep to distribute value
         assertOpenEventually(latch);
 
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(321, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("321", member.getAttribute("Test"));
 
         h1.shutdown();
         h2.shutdown();
@@ -205,7 +205,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         HazelcastInstance h1 = factory.newHazelcastInstance();
         Member m1 = h1.getCluster().getLocalMember();
-        m1.setIntAttribute("Test", 123);
+        m1.setAttribute("Test", "123");
 
         HazelcastInstance h2 = factory.newHazelcastInstance();
         assertClusterSize(2, h2);
@@ -220,8 +220,8 @@ public class MemberAttributeTest extends HazelcastTestSupport {
 
         assertNotNull(member);
         assertEquals(m1, member);
-        assertNotNull(member.getIntAttribute("Test"));
-        assertEquals(123, (int) member.getIntAttribute("Test"));
+        assertNotNull(member.getAttribute("Test"));
+        assertEquals("123", member.getAttribute("Test"));
 
         final CountDownLatch latch = new CountDownLatch(2);
         final MembershipListener listener = new LatchMembershipListener(latch);
@@ -233,7 +233,7 @@ public class MemberAttributeTest extends HazelcastTestSupport {
         // Force sleep to distribute value
         assertOpenEventually(latch);
 
-        assertNull(member.getIntAttribute("Test"));
+        assertNull(member.getAttribute("Test"));
 
         h1.shutdown();
         h2.shutdown();
@@ -246,17 +246,17 @@ public class MemberAttributeTest extends HazelcastTestSupport {
         System.setProperty("hazelcast.member.attribute.Test-4", "123456");
 
         Config config = new Config();
-        config.getMemberAttributeConfig().setIntAttribute("Test-1", 123);
-        config.getMemberAttributeConfig().setIntAttribute("Test-2", 123);
+        config.getMemberAttributeConfig().setAttribute("Test-1", "123");
+        config.getMemberAttributeConfig().setAttribute("Test-2", "123");
 
         HazelcastInstance h1 = createHazelcastInstance(config);
         Member m1 = h1.getCluster().getLocalMember();
-        m1.setIntAttribute("Test-4", 1234567);
+        m1.setAttribute("Test-4", "1234567");
 
-        assertEquals(123, (int) m1.getIntAttribute("Test-1"));
-        assertEquals("1234", m1.getStringAttribute("Test-2"));
-        assertEquals("12345", m1.getStringAttribute("Test-3"));
-        assertEquals(1234567, (int) m1.getIntAttribute("Test-4"));
+        assertEquals("123", m1.getAttribute("Test-1"));
+        assertEquals("1234", m1.getAttribute("Test-2"));
+        assertEquals("12345", m1.getAttribute("Test-3"));
+        assertEquals("1234567", m1.getAttribute("Test-4"));
 
         h1.shutdown();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/MemberAttributeConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/MemberAttributeConfigTest.java
@@ -34,6 +34,6 @@ public class MemberAttributeConfigTest {
      */
     @Test(expected = java.lang.UnsupportedOperationException.class)
     public void testReadOnlyMemberAttributeConfigSetAttributes() {
-        new MemberAttributeConfigReadOnly(new MemberAttributeConfig()).setAttributes(new HashMap<String, Object>());
+        new MemberAttributeConfigReadOnly(new MemberAttributeConfig()).setAttributes(new HashMap<>());
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -3006,7 +3006,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         } finally {
             IOUtil.closeResource(xmlResource);
         }
-        Set<PermissionType> permTypes = new HashSet<PermissionType>(Arrays.asList(PermissionType.values()));
+        Set<PermissionType> permTypes = new HashSet<>(Arrays.asList(PermissionType.values()));
         for (PermissionConfig pc : config.getSecurityConfig().getClientPermissionConfigs()) {
             permTypes.remove(pc.getType());
         }
@@ -3187,14 +3187,14 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
     public void testHandleMemberAttributes() {
         String xml = HAZELCAST_START_TAG
                 + "<member-attributes>\n"
-                + "     <attribute name=\"IDENTIFIER\" type=\"string\">ID</attribute>\n"
+                + "     <attribute name=\"IDENTIFIER\">ID</attribute>\n"
                 + "</member-attributes>"
                 + HAZELCAST_END_TAG;
 
         Config config = buildConfig(xml);
         MemberAttributeConfig memberAttributeConfig = config.getMemberAttributeConfig();
         assertNotNull(memberAttributeConfig);
-        assertEquals("ID", memberAttributeConfig.getStringAttribute("IDENTIFIER"));
+        assertEquals("ID", memberAttributeConfig.getAttribute("IDENTIFIER"));
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlSchemaValidationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlSchemaValidationTest.java
@@ -148,7 +148,7 @@ public class XmlSchemaValidationTest {
         expectDuplicateElementError("member-attributes");
         String memberAttConfig = ""
                 + "    <member-attributes>\n"
-                + "        <attribute name=\"attribute.float\" type=\"float\">1234.5678</attribute>\n"
+                + "        <attribute name=\"attribute\">1234.5678</attribute>\n"
                 + "    </member-attributes>\n";
         buildConfig(HAZELCAST_START_TAG + memberAttConfig + memberAttConfig + HAZELCAST_END_TAG);
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -3229,7 +3229,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         Config config = buildConfig(yaml);
         MemberAttributeConfig memberAttributeConfig = config.getMemberAttributeConfig();
         assertNotNull(memberAttributeConfig);
-        assertEquals("ID", memberAttributeConfig.getStringAttribute("IDENTIFIER"));
+        assertEquals("ID", memberAttributeConfig.getAttribute("IDENTIFIER"));
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/MemberImplTest.java
@@ -115,9 +115,9 @@ public class MemberImplTest extends HazelcastTestSupport {
 
     @Test
     public void testConstructor_withAttributes() throws Exception {
-        Map<String, Object> attributes = new HashMap<String, Object>();
+        Map<String, String> attributes = new HashMap<>();
         attributes.put("key1", "value");
-        attributes.put("key2", 12345);
+        attributes.put("key2", "12345");
 
         MemberImpl member = new MemberImpl.Builder(address).version(MemberVersion.of("3.8.0")).localMember(true)
                 .uuid("uuid2342").attributes(attributes).instance(hazelcastInstance).build();
@@ -126,7 +126,7 @@ public class MemberImplTest extends HazelcastTestSupport {
         assertTrue(member.localMember());
         assertEquals("uuid2342", member.getUuid());
         assertEquals("value", member.getAttribute("key1"));
-        assertEquals(12345, member.getAttribute("key2"));
+        assertEquals("12345", member.getAttribute("key2"));
         assertFalse(member.isLiteMember());
     }
 
@@ -151,95 +151,22 @@ public class MemberImplTest extends HazelcastTestSupport {
     @Test
     public void testStringAttribute() {
         MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true);
-        assertNull(member.getStringAttribute("stringKey"));
+        assertNull(member.getAttribute("stringKey"));
 
-        member.setStringAttribute("stringKey", "stringValue");
-        assertEquals("stringValue", member.getStringAttribute("stringKey"));
-    }
-
-    @Test
-    public void testBooleanAttribute() {
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true);
-        assertNull(member.getBooleanAttribute("booleanKeyTrue"));
-        assertNull(member.getBooleanAttribute("booleanKeyFalse"));
-
-        member.setBooleanAttribute("booleanKeyTrue", true);
-        assertTrue(member.getBooleanAttribute("booleanKeyTrue"));
-
-        member.setBooleanAttribute("booleanKeyFalse", false);
-        assertFalse(member.getBooleanAttribute("booleanKeyFalse"));
-    }
-
-    @Test
-    public void testByteAttribute() {
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true);
-        assertNull(member.getByteAttribute("byteKey"));
-
-        Byte value = Byte.MAX_VALUE;
-        member.setByteAttribute("byteKey", value);
-        assertEquals(value, member.getByteAttribute("byteKey"));
-    }
-
-    @Test
-    public void testShortAttribute() {
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true);
-        assertNull(member.getShortAttribute("shortKey"));
-
-        Short value = Short.MAX_VALUE;
-        member.setShortAttribute("shortKey", value);
-        assertEquals(value, member.getShortAttribute("shortKey"));
-    }
-
-    @Test
-    public void testIntAttribute() {
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true);
-        assertNull(member.getIntAttribute("intKey"));
-
-        Integer value = Integer.MAX_VALUE;
-        member.setIntAttribute("intKey", value);
-        assertEquals(value, member.getIntAttribute("intKey"));
-    }
-
-    @Test
-    public void testLongAttribute() {
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true);
-        assertNull(member.getLongAttribute("longKey"));
-
-        Long value = Long.MAX_VALUE;
-        member.setLongAttribute("longKey", value);
-        assertEquals(value, member.getLongAttribute("longKey"));
-    }
-
-    @Test
-    public void testFloatAttribute() {
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true);
-        assertNull(member.getFloatAttribute("floatKey"));
-
-        Float value = Float.MAX_VALUE;
-        member.setFloatAttribute("floatKey", value);
-        assertEquals(value, member.getFloatAttribute("floatKey"), 0.001);
-    }
-
-    @Test
-    public void testDoubleAttribute() {
-        MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true);
-        assertNull(member.getDoubleAttribute("doubleKey"));
-
-        Double value = Double.MAX_VALUE;
-        member.setDoubleAttribute("doubleKey", value);
-        assertEquals(value, member.getDoubleAttribute("doubleKey"), 0.001);
+        member.setAttribute("stringKey", "stringValue");
+        assertEquals("stringValue", member.getAttribute("stringKey"));
     }
 
     @Test
     public void testRemoveAttribute() {
         MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), true);
-        assertNull(member.getStringAttribute("removeKey"));
+        assertNull(member.getAttribute("removeKey"));
 
-        member.setStringAttribute("removeKey", "removeValue");
-        assertEquals("removeValue", member.getStringAttribute("removeKey"));
+        member.setAttribute("removeKey", "removeValue");
+        assertEquals("removeValue", member.getAttribute("removeKey"));
 
         member.removeAttribute("removeKey");
-        assertNull(member.getStringAttribute("removeKey"));
+        assertNull(member.getAttribute("removeKey"));
     }
 
     @Test
@@ -248,7 +175,7 @@ public class MemberImplTest extends HazelcastTestSupport {
                 .instance(hazelcastInstance).build();
 
         member.removeAttribute("removeKeyWithInstance");
-        assertNull(member.getStringAttribute("removeKeyWithInstance"));
+        assertNull(member.getAttribute("removeKeyWithInstance"));
     }
 
     @Test
@@ -256,8 +183,8 @@ public class MemberImplTest extends HazelcastTestSupport {
         MemberImpl member = new MemberImpl.Builder(address).version(MemberVersion.of("3.8.0")).localMember(true).uuid("uuid")
                 .instance(hazelcastInstance).build();
 
-        member.setStringAttribute("setKeyWithInstance", "setValueWithInstance");
-        assertEquals("setValueWithInstance", member.getStringAttribute("setKeyWithInstance"));
+        member.setAttribute("setKeyWithInstance", "setValueWithInstance");
+        assertEquals("setValueWithInstance", member.getAttribute("setKeyWithInstance"));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -269,7 +196,7 @@ public class MemberImplTest extends HazelcastTestSupport {
     @Test(expected = UnsupportedOperationException.class)
     public void testSetAttribute_onRemoteMember() {
         MemberImpl member = new MemberImpl(address, MemberVersion.of("3.8.0"), false);
-        member.setStringAttribute("remoteMemberSet", "wontWork");
+        member.setAttribute("remoteMemberSet", "wontWork");
     }
 
     @Test

--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -90,80 +90,17 @@ public class SimpleMemberImpl implements Member {
     }
 
     @Override
-    public Map<String, Object> getAttributes() {
+    public Map<String, String> getAttributes() {
         return null;
     }
 
     @Override
-    public String getStringAttribute(String key) {
+    public String getAttribute(String key) {
         return null;
     }
 
     @Override
-    public void setStringAttribute(String key, String value) {
-    }
-
-    @Override
-    public Boolean getBooleanAttribute(String key) {
-        return null;
-    }
-
-    @Override
-    public void setBooleanAttribute(String key, boolean value) {
-    }
-
-    @Override
-    public Byte getByteAttribute(String key) {
-        return null;
-    }
-
-    @Override
-    public void setByteAttribute(String key, byte value) {
-    }
-
-    @Override
-    public Short getShortAttribute(String key) {
-        return null;
-    }
-
-    @Override
-    public void setShortAttribute(String key, short value) {
-    }
-
-    @Override
-    public Integer getIntAttribute(String key) {
-        return null;
-    }
-
-    @Override
-    public void setIntAttribute(String key, int value) {
-    }
-
-    @Override
-    public Long getLongAttribute(String key) {
-        return null;
-    }
-
-    @Override
-    public void setLongAttribute(String key, long value) {
-    }
-
-    @Override
-    public Float getFloatAttribute(String key) {
-        return null;
-    }
-
-    @Override
-    public void setFloatAttribute(String key, float value) {
-    }
-
-    @Override
-    public Double getDoubleAttribute(String key) {
-        return null;
-    }
-
-    @Override
-    public void setDoubleAttribute(String key, double value) {
+    public void setAttribute(String key, String value) {
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializationTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/ClusterDataSerializationTest.java
@@ -110,10 +110,9 @@ public class ClusterDataSerializationTest {
         Address clientAddress = new Address("127.0.0.1", 7654);
         Address restAddress = new Address("127.0.0.1", 8080);
         // member attributes, test an integer, a String and an IdentifiedDataSerializable as values
-        Map<String, Object> attributes = new HashMap<String, Object>();
-        attributes.put("a", 2);
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("a", "2");
         attributes.put("b", "b");
-        attributes.put("c", new Address("127.0.0.1", 5999));
         Map<EndpointQualifier, Address> addressMap = new HashMap<EndpointQualifier, Address>();
         addressMap.put(MEMBER, memberAddress);
         addressMap.put(CLIENT, clientAddress);
@@ -129,7 +128,6 @@ public class ClusterDataSerializationTest {
         assertEquals(deserialized.getUuid(), memberInfo.getUuid());
         assertEquals(deserialized.getAttributes().get("a"), memberInfo.getAttributes().get("a"));
         assertEquals(deserialized.getAttributes().get("b"), memberInfo.getAttributes().get("b"));
-        assertEquals(deserialized.getAttributes().get("c"), memberInfo.getAttributes().get("c"));
         assertEquals(3, deserialized.getAddressMap().size());
         assertEquals(memberAddress, deserialized.getAddressMap().get(MEMBER));
         assertEquals(clientAddress, deserialized.getAddressMap().get(CLIENT));

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/MembershipUpdateTest.java
@@ -607,7 +607,7 @@ public class MembershipUpdateTest extends HazelcastTestSupport {
         MembershipManager membershipManager = clusterService.getMembershipManager();
 
         MemberInfo newMemberInfo = new MemberInfo(new Address("127.0.0.1", 6000), newUnsecureUuidString(),
-                Collections.<String, Object>emptyMap(), node.getVersion());
+                Collections.emptyMap(), node.getVersion());
         MembersView membersView =
                 MembersView.cloneAdding(membershipManager.getMembersView(), singleton(newMemberInfo));
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/cluster/impl/PromoteLiteMemberTest.java
@@ -350,25 +350,25 @@ public class PromoteLiteMemberTest extends HazelcastTestSupport {
 
         // Get local member and SET attribute BEFORE promotion
         Member localMember = hz.getCluster().getLocalMember();
-        localMember.setStringAttribute(attribute1, attributeValue);
-        assertEquals(attributeValue, localMember.getStringAttribute(attribute1));
+        localMember.setAttribute(attribute1, attributeValue);
+        assertEquals(attributeValue, localMember.getAttribute(attribute1));
 
         // Promote local Lite member
         hz.getCluster().promoteLocalLiteMember();
 
         // Get local member and SET attribute AFTER promotion
         localMember = hz.getCluster().getLocalMember();
-        localMember.setStringAttribute(attribute2, attributeValue);
+        localMember.setAttribute(attribute2, attributeValue);
 
         // Check attributes from localMember
-        assertEquals(attributeValue, localMember.getStringAttribute(attribute1));
-        assertEquals(attributeValue, localMember.getStringAttribute(attribute2));
+        assertEquals(attributeValue, localMember.getAttribute(attribute1));
+        assertEquals(attributeValue, localMember.getAttribute(attribute2));
 
         // Check attributes from member list
         for (Member member : hz.getCluster().getMembers()) {
             if (member.localMember()) {
-                assertEquals(attributeValue, member.getStringAttribute(attribute1));
-                assertEquals(attributeValue, member.getStringAttribute(attribute2));
+                assertEquals(attributeValue, member.getAttribute(attribute1));
+                assertEquals(attributeValue, member.getAttribute(attribute2));
                 break;
             }
         }

--- a/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/MemberProviderFilterParserTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/MemberProviderFilterParserTest.java
@@ -64,8 +64,8 @@ public class MemberProviderFilterParserTest extends HazelcastTestSupport {
     @Test
     public void givenMemberAttributeFilterIsUsed_whenMemberAttributeIsPresent_thenFilterMatches() {
         Filter<Member> memberFilter = MemberProviderFilterParser.parseMemberFilter("HAS_ATTRIBUTE:foo");
-        Map<String, Object> attributes = ImmutableMap.of(
-                "foo", (Object) "bar"
+        Map<String, String> attributes = ImmutableMap.of(
+                "foo", "bar"
         );
         Member mockMember = createMockMemberWithAttributes(attributes);
         assertTrue(memberFilter.accept(mockMember));
@@ -74,14 +74,14 @@ public class MemberProviderFilterParserTest extends HazelcastTestSupport {
     @Test
     public void givenMemberAttributeFilterIsUsed_whenMemberAttributeIsNotPresent_thenFilterDoesNotMatch() {
         Filter<Member> memberFilter = MemberProviderFilterParser.parseMemberFilter("HAS_ATTRIBUTE:foo");
-        Map<String, Object> attributes = ImmutableMap.of(
-                "bar", (Object) "other"
+        Map<String, String> attributes = ImmutableMap.of(
+                "bar", "other"
         );
         Member mockMember = createMockMemberWithAttributes(attributes);
         assertFalse(memberFilter.accept(mockMember));
     }
 
-    private static Member createMockMemberWithAttributes(Map<String, Object> attributes) {
+    private static Member createMockMemberWithAttributes(Map<String, String> attributes) {
         Member mockMember = mock(Member.class);
         when(mockMember.getAttributes()).thenReturn(attributes);
         return mockMember;

--- a/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/UserCodeDeploymentAbstractTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/usercodedeployment/impl/filter/UserCodeDeploymentAbstractTest.java
@@ -200,7 +200,7 @@ public abstract class UserCodeDeploymentAbstractTest extends HazelcastTestSuppor
     @Test
     public void givenProviderFilterUsesMemberAttribute_whenSomeMemberHasMatchingAttribute_thenClassLoadingRequestSucceed() {
         Config i1Config = new Config();
-        i1Config.getMemberAttributeConfig().setStringAttribute("foo", "bar");
+        i1Config.getMemberAttributeConfig().setAttribute("foo", "bar");
         i1Config.getUserCodeDeploymentConfig()
                 .setEnabled(true)
                 .setClassCacheMode(getClassCacheMode());

--- a/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/partition/membergroup/MemberGroupFactoryTest.java
@@ -96,13 +96,13 @@ public class MemberGroupFactoryTest {
     private Collection<Member> createMembersWithZoneAwareMetadata() {
         Collection<Member> members = new HashSet<Member>();
         MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
-        member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "us-east-1");
+        member1.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "us-east-1");
 
         MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
-        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "us-west-1");
+        member2.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "us-west-1");
 
         MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
-        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "eu-central-1");
+        member3.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_ZONE, "eu-central-1");
 
         members.add(member1);
         members.add(member2);
@@ -125,13 +125,13 @@ public class MemberGroupFactoryTest {
     private Collection<Member> createMembersWithRackAwareMetadata() {
         Collection<Member> members = new HashSet<Member>();
         MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
-        member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-1");
+        member1.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-1");
 
         MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
-        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-2");
+        member2.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-2");
 
         MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
-        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-3");
+        member3.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_RACK, "rack-3");
 
         members.add(member1);
         members.add(member2);
@@ -154,13 +154,13 @@ public class MemberGroupFactoryTest {
     private Collection<Member> createMembersWithHostAwareMetadata() {
         Collection<Member> members = new HashSet<Member>();
         MemberImpl member1 = new MemberImpl(new Address("192.192.0.1", fakeAddress, 5701), VERSION, true);
-        member1.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-1");
+        member1.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-1");
 
         MemberImpl member2 = new MemberImpl(new Address("192.192.0.2", fakeAddress, 5701), VERSION, true);
-        member2.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-2");
+        member2.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-2");
 
         MemberImpl member3 = new MemberImpl(new Address("192.192.0.3", fakeAddress, 5701), VERSION, true);
-        member3.setStringAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-3");
+        member3.setAttribute(PartitionGroupMetaData.PARTITION_GROUP_HOST, "host-3");
 
         members.add(member1);
         members.add(member2);

--- a/hazelcast/src/test/java/com/hazelcast/spi/discovery/impl/SimplePredefinedDiscoveryServiceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/discovery/impl/SimplePredefinedDiscoveryServiceTest.java
@@ -68,12 +68,12 @@ public class SimplePredefinedDiscoveryServiceTest {
 
     @Test
     public void discoverLocalMetadata() {
-        final Map<String, Object> metadata = new HashMap<String, Object>();
-        metadata.put("a", 1);
-        metadata.put("b", 2);
+        final Map<String, String> metadata = new HashMap<>();
+        metadata.put("a", "1");
+        metadata.put("b", "2");
         final PredefinedDiscoveryService service = new PredefinedDiscoveryService(new ExtendableDiscoveryStrategy() {
             @Override
-            public Map<String, Object> discoverLocalMetadata() {
+            public Map<String, String> discoverLocalMetadata() {
                 return metadata;
             }
         });

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.xml
@@ -39,7 +39,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
     <group>
         <name>dev</name>
@@ -767,13 +767,6 @@
 
     <member-attributes>
         <attribute name="attribute.string">hazelcast</attribute>
-        <attribute name="attribute.int" type="int">123</attribute>
-        <attribute name="attribute.long" type="long">456</attribute>
-        <attribute name="attribute.short" type="short">789</attribute>
-        <attribute name="attribute.byte" type="byte">111</attribute>
-        <attribute name="attribute.boolean" type="boolean">true</attribute>
-        <attribute name="attribute.double" type="double">0.0d</attribute>
-        <attribute name="attribute.float" type="float">1234.5678</attribute>
     </member-attributes>
 
 

--- a/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig-without-network.yaml
@@ -765,28 +765,6 @@ hazelcast:
   member-attributes:
     attribute.string:
       value: hazelcast
-    attribute.int:
-      type: int
-      value: 123
-    attribute.long:
-      type: long
-      value: 456
-    attribute.short:
-      type: short
-      value: 789
-    attribute.byte:
-      type: byte
-      value: 111
-    attribute.boolean:
-      type: boolean
-      value: true
-    attribute.double:
-      type: double
-      value: 0.0d
-    attribute.float:
-      type: float
-      value: 1234.5678
-
 
   crdt-replication:
     replication-period-millis: 1000

--- a/hazelcast/src/test/resources/hazelcast-fullconfig.xml
+++ b/hazelcast/src/test/resources/hazelcast-fullconfig.xml
@@ -36,7 +36,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
 
     <import resource="hazelcast-fullconfig-without-network.xml"/>
 


### PR DESCRIPTION
Removes primitives support for [set|get]Attribute operations. All member attributes including DiscoveryStrategy#discoverLocalMetadata and spring supports only string attributes now.

Fixes #14907