### PR TITLE
Ignore compatibility tests

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/starter/HazelcastClientStarterTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/starter/HazelcastClientStarterTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.starter.HazelcastStarter;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -57,6 +58,7 @@ public class HazelcastClientStarterTest {
         }
     }
 
+    @Ignore("https://github.com/hazelcast/hazelcast/issues/15021")
     @Test
     public void testClientMap() {
         HazelcastInstance clientInstance = null;
@@ -87,6 +89,7 @@ public class HazelcastClientStarterTest {
         System.out.println("Client terminated");
     }
 
+    @Ignore("https://github.com/hazelcast/hazelcast/issues/15021")
     @Test
     public void testClientMap_async() throws InterruptedException, ExecutionException {
         HazelcastInstance clientInstance = null;

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/answer/test/AnswerTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/answer/test/AnswerTest.java
@@ -67,6 +67,7 @@ import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.SlowTest;
 import com.hazelcast.test.starter.HazelcastStarter;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -86,6 +87,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.hazelcast.internal.cluster.Versions.CURRENT_CLUSTER_VERSION;
 import static com.hazelcast.internal.cluster.Versions.PREVIOUS_CLUSTER_VERSION;
 import static com.hazelcast.internal.partition.TestPartitionUtils.getPartitionServiceState;
 import static java.lang.reflect.Proxy.isProxyClass;
@@ -103,6 +105,8 @@ public class AnswerTest extends HazelcastTestSupport {
 
     @Before
     public void setUp() {
+        Assume.assumeTrue("This test ensures access to internals works with a previous minor version. "
+                + "Test execution is skipped for new major versions.", CURRENT_CLUSTER_VERSION.getMinor() > 0);
         Config config = smallInstanceConfig()
                 .setInstanceName("test-name");
 

--- a/hazelcast/src/test/java/com/hazelcast/test/starter/test/PatchLevelCompatibilityTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/test/starter/test/PatchLevelCompatibilityTest.java
@@ -23,6 +23,7 @@ import com.hazelcast.test.HazelcastSerialClassRunner;
 import com.hazelcast.test.annotation.NightlyTest;
 import com.hazelcast.test.starter.HazelcastStarter;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -72,6 +73,7 @@ public class PatchLevelCompatibilityTest {
         testAllGivenVersions(versions);
     }
 
+    @Ignore("https://github.com/hazelcast/hazelcast/issues/15021")
     @Test
     public void testMap_whenMixed_V37_Cluster() {
         String[] versions = new String[]{"3.7.4", "3.7.5"};


### PR DESCRIPTION
These tests are broken due to (expected) incompatible changes in 4.0
so should be ignored and enabled again in 4.1 development cycle.

Fixes #15001 