### PR TITLE
Cleanup c.h.instance package

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/core/Member.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/Member.java
@@ -64,23 +64,11 @@ public interface Member extends DataSerializable, Endpoint {
     Map<EndpointQualifier, Address> getAddressMap();
 
     /**
-     * Returns the InetSocketAddress of this member.
-     *
-     * @return InetSocketAddress of this member
-     *
-     * @deprecated use {@link #getSocketAddress()} instead
-     */
-    @Deprecated
-    InetSocketAddress getInetSocketAddress();
-
-    /**
      * Returns the socket address of this member for member to member communications or unified depending on config.
      * Equivalent to {@link #getSocketAddress(EndpointQualifier) getSocketAddress(ProtocolType.MEMBER)}.
      *
      * @return the socket address of this member for member to member communications or unified depending on config.
-     * @deprecated as of Hazelcast 3.12, use {@link #getSocketAddress(EndpointQualifier)}
      */
-    @Deprecated
     InetSocketAddress getSocketAddress();
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AbstractMember.java
@@ -100,11 +100,6 @@ public abstract class AbstractMember implements Member {
     protected abstract ILogger getLogger();
 
     @Override
-    public InetSocketAddress getInetSocketAddress() {
-        return getSocketAddress();
-    }
-
-    @Override
     public InetSocketAddress getSocketAddress() {
         return getSocketAddress(MEMBER);
     }

--- a/hazelcast/src/main/java/com/hazelcast/instance/AddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AddressPicker.java
@@ -36,13 +36,6 @@ public interface AddressPicker {
     void pickAddress() throws Exception;
 
     /**
-     * @return the bind address for this node's member server socket
-     * @deprecated use {@link #getBindAddress(EndpointQualifier) getBindAddress(EndpointQualifier.MEMBER} instead
-     */
-    @Deprecated
-    Address getBindAddress();
-
-    /**
      * Returns a server socket listener address. The returned address for different {@link EndpointQualifier}s
      * may be the same or different, depending on the actual network configuration.
      *
@@ -51,13 +44,6 @@ public interface AddressPicker {
      * @since 3.12
      */
     Address getBindAddress(EndpointQualifier qualifier);
-
-    /**
-     * @return the public address for this node's member server socket
-     * @deprecated use {@link #getPublicAddress(EndpointQualifier) getPublicAddress(EndpointQualifier.MEMBER} instead
-     */
-    @Deprecated
-    Address getPublicAddress();
 
     /**
      * Returns a public address to be advertised to other cluster members and clients.
@@ -69,13 +55,6 @@ public interface AddressPicker {
     Address getPublicAddress(EndpointQualifier qualifier);
 
     Map<EndpointQualifier, Address> getPublicAddressMap();
-
-    /**
-     * @return the server socket channel for this node's member server socket
-     * @deprecated use {@link #getServerSocketChannel(EndpointQualifier) getServerSocketChannel(EndpointQualifier.MEMBER} instead
-     */
-    @Deprecated
-    ServerSocketChannel getServerSocketChannel();
 
     /**
      * Returns a server channel.

--- a/hazelcast/src/main/java/com/hazelcast/instance/AdvancedNetworkAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/AdvancedNetworkAddressPicker.java
@@ -38,7 +38,7 @@ class AdvancedNetworkAddressPicker
         implements AddressPicker {
 
     private final AdvancedNetworkConfig advancedNetworkConfig;
-    private final Map<EndpointQualifier, AddressPicker> pickers = new HashMap<EndpointQualifier, AddressPicker>();
+    private final Map<EndpointQualifier, AddressPicker> pickers = new HashMap<>();
 
     AdvancedNetworkAddressPicker(Config config, ILogger logger) {
         this.advancedNetworkConfig = config.getAdvancedNetworkConfig();
@@ -71,18 +71,8 @@ class AdvancedNetworkAddressPicker
     }
 
     @Override
-    public Address getBindAddress() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Address getBindAddress(EndpointQualifier qualifier) {
         return pickers.get(qualifier).getBindAddress(qualifier);
-    }
-
-    @Override
-    public Address getPublicAddress() {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -92,17 +82,12 @@ class AdvancedNetworkAddressPicker
 
     @Override
     public Map<EndpointQualifier, Address> getPublicAddressMap() {
-        Map<EndpointQualifier, Address> pubAddressMap = new HashMap<EndpointQualifier, Address>(pickers.size());
+        Map<EndpointQualifier, Address> pubAddressMap = new HashMap<>(pickers.size());
         for (Map.Entry<EndpointQualifier, AddressPicker>  entry : pickers.entrySet()) {
             pubAddressMap.put(entry.getKey(), entry.getValue().getPublicAddress(entry.getKey()));
         }
 
         return pubAddressMap;
-    }
-
-    @Override
-    public ServerSocketChannel getServerSocketChannel() {
-        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -112,9 +97,7 @@ class AdvancedNetworkAddressPicker
 
     @Override
     public Map<EndpointQualifier, ServerSocketChannel> getServerSocketChannels() {
-        Map<EndpointQualifier, ServerSocketChannel> channels
-                = new HashMap<EndpointQualifier, ServerSocketChannel>(pickers.size());
-
+        Map<EndpointQualifier, ServerSocketChannel> channels = new HashMap<>(pickers.size());
         for (Map.Entry<EndpointQualifier, AddressPicker>  entry : pickers.entrySet()) {
             channels.put(entry.getKey(), entry.getValue().getServerSocketChannel(entry.getKey()));
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DefaultAddressPicker.java
@@ -43,6 +43,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import static com.hazelcast.instance.ServerSocketHelper.createServerSocketChannel;
 import static com.hazelcast.instance.EndpointQualifier.MEMBER;
@@ -150,7 +151,7 @@ class DefaultAddressPicker
         return getPublicAddress(port);
     }
 
-    private static Address createAddress(AddressDefinition addressDef, int port) throws UnknownHostException {
+    private static Address createAddress(AddressDefinition addressDef, int port) {
         if (addressDef.host == null) {
             return new Address(addressDef.inetAddress, port);
         }
@@ -205,7 +206,7 @@ class DefaultAddressPicker
         Map<String, String> addressDomainMap = createAddressToDomainMap(tcpIpConfig);
 
         // must preserve insertion order
-        List<InterfaceDefinition> interfaceDefs = new ArrayList<InterfaceDefinition>();
+        List<InterfaceDefinition> interfaceDefs = new ArrayList<>();
         if (interfacesConfig.isEnabled()) {
             Collection<String> configInterfaces = interfacesConfig.getInterfaces();
             for (String configInterface : configInterfaces) {
@@ -405,28 +406,13 @@ class DefaultAddressPicker
     }
 
     @Override
-    public Address getBindAddress() {
-        return bindAddress;
-    }
-
-    @Override
     public Address getBindAddress(EndpointQualifier qualifier) {
         return bindAddress;
     }
 
     @Override
-    public Address getPublicAddress() {
-        return publicAddress;
-    }
-
-    @Override
     public Address getPublicAddress(EndpointQualifier qualifier) {
         return publicAddress;
-    }
-
-    @Override
-    public ServerSocketChannel getServerSocketChannel() {
-        return getServerSocketChannel(MEMBER);
     }
 
     @Override
@@ -478,13 +464,10 @@ class DefaultAddressPicker
             }
 
             InterfaceDefinition that = (InterfaceDefinition) o;
-            if (address != null ? !address.equals(that.address) : that.address != null) {
+            if (!Objects.equals(address, that.address)) {
                 return false;
             }
-            if (host != null ? !host.equals(that.host) : that.host != null) {
-                return false;
-            }
-            return true;
+            return Objects.equals(host, that.host);
         }
 
         @Override
@@ -532,10 +515,7 @@ class DefaultAddressPicker
             if (port != that.port) {
                 return false;
             }
-            if (inetAddress != null ? !inetAddress.equals(that.inetAddress) : that.inetAddress != null) {
-                return false;
-            }
-            return true;
+            return Objects.equals(inetAddress, that.inetAddress);
         }
 
         @Override
@@ -555,7 +535,7 @@ class DefaultAddressPicker
         @Override
         public Collection<String> resolve(String hostname) throws UnknownHostException {
             InetAddress[] inetAddresses = InetAddress.getAllByName(hostname);
-            Collection<String> addresses = new LinkedList<String>();
+            Collection<String> addresses = new LinkedList<>();
             for (InetAddress inetAddress : inetAddresses) {
                 addresses.add(inetAddress.getHostAddress());
             }

--- a/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/DelegatingAddressPicker.java
@@ -42,14 +42,11 @@ import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 final class DelegatingAddressPicker
         implements AddressPicker {
 
-    private final Map<EndpointQualifier, InetSocketAddress> bindAddresses =
-            new ConcurrentHashMap<EndpointQualifier, InetSocketAddress>();
+    private final Map<EndpointQualifier, InetSocketAddress> bindAddresses = new ConcurrentHashMap<>();
 
-    private final Map<EndpointQualifier, InetSocketAddress> publicAddresses =
-                new ConcurrentHashMap<EndpointQualifier, InetSocketAddress>();
+    private final Map<EndpointQualifier, InetSocketAddress> publicAddresses = new ConcurrentHashMap<>();
 
-    private final Map<EndpointQualifier, ServerSocketChannel> serverSocketChannels =
-            new ConcurrentHashMap<EndpointQualifier, ServerSocketChannel>();
+    private final Map<EndpointQualifier, ServerSocketChannel> serverSocketChannels = new ConcurrentHashMap<>();
 
     private final MemberAddressProvider memberAddressProvider;
     private final Config config;
@@ -165,11 +162,6 @@ final class DelegatingAddressPicker
     }
 
     @Override
-    public Address getBindAddress() {
-        return getBindAddress(MEMBER);
-    }
-
-    @Override
     public Address getBindAddress(EndpointQualifier qualifier) {
         return usesAdvancedNetworkConfig
                 ? new Address(bindAddresses.get(qualifier))
@@ -177,20 +169,10 @@ final class DelegatingAddressPicker
     }
 
     @Override
-    public Address getPublicAddress() {
-        return getPublicAddress(MEMBER);
-    }
-
-    @Override
     public Address getPublicAddress(EndpointQualifier qualifier) {
         return usesAdvancedNetworkConfig
                 ? new Address(publicAddresses.get(qualifier))
                 : new Address(publicAddresses.get(MEMBER));
-    }
-
-    @Override
-    public ServerSocketChannel getServerSocketChannel() {
-        return getServerSocketChannel(MEMBER);
     }
 
     @Override
@@ -207,7 +189,7 @@ final class DelegatingAddressPicker
 
     @Override
     public Map<EndpointQualifier, Address> getPublicAddressMap() {
-        Map<EndpointQualifier, Address> mappings = new HashMap<EndpointQualifier, Address>(publicAddresses.size());
+        Map<EndpointQualifier, Address> mappings = new HashMap<>(publicAddresses.size());
         for (Map.Entry<EndpointQualifier, InetSocketAddress> entry : publicAddresses.entrySet()) {
             mappings.put(entry.getKey(), new Address(entry.getValue()));
         }

--- a/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/instance/HazelcastInstanceImpl.java
@@ -61,7 +61,6 @@ import com.hazelcast.durableexecutor.impl.DistributedDurableExecutorService;
 import com.hazelcast.executor.impl.DistributedExecutorService;
 import com.hazelcast.flakeidgen.FlakeIdGenerator;
 import com.hazelcast.flakeidgen.impl.FlakeIdGeneratorService;
-import com.hazelcast.internal.cluster.Versions;
 import com.hazelcast.internal.jmx.ManagementService;
 import com.hazelcast.internal.serialization.InternalSerializationService;
 import com.hazelcast.logging.ILogger;
@@ -105,7 +104,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
     @SuppressWarnings("checkstyle:visibilitymodifier")
     public final Node node;
 
-    final ConcurrentMap<String, Object> userContext = new ConcurrentHashMap<String, Object>();
+    final ConcurrentMap<String, Object> userContext = new ConcurrentHashMap<>();
 
     final ILogger logger;
     final String name;
@@ -157,7 +156,7 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
         }
     }
 
-    protected Node createNode(Config config, NodeContext nodeContext) {
+    private Node createNode(Config config, NodeContext nodeContext) {
         return new Node(this, config, nodeContext);
     }
 
@@ -430,9 +429,6 @@ public class HazelcastInstanceImpl implements HazelcastInstance, SerializationSe
 
     @Override
     public CPSubsystem getCPSubsystem() {
-        if (node.getClusterService().getClusterVersion().isLessThan(Versions.V3_12)) {
-            throw new UnsupportedOperationException("CP Subsystem is not available before version 3.12!");
-        }
         return cpSubsystem;
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/DelegatingAddressPickerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/DelegatingAddressPickerTest.java
@@ -82,13 +82,11 @@ public class DelegatingAddressPickerTest {
 
         picker.pickAddress();
 
-        assertEquals(memberBindAddress, picker.getBindAddress());
         assertEquals(memberBindAddress, picker.getBindAddress(EndpointQualifier.MEMBER));
         assertEquals(clientBindAddress, picker.getBindAddress(EndpointQualifier.CLIENT));
         assertEquals(textBindAddress, picker.getBindAddress(EndpointQualifier.REST));
         assertEquals(wan1BindAddress, picker.getBindAddress(EndpointQualifier.resolve(ProtocolType.WAN, "wan1")));
 
-        assertEquals(memberPublicAddress, picker.getPublicAddress());
         assertEquals(memberPublicAddress, picker.getPublicAddress(EndpointQualifier.MEMBER));
         assertEquals(clientPublicAddress, picker.getPublicAddress(EndpointQualifier.CLIENT));
         assertEquals(textPublicAddress, picker.getPublicAddress(EndpointQualifier.REST));
@@ -102,13 +100,11 @@ public class DelegatingAddressPickerTest {
 
         picker.pickAddress();
 
-        assertEquals(memberBindAddress, picker.getBindAddress());
         assertEquals(memberBindAddress, picker.getBindAddress(EndpointQualifier.MEMBER));
         assertEquals(memberBindAddress, picker.getBindAddress(EndpointQualifier.CLIENT));
         assertEquals(memberBindAddress, picker.getBindAddress(EndpointQualifier.REST));
         assertEquals(memberBindAddress, picker.getBindAddress(EndpointQualifier.resolve(ProtocolType.WAN, "wan1")));
 
-        assertEquals(memberPublicAddress, picker.getPublicAddress());
         assertEquals(memberPublicAddress, picker.getPublicAddress(EndpointQualifier.MEMBER));
         assertEquals(memberPublicAddress, picker.getPublicAddress(EndpointQualifier.CLIENT));
         assertEquals(memberPublicAddress, picker.getPublicAddress(EndpointQualifier.REST));

--- a/hazelcast/src/test/java/com/hazelcast/instance/IpVersionPreferenceTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/IpVersionPreferenceTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import static com.hazelcast.instance.DefaultAddressPicker.PREFER_IPV4_STACK;
 import static com.hazelcast.instance.DefaultAddressPicker.PREFER_IPV6_ADDRESSES;
 import static com.hazelcast.instance.DefaultAddressPickerTest.findIPv6NonLoopbackInterface;
+import static com.hazelcast.instance.EndpointQualifier.MEMBER;
 import static com.hazelcast.spi.properties.GroupProperty.PREFER_IPv4_STACK;
 import static com.hazelcast.test.OverridePropertyRule.clear;
 import static org.junit.Assert.assertEquals;
@@ -100,10 +101,10 @@ public class IpVersionPreferenceTest {
         DefaultAddressPicker addressPicker = new DefaultAddressPicker(new Config(), Logger.getLogger(AddressPicker.class));
         try {
             addressPicker.pickAddress();
-            Address bindAddress = addressPicker.getBindAddress();
+            Address bindAddress = addressPicker.getBindAddress(MEMBER);
             assertEquals("Bind address: " + bindAddress, expectedIPv6, bindAddress.isIPv6());
         } finally {
-            IOUtil.closeResource(addressPicker.getServerSocketChannel());
+            IOUtil.closeResource(addressPicker.getServerSocketChannel(MEMBER));
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/SimpleMemberImpl.java
@@ -65,11 +65,6 @@ public class SimpleMemberImpl implements Member {
     }
 
     @Override
-    public InetSocketAddress getInetSocketAddress() {
-        return getSocketAddress();
-    }
-
-    @Override
     public InetSocketAddress getSocketAddress() {
         return address;
     }

--- a/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/TestNodeContext.java
@@ -101,21 +101,6 @@ public class TestNodeContext implements NodeContext {
         }
 
         @Override
-        public Address getBindAddress() {
-            return address;
-        }
-
-        @Override
-        public Address getPublicAddress() {
-            return address;
-        }
-
-        @Override
-        public ServerSocketChannel getServerSocketChannel() {
-            return null;
-        }
-
-        @Override
         public Address getBindAddress(EndpointQualifier qualifier) {
             return address;
         }

--- a/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/StaticAddressPicker.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/mocknetwork/StaticAddressPicker.java
@@ -37,17 +37,7 @@ class StaticAddressPicker implements AddressPicker {
     }
 
     @Override
-    public Address getBindAddress() {
-        return thisAddress;
-    }
-
-    @Override
     public Address getBindAddress(EndpointQualifier qualifier) {
-        return thisAddress;
-    }
-
-    @Override
-    public Address getPublicAddress() {
         return thisAddress;
     }
 
@@ -59,11 +49,6 @@ class StaticAddressPicker implements AddressPicker {
     @Override
     public Map<EndpointQualifier, Address> getPublicAddressMap() {
         return singletonMap(EndpointQualifier.MEMBER, thisAddress);
-    }
-
-    @Override
-    public ServerSocketChannel getServerSocketChannel() {
-        return null;
     }
 
     @Override


### PR DESCRIPTION
- Removed 3.12 version checks
- Removed deprecated methods in `Member` and `AddressPicker`