### PR TITLE
[FORWARD PORT] Report error message/stack trace separately to MC

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/ManagementCenterService.java
@@ -77,6 +77,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -257,6 +258,28 @@ public class ManagementCenterService {
         return callOnAddress(instance.node.getThisAddress(), operation);
     }
 
+    public JsonObject syncCallOnThis(Operation operation) {
+        InternalCompletableFuture<Object> future = callOnThis(operation);
+        JsonObject result = new JsonObject();
+        Object operationResult;
+        try {
+            operationResult = future.get();
+            if (operationResult == null) {
+                result.add("result", "success");
+            } else {
+                result.add("result", operationResult.toString());
+            }
+        } catch (ExecutionException e) {
+            result.add("result", e.getMessage());
+            result.add("stackTrace", ExceptionUtil.toString(e));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            result.add("result", e.getMessage());
+            result.add("stackTrace", ExceptionUtil.toString(e));
+        }
+        return result;
+    }
+
     public InternalCompletableFuture<Object> callOnMember(Member member, Operation operation) {
         return callOnAddress(member.getAddress(), operation);
     }
@@ -284,7 +307,7 @@ public class ManagementCenterService {
 
     /**
      * Logs an event to Management Center.
-     *
+     * <p>
      * Events are used by Management Center to show the user what happens when on a cluster member.
      */
     public void log(Event event) {

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ChangeWanStateRequest.java
@@ -17,22 +17,16 @@
 package com.hazelcast.internal.management.request;
 
 import com.hazelcast.config.WanPublisherState;
+import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ChangeWanStateOperation;
-import com.hazelcast.internal.json.JsonObject;
 
-import static com.hazelcast.internal.management.ManagementCenterService.resolveFuture;
 import static com.hazelcast.util.JsonUtil.getString;
 
 /**
  * Request coming from Management Center for {@link ChangeWanStateOperation}
  */
 public class ChangeWanStateRequest implements ConsoleRequest {
-
-    /**
-     * Result message when {@link ChangeWanStateOperation} is invoked successfully
-     */
-    public static final String SUCCESS = "success";
 
     private String schemeName;
     private String publisherName;
@@ -54,15 +48,8 @@ public class ChangeWanStateRequest implements ConsoleRequest {
 
     @Override
     public void writeResponse(ManagementCenterService mcs, JsonObject out) {
-        Object operationResult = resolveFuture(
-                mcs.callOnThis(new ChangeWanStateOperation(schemeName, publisherName, state)));
-        JsonObject result = new JsonObject();
-        if (operationResult == null) {
-            result.add("result", SUCCESS);
-        } else {
-            result.add("result", operationResult.toString());
-        }
-        out.add("result", result);
+        out.add("result", mcs.syncCallOnThis(
+                new ChangeWanStateOperation(schemeName, publisherName, state)));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/ClearWanQueuesRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/ClearWanQueuesRequest.java
@@ -16,22 +16,16 @@
 
 package com.hazelcast.internal.management.request;
 
+import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.ClearWanQueuesOperation;
-import com.hazelcast.internal.json.JsonObject;
 
-import static com.hazelcast.internal.management.ManagementCenterService.resolveFuture;
 import static com.hazelcast.util.JsonUtil.getString;
 
 /**
  * Request coming from Management Center for {@link ClearWanQueuesRequest}
  */
 public class ClearWanQueuesRequest implements ConsoleRequest {
-
-    /**
-     * Result message when {@link ClearWanQueuesRequest} is invoked successfully
-     */
-    public static final String SUCCESS = "success";
 
     private String schemeName;
     private String publisherName;
@@ -51,15 +45,7 @@ public class ClearWanQueuesRequest implements ConsoleRequest {
 
     @Override
     public void writeResponse(ManagementCenterService mcs, JsonObject out) {
-        ClearWanQueuesOperation operation = new ClearWanQueuesOperation(schemeName, publisherName);
-        Object operationResult = resolveFuture(mcs.callOnThis(operation));
-        JsonObject result = new JsonObject();
-        if (operationResult == null) {
-            result.add("result", SUCCESS);
-        } else {
-            result.add("result", operationResult.toString());
-        }
-        out.add("result", result);
+        out.add("result", mcs.syncCallOnThis(new ClearWanQueuesOperation(schemeName, publisherName)));
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/internal/management/request/WanCheckConsistencyRequest.java
+++ b/hazelcast/src/main/java/com/hazelcast/internal/management/request/WanCheckConsistencyRequest.java
@@ -20,7 +20,6 @@ import com.hazelcast.internal.json.JsonObject;
 import com.hazelcast.internal.management.ManagementCenterService;
 import com.hazelcast.internal.management.operation.WanCheckConsistencyOperation;
 
-import static com.hazelcast.internal.management.ManagementCenterService.resolveFuture;
 import static com.hazelcast.util.JsonUtil.getString;
 
 public class WanCheckConsistencyRequest implements ConsoleRequest {
@@ -49,16 +48,9 @@ public class WanCheckConsistencyRequest implements ConsoleRequest {
     }
 
     @Override
-    public void writeResponse(ManagementCenterService mcs, JsonObject out) throws Exception {
-        WanCheckConsistencyOperation operation = new WanCheckConsistencyOperation(schemeName, publisherName, mapName);
-        Object operationResult = resolveFuture(mcs.callOnThis(operation));
-        JsonObject result = new JsonObject();
-        if (operationResult == null) {
-            result.add("result", SUCCESS);
-        } else {
-            result.add("result", operationResult.toString());
-        }
-        out.add("result", result);
+    public void writeResponse(ManagementCenterService mcs, JsonObject out) {
+        out.add("result", mcs.syncCallOnThis(
+                new WanCheckConsistencyOperation(schemeName, publisherName, mapName)));
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ChangeWanStateRequestTest.java
@@ -68,6 +68,6 @@ public class ChangeWanStateRequestTest extends HazelcastTestSupport {
         changeWanStateRequest.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        assertNotEquals(ChangeWanStateRequest.SUCCESS, getString(result, "result"));
+        assertNotEquals("success", getString(result, "result"));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/ClearWanQueuesTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/ClearWanQueuesTest.java
@@ -18,13 +18,13 @@ package com.hazelcast.internal.management;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
-import com.hazelcast.internal.management.request.ChangeWanStateRequest;
-import com.hazelcast.internal.management.request.ClearWanQueuesRequest;
 import com.hazelcast.internal.json.JsonObject;
+import com.hazelcast.internal.management.request.ClearWanQueuesRequest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,12 +47,12 @@ public class ClearWanQueuesTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testClearWanQueue() throws Exception {
+    public void testClearWanQueue() {
         ClearWanQueuesRequest clearWanQueuesRequest = new ClearWanQueuesRequest("schema", "publisher");
         JsonObject jsonObject = new JsonObject();
         clearWanQueuesRequest.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        assertNotEquals(ChangeWanStateRequest.SUCCESS, getString(result, "result"));
+        assertNotEquals("success", getString(result, "result"));
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/internal/management/WanCheckConsistencyRequestTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/internal/management/WanCheckConsistencyRequestTest.java
@@ -19,12 +19,12 @@ package com.hazelcast.internal.management;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.Node;
 import com.hazelcast.internal.json.JsonObject;
-import com.hazelcast.internal.management.request.ChangeWanStateRequest;
 import com.hazelcast.internal.management.request.WanCheckConsistencyRequest;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.HazelcastTestSupport;
 import com.hazelcast.test.annotation.ParallelTest;
 import com.hazelcast.test.annotation.QuickTest;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -46,16 +46,16 @@ public class WanCheckConsistencyRequestTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void testCheckConsistency() throws Exception {
+    public void testCheckConsistency() {
         WanCheckConsistencyRequest request = new WanCheckConsistencyRequest("schema", "publisher", "mapName");
         performTest(request);
     }
 
-    private void performTest(WanCheckConsistencyRequest request) throws Exception {
+    private void performTest(WanCheckConsistencyRequest request) {
         JsonObject jsonObject = new JsonObject();
         request.writeResponse(managementCenterService, jsonObject);
 
         JsonObject result = (JsonObject) jsonObject.get("result");
-        assertNotEquals(ChangeWanStateRequest.SUCCESS, getString(result, "result"));
+        assertNotEquals("success", getString(result, "result"));
     }
 }


### PR DESCRIPTION
When WAN check consistency fails, we now report error message and stack
trace separately. We need this to report the error on the UI and log the
stacktrace in logs. Tests will be added on MC side.

Forward port of #15045