### PR TITLE
Ignore new config resolution tests in pre-jdk8 builds

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientConfigResolutionTest.java
@@ -34,6 +34,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -86,6 +87,7 @@ public class HazelcastClientConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_file_yaml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         File file = helper.givenYamlClientConfigFileInWorkDir("foo.yaml", "cluster-yaml");
         System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
 
@@ -97,6 +99,7 @@ public class HazelcastClientConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_classpath_yaml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlClientConfigFileOnClasspath("foo.yaml", "cluster-yaml");
         System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
 
@@ -108,6 +111,7 @@ public class HazelcastClientConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_file_yml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         File file = helper.givenYamlClientConfigFileInWorkDir("foo.yml", "cluster-yaml");
         System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
 
@@ -119,6 +123,7 @@ public class HazelcastClientConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_classpath_yml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlClientConfigFileOnClasspath("foo.yml", "cluster-yaml");
         System.setProperty(SYSPROP_NAME, "classpath:foo.yml");
 
@@ -256,6 +261,7 @@ public class HazelcastClientConfigResolutionTest {
 
     @Test
     public void testResolveWorkDir_yaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlClientConfigFileInWorkDir("cluster-yaml");
 
         instance = HazelcastClient.newHazelcastClient();
@@ -266,6 +272,7 @@ public class HazelcastClientConfigResolutionTest {
 
     @Test
     public void testResolveClasspath_yaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlClientConfigFileOnClasspath("cluster-yaml");
 
         instance = HazelcastClient.newHazelcastClient();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientFailoverConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientFailoverConfigResolutionTest.java
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -85,6 +86,7 @@ public class HazelcastClientFailoverConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_file_yaml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         File file = helper.givenYamlClientFailoverConfigFileInWorkDir("foo.yaml", 42);
         System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
 
@@ -96,6 +98,7 @@ public class HazelcastClientFailoverConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_classpath_yaml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlClientFailoverConfigFileOnClasspath("foo.yaml", 42);
         System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
 
@@ -107,6 +110,7 @@ public class HazelcastClientFailoverConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_file_yml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         File file = helper.givenYamlClientFailoverConfigFileInWorkDir("foo.yml", 42);
         System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
 
@@ -118,6 +122,7 @@ public class HazelcastClientFailoverConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_classpath_yml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlClientFailoverConfigFileOnClasspath("foo.yml", 42);
         System.setProperty(SYSPROP_NAME, "classpath:foo.yml");
 
@@ -255,6 +260,7 @@ public class HazelcastClientFailoverConfigResolutionTest {
 
     @Test
     public void testResolveWorkDir_yaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlClientFailoverConfigFileInWorkDir(42);
 
         instance = HazelcastClient.newHazelcastFailoverClient();
@@ -265,6 +271,7 @@ public class HazelcastClientFailoverConfigResolutionTest {
 
     @Test
     public void testResolveClasspath_yaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlClientFailoverConfigFileOnClasspath(42);
 
         instance = HazelcastClient.newHazelcastFailoverClient();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderResolutionTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -44,8 +45,13 @@ public class YamlClientConfigBuilderResolutionTest {
     private DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
 
     @Before
+    public void setUp() {
+        assumeThatJDK8OrHigher();
+        System.clearProperty(SYSPROP_NAME);
+    }
+
     @After
-    public void beforeAndAfter() {
+    public void tearDown() {
         System.clearProperty(SYSPROP_NAME);
         helper.ensureTestConfigDeleted();
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilderConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilderConfigResolutionTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -44,8 +45,13 @@ public class YamlClientFailoverConfigBuilderConfigResolutionTest {
     private DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
 
     @Before
+    public void setUp() {
+        assumeThatJDK8OrHigher();
+        System.clearProperty(SYSPROP_NAME);
+    }
+
     @After
-    public void beforeAndAfter() {
+    public void tearDown() {
         System.clearProperty(SYSPROP_NAME);
         helper.ensureTestConfigDeleted();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderConfigResolutionTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -44,8 +45,13 @@ public class YamlConfigBuilderConfigResolutionTest {
     private DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
 
     @Before
+    public void setUp() {
+        assumeThatJDK8OrHigher();
+        System.clearProperty(SYSPROP_NAME);
+    }
+
     @After
-    public void beforeAndAfter() {
+    public void tearDown() {
         System.clearProperty(SYSPROP_NAME);
         helper.ensureTestConfigDeleted();
     }

--- a/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryConfigResolutionTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 
+import static com.hazelcast.test.HazelcastTestSupport.assumeThatJDK8OrHigher;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(HazelcastSerialClassRunner.class)
@@ -84,6 +85,7 @@ public class HazelcastInstanceFactoryConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_file_yaml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         File file = helper.givenYamlConfigFileInWorkDir("foo.yaml", "cluster-yaml");
         System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
 
@@ -95,6 +97,7 @@ public class HazelcastInstanceFactoryConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_classpath_yaml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlConfigFileOnClasspath("foo.yaml", "cluster-yaml");
         System.setProperty(SYSPROP_NAME, "classpath:foo.yaml");
 
@@ -106,6 +109,7 @@ public class HazelcastInstanceFactoryConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_file_yml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         File file = helper.givenYamlConfigFileInWorkDir("foo.yml", "cluster-yaml");
         System.setProperty(SYSPROP_NAME, file.getAbsolutePath());
 
@@ -117,6 +121,7 @@ public class HazelcastInstanceFactoryConfigResolutionTest {
 
     @Test
     public void testResolveSystemProperty_classpath_yml_loadedAsYaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlConfigFileOnClasspath("foo.yml", "cluster-yaml");
         System.setProperty(SYSPROP_NAME, "classpath:foo.yml");
 
@@ -254,6 +259,7 @@ public class HazelcastInstanceFactoryConfigResolutionTest {
 
     @Test
     public void testResolveWorkDir_yaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlConfigFileInWorkDir("cluster-yaml");
 
         instance = HazelcastInstanceFactory.newHazelcastInstance(null);
@@ -264,6 +270,7 @@ public class HazelcastInstanceFactoryConfigResolutionTest {
 
     @Test
     public void testResolveClasspath_yaml() throws Exception {
+        assumeThatJDK8OrHigher();
         helper.givenYamlConfigFileOnClasspath("cluster-yaml");
 
         instance = HazelcastInstanceFactory.newHazelcastInstance(null);


### PR DESCRIPTION
The new declarative config resolution tests got merged without ignoring the tests may use YAML in the pre-jdk8 builds and failing on such builds.

This commit ignores the ones that may use YAML, but keeps the XML-specific ones running.

Fixes #14988