### PR TITLE
Skip auth if it is already authenticated

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/task/AuthenticationBaseMessageTask.java
@@ -128,7 +128,9 @@ public abstract class AuthenticationBaseMessageTask<P> extends AbstractStableClu
     private AuthenticationStatus authenticate() {
         ILogger logger = clientEngine.getLogger(getClass());
         AuthenticationStatus status;
-        if (credentials == null) {
+        if (endpoint.isAuthenticated()) {
+            status = AuthenticationStatus.AUTHENTICATED;
+        } else if (credentials == null) {
             status = AuthenticationStatus.CREDENTIALS_FAILED;
             logger.severe("Could not retrieve Credentials object!");
         } else if (clientEngine.getSecurityContext() != null) {


### PR DESCRIPTION
An authentication message can be send over a connection to upgrade
client to owner node. In that case, authentication does not need
to work again. Adding a check to prevent authentication if the
connection is already authenticated.

(cherry picked from commit bf9e829922dfc211ff17a2a568714e743c9014a0)