### PR TITLE
Avoid deserialization when merging entries received via WAN

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/EntryViews.java
@@ -19,7 +19,6 @@ package com.hazelcast.map.impl;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.map.impl.record.Record;
 import com.hazelcast.map.merge.MapMergePolicy;
-import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
 
 /**
@@ -38,8 +37,9 @@ public final class EntryViews {
      * @param <V> the type of value.
      * @return returns  null entry view.
      */
-    public static <K, V> EntryView<K, V> createNullEntryView(K key) {
-        return new NullEntryView<>(key);
+    public static <K, V> EntryView<K, V> createLazyNullEntryView(K key,
+                                                                 SerializationService serializationService) {
+        return new LazyNullEntryView<>(key, serializationService);
     }
 
     public static <K, V> EntryView<K, V> createSimpleEntryView() {
@@ -48,20 +48,6 @@ public final class EntryViews {
 
     public static <K, V> EntryView<K, V> createSimpleEntryView(K key, V value, Record record) {
         return new SimpleEntryView<>(key, value)
-                .withCost(record.getCost())
-                .withVersion(record.getVersion())
-                .withHits(record.getHits())
-                .withLastAccessTime(record.getLastAccessTime())
-                .withLastUpdateTime(record.getLastUpdateTime())
-                .withTtl(record.getTtl())
-                .withMaxIdle(record.getMaxIdle())
-                .withCreationTime(record.getCreationTime())
-                .withExpirationTime(record.getExpirationTime())
-                .withLastStoredTime(record.getLastStoredTime());
-    }
-
-    public static EntryView<Data, Data> toSimpleEntryView(Record<Data> record) {
-        return new SimpleEntryView<>(record.getKey(), record.getValue())
                 .withCost(record.getCost())
                 .withVersion(record.getVersion())
                 .withHits(record.getHits())

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/LazyNullEntryView.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/LazyNullEntryView.java
@@ -17,23 +17,27 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.EntryView;
+import com.hazelcast.spi.serialization.SerializationService;
 
 /**
- * Contains only key no value.
+ * Contains only key and no value.
  *
- * @param <K>
- * @param <V>
+ * @param <K> key type
+ * @param <V> value type
  */
-class NullEntryView<K, V> implements EntryView<K, V> {
+class LazyNullEntryView<K, V> implements EntryView<K, V> {
 
+    private final SerializationService serializationService;
     private K key;
 
-    NullEntryView(K key) {
+    LazyNullEntryView(K key, SerializationService serializationService) {
         this.key = key;
+        this.serializationService = serializationService;
     }
 
     @Override
     public K getKey() {
+        key = serializationService.toObject(key);
         return key;
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/recordstore/DefaultRecordStore.java
@@ -787,8 +787,7 @@ public class DefaultRecordStore extends AbstractEvictableRecordStore {
         Object newValue;
         Object oldValue = null;
         if (record == null) {
-            Object notExistingKey = mapServiceContext.toObject(key);
-            EntryView nullEntryView = EntryViews.createNullEntryView(notExistingKey);
+            EntryView nullEntryView = EntryViews.createLazyNullEntryView(key, serializationService);
             newValue = mergePolicy.merge(name, mergingEntry, nullEntryView);
             if (newValue == null) {
                 return false;


### PR DESCRIPTION
Even with hazelcast.wan.map.useDeleteWhenProcessingRemoveEvents set to
true, the key would unconditionally be deserialized. This not only
introduces a overhead in the case when using built-in merge policies but
also fails when the class is not present in the target cluster,
rendering WAN replication unusable. Fixed by using lazy deserialization.

EE (contains test): https://github.com/hazelcast/hazelcast-enterprise/pull/2951