### PR TITLE
ClientExecutorService does not need to use RunnableAdapter

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceExecuteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/executor/ClientExecutorServiceExecuteTest.java
@@ -28,7 +28,6 @@ import com.hazelcast.core.IExecutorService;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.Member;
 import com.hazelcast.core.MemberSelector;
-import com.hazelcast.test.AssertTask;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -119,11 +118,7 @@ public class ClientExecutorServiceExecuteTest {
 
         final IMap map = client.getMap(mapName);
 
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertTrue(map.containsKey(targetUuid));
-            }
-        });
+        assertTrueEventually(() -> assertTrue(map.containsKey(targetUuid)));
     }
 
     @Test(expected = NullPointerException.class)
@@ -144,11 +139,7 @@ public class ClientExecutorServiceExecuteTest {
 
         final IMap map = client.getMap(mapName);
 
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertTrue(map.containsKey(targetUuid));
-            }
-        });
+        assertTrueEventually(() -> assertTrue(map.containsKey(targetUuid)));
     }
 
     @Test(expected = NullPointerException.class)
@@ -171,11 +162,9 @@ public class ClientExecutorServiceExecuteTest {
         service.executeOnMembers(new MapPutRunnable(mapName), collection);
 
         final IMap map = client.getMap(mapName);
-        assertTrueEventually(new AssertTask() {
-            public void run() {
-                assertTrue(map.containsKey(member1.getUuid()));
-                assertTrue(map.containsKey(member2.getUuid()));
-            }
+        assertTrueEventually(() -> {
+            assertTrue(map.containsKey(member1.getUuid()));
+            assertTrue(map.containsKey(member2.getUuid()));
         });
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToAddressMessageTask.java
@@ -53,9 +53,14 @@ public class ExecutorServiceSubmitToAddressMessageTask
         SecurityContext securityContext = clientEngine.getSecurityContext();
         Data callableData = parameters.callable;
         if (securityContext != null) {
-            Callable callable = serializationService.toObject(parameters.callable);
             Subject subject = endpoint.getSubject();
-            callable = securityContext.createSecureCallable(subject, callable);
+            Object taskObject = serializationService.toObject(parameters.callable);
+            Callable callable;
+            if (taskObject instanceof Runnable) {
+                callable = securityContext.createSecureCallable(subject, (Runnable) taskObject);
+            } else {
+                callable = securityContext.createSecureCallable(subject, (Callable<? extends Object>) taskObject);
+            }
             callableData = serializationService.toData(callable);
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/ExecutorServiceSubmitToPartitionMessageTask.java
@@ -58,8 +58,13 @@ public class ExecutorServiceSubmitToPartitionMessageTask
         Data callableData = parameters.callable;
         if (securityContext != null) {
             Subject subject = endpoint.getSubject();
-            Callable callable = serializationService.toObject(parameters.callable);
-            callable = securityContext.createSecureCallable(subject, callable);
+            Object taskObject = serializationService.toObject(parameters.callable);
+            Callable callable;
+            if (taskObject instanceof Runnable) {
+                callable = securityContext.createSecureCallable(subject, (Runnable) taskObject);
+            } else {
+                callable = securityContext.createSecureCallable(subject, (Callable<? extends Object>) taskObject);
+            }
             callableData = serializationService.toData(callable);
         }
         return new CallableTaskOperation(parameters.name, parameters.uuid, callableData);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorSubmitToPartitionMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/executorservice/durable/DurableExecutorSubmitToPartitionMessageTask.java
@@ -47,8 +47,13 @@ public class DurableExecutorSubmitToPartitionMessageTask
         Data callableData = parameters.callable;
         if (securityContext != null) {
             Subject subject = endpoint.getSubject();
-            Callable callable = serializationService.toObject(parameters.callable);
-            callable = securityContext.createSecureCallable(subject, callable);
+            Object taskObject = serializationService.toObject(parameters.callable);
+            Callable callable;
+            if (taskObject instanceof Runnable) {
+                callable = securityContext.createSecureCallable(subject, (Runnable) taskObject);
+            } else {
+                callable = securityContext.createSecureCallable(subject, (Callable<? extends Object>) taskObject);
+            }
             callableData = serializationService.toData(callable);
         }
         return new TaskOperation(parameters.name, callableData);

--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/DistributedExecutorService.java
@@ -105,16 +105,16 @@ public class DistributedExecutorService implements ManagedService, RemoteService
         reset();
     }
 
-    public <T> void execute(String name, String uuid, T callable, Operation op) {
+    public <T> void execute(String name, String uuid, T task, Operation op) {
         ExecutorConfig cfg = getOrFindExecutorConfig(name);
         if (cfg.isStatisticsEnabled()) {
             startPending(name);
         }
         Processor processor;
-        if (callable instanceof Runnable) {
-            processor = new Processor(name, uuid, (Runnable) callable, op, cfg.isStatisticsEnabled());
+        if (task instanceof Runnable) {
+            processor = new Processor(name, uuid, (Runnable) task, op, cfg.isStatisticsEnabled());
         } else {
-            processor = new Processor(name, uuid, (Callable) callable, op, cfg.isStatisticsEnabled());
+            processor = new Processor(name, uuid, (Callable) task, op, cfg.isStatisticsEnabled());
         }
         if (uuid != null) {
             submittedTasks.put(uuid, processor);
@@ -126,7 +126,7 @@ public class DistributedExecutorService implements ManagedService, RemoteService
             if (cfg.isStatisticsEnabled()) {
                 rejectExecution(name);
             }
-            logger.warning("While executing " + callable + " on Executor[" + name + "]", e);
+            logger.warning("While executing " + task + " on Executor[" + name + "]", e);
             if (uuid != null) {
                 submittedTasks.remove(uuid);
             }

--- a/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/security/SecurityContext.java
@@ -103,6 +103,16 @@ public interface SecurityContext {
     <V> SecureCallable<V> createSecureCallable(Subject subject, Callable<V> callable);
 
     /**
+     * Creates secure callable that runs in a sandbox.
+     *
+     * @param <V>      return type of callable
+     * @param subject
+     * @param runnable
+     * @return Will always return null after {@link Runnable} finishes running.
+     */
+    <V> SecureCallable<?> createSecureCallable(Subject subject, Runnable runnable);
+
+    /**
      * Destroys {@link SecurityContext} and all security elements.
      */
     void destroy();


### PR DESCRIPTION
Removed `RunnableAdapter` usage from the `ClientExecutorService` implementation. The executor service codec uses `Data` to send the task and hence ıt does not need to be `Callable`.