### PR TITLE
[4.0] Close resources in config builders

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilder.java
@@ -104,11 +104,14 @@ public class XmlClientFailoverConfigBuilder extends AbstractXmlConfigBuilder {
     public XmlClientFailoverConfigBuilder(XmlClientFailoverConfigLocator locator) {
         if (locator == null) {
             locator = new XmlClientFailoverConfigLocator();
+            locator.locateEverywhere();
         }
-        boolean located = locator.locateEverywhere();
+
+        boolean located = locator.isConfigPresent();
         if (!located) {
             throw new HazelcastException("Failed to load ClientFailoverConfig");
         }
+
         this.in = locator.getIn();
     }
 

--- a/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientConfigResolutionTest.java
@@ -54,7 +54,7 @@ public class HazelcastClientConfigResolutionTest {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         if (instance != null) {
             instance.shutdown();
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientFailoverConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/HazelcastClientFailoverConfigResolutionTest.java
@@ -53,7 +53,7 @@ public class HazelcastClientFailoverConfigResolutionTest {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         if (instance != null) {
             instance.shutdown();
         }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientConfigBuilderResolutionTest.java
@@ -45,7 +45,7 @@ public class XmlClientConfigBuilderResolutionTest {
 
     @Before
     @After
-    public void beforeAndAfter() {
+    public void beforeAndAfter() throws Exception {
         System.clearProperty(SYSPROP_CLIENT_CONFIG);
         helper.ensureTestConfigDeleted();
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderConfigResolutionTest.java
@@ -29,6 +29,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import java.io.File;
+import java.io.IOException;
 
 import static com.hazelcast.config.DeclarativeConfigUtil.SYSPROP_CLIENT_FAILOVER_CONFIG;
 import static com.hazelcast.config.DeclarativeConfigUtil.XML_ACCEPTED_SUFFIXES_STRING;
@@ -45,7 +46,7 @@ public class XmlClientFailoverConfigBuilderConfigResolutionTest {
 
     @Before
     @After
-    public void beforeAndAfter() {
+    public void beforeAndAfter() throws IOException {
         System.clearProperty(SYSPROP_CLIENT_FAILOVER_CONFIG);
         helper.ensureTestConfigDeleted();
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientConfigBuilderResolutionTest.java
@@ -45,7 +45,7 @@ public class YamlClientConfigBuilderResolutionTest {
 
     @Before
     @After
-    public void beforeAndAfter() {
+    public void tearDown() throws Exception {
         System.clearProperty(SYSPROP_CLIENT_CONFIG);
         helper.ensureTestConfigDeleted();
     }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilderConfigResolutionTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/YamlClientFailoverConfigBuilderConfigResolutionTest.java
@@ -45,7 +45,7 @@ public class YamlClientFailoverConfigBuilderConfigResolutionTest {
 
     @Before
     @After
-    public void beforeAndAfter() {
+    public void tearDown() throws Exception {
         System.clearProperty(SYSPROP_CLIENT_FAILOVER_CONFIG);
         helper.ensureTestConfigDeleted();
     }

--- a/hazelcast/src/main/java/com/hazelcast/config/AbstractYamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/AbstractYamlConfigBuilder.java
@@ -29,6 +29,7 @@ import com.hazelcast.internal.yaml.YamlScalar;
 import com.hazelcast.internal.yaml.YamlSequence;
 import org.w3c.dom.Node;
 
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -99,8 +100,8 @@ public abstract class AbstractYamlConfigBuilder {
             }
 
             YamlNode rootLoaded;
-            try {
-                rootLoaded = YamlLoader.load(url.openStream());
+            try (InputStream inputStream = url.openStream()) {
+                rootLoaded = YamlLoader.load(inputStream);
             } catch (Exception ex) {
                 throw new InvalidConfigurationException("Loading YAML document from resource " + url.getPath() + " failed", ex);
             }

--- a/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/YamlConfigBuilder.java
@@ -20,6 +20,7 @@ import com.hazelcast.config.yaml.YamlDomChecker;
 import com.hazelcast.internal.yaml.YamlLoader;
 import com.hazelcast.internal.yaml.YamlMapping;
 import com.hazelcast.internal.yaml.YamlNode;
+import com.hazelcast.nio.IOUtil;
 import com.hazelcast.util.ExceptionUtil;
 import org.w3c.dom.Node;
 
@@ -127,6 +128,8 @@ public class YamlConfigBuilder extends AbstractYamlConfigBuilder implements Conf
             parseAndBuildConfig(config);
         } catch (Exception e) {
             throw ExceptionUtil.rethrow(e);
+        } finally {
+            IOUtil.closeResource(in);
         }
         return config;
     }

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlLoader.java
@@ -51,6 +51,8 @@ public final class YamlLoader {
     public static YamlNode load(InputStream inputStream, String rootName) {
         try {
             Object document = getLoad().loadFromInputStream(inputStream);
+            inputStream.close();
+
             return buildDom(rootName, document);
         } catch (Exception ex) {
             throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);
@@ -67,6 +69,8 @@ public final class YamlLoader {
     public static YamlNode load(InputStream inputStream) {
         try {
             Object document = getLoad().loadFromInputStream(inputStream);
+            inputStream.close();
+
             return buildDom(document);
         } catch (Exception ex) {
             throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);
@@ -86,6 +90,8 @@ public final class YamlLoader {
     public static YamlNode load(Reader reader, String rootName) {
         try {
             Object document = getLoad().loadFromReader(reader);
+            reader.close();
+
             return buildDom(rootName, document);
         } catch (Exception ex) {
             throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);
@@ -102,6 +108,8 @@ public final class YamlLoader {
     public static YamlNode load(Reader reader) {
         try {
             Object document = getLoad().loadFromReader(reader);
+            reader.close();
+
             return buildDom(document);
         } catch (Exception ex) {
             throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);

--- a/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlLoader.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/yaml/YamlLoader.java
@@ -51,8 +51,6 @@ public final class YamlLoader {
     public static YamlNode load(InputStream inputStream, String rootName) {
         try {
             Object document = getLoad().loadFromInputStream(inputStream);
-            inputStream.close();
-
             return buildDom(rootName, document);
         } catch (Exception ex) {
             throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);
@@ -69,8 +67,6 @@ public final class YamlLoader {
     public static YamlNode load(InputStream inputStream) {
         try {
             Object document = getLoad().loadFromInputStream(inputStream);
-            inputStream.close();
-
             return buildDom(document);
         } catch (Exception ex) {
             throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);
@@ -90,8 +86,6 @@ public final class YamlLoader {
     public static YamlNode load(Reader reader, String rootName) {
         try {
             Object document = getLoad().loadFromReader(reader);
-            reader.close();
-
             return buildDom(rootName, document);
         } catch (Exception ex) {
             throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);
@@ -108,8 +102,6 @@ public final class YamlLoader {
     public static YamlNode load(Reader reader) {
         try {
             Object document = getLoad().loadFromReader(reader);
-            reader.close();
-
             return buildDom(document);
         } catch (Exception ex) {
             throw new YamlException("An error occurred while loading and parsing the YAML stream", ex);

--- a/hazelcast/src/test/java/com/hazelcast/config/XmlConfigBuilderConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XmlConfigBuilderConfigResolutionTest.java
@@ -45,7 +45,7 @@ public class XmlConfigBuilderConfigResolutionTest {
 
     @Before
     @After
-    public void beforeAndAfter() {
+    public void beforeAndAfter() throws Exception {
         System.clearProperty(SYSPROP_MEMBER_CONFIG);
         helper.ensureTestConfigDeleted();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderConfigResolutionTest.java
@@ -45,7 +45,7 @@ public class YamlConfigBuilderConfigResolutionTest {
 
     @Before
     @After
-    public void beforeAndAfter() {
+    public void tearDown() throws Exception {
         System.clearProperty(SYSPROP_MEMBER_CONFIG);
         helper.ensureTestConfigDeleted();
     }

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
@@ -19,8 +19,12 @@ package com.hazelcast.config.helpers;
 import com.hazelcast.config.Config;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class DeclarativeConfigFileHelper {
     private static final String HAZELCAST_START_TAG = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n";
@@ -221,10 +225,10 @@ public class DeclarativeConfigFileHelper {
                 + "    - hazelcast-client-c1.yaml";
     }
 
-    public void ensureTestConfigDeleted() {
+    public void ensureTestConfigDeleted() throws IOException {
         if (testConfigPath != null) {
-            File file = new File(testConfigPath);
-            file.delete();
+            Path pathToDelete = Paths.get(testConfigPath);
+            Files.delete(pathToDelete);
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryConfigResolutionTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/instance/HazelcastInstanceFactoryConfigResolutionTest.java
@@ -52,7 +52,7 @@ public class HazelcastInstanceFactoryConfigResolutionTest {
     }
 
     @After
-    public void tearDown() {
+    public void tearDown() throws Exception {
         if (instance != null) {
             instance.shutdown();
         }


### PR DESCRIPTION
The recently written config resolution tests failed on Windows because
some config files created during the test remained open and due to this
these files on Windows couldn't be deleted at the end of the test,
failing the subsequent tests. This commit fixes the unclosed resources
issues at two places.

1. Makes YamlLoader to close the resources it loaded the YAML document
from.
2. Fixed XMLClientFailoverBuilder to call locateEverywhere() method of
the used locator only if the provided locator instance is null and a
newly created locator is being used. Otherwise the locator logic is
executed twice and the config file gets open twice, but only one of the
resources are closed.

Fixes #14988

3.12.x PR: https://github.com/hazelcast/hazelcast/pull/15027