### PR TITLE
Skip auth if it is already authenticated

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -112,7 +112,9 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClu
 
     @SuppressWarnings("checkstyle:returncount")
     private AuthenticationStatus authenticate() {
-        if (clientSerializationVersion != serializationService.getVersion()) {
+        if (endpoint.isAuthenticated()) {
+            return AUTHENTICATED;
+        } else if (clientSerializationVersion != serializationService.getVersion()) {
             return SERIALIZATION_VERSION_MISMATCH;
         } else if (!isOwnerConnection() && !isMember(principal)) {
             logger.warning("Member having UUID " + principal.getOwnerUuid()


### PR DESCRIPTION
An authentication message can be send over a connection to upgrade
client to owner node. In that case, authentication does not need
to work again. Adding a check to prevent authentication if the
connection is already authenticated.

(cherry picked from commit bf9e829922dfc211ff17a2a568714e743c9014a0)