### PR TITLE
Raft linearizable read optimization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/NodeEngineRaftIntegration.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/NodeEngineRaftIntegration.java
@@ -61,6 +61,7 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.cp.internal.raft.impl.RaftNodeStatus.STEPPED_DOWN;
 import static com.hazelcast.cp.internal.raft.impl.RaftNodeStatus.TERMINATED;
 import static com.hazelcast.spi.ExecutionService.ASYNC_EXECUTOR;
+import static com.hazelcast.spi.properties.GroupProperty.RAFT_LINEARIZABLE_READ_OPTIMIZATION_ENABLED;
 
 /**
  * The integration point of the Raft algorithm implementation and
@@ -77,6 +78,7 @@ final class NodeEngineRaftIntegration implements RaftIntegration {
     private final TaskScheduler taskScheduler;
     private final int partitionId;
     private final int threadId;
+    private final boolean linearizableReadOptimizationEnabled;
 
     NodeEngineRaftIntegration(NodeEngineImpl nodeEngine, CPGroupId groupId, CPMember localCPMember) {
         this.nodeEngine = nodeEngine;
@@ -88,6 +90,8 @@ final class NodeEngineRaftIntegration implements RaftIntegration {
         OperationExecutorImpl operationExecutor = (OperationExecutorImpl) operationService.getOperationExecutor();
         this.threadId = operationExecutor.toPartitionThreadIndex(partitionId);
         this.taskScheduler = nodeEngine.getExecutionService().getGlobalTaskScheduler();
+        this.linearizableReadOptimizationEnabled = nodeEngine.getProperties()
+                                                             .getBoolean(RAFT_LINEARIZABLE_READ_OPTIMIZATION_ENABLED);
     }
 
     @Override
@@ -115,6 +119,11 @@ final class NodeEngineRaftIntegration implements RaftIntegration {
     @Override
     public Object getAppendedEntryOnLeaderElection() {
         return new NotifyTermChangeOp();
+    }
+
+    @Override
+    public boolean isLinearizableReadOptimizationEnabled() {
+        return linearizableReadOptimizationEnabled;
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/NodeEngineRaftIntegration.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/NodeEngineRaftIntegration.java
@@ -51,6 +51,7 @@ import com.hazelcast.spi.impl.operationexecutor.impl.PartitionOperationThread;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.spi.impl.operationservice.impl.OperationServiceImpl;
 import com.hazelcast.spi.impl.servicemanager.ServiceInfo;
+import com.hazelcast.spi.properties.HazelcastProperty;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -61,7 +62,6 @@ import java.util.concurrent.TimeUnit;
 import static com.hazelcast.cp.internal.raft.impl.RaftNodeStatus.STEPPED_DOWN;
 import static com.hazelcast.cp.internal.raft.impl.RaftNodeStatus.TERMINATED;
 import static com.hazelcast.spi.ExecutionService.ASYNC_EXECUTOR;
-import static com.hazelcast.spi.properties.GroupProperty.RAFT_LINEARIZABLE_READ_OPTIMIZATION_ENABLED;
 
 /**
  * The integration point of the Raft algorithm implementation and
@@ -70,6 +70,14 @@ import static com.hazelcast.spi.properties.GroupProperty.RAFT_LINEARIZABLE_READ_
  */
 @SuppressWarnings("checkstyle:classfanoutcomplexity")
 final class NodeEngineRaftIntegration implements RaftIntegration {
+
+    /**
+     * !!! ONLY FOR INTERNAL USAGE AND TESTING !!!
+     * Enables / disables the linearizable read optimization described in the Raft Dissertation Section 6.4.
+     */
+    public static final HazelcastProperty RAFT_LINEARIZABLE_READ_OPTIMIZATION_ENABLED
+            = new HazelcastProperty("raft.linearizable.read.optimization.enabled", true);
+
 
     private final NodeEngineImpl nodeEngine;
     private final CPGroupId groupId;

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftInvocationManager.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftInvocationManager.java
@@ -44,14 +44,14 @@ import com.hazelcast.spi.impl.operationservice.impl.RaftInvocationContext;
 import com.hazelcast.spi.properties.GroupProperty;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 
-import static com.hazelcast.cp.internal.raft.QueryPolicy.LEADER_LOCAL;
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.spi.ExecutionService.ASYNC_EXECUTOR;
+import static java.util.Collections.shuffle;
 
 /**
  * Performs invocations to create & destroy Raft groups,
@@ -112,7 +112,7 @@ public class RaftInvocationManager {
     private void invokeGetMembersToCreateRaftGroup(String groupName, int groupSize,
                                                    SimpleCompletableFuture<RaftGroupId> resultFuture) {
         RaftOp op = new GetActiveCPMembersOp();
-        ICompletableFuture<List<CPMemberInfo>> f = query(raftService.getMetadataGroupId(), op, LEADER_LOCAL);
+        ICompletableFuture<List<CPMemberInfo>> f = query(raftService.getMetadataGroupId(), op, LINEARIZABLE);
 
         f.andThen(new ExecutionCallback<List<CPMemberInfo>>() {
             @Override
@@ -126,7 +126,7 @@ public class RaftInvocationManager {
                     return;
                 }
 
-                Collections.shuffle(members);
+                shuffle(members);
                 members.sort(new CPMemberReachabilityComparator());
                 members = members.subList(0, groupSize);
                 invokeCreateRaftGroup(groupName, groupSize, members, resultFuture);

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/RaftService.java
@@ -90,6 +90,7 @@ import static com.hazelcast.cp.CPGroup.DEFAULT_GROUP_NAME;
 import static com.hazelcast.cp.CPGroup.METADATA_CP_GROUP_NAME;
 import static com.hazelcast.cp.internal.RaftGroupMembershipManager.MANAGEMENT_TASK_PERIOD_IN_MILLIS;
 import static com.hazelcast.cp.internal.raft.QueryPolicy.LEADER_LOCAL;
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.internal.config.ConfigValidator.checkCPSubsystemConfig;
 import static com.hazelcast.spi.ExecutionService.ASYNC_EXECUTOR;
 import static com.hazelcast.spi.ExecutionService.SYSTEM_EXECUTOR;
@@ -167,21 +168,21 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
     }
 
     public ICompletableFuture<Collection<CPGroupId>> getAllCPGroupIds() {
-        return invocationManager.invoke(getMetadataGroupId(), new GetRaftGroupIdsOp());
+        return invocationManager.query(getMetadataGroupId(), new GetRaftGroupIdsOp(), LINEARIZABLE);
     }
 
     @Override
     public ICompletableFuture<Collection<CPGroupId>> getCPGroupIds() {
-        return invocationManager.invoke(getMetadataGroupId(), new GetActiveRaftGroupIdsOp());
+        return invocationManager.query(getMetadataGroupId(), new GetActiveRaftGroupIdsOp(), LINEARIZABLE);
     }
 
     public ICompletableFuture<CPGroup> getCPGroup(CPGroupId groupId) {
-        return invocationManager.invoke(getMetadataGroupId(), new GetRaftGroupOp(groupId));
+        return invocationManager.query(getMetadataGroupId(), new GetRaftGroupOp(groupId), LINEARIZABLE);
     }
 
     @Override
     public ICompletableFuture<CPGroup> getCPGroup(String name) {
-        return invocationManager.invoke(getMetadataGroupId(), new GetActiveRaftGroupByNameOp(name));
+        return invocationManager.query(getMetadataGroupId(), new GetActiveRaftGroupByNameOp(name), LINEARIZABLE);
     }
 
     @Override
@@ -387,7 +388,7 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
 
     @Override
     public ICompletableFuture<Collection<CPMember>> getCPMembers() {
-        return invocationManager.invoke(getMetadataGroupId(), new GetActiveCPMembersOp());
+        return invocationManager.query(getMetadataGroupId(), new GetActiveCPMembersOp(), LINEARIZABLE);
     }
 
     @Override
@@ -739,8 +740,7 @@ public class RaftService implements ManagedService, SnapshotAwareService<Metadat
     }
 
     private InternalCompletableFuture<CPGroupInfo> getGroupInfoForProxy(String groupName) {
-        RaftOp op = new GetActiveRaftGroupByNameOp(groupName);
-        return invocationManager.invoke(getMetadataGroupId(), op);
+        return invocationManager.query(getMetadataGroupId(), new GetActiveRaftGroupByNameOp(groupName), LINEARIZABLE);
     }
 
     private ICompletableFuture<Void> invokeTriggerRemoveMember(CPMemberInfo member) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/ApplyMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/ApplyMessageTask.java
@@ -31,6 +31,8 @@ import com.hazelcast.security.permission.AtomicLongPermission;
 
 import java.security.Permission;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
+
 /**
  * Client message task for {@link ApplyOp}
  */
@@ -46,7 +48,7 @@ public class ApplyMessageTask extends AbstractMessageTask<CPAtomicLongApplyCodec
         IFunction<Long, Object> function = serializationService.toObject(parameters.function);
         RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         service.getInvocationManager()
-               .invoke(parameters.groupId, new ApplyOp<>(parameters.name, function))
+               .query(parameters.groupId, new ApplyOp<>(parameters.name, function), LINEARIZABLE)
                .andThen(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetAndAddMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetAndAddMessageTask.java
@@ -20,6 +20,10 @@ import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.codec.CPAtomicLongGetAndAddCodec;
 import com.hazelcast.client.impl.protocol.task.AbstractMessageTask;
 import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.cp.CPGroupId;
+import com.hazelcast.cp.internal.RaftInvocationManager;
+import com.hazelcast.cp.internal.RaftOp;
 import com.hazelcast.cp.internal.RaftService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.RaftAtomicLongService;
 import com.hazelcast.cp.internal.datastructures.atomiclong.operation.GetAndAddOp;
@@ -29,6 +33,8 @@ import com.hazelcast.security.permission.ActionConstants;
 import com.hazelcast.security.permission.AtomicLongPermission;
 
 import java.security.Permission;
+
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 
 /**
  * Client message task for {@link GetAndAddOp}
@@ -43,9 +49,13 @@ public class GetAndAddMessageTask extends AbstractMessageTask<CPAtomicLongGetAnd
     @Override
     protected void processMessage() {
         RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
-        service.getInvocationManager()
-               .<Long>invoke(parameters.groupId, new GetAndAddOp(parameters.name, parameters.delta))
-               .andThen(this);
+        RaftInvocationManager invocationManager = service.getInvocationManager();
+        CPGroupId groupId = parameters.groupId;
+        long delta = parameters.delta;
+        RaftOp op = new GetAndAddOp(parameters.name, delta);
+        ICompletableFuture<Long> future = (delta == 0)
+                ? invocationManager.query(groupId, op, LINEARIZABLE) : invocationManager.invoke(groupId, op);
+        future.andThen(this);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomiclong/client/GetMessageTask.java
@@ -30,6 +30,8 @@ import com.hazelcast.security.permission.AtomicLongPermission;
 
 import java.security.Permission;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
+
 /**
  * Client message task for {@link GetAndAddOp}
  */
@@ -44,7 +46,7 @@ public class GetMessageTask extends AbstractMessageTask<CPAtomicLongGetCodec.Req
     protected void processMessage() {
         RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         service.getInvocationManager()
-               .<Long>invoke(parameters.groupId, new GetAndAddOp(parameters.name, 0))
+               .<Long>query(parameters.groupId, new GetAndAddOp(parameters.name, 0), LINEARIZABLE)
                .andThen(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/ContainsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/ContainsMessageTask.java
@@ -30,6 +30,8 @@ import com.hazelcast.security.permission.AtomicReferencePermission;
 
 import java.security.Permission;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
+
 /**
  * Client message task for {@link ContainsOp}
  */
@@ -44,7 +46,7 @@ public class ContainsMessageTask extends AbstractMessageTask<CPAtomicRefContains
     protected void processMessage() {
         RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         service.getInvocationManager()
-               .<Boolean>invoke(parameters.groupId, new ContainsOp(parameters.name, parameters.value))
+               .<Boolean>query(parameters.groupId, new ContainsOp(parameters.name, parameters.value), LINEARIZABLE)
                .andThen(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/GetMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/atomicref/client/GetMessageTask.java
@@ -30,6 +30,8 @@ import com.hazelcast.security.permission.AtomicReferencePermission;
 
 import java.security.Permission;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
+
 /**
  * Client message task for {@link GetOp}
  */
@@ -44,7 +46,7 @@ public class GetMessageTask extends AbstractMessageTask<CPAtomicRefGetCodec.Requ
     protected void processMessage() {
         RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         service.getInvocationManager()
-               .invoke(parameters.groupId, new GetOp(parameters.name))
+               .query(parameters.groupId, new GetOp(parameters.name), LINEARIZABLE)
                .andThen(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/GetCountMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/GetCountMessageTask.java
@@ -30,6 +30,8 @@ import com.hazelcast.security.permission.CountDownLatchPermission;
 
 import java.security.Permission;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
+
 /**
  * Client message task for {@link GetCountOp}
  */
@@ -44,7 +46,7 @@ public class GetCountMessageTask extends AbstractMessageTask<CPCountDownLatchGet
     protected void processMessage() {
         RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         service.getInvocationManager()
-               .<Integer>invoke(parameters.groupId, new GetCountOp(parameters.name))
+               .<Integer>query(parameters.groupId, new GetCountOp(parameters.name), LINEARIZABLE)
                .andThen(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/GetRoundMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/client/GetRoundMessageTask.java
@@ -30,6 +30,8 @@ import com.hazelcast.security.permission.CountDownLatchPermission;
 
 import java.security.Permission;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
+
 /**
  * Client message task for {@link GetRoundOp}
  */
@@ -44,7 +46,7 @@ public class GetRoundMessageTask extends AbstractMessageTask<CPCountDownLatchGet
     protected void processMessage() {
         RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         service.getInvocationManager()
-               .<Integer>invoke(parameters.groupId, new GetRoundOp(parameters.name))
+                .<Integer>query(parameters.groupId, new GetRoundOp(parameters.name), LINEARIZABLE)
                 .andThen(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/proxy/RaftCountDownLatchProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/countdownlatch/proxy/RaftCountDownLatchProxy.java
@@ -32,6 +32,7 @@ import com.hazelcast.spi.NodeEngine;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.util.Preconditions.checkNotNull;
 import static com.hazelcast.util.UuidUtil.newUnsecureUUID;
 
@@ -63,13 +64,13 @@ public class RaftCountDownLatchProxy implements ICountDownLatch {
 
     @Override
     public void countDown() {
-        int round = invocationManager.<Integer>invoke(groupId, new GetRoundOp(objectName)).join();
+        int round = invocationManager.<Integer>query(groupId, new GetRoundOp(objectName), LINEARIZABLE).join();
         invocationManager.invoke(groupId, new CountDownOp(objectName, newUnsecureUUID(), round)).join();
     }
 
     @Override
     public int getCount() {
-        return invocationManager.<Integer>invoke(groupId, new GetCountOp(objectName)).join();
+        return invocationManager.<Integer>query(groupId, new GetCountOp(objectName), LINEARIZABLE).join();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/GetLockOwnershipStateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/lock/client/GetLockOwnershipStateMessageTask.java
@@ -31,6 +31,8 @@ import com.hazelcast.security.permission.LockPermission;
 
 import java.security.Permission;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
+
 /**
  * Client message task for {@link GetLockOwnershipStateOp}
  */
@@ -45,7 +47,7 @@ public class GetLockOwnershipStateMessageTask extends AbstractMessageTask<CPFenc
     protected void processMessage() {
         RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         service.getInvocationManager()
-               .<RaftLockOwnershipState>invoke(parameters.groupId, new GetLockOwnershipStateOp(parameters.name))
+               .<RaftLockOwnershipState>query(parameters.groupId, new GetLockOwnershipStateOp(parameters.name), LINEARIZABLE)
                .andThen(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/AvailablePermitsMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/client/AvailablePermitsMessageTask.java
@@ -30,6 +30,8 @@ import com.hazelcast.security.permission.SemaphorePermission;
 
 import java.security.Permission;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
+
 /**
  * Client message task for {@link AvailablePermitsOp}
  */
@@ -44,7 +46,7 @@ public class AvailablePermitsMessageTask extends AbstractMessageTask<CPSemaphore
     protected void processMessage() {
         RaftService service = nodeEngine.getService(RaftService.SERVICE_NAME);
         service.getInvocationManager()
-               .<Integer>invoke(parameters.groupId, new AvailablePermitsOp(parameters.name))
+               .<Integer>query(parameters.groupId, new AvailablePermitsOp(parameters.name), LINEARIZABLE)
                .andThen(this);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/proxy/RaftSessionAwareSemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/proxy/RaftSessionAwareSemaphoreProxy.java
@@ -39,6 +39,7 @@ import com.hazelcast.util.Clock;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.cp.internal.session.AbstractProxySessionManager.NO_SESSION_ID;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
 import static com.hazelcast.util.Preconditions.checkPositive;
@@ -170,7 +171,7 @@ public class RaftSessionAwareSemaphoreProxy extends SessionAwareProxy implements
 
     @Override
     public int availablePermits() {
-        return invocationManager.<Integer>invoke(groupId, new AvailablePermitsOp(objectName)).join();
+        return invocationManager.<Integer>query(groupId, new AvailablePermitsOp(objectName), LINEARIZABLE).join();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/proxy/RaftSessionlessSemaphoreProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/datastructures/semaphore/proxy/RaftSessionlessSemaphoreProxy.java
@@ -35,6 +35,7 @@ import com.hazelcast.spi.NodeEngine;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.cp.internal.session.AbstractProxySessionManager.NO_SESSION_ID;
 import static com.hazelcast.util.Preconditions.checkNotNegative;
 import static com.hazelcast.util.Preconditions.checkPositive;
@@ -116,7 +117,7 @@ public class RaftSessionlessSemaphoreProxy extends SessionAwareProxy implements 
 
     @Override
     public int availablePermits() {
-        return invocationManager.<Integer>invoke(groupId, new AvailablePermitsOp(objectName)).join();
+        return invocationManager.<Integer>query(groupId, new AvailablePermitsOp(objectName), LINEARIZABLE).join();
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftIntegration.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftIntegration.java
@@ -195,6 +195,14 @@ public interface RaftIntegration {
     Object getAppendedEntryOnLeaderElection();
 
     /**
+     * Returns true if the linearizable read optimization is enabled.
+     * <p>
+     * See Section 6.4 of the Raft Dissertation for more information about
+     * the linearizable read optimization.
+     */
+    boolean isLinearizableReadOptimizationEnabled();
+
+    /**
      * Called when RaftNode status changes.
      * @param status new status
      */

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/dto/AppendRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/dto/AppendRequest.java
@@ -45,19 +45,21 @@ public class AppendRequest implements IdentifiedDataSerializable {
     private long prevLogIndex;
     private long leaderCommitIndex;
     private LogEntry[] entries;
+    private long queryRound;
 
     public AppendRequest() {
     }
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public AppendRequest(Endpoint leader, int term, int prevLogTerm, long prevLogIndex, long leaderCommitIndex,
-            LogEntry[] entries) {
-        this.term = term;
+                         LogEntry[] entries, long queryRound) {
         this.leader = leader;
+        this.term = term;
         this.prevLogTerm = prevLogTerm;
         this.prevLogIndex = prevLogIndex;
         this.leaderCommitIndex = leaderCommitIndex;
         this.entries = entries;
+        this.queryRound = queryRound;
     }
 
     public Endpoint leader() {
@@ -89,6 +91,10 @@ public class AppendRequest implements IdentifiedDataSerializable {
         return entries.length;
     }
 
+    public long queryRound() {
+        return queryRound;
+    }
+
     @Override
     public int getFactoryId() {
         return RaftDataSerializerHook.F_ID;
@@ -111,6 +117,8 @@ public class AppendRequest implements IdentifiedDataSerializable {
         for (LogEntry entry : entries) {
             out.writeObject(entry);
         }
+
+        out.writeLong(queryRound);
     }
 
     @Override
@@ -126,13 +134,15 @@ public class AppendRequest implements IdentifiedDataSerializable {
         for (int i = 0; i < len; i++) {
             entries[i] = in.readObject();
         }
+
+        queryRound = in.readLong();
     }
 
     @Override
     public String toString() {
         return "AppendRequest{" + "leader=" + leader + ", term=" + term + ", prevLogTerm=" + prevLogTerm
-                + ", prevLogIndex=" + prevLogIndex + ", leaderCommitIndex=" + leaderCommitIndex + ", entries=" + Arrays
-                .toString(entries) + '}';
+                + ", prevLogIndex=" + prevLogIndex + ", leaderCommitIndex=" + leaderCommitIndex + ", queryRound=" + queryRound
+                + ", entries=" + Arrays.toString(entries) + '}';
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/dto/AppendSuccessResponse.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/dto/AppendSuccessResponse.java
@@ -39,14 +39,16 @@ public class AppendSuccessResponse implements IdentifiedDataSerializable {
     private Endpoint follower;
     private int term;
     private long lastLogIndex;
+    private long queryRound;
 
     public AppendSuccessResponse() {
     }
 
-    public AppendSuccessResponse(Endpoint follower, int term, long lastLogIndex) {
+    public AppendSuccessResponse(Endpoint follower, int term, long lastLogIndex, long queryRound) {
         this.follower = follower;
         this.term = term;
         this.lastLogIndex = lastLogIndex;
+        this.queryRound = queryRound;
     }
 
     public Endpoint follower() {
@@ -59,6 +61,10 @@ public class AppendSuccessResponse implements IdentifiedDataSerializable {
 
     public long lastLogIndex() {
         return lastLogIndex;
+    }
+
+    public long queryRound() {
+        return queryRound;
     }
 
     @Override
@@ -76,6 +82,7 @@ public class AppendSuccessResponse implements IdentifiedDataSerializable {
         out.writeInt(term);
         out.writeObject(follower);
         out.writeLong(lastLogIndex);
+        out.writeLong(queryRound);
     }
 
     @Override
@@ -83,12 +90,13 @@ public class AppendSuccessResponse implements IdentifiedDataSerializable {
         term = in.readInt();
         follower = in.readObject();
         lastLogIndex = in.readLong();
+        queryRound = in.readLong();
     }
 
     @Override
     public String toString() {
         return "AppendSuccessResponse{" + "follower=" + follower + ", term=" + term  + ", lastLogIndex="
-                + lastLogIndex + '}';
+                + lastLogIndex + ", queryRound=" + queryRound + '}';
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/dto/InstallSnapshot.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/dto/InstallSnapshot.java
@@ -38,18 +38,18 @@ import java.io.IOException;
 public class InstallSnapshot implements IdentifiedDataSerializable {
 
     private Endpoint leader;
-
     private int term;
-
     private SnapshotEntry snapshot;
+    private long queryRound;
 
     public InstallSnapshot() {
     }
 
-    public InstallSnapshot(Endpoint leader, int term, SnapshotEntry snapshot) {
+    public InstallSnapshot(Endpoint leader, int term, SnapshotEntry snapshot, long queryRound) {
         this.leader = leader;
         this.term = term;
         this.snapshot = snapshot;
+        this.queryRound = queryRound;
     }
 
     public Endpoint leader() {
@@ -62,6 +62,10 @@ public class InstallSnapshot implements IdentifiedDataSerializable {
 
     public SnapshotEntry snapshot() {
         return snapshot;
+    }
+
+    public long queryRound() {
+        return queryRound;
     }
 
     @Override
@@ -79,6 +83,7 @@ public class InstallSnapshot implements IdentifiedDataSerializable {
         out.writeObject(leader);
         out.writeInt(term);
         out.writeObject(snapshot);
+        out.writeLong(queryRound);
     }
 
     @Override
@@ -86,11 +91,13 @@ public class InstallSnapshot implements IdentifiedDataSerializable {
         leader = in.readObject();
         term = in.readInt();
         snapshot = in.readObject();
+        queryRound = in.readLong();
     }
 
     @Override
     public String toString() {
-        return "InstallSnapshot{" + "leader=" + leader + ", term=" + term + ", snapshot=" + snapshot + '}';
+        return "InstallSnapshot{" + "leader=" + leader + ", term=" + term + ", snapshot=" + snapshot + ", queryRound="
+                + queryRound + '}';
     }
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendFailureResponseHandlerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendFailureResponseHandlerTask.java
@@ -61,8 +61,7 @@ public class AppendFailureResponseHandlerTask extends AbstractResponseHandlerTas
         if (resp.term() > state.term()) {
             // If RPC request or response contains term T > currentTerm: set currentTerm = T, convert to follower (§5.1)
             logger.info("Demoting to FOLLOWER after " + resp + " from current term: " + state.term());
-            state.toFollower(resp.term());
-            raftNode.printMemberState();
+            raftNode.toFollower(resp.term());
             return;
         }
 
@@ -78,7 +77,6 @@ public class AppendFailureResponseHandlerTask extends AbstractResponseHandlerTas
     private boolean updateNextIndex(RaftState state) {
         LeaderState leaderState = state.leaderState();
         FollowerState followerState = leaderState.getFollowerState(resp.follower());
-
 
         long nextIndex = followerState.nextIndex();
         long matchIndex = followerState.matchIndex();

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendSuccessResponseHandlerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/AppendSuccessResponseHandlerTask.java
@@ -23,9 +23,13 @@ import com.hazelcast.cp.internal.raft.impl.log.LogEntry;
 import com.hazelcast.cp.internal.raft.impl.log.RaftLog;
 import com.hazelcast.cp.internal.raft.impl.state.FollowerState;
 import com.hazelcast.cp.internal.raft.impl.state.LeaderState;
+import com.hazelcast.cp.internal.raft.impl.state.QueryState;
 import com.hazelcast.cp.internal.raft.impl.state.RaftState;
+import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.SimpleCompletableFuture;
 
 import java.util.Arrays;
+import java.util.Collection;
 
 import static com.hazelcast.cp.internal.raft.impl.RaftRole.LEADER;
 import static java.util.Arrays.sort;
@@ -69,35 +73,29 @@ public class AppendSuccessResponseHandlerTask extends AbstractResponseHandlerTas
             logger.fine("Received " + resp);
         }
 
-        // If successful: update nextIndex and matchIndex for follower (§5.3)
         if (!updateFollowerIndices(state)) {
+            tryRunQueries(state);
             return;
         }
 
-        // If there exists an N such that N > commitIndex, a majority of matchIndex[i] ≥ N, and log[N].term == currentTerm:
-        // set commitIndex = N (§5.3, §5.4)
-        long quorumMatchIndex = findQuorumMatchIndex(state);
-        long commitIndex = state.commitIndex();
-        RaftLog raftLog = state.log();
-        for (; quorumMatchIndex > commitIndex; quorumMatchIndex--) {
-            // Only log entries from the leader’s current term are committed by counting replicas; once an entry
-            // from the current term has been committed in this way, then all prior entries are committed indirectly
-            // because of the Log Matching Property.
-            LogEntry entry = raftLog.getLogEntry(quorumMatchIndex);
-            if (entry.term() == state.term()) {
-                commitEntries(state, quorumMatchIndex);
-                break;
-            } else if (logger.isFineEnabled()) {
-                logger.fine("Cannot commit " + entry + " since an entry from the current term: " + state.term() + " is needed.");
-            }
+        if (!tryAdvanceCommitIndex(state)) {
+            trySendAppendRequest(state);
         }
     }
 
     private boolean updateFollowerIndices(RaftState state) {
+        // If successful: update nextIndex and matchIndex for follower (§5.3)
+
         Endpoint follower = resp.follower();
         LeaderState leaderState = state.leaderState();
         FollowerState followerState = leaderState.getFollowerState(follower);
+        QueryState queryState = leaderState.queryState();
 
+        if (queryState.tryAck(resp.queryRound(), follower)) {
+            if (logger.isFineEnabled()) {
+                logger.fine("Ack from " + follower + " for query round: " + resp.queryRound());
+            }
+        }
 
         long matchIndex = followerState.matchIndex();
         long followerLastLogIndex = resp.lastLogIndex();
@@ -113,12 +111,6 @@ public class AppendSuccessResponseHandlerTask extends AbstractResponseHandlerTas
             if (logger.isFineEnabled()) {
                 logger.fine("Updated match index: " + followerLastLogIndex + " and next index: " + newNextIndex
                         + " for follower: " + follower);
-            }
-
-            if (state.log().lastLogOrSnapshotIndex() > followerLastLogIndex || state.commitIndex() == followerLastLogIndex) {
-                // If the follower is still missing some log entries or has not learnt the latest commit index yet,
-                // then send another append request.
-                raftNode.sendAppendRequest(follower);
             }
 
             return true;
@@ -137,7 +129,7 @@ public class AppendSuccessResponseHandlerTask extends AbstractResponseHandlerTas
         long[] indices = leaderState.matchIndices();
 
         // if the leader is leaving, it should not count its vote for quorum...
-        if (raftNode.state().isKnownMember(raftNode.getLocalMember())) {
+        if (raftNode.state().isKnownMember(localMember())) {
             indices[indices.length - 1] = state.log().lastLogOrSnapshotIndex();
         } else {
             // Remove the last empty slot reserved for leader index
@@ -154,6 +146,27 @@ public class AppendSuccessResponseHandlerTask extends AbstractResponseHandlerTas
         return quorumMatchIndex;
     }
 
+    private boolean tryAdvanceCommitIndex(RaftState state) {
+        // If there exists an N such that N > commitIndex, a majority of matchIndex[i] ≥ N, and log[N].term == currentTerm:
+        // set commitIndex = N (§5.3, §5.4)
+        long quorumMatchIndex = findQuorumMatchIndex(state);
+        long commitIndex = state.commitIndex();
+        RaftLog raftLog = state.log();
+        for (; quorumMatchIndex > commitIndex; quorumMatchIndex--) {
+            // Only log entries from the leader’s current term are committed by counting replicas; once an entry
+            // from the current term has been committed in this way, then all prior entries are committed indirectly
+            // because of the Log Matching Property.
+            LogEntry entry = raftLog.getLogEntry(quorumMatchIndex);
+            if (entry.term() == state.term()) {
+                commitEntries(state, quorumMatchIndex);
+                return true;
+            } else if (logger.isFineEnabled()) {
+                logger.fine("Cannot commit " + entry + " since an entry from the current term: " + state.term() + " is needed.");
+            }
+        }
+        return false;
+    }
+
     private void commitEntries(RaftState state, long commitIndex) {
         if (logger.isFineEnabled()) {
             logger.fine("Setting commit index: " + commitIndex);
@@ -161,6 +174,44 @@ public class AppendSuccessResponseHandlerTask extends AbstractResponseHandlerTas
         state.commitIndex(commitIndex);
         raftNode.broadcastAppendRequest();
         raftNode.applyLogEntries();
+        tryRunQueries(state);
+    }
+
+    private void tryRunQueries(RaftState state) {
+        QueryState queryState = state.leaderState().queryState();
+        if (queryState.queryCount() == 0) {
+            return;
+        }
+
+        long commitIndex = state.commitIndex();
+        if (!queryState.isMajorityAcked(commitIndex, state.majority())) {
+            return;
+        } else if (queryState.isAckNeeded(resp.follower(), state.majority())) {
+            raftNode.sendAppendRequest(resp.follower());
+            return;
+        }
+
+        Collection<Tuple2<Object, SimpleCompletableFuture>> operations = queryState.operations();
+
+        if (logger.isFineEnabled()) {
+            logger.fine("Running " + operations.size() + " queries at commit index: " + commitIndex
+                    + ", query round: " + queryState.queryRound());
+        }
+
+        for (Tuple2<Object, SimpleCompletableFuture> t : operations) {
+            raftNode.runQuery(t.element1, t.element2);
+        }
+
+        queryState.reset();
+    }
+
+    private void trySendAppendRequest(RaftState state) {
+        long followerLastLogIndex = resp.lastLogIndex();
+        if (state.log().lastLogOrSnapshotIndex() > followerLastLogIndex || state.commitIndex() == followerLastLogIndex) {
+            // If the follower is still missing some log entries or has not learnt the latest commit index yet,
+            // then send another append request.
+            raftNode.sendAppendRequest(resp.follower());
+        }
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/InstallSnapshotHandlerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/InstallSnapshotHandlerTask.java
@@ -55,7 +55,6 @@ public class InstallSnapshotHandlerTask extends RaftNodeStatusAwareTask implemen
         }
 
         RaftState state = raftNode.state();
-
         SnapshotEntry snapshot = req.snapshot();
 
         // Reply false if term < currentTerm (§5.1)
@@ -64,8 +63,7 @@ public class InstallSnapshotHandlerTask extends RaftNodeStatusAwareTask implemen
                 logger.warning("Stale snapshot: " + req + " received in current term: " + state.term());
             }
 
-            AppendFailureResponse resp = new AppendFailureResponse(raftNode.getLocalMember(), state.term(), snapshot.index() + 1);
-            raftNode.send(resp, req.leader());
+            raftNode.send(new AppendFailureResponse(localMember(), state.term(), snapshot.index() + 1), req.leader());
             return;
         }
 
@@ -76,18 +74,16 @@ public class InstallSnapshotHandlerTask extends RaftNodeStatusAwareTask implemen
             logger.info("Demoting to FOLLOWER from current role: " + state.role() + ", term: " + state.term()
                     + " to new term: " + req.term() + " and leader: " + req.leader());
 
-            state.toFollower(req.term());
-            raftNode.printMemberState();
+            raftNode.toFollower(req.term());
         }
 
         if (!req.leader().equals(state.leader())) {
             logger.info("Setting leader: " + req.leader());
-            state.leader(req.leader());
-            raftNode.printMemberState();
+            raftNode.leader(req.leader());
         }
 
         if (raftNode.installSnapshot(snapshot)) {
-            raftNode.send(new AppendSuccessResponse(raftNode.getLocalMember(), req.term(), snapshot.index()), req.leader());
+            raftNode.send(new AppendSuccessResponse(localMember(), req.term(), snapshot.index(), req.queryRound()), req.leader());
         }
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/PreVoteRequestHandlerTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/handler/PreVoteRequestHandlerTask.java
@@ -50,7 +50,7 @@ public class PreVoteRequestHandlerTask extends RaftNodeStatusAwareTask implement
     @Override
     protected void innerRun() {
         RaftState state = raftNode.state();
-        Endpoint localEndpoint = raftNode.getLocalMember();
+        Endpoint localEndpoint = localMember();
 
         // Reply false if term < currentTerm (§5.1)
         if (state.term() > req.nextTerm()) {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/LeaderState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/LeaderState.java
@@ -31,6 +31,7 @@ import java.util.Map;
 public class LeaderState {
 
     private final Map<Endpoint, FollowerState> followerStates = new HashMap<>();
+    private final QueryState queryState = new QueryState();
 
     LeaderState(Collection<Endpoint> remoteMembers, long lastLogIndex) {
         for (Endpoint follower : remoteMembers) {
@@ -53,6 +54,7 @@ public class LeaderState {
      */
     public void remove(Endpoint follower) {
         FollowerState removed = followerStates.remove(follower);
+        queryState.removeAck(follower);
         assert removed != null : "Unknown follower " + follower;
     }
 
@@ -79,5 +81,13 @@ public class LeaderState {
 
     public Map<Endpoint, FollowerState> getFollowerStates() {
         return followerStates;
+    }
+
+    public QueryState queryState() {
+        return queryState;
+    }
+
+    public long queryRound() {
+        return queryState.queryRound();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/QueryState.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/state/QueryState.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.raft.impl.state;
+
+import com.hazelcast.core.Endpoint;
+import com.hazelcast.cp.internal.util.Tuple2;
+import com.hazelcast.internal.util.SimpleCompletableFuture;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.hazelcast.util.Preconditions.checkTrue;
+
+/**
+ * This class is used to keep the queries until a heartbeat round is performed
+ * for running queries without appending entries to the Raft log. These queries
+ * still achieve linearizability.
+ * <p>
+ * Section 6.4 of Raft Dissertation:
+ * ...
+ * Linearizability requires the results of a read to reflect a state of the
+ * system sometime after the read was initiated; each read must at least return
+ * the results of the latest committed write.
+ * ...
+ * Fortunately, it is possible to bypass the Raft log for read-only queries and
+ * still preserve linearizability.
+ */
+public class QueryState {
+
+    /**
+     * The minimum commit index required on the leader to execute the queries.
+     */
+    private long queryCommitIndex;
+
+    /**
+     * The index of the heartbeat round to execute the currently waiting
+     * queries. When a query is received and there is no other query waiting
+     * to be executed, a new heartbeat round is started by incrementing this
+     * field.
+     * <p>
+     * Value of this field is put into AppendEntriesRPCs sent to followers and
+     * bounced back to the leader to complete the heartbeat round and execute
+     * the queries.
+     */
+    private long queryRound;
+
+    /**
+     * Queries waiting to be executed.
+     */
+    private final List<Tuple2<Object, SimpleCompletableFuture>> operations = new ArrayList<>();
+
+    /**
+     * The set of followers acknowledged the leader in the current heartbeat
+     * round that is specified by {@link #queryRound}.
+     */
+    private final Set<Endpoint> acks = new HashSet<>();
+
+    /**
+     * Adds the given query to the collection of queries and returns the number
+     * of queries waiting to be executed. Also updates the minimum commit index
+     * that is expected on the leader to execute the queries.
+     */
+    public int addQuery(long commitIndex, Object operation, SimpleCompletableFuture resultFuture) {
+        if (commitIndex < queryCommitIndex) {
+            throw new IllegalArgumentException("Cannot execute query: " + operation + " at commit index because of the current "
+                    + this);
+        }
+
+        if (queryCommitIndex < commitIndex) {
+            queryCommitIndex = commitIndex;
+        }
+
+        operations.add(Tuple2.of(operation, resultFuture));
+        int size = operations.size();
+        if (size == 1) {
+            queryRound++;
+        }
+
+        return size;
+    }
+
+    /**
+     * Returns {@code true} if the given follower is accepted as an acker
+     * for the current query round. It is accepted only if there are
+     * waiting queries to be executed and the {@code queryRound} argument
+     * matches to the current query round.
+     */
+    public boolean tryAck(long queryRound, Endpoint follower) {
+        // If there is no query waiting to be executed or the received ack
+        // belongs to an earlier query round, we ignore it.
+        if (operations.isEmpty() || this.queryRound > queryRound) {
+            return false;
+        }
+
+        checkTrue(queryRound == this.queryRound, this + ", acked query round: "
+                + queryRound + ", follower: " + follower);
+
+        return acks.add(follower);
+    }
+
+    /**
+     * Returns {@code true} if the given follower is removed from the ack list.
+     */
+    public boolean removeAck(Endpoint follower) {
+        return acks.remove(follower);
+    }
+
+    /**
+     * Returns the number of queries waiting for execution.
+     */
+    public int queryCount() {
+        return operations.size();
+    }
+
+    /**
+     * Returns the index of the heartbeat round to execute the currently
+     * waiting queries.
+     */
+    public long queryRound() {
+        return queryRound;
+    }
+
+    /**
+     * Returns {@code true} if there are queries waiting and acks are received
+     * from the majority. Fails with {@link IllegalStateException} if
+     * the given commit index is smaller than {@link #queryCommitIndex}.
+     */
+    public boolean isMajorityAcked(long commitIndex, int majority) {
+        if (queryCommitIndex > commitIndex) {
+            throw new IllegalStateException("Cannot execute: " + this + ", current commit index: " + commitIndex);
+        }
+
+        return operations.size() > 0 && majority <= ackCount();
+    }
+
+    public boolean isAckNeeded(Endpoint follower, int majority) {
+        return !acks.contains(follower) && ackCount() < majority;
+    }
+
+    private int ackCount() {
+        return acks.size() + 1;
+    }
+
+    /**
+     * Returns the queries waiting to be executed.
+     */
+    public Collection<Tuple2<Object, SimpleCompletableFuture>> operations() {
+        return operations;
+    }
+
+    /**
+     * Resets the collection of waiting queries and acknowledged followers.
+     */
+    public void reset() {
+        operations.clear();
+        acks.clear();
+    }
+
+    @Override
+    public String toString() {
+        return "QueryState{" + "queryCommitIndex=" + queryCommitIndex + ", queryRound=" + queryRound + ", queryCount="
+                + queryCount() + ", acks=" + acks + '}';
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/task/PreVoteTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/task/PreVoteTask.java
@@ -60,12 +60,11 @@ public class PreVoteTask extends RaftNodeStatusAwareTask implements Runnable {
             return;
         }
 
-
         state.initPreCandidateState();
         int nextTerm = state.term() + 1;
         RaftLog log = state.log();
-        PreVoteRequest request = new PreVoteRequest(raftNode.getLocalMember(), nextTerm,
-                log.lastLogOrSnapshotTerm(), log.lastLogOrSnapshotIndex());
+        PreVoteRequest request = new PreVoteRequest(localMember(), nextTerm, log.lastLogOrSnapshotTerm(),
+                log.lastLogOrSnapshotIndex());
 
         logger.info("Pre-vote started for next term: " + request.nextTerm() + ", last log index: " + request.lastLogIndex()
                 + ", last log term: " + request.lastLogTerm());

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/task/QueryTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/task/QueryTask.java
@@ -18,11 +18,13 @@ package com.hazelcast.cp.internal.raft.impl.task;
 
 import com.hazelcast.cp.exception.CPGroupDestroyedException;
 import com.hazelcast.cp.exception.CPSubsystemException;
+import com.hazelcast.cp.exception.CannotReplicateException;
 import com.hazelcast.cp.exception.NotLeaderException;
 import com.hazelcast.cp.internal.raft.QueryPolicy;
 import com.hazelcast.cp.internal.raft.command.RaftGroupCmd;
 import com.hazelcast.cp.internal.raft.impl.RaftNodeImpl;
 import com.hazelcast.cp.internal.raft.impl.RaftNodeStatus;
+import com.hazelcast.cp.internal.raft.impl.state.QueryState;
 import com.hazelcast.cp.internal.raft.impl.state.RaftState;
 import com.hazelcast.internal.util.SimpleCompletableFuture;
 import com.hazelcast.logging.ILogger;
@@ -69,7 +71,7 @@ public class QueryTask implements Runnable {
                     handleAnyLocalRead();
                     break;
                 case LINEARIZABLE:
-                    new ReplicateTask(raftNode, operation, resultFuture).run();
+                    handleLinearizableRead();
                     break;
                 default:
                     resultFuture.setResult(new IllegalArgumentException("Invalid query policy: " + queryPolicy));
@@ -100,7 +102,36 @@ public class QueryTask implements Runnable {
 
         // TODO: We can reject the query, if follower have not received any heartbeat recently
 
-        raftNode.runQueryOperation(operation, resultFuture);
+        raftNode.runQuery(operation, resultFuture);
+    }
+
+    private void handleLinearizableRead() {
+        if (!raftNode.isLinearizableReadOptimizationEnabled()) {
+            new ReplicateTask(raftNode, operation, resultFuture).run();
+            return;
+        }
+
+        RaftState state = raftNode.state();
+        if (state.role() != LEADER) {
+            resultFuture.setResult(new NotLeaderException(raftNode.getGroupId(), raftNode.getLocalMember(), state.leader()));
+            return;
+        }
+
+        if (!raftNode.canQueryLinearizable()) {
+            resultFuture.setResult(new CannotReplicateException(state.leader()));
+            return;
+        }
+
+        long commitIndex = state.commitIndex();
+        QueryState queryState = state.leaderState().queryState();
+
+        if (logger.isFineEnabled()) {
+            logger.fine("Adding query at commit index: " + commitIndex + ", query round: " + queryState.queryRound());
+        }
+
+        if (queryState.addQuery(commitIndex, operation, resultFuture) == 1) {
+            raftNode.broadcastAppendRequest();
+        }
     }
 
     private boolean verifyOperation() {

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/task/RaftNodeStatusAwareTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/task/RaftNodeStatusAwareTask.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.cp.internal.raft.impl.task;
 
+import com.hazelcast.core.Endpoint;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.cp.internal.raft.impl.RaftNodeImpl;
 
@@ -47,6 +48,10 @@ public abstract class RaftNodeStatusAwareTask implements Runnable {
         } catch (Throwable e) {
             logger.severe(e);
         }
+    }
+
+    protected final Endpoint localMember() {
+        return raftNode.getLocalMember();
     }
 
     protected abstract void innerRun();

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/session/RaftSessionService.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 
 import static com.hazelcast.cp.CPGroup.METADATA_CP_GROUP_NAME;
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.spi.ExecutionService.SYSTEM_EXECUTOR;
 import static com.hazelcast.util.Preconditions.checkTrue;
 import static java.util.Collections.unmodifiableCollection;
@@ -180,7 +181,7 @@ public class RaftSessionService implements ManagedService, SnapshotAwareService<
             public void onResponse(CPGroup group) {
                 if (group != null) {
                     raftService.getInvocationManager()
-                            .<Collection<CPSession>>invoke(group.id(), new GetSessionsOp())
+                            .<Collection<CPSession>>query(group.id(), new GetSessionsOp(), LINEARIZABLE)
                             .andThen(callback);
                 } else {
                     future.setResult(new ExecutionException(new IllegalArgumentException()));

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -1029,6 +1029,13 @@ public final class GroupProperty {
     public static final HazelcastProperty SEARCH_DYNAMIC_CONFIG_FIRST
             = new HazelcastProperty("hazelcast.data.search.dynamic.config.first.enabled", false);
 
+    /**
+     * !!! ONLY FOR INTERNAL USAGE AND TESTING !!!
+     * Enables / disables the linearizable read optimization described in the Raft Dissertation Section 6.4.
+     */
+    public static final HazelcastProperty RAFT_LINEARIZABLE_READ_OPTIMIZATION_ENABLED
+            = new HazelcastProperty("raft.linearizable.read.optimization.enabled", true);
+
     private GroupProperty() {
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/properties/GroupProperty.java
@@ -1029,13 +1029,6 @@ public final class GroupProperty {
     public static final HazelcastProperty SEARCH_DYNAMIC_CONFIG_FIRST
             = new HazelcastProperty("hazelcast.data.search.dynamic.config.first.enabled", false);
 
-    /**
-     * !!! ONLY FOR INTERNAL USAGE AND TESTING !!!
-     * Enables / disables the linearizable read optimization described in the Raft Dissertation Section 6.4.
-     */
-    public static final HazelcastProperty RAFT_LINEARIZABLE_READ_OPTIMIZATION_ENABLED
-            = new HazelcastProperty("raft.linearizable.read.optimization.enabled", true);
-
     private GroupProperty() {
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/MetadataRaftGroupTest.java
@@ -54,7 +54,7 @@ import java.util.concurrent.Future;
 import static com.hazelcast.cp.internal.MetadataRaftGroupManager.INITIAL_METADATA_GROUP_ID;
 import static com.hazelcast.cp.internal.MetadataRaftGroupManager.MetadataRaftGroupInitStatus.IN_PROGRESS;
 import static com.hazelcast.cp.internal.MetadataRaftGroupManager.MetadataRaftGroupInitStatus.SUCCESSFUL;
-import static com.hazelcast.cp.internal.raft.QueryPolicy.LEADER_LOCAL;
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getLeaderMember;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getSnapshotEntry;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.waitUntilLeaderElected;
@@ -302,8 +302,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
 
         assertTrueEventually(() -> {
             Future<CPGroupInfo> f = invocationService.query(getMetadataGroupId(instances[0]), new GetRaftGroupOp(groupId),
-                    LEADER_LOCAL);
-
+                    LINEARIZABLE);
             CPGroupInfo group1 = f.get();
             assertEquals(CPGroupStatus.DESTROYED, group1.status());
         });
@@ -359,7 +358,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
         getRaftService(instances[0]).forceDestroyCPGroup(groupId.name()).get();
 
         group = getRaftInvocationManager(instances[0]).<CPGroupInfo>query(getMetadataGroupId(instances[0]),
-                new GetRaftGroupOp(groupId), LEADER_LOCAL).get();
+                new GetRaftGroupOp(groupId), LINEARIZABLE).get();
         assertEquals(CPGroupStatus.DESTROYED, group.status());
 
         assertTrueEventually(() -> {
@@ -400,7 +399,7 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
         getRaftService(runningInstance).forceDestroyCPGroup(groupId.name()).get();
 
         group = getRaftInvocationManager(runningInstance).<CPGroupInfo>query(getMetadataGroupId(runningInstance),
-                new GetRaftGroupOp(groupId), LEADER_LOCAL).get();
+                new GetRaftGroupOp(groupId), LINEARIZABLE).get();
         assertEquals(CPGroupStatus.DESTROYED, group.status());
 
         assertTrueEventually(() -> assertNull(getRaftNode(runningInstance, groupId)));
@@ -539,19 +538,19 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
 
         CPGroupId metadataGroupId = getMetadataGroupId(aliveInstance);
         ICompletableFuture<List<CPMemberInfo>> f1 = invocationService.query(metadataGroupId, new GetActiveCPMembersOp(),
-                LEADER_LOCAL);
+                LINEARIZABLE);
 
         List<CPMemberInfo> activeEndpoints = f1.get();
         assertThat(activeEndpoints, not(hasItem(endpoint)));
 
         ICompletableFuture<CPGroupInfo> f2 = invocationService.query(metadataGroupId, new GetRaftGroupOp(metadataGroupId),
-                LEADER_LOCAL);
+                LINEARIZABLE);
 
         ICompletableFuture<CPGroupInfo> f3 = invocationService.query(metadataGroupId, new GetRaftGroupOp(groupId1),
-                LEADER_LOCAL);
+                LINEARIZABLE);
 
         ICompletableFuture<CPGroupInfo> f4 = invocationService.query(metadataGroupId, new GetRaftGroupOp(groupId2),
-                LEADER_LOCAL);
+                LINEARIZABLE);
 
         CPGroupInfo metadataGroup = f2.get();
         assertFalse(metadataGroup.containsMember(endpoint));
@@ -695,9 +694,9 @@ public class MetadataRaftGroupTest extends HazelcastRaftTestSupport {
             throws ExecutionException, InterruptedException {
         RaftInvocationManager invocationService = getRaftInvocationManager(instance);
         ICompletableFuture<CPGroupInfo> f1 = invocationService.query(getMetadataGroupId(instance), new GetRaftGroupOp(groupId1),
-                LEADER_LOCAL);
+                LINEARIZABLE);
         ICompletableFuture<CPGroupInfo> f2 = invocationService.query(getMetadataGroupId(instance), new GetRaftGroupOp(groupId2),
-                LEADER_LOCAL);
+                LINEARIZABLE);
         CPGroupInfo group1 = f1.get();
         CPGroupInfo group2 = f2.get();
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/atomiclong/RaftAtomicLongBasicTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/atomiclong/RaftAtomicLongBasicTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.cp.CPGroup.DEFAULT_GROUP_NAME;
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -270,7 +271,7 @@ public class RaftAtomicLongBasicTest extends HazelcastRaftTestSupport {
         invocationManager.invoke(getRaftService(instances[0]).getMetadataGroupId(), new TriggerDestroyRaftGroupOp(groupId)).get();
 
         assertTrueEventually(() -> {
-            CPGroup group = invocationManager.<CPGroup>invoke(getMetadataGroupId(instances[0]), new GetRaftGroupOp(groupId)).join();
+            CPGroup group = invocationManager.<CPGroup>query(getMetadataGroupId(instances[0]), new GetRaftGroupOp(groupId), LINEARIZABLE).join();
             assertEquals(CPGroupStatus.DESTROYED, group.status());
         });
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/RaftSemaphoreAdvancedTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/datastructures/semaphore/RaftSemaphoreAdvancedTest.java
@@ -49,7 +49,6 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
 import com.hazelcast.util.RandomPicker;
-import com.hazelcast.util.ThreadUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -448,7 +447,7 @@ public class RaftSemaphoreAdvancedTest extends HazelcastRaftTestSupport {
         Tuple2[] acquireWaitTimeoutKeyRef = new Tuple2[1];
 
         InternalCompletableFuture<Boolean> f1 = invocationManager
-                .invoke(groupId, new AcquirePermitsOp(objectName, sessionId, ThreadUtil.getThreadId(), invUid, 1, SECONDS.toMillis(300)));
+                .invoke(groupId, new AcquirePermitsOp(objectName, sessionId, getThreadId(), invUid, 1, SECONDS.toMillis(300)));
 
         assertTrueEventually(() -> {
             RaftSemaphoreRegistry registry = service.getRegistryOrNull(groupId);
@@ -458,7 +457,7 @@ public class RaftSemaphoreAdvancedTest extends HazelcastRaftTestSupport {
         });
 
         InternalCompletableFuture<Boolean> f2 = invocationManager
-                .invoke(groupId, new AcquirePermitsOp(objectName, sessionId, ThreadUtil.getThreadId(), invUid, 1, SECONDS.toMillis(300)));
+                .invoke(groupId, new AcquirePermitsOp(objectName, sessionId, getThreadId(), invUid, 1, SECONDS.toMillis(300)));
 
         assertTrueEventually(() -> {
             int partitionId = nodeEngine.getPartitionService().getPartitionId(groupId);

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LinearizableQueryTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LinearizableQueryTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.cp.internal.raft.impl;
+
+import com.hazelcast.config.cp.RaftAlgorithmConfig;
+import com.hazelcast.core.Endpoint;
+import com.hazelcast.core.ICompletableFuture;
+import com.hazelcast.cp.exception.CannotReplicateException;
+import com.hazelcast.cp.exception.NotLeaderException;
+import com.hazelcast.cp.internal.raft.impl.dataservice.ApplyRaftRunnable;
+import com.hazelcast.cp.internal.raft.impl.dataservice.QueryRaftRunnable;
+import com.hazelcast.cp.internal.raft.impl.dto.AppendRequest;
+import com.hazelcast.cp.internal.raft.impl.testing.LocalRaftGroup;
+import com.hazelcast.test.HazelcastSerialClassRunner;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import static com.hazelcast.cp.internal.raft.QueryPolicy.LINEARIZABLE;
+import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getCommitIndex;
+import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getLeaderMember;
+import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getLeaderQueryRound;
+import static com.hazelcast.cp.internal.raft.impl.RaftUtil.newGroupWithService;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(HazelcastSerialClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class LinearizableQueryTest extends HazelcastTestSupport {
+
+    private LocalRaftGroup group;
+
+    @Before
+    public void init() {
+    }
+
+    @After
+    public void destroy() {
+        if (group != null) {
+            group.destroy();
+        }
+    }
+
+    @Test(timeout = 300_000)
+    public void when_linearizableQueryIsIssued_then_itReadsLastState() throws Exception {
+        group = newGroup();
+        group.start();
+
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+        leader.replicate(new ApplyRaftRunnable("value1")).get();
+        long commitIndex1 = getCommitIndex(leader);
+
+        Object o1 = leader.query(new QueryRaftRunnable(), LINEARIZABLE).get();
+
+        assertEquals("value1", o1);
+        long leaderQueryRound1 = getLeaderQueryRound(leader);
+        assertTrue(leaderQueryRound1 > 0);
+        assertEquals(commitIndex1, getCommitIndex(leader));
+
+        leader.replicate(new ApplyRaftRunnable("value2")).get();
+        long commitIndex2 = getCommitIndex(leader);
+
+        Object o2 = leader.query(new QueryRaftRunnable(), LINEARIZABLE).get();
+
+        assertEquals("value2", o2);
+        long leaderQueryRound2 = getLeaderQueryRound(leader);
+        assertEquals(leaderQueryRound1 + 1, leaderQueryRound2);
+        assertEquals(commitIndex2, getCommitIndex(leader));
+    }
+
+    @Test(timeout = 300_000)
+    public void when_newCommitIsDoneWhileThereIsWaitingQuery_then_queryRunsAfterNewCommit() throws Exception {
+        group = newGroup();
+        group.start();
+
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+        leader.replicate(new ApplyRaftRunnable("value1")).get();
+        RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
+        group.dropMessagesToMember(leader.getLocalMember(), followers[0].getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), followers[1].getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), followers[2].getLocalMember(), AppendRequest.class);
+
+        ICompletableFuture replicateFuture = leader.replicate(new ApplyRaftRunnable("value2"));
+        ICompletableFuture queryFuture = leader.query(new QueryRaftRunnable(), LINEARIZABLE);
+
+        group.resetAllRulesFrom(leader.getLocalMember());
+
+        replicateFuture.get();
+        Object o = queryFuture.get();
+        assertEquals("value2", o);
+    }
+
+    @Test(timeout = 300_000)
+    public void when_multipleQueriesAreIssuedBeforeHeartbeatAcksReceived_then_allQueriesExecutedAtOnce() throws Exception {
+        group = newGroup();
+        group.start();
+
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+        leader.replicate(new ApplyRaftRunnable("value1")).get();
+        RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
+        group.dropMessagesToMember(leader.getLocalMember(), followers[0].getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), followers[1].getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), followers[2].getLocalMember(), AppendRequest.class);
+
+        ICompletableFuture queryFuture1 = leader.query(new QueryRaftRunnable(), LINEARIZABLE);
+        ICompletableFuture queryFuture2 = leader.query(new QueryRaftRunnable(), LINEARIZABLE);
+
+        group.resetAllRulesFrom(leader.getLocalMember());
+
+        assertEquals("value1", queryFuture1.get());
+        assertEquals("value1", queryFuture2.get());
+    }
+
+    @Test(timeout = 300_000)
+    public void when_newCommitIsDoneWhileThereAreMultipleQueries_then_allQueriesRunAfterCommit() throws Exception {
+        group = newGroup();
+        group.start();
+
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+        leader.replicate(new ApplyRaftRunnable("value1")).get();
+        RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
+        group.dropMessagesToMember(leader.getLocalMember(), followers[0].getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), followers[1].getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), followers[2].getLocalMember(), AppendRequest.class);
+
+        ICompletableFuture replicateFuture = leader.replicate(new ApplyRaftRunnable("value2"));
+        ICompletableFuture queryFuture1 = leader.query(new QueryRaftRunnable(), LINEARIZABLE);
+        ICompletableFuture queryFuture2 = leader.query(new QueryRaftRunnable(), LINEARIZABLE);
+
+        group.resetAllRulesFrom(leader.getLocalMember());
+
+        replicateFuture.get();
+        assertEquals("value2", queryFuture1.get());
+        assertEquals("value2", queryFuture2.get());
+    }
+
+    @Test(timeout = 300_000)
+    public void when_linearizableQueryIsIssuedToFollower_then_queryFails() throws Exception {
+        group = newGroup();
+        group.start();
+
+        group.waitUntilLeaderElected();
+        try {
+            group.getAnyFollowerNode().query(new QueryRaftRunnable(), LINEARIZABLE).get();
+            fail();
+        } catch (NotLeaderException ignored) {
+        }
+    }
+
+    @Test(timeout = 300_000)
+    public void when_multipleQueryLimitIsReachedBeforeHeartbeatAcks_then_noNewQueryIsAccepted() throws Exception {
+        RaftAlgorithmConfig config = new RaftAlgorithmConfig().setUncommittedEntryCountToRejectNewAppends(1);
+        group = newGroupWithService(5, config, true);
+        group.start();
+
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+        assertTrueEventually(() -> assertEquals(1, getCommitIndex(leader)));
+
+        RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
+        group.dropMessagesToMember(leader.getLocalMember(), followers[0].getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), followers[1].getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), followers[2].getLocalMember(), AppendRequest.class);
+
+        ICompletableFuture queryFuture1 = leader.query(new QueryRaftRunnable(), LINEARIZABLE);
+        ICompletableFuture queryFuture2 = leader.query(new QueryRaftRunnable(), LINEARIZABLE);
+
+        try {
+            queryFuture2.get();
+            fail();
+        } catch (CannotReplicateException ignored) {
+        }
+
+        group.resetAllRulesFrom(leader.getLocalMember());
+
+        queryFuture1.get();
+    }
+
+    @Test(timeout = 300_000)
+    public void when_leaderDemotesToFollowerWhileThereIsOngoingQuery_then_queryFails() throws Exception {
+        group = newGroup();
+        group.start();
+
+        RaftNodeImpl oldLeader = group.waitUntilLeaderElected();
+
+        final int[] split = group.createMajoritySplitIndexes(false);
+        group.split(split);
+
+        assertTrueEventually(() -> {
+            for (int ix : split) {
+                Endpoint newLeader = getLeaderMember(group.getNode(ix));
+                assertNotNull(newLeader);
+                assertNotEquals(oldLeader.getLocalMember(), newLeader);
+            }
+        });
+
+        RaftNodeImpl newLeader = group.getNode(getLeaderMember(group.getNode(split[0])));
+        newLeader.replicate(new ApplyRaftRunnable("value1")).get();
+
+        ICompletableFuture queryFuture = oldLeader.query(new QueryRaftRunnable(), LINEARIZABLE);
+
+        group.merge();
+        group.waitUntilLeaderElected();
+
+        assertEquals(oldLeader.getLeader(), newLeader.getLocalMember());
+        try {
+            queryFuture.get();
+            fail();
+        } catch (NotLeaderException ignored) {
+        }
+    }
+
+    private LocalRaftGroup newGroup() {
+        return newGroupWithService(5, new RaftAlgorithmConfig(), true);
+    }
+
+}

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LocalRaftTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/LocalRaftTest.java
@@ -448,7 +448,9 @@ public class LocalRaftTest extends HazelcastTestSupport {
 
         assertTrueEventually(() -> {
             for (RaftNodeImpl raftNode : followers) {
-                assertNotEquals(leaderNode.getLocalMember(), getLeaderMember(raftNode));
+                Endpoint newLeader = getLeaderMember(raftNode);
+                assertNotNull(newLeader);
+                assertNotEquals(leaderNode.getLocalMember(), newLeader);
             }
         });
 
@@ -491,7 +493,9 @@ public class LocalRaftTest extends HazelcastTestSupport {
 
         assertTrueEventually(() -> {
             for (int ix : split) {
-                assertNotEquals(leaderEndpoint, getLeaderMember(group.getNode(ix)));
+                Endpoint newLeader = getLeaderMember(group.getNode(ix));
+                assertNotNull(newLeader);
+                assertNotEquals(leaderEndpoint, newLeader);
             }
         });
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/MembershipChangeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/MembershipChangeTest.java
@@ -286,7 +286,9 @@ public class MembershipChangeTest extends HazelcastTestSupport {
 
         assertTrueEventually(() -> {
             for (RaftNodeImpl raftNode : followers) {
-                assertNotEquals(leader.getLocalMember(), getLeaderMember(raftNode));
+                Endpoint newLeader = getLeaderMember(raftNode);
+                assertNotNull(newLeader);
+                assertNotEquals(leader.getLocalMember(), newLeader);
             }
         });
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/RaftUtil.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/RaftUtil.java
@@ -83,6 +83,16 @@ public class RaftUtil {
         return readRaftState(leader, task);
     }
 
+    public static long getLeaderQueryRound(RaftNodeImpl leader) {
+        Callable<Long> task = () -> {
+            LeaderState leaderState = leader.state().leaderState();
+            assertNotNull(leader.getLocalMember() + " has no leader state!", leaderState);
+            return leaderState.queryRound();
+        };
+
+        return readRaftState(leader, task);
+    }
+
     public static RaftNodeStatus getStatus(RaftNodeImpl node) {
         Callable<RaftNodeStatus> task = node::getStatus;
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/SnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/SnapshotTest.java
@@ -473,10 +473,10 @@ public class SnapshotTest extends HazelcastTestSupport {
                 if (entries.length > 0) {
                     if (entries[entries.length - 1].operation() instanceof UpdateRaftGroupMembersCmd) {
                         entries = Arrays.copyOf(entries, entries.length - 1);
-                        return new AppendRequest(request.leader(), request.term(), request.prevLogTerm(), request.prevLogIndex(), request.leaderCommitIndex(), entries);
+                        return new AppendRequest(request.leader(), request.term(), request.prevLogTerm(), request.prevLogIndex(), request.leaderCommitIndex(), entries, 0);
                     } else if (entries[0].operation() instanceof UpdateRaftGroupMembersCmd) {
                         entries = new LogEntry[0];
-                        return new AppendRequest(request.leader(), request.term(), request.prevLogTerm(), request.prevLogIndex(), request.leaderCommitIndex(), entries);
+                        return new AppendRequest(request.leader(), request.term(), request.prevLogTerm(), request.prevLogIndex(), request.leaderCommitIndex(), entries, 0);
                     }
                 }
             }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/state/RaftStateTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/state/RaftStateTest.java
@@ -26,7 +26,6 @@ import com.hazelcast.cp.internal.raft.impl.testing.TestRaftMember;
 import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -78,7 +77,7 @@ public class RaftStateTest {
         assertEquals(remoteMembers, state.remoteMembers());
 
         assertEquals(0, state.term());
-        Assert.assertEquals(RaftRole.FOLLOWER, state.role());
+        assertEquals(RaftRole.FOLLOWER, state.role());
         assertNull(state.leader());
         assertEquals(0, state.commitIndex());
         assertEquals(0, state.lastApplied());

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftGroup.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftGroup.java
@@ -21,12 +21,12 @@ import com.hazelcast.core.Endpoint;
 import com.hazelcast.cp.CPGroupId;
 import com.hazelcast.cp.internal.raft.SnapshotAwareService;
 import com.hazelcast.cp.internal.raft.impl.RaftNodeImpl;
-import com.hazelcast.cp.internal.raft.impl.RaftUtil;
 import org.junit.Assert;
 
 import java.util.Arrays;
 import java.util.function.Function;
 
+import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getLeaderMember;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.getTerm;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.majority;
 import static com.hazelcast.cp.internal.raft.impl.RaftUtil.minority;
@@ -219,9 +219,9 @@ public class LocalRaftGroup {
                     continue;
                 }
 
-                assertEquals(leaderNode.getLocalMember(), RaftUtil.getLeaderMember(raftNode));
-                assertEquals(leaderTerm, getTerm(raftNode));
-            }
+                    assertEquals(leaderNode.getLocalMember(), getLeaderMember(raftNode));
+                    assertEquals(leaderTerm, getTerm(raftNode));
+                }
 
             leaderRef[0] = leaderNode;
         });
@@ -236,7 +236,7 @@ public class LocalRaftGroup {
                 continue;
             }
             RaftNodeImpl node = nodes[i];
-            Endpoint endpoint = RaftUtil.getLeaderMember(node);
+            Endpoint endpoint = getLeaderMember(node);
             if (leader == null) {
                 leader = endpoint;
             } else if (!leader.equals(endpoint)) {

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftIntegration.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/LocalRaftIntegration.java
@@ -135,6 +135,11 @@ public class LocalRaftIntegration implements RaftIntegration {
     }
 
     @Override
+    public boolean isLinearizableReadOptimizationEnabled() {
+        return true;
+    }
+
+    @Override
     public ILogger getLogger(String name) {
         return loggingService.getLogger(name);
     }

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/NopEntry.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/testing/NopEntry.java
@@ -25,4 +25,9 @@ public class NopEntry implements RaftRunnable {
     public Object run(Object service, long commitIndex) {
         return null;
     }
+
+    @Override
+    public String toString() {
+        return "NopEntry{}";
+    }
 }


### PR DESCRIPTION
With this optimization, queries (read-only operations) are executed
with linearizability but they are not appended to the Raft log. By this
way, we prevent the Raft log to grow and snapshots to be taken because
of read-only operations.

Even the CP Subsystem works only in memory for now, this optimization 
results in ~25% improvement in throughput when the read/write ratio is 80/20. 
We will see a much bigger difference when we have persistence. 