### PR TITLE
Naming cleanup diagnostics properties

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/Diagnostics.java
@@ -44,8 +44,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @SuppressWarnings("WeakerAccess")
 public class Diagnostics {
 
-    public static final String PREFIX = "hazelcast.diagnostics";
-
     /**
      * The minimum level for probes is MANDATORY, but it can be changed to INFO
      * or DEBUG. A lower level will increase memory usage (probably just a few
@@ -55,7 +53,7 @@ public class Diagnostics {
      * By default only mandatory probes are being tracked
      */
     public static final HazelcastProperty METRICS_LEVEL
-            = new HazelcastProperty(PREFIX + ".metric.level", ProbeLevel.MANDATORY.name());
+            = new HazelcastProperty("hazelcast.diagnostics.metric.level", ProbeLevel.MANDATORY.name());
 
     /**
      * If metrics should be tracked on distributed data structures like IMap,
@@ -65,7 +63,7 @@ public class Diagnostics {
      * this will probably be changed to {@code true}.
      */
     public static final HazelcastProperty METRICS_DISTRIBUTED_DATASTRUCTURES
-            = new HazelcastProperty(PREFIX + ".metric.distributed.datastructures", false);
+            = new HazelcastProperty("hazelcast.diagnostics.metric.distributed.datastructures", false);
 
 
     /**
@@ -78,7 +76,7 @@ public class Diagnostics {
      * <p>
      * The default is {@code false}.
      */
-    public static final HazelcastProperty ENABLED = new HazelcastProperty(PREFIX + ".enabled", false);
+    public static final HazelcastProperty ENABLED = new HazelcastProperty("hazelcast.diagnostics.enabled", false);
 
     /**
      * The {@link DiagnosticsLogFile} uses a rolling file approach to prevent
@@ -92,8 +90,7 @@ public class Diagnostics {
      */
     @SuppressWarnings("checkstyle:magicnumber")
     public static final HazelcastProperty MAX_ROLLED_FILE_SIZE_MB
-            = new HazelcastProperty(PREFIX + ".max.rolled.file.size.mb", 50);
-
+            = new HazelcastProperty("hazelcast.diagnostics.max.rolled.file.size.mb", 50);
     /**
      * The {@link DiagnosticsLogFile} uses a rolling file approach to prevent
      * eating too much disk space.
@@ -104,7 +101,7 @@ public class Diagnostics {
      */
     @SuppressWarnings("checkstyle:magicnumber")
     public static final HazelcastProperty MAX_ROLLED_FILE_COUNT
-            = new HazelcastProperty(PREFIX + ".max.rolled.file.count", 10);
+            = new HazelcastProperty("hazelcast.diagnostics.max.rolled.file.count", 10);
 
     /**
      * Configures if the epoch time should be included in the 'top' section.
@@ -112,7 +109,7 @@ public class Diagnostics {
      * needing to parse the date-format section. The default is {@code false}
      * since it will cause more noise.
      */
-    public static final HazelcastProperty INCLUDE_EPOCH_TIME = new HazelcastProperty(PREFIX + ".include.epoch", true);
+    public static final HazelcastProperty INCLUDE_EPOCH_TIME = new HazelcastProperty("hazelcast.diagnostics.include.epoch", true);
 
     /**
      * Configures the output directory of the performance log files.
@@ -120,7 +117,7 @@ public class Diagnostics {
      * Defaults to the 'user.dir'.
      */
     public static final HazelcastProperty DIRECTORY
-            = new HazelcastProperty(PREFIX + ".directory", "" + System.getProperty("user.dir"));
+            = new HazelcastProperty("hazelcast.diagnostics.directory", "" + System.getProperty("user.dir"));
 
     /**
      * Configures the prefix for the diagnostics file.
@@ -128,7 +125,7 @@ public class Diagnostics {
      * So instead of having e.g. 'diagnostics-...log' you get 'foobar-diagnostics-...log'.
      */
     public static final HazelcastProperty FILENAME_PREFIX
-            = new HazelcastProperty(PREFIX + ".filename.prefix");
+            = new HazelcastProperty("hazelcast.diagnostics.filename.prefix");
 
     final AtomicReference<DiagnosticsPlugin[]> staticTasks = new AtomicReference<DiagnosticsPlugin[]>(
             new DiagnosticsPlugin[0]

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/EventQueuePlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/EventQueuePlugin.java
@@ -39,7 +39,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -61,13 +60,13 @@ public class EventQueuePlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
-            = new HazelcastProperty(PREFIX + ".event.queue.period.seconds", 0, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.event.queue.period.seconds", 0, SECONDS);
 
     /**
      * The minimum number of events in the queue before it is being sampled.
      */
     public static final HazelcastProperty THRESHOLD
-            = new HazelcastProperty(PREFIX + ".event.queue.threshold", 1000);
+            = new HazelcastProperty("hazelcast.diagnostics.event.queue.threshold", 1000);
 
     /**
      * The number of samples to take from the event queue. Increasing the number
@@ -75,7 +74,7 @@ public class EventQueuePlugin extends DiagnosticsPlugin {
      * price.
      */
     public static final HazelcastProperty SAMPLES
-            = new HazelcastProperty(PREFIX + ".event.queue.samples", 100);
+            = new HazelcastProperty("hazelcast.diagnostics.event.queue.samples", 100);
 
     private final ItemCounter<String> occurrenceMap = new ItemCounter<String>();
     private final Random random = new Random();

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/InvocationPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/InvocationPlugin.java
@@ -26,7 +26,6 @@ import com.hazelcast.spi.properties.HazelcastProperty;
 import com.hazelcast.util.Clock;
 import com.hazelcast.util.ItemCounter;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static com.hazelcast.internal.diagnostics.OperationDescriptors.toOperationDesc;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -48,19 +47,19 @@ public class InvocationPlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty SAMPLE_PERIOD_SECONDS
-            = new HazelcastProperty(PREFIX + ".invocation.sample.period.seconds", 0, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.invocation.sample.period.seconds", 0, SECONDS);
 
     /**
      * The threshold in seconds to consider an invocation to be slow.
      */
     public static final HazelcastProperty SLOW_THRESHOLD_SECONDS
-            = new HazelcastProperty(PREFIX + ".invocation.slow.threshold.seconds", 5, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.invocation.slow.threshold.seconds", 5, SECONDS);
 
     /**
      * The maximum number of slow invocations to print.
      */
     public static final HazelcastProperty SLOW_MAX_COUNT
-            = new HazelcastProperty(PREFIX + ".invocation.slow.max.count", 100);
+            = new HazelcastProperty("hazelcast.diagnostics.invocation.slow.max.count", 100);
 
     private final InvocationRegistry invocationRegistry;
     private final long samplePeriodMillis;

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHazelcastInstanceInfoPlugin.java
@@ -22,7 +22,6 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -40,7 +39,7 @@ public class MemberHazelcastInstanceInfoPlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty(
-            PREFIX + ".memberinfo.period.seconds", 60, SECONDS);
+            "hazelcast.diagnostics.memberinfo.period.seconds", 60, SECONDS);
 
     private final long periodMillis;
     private final NodeEngineImpl nodeEngine;

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHeartbeatPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MemberHeartbeatPlugin.java
@@ -24,7 +24,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -51,7 +50,7 @@ public class MemberHeartbeatPlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty(
-            PREFIX + ".member-heartbeat.period.seconds", 10, SECONDS);
+            "hazelcast.diagnostics.member-heartbeat.period.seconds", 10, SECONDS);
 
     /**
      * The maximum allowed deviation. E.g. if the interval of member/member
@@ -61,7 +60,7 @@ public class MemberHeartbeatPlugin extends DiagnosticsPlugin {
      * will be rendered.
      */
     public static final HazelcastProperty MAX_DEVIATION_PERCENTAGE
-            = new HazelcastProperty(PREFIX + ".member-heartbeat.max-deviation-percentage", 100);
+            = new HazelcastProperty("hazelcast.diagnostics.member-heartbeat.max-deviation-percentage", 100);
 
     private static final float HUNDRED = 100f;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/MetricsPlugin.java
@@ -23,7 +23,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -44,7 +43,7 @@ public class MetricsPlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
-            = new HazelcastProperty(PREFIX + ".metrics.period.seconds", 60, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.metrics.period.seconds", 60, SECONDS);
 
     private final MetricsRegistry metricsRegistry;
     private final long periodMillis;

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/NetworkingImbalancePlugin.java
@@ -26,7 +26,6 @@ import com.hazelcast.spi.impl.NodeEngineImpl;
 import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
@@ -47,7 +46,7 @@ public class NetworkingImbalancePlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
-            = new HazelcastProperty(PREFIX + ".networking-imbalance.seconds", 0, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.networking-imbalance.seconds", 0, SECONDS);
 
     private static final double HUNDRED = 100d;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationHeartbeatPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationHeartbeatPlugin.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 
@@ -53,7 +52,7 @@ public class OperationHeartbeatPlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
-            = new HazelcastProperty(PREFIX + ".operation-heartbeat.seconds", 10, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.operation-heartbeat.seconds", 10, SECONDS);
 
     /**
      * The maximum allowed deviation. E.g. with a default 60 call timeout and operation-heartbeat interval being 15 seconds,
@@ -61,7 +60,7 @@ public class OperationHeartbeatPlugin extends DiagnosticsPlugin {
      * problem; but if it arrives after 21 seconds, then the plugin will render.
      */
     public static final HazelcastProperty MAX_DEVIATION_PERCENTAGE
-            = new HazelcastProperty(PREFIX + ".operation-heartbeat.max-deviation-percentage", 33);
+            = new HazelcastProperty("hazelcast.diagnostics.operation-heartbeat.max-deviation-percentage", 33);
 
     private static final float HUNDRED = 100f;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationThreadSamplerPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OperationThreadSamplerPlugin.java
@@ -28,7 +28,6 @@ import com.hazelcast.util.ItemCounter;
 
 import java.util.concurrent.locks.LockSupport;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -53,7 +52,7 @@ public class OperationThreadSamplerPlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
-            = new HazelcastProperty(PREFIX + ".operationthreadsamples.period.seconds", 0, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.operationthreadsamples.period.seconds", 0, SECONDS);
 
     /**
      * The period in milliseconds between taking samples.
@@ -62,7 +61,7 @@ public class OperationThreadSamplerPlugin extends DiagnosticsPlugin {
      * precision.
      */
     public static final HazelcastProperty SAMPLER_PERIOD_MILLIS
-            = new HazelcastProperty(PREFIX + ".operationthreadsamples.sampler.period.millis", 100, MILLISECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.operationthreadsamples.sampler.period.millis", 100, MILLISECONDS);
 
     /**
      * If the name the data-structure the operation operates on should be included.
@@ -76,7 +75,7 @@ public class OperationThreadSamplerPlugin extends DiagnosticsPlugin {
      * it gets, the more litter is created.
      */
     public static final HazelcastProperty INCLUDE_NAME
-            = new HazelcastProperty(PREFIX + ".operationthreadsamples.includeName", false);
+            = new HazelcastProperty("hazelcast.diagnostics.operationthreadsamples.includeName", false);
     public static final float HUNDRED = 100f;
 
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/OverloadedConnectionsPlugin.java
@@ -37,7 +37,6 @@ import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Random;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static java.lang.Math.min;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -64,20 +63,20 @@ public class OverloadedConnectionsPlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
-            = new HazelcastProperty(PREFIX + ".overloaded.connections.period.seconds", 0, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.overloaded.connections.period.seconds", 0, SECONDS);
 
     /**
      * The minimum number of packets in the connection before it is considered to be overloaded.
      */
     public static final HazelcastProperty THRESHOLD
-            = new HazelcastProperty(PREFIX + ".overloaded.connections.threshold", 10000);
+            = new HazelcastProperty("hazelcast.diagnostics.overloaded.connections.threshold", 10000);
 
     /**
      * The number of samples to take from a single overloaded connection. Increasing the number of packages gives
      * more accuracy of the content, but it will come at greater price.
      */
     public static final HazelcastProperty SAMPLES
-            = new HazelcastProperty(PREFIX + ".overloaded.connections.samples", 1000);
+            = new HazelcastProperty("hazelcast.diagnostics.overloaded.connections.samples", 1000);
 
     private static final Queue<OutboundFrame> EMPTY_QUEUE = new LinkedList<OutboundFrame>();
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/PendingInvocationsPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/PendingInvocationsPlugin.java
@@ -25,7 +25,6 @@ import com.hazelcast.spi.properties.HazelcastProperties;
 import com.hazelcast.spi.properties.HazelcastProperty;
 import com.hazelcast.util.ItemCounter;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static com.hazelcast.internal.diagnostics.OperationDescriptors.toOperationDesc;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -46,13 +45,13 @@ public final class PendingInvocationsPlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
-            = new HazelcastProperty(PREFIX + ".pending.invocations.period.seconds", 0, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.pending.invocations.period.seconds", 0, SECONDS);
 
     /**
      * The minimum number of invocations per type of operation before it start logging this particular operation.
      */
     public static final HazelcastProperty THRESHOLD
-            = new HazelcastProperty(PREFIX + ".pending.invocations.threshold", 1);
+            = new HazelcastProperty("hazelcast.diagnostics.pending.invocations.threshold", 1);
 
     private final InvocationRegistry invocationRegistry;
     private final ItemCounter<String> occurrenceMap = new ItemCounter<String>();

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SlowOperationPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SlowOperationPlugin.java
@@ -27,7 +27,6 @@ import com.hazelcast.spi.properties.HazelcastProperty;
 
 import java.util.List;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static com.hazelcast.util.StringUtil.LINE_SEPARATOR;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -49,7 +48,7 @@ public class SlowOperationPlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS = new HazelcastProperty(
-            PREFIX + ".slowoperations.period.seconds", 60, SECONDS);
+            "hazelcast.diagnostics.slowoperations.period.seconds", 60, SECONDS);
 
     private final InternalOperationService operationService;
     private final long periodMillis;

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/StoreLatencyPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/StoreLatencyPlugin.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
-import static com.hazelcast.internal.diagnostics.Diagnostics.PREFIX;
 import static com.hazelcast.util.ConcurrencyUtil.getOrPutIfAbsent;
 import static java.lang.Math.max;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -57,7 +56,7 @@ public class StoreLatencyPlugin extends DiagnosticsPlugin {
      * If set to 0, the plugin is disabled.
      */
     public static final HazelcastProperty PERIOD_SECONDS
-            = new HazelcastProperty(PREFIX + ".storeLatency.period.seconds", 0, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.storeLatency.period.seconds", 0, SECONDS);
 
     /**
      * The period in second the statistics should be reset. Normally the statistics are not reset and if the system
@@ -67,7 +66,7 @@ public class StoreLatencyPlugin extends DiagnosticsPlugin {
      * setting will periodically reset the statistics.
      */
     public static final HazelcastProperty RESET_PERIOD_SECONDS
-            = new HazelcastProperty(PREFIX + ".storeLatency.reset.period.seconds", 0, SECONDS);
+            = new HazelcastProperty("hazelcast.diagnostics.storeLatency.reset.period.seconds", 0, SECONDS);
 
     private static final int LOW_WATERMARK_MICROS = 100;
 

--- a/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemLogPlugin.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/diagnostics/SystemLogPlugin.java
@@ -61,14 +61,14 @@ public class SystemLogPlugin extends DiagnosticsPlugin {
      * If this plugin is enabled.
      */
     public static final HazelcastProperty ENABLED
-            = new HazelcastProperty(Diagnostics.PREFIX + ".systemlog.enabled", "true");
+            = new HazelcastProperty("hazelcast.diagnostics.systemlog.enabled", "true");
 
     /**
      * If logging partition migration is enabled. Because there can be so many partitions, logging the partition migration
      * can be very noisy.
      */
     public static final HazelcastProperty LOG_PARTITIONS
-            = new HazelcastProperty(Diagnostics.PREFIX + ".systemlog.partitions", "false");
+            = new HazelcastProperty("hazelcast.diagnostics.systemlog.partitions", "false");
 
     /**
      * Currently the Diagnostic is scheduler based, so each task gets to run as often at is has been configured. This works


### PR DESCRIPTION
Instead of being preventing repeating patterns by using a common prefix,
repeat the prefix at each and every property.

This makes searching and copy pasting of diagnostics properties a lot easier.