### PR TITLE
Adds support for HazelcastJsonValue over Rest

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/ascii/rest/HttpGetCommandProcessor.java
@@ -18,6 +18,7 @@ package com.hazelcast.internal.ascii.rest;
 
 import com.hazelcast.cluster.ClusterState;
 import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastJsonValue;
 import com.hazelcast.core.ICompletableFuture;
 import com.hazelcast.cp.CPGroup;
 import com.hazelcast.cp.CPGroupId;
@@ -44,6 +45,7 @@ import java.util.Collection;
 import static com.hazelcast.instance.EndpointQualifier.CLIENT;
 import static com.hazelcast.internal.ascii.TextCommandConstants.MIME_TEXT_PLAIN;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_BINARY;
+import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_JSON;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.CONTENT_TYPE_PLAIN_TEXT;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.RES_200_WITH_NO_CONTENT;
 import static com.hazelcast.internal.ascii.rest.HttpCommand.RES_503;
@@ -397,6 +399,8 @@ public class HttpGetCommandProcessor extends HttpCommandProcessor<HttpGetCommand
         } else if (value instanceof RestValue) {
             RestValue restValue = (RestValue) value;
             command.setResponse(restValue.getContentType(), restValue.getValue());
+        } else if (value instanceof HazelcastJsonValue) {
+            command.setResponse(CONTENT_TYPE_JSON, stringToBytes(value.toString()));
         } else if (value instanceof String) {
             command.setResponse(CONTENT_TYPE_PLAIN_TEXT, stringToBytes((String) value));
         } else {

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/InvalidEndpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/InvalidEndpointTest.java
@@ -28,12 +28,10 @@ import net.spy.memcached.ConnectionFactory;
 import net.spy.memcached.ConnectionFactoryBuilder;
 import net.spy.memcached.FailureMode;
 import net.spy.memcached.MemcachedClient;
-import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -140,10 +138,7 @@ public class InvalidEndpointTest {
             HttpGet request = new HttpGet(url);
             request.setHeader("Content-type", "text/xml; charset=" + "UTF-8");
             response = client.execute(request);
-            int responseCode = response.getStatusLine().getStatusCode();
-            HttpEntity entity = response.getEntity();
-            String responseStr = entity != null ? EntityUtils.toString(entity, "UTF-8") : "";
-            return new HTTPCommunicator.ConnectionResponse(responseStr, responseCode);
+            return new HTTPCommunicator.ConnectionResponse(response);
         } finally {
             IOUtil.closeResource(response);
             IOUtil.closeResource(client);

--- a/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestMultiendpointTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/ascii/RestMultiendpointTest.java
@@ -43,7 +43,8 @@ public class RestMultiendpointTest
         extends RestTest {
 
     @Override
-    public Config setup() {
+    public Config getConfig() {
+        Config config = super.getConfig();
         config.getGroupConfig().setName(randomString());
         ServerSocketEndpointConfig memberEndpointConfig = new ServerSocketEndpointConfig();
         memberEndpointConfig.setName("MEMBER")
@@ -86,8 +87,7 @@ public class RestMultiendpointTest
 
     @Test
     public void assertAdvancedNetworkInUse() {
-        setup();
-        int numberOfEndpointsInConfig = config.getAdvancedNetworkConfig().getEndpointConfigs().size();
+        int numberOfEndpointsInConfig = instance.getConfig().getAdvancedNetworkConfig().getEndpointConfigs().size();
         MemberImpl local = getNode(instance).getClusterService().getLocalMember();
         assertTrue(local.getAddressMap().size() == numberOfEndpointsInConfig);
         assertFalse(local.getSocketAddress(EndpointQualifier.REST).equals(local.getSocketAddress(EndpointQualifier.MEMBER)));


### PR DESCRIPTION
When a HazelcastJsonValue is requested over Rest API, we return UTF8 encoded json value. Response has the json string in payload and "Content-Type" header is set to application/json. This is a very small change. Rest of the PR is about refactoring to test classes.