### PR TITLE
Improve the Raft snapshotting optimization

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/cp/internal/raft/impl/RaftNodeImpl.java
@@ -80,7 +80,6 @@ import static com.hazelcast.cp.internal.raft.impl.RaftNodeStatus.UPDATING_GROUP_
 import static com.hazelcast.cp.internal.raft.impl.RaftRole.FOLLOWER;
 import static com.hazelcast.cp.internal.raft.impl.RaftRole.LEADER;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -493,6 +492,7 @@ public class RaftNodeImpl implements RaftNode {
 
         // if the first log entry to be sent is put into the snapshot, check if we still keep it in the log
         // if we still keep that log entry and its previous entry, we don't need to send a snapshot
+
         if (nextIndex <= raftLog.snapshotIndex()
                 && (!raftLog.containsLogEntry(nextIndex) || (nextIndex > 1 && !raftLog.containsLogEntry(nextIndex - 1)))) {
             InstallSnapshot installSnapshot = new InstallSnapshot(localMember, state.term(), raftLog.snapshot(),
@@ -789,21 +789,38 @@ public class RaftNodeImpl implements RaftNode {
         RaftGroupMembers members = state.committedGroupMembers();
         SnapshotEntry snapshotEntry = new SnapshotEntry(snapshotTerm, commitIndex, snapshot, members.index(), members.members());
 
-        long minMatchIndex = 0L;
+        long highestLogIndexToTruncate = commitIndex - maxNumberOfLogsToKeepAfterSnapshot;
         LeaderState leaderState = state.leaderState();
         if (leaderState != null) {
-            long[] indices = leaderState.matchIndices();
-            // Last slot is reserved for leader index,
-            // and always zero. That's why we are skipping it.
-            Arrays.sort(indices, 0, indices.length - 1);
-            minMatchIndex = indices[0];
+            long[] matchIndices = leaderState.matchIndices();
+            // Last slot is reserved for leader index and always zero.
+
+            // If there is at least one follower with unknown match index,
+            // its log can be close to the leader's log so we are keeping the old log entries.
+            boolean allMatchIndicesKnown = Arrays.stream(matchIndices, 0, matchIndices.length - 1)
+                                                 .noneMatch(i -> i == 0);
+
+            if (allMatchIndicesKnown) {
+                // Otherwise, we will keep the log entries until the minimum match index
+                // that is bigger than (commitIndex - maxNumberOfLogsToKeepAfterSnapshot).
+                // If there is no such follower (all of the minority followers are far behind),
+                // then there is no need to keep the old log entries.
+                highestLogIndexToTruncate = Arrays.stream(matchIndices)
+                                                  // No need to keep any log entry if all followers are up to date
+                                                  .filter(i -> i < commitIndex)
+                                                  .filter(i -> i > commitIndex - maxNumberOfLogsToKeepAfterSnapshot)
+                                                  // We should not delete the smallest matchIndex
+                                                  .map(i -> i - 1)
+                                                  .sorted()
+                                                  .findFirst()
+                                                  .orElse(commitIndex);
+            }
         }
 
-        long truncateLogsUpToIndex = max(commitIndex - maxNumberOfLogsToKeepAfterSnapshot, minMatchIndex);
-        int truncated = log.setSnapshot(snapshotEntry, truncateLogsUpToIndex);
+        int truncatedEntryCount = log.setSnapshot(snapshotEntry, highestLogIndexToTruncate);
 
         if (logger.isFineEnabled()) {
-            logger.fine(snapshotEntry + " is taken, " + truncated + " entries are truncated.");
+            logger.fine(snapshotEntry + " is taken, " + truncatedEntryCount + " entries are truncated.");
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/SnapshotTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/cp/internal/raft/impl/SnapshotTest.java
@@ -143,7 +143,7 @@ public class SnapshotTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void when_followerFallsTooFarBehind_then_itInstallsSnapshot() throws ExecutionException, InterruptedException {
+    public void when_followersMatchIndexIsUnknown_then_itInstallsSnapshot() throws ExecutionException, InterruptedException {
         int entryCount = 50;
         RaftAlgorithmConfig raftAlgorithmConfig = new RaftAlgorithmConfig().setCommitIndexAdvanceCountToSnapshot(entryCount);
         group = newGroupWithService(3, raftAlgorithmConfig);
@@ -155,6 +155,7 @@ public class SnapshotTest extends HazelcastTestSupport {
         RaftNodeImpl slowFollower = followers[1];
 
         group.dropMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), InstallSnapshot.class);
 
         for (int i = 0; i < entryCount; i++) {
             leader.replicate(new ApplyRaftRunnable("val" + i)).get();
@@ -163,6 +164,54 @@ public class SnapshotTest extends HazelcastTestSupport {
         assertTrueEventually(() -> assertEquals(entryCount, getSnapshotEntry(leader).index()));
 
         leader.replicate(new ApplyRaftRunnable("valFinal")).get();
+
+        group.allowMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), InstallSnapshot.class);
+
+        assertTrueEventually(() -> assertEquals(entryCount, getCommitIndex(slowFollower)));
+
+        group.resetAllRulesFrom(leader.getLocalMember());
+
+        assertTrueEventually(() -> {
+            for (RaftNodeImpl raftNode : group.getNodes()) {
+                assertEquals(entryCount + 1, getCommitIndex(raftNode));
+                RaftDataService service = group.getService(raftNode);
+                assertEquals(entryCount + 1, service.size());
+                for (int i = 0; i < entryCount; i++) {
+                    assertEquals(("val" + i), service.get(i + 1));
+                }
+                assertEquals("valFinal", service.get(51));
+            }
+        });
+    }
+
+    @Test
+    public void when_followersIsFarBehind_then_itInstallsSnapshot() throws ExecutionException, InterruptedException {
+        int entryCount = 50;
+        RaftAlgorithmConfig raftAlgorithmConfig = new RaftAlgorithmConfig().setCommitIndexAdvanceCountToSnapshot(entryCount);
+        group = newGroupWithService(3, raftAlgorithmConfig);
+        group.start();
+
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+
+        leader.replicate(new ApplyRaftRunnable("val0")).get();
+
+        RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
+        RaftNodeImpl slowFollower = followers[1];
+
+        group.dropMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), InstallSnapshot.class);
+
+        for (int i = 1; i < entryCount; i++) {
+            leader.replicate(new ApplyRaftRunnable("val" + i)).get();
+        }
+
+        assertTrueEventually(() -> assertEquals(entryCount, getSnapshotEntry(leader).index()));
+
+        leader.replicate(new ApplyRaftRunnable("valFinal")).get();
+
+        group.allowMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), InstallSnapshot.class);
+
+        assertTrueEventually(() -> assertEquals(entryCount, getCommitIndex(slowFollower)));
 
         group.resetAllRulesFrom(leader.getLocalMember());
 
@@ -240,7 +289,7 @@ public class SnapshotTest extends HazelcastTestSupport {
     }
 
     @Test
-    public void when_followerMissesTheLastEntryThatGoesIntoTheSnapshot_then_itInstallsSnapshot() throws ExecutionException, InterruptedException {
+    public void when_followerMissesTheLastEntryThatGoesIntoTheSnapshot_then_itCatchesUpWithoutInstallingSnapshot() throws ExecutionException, InterruptedException {
         int entryCount = 50;
         RaftAlgorithmConfig raftAlgorithmConfig = new RaftAlgorithmConfig().setCommitIndexAdvanceCountToSnapshot(entryCount);
         group = newGroupWithService(3, raftAlgorithmConfig);
@@ -262,6 +311,7 @@ public class SnapshotTest extends HazelcastTestSupport {
         });
 
         group.dropMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), InstallSnapshot.class);
 
         leader.replicate(new ApplyRaftRunnable("val" + (entryCount - 1))).get();
 
@@ -269,7 +319,7 @@ public class SnapshotTest extends HazelcastTestSupport {
 
         leader.replicate(new ApplyRaftRunnable("valFinal")).get();
 
-        group.resetAllRulesFrom(leader.getLocalMember());
+        group.allowMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), AppendRequest.class);
 
         assertTrueEventually(() -> {
             for (RaftNodeImpl raftNode : group.getNodes()) {
@@ -281,7 +331,56 @@ public class SnapshotTest extends HazelcastTestSupport {
                 }
                 assertEquals("valFinal", service.get(51));
             }
-        }, 30);
+        });
+    }
+
+    @Test
+    public void when_followerMissesAFewEntriesBeforeTheSnapshot_then_itCatchesUpWithoutInstallingSnapshot() throws ExecutionException, InterruptedException {
+        int entryCount = 50;
+        int missingEntryCountOnSlowFollower = 4; // entryCount * 0.1 - 2
+        RaftAlgorithmConfig raftAlgorithmConfig = new RaftAlgorithmConfig().setCommitIndexAdvanceCountToSnapshot(entryCount);
+        group = newGroupWithService(3, raftAlgorithmConfig);
+        group.start();
+
+        RaftNodeImpl leader = group.waitUntilLeaderElected();
+
+        RaftNodeImpl[] followers = group.getNodesExcept(leader.getLocalMember());
+        RaftNodeImpl slowFollower = followers[1];
+
+        for (int i = 0; i < entryCount - missingEntryCountOnSlowFollower; i++) {
+            leader.replicate(new ApplyRaftRunnable("val" + i)).get();
+        }
+
+        assertTrueEventually(() -> {
+            for (RaftNodeImpl follower : group.getNodesExcept(leader.getLocalMember())) {
+                assertEquals(entryCount - missingEntryCountOnSlowFollower, getMatchIndex(leader, follower.getLocalMember()));
+            }
+        });
+
+        group.dropMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), AppendRequest.class);
+        group.dropMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), InstallSnapshot.class);
+
+        for (int i = entryCount - missingEntryCountOnSlowFollower; i < entryCount; i++) {
+            leader.replicate(new ApplyRaftRunnable("val" + i)).get();
+        }
+
+        assertTrueEventually(() -> assertEquals(entryCount, getSnapshotEntry(leader).index()));
+
+        leader.replicate(new ApplyRaftRunnable("valFinal")).get();
+
+        group.allowMessagesToMember(leader.getLocalMember(), slowFollower.getLocalMember(), AppendRequest.class);
+
+        assertTrueEventually(() -> {
+            for (RaftNodeImpl raftNode : group.getNodes()) {
+                assertEquals(entryCount + 1, getCommitIndex(raftNode));
+                RaftDataService service = group.getService(raftNode);
+                assertEquals(entryCount + 1, service.size());
+                for (int i = 0; i < entryCount; i++) {
+                    assertEquals(("val" + i), service.get(i + 1));
+                }
+                assertEquals("valFinal", service.get(51));
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
If there is at least one follower with unknown match index, its log can
be close to the leader's log so we are keeping the old log entries.
Otherwise, we will keep the log entries until the minimum match index
that is bigger than `(commitIndex - maxNumberOfLogsToKeepAfterSnapshot)`.
If there is no such follower (all of the minority followers are far
behind), then there is no need to keep the old log entries.