### PR TITLE
Run raft callbacks on partition threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftQueryOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftQueryOp.java
@@ -36,6 +36,8 @@ import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
 
+import static com.hazelcast.cp.internal.operation.RaftReplicateOp.CALLER_RUNS_EXECUTOR;
+
 /**
  * The operation that passes a query to leader or a follower of a Raft group.
  * The given query can run locally on leader or a follower, or can be committed
@@ -82,7 +84,7 @@ public class RaftQueryOp extends Operation implements IndeterminateOperationStat
             ((RaftNodeAware) op).setRaftNode(raftNode);
         }
 
-        raftNode.query(op, queryPolicy).andThen(this);
+        raftNode.query(op, queryPolicy).andThen(this, CALLER_RUNS_EXECUTOR);
     }
 
     @Override

--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftReplicateOp.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/operation/RaftReplicateOp.java
@@ -32,6 +32,7 @@ import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.Operation;
 
 import java.io.IOException;
+import java.util.concurrent.Executor;
 
 /**
  * The base class that replicates the given {@link RaftOp}
@@ -42,6 +43,9 @@ import java.io.IOException;
  */
 public abstract class RaftReplicateOp extends Operation implements IdentifiedDataSerializable, RaftSystemOperation,
                                                                    ExecutionCallback {
+
+    static final Executor CALLER_RUNS_EXECUTOR = Runnable::run;
+
 
     private CPGroupId groupId;
 
@@ -69,7 +73,7 @@ public abstract class RaftReplicateOp extends Operation implements IdentifiedDat
             return;
         }
 
-        replicate(raftNode).andThen(this);
+        replicate(raftNode).andThen(this, CALLER_RUNS_EXECUTOR);
     }
 
     protected abstract ICompletableFuture replicate(RaftNode raftNode);


### PR DESCRIPTION
When a RaftOp that is passed to a RaftNode receives its response, its
response is not needed to be offloaded to an executor.