### PR TITLE
Fixes ClientScheduledExecutorQuorumWriteTest using member over client

### DIFF
--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumReadTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumReadTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.quorum.scheduledexecutor;
 import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
+import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.quorum.scheduledexecutor.ScheduledExecutorQuorumReadTest;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -54,7 +55,7 @@ public class ClientScheduledExecutorQuorumReadTest extends ScheduledExecutorQuor
     }
 
     @Override
-    protected IScheduledExecutorService exec(int index) {
-        return clients.client(index).getScheduledExecutorService(SCHEDULED_EXEC_NAME + quorumType.name());
+    protected IScheduledExecutorService scheduledExec(int index, QuorumType quorumType, String postfix) {
+        return clients.client(index).getScheduledExecutorService(SCHEDULED_EXEC_NAME + quorumType.name() + postfix);
     }
 }

--- a/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumWriteTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/quorum/scheduledexecutor/ClientScheduledExecutorQuorumWriteTest.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.quorum.scheduledexecutor;
 import com.hazelcast.client.quorum.PartitionedClusterClients;
 import com.hazelcast.client.test.TestHazelcastFactory;
 import com.hazelcast.config.Config;
+import com.hazelcast.quorum.QuorumType;
 import com.hazelcast.quorum.scheduledexecutor.ScheduledExecutorQuorumWriteTest;
 import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
 import com.hazelcast.test.HazelcastSerialParametersRunnerFactory;
@@ -54,12 +55,7 @@ public class ClientScheduledExecutorQuorumWriteTest extends ScheduledExecutorQuo
     }
 
     @Override
-    protected IScheduledExecutorService exec(int index) {
-        return scheduledExec(index, quorumType);
-    }
-
-    @Override
-    protected IScheduledExecutorService exec(int index, String postfix) {
+    protected IScheduledExecutorService scheduledExec(int index, QuorumType quorumType, String postfix) {
         return clients.client(index).getScheduledExecutorService(SCHEDULED_EXEC_NAME + quorumType.name() + postfix);
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/AbstractQuorumTest.java
@@ -347,10 +347,6 @@ public abstract class AbstractQuorumTest {
         return cluster.instance[index].getRingbuffer(RINGBUFFER_NAME + quorumType.name());
     }
 
-    protected IScheduledExecutorService scheduledExec(int index, QuorumType quorumType) {
-        return scheduledExec(index, quorumType, "");
-    }
-
     protected IScheduledExecutorService scheduledExec(int index, QuorumType quorumType, String postfix) {
         return cluster.instance[index].getScheduledExecutorService(SCHEDULED_EXEC_NAME + quorumType.name() + postfix);
     }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumReadTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumReadTest.java
@@ -76,6 +76,6 @@ public class ScheduledExecutorQuorumReadTest extends AbstractQuorumTest {
     }
 
     protected IScheduledExecutorService exec(int index) {
-        return scheduledExec(index, quorumType);
+        return scheduledExec(index, quorumType, "");
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/quorum/scheduledexecutor/ScheduledExecutorQuorumWriteTest.java
@@ -281,7 +281,7 @@ public class ScheduledExecutorQuorumWriteTest extends AbstractQuorumTest {
     }
 
     protected IScheduledExecutorService exec(int index) {
-        return scheduledExec(index, quorumType);
+        return exec(index, "");
     }
 
     protected IScheduledExecutorService exec(int index, String postfix) {


### PR DESCRIPTION
exec(int) calls scheduledExec(int, QuorumType). This method is not overridden in client test and calls members instead of clients. So client quorum was not tested by many tests.