### PR TITLE
[3.12.x] Add client full example configuration files

### DIFF
--- a/hazelcast-client/pom.xml
+++ b/hazelcast-client/pom.xml
@@ -134,6 +134,33 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>${maven.antrun.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-hazelcast-xml</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copy file="${basedir}/src/main/resources/hazelcast-client-full-example.xml"
+                                      tofile="${basedir}/target/hazelcast-client-full-example.xml"/>
+                                <copy file="${basedir}/src/main/resources/hazelcast-client-full-example.yaml"
+                                      tofile="${basedir}/target/hazelcast-client-full-example.yaml"/>
+                                <copy file="${basedir}/src/main/resources/hazelcast-client-failover-full-example.xml"
+                                      tofile="${basedir}/target/hazelcast-client-failover-full-example.xml"/>
+                                <copy file="${basedir}/src/main/resources/hazelcast-client-failover-full-example.yaml"
+                                      tofile="${basedir}/target/hazelcast-client-failover-full-example.yaml"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/hazelcast-client/src/main/resources/hazelcast-client-failover-config-3.12.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-failover-config-3.12.xsd
@@ -16,13 +16,15 @@
   -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="http://www.hazelcast.com/schema/client-config"
            elementFormDefault="qualified"
+           targetNamespace="http://www.hazelcast.com/schema/client-config"
            attributeFormDefault="unqualified">
 
     <xs:element name="hazelcast-client-failover">
         <xs:complexType>
             <xs:choice minOccurs="1" maxOccurs="unbounded">
-                <xs:element name="try-count" type="xs:int" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="try-count" type="non-space-string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="clients" type="clients" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
         </xs:complexType>

--- a/hazelcast-client/src/main/resources/hazelcast-client-failover-config-3.12.xsd
+++ b/hazelcast-client/src/main/resources/hazelcast-client-failover-config-3.12.xsd
@@ -24,7 +24,7 @@
     <xs:element name="hazelcast-client-failover">
         <xs:complexType>
             <xs:choice minOccurs="1" maxOccurs="unbounded">
-                <xs:element name="try-count" type="non-space-string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="try-count" type="xs:int" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="clients" type="clients" minOccurs="0" maxOccurs="1"/>
             </xs:choice>
         </xs:complexType>

--- a/hazelcast-client/src/main/resources/hazelcast-client-failover-full-example.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-failover-full-example.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+  This is a full example hazelcast-client-failover.xml that includes all
+  the configuration elements and attributes of a Hazelcast client
+  Blue/Green Deployment and Disaster Recovery configuration.
+
+  To use this, rename it to hazelcast-client-failover.xml and place it in
+  the directory where you start your Hazelcast client.
+
+  To learn how to configure Hazelcast clients for Blue/Green Deployment and
+  Disaster Recovery, please see the Reference Manual at
+  https://hazelcast.org/documentation/
+-->
+
+<!--suppress XmlDefaultAttributeValue -->
+<hazelcast-client-failover xmlns="http://www.hazelcast.com/schema/client-config"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                           http://www.hazelcast.com/schema/client-config/hazelcast-client-failover-config-3.12.xsd">
+
+    <!--
+        The Hazelcast client can configurations that the client is using to connect to a Hazelcast cluster in the case
+        of a disconnect is listed under the <clients> element. You can list client configurations as many as you want.
+        Each client configuration can be listed via <client> element nested into the <clients> element.
+    -->
+    <clients>
+        <client>your-first-hazelcast-client-configuration.xml</client>
+        <client>your-second-hazelcast-client-configuration.xml</client>
+    </clients>
+
+    <!--
+        Each time the client is disconnected from a cluster and it cannot connect back to the same one, the configured
+        client configuration defined under the <clients> element is iterated over. Count of these iterations before the
+        client decides to shut down is provided using the <try-count> configuration element. See the following
+        configuration related sections.
+    -->
+    <try-count>4</try-count>
+
+</hazelcast-client-failover>

--- a/hazelcast-client/src/main/resources/hazelcast-client-failover-full-example.yaml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-failover-full-example.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a full example hazelcast-client-failover.yaml that includes all
+# the configuration nodes of a Hazelcast client Blue/Green Deployment and
+# Disaster Recovery configuration.
+#
+# To use this, rename it to hazelcast-client-failover.yaml and place it in
+# the directory where you start your Hazelcast client.
+#
+# To learn how to configure Hazelcast clients for Blue/Green Deployment and
+# Disaster Recovery, please see the Reference Manual at
+# https://hazelcast.org/documentation/
+
+hazelcast-client-failover:
+  # 
+  # The Hazelcast client can configurations that the client is using to connect to a Hazelcast cluster in the case
+  # of a disconnect is listed under the <clients> element. You can list client configurations as many as you want.
+  # Each client configuration can be listed via <client> element nested into the <clients> element.
+  #
+  clients:
+    - your-first-hazelcast-client-configuration.yaml
+    - your-second-hazelcast-client-configuration.yaml
+  #
+  # Each time the client is disconnected from a cluster and it cannot connect back to the same one, the configured
+  # client configuration defined under the "clients" element is iterated over. Count of these iterations before the
+  # client decides to shut down is provided using the "try-count" configuration element. See the following
+  # configuration related sections.
+  # 
+  try-count: 4

--- a/hazelcast-client/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full-example.xml
@@ -1,0 +1,879 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+  This is a full example hazelcast-client.xml that includes all the
+  configuration elements and attributes of a Hazelcast client.
+
+  To use this, rename it to hazelcast-client.xml and place it in
+  the directory where you start your Hazelcast client.
+
+  To learn how to configure Hazelcast, please see the schema at
+  https://hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd
+  or the Reference Manual at https://hazelcast.org/documentation/
+-->
+
+<!--suppress XmlDefaultAttributeValue -->
+<hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.12.xsd">
+
+    <!--
+        You can use the <import> element to load different Hazelcast declarative configuration files you prepared.
+        You can import as many XML files as you want and hence compose your Hazelcast configuration
+        out of those XML files. If you want to use the <import> element, it should be placed at the top of your
+        Hazelcast XML file right after the <hazelcast-client> element, and it should have the required attribute "resource".
+
+        Below is an example where the configuration files you want to include are located at your
+        Hazelcast working directory:
+        <import resource="your-client-configuration-file.xml"/>
+
+        Below are examples showing a classpath or filesystem location:
+        <import resource="file:///etc/hazelcast/your-client-configuration-file-1.xml"/>
+        <import resource="classpath:your-client-configuration-file-2.xml"/>
+
+        Below is an example showing property placeholders:
+        <import resource="${environment}-your-client-configuration-file.xml"/>
+
+    -->
+    <import resource="your-client-configuration-XML-file"/>
+
+    <!--
+        The <config-replacers> allow to use variables (placeholders) within the configuration file and use an external
+        class to retrieve correct values (replacements).
+
+        It can be used for masking sensitive strings such as passwords for instance.
+
+        Format of a variable is:
+        $ PREFIX { STRING_TO_BE_REPLACED }      e.g. $ENC{nnPgTqJCcCQ=:23000:B4y/nlp6M0t3q6YiKImW+w==}
+
+        The PREFIX value depends on the replacer implementation (e.g. "ENC" is used for the EncryptionReplacer)
+        The STRING_TO_BE_REPLACED is the value which is provided to replacer implementation.
+    -->
+    <config-replacers fail-if-value-missing="false">
+        <replacer class-name="com.hazelcast.config.replacer.EncryptionReplacer">
+            <properties>
+                <property name="passwordFile">password.txt</property>
+                <property name="passwordUserProperties">false</property>
+                <property name="cipherAlgorithm">DES</property>
+                <property name="keyLengthBits">64</property>
+                <property name="secretKeyAlgorithm">DES</property>
+                <property name="secretKeyFactoryAlgorithm">PBKDF2WithHmacSHA1</property>
+            </properties>
+        </replacer>
+    </config-replacers>
+
+    <!--
+        Specifies the name and password for a cluster group you connect to.
+        Cluster groups allow you to create separate sub-clusters with different names.
+        The password is only checked when security is enabled on Hazelcast members (Enterprise edition feature).
+    -->
+    <group>
+        <name>dev</name>
+        <password>dev-pass</password>
+    </group>
+
+    <!--
+        When Hazelcast instances are created, they are put in a global registry with their creation names.
+        <instance-name> elements gives you the ability to get a specific Hazelcast instance from this registry
+        by giving the instance's name.
+    -->
+    <instance-name>CLIENT_NAME</instance-name>
+
+    <!--
+        ===== HAZELCAST LICENSE CONFIGURATION =====
+
+        If you have an Enterprise or Enterprise HD license, you can enter it here.
+        You can also set your license key programmatically; please refer to
+        http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#setting-the-license-key
+    -->
+    <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>
+    <!--
+        The <properties> element lets you add properties to some of the Hazelcast elements used to configure some of
+        the Hazelcast client modules.
+        You can define the name and value of these properties using the sub-element <property>.
+        Please check the source of the ClientProperty class for the complete list of the client properties and their
+        documentation.
+    -->
+    <properties>
+        <property name="hazelcast.client.shuffle.member.list">true</property>
+        <property name="hazelcast.client.heartbeat.timeout">60000</property>
+        <property name="hazelcast.client.heartbeat.interval">5000</property>
+        <property name="hazelcast.client.event.thread.count">5</property>
+        <property name="hazelcast.client.event.queue.capacity">1000000</property>
+        <property name="hazelcast.client.invocation.timeout.seconds">120</property>
+    </properties>
+    <!--
+        The <client-labels> element lets you define labels in your Java client, similar to the way it can be done for the
+        members. Through the client labels, you can assign special roles for your clients and use these roles to perform
+        some actions specific to those client connections.
+
+        You can also group your clients using the client labels. These client groups can be blacklisted in the Hazelcast
+        Management Center so that they can be prevented from connecting to a cluster. See the related section in the
+        Hazelcast Management Center Reference Manual for more information on this topic.
+
+        You can define the labels with the <label> sub-element.
+    -->
+    <client-labels>
+        <label>admin</label>
+        <label>foo</label>
+    </client-labels>
+
+    <!--
+        ===== HAZELCAST NETWORK CONFIGURATION =====
+
+        The configuration to build your Hazelcast's network includes configuration for port, interface, discovery
+        mechanism, SSL, encryption, etc. The configuration element's name is <network>.
+        It has the following sub-elements:
+        * <cluster-members>:
+            This configuration lets you define the members in your cluster the client is connecting to. The members
+            can be configured with the <address> sub-element.
+        * <outbound-ports>:
+            By default, Hazelcast lets the system pick up an ephemeral port during socket bind operation. But security
+            policies/firewalls may require you to restrict outbound ports to be used by Hazelcast-enabled applications.
+            You can specify these ports using <ports> under the element <outbound-ports>. You can give a single
+            port number, comma separated multiple ports or port ranges. See the example below.
+            <outbound-ports>
+                <ports>33000-35000</ports>
+                <ports>37000,37001,37002,37003</ports>
+                <ports>38000,38500-38600</ports>
+            </outbound-ports>
+        * <smart-routing>:
+            If true, client will route the key based operations to owner of the key at the best effort. Note that it
+            uses a cached version of com.hazelcast.core.PartitionService#getPartitions() and doesn't guarantee that
+            the operation will always be executed on the owner. The cached table is updated every second.
+        * <redo-operation>:
+            If true, client will redo the operations that were executing on the server and client lost the connection.
+            This can be because of network, or simply because the member died. However it is not clear whether the
+            application is performed or not. For idempotent operations this is harmless, but for non idempotent ones
+            retrying can cause to undesirable effects. Note that the redo can perform on any member. If false, the
+            operation will throw a RuntimeException that is wrapping a java.io.IOException.
+        * <connection-timeout>:
+            Connection timeout is the timeout value in milliseconds for members to accept client connection requests.
+            The following are the example configurations. Its default value is 5000.
+        * <connection-attempt-limit>:
+            While the client is trying to connect initially to one of the members in the <cluster-members>, that
+            member might not  be available at that moment. Instead of giving up, throwing an exception and stopping
+            the client, the client retries as many the times configured by this setting. This is also the case
+            when the previously established connection between the client and that member goes down.
+        * <connection-attempt-period>:
+            Connection attempt period is the duration in milliseconds between the connection attempts defined by
+            <connection-attempt-limit>.
+        * <socket-options>:
+            You can configure the network socket options using this setting. It has the following sub-elements:
+            - <tcp-no-delay>: Enables/disables the TCP_NODELAY socket option. Its default value is true.
+            - <keep-alive>: Enables/disables the SO_KEEPALIVE socket option. Its default value is true.
+            - <reuse-address>: Enables/disables the SO_REUSEADDR socket option. Its default value is true.
+            - <linger-seconds>:
+                Enables/disables SO_LINGER with the specified linger time in seconds.
+                Its default value is 3.
+            - <buffer-size>:
+                Sets the SO_SNDBUF and SO_RCVBUF options to the specified value in KB for this Socket.
+                Its default value is 128.
+        * <socket-interceptor>:
+            Lets you add custom hooks to join and perform connection procedures (like identity checking using
+            Kerberos, etc.). This feature is available only in Hazelcast Enterprise. To be able to use it, you
+            should first implement SocketInterceptor interface. Its configuration contains the class you
+            implemented and socket interceptor properties. By default, it is disabled. The following is an example:
+            <socket-interceptor enabled="true">
+                <class-name>
+                    com.hazelcast.examples.MySocketInterceptor
+                </class-name>
+                <properties>
+                    <property name="kerberos-host">kerb-host-name</property>
+                    <property name="kerberos-config-file">kerb.conf</property>
+                </properties>
+            </socket-interceptor>
+        * <ssl>:
+            Lets you configure SSL using the SSL context factory. This feature is available only in Hazelcast
+            Enterprise. To be able to use it, encryption should NOT be enabled and you should first implement
+            your SSLContextFactory class. Its configuration contains the factory class and SSL properties.
+            By default, it is disabled. The following is an example:
+            <ssl enabled="true">
+                <factory-class-name>
+                    com.hazelcast.nio.ssl.BasicSSLContextFactory
+                </factory-class-name>
+                <properties>
+                    <property name="keyStore">keyStore</property>
+                    <property name="keyStorePassword">keyStorePassword</property>
+                    <property name="keyManagerAlgorithm">SunX509</property>
+                    <property name="trustManagerAlgorithm">SunX509</property>
+                    <property name="protocol">TLS</property>
+                    <property name="mutualAuthentication">REQUIRED</property>
+                </properties>
+            </ssl>
+        * <aws>:
+            Set its "enabled" attribute to true for cluster discovery within Amazon EC2.
+            Please refer to https://github.com/hazelcast/hazelcast-aws/#configuration for the configuration details.
+        * <gcp>:
+            Set its "enabled" attribute to true for cluster discovery within the Google Cloud Platform.
+            Please refer to https://github.com/hazelcast/hazelcast-gcp/#configuration for the configuration details.
+        * <azure>:
+            Set its "enabled" attribute to true for cluster discovery within Microsoft Azure.
+            Please refer to https://github.com/hazelcast/hazelcast-azure/#configuring-at-hazelcast-side for
+            the configuration details.
+        * <kubernetes>:
+            Set its "enabled" attribute to true for cluster discovery in the Kubernetes environment.
+            Please refer to https://github.com/hazelcast/hazelcast-kubernetes#hazelcast-configuration for
+            the configuration details.
+        * <eureka>:
+            Set its "enabled" attribute to true for cluster discovery with using Eureka Service Registry.
+            Please refer to https://github.com/hazelcast/hazelcast-eureka#hazelcast-configuration for
+            the configuration details.
+        * <hazelcast-cloud>:
+            Set its "enabled" attribute to true for cluster discovery in the Hazelcast Cloud infrastructure. You need to
+            define the mandatory <discovery-token> used by the discovery mechanism.
+        * <discovery-strategies>:
+            Set its "enabled" attribute to true for cluster discovery in various cloud infrastructures. You also need to set the
+            value of "hazelcast.discovery.enabled" property to true. See the description of the <properties> element
+            to learn how to do this.
+            You can define multiple discovery strategies using the <discovery-strategy> sub-element and its
+            properties. Please refer to
+            http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-cluster-members
+            to see the properties you can use.
+            The following is an example for EC2 cloud.
+            <discovery-strategies>
+                <discovery-strategy class="com.hazelcast.jclouds.JCloudsDiscoveryStrategy" enabled="true">
+                <properties>
+                    <property name="provider">aws-ec2</property>
+                    <property name="identity">AWS_IDENTITY</property>
+                    <property name="credential">AWS_CREDENTIAL</property>
+                </properties>
+                </discovery-strategy>
+            </discovery-strategies>
+        * <icmp-ping>:
+            ICMP can be used in addition to the other detectors. It operates at OSI layer 3 and detects network
+            and hardware issues more quickly. This detector needs to be turned on by setting the "enabled" attribute
+            to true. It is turned off by default.
+
+            It has the following sub-elements:
+            * <timeout-milliseconds>:
+                Number of milliseconds until a ping attempt is considered failed if there was no reply.
+                Its default value is 1000 milliseconds.
+            * <interval-milliseconds>:
+                Interval, in milliseconds, between each ping attempt. 1000ms (1 sec) is also the minimum interval allowed.
+                Its default value is 1000 milliseconds.
+            * <max-attempts>:
+                Maximum number of ping attempts before the member gets suspected by the detector. Its default value is 3.
+            * <ttl>:
+                Maximum number of hops the packets should go through. Its default value is 255. You can set to 0 to use
+                your system’s default TTL.
+            * <echo-fail-fast-on-startup>:
+                Cluster Member will fail to start if it is unable to action an ICMP ping command when ICMP is enabled.
+                Failure is usually due to OS level restrictions.
+    -->
+    <network>
+        <cluster-members>
+            <address>127.0.0.1</address>
+            <address>127.0.0.2</address>
+        </cluster-members>
+        <outbound-ports>
+            <ports>34600</ports>
+            <ports>34700-34710</ports>
+        </outbound-ports>
+        <smart-routing>true</smart-routing>
+        <redo-operation>true</redo-operation>
+        <connection-timeout>60000</connection-timeout>
+        <connection-attempt-period>3000</connection-attempt-period>
+        <connection-attempt-limit>2</connection-attempt-limit>
+        <socket-options>
+            <tcp-no-delay>false</tcp-no-delay>
+            <keep-alive>true</keep-alive>
+            <reuse-address>true</reuse-address>
+            <linger-seconds>3</linger-seconds>
+            <buffer-size>128</buffer-size>
+        </socket-options>
+        <socket-interceptor enabled="true">
+            <class-name>com.hazelcast.examples.MySocketInterceptor</class-name>
+            <properties>
+                <property name="foo">bar</property>
+            </properties>
+        </socket-interceptor>
+
+        <ssl enabled="false">
+            <factory-class-name>com.hazelcast.nio.ssl.BasicSSLContextFactory</factory-class-name>
+            <properties>
+                <property name="protocol">TLS</property>
+
+                <property name="trustStore">/opt/hazelcast-client.truststore</property>
+                <property name="trustStorePassword">secret.123456</property>
+                <property name="trustStoreType">JKS</property>
+
+                <!-- Following properties are only needed when the mutual authentication is used. -->
+                <property name="keyStore">/opt/hazelcast-client.keystore</property>
+                <property name="keyStorePassword">keystorePassword123</property>
+                <property name="keyStoreType">JKS</property>
+            </properties>
+        </ssl>
+        <aws enabled="true" connection-timeout-seconds="11">
+            <inside-aws>true</inside-aws>
+            <access-key>TEST_ACCESS_KEY</access-key>
+            <secret-key>TEST_SECRET_KEY</secret-key>
+            <region>us-east-1</region>
+            <host-header>ec2.amazonaws.com</host-header>
+            <security-group-name>hazelcast-sg</security-group-name>
+            <tag-key>type</tag-key>
+            <tag-value>hz-nodes</tag-value>
+        </aws>
+        <gcp enabled="false">
+            <zones>us-east1-b,us-east1-c</zones>
+        </gcp>
+        <azure enabled="false">
+            <client-id>CLIENT_ID</client-id>
+            <client-secret>CLIENT_SECRET</client-secret>
+            <tenant-id>TENANT_ID</tenant-id>
+            <subscription-id>SUB_ID</subscription-id>
+            <cluster-id>HZLCAST001</cluster-id>
+            <group-name>GROUP-NAME</group-name>
+        </azure>
+        <kubernetes enabled="false">
+            <namespace>MY-KUBERNETES-NAMESPACE</namespace>
+            <service-name>MY-SERVICE-NAME</service-name>
+            <service-label-name>MY-SERVICE-LABEL-NAME</service-label-name>
+            <service-label-value>MY-SERVICE-LABEL-VALUE</service-label-value>
+        </kubernetes>
+        <eureka enabled="false">
+            <self-registration>true</self-registration>
+            <namespace>hazelcast</namespace>
+        </eureka>
+        <icmp-ping enabled="false">
+            <timeout-milliseconds>2000</timeout-milliseconds>
+            <interval-milliseconds>3000</interval-milliseconds>
+            <ttl>100</ttl>
+            <max-attempts>5</max-attempts>
+            <echo-fail-fast-on-startup>false</echo-fail-fast-on-startup>
+        </icmp-ping>
+        <hazelcast-cloud enabled="false">
+            <discovery-token>EXAMPLE_TOKEN</discovery-token>
+        </hazelcast-cloud>
+        <discovery-strategies>
+            <node-filter class="DummyFilterClass"/>
+            <discovery-strategy class="DummyDiscoveryStrategy1" enabled="true">
+                <properties>
+                    <property name="key-string">foo</property>
+                    <property name="key-int">123</property>
+                    <property name="key-boolean">true</property>
+                </properties>
+            </discovery-strategy>
+        </discovery-strategies>
+    </network>
+    <!--
+        The <executor-pool-size> element lets you configure the pool size for an internal executor service
+        (different from the data structure Executor Service) that has threads and queues to perform internal operations
+        such as handling responses. This parameter specifies the size of the pool of threads which perform these
+        operations laying in the executor’s queue. If not configured, this parameter has the value of 5 x core size of
+        the client, i.e., it is 20 for a machine that has 4 cores.
+    -->
+    <executor-pool-size>40</executor-pool-size>
+
+    <!--
+        ===== HAZELCAST SECURITY CONFIGURATION =====
+
+        This feature is available only in Hazelcast Enterprise. Configuration element's name is <security>.
+        It has the following sub-elements:
+        * <credentials>:
+            The name of the class implementing Hazelcast's Credentials interface.
+        * <credentials-factory>:
+            Specifies the name and properties of your class that you developed by implementing Hazelcast's Credentials
+            interface.
+            This element has a mandatory "class-name" attribute where you should define the factory class implementing
+            ICredentialsFactory used to create Credentials objects.
+            With the <properties> sub-element, you can define properties for the factory class. The properties can be
+            defined with the <property> sub-element nested in the <properties>. The <property> element has the attribute
+            "name" used to define the name of the attribute. The value of the property is defined in the body.
+    -->
+    <security>
+        <credentials>com.hazelcast.security.UsernamePasswordCredentials</credentials>
+        <credentials-factory class-name="com.hazelcast.examples.MyCredentialsFactory">
+            <properties>
+                <property name="property">value</property>
+            </properties>
+        </credentials-factory>
+    </security>
+
+    <!--
+        ===== HAZELCAST LISTENER CONFIGURATIONS =====
+
+        Configuration used to register the listeners that you created by implementing Hazelcast's
+        MembershipListener, InstanceListener and MigrationListener interfaces.
+    -->
+    <listeners>
+        <listener>com.hazelcast.examples.MembershipListener</listener>
+        <listener>com.hazelcast.examples.InstanceListener</listener>
+        <listener>com.hazelcast.examples.MigrationListener</listener>
+    </listeners>
+
+    <!--
+        ===== HAZELCAST SERIALIZATION CONFIGURATION =====
+
+        Configuration element's name is <serialization>.
+        It has the following sub-elements:
+        * <portable-version>:
+            Version of the portable serialization. Portable version is used to differentiate two
+            of the same classes that have changes such as a new field or a new field type.
+        * <use-native-byte-order>:
+            Set as true if you want to use the native byte order of the underlying platform. Its default value is false.
+        * <byte-order>:
+            Specifies the byte order that the serialization will use. Its default value is BIG_ENDIAN. Available values
+            are BIG_ENDIAN and LITTLE_ENDIAN.
+        * <enable-compression>:
+            Set as true to enable compression when default Java serialization is used. Its default value is false.
+        * <enable-shared-object>:
+            Set as true to enable shared object when default Java serialization is used. Its default value is false.
+        * <allow-unsafe>:
+            Set as true to allow the usage of unsafe. Its default value is false.
+        * <data-serializable-factories>:
+            Lists your class implementations of Hazelcast's DataSerializableFactory using the <data-serializable-factory>
+            sub-elements. Each factory has the required "factory-id" attribute that you should give as the ID of your
+            factory.
+        * <portable-factories>:
+            Lists your class implementations of Hazelcast's PortableFactory using the <portable-factory>
+            sub-elements. Each factory has the required "factory-id" attribute that you should give as the ID of your
+            factory.
+        * <serializers>:
+            Lists the serializers (classes) that you implement using Hazelcast's StreamSerializer, ByteArraySerializer,
+            Global Serializer, etc. Global serializer should be specified using the <global-serializer> sub-element.
+            For others, use the <serializer> sub-element.
+
+            The <serializer> sub-element has two required attributes:
+            - class-name: Full class name of the serializer you implemented.
+            - type-class: Type of your serializer class implementation.
+
+            The <global-serializer> sub-element has an optional boolean "override-java-serialization" attribute. If you set
+            it as true, the Java serialization step will be handled by the global serializer, not by the Java Serializable or
+            Externalizable.
+        * <check-class-def-errors>:
+            If set to true, serialization system will check the class definitions error at the start of serialization process
+            and throw a Serialization Exception with the error definition.
+        * <java-serialization-filter>:
+            Allows to configure blacklisting and whitelisting for deserialized classes when Java serialization is used.
+    -->
+    <serialization>
+        <portable-version>3</portable-version>
+        <use-native-byte-order>true</use-native-byte-order>
+        <byte-order>BIG_ENDIAN</byte-order>
+        <enable-compression>false</enable-compression>
+        <enable-shared-object>true</enable-shared-object>
+        <allow-unsafe>false</allow-unsafe>
+        <data-serializable-factories>
+            <data-serializable-factory factory-id="1">com.hazelcast.examples.DataSerializableFactory
+            </data-serializable-factory>
+        </data-serializable-factories>
+        <portable-factories>
+            <portable-factory factory-id="2">com.hazelcast.examples.PortableFactory</portable-factory>
+        </portable-factories>
+        <serializers>
+            <global-serializer override-java-serialization="true">com.hazelcast.examples.GlobalSerializerFactory
+            </global-serializer>
+            <serializer type-class="com.hazelcast.examples.DummyType"
+                        class-name="com.hazelcast.examples.SerializerFactory"/>
+        </serializers>
+        <check-class-def-errors>true</check-class-def-errors>
+        <java-serialization-filter>
+            <blacklist>
+                <class>com.acme.app.BeanComparator</class>
+            </blacklist>
+            <whitelist>
+                <class>java.lang.String</class>
+                <class>example.Foo</class>
+                <package>com.acme.app</package>
+                <package>com.acme.app.subpkg</package>
+                <prefix>java</prefix>
+                <prefix>[</prefix>
+                <prefix>com.</prefix>
+            </whitelist>
+        </java-serialization-filter>
+    </serialization>
+    <!--
+        ===== HAZELCAST HIGH-DENSITY MEMORY STORE CONFIGURATION =====
+
+        This feature is available only in Hazelcast Enterprise HD. Configuration element's name is
+        <native-memory>.
+        It has the following attributes:
+        - enabled:
+            Set as true to enable the High-Density Memory Store usage. Its default value is false.
+        - allocator-type:
+            Type of the memory allocator. Its default value is POOLED. Available values are as follows:
+        * STANDARD: Allocates/frees the memory using default OS memory manager.
+        * POOLED: Manages memory blocks in thread local pools.
+
+        It has the following sub-elements:
+        - <size>:
+            Size of the total native memory to allocate. You can give the size using its "value" attribute and the unit
+            using its "unit" attribute. Unit can be bytes, kilobytes, megabytes and gigabytes. Default value is 128 and
+            default unit is MEGABYTES.
+        - <min-block-size>:
+            Minimum size of the blocks in bytes to split and fragment a page block to assign to an allocation request.
+            It is used only by the POOLED memory allocator. The value has to be power of two.  Default value is 16.
+        - <page-size>:
+            Size of the page in bytes to allocate memory as a block. It is used only by the POOLED memory allocator. Its
+            default value is 1 << 22 (about 4 MB).
+        - <metadata-space-percentage>:
+            Percentage of the allocated native memory that is used for the metadata such as indexes, offsets, etc. It is
+            used only by the POOLED memory allocator. Its default value is 12.5.
+    -->
+    <native-memory enabled="false" allocator-type="POOLED">
+        <size unit="MEGABYTES" value="128"/>
+        <min-block-size>1</min-block-size>
+        <page-size>1</page-size>
+        <metadata-space-percentage>40.5</metadata-space-percentage>
+    </native-memory>
+    <!--
+        ===== HAZELCAST PROXY FACTORY CONFIGURATION =====
+
+        Configuration element's name is <proxy-factories>.
+        The client proxy factories can be defined with the <proxy-factory> sub-element. It has the following attributes:
+        * "class-name": The name of the client proxy factory class.
+        * "service": The name of the service.
+    -->
+    <proxy-factories>
+        <proxy-factory class-name="com.hazelcast.examples.ProxyXYZ1" service="sampleService1"/>
+        <proxy-factory class-name="com.hazelcast.examples.ProxyXYZ2" service="sampleService1"/>
+        <proxy-factory class-name="com.hazelcast.examples.ProxyXYZ3" service="sampleService3"/>
+    </proxy-factories>
+
+    <!--
+        ===== HAZELCAST LOAD BALANCER CONFIGURATION =====
+
+        Configuration element's name is <load-balancer>.
+        It has the attribute "type". The valid values for the type of the load balancer are"
+        * "random": The member the operations to be sent to is chosen randomly.
+        * "round-robin": The member the operations to be sent to is chosen in a round-robin fashion.
+    -->
+    <load-balancer type="random"/>
+
+    <!--
+        ===== HAZELCAST NEAR CACHE CONFIGURATION =====
+
+        Configuration element's name is <near-cache>.
+        It has the following attribute:
+        - name: You can give a name for your Near Cache. It is optional and its default value is "default".
+
+        It has the following sub-elements:
+            - <max-size>:
+                Maximum size of the Near Cache. When this is reached, Near Cache is evicted based on the policy defined.
+                Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Its default value is 0.
+            - <time-to-live-seconds>:
+                Maximum number of seconds for each entry to stay in the Near Cache. Entries that are older than this
+                period are automatically evicted from the Near Cache. Any integer between 0 and Integer.MAX_VALUE.
+                0 means infinite. Its default value is 0.
+            - <max-idle-seconds>:
+                Maximum number of seconds each entry can stay in the Near Cache as untouched (not read). Entries that
+                are not read more than this period are removed from the Near Cache. Any integer between 0 and
+                Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Its default value is 0.
+            - <eviction-policy>:
+                Eviction policy configuration. Its default values is NONE. Available values are as follows:
+                - NONE:
+                    No items will be evicted and the property max-size will be ignored. You still
+                    can combine it with time-to-live-seconds and max-idle-seconds.
+                - LRU: 	Least Recently Used.
+                - LFU: 	Least Frequently Used.
+                - <invalidate-on-change>:
+                    Specifies whether the cached entries are evicted when the entries are updated or removed. Its default
+                    value is true.
+            - <in-memory-format>:
+                Specifies in which format data will be stored in your Near Cache. Note that a map's in-memory format
+                can be different from that of its Near Cache.
+                Available values are as follows:
+                - BINARY:
+                    Data will be stored in serialized binary format. It is the default option.
+                - OBJECT:
+                    Data will be stored in deserialized form.
+                - NATIVE:
+                    Data will be stored in the Near Cache that uses Hazelcast's High-Density Memory Store feature.
+                    This option is available only in Hazelcast Enterprise HD. Note that a map and its Near Cache
+                    can independently use High-Density Memory Store. For example, while your map does not use
+                    High-Density Memory Store, its Near Cache can use it.
+            - <cache-local-entries>:
+                Specifies whether the local entries will be cached. It can be useful when in-memory format for
+                Near Cache is different from that of the map. By default, it is disabled.
+            - <invalidate-on-change>:
+                Specifies whether the cached entries are evicted when the entries are updated or removed.
+                Its default value is true.
+            - <serialize-keys>:
+                Specifies if the keys of a Near Cache entry should be serialized or not. Serializing the keys has
+                a big impact on the read performance of the Near Cache. It should just be activated when you have
+                mutable keys, which are changed after use for the Near Cache. Its default value is false.
+            - <eviction>:
+                Configuration for the eviction when the in-memory format of the Near Cache is NATIVE. It has the
+                following attributes:
+                - size: Maximum size (entry count) of the Near Cache.
+                - max-size-policy: Maximum size policy for eviction of the Near Cache. Available values are as follows:
+                    * ENTRY_COUNT: Maximum entry count per member.
+                    * USED_NATIVE_MEMORY_SIZE: Maximum used native memory size in megabytes.
+                    * USED_NATIVE_MEMORY_PERCENTAGE: Maximum used native memory percentage.
+                    * FREE_NATIVE_MEMORY_SIZE: Minimum free native memory size to trigger cleanup.
+                    * FREE_NATIVE_MEMORY_PERCENTAGE: Minimum free native memory percentage to trigger cleanup.
+                - eviction-policy: See the <eviction-policy> element above.
+
+        Note that the Near Cache eviction configuration is different for NATIVE in-memory format.
+        Proper eviction configuration example for NATIVE in-memory format :
+           `<eviction max-size-policy="USED_NATIVE_MEMORY_SIZE" eviction-policy="LFU" size="60"/>`
+    -->
+    <near-cache name="default">
+        <max-size>2000</max-size>
+        <time-to-live-seconds>90</time-to-live-seconds>
+        <max-idle-seconds>100</max-idle-seconds>
+        <eviction-policy>LFU</eviction-policy>
+        <in-memory-format>OBJECT</in-memory-format>
+        <cache-local-entries>true</cache-local-entries>
+        <invalidate-on-change>true</invalidate-on-change>
+        <serialize-keys>true</serialize-keys>
+        <local-update-policy>INVALIDATE</local-update-policy>
+        <preloader enabled="true" directory="directory" store-initial-delay-seconds="50" store-interval-seconds="10"/>
+    </near-cache>
+
+    <near-cache name="NearCacheEvictionConfigExample">
+        <eviction eviction-policy="LRU" max-size-policy="ENTRY_COUNT" size="10000"
+                  comparator-class-name="com.hazelcast.examples.MyEvictionComparator"/>
+    </near-cache>
+
+    <!--
+        ===== HAZELCAST FLAKE ID GENERATOR CONFIGURATION =====
+        Configuration element's name is <flake-id-generator>. It has the required attribute "name" with which you
+        can specify the name of your Flake ID generator.
+        It has the following sub-elements:
+
+        * <prefetch-count>:
+            Sets how many IDs are pre-fetched on the background when one call to
+            FlakeIdGenerator.newId() is made. Value must be in the range 1..100,000, default
+            is 100.
+
+            This setting pertains only to newId() calls made on the member that configured it.
+
+        * <prefetch-validity-millis>:
+            Sets for how long the pre-fetched IDs can be used. If this time elapses, a new batch of IDs
+            will be fetched. Time unit is milliseconds, default is 600,000 (10 minutes).
+
+            The IDs contain timestamp component, which ensures rough global ordering of IDs. If an
+            ID is assigned to an object that was created much later, it will be much out of order. If you
+            don't care about ordering, set this value to 0.
+
+            This setting pertains only to newId() calls made on the member that configured it.
+    -->
+    <flake-id-generator name="default">
+        <prefetch-count>100</prefetch-count>
+        <prefetch-validity-millis>600000</prefetch-validity-millis>
+    </flake-id-generator>
+
+    <!--
+        ===== HAZELCAST CONTINUOUS QUERY CACHE CONFIGURATION =====
+
+        Configuration element's name is <query-caches>.
+        You can create your query caches using its <query-cache> sub-element. It has the following attributes:
+        - "name": Specifies the name of your query cache.
+        - "mapName": Specifies the name of the map the query cache is used for.
+        It has the following sub-elements:
+        * <predicate>:
+            Predicate to filter events which will be applied to the query cache.
+        * <entry-listeners>:
+            Adds listeners (listener classes) for your query cache entries. See <entry-listeners> in the map configuration above.
+        * <include-value>:
+            Set to true if you want to cache the value too. Its default value is true.
+        * <batch-size>:
+            Batch size used to determine the number of events sent in a batch to your query cache. Its default value is 1.
+        * <buffer-size>:
+            Maximum number of events which can be stored in a partition buffer. Its default value is 16.
+        * <in-memory-format>:
+            Type of the data to be stored in your query cache. See <in-memory-format> in the map configuration above.
+        * <delay-seconds>:
+            Minimum time in seconds that an event waits in the member's buffer. Its default value is 0.
+        * <coalesce>:
+            Set to true if you want to enable the coalescing of your query cache. Its default value is false.
+        * <populate>:
+            Set to true if you want to enable the initial population of your query cache. Its default value is true.
+        * <eviction>:
+            Configuration for the eviction of your query cache.
+            It has the following attributes:
+                - size: Maximum size (entry count) of the Near Cache.
+                - max-size-policy: Maximum size policy for eviction of the Near Cache. Available values are as follows:
+                    * ENTRY_COUNT: Maximum entry count per member.
+                     * USED_NATIVE_MEMORY_SIZE: Maximum used native memory size in megabytes.
+                     * USED_NATIVE_MEMORY_PERCENTAGE: Maximum used native memory percentage.
+                     * FREE_NATIVE_MEMORY_SIZE: Minimum free native memory size to trigger cleanup.
+                     * FREE_NATIVE_MEMORY_PERCENTAGE: Minimum free native memory percentage to trigger cleanup.
+                - eviction-policy: Eviction policy configuration. Its default values is NONE. Available values are as follows:
+                    - NONE:
+                        No items will be evicted and the property max-size will be ignored. You still
+                        can combine it with time-to-live-seconds and max-idle-seconds.
+                    - LRU: 	Least Recently Used.
+                    - LFU: 	Least Frequently Used.
+                - comparator-class-name: The comparator to be used while comparing entries to be evicted.
+
+        * <indexes>:
+            You can define indexes for your map using this element's <index> sub-elements. Each <index> has
+            only the boolean "ordered" attribute. For example, if you will have a ranged query for a field of a map
+            entry, then this attribute should be set to true. But if the field has a boolean value, then it should
+            be set to false. Its default value is false.
+    -->
+    <query-caches>
+        <query-cache name="query-cache-class-name-predicate" mapName="map-name">
+            <predicate type="class-name">com.hazelcast.examples.ExamplePredicate</predicate>
+            <entry-listeners>
+                <entry-listener include-value="true" local="false">com.hazelcast.examples.EntryListener</entry-listener>
+            </entry-listeners>
+            <include-value>true</include-value>
+            <batch-size>1</batch-size>
+            <buffer-size>16</buffer-size>
+            <delay-seconds>0</delay-seconds>
+            <in-memory-format>BINARY</in-memory-format>
+            <coalesce>false</coalesce>
+            <populate>true</populate>
+            <eviction eviction-policy="LRU" max-size-policy="ENTRY_COUNT" size="10000"
+                      comparator-class-name="com.hazelcast.examples.MyEvictionComparator"/>
+            <indexes>
+                <index ordered="false">name</index>
+            </indexes>
+        </query-cache>
+        <query-cache name="query-cache-sql-predicate" mapName="map-name">
+            <predicate type="sql">%age=40</predicate>
+        </query-cache>
+    </query-caches>
+
+    <!--
+        ===== HAZELCAST CONNECTION STRATEGY CONFIGURATION =====
+
+        Configuration element's name is <connection-strategy>.
+        It has the following attributes:
+            - "async-start": If set to true, creating Hazelcast client doesn't not wait for connecting to the cluster.
+            - "reconnect-mode": Defines the reconnection mode. The valid values are:
+                - "ON":
+                    Enables reconnection in a blocking manner where all the waiting invocations are blocked until a
+                    cluster connection is established or failed. This is the default value.
+                - "OFF": Disables the reconnection.
+                - "ASYNC":
+                    Enables reconnection in a non-blocking manner where all the waiting invocations receive a
+                    HazelcastClientOfflineException.
+
+        It has the <connection-retry> sub-element, defining the configuration used when retrying to connect to the cluster.
+        It can be enabled by setting the "enabled" attribute to true.
+        The <connection-retry> element has the following sub-elements:
+            * <initial-backoff-millis>:
+                Specifies how long to wait (backoff) after the first failure before retrying in milliseconds.
+                Its default value is 1000 ms.
+            * <max-backoff-millis>: Specifies the upper limit for the backoff in milliseconds. Its default value is 30000 ms.
+            * <multiplier>: Factor to multiply the backoff after a failed retry. Its default value is 2.
+            * <fail-on-max-backoff>:
+                Specifies whether to fail when the max-backoff-millis has reached or continue waiting max-backoff-millis
+                at each iteration. Its default value is false.
+            * <jitter>: Specifies by how much to randomize backoffs. Its default value is 0.2.
+    -->
+    <connection-strategy async-start="true" reconnect-mode="ASYNC">
+        <connection-retry enabled="true">
+            <initial-backoff-millis>2000</initial-backoff-millis>
+            <max-backoff-millis>60000</max-backoff-millis>
+            <multiplier>3</multiplier>
+            <fail-on-max-backoff>true</fail-on-max-backoff>
+            <jitter>0.5</jitter>
+        </connection-retry>
+    </connection-strategy>
+
+    <!--
+        ===== HAZELCAST RELIABLE TOPIC CONFIGURATION =====
+
+        Reliable Topic uses the same ITopic interface. The main difference is that it is backed up by
+        Hazelcast Ringbuffer data structure. Reliable Topic messages are stored in the Ringbuffer
+        Configuration element's name is <reliable-topic>. It has the optional attribute "name" with which you
+        can specify the name of your Reliable Topic, which is the same name you give to your Ringbuffer.
+        This attribute's default value is "default".
+        It has the following sub-elements:
+        * <read-batch-size>:
+            Sets the read batch size.
+            The ReliableTopic tries to read a batch of messages from the ringbuffer.
+            It will get at least one, but if there are more available, then it will
+            try to get more to increase throughput. The maximum read batch size can
+            be influenced using the read batch size.
+            Apart from influencing the number of messages to retrieve, the
+            readBatchSize also determines how many messages will be processed
+            by the thread running the MessageListener before it returns back
+            to the pool to look for other MessageListeners that need to be
+            processed. The problem with returning to the pool and looking for new work
+            is that interacting with an executor is quite expensive due to contention
+            on the work-queue. The more work that can be done without retuning to the
+            pool, the smaller the overhead.
+            If the readBatchSize is 10 and there are 50 messages available,
+            10 items are retrieved and processed consecutively before the thread goes
+            back to the pool and helps out with the processing of other messages.
+            If the readBatchSize is 10 and there are 2 items available,
+            2 items are retrieved and processed consecutively.
+            If the readBatchSize is an issue because a thread will be busy
+            too long with processing a single MessageListener and it can't
+            help out other MessageListeners, increase the size of the
+            threadpool so the other MessageListeners don't need to wait for
+            a thread, but can be processed in parallel.
+        * <topic-overload-policy>:
+            A policy to deal with an overloaded topic; so topic where there is no place to store new messages.
+            This policy can only be used in combination with the
+            com.hazelcast.core.HazelcastInstance#getReliableTopic(String).
+            The reliable topic uses a com.hazelcast.ringbuffer.Ringbuffer to
+            store the messages. A ringbuffer doesn't track where readers are, so
+            it has no concept of a slow consumers. This provides many advantages like
+            high performance reads, but it also gives the ability to the reader to
+            re-read the same message multiple times in case of an error.
+            A ringbuffer has a limited, fixed capacity. A fast producer may overwrite
+            old messages that are still being read by a slow consumer. To prevent
+            this, we may configure a time-to-live on the ringbuffer (see
+            com.hazelcast.config.RingbufferConfig#setTimeToLiveSeconds(int).
+            Once the time-to-live is configured, the TopicOverloadPolicy
+            controls how the publisher is going to deal with the situation that a
+            ringbuffer is full and the oldest item in the ringbuffer is not old
+            enough to get overwritten.
+            Keep in mind that this retention period (time-to-live) can keep messages
+            from being overwritten, even though all readers might have already completed reading.
+            Its default value is BLOCK. Available values are as follows:
+            - DISCARD_OLDEST:
+                Using this policy, a message that has not expired can be overwritten.
+                No matter the retention period set, the overwrite will just overwrite
+                the item.
+                This can be a problem for slow consumers because they were promised a
+                certain time window to process messages. But it will benefit producers
+                and fast consumers since they are able to continue. This policy sacrifices
+                the slow producer in favor of fast producers/consumers.
+            - DISCARD_NEWEST:
+                Message that was to be published is discarded.
+            - BLOCK:
+                The caller will wait until there is space in the Ringbuffer.
+            - ERROR:
+                The publish call fails immediately.
+    -->
+    <reliable-topic name="rel-topic">
+        <read-batch-size>100</read-batch-size>
+        <topic-overload-policy>DISCARD_NEWEST</topic-overload-policy>
+    </reliable-topic>
+
+    <!--
+        ===== HAZELCAST USER CODE DEPLOYMENT CONFIGURATION =====
+
+        Configuration element's name is <user-code-deployment>. It has the required attribute "enabled" to
+        specify whether this feature will be enabled on your cluster.
+        It has the following sub-elements:
+        * <jarPaths>: Defines the jar files containing the classes to load listed by the <jarPath> sub-element.
+        * <classNames>: Defines the classes available in the client class path to load.
+    -->
+    <user-code-deployment enabled="true">
+        <jarPaths>
+            <jarPath>/User/test/sample.jar</jarPath>
+            <jarPath>https://hazelcast.com/</jarPath>
+            <jarPath>file://User/test/sample.jar</jarPath>
+        </jarPaths>
+        <classNames>
+            <className>test.sampleClassName</className>
+        </classNames>
+    </user-code-deployment>
+
+</hazelcast-client>

--- a/hazelcast-client/src/main/resources/hazelcast-client-full-example.xml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full-example.xml
@@ -101,6 +101,9 @@
         If you have an Enterprise or Enterprise HD license, you can enter it here.
         You can also set your license key programmatically; please refer to
         http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#setting-the-license-key
+
+        Please note that providing the license key is not required in client
+        configuration, it is kept only for backward compatibility.
     -->
     <license-key>HAZELCAST_ENTERPRISE_LICENSE_KEY</license-key>
     <!--

--- a/hazelcast-client/src/main/resources/hazelcast-client-full-example.yaml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-full-example.yaml
@@ -1,0 +1,840 @@
+# Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a full example hazelcast-client.yaml that includes all the
+# configuration elements of a Hazelcast client.
+#
+# To use this, rename it to hazelcast-client.yaml and place it in
+# the directory where you start your Hazelcast client.
+#
+# To learn how to configure Hazelcast, please see the Reference Manual
+# at https://hazelcast.org/documentation/
+
+hazelcast-client:
+
+  # You can use import to load different Hazelcast declarative configuration files you prepared.
+  # You can import as many YAML files as you want and hence compose your Hazelcast configuration
+  # out of those YAML files. If you want to use import, it should be placed at the top of your
+  # Hazelcast YAML file right after the "hazelcast-client" root node.
+  #
+  # Below is an example where the configuration files you want to include are located at your
+  # Hazelcast working directory:
+  #   import:
+  #     - your-client-configuration-file.yaml
+  #
+  # Below are examples showing a classpath or filesystem location:
+  #   import:
+  #     - file:///etc/hazelcast/your-client-configuration-file-1.yaml
+  #     - classpath:your-client-configuration-file-2.yaml
+  #
+  # Below is an example showing property placeholders:
+  #   import:
+  #     - ${environment}-your-client-configuration-file.yaml
+  #
+  import:
+    - your-client-configuration-YAML-file
+
+  # The "config-replacers" allow to use variables (placeholders) within the configuration file and use an external
+  # class to retrieve correct values (replacements).
+  #
+  # It can be used for masking sensitive strings such as passwords for instance.
+  #
+  # Format of a variable is:
+  # $ PREFIX { STRING_TO_BE_REPLACED }      e.g. $ENC{nnPgTqJCcCQ=:23000:B4y/nlp6M0t3q6YiKImW+w==}
+  #
+  # The PREFIX value depends on the replacer implementation (e.g. "ENC" is used for the EncryptionReplacer)
+  # The STRING_TO_BE_REPLACED is the value which is provided to replacer implementation.
+  #
+  config-replacers:
+    fail-if-value-missing: false
+    replacers:
+      - class-name: com.hazelcast.config.replacer.EncryptionReplacer
+        properties:
+          passwordFile: password
+          passwordUserProperties: false
+          cipherAlgorithm: DES
+          keyLengthBits: 64
+          secretKeyAlgorithm: DES
+          secretKeyFactoryAlgorithm: PBKDF2WithHmacSHA1
+  #
+  # Specifies the name and password for a cluster group you connect to.
+  # Cluster groups allow you to create separate sub-clusters with different names.
+  # The password is only checked when security is enabled on Hazelcast members (Enterprise edition feature).
+  group:
+    name: dev
+    password: dev-pass
+  #
+  # When Hazelcast instances are created, they are put in a global registry with their creation names.
+  # "instance-name" gives you the ability to get a specific Hazelcast instance from this registry
+  # by giving the instance's name.
+  #
+  instance-name: CLIENT_NAME
+  #
+  # ===== HAZELCAST LICENSE CONFIGURATION =====
+  #
+  # If you have an Enterprise or Enterprise HD license, you can enter it here.
+  # You can also set your license key programmatically; please refer to
+  # http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#setting-the-license-key
+  #
+  license-key: HAZELCAST_ENTERPRISE_LICENSE_KEY
+  #
+  # The "properties" mapping lets you add properties to some of the Hazelcast elements used to configure some of
+  # the Hazelcast client modules.
+  # You can define the name and value of these properties.
+  # Please check the source of the ClientProperty class for the complete list of the client properties and their
+  # documentation.
+  #
+  properties:
+    hazelcast.client.shuffle.member.list: true
+    hazelcast.client.heartbeat.timeout: 60000
+    hazelcast.client.heartbeat.interval: 5000
+    hazelcast.client.event.thread.count: 5
+    hazelcast.client.event.queue.capacity: 1000000
+    hazelcast.client.invocation.timeout.seconds: 120
+  #
+  # The "client-labels" sequence lets you define labels in your Java client, similar to the way it can be done for the
+  # members. Through the client labels, you can assign special roles for your clients and use these roles to perform
+  # some actions specific to those client connections.
+  #
+  # You can also group your clients using the client labels. These client groups can be blacklisted in the Hazelcast
+  # Management Center so that they can be prevented from connecting to a cluster. See the related section in the
+  # Hazelcast Management Center Reference Manual for more information on this topic.
+  #
+  client-labels:
+    - admin
+    - foo
+  #
+  # ===== HAZELCAST NETWORK CONFIGURATION =====
+  #
+  # The configuration to build your Hazelcast's network includes configuration for port, interface, discovery
+  # mechanism, SSL, encryption, etc. The configuration node's name is "network".
+  #   It has the following sub-nodes:
+  # * "cluster-members":
+  #     This sequence lets you list the members in your cluster the client is connecting to.
+  # * "outbound-ports":
+  #     By default, Hazelcast lets the system pick up an ephemeral port during socket bind operation.
+  #     But security policies/firewalls may require to restrict outbound ports to be used by
+  #     Hazelcast-enabled applications. To fulfill this requirement, you can configure Hazelcast to use
+  #     only defined outbound ports.
+  #     The outbound ports are listed as a sequence under the "outbound-ports" element.
+  # * "smart-routing":
+  #     If true, client will route the key based operations to owner of the key at the best effort. Note that it
+  #     uses a cached version of com.hazelcast.core.PartitionService#getPartitions() and doesn't guarantee that
+  #     the operation will always be executed on the owner. The cached table is updated every second.
+  # * "redo-operation":
+  #     If true, client will redo the operations that were executing on the server and client lost the connection.
+  #     This can be because of network, or simply because the member died. However it is not clear whether the
+  #     application is performed or not. For idempotent operations this is harmless, but for non idempotent ones
+  #     retrying can cause to undesirable effects. Note that the redo can perform on any member. If false, the
+  #     operation will throw a RuntimeException that is wrapping a java.io.IOException.
+  # * "connection-timeout":
+  #     Connection timeout is the timeout value in milliseconds for members to accept client connection requests.
+  #     The following are the example configurations. Its default value is 5000.
+  # * "connection-attempt-limit":
+  #     While the client is trying to connect initially to one of the members in the "cluster-members", that
+  #     member might not  be available at that moment. Instead of giving up, throwing an exception and stopping
+  #     the client, the client retries as many the times configured by this setting. This is also the case
+  #     when the previously established connection between the client and that member goes down.
+  # * "connection-attempt-period":
+  #     Connection attempt period is the duration in milliseconds between the connection attempts defined by
+  #     "connection-attempt-limit".
+  # * "socket-options":
+  #     You can configure the network socket options using this setting. It has the following sub-elements:
+  #       - "tcp-no-delay": Enables/disables the TCP_NODELAY socket option. Its default value is true.
+  #       - "keep-alive": Enables/disables the SO_KEEPALIVE socket option. Its default value is true.
+  #       - "reuse-address": Enables/disables the SO_REUSEADDR socket option. Its default value is true.
+  #       - "linger-seconds":
+  #           Enables/disables SO_LINGER with the specified linger time in seconds.
+  #           Its default value is 3.
+  #       - "buffer-size":
+  #           Sets the SO_SNDBUF and SO_RCVBUF options to the specified value in KB for this Socket.
+  #           Its default value is 128.
+  # * "socket-interceptor":
+  #     Lets you add custom hooks to join and perform connection procedures (like identity checking using
+  #     Kerberos, etc.). This feature is available only in Hazelcast Enterprise. To be able to use it, you
+  #     should first implement the MemberSocketInterceptor (for members joining to a cluster) or
+  #     SocketInterceptor (for clients connecting to a member) class. Its configuration contains the class you
+  #     implemented and socket interceptor properties. By default, it is disabled. The following is an example:
+  #     socket-interceptor:
+  #       enabled: true
+  #       class-name: com.hazelcast.examples.MySocketInterceptor
+  #       properties:
+  #         kerberos-host: kerb-host-name
+  #         kerberos-config-file: kerb.conf
+  # * "ssl":
+  #     Lets you configure SSL using the SSL context factory. This feature is available only in Hazelcast
+  #     Enterprise. To be able to use it, encryption should NOT be enabled and you should first implement
+  #     your SSLContextFactory class. Its configuration contains the factory class and SSL properties.
+  #     By default, it is disabled. The following is an example:
+  #     ssl:
+  #       enabled: true
+  #       factory-class-name: com.hazelcast.nio.ssl.BasicSSLContextFactory
+  #       properties:
+  #         keyStore: keyStore
+  #         keyStorePassword: keyStorePassword
+  #         keyManagerAlgorithm: SunX509
+  #         trustManagerAlgorithm: SunX509
+  #         protocol: TLS
+  #         mutualAuthentication: REQUIRED
+  # * "aws":
+  #     Set its "enabled" sub-element to true for discovery within Amazon EC2.
+  #     Please refer to https://github.com/hazelcast/hazelcast-aws/#configuration for the configuration details.
+  # * "gcp":
+  #     Set its "enabled" sub-element to true for discovery within the Google Cloud Platform.
+  #     Please refer to https://github.com/hazelcast/hazelcast-gcp/#configuration for the configuration details.
+  # * "azure":
+  #     Set its "enabled" sub-element to true for discovery within Microsoft Azure.
+  #     Please refer to https://github.com/hazelcast/hazelcast-azure/#configuring-at-hazelcast-side for
+  #     the configuration details.
+  # * "kubernetes":
+  #     Set its "enabled" sub-element to true for discovery in the Kubernetes environment.
+  #     Please refer to https://github.com/hazelcast/hazelcast-kubernetes#hazelcast-configuration for
+  #     the configuration details.
+  # * "eureka":
+  #     Set its "enabled" sub-element to true for discovery with using Eureka Service Registry.
+  #     Please refer to https://github.com/hazelcast/hazelcast-eureka#hazelcast-configuration for
+  #     the configuration details.
+  # * "hazelcast-cloud":
+  #     Set its "enabled" sub-element to true for cluster discovery in the Hazelcast Cloud infrastructure. You need to
+  #     define the mandatory "discovery-token" sub-node used by the discovery mechanism.
+  # * "discovery-strategies":
+  #     Set its "enabled" sub-element to true for discovery in various cloud infrastructures. You also need to set the
+  #     value of "hazelcast.discovery.enabled" property to true. See the description of the "properties" element
+  #     to learn how to do this.
+  #     You can define multiple discovery strategies using the "discovery-strategy" sub-element and its
+  #     properties. Please refer to
+  #     http://docs.hazelcast.org/docs/latest/manual/html-single/index.html#discovering-cluster-members
+  #     to see the properties you can use.
+  #     The following is an example for EC2 cloud.
+  #     discovery-strategies:
+  #         - enabled: true
+  #           class: com.hazelcast.jclouds.JCloudsDiscoveryStrategy
+  #           properties:
+  #             provider: aws-ec2
+  #             identity: AWS_IDENTITY
+  #             credential: AWS_CREDENTIAL
+  # * "icmp-ping":
+  #     ICMP can be used in addition to the other detectors. It operates at OSI layer 3 and detects network
+  #     and hardware issues more quickly. This detector needs to be turned on by setting the "enabled" attribute
+  #     to true. It is turned off by default.
+  #
+  #       It has the following sub-elements:
+  #     * "timeout-milliseconds":
+  #         Number of milliseconds until a ping attempt is considered failed if there was no reply.
+  #         Its default value is 1000 milliseconds.
+  #     * "interval-milliseconds":
+  #         Interval, in milliseconds, between each ping attempt. 1000ms (1 sec) is also the minimum interval allowed.
+  #         Its default value is 1000 milliseconds.
+  #     * "max-attempts":
+  #         Maximum number of ping attempts before the member gets suspected by the detector. Its default value is 3.
+  #     * "ttl":
+  #         Maximum number of hops the packets should go through. Its default value is 255. You can set to 0 to use
+  #         your system’s default TTL.
+  #     * "echo-fail-fast-on-startup":
+  #         Cluster Member will fail to start if it is unable to action an ICMP ping command when ICMP is enabled.
+  #         Failure is usually due to OS level restrictions.
+  #
+  network:
+    cluster-members:
+      - 127.0.0.1
+      - 127.0.0.2
+    outbound-ports:
+      - 34600
+      - 34700-34710
+    smart-routing: true
+    redo-operation: true
+    connection-timeout: 60000
+    connection-attempt-period: 3000
+    connection-attempt-limit: 2
+    socket-options:
+      tcp-no-delay: false
+      keep-alive: true
+      reuse-address: true
+      linger-seconds: 3
+      buffer-size: 128
+    socket-interceptor:
+      enabled: true
+      class-name: com.hazelcast.examples.MySocketInterceptor
+      properties:
+        foo: bar
+
+    ssl:
+      enabled: false
+      factory-class-name: com.hazelcast.nio.ssl.BasicSSLContextFactory
+      properties:
+        protocol: TLS
+
+        trustStore: /opt/hazelcast-client.truststore
+        trustStorePassword: secret.123456
+        trustStoreType: JKS
+
+        # Following properties are only needed when the mutual authentication is used.
+        keyStore: /opt/hazelcast-client.keystore
+        keyStorePassword: keystorePassword123
+        keyStoreType: JKS
+
+    aws:
+      enabled: true
+      connection-timeout-seconds: 11
+      inside-aws: true
+      access-key: TEST_ACCESS_KEY
+      secret-key: TEST_SECRET_KEY
+      region: us-east-1
+      host-header: ec2.amazonaws.com
+      security-group-name: hazelcast-sg
+      tag-key: type
+      tag-value: hz-nodes
+    gcp:
+      enabled: false
+      zones: us-east1-b,us-east1-c
+    azure:
+      enabled: false
+      client-id: CLIENT_ID
+      client-secret: CLIENT_SECRET
+      tenant-id: TENANT_ID
+      subscription-id: SUB_ID
+      cluster-id: HZLCAST001
+      group-name: GROUP-NAME
+    kubernetes:
+      enabled: false
+      namespace: MY-KUBERNETES-NAMESPACE
+      service-name: MY-SERVICE-NAME
+      service-label-name: MY-SERVICE-LABEL-NAME
+      service-label-value: MY-SERVICE-LABEL-VALUE
+    eureka:
+      enabled: false
+      self-registration: true
+      namespace: hazelcast
+    icmp-ping:
+      enabled: false
+      timeout-milliseconds: 2000
+      interval-milliseconds: 3000
+      ttl: 100
+      max-attempts: 5
+      echo-fail-fast-on-startup: false
+    hazelcast-cloud:
+      enabled: false
+      discovery-token: EXAMPLE_TOKEN
+    discovery-strategies:
+      node-filter:
+        class: DummyFilterClass
+      discovery-strategies:
+        - class: DummyDiscoveryStrategy1
+          enabled: true
+          properties:
+            key-string: foo
+            key-int: 123
+            key-boolean: true
+  #
+  # The "executor-pool-size" scalar lets you configure the pool size for an internal executor service
+  # (different from the data structure Executor Service) that has threads and queues to perform internal operations
+  # such as handling responses. This parameter specifies the size of the pool of threads which perform these
+  # operations laying in the executor’s queue. If not configured, this parameter has the value of 5 x core size of
+  # the client, i.e., it is 20 for a machine that has 4 cores.
+  #
+  executor-pool-size: 40
+
+  #
+  # ===== HAZELCAST SECURITY CONFIGURATION =====
+  #
+  # This feature is available only in Hazelcast Enterprise. Configuration element's name is "security".
+  #   It has the following sub-nodes:
+  # * "credentials":
+  #     The name of the class implementing Hazelcast's Credentials interface.
+  # * "credentials-factory":
+  #     Specifies the name and properties of your class that you developed by implementing Hazelcast's Credentials
+  #     interface.
+  #     This element has a mandatory "class-name" attribute where you should define the factory class implementing
+  #     ICredentialsFactory used to create Credentials objects.
+  #     With the "properties" sub-element, you can define properties for the factory class. The properties can be
+  #     defined as a mapping where the key is the name of the property.
+  #
+  security:
+    credentials: com.hazelcast.security.UsernamePasswordCredentials
+    credentials-factory:
+      class-name: com.hazelcast.examples.MyCredentialsFactory
+      properties:
+        property: value
+  #
+  # ===== HAZELCAST LISTENER CONFIGURATIONS =====
+  #
+  # Configuration used to register the listeners that you created by implementing Hazelcast's
+  # MembershipListener, InstanceListener and MigrationListener interfaces.
+  #
+  listeners:
+    - com.hazelcast.examples.MembershipListener
+    - com.hazelcast.examples.InstanceListener
+    - com.hazelcast.examples.MigrationListener
+  #
+  # ===== HAZELCAST SERIALIZATION CONFIGURATION =====
+  #
+  # Configuration element's name is "serialization".
+  # It has the following sub-elements:
+  # * "portable-version":
+  #     Version of the portable serialization. Portable version is used to differentiate two
+  #     of the same classes that have changes such as a new field or a new field type.
+  # * "use-native-byte-order":
+  #     Set as true if you want to use the native byte order of the underlying platform. Its default value is false.
+  # * "byte-order":
+  #     Specifies the byte order that the serialization will use. Its default value is BIG_ENDIAN. Available values
+  #     are BIG_ENDIAN and LITTLE_ENDIAN.
+  # * "enable-compression":
+  #     Set as true to enable compression when default Java serialization is used. Its default value is false.
+  # * "enable-shared-object":
+  #     Set as true to enable shared object when default Java serialization is used. Its default value is false.
+  # * "allow-unsafe":
+  #     Set as true to allow the usage of unsafe. Its default value is false.
+  # * "data-serializable-factories":
+  #     Lists your class implementations of Hazelcast's DataSerializableFactory. Each factory has the required
+  #     "factory-id" attribute that you should give as the ID of your factory.
+  # * "portable-factories":
+  #     Lists your class implementations of Hazelcast's PortableFactory. Each factory has the required "factory-id"
+  #     attribute that you should give as the ID of your factory.
+  # * "global-serializer":
+  #     Global serializer should be defined with "global-serializer" element. It has an optional boolean
+  #     "override-java-serialization" attribute. If you set it as true, the Java serialization step will be handled by the
+  #     global serializer, not by the Java Serializable or Externalizable
+  # * "serializers":
+  #     Lists the serializers (classes) that you implement using Hazelcast's StreamSerializer, ByteArraySerializer etc.
+  #
+  #     The serializer sub-elements has two required attributes:
+  #     - class-name: Full class name of the serializer you implemented.
+  #     - type-class: Type of your serializer class implementation.
+  #
+  # * "check-class-def-errors":
+  #     If set to true, serialization system will check the class definitions error at the start of serialization process
+  #     and throw a Serialization Exception with the error definition.
+  # * "java-serialization-filter":
+  #     Allows to configure blacklisting and whitelisting for deserialized classes when Java serialization is used.
+  #
+  serialization:
+    portable-version: 3
+    use-native-byte-order: true
+    byte-order: BIG_ENDIAN
+    enable-compression: false
+    enable-shared-object: true
+    allow-unsafe: false
+    data-serializable-factories:
+      - factory-id: 1
+        class-name: com.hazelcast.examples.DataSerializableFactory
+    portable-factories:
+      - factory-id: 2
+        class-name: com.hazelcast.examples.PortableFactory
+    global-serializer:
+      override-java-serialization: true
+      class-name: com.hazelcast.examples.GlobalSerializerFactory
+    serializers:
+      - type-class: com.hazelcast.examples.DummyType
+        class-name: com.hazelcast.examples.SerializerFactory
+    check-class-def-errors: true
+    java-serialization-filter:
+      blacklist:
+        class:
+          - com.acme.app.BeanComparator
+      whitelist:
+        class:
+          - java.lang.String
+          - example.Foo
+        package:
+          - com.acme.app
+          - com.acme.app.subpkg
+        prefix:
+          - java
+          - "["
+          - com.
+  #
+  # ===== HAZELCAST HIGH-DENSITY MEMORY STORE CONFIGURATION =====
+  #
+  # This feature is available only in Hazelcast Enterprise HD. Configuration element's name is
+  # "native-memory".
+  # It has the following attributes:
+  # - enabled:
+  #     Set as true to enable the High-Density Memory Store usage. Its default value is false.
+  # - allocator-type:
+  #     Type of the memory allocator. Its default value is POOLED. Available values are as follows:
+  # * STANDARD: Allocates/frees the memory using default OS memory manager.
+  # * POOLED: Manages memory blocks in thread local pools.
+  #
+  # It has the following sub-elements:
+  # - "size":
+  #     Size of the total native memory to allocate. You can give the size using its "value" attribute and the unit
+  #     using its "unit" attribute. Unit can be bytes, kilobytes, megabytes and gigabytes. Default value is 128 and
+  #     default unit is MEGABYTES.
+  # - "min-block-size":
+  #     Minimum size of the blocks in bytes to split and fragment a page block to assign to an allocation request.
+  #     It is used only by the POOLED memory allocator. The value has to be power of two.  Default value is 16.
+  # - "page-size":
+  #     Size of the page in bytes to allocate memory as a block. It is used only by the POOLED memory allocator. Its
+  #     default value is 1 << 22 (about 4 MB).
+  # - "metadata-space-percentage":
+  #     Percentage of the allocated native memory that is used for the metadata such as indexes, offsets, etc. It is
+  #     used only by the POOLED memory allocator. Its default value is 12.5.
+  #
+  native-memory:
+    enabled: false
+    allocator-type: POOLED
+    size:
+      unit: MEGABYTES
+      value: 128
+    min-block-size: 1
+    page-size: 1
+    metadata-space-percentage: 40.5
+  #
+  # ===== HAZELCAST PROXY FACTORY CONFIGURATION =====
+  #
+  # The client proxy factories can be defined under the "proxy-factories" sequence. Each node in the sequence is
+  # a mapping, with the following sub-nodes:
+  # * "class-name": The name of the client proxy factory class.
+  # * "service": The name of the service.
+  #
+  proxy-factories:
+    - class-name: com.hazelcast.examples.ProxyXYZ1
+      service: sampleService1
+    - class-name: com.hazelcast.examples.ProxyXYZ2
+      service: sampleService1
+    - class-name: com.hazelcast.examples.ProxyXYZ3
+      service: sampleService3
+  #
+  # ===== HAZELCAST LOAD BALANCER CONFIGURATION =====
+  #
+  # The load balancer can be configured with the "load-balancer" mapping.
+  # It has a scalar sub-node called "type". The valid values for the type of the load balancer are:
+  # * "random": The member the operations to be sent to is chosen randomly.
+  # * "round-robin": The member the operations to be sent to is chosen in a round-robin fashion.
+  #
+  load-balancer:
+    type: random
+  #
+  # ===== HAZELCAST NEAR CACHE CONFIGURATION =====
+  #
+  # Configuration element's name is "near-cache".
+  # It has the following attribute:
+  #   - name: You can give a name for your Near Cache. It is optional and its default value is "default".
+  #
+  # It has the following sub-nodes:
+  #   - "max-size":
+  #       Maximum size of the Near Cache. When this is reached, Near Cache is evicted based on the policy defined.
+  #       Any integer between 0 and Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Its default value is 0.
+  #   - "time-to-live-seconds":
+  #       Maximum number of seconds for each entry to stay in the Near Cache. Entries that are older than this
+  #       period are automatically evicted from the Near Cache. Any integer between 0 and Integer.MAX_VALUE.
+  #       0 means infinite. Its default value is 0.
+  #   - "max-idle-seconds":
+  #       Maximum number of seconds each entry can stay in the Near Cache as untouched (not read). Entries that
+  #       are not read more than this period are removed from the Near Cache. Any integer between 0 and
+  #       Integer.MAX_VALUE. 0 means Integer.MAX_VALUE. Its default value is 0.
+  #   - "eviction-policy":
+  #       Eviction policy configuration. Its default values is NONE. Available values are as follows:
+  #         - NONE:
+  #             No items will be evicted and the property max-size will be ignored. You still
+  #             can combine it with time-to-live-seconds and max-idle-seconds.
+  #         - LRU: 	Least Recently Used.
+  #         - LFU: 	Least Frequently Used.
+  #         - "invalidate-on-change":
+  #             Specifies whether the cached entries are evicted when the entries are updated or removed. Its default
+  #             value is true.
+  #   - "in-memory-format":
+  #       Specifies in which format data will be stored in your Near Cache. Note that a map's in-memory format
+  #       can be different from that of its Near Cache.
+  #       Available values are as follows:
+  #         - BINARY:
+  #             Data will be stored in serialized binary format. It is the default option.
+  #         - OBJECT:
+  #             Data will be stored in deserialized form.
+  #         - NATIVE:
+  #             Data will be stored in the Near Cache that uses Hazelcast's High-Density Memory Store feature.
+  #             This option is available only in Hazelcast Enterprise HD. Note that a map and its Near Cache
+  #             can independently use High-Density Memory Store. For example, while your map does not use
+  #             High-Density Memory Store, its Near Cache can use it.
+  #   - "cache-local-entries":
+  #       Specifies whether the local entries will be cached. It can be useful when in-memory format for
+  #       Near Cache is different from that of the map. By default, it is disabled.
+  #   - "invalidate-on-change":
+  #       Specifies whether the cached entries are evicted when the entries are updated or removed.
+  #       Its default value is true.
+  #   - "serialize-keys":
+  #       Specifies if the keys of a Near Cache entry should be serialized or not. Serializing the keys has
+  #       a big impact on the read performance of the Near Cache. It should just be activated when you have
+  #       mutable keys, which are changed after use for the Near Cache. Its default value is false.
+  #   - "eviction":
+  #       Configuration for the eviction when the in-memory format of the Near Cache is NATIVE. It has the
+  #       following attributes:
+  #         - size: Maximum size (entry count) of the Near Cache.
+  #         - max-size-policy: Maximum size policy for eviction of the Near Cache. Available values are as follows:
+  #                              * ENTRY_COUNT: Maximum entry count per member.
+  #                              * USED_NATIVE_MEMORY_SIZE: Maximum used native memory size in megabytes.
+  #                              * USED_NATIVE_MEMORY_PERCENTAGE: Maximum used native memory percentage.
+  #                              * FREE_NATIVE_MEMORY_SIZE: Minimum free native memory size to trigger cleanup.
+  #                              * FREE_NATIVE_MEMORY_PERCENTAGE: Minimum free native memory percentage to trigger cleanup.
+  #         - eviction-policy: See the "eviction-policy" element above.
+  #
+  # Note that the Near Cache eviction configuration is different for NATIVE in-memory format.
+  # Proper eviction configuration example for NATIVE in-memory can be seen under 'NearCacheEvictionConfigExample'.
+  near-cache:
+    default:
+      max-size: 2000
+      time-to-live-seconds: 90
+      max-idle-seconds: 100
+      eviction-policy: LFU
+      invalidate-on-change: true
+      cache-local-entries: true
+      in-memory-format: OBJECT
+      serialize-keys: true
+      local-update-policy: INVALIDATE
+      preloader:
+        enabled: true
+        directory: directory
+        store-initial-delay-seconds: 50
+        store-interval-seconds: 10
+
+    NearCacheEvictionConfigExample:
+      eviction:
+        eviction-policy: LRU
+        max-size-policy: ENTRY_COUNT
+        size: 10000
+        comparator-class-name: com.hazelcast.examples.MyEvictionComparator
+
+  #
+  # ===== HAZELCAST FLAKE ID GENERATOR CONFIGURATION =====
+  #
+  # Configuration element's name is "flake-id-generator". The name of the Flake ID generator is defined by the name
+  # of the key right under the "flake-id-generator" node.
+  # It has the following sub-ndoes:
+  #
+  # * "prefetch-count":
+  #     Sets how many IDs are pre-fetched on the background when one call to
+  #     FlakeIdGenerator.newId() is made. Value must be in the range 1..100,000, default
+  #     is 100.
+  #
+  #     This setting pertains only to newId() calls made on the member that configured it.
+  #
+  # * "prefetch-validity-millis":
+  #     Sets for how long the pre-fetched IDs can be used. If this time elapses, a new batch of IDs
+  #     will be fetched. Time unit is milliseconds, default is 600,000 (10 minutes).
+  #
+  #     The IDs contain timestamp component, which ensures rough global ordering of IDs. If an
+  #     ID is assigned to an object that was created much later, it will be much out of order. If you
+  #     don't care about ordering, set this value to 0.
+  #
+  #     This setting pertains only to newId() calls made on the member that configured it.
+  #
+  flake-id-generator:
+    default:
+      prefetch-count: 100
+      prefetch-validity-millis: 600000
+
+  #
+  # ===== HAZELCAST CONTINUOUS QUERY CACHE CONFIGURATION =====
+  #
+  # Configuration element's name is "query-caches".
+  # You can create your query caches by defining mappings with the key used as the name of the query cache.
+  # It has the following sub-elements:
+  # * "map-name": Specifies the name of the map the query cache is used for.
+  # * "predicate":
+  #     Predicate to filter events which will be applied to the query cache.
+  # * "entry-listeners":
+  #     Adds listeners (listener classes) for your query cache entries. See "entry-listeners" in the map configuration above.
+  # * "include-value":
+  #     Set to true if you want to cache the value too. Its default value is true.
+  # * "batch-size":
+  #     Batch size used to determine the number of events sent in a batch to your query cache. Its default value is 1.
+  # * "buffer-size":
+  #     Maximum number of events which can be stored in a partition buffer. Its default value is 16.
+  # * "delay-seconds":
+  #     Minimum time in seconds that an event waits in the member's buffer. Its default value is 0.
+  # * "in-memory-format":
+  #     Type of the data to be stored in your query cache. See "in-memory-format" in the map configuration above.
+  # * "coalesce":
+  #     Set to true if you want to enable the coalescing of your query cache. Its default value is false.
+  # * "populate":
+  #     Set to true if you want to enable the initial population of your query cache. Its default value is true.
+  # * "eviction":
+  #     Configuration for the eviction of your query cache.
+  #     It has the following attributes:
+  #         - size: Maximum size (entry count) of the Near Cache.
+  #         - max-size-policy: Maximum size policy for eviction of the Near Cache. Available values are as follows:
+  #                               * ENTRY_COUNT: Maximum entry count per member.
+  #                               * USED_NATIVE_MEMORY_SIZE: Maximum used native memory size in megabytes.
+  #                               * USED_NATIVE_MEMORY_PERCENTAGE: Maximum used native memory percentage.
+  #                               * FREE_NATIVE_MEMORY_SIZE: Minimum free native memory size to trigger cleanup.
+  #                               * FREE_NATIVE_MEMORY_PERCENTAGE: Minimum free native memory percentage to trigger cleanup.
+  #          - eviction-policy: Eviction policy configuration. Its default values is NONE. Available values are as follows:
+  #                               - NONE:
+  #                                   No items will be evicted and the property max-size will be ignored. You still
+  #                                   can combine it with time-to-live-seconds and max-idle-seconds.
+  #                               - LRU: 	Least Recently Used.
+  #                               - LFU: 	Least Frequently Used.
+  #          - comparator-class-name: The comparator to be used while comparing entries to be evicted.
+  #
+  # * "indexes":
+  #     You can define indexes for your map using the "indexes" mapping. Each "index" is defined as a mapping under "indexes"
+  #     where the key of the mapping is the name of the index. For the indexes you can define the boolean "ordered" scalar.
+  #     For example, if you will have a ranged query for a field of a map entry, then "ordered" should be set to true. But
+  #     if the field has a boolean value, then it should be set to false. Its default value is false.
+  #
+  query-caches:
+    query-cache-class-name-predicate:
+      map-name: map-name
+      predicate:
+        class-name: com.hazelcast.examples.ExamplePredicate
+      entry-listeners:
+        - include-value: true
+          local: false
+          class-name: com.hazelcast.examples.EntryListener
+      include-value: true
+      batch-size: 1
+      buffer-size: 16
+      delay-seconds: 0
+      in-memory-format: BINARY
+      coalesce: false
+      populate: true
+      eviction:
+        eviction-policy: LRU
+        max-size-policy: ENTRY_COUNT
+        size: 10000
+        comparator-class-name: com.hazelcast.examples.MyEvictionComparator
+      indexes:
+        name:
+          ordered: false
+    query-cache-sql-predicate:
+      map-name: map-name
+      predicate:
+        sql: "%age=40"
+  #
+  # ===== HAZELCAST CONNECTION STRATEGY CONFIGURATION =====
+  #
+  # Configuration node's name is "connection-strategy".
+  # It has the following sub-nodes:
+  #   - "async-start": If set to true, creating Hazelcast client doesn't not wait for connecting to the cluster.
+  #   - "reconnect-mode": Defines the reconnection mode. The valid values are:
+  #     - "ON":
+  #         Enables reconnection in a blocking manner where all the waiting invocations are blocked until a
+  #         cluster connection is established or failed. This is the default value.
+  #     - "OFF": Disables the reconnection.
+  #     - "ASYNC":
+  #         Enables reconnection in a non-blocking manner where all the waiting invocations receive a
+  #         HazelcastClientOfflineException.
+  #   - "connection-retry":
+  #         Defines the configuration used when retrying to connect to the cluster.
+  #         It has the following sub-nodes:
+  #   * "enabled": Specifies if retrying is enabled
+  #   * "initial-backoff-millis":
+  #       Specifies how long to wait (backoff) after the first failure before retrying in milliseconds.
+  #       Its default value is 1000 ms.
+  #   * "max-backoff-millis": Specifies the upper limit for the backoff in milliseconds. Its default value is 30000 ms.
+  #   * "multiplier": Factor to multiply the backoff after a failed retry. Its default value is 2.
+  #   * "fail-on-max-backoff":
+  #       Specifies whether to fail when the max-backoff-millis has reached or continue waiting max-backoff-millis
+  #       at each iteration. Its default value is false.
+  #   * "jitter": Specifies by how much to randomize backoffs. Its default value is 0.2.
+  #
+  connection-strategy:
+    async-start: true
+    reconnect-mode: ASYNC
+    connection-retry:
+      enabled: true
+      initial-backoff-millis: 2000
+      max-backoff-millis: 60000
+      multiplier: 3
+      fail-on-max-backoff: true
+      jitter: 0.5
+
+  #
+  # ===== HAZELCAST RELIABLE TOPIC CONFIGURATION =====
+  #
+  # Reliable Topic uses the same ITopic interface. The main difference is that it is backed up by
+  # Hazelcast Ringbuffer data structure. Reliable Topic messages are stored in the Ringbuffer
+  # Configuration element's name is "reliable-topic". It has the optional attribute "name" with which you
+  # can specify the name of your Reliable Topic, which is the same name you give to your Ringbuffer.
+  # This attribute's default value is "default".
+  # It has the following sub-elements:
+  # * "read-batch-size":
+  #     Sets the read batch size.
+  #     The ReliableTopic tries to read a batch of messages from the ringbuffer.
+  #     It will get at least one, but if there are more available, then it will
+  #     try to get more to increase throughput. The maximum read batch size can
+  #     be influenced using the read batch size.
+  #     Apart from influencing the number of messages to retrieve, the
+  #     readBatchSize also determines how many messages will be processed
+  #     by the thread running the MessageListener before it returns back
+  #     to the pool to look for other MessageListeners that need to be
+  #     processed. The problem with returning to the pool and looking for new work
+  #     is that interacting with an executor is quite expensive due to contention
+  #     on the work-queue. The more work that can be done without retuning to the
+  #     pool, the smaller the overhead.
+  #     If the readBatchSize is 10 and there are 50 messages available,
+  #     10 items are retrieved and processed consecutively before the thread goes
+  #     back to the pool and helps out with the processing of other messages.
+  #     If the readBatchSize is 10 and there are 2 items available,
+  #     2 items are retrieved and processed consecutively.
+  #     If the readBatchSize is an issue because a thread will be busy
+  #     too long with processing a single MessageListener and it can't
+  #     help out other MessageListeners, increase the size of the
+  #     threadpool so the other MessageListeners don't need to wait for
+  #     a thread, but can be processed in parallel.
+  # * "topic-overload-policy":
+  #     A policy to deal with an overloaded topic; so topic where there is no place to store new messages.
+  #     This policy can only be used in combination with the
+  #     com.hazelcast.core.HazelcastInstance#getReliableTopic(String).
+  #     The reliable topic uses a com.hazelcast.ringbuffer.Ringbuffer to
+  #     store the messages. A ringbuffer doesn't track where readers are, so
+  #     it has no concept of a slow consumers. This provides many advantages like
+  #     high performance reads, but it also gives the ability to the reader to
+  #     re-read the same message multiple times in case of an error.
+  #     A ringbuffer has a limited, fixed capacity. A fast producer may overwrite
+  #     old messages that are still being read by a slow consumer. To prevent
+  #     this, we may configure a time-to-live on the ringbuffer (see
+  #     com.hazelcast.config.RingbufferConfig#setTimeToLiveSeconds(int).
+  #     Once the time-to-live is configured, the TopicOverloadPolicy
+  #     controls how the publisher is going to deal with the situation that a
+  #     ringbuffer is full and the oldest item in the ringbuffer is not old
+  #     enough to get overwritten.
+  #     Keep in mind that this retention period (time-to-live) can keep messages
+  #     from being overwritten, even though all readers might have already completed reading.
+  #     Its default value is BLOCK. Available values are as follows:
+  #     - DISCARD_OLDEST:
+  #         Using this policy, a message that has not expired can be overwritten.
+  #         No matter the retention period set, the overwrite will just overwrite
+  #         the item.
+  #         This can be a problem for slow consumers because they were promised a
+  #         certain time window to process messages. But it will benefit producers
+  #         and fast consumers since they are able to continue. This policy sacrifices
+  #         the slow producer in favor of fast producers/consumers.
+  #     - DISCARD_NEWEST:
+  #         Message that was to be published is discarded.
+  #     - BLOCK:
+  #         The caller will wait until there is space in the Ringbuffer.
+  #     - ERROR:
+  #         The publish call fails immediately.
+  #
+  reliable-topic:
+    rel-topic:
+      read-batch-size: 100
+      topic-overload-policy: DISCARD_NEWEST
+  #
+  # ===== HAZELCAST USER CODE DEPLOYMENT CONFIGURATION =====
+  #
+  # Configuration element's name is "user-code-deployment".
+  # It has the following sub-nodes:
+  # * "enabled": If set to true, user code deployment is enabled.
+  # * "jarPaths": Sequence lists the jar files containing the classes to load.
+  # * "classNames": Sequence lists the classes available in the client class path to load.
+  user-code-deployment:
+    enabled: true
+    jarPaths:
+      - /User/test/sample.jar
+      - https://hazelcast.com/
+      - file://User/test/sample.jar
+    classNames:
+      - test.sampleClassName

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlClientFailoverConfigBuilderTest.java
@@ -33,6 +33,9 @@ import static org.junit.Assert.assertEquals;
 @RunWith(HazelcastSerialClassRunner.class)
 @Category(QuickTest.class)
 public class XmlClientFailoverConfigBuilderTest extends AbstractClientFailoverConfigBuilderTest {
+    private static final String HAZELCAST_CLIENT_FAILOVER_START_TAG =
+            "<hazelcast-client-failover xmlns=\"http://www.hazelcast.com/schema/client-config\">\n";
+    private static final String HAZELCAST_CLIENT_FAILOVER_END_TAG = "</hazelcast-client-failover>";
 
     @Before
     public void init() throws Exception {
@@ -68,13 +71,13 @@ public class XmlClientFailoverConfigBuilderTest extends AbstractClientFailoverCo
     @Test
     public void testVariableReplacementFromProperties() {
         String xml = ""
-                + "<hazelcast-client-failover>"
+                + HAZELCAST_CLIENT_FAILOVER_START_TAG
                 + "  <clients>"
                 + "    <client>hazelcast-client-c1.xml</client>\n"
                 + "    <client>hazelcast-client-c2.xml</client>\n"
                 + "  </clients>"
                 + "  <try-count>${try-count}</try-count>"
-                + "</hazelcast-client-failover>";
+                + HAZELCAST_CLIENT_FAILOVER_END_TAG;
 
         Properties properties = new Properties();
         properties.setProperty("try-count", "11");
@@ -86,13 +89,13 @@ public class XmlClientFailoverConfigBuilderTest extends AbstractClientFailoverCo
     @Test
     public void testVariableReplacementFromSystemProperties() {
         String xml = ""
-                + "<hazelcast-client-failover>"
+                + HAZELCAST_CLIENT_FAILOVER_START_TAG
                 + "  <clients>"
                 + "    <client>hazelcast-client-c1.xml</client>\n"
                 + "    <client>hazelcast-client-c2.xml</client>\n"
                 + "  </clients>"
                 + "  <try-count>${try-count}</try-count>"
-                + "</hazelcast-client-failover>";
+                + HAZELCAST_CLIENT_FAILOVER_END_TAG;
 
         System.setProperty("try-count", "11");
         ClientFailoverConfig config = buildConfig(xml);

--- a/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlYamlClientConfigBuilderEqualsTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/config/XmlYamlClientConfigBuilderEqualsTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.config;
+
+import com.hazelcast.config.helpers.DeclarativeConfigFileHelper;
+import com.hazelcast.nio.IOUtil;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelTest.class})
+public class XmlYamlClientConfigBuilderEqualsTest {
+
+    @Test
+    public void testDefaultClientConfig() {
+        ClientConfig xmlConfig = new ClientClasspathXmlConfig("hazelcast-client-default.xml");
+        ClientConfig yamlConfig = new ClientClasspathYamlConfig("hazelcast-client-default.yaml");
+
+        String xmlConfigFromXml = ClientConfigXmlGenerator.generate(xmlConfig);
+        String xmlConfigFromYaml = ClientConfigXmlGenerator.generate(yamlConfig);
+
+        assertEquals(xmlConfigFromXml, xmlConfigFromYaml);
+    }
+
+    @Test
+    public void testFullClientConfig() throws IOException {
+        String fullExampleXml = readResourceToString("hazelcast-client-full-example.xml");
+        String fullExampleYaml = readResourceToString("hazelcast-client-full-example.yaml");
+
+        // remove imports to prevent the test from failing with importing non-existing files
+        fullExampleXml = fullExampleXml.replace("<import resource=\"your-client-configuration-XML-file\"/>", "");
+        fullExampleYaml = fullExampleYaml
+                .replace("\r", "")
+                .replace("import:\n    - your-client-configuration-YAML-file", "");
+
+        ClientConfig xmlConfig = buildConfigFromXml(fullExampleXml);
+        ClientConfig yamlConfig = buildConfigFromYaml(fullExampleYaml);
+
+        String xmlConfigFromXml = ClientConfigXmlGenerator.generate(xmlConfig, 4);
+        String xmlConfigFromYaml = ClientConfigXmlGenerator.generate(yamlConfig, 4);
+
+        assertEquals(xmlConfigFromXml, xmlConfigFromYaml);
+    }
+
+    @Test
+    public void testFullClientFailoverConfig() throws Exception {
+        DeclarativeConfigFileHelper helper = new DeclarativeConfigFileHelper();
+        helper.givenXmlClientConfigFileOnClasspath("your-first-hazelcast-client-configuration.xml", "instance0");
+        helper.givenXmlClientConfigFileOnClasspath("your-second-hazelcast-client-configuration.xml", "instance1");
+        helper.givenYamlClientConfigFileOnClasspath("your-first-hazelcast-client-configuration.yaml", "instance0");
+        helper.givenYamlClientConfigFileOnClasspath("your-second-hazelcast-client-configuration.yaml", "instance1");
+
+        try {
+            ClientFailoverConfig xmlConfig = new ClientFailoverClasspathXmlConfig("hazelcast-client-failover-full-example.xml");
+            ClientFailoverConfig yamlConfig = new ClientFailoverClasspathYamlConfig(
+                    "hazelcast-client-failover-full-example.yaml");
+
+            assertEquals(xmlConfig.getTryCount(), yamlConfig.getTryCount());
+
+            ClientConfig xmlClientConfig0 = xmlConfig.getClientConfigs().get(0);
+            ClientConfig xmlClientConfig1 = xmlConfig.getClientConfigs().get(1);
+            ClientConfig yamlClientConfig0 = yamlConfig.getClientConfigs().get(0);
+            ClientConfig yamlClientConfig1 = yamlConfig.getClientConfigs().get(1);
+
+            assertEquals("instance0", xmlClientConfig0.getInstanceName());
+            assertEquals("instance1", xmlClientConfig1.getInstanceName());
+            assertEquals("instance0", yamlClientConfig0.getInstanceName());
+            assertEquals("instance1", yamlClientConfig1.getInstanceName());
+        } finally {
+            helper.ensureTestConfigDeleted();
+        }
+    }
+
+    private String readResourceToString(String resource) throws IOException {
+        InputStream xmlInputStream = getClass().getClassLoader().getResourceAsStream(resource);
+        return new String(IOUtil.toByteArray(xmlInputStream));
+    }
+
+    private static ClientConfig buildConfigFromXml(String xml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(xml.getBytes());
+        return new XmlClientConfigBuilder(bis).build();
+    }
+
+    private static ClientConfig buildConfigFromYaml(String yaml) {
+        ByteArrayInputStream bis = new ByteArrayInputStream(yaml.getBytes());
+        return new YamlClientConfigBuilder(bis).build();
+    }
+}

--- a/hazelcast-client/src/test/resources/hazelcast-client-failover-sample-with-variable.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-failover-sample-with-variable.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
   ~
@@ -14,7 +15,10 @@
   ~ limitations under the License.
   -->
 
-<hazelcast-client-failover>
+<hazelcast-client-failover xmlns="http://www.hazelcast.com/schema/client-config"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                           http://www.hazelcast.com/schema/client-config/hazelcast-client-failover-config-3.12.xsd">
     <try-count>${try-count}</try-count>
     <clients>
         <client>hazelcast-client-c1.xml</client>

--- a/hazelcast-client/src/test/resources/hazelcast-client-failover-sample.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-failover-sample.xml
@@ -1,4 +1,24 @@
-<hazelcast-client-failover>
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<hazelcast-client-failover xmlns="http://www.hazelcast.com/schema/client-config"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
+                           http://www.hazelcast.com/schema/client-config/hazelcast-client-failover-config-3.12.xsd">
     <try-count>4</try-count>
     <clients>
         <client>hazelcast-client-c1.xml</client>

--- a/hazelcast-client/src/test/resources/hazelcast-client-full.xml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-full.xml
@@ -150,7 +150,7 @@
             <discovery-token>EXAMPLE_TOKEN</discovery-token>
         </hazelcast-cloud>
         <discovery-strategies>
-            <node-filter class="DummyFilterClass" />
+            <node-filter class="DummyFilterClass"/>
             <discovery-strategy class="DummyDiscoveryStrategy1" enabled="true">
                 <properties>
                     <property name="key-string">foo</property>

--- a/hazelcast-client/src/test/resources/hazelcast-client-full.yaml
+++ b/hazelcast-client/src/test/resources/hazelcast-client-full.yaml
@@ -292,4 +292,3 @@ hazelcast-client:
       - file://User/test/sample.jar
     classNames:
       - test.sampleClassName
-

--- a/hazelcast/src/main/resources/hazelcast-full-example.xml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.xml
@@ -1111,6 +1111,7 @@
                      * FREE_NATIVE_MEMORY_SIZE: Minimum free native memory size to trigger cleanup.
                      * FREE_NATIVE_MEMORY_PERCENTAGE: Minimum free native memory percentage to trigger cleanup.
                 - eviction-policy: See the <eviction-policy> element above.
+                - comparator-class-name: The comparator to be used while comparing entries to be evicted.
         * <wan-replication-ref>:
             Configuration of the WAN replication for your map.
             It has the following attributes:

--- a/hazelcast/src/main/resources/hazelcast-full-example.yaml
+++ b/hazelcast/src/main/resources/hazelcast-full-example.yaml
@@ -1099,6 +1099,7 @@ hazelcast:
   #              * FREE_NATIVE_MEMORY_SIZE: Minimum free native memory size to trigger cleanup.
   #              * FREE_NATIVE_MEMORY_PERCENTAGE: Minimum free native memory percentage to trigger cleanup.
   #         - eviction-policy: See the "eviction-policy" element above.
+  #         - comparator-class-name: The comparator to be used while comparing entries to be evicted.
   # * "wan-replication-ref":
   #     Configuration of the WAN replication for your map.
   #     It has the following attributes:

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
@@ -19,12 +19,10 @@ package com.hazelcast.config.helpers;
 import com.hazelcast.config.Config;
 
 import java.io.File;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.LinkedList;
+import java.util.List;
 
 public class DeclarativeConfigFileHelper {
     private static final String HAZELCAST_START_TAG = "<hazelcast xmlns=\"http://www.hazelcast.com/schema/config\">\n";
@@ -32,8 +30,11 @@ public class DeclarativeConfigFileHelper {
     private static final String HAZELCAST_CLIENT_START_TAG =
             "<hazelcast-client xmlns=\"http://www.hazelcast.com/schema/client-config\">\n";
     private static final String HAZELCAST_CLIENT_END_TAG = "</hazelcast-client>";
+    private static final String HAZELCAST_CLIENT_FAILOVER_START_TAG =
+            "<hazelcast-client-failover xmlns=\"http://www.hazelcast.com/schema/client-config\">\n";
+    private static final String HAZELCAST_CLIENT_FAILOVER_END_TAG = "</hazelcast-client-failover>";
 
-    private String testConfigPath;
+    private List<String> testConfigPaths = new LinkedList<>();
 
     // MEMBER
 
@@ -155,7 +156,7 @@ public class DeclarativeConfigFileHelper {
         writer.println(content);
         writer.close();
 
-        testConfigPath = file.getAbsolutePath();
+        testConfigPaths.add(file.getAbsolutePath());
 
         return file;
     }
@@ -168,7 +169,7 @@ public class DeclarativeConfigFileHelper {
         writer.println(content);
         writer.close();
 
-        testConfigPath = file.getAbsolutePath();
+        testConfigPaths.add(file.getAbsolutePath());
 
         return getClass().getClassLoader().getResource(filename);
     }
@@ -192,12 +193,12 @@ public class DeclarativeConfigFileHelper {
 
     private String xmlFailoverClientConfig(int tryCount) {
         return ""
-                + "<hazelcast-client-failover>"
+                + HAZELCAST_CLIENT_FAILOVER_START_TAG
                 + "  <try-count>" + tryCount + "</try-count>"
                 + "  <clients>"
                 + "    <client>hazelcast-client-c1.xml</client>"
                 + "  </clients>"
-                + "</hazelcast-client-failover>";
+                + HAZELCAST_CLIENT_FAILOVER_END_TAG;
     }
 
     private String yamlConfig(String instanceName) {
@@ -225,10 +226,12 @@ public class DeclarativeConfigFileHelper {
                 + "    - hazelcast-client-c1.yaml";
     }
 
-    public void ensureTestConfigDeleted() throws IOException {
-        if (testConfigPath != null) {
-            Path pathToDelete = Paths.get(testConfigPath);
-            Files.delete(pathToDelete);
+    public void ensureTestConfigDeleted() {
+        if (!testConfigPaths.isEmpty()) {
+            for (String testConfigPath : testConfigPaths) {
+                File file = new File(testConfigPath);
+                file.delete();
+            }
         }
     }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/helpers/DeclarativeConfigFileHelper.java
@@ -34,7 +34,7 @@ public class DeclarativeConfigFileHelper {
             "<hazelcast-client-failover xmlns=\"http://www.hazelcast.com/schema/client-config\">\n";
     private static final String HAZELCAST_CLIENT_FAILOVER_END_TAG = "</hazelcast-client-failover>";
 
-    private List<String> testConfigPaths = new LinkedList<>();
+    private List<String> testConfigPaths = new LinkedList<String>();
 
     // MEMBER
 

--- a/src/main/assembly/assembly.xml
+++ b/src/main/assembly/assembly.xml
@@ -103,6 +103,17 @@
             <includes>
                 <include>hazelcast.xml</include>
                 <include>hazelcast-full-example.xml</include>
+                <include>hazelcast-full-example.yaml</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>hazelcast-client/target/</directory>
+            <outputDirectory>/bin/</outputDirectory>
+            <includes>
+                <include>hazelcast-client-full-example.xml</include>
+                <include>hazelcast-client-full-example.yaml</include>
+                <include>hazelcast-client-failover-full-example.xml</include>
+                <include>hazelcast-client-failover-full-example.yaml</include>
             </includes>
         </fileSet>
         <fileSet>


### PR DESCRIPTION
There were `hazelcast-client-full.[xml|yaml]` configuration files shipped with the `hazelcast-client.jar`. These files however had no comments, and the files were used by tests too. To make test files and full example configs separated, these files are moved to the test scope, but also used as a basis for the full example config files that are extended with explanatory comments. Client failover full example configs are added too.

Besides this, the client failover config XSDs got fixed. These fixes include:
- Defining target namespace
- Change the `<try-count>` element's type from `xs:int` to `non-space-string` otherwise schema validation error is thrown if the variable replacer is used to configure the try count value.

The client failover XSD is changed retrospectively, but without the fix, schema validation fails if used. This needs further coordination to update the XSD.

Implements #14948

4.0 PR: https://github.com/hazelcast/hazelcast/pull/15056

3.12.x EE PR: hazelcast/hazelcast-enterprise#2992