### PR TITLE
Make collection clones of IMap immutable (#12198)

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -1171,8 +1171,8 @@ public class ClientMapProxy<K, V> extends ClientProxy
         ClientMessage response = invoke(request);
         MapKeySetCodec.ResponseParameters resultParameters = MapKeySetCodec.decodeResponse(response);
 
-        ImmutableInflatableSet.ImmutableBuilder<K> setBuilder =
-                ImmutableInflatableSet.newImmutableBuilder(resultParameters.response.size());
+        ImmutableInflatableSet.ImmutableSetBuilder<K> setBuilder =
+                ImmutableInflatableSet.newImmutableSetBuilder(resultParameters.response.size());
         for (Data data : resultParameters.response) {
             K key = toObject(data);
             setBuilder.add(key);
@@ -1264,8 +1264,8 @@ public class ClientMapProxy<K, V> extends ClientProxy
         ClientMessage response = invoke(request);
         MapEntrySetCodec.ResponseParameters resultParameters = MapEntrySetCodec.decodeResponse(response);
 
-        ImmutableInflatableSet.ImmutableBuilder<Entry<K, V>> setBuilder =
-                ImmutableInflatableSet.newImmutableBuilder(resultParameters.response.size());
+        ImmutableInflatableSet.ImmutableSetBuilder<Entry<K, V>> setBuilder =
+                ImmutableInflatableSet.newImmutableSetBuilder(resultParameters.response.size());
         InternalSerializationService serializationService = getContext().getSerializationService();
         for (Entry<Data, Data> row : resultParameters.response) {
             LazyMapEntry<K, V> entry = new LazyMapEntry<K, V>(row.getKey(), row.getValue(), serializationService);
@@ -1285,8 +1285,8 @@ public class ClientMapProxy<K, V> extends ClientProxy
         ClientMessage response = invokeWithPredicate(request, predicate);
         MapKeySetWithPredicateCodec.ResponseParameters resultParameters = MapKeySetWithPredicateCodec.decodeResponse(response);
 
-        ImmutableInflatableSet.ImmutableBuilder<K> setBuilder =
-                ImmutableInflatableSet.newImmutableBuilder(resultParameters.response.size());
+        ImmutableInflatableSet.ImmutableSetBuilder<K> setBuilder =
+                ImmutableInflatableSet.newImmutableSetBuilder(resultParameters.response.size());
         for (Data data : resultParameters.response) {
             K key = toObject(data);
             setBuilder.add(key);
@@ -1323,8 +1323,8 @@ public class ClientMapProxy<K, V> extends ClientProxy
         ClientMessage response = invokeWithPredicate(request, predicate);
         MapEntriesWithPredicateCodec.ResponseParameters resultParameters = MapEntriesWithPredicateCodec.decodeResponse(response);
 
-        ImmutableInflatableSet.ImmutableBuilder<Entry<K, V>> setBuilder =
-                ImmutableInflatableSet.newImmutableBuilder(resultParameters.response.size());
+        ImmutableInflatableSet.ImmutableSetBuilder<Entry<K, V>> setBuilder =
+                ImmutableInflatableSet.newImmutableSetBuilder(resultParameters.response.size());
         InternalSerializationService serializationService = getContext().getSerializationService();
         for (Entry<Data, Data> row : resultParameters.response) {
             LazyMapEntry<K, V> entry = new LazyMapEntry<K, V>(row.getKey(), row.getValue(), serializationService);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/map/ClientMapBasicTest.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.EntryListener;
 import com.hazelcast.core.EntryView;
 import com.hazelcast.core.IMap;
 import com.hazelcast.core.MapEvent;
+import com.hazelcast.map.BasicMapTest;
 import com.hazelcast.map.MapInterceptor;
 import com.hazelcast.map.listener.EntryEvictedListener;
 import com.hazelcast.monitor.LocalMapStats;
@@ -928,6 +929,11 @@ public class ClientMapBasicTest extends AbstractClientMapTest {
             Integer expectedValue = expected.get(key);
             assertEquals(expectedValue, value);
         }
+    }
+
+    @Test
+    public void testMapClonedCollectionsImmutable() {
+        BasicMapTest.testMapClonedCollectionsImmutable(client, false);
     }
 
     @Test

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.util.collection.InflatableSet;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultRow;
@@ -35,7 +36,6 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.ExceptionUtil;
-import com.hazelcast.util.collection.InflatableSet;
 
 import java.security.Permission;
 import java.util.ArrayList;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateWithValueMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/map/MapPublisherCreateWithValueMessageTask.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.impl.protocol.task.BlockingMessageTask;
 import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.cluster.ClusterService;
+import com.hazelcast.internal.util.collection.InflatableSet;
 import com.hazelcast.map.impl.MapService;
 import com.hazelcast.map.impl.query.QueryResult;
 import com.hazelcast.map.impl.query.QueryResultRow;
@@ -35,7 +36,6 @@ import com.hazelcast.query.Predicate;
 import com.hazelcast.spi.InvocationBuilder;
 import com.hazelcast.spi.impl.operationservice.InternalOperationService;
 import com.hazelcast.util.ExceptionUtil;
-import com.hazelcast.util.collection.InflatableSet;
 
 import java.security.Permission;
 import java.util.AbstractMap;

--- a/hazelcast/src/main/java/com/hazelcast/core/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/core/IMap.java
@@ -59,9 +59,9 @@ import java.util.concurrent.TimeUnit;
  * <li>The {@code get} method returns a clone of original values, so modifying the returned value does not change
  * the actual value in the map. You should put the modified value back to make changes visible to all nodes.
  * For additional info, see {@link IMap#get(Object)}.</li>
- * <li>Methods, including but not limited to {@code keySet}, {@code values}, {@code entrySet}, return a collection
- * clone of the values. The collection is <b>NOT</b> backed by the map, so changes to the map are <b>NOT</b> reflected
- * in the collection, and vice-versa.</li>
+ * <li>Methods, including but not limited to {@code keySet}, {@code values}, {@code entrySet}, return an <b>immutable</b>
+ * collection clone of the values. The collection is <b>NOT</b> backed by the map, so changes to the map are <b>NOT</b>
+ * reflected in the collection.</li>
  * <li>Since Hazelcast is compiled with Java 1.6, we can't override default methods introduced in later Java versions,
  * nor can we add documentation to them. Methods, including but not limited to {@code computeIfPresent}, may behave
  * incorrectly if the value passed to the update function is modified in-place and returned as a result of the invocation.
@@ -470,13 +470,13 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
     void flush();
 
     /**
-     * Returns the entries for the given keys.
+     * Returns an immutable map of entries for the given keys.
      * <p>
      * <b>Warning 1:</b>
      * <p>
      * The returned map is <b>NOT</b> backed by the original map, so
      * changes to the original map are <b>NOT</b> reflected in the
-     * returned map, and vice-versa.
+     * returned map.
      * <p>
      * <b>Warning 2:</b>
      * <p>
@@ -493,7 +493,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * and are propagated to the caller.
      *
      * @param keys keys to get (keys inside the collection cannot be null)
-     * @return map of entries
+     * @return an immutable map of entries
      * @throws NullPointerException if any of the specified keys are null
      */
     Map<K, V> getAll(Set<K> keys);
@@ -2252,54 +2252,54 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
     void evictAll();
 
     /**
-     * Returns a set clone of the keys contained in this map.
+     * Returns an immutable set clone of the keys contained in this map.
      * <p>
      * <b>Warning:</b>
      * <p>
      * The set is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * so changes to the map are <b>NOT</b> reflected in the set.
      * <p>
      * This method is always executed by a distributed query,
      * so it may throw a {@link QueryResultSizeExceededException}
      * if {@link GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
-     * @return a set clone of the keys contained in this map
+     * @return an immutable set clone of the keys contained in this map
      * @throws QueryResultSizeExceededException if query result size limit is exceeded
      * @see GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Set<K> keySet();
 
     /**
-     * Returns a collection clone of the values contained in this map.
+     * Returns an immutable collection clone of the values contained in this map.
      * <p>
      * <b>Warning:</b>
      * <p>
      * The collection is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the collection, and vice-versa.
+     * so changes to the map are <b>NOT</b> reflected in the collection.
      * <p>
      * This method is always executed by a distributed query,
      * so it may throw a {@link QueryResultSizeExceededException}
      * if {@link GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
-     * @return a collection clone of the values contained in this map
+     * @return an immutable collection clone of the values contained in this map
      * @throws QueryResultSizeExceededException if query result size limit is exceeded
      * @see GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Collection<V> values();
 
     /**
-     * Returns a {@link Set} clone of the mappings contained in this map.
+     * Returns an immutable {@link Set} clone of the mappings contained in this map.
      * <p>
      * <b>Warning:</b>
      * <p>
      * The set is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * so changes to the map are <b>NOT</b> reflected in the set.
      * <p>
      * This method is always executed by a distributed query,
      * so it may throw a {@link QueryResultSizeExceededException}
      * if {@link GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
-     * @return a set clone of the keys mappings in this map
+     * @return an immutable set clone of the keys mappings in this map
      * @throws QueryResultSizeExceededException if query result size limit is exceeded
      * @see GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
@@ -2307,14 +2307,14 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
 
     /**
      * Queries the map based on the specified predicate and
-     * returns the keys of matching entries.
+     * returns an immutable {@link Set} clone of the keys of matching entries.
      * <p>
      * Specified predicate runs on all members in parallel.
      * <p>
      * <b>Warning:</b>
      * <p>
      * The set is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * so changes to the map are <b>NOT</b> reflected in the set.
      * <p>
      * This method is always executed by a distributed query,
      * so it may throw a {@link QueryResultSizeExceededException}
@@ -2329,14 +2329,14 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
     Set<K> keySet(Predicate predicate);
 
     /**
-     * Queries the map based on the specified predicate and returns the matching entries.
+     * Queries the map based on the specified predicate and returns an immutable set of the matching entries.
      * <p>
      * Specified predicate runs on all members in parallel.
      * <p>
      * <b>Warning:</b>
      * <p>
      * The set is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * so changes to the map are <b>NOT</b> reflected in the set.
      * <p>
      * This method is always executed by a distributed query,
      * so it may throw a {@link QueryResultSizeExceededException}
@@ -2351,14 +2351,15 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
     Set<Map.Entry<K, V>> entrySet(Predicate predicate);
 
     /**
-     * Queries the map based on the specified predicate and returns the values of matching entries.
+     * Queries the map based on the specified predicate and returns an immutable collection of the values
+     * of matching entries.
      * <p>
      * Specified predicate runs on all members in parallel.
      * <p>
      * <b>Warning:</b>
      * <p>
      * The collection is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the collection, and vice-versa.
+     * so changes to the map are <b>NOT</b> reflected in the collection.
      * <p>
      * This method is always executed by a distributed query,
      * so it may throw a {@link QueryResultSizeExceededException}
@@ -2373,7 +2374,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
     Collection<V> values(Predicate predicate);
 
     /**
-     * Returns the locally owned set of keys.
+     * Returns the locally owned immutable set of keys.
      * <p>
      * Each key in this map is owned and managed by a specific
      * member in the cluster.
@@ -2385,20 +2386,20 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * <b>Warning:</b>
      * <p>
      * The set is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * so changes to the map are <b>NOT</b> reflected in the set.
      * <p>
      * This method is always executed by a distributed query,
      * so it may throw a {@link QueryResultSizeExceededException}
      * if {@link GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
-     * @return locally owned keys
+     * @return locally owned immutable set of keys
      * @throws QueryResultSizeExceededException if query result size limit is exceeded
      * @see GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
     Set<K> localKeySet();
 
     /**
-     * Returns the keys of matching locally owned entries.
+     * Returns an immutable set of the keys of matching locally owned entries.
      * <p>
      * Each key in this map is owned and managed by a specific
      * member in the cluster.
@@ -2410,14 +2411,14 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * <b>Warning:</b>
      * <p>
      * The set is <b>NOT</b> backed by the map,
-     * so changes to the map are <b>NOT</b> reflected in the set, and vice-versa.
+     * so changes to the map are <b>NOT</b> reflected in the set.
      * <p>
      * This method is always executed by a distributed query,
      * so it may throw a {@link QueryResultSizeExceededException}
      * if {@link GroupProperty#QUERY_RESULT_SIZE_LIMIT} is configured.
      *
      * @param predicate specified query criteria
-     * @return keys of matching locally owned entries
+     * @return an immutable set of the keys of matching locally owned entries
      * @throws QueryResultSizeExceededException if query result size limit is exceeded
      * @see GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */

--- a/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/nearcache/impl/preloader/NearCachePreloader.java
@@ -20,14 +20,14 @@ import com.hazelcast.config.NearCachePreloaderConfig;
 import com.hazelcast.internal.adapter.DataStructureAdapter;
 import com.hazelcast.internal.serialization.impl.HeapData;
 import com.hazelcast.internal.util.BufferingInputStream;
+import com.hazelcast.internal.util.collection.InflatableSet;
+import com.hazelcast.internal.util.collection.InflatableSet.Builder;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.memory.MemoryUnit;
 import com.hazelcast.monitor.impl.NearCacheStatsImpl;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.serialization.SerializationService;
-import com.hazelcast.util.collection.InflatableSet;
-import com.hazelcast.util.collection.InflatableSet.Builder;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/ResultSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/ResultSet.java
@@ -19,10 +19,12 @@ package com.hazelcast.internal.util;
 import com.hazelcast.util.IterationType;
 
 import java.util.AbstractSet;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /**
  *
@@ -87,5 +89,34 @@ public class ResultSet extends AbstractSet<Map.Entry> {
         public void remove() {
             throw new UnsupportedOperationException();
         }
+    }
+
+    @Override
+    public boolean addAll(Collection c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeIf(Predicate filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    public boolean retainAll(Collection<?> coll) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ImmutableInflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ImmutableInflatableSet.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.internal.util.collection;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Predicate;
+
+import com.hazelcast.nio.serialization.SerializableByConvention;
+
+/**
+ * An immutable {@link InflatableSet}.
+ *
+ * @param <T> the type of elements maintained by this set
+ */
+@SerializableByConvention
+public final class ImmutableInflatableSet<T> extends InflatableSet<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    private ImmutableInflatableSet(List<T> compactList) {
+        super(compactList);
+    }
+
+    public static <T> ImmutableBuilder<T> newImmutableBuilder(int initialCapacity) {
+        return new ImmutableBuilder<T>(initialCapacity);
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        if (state == State.INFLATED) {
+            return Collections.unmodifiableSet(inflatedSet).iterator();
+        }
+        return new ImmutableHybridIterator();
+    }
+
+    private final class ImmutableHybridIterator extends HybridIterator {
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * Builder for {@link ImmutableInflatableSet}.
+     * This is the only way to create a new instance of ImmutableInflatableSet.
+     *
+     * @param <T> the type of elements maintained by this set
+     */
+    public static final class ImmutableBuilder<T> extends AbstractBuilder<T> {
+
+        private ImmutableBuilder(int initialCapacity) {
+            super(initialCapacity);
+        }
+
+        private ImmutableBuilder(List<T> list) {
+            super(list);
+        }
+
+        public ImmutableBuilder<T> add(T item) {
+            super.add(item);
+            return this;
+        }
+
+        public ImmutableInflatableSet<T> build() {
+            ImmutableInflatableSet<T> set = new ImmutableInflatableSet<T>(list);
+
+            // make sure no further insertions are possible
+            list = Collections.emptyList();
+            return set;
+        }
+    }
+
+    @Override
+    public boolean add(T t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super T> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> coll) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ImmutableInflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/ImmutableInflatableSet.java
@@ -38,14 +38,14 @@ public final class ImmutableInflatableSet<T> extends InflatableSet<T> {
         super(compactList);
     }
 
-    public static <T> ImmutableBuilder<T> newImmutableBuilder(int initialCapacity) {
-        return new ImmutableBuilder<T>(initialCapacity);
+    public static <T> ImmutableSetBuilder<T> newImmutableSetBuilder(int initialCapacity) {
+        return new ImmutableSetBuilder<T>(initialCapacity);
     }
 
     @Override
     public Iterator<T> iterator() {
         if (state == State.INFLATED) {
-            return Collections.unmodifiableSet(inflatedSet).iterator();
+            throw new IllegalStateException("Set is immutable and can not be inflated.");
         }
         return new ImmutableHybridIterator();
     }
@@ -64,23 +64,19 @@ public final class ImmutableInflatableSet<T> extends InflatableSet<T> {
      *
      * @param <T> the type of elements maintained by this set
      */
-    public static final class ImmutableBuilder<T> extends AbstractBuilder<T> {
+    public static final class ImmutableSetBuilder<T> extends AbstractBuilder<T> {
 
-        private ImmutableBuilder(int initialCapacity) {
+        private ImmutableSetBuilder(int initialCapacity) {
             super(initialCapacity);
         }
 
-        private ImmutableBuilder(List<T> list) {
-            super(list);
-        }
-
-        public ImmutableBuilder<T> add(T item) {
+        public ImmutableSetBuilder<T> add(T item) {
             super.add(item);
             return this;
         }
 
         public ImmutableInflatableSet<T> build() {
-            ImmutableInflatableSet<T> set = new ImmutableInflatableSet<T>(list);
+            ImmutableInflatableSet<T> set = new ImmutableInflatableSet<>(list);
 
             // make sure no further insertions are possible
             list = Collections.emptyList();

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/InflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/InflatableSet.java
@@ -73,16 +73,16 @@ public class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Serializ
     }
 
     /**
-     * The fields are package-visible to use in {@link com.hazelcast.internal.util.collection.ImmutableInflatableSet#iterator}.
+     * The field is package-visible to use in {@link com.hazelcast.internal.util.collection.ImmutableInflatableSet#iterator}.
      */
-    Set<T> inflatedSet;
     State state;
+    private Set<T> inflatedSet;
     private final List<T> compactList;
 
 
     /**
      * This constructor is intended to be used by {@link com.hazelcast.internal.util.collection.InflatableSet.Builder} and
-     * {@link com.hazelcast.internal.util.collection.ImmutableInflatableSet.ImmutableBuilder} only.
+     * {@link com.hazelcast.internal.util.collection.ImmutableInflatableSet.ImmutableSetBuilder} only.
      *
      * The constructor is package-visible to support {@link com.hazelcast.internal.util.collection.ImmutableInflatableSet}
      *
@@ -262,7 +262,7 @@ public class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Serializ
         List<T> list;
 
         AbstractBuilder(int initialCapacity) {
-            this.list = new ArrayList<T>(initialCapacity);
+            this.list = new ArrayList<>(initialCapacity);
         }
 
         AbstractBuilder(List<T> list) {
@@ -301,7 +301,7 @@ public class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Serializ
         }
 
         public InflatableSet<T> build() {
-            InflatableSet<T> set = new InflatableSet<T>(list);
+            InflatableSet<T> set = new InflatableSet<>(list);
 
             // make sure no further insertions are possible
             list = Collections.emptyList();

--- a/hazelcast/src/main/java/com/hazelcast/internal/util/collection/InflatableSet.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/util/collection/InflatableSet.java
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package com.hazelcast.util.collection;
+package com.hazelcast.internal.util.collection;
 
 import com.hazelcast.nio.serialization.SerializableByConvention;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.Serializable;
@@ -34,7 +35,7 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * Provides fast {@link Set} implementation for cases where items are known to not
  * contain duplicates.
  * <p>
- * It requires creation via {@link com.hazelcast.util.collection.InflatableSet.Builder}
+ * It requires creation via {@link com.hazelcast.internal.util.collection.InflatableSet.Builder}
  * <p>
  * The builder doesn't call equals/hash methods on initial data insertion, hence it avoids
  * performance penalty in the case these methods are expensive. It also means it does
@@ -54,11 +55,11 @@ import static com.hazelcast.util.Preconditions.checkNotNull;
  * @param <T> the type of elements maintained by this set
  */
 @SerializableByConvention
-public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Serializable, Cloneable {
+public class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Serializable, Cloneable {
 
     private static final long serialVersionUID = 0L;
 
-    private enum State {
+    enum State {
         // only array-backed representation exists
         COMPACT,
 
@@ -71,16 +72,23 @@ public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Se
         INFLATED
     }
 
+    /**
+     * The fields are package-visible to use in {@link com.hazelcast.internal.util.collection.ImmutableInflatableSet#iterator}.
+     */
+    Set<T> inflatedSet;
+    State state;
     private final List<T> compactList;
-    private Set<T> inflatedSet;
-    private State state;
+
 
     /**
-     * This constructor is intended to be used by {@link com.hazelcast.util.collection.InflatableSet.Builder} only.
+     * This constructor is intended to be used by {@link com.hazelcast.internal.util.collection.InflatableSet.Builder} and
+     * {@link com.hazelcast.internal.util.collection.ImmutableInflatableSet.ImmutableBuilder} only.
+     *
+     * The constructor is package-visible to support {@link com.hazelcast.internal.util.collection.ImmutableInflatableSet}
      *
      * @param compactList list of elements for the InflatableSet
      */
-    private InflatableSet(List<T> compactList) {
+    InflatableSet(List<T> compactList) {
         this.state = State.COMPACT;
         this.compactList = compactList;
     }
@@ -221,7 +229,7 @@ public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Se
         }
     }
 
-    private class HybridIterator implements Iterator<T> {
+    class HybridIterator implements Iterator<T> {
 
         private Iterator<T> innerIterator;
         private T currentValue;
@@ -250,21 +258,14 @@ public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Se
         }
     }
 
-    /**
-     * Builder for {@link InflatableSet}.
-     * This is the only way to create a new instance of InflatableSet.
-     *
-     * @param <T> the type of elements maintained by this set
-     */
-    public static final class Builder<T> {
+    abstract static class AbstractBuilder<T> {
+        List<T> list;
 
-        private List<T> list;
-
-        private Builder(int initialCapacity) {
+        AbstractBuilder(int initialCapacity) {
             this.list = new ArrayList<T>(initialCapacity);
         }
 
-        private Builder(List<T> list) {
+        AbstractBuilder(List<T> list) {
             this.list = checkNotNull(list, "list cannot be null");
         }
 
@@ -272,8 +273,30 @@ public final class InflatableSet<T> extends AbstractSet<T> implements Set<T>, Se
             return list.size();
         }
 
-        public Builder add(T item) {
+        AbstractBuilder<T> add(T item) {
             list.add(item);
+            return this;
+        }
+    }
+
+    /**
+     * Builder for {@link InflatableSet}.
+     * This is the only way to create a new instance of InflatableSet.
+     *
+     * @param <T> the type of elements maintained by this set
+     */
+    public static final class Builder<T> extends AbstractBuilder<T> {
+
+        private Builder(int initialCapacity) {
+            super(initialCapacity);
+        }
+
+        private Builder(List<T> list) {
+            super(list);
+        }
+
+        public Builder<T> add(T item) {
+            super.add(item);
             return this;
         }
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/MerkleTreeNodeEntries.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/MerkleTreeNodeEntries.java
@@ -17,12 +17,12 @@
 package com.hazelcast.map.impl;
 
 import com.hazelcast.core.EntryView;
+import com.hazelcast.internal.util.collection.InflatableSet;
+import com.hazelcast.internal.util.collection.InflatableSet.Builder;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
-import com.hazelcast.util.collection.InflatableSet;
-import com.hazelcast.util.collection.InflatableSet.Builder;
 import com.hazelcast.wan.merkletree.MerkleTree;
 
 import java.io.IOException;

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/operation/PartitionWideEntryWithPredicateOperationFactory.java
@@ -16,6 +16,8 @@
 
 package com.hazelcast.map.impl.operation;
 
+import com.hazelcast.internal.util.collection.InflatableSet;
+import com.hazelcast.internal.util.collection.InflatableSet.Builder;
 import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.impl.MapDataSerializerHook;
 import com.hazelcast.map.impl.MapService;
@@ -34,8 +36,6 @@ import com.hazelcast.spi.Operation;
 import com.hazelcast.spi.impl.operationservice.impl.operations.PartitionAwareOperationFactory;
 import com.hazelcast.spi.partition.IPartitionService;
 import com.hazelcast.util.IterationType;
-import com.hazelcast.util.collection.InflatableSet;
-import com.hazelcast.util.collection.InflatableSet.Builder;
 import com.hazelcast.util.collection.Int2ObjectHashMap;
 
 import java.io.IOException;
@@ -45,9 +45,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.hazelcast.internal.util.collection.InflatableSet.newBuilder;
 import static com.hazelcast.map.impl.MapService.SERVICE_NAME;
 import static com.hazelcast.util.MapUtil.createInt2ObjectHashMap;
-import static com.hazelcast.util.collection.InflatableSet.newBuilder;
 
 public class PartitionWideEntryWithPredicateOperationFactory extends PartitionAwareOperationFactory {
 

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -428,7 +428,8 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public Map<K, V> getAll(Set<K> keys) {
         if (CollectionUtil.isEmpty(keys)) {
-            return emptyMap();
+            // Wrap emptyMap() into unmodifiableMap to make sure put/putAll methods throw UnsupportedOperationException
+            return Collections.unmodifiableMap(emptyMap());
         }
 
         int keysSize = keys.size();
@@ -442,7 +443,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
             V value = toObject(resultingKeyValuePairs.get(i++));
             result.put(key, value);
         }
-        return result;
+        return Collections.unmodifiableMap(result);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/query/QueryResultCollection.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.function.Predicate;
 
 public class QueryResultCollection<E> extends AbstractSet<E> {
 
@@ -72,5 +73,35 @@ public class QueryResultCollection<E> extends AbstractSet<E> {
     @Override
     public int size() {
         return rows.size();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super E> filter) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> coll) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/UnmodifiableLazyList.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/UnmodifiableLazyList.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.function.Predicate;
 
 import static com.hazelcast.util.EmptyStatement.ignore;
 
@@ -53,6 +54,16 @@ public class UnmodifiableLazyList<E> extends AbstractList<E> implements Identifi
     }
 
     @Override
+    public boolean add(E t) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean remove(Object o) {
         throw new UnsupportedOperationException();
     }
@@ -63,12 +74,17 @@ public class UnmodifiableLazyList<E> extends AbstractList<E> implements Identifi
     }
 
     @Override
-    public boolean retainAll(Collection<?> c) {
+    public boolean removeIf(Predicate<? super E> filter) {
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> coll) {
         throw new UnsupportedOperationException();
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/internal/util/collection/InflatableSetTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/util/collection/InflatableSetTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.hazelcast.util.collection;
+package com.hazelcast.internal.util.collection;
 
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.TestJavaSerializationUtils;

--- a/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/BasicMapTest.java
@@ -676,6 +676,9 @@ public class BasicMapTest extends HazelcastTestSupport {
         assertThrows(UnsupportedOperationException.class, () -> map.replace(key, value));
         assertThrows(UnsupportedOperationException.class, () -> map.replace(key, value, value));
         assertThrows(UnsupportedOperationException.class, () -> map.replaceAll((k, v) -> value));
+        assertThrows(UnsupportedOperationException.class, () -> map.compute(key, (k, v) -> v));
+        assertThrows(UnsupportedOperationException.class, () -> map.computeIfAbsent(key, k -> value));
+        assertThrows(UnsupportedOperationException.class, () -> map.computeIfPresent(key, (k, v) -> v));
         checkCollectionImmutable(map.entrySet());
         checkCollectionImmutable(map.keySet());
         checkCollectionImmutable(map.values());

--- a/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/HazelcastTestSupport.java
@@ -17,6 +17,8 @@
 package com.hazelcast.test;
 
 import classloading.ThreadLocalLeakTestUtils;
+import junit.framework.AssertionFailedError;
+
 import com.hazelcast.client.impl.ClientEngineImpl;
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.config.Config;
@@ -1496,6 +1498,23 @@ public abstract class HazelcastTestSupport {
                 assertEquals(expectedOpsCount, waitNotifyService.getTotalParkedOperationCount());
             }
         });
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Throwable> T assertThrows(Class<T> expectedType, Runnable r) {
+        try {
+            r.run();
+        } catch (Throwable actualException) {
+            if (expectedType.isInstance(actualException)) {
+                return (T) actualException;
+            } else {
+                String excMsg = String.format("Unexpected %s exception type thrown", actualException.getClass().getName());
+                throw new AssertionFailedError(excMsg);
+            }
+        }
+
+        String excMsg = String.format("Expected %s to be thrown, but nothing was thrown.", expectedType.getName());
+        throw new AssertionFailedError(excMsg);
     }
 
     private static OperationParkerImpl getOperationParkingService(HazelcastInstance instance) {


### PR DESCRIPTION
Consistently throw UnsupportedOperationException on attempt to update a
collection returned by keySet, entrySet, localKeySet, values and getAll
methods.

The fix may change the behavior of existing customers throwing an
exception instead of ignoring the updates.

Moved InflatableSet to internal package making it for internal use only.

Fixes: https://github.com/hazelcast/hazelcast/issues/12198