### PR TITLE
Cleanup the helper code since initial problem is no more relevant

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnector.java
+++ b/hazelcast/src/main/java/com/hazelcast/nio/tcp/TcpIpConnector.java
@@ -187,17 +187,6 @@ class TcpIpConnector {
                     connection = endpointManager.newConnection(channel, address);
                     BindRequest request = new BindRequest(logger, ioService, connection, address, true);
                     request.send();
-                } catch (NullPointerException e) {
-                    // Helper piece of code, which will allow to identify rare NPEs in TLS connections
-                    // https://github.com/hazelcast/hazelcast-enterprise/issues/2104
-                    //TODO remove this catch block once the TLS NPE problem is successfully resolved
-                    closeConnection(connection, e);
-                    closeSocket(socketChannel);
-                    logger.log(level, "Could not connect to: " + socketAddress + ". Reason: " + e.getClass().getSimpleName()
-                            + "[" + e.getMessage() + "]");
-                    logger.log(Level.INFO,
-                            "Add this stacktrace to https://github.com/hazelcast/hazelcast-enterprise/issues/2104 please!", e);
-                    throw e;
                 } catch (Exception e) {
                     closeConnection(connection, e);
                     closeSocket(socketChannel);


### PR DESCRIPTION
The NPE occurred due to https://bugs.openjdk.java.net/browse/JDK-7043514
that was fixed in java7. Since java6 is no more supported, the helper
code should be removed.