### PR TITLE
Fix flaky SlowOperationDetector_purgeTest.testPurging_Invocation test

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector.java
@@ -51,7 +51,6 @@ public final class SlowOperationDetector {
 
     private final ConcurrentHashMap<Integer, SlowOperationLog> slowOperationLogs
             = new ConcurrentHashMap<>();
-    private final StringBuilder stackTraceStringBuilder = new StringBuilder();
 
     private final ILogger logger;
 
@@ -130,6 +129,7 @@ public final class SlowOperationDetector {
 
     private final class DetectorThread extends Thread {
 
+        private final StringBuilder stackTraceStringBuilder = new StringBuilder();
         private volatile boolean running = true;
 
         private DetectorThread(String hzName) {
@@ -203,16 +203,15 @@ public final class SlowOperationDetector {
         }
 
         private String getStackTraceOrNull(OperationRunner operationRunner, Object operation) {
+            StackTraceElement[] stackTraceElements = operationRunner.currentThread().getStackTrace();
+            // check if the operation is still the same, if not, we can't use this stacktrace
+            if (operationRunner.currentTask() != operation) {
+                return null;
+            }
             String prefix = "";
-            for (StackTraceElement stackTraceElement : operationRunner.currentThread().getStackTrace()) {
+            for (StackTraceElement stackTraceElement : stackTraceElements) {
                 stackTraceStringBuilder.append(prefix).append(stackTraceElement.toString());
                 prefix = "\n\t";
-            }
-
-            // check if the operation is still the same
-            if (operationRunner.currentTask() != operation) {
-                stackTraceStringBuilder.setLength(0);
-                return null;
             }
 
             String stackTrace = stackTraceStringBuilder.toString();

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
@@ -73,7 +73,12 @@ public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstra
         Collection<SlowOperationLog> logs = getSlowOperationLogsAndAssertNumberOfSlowOperationLogs(instance, 1);
 
         SlowOperationLog firstLog = logs.iterator().next();
-        assertTotalInvocations(firstLog, 4);
+        int totalInvocations = firstLog.totalInvocations.get();
+
+        //If due to race condition unable to collect a stacktrace of the operation before the next operation so the invocation
+        //will be dropped.
+        assertTrue(String.format("Expected 3 or 4 total invocations, but was %s, logs: %s", totalInvocations,
+                firstLog.createDTO().toJson()), totalInvocations >= 3 && totalInvocations <= 4);
         assertEntryProcessorOperation(firstLog);
         assertStackTraceContainsClassName(firstLog, "SlowEntryProcessor");
 

--- a/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/spi/impl/operationexecutor/slowoperationdetector/SlowOperationDetector_purgeTest.java
@@ -40,7 +40,7 @@ public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstra
 
     private void setup(String logRetentionSeconds) {
         Config config = new Config();
-        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS.getName(), "1000");
+        config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_THRESHOLD_MILLIS.getName(), "800");
         config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_LOG_RETENTION_SECONDS.getName(), logRetentionSeconds);
         config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_LOG_PURGE_INTERVAL_SECONDS.getName(), "1");
         config.setProperty(GroupProperty.SLOW_OPERATION_DETECTOR_STACK_TRACE_LOGGING_ENABLED.getName(), "true");
@@ -61,10 +61,10 @@ public class SlowOperationDetector_purgeTest extends SlowOperationDetectorAbstra
 
         // all of these entry processors are executed after each other, not in parallel
         for (int i = 0; i < 2; i++) {
-            map.executeOnEntries(getSlowEntryProcessor(3));
+            map.executeOnEntries(getSlowEntryProcessor(4));
         }
         map.executeOnEntries(getSlowEntryProcessor(4));
-        map.executeOnEntries(getSlowEntryProcessor(3));
+        map.executeOnEntries(getSlowEntryProcessor(4));
         awaitSlowEntryProcessors();
 
         // shutdown to stop purging, so the last one or two entry processor invocations will survive


### PR DESCRIPTION
Fixes: hazelcast/hazelcast#15002

The instability of this test comes from the fact that in the current
implementation we can't atomically read the current operation and the
stacktrace. In this commit the test can digest the hiccups up to 2
seconds (in the worst case) that occur during our states reads.