### PR TITLE
[Backport] ExecutorServiceProxy serializes a submitted task once

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/executor/impl/ExecutorServiceProxy.java
@@ -26,7 +26,6 @@ import com.hazelcast.core.PartitionAware;
 import com.hazelcast.executor.impl.operations.CallableTaskOperation;
 import com.hazelcast.executor.impl.operations.MemberCallableTaskOperation;
 import com.hazelcast.executor.impl.operations.ShutdownOperation;
-import com.hazelcast.instance.MemberImpl;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.monitor.LocalExecutorStats;
 import com.hazelcast.nio.Address;
@@ -305,10 +304,14 @@ public class ExecutorServiceProxy
         checkNotNull(task, "task can't be null");
         checkNotShutdown();
 
+        Data taskData = getNodeEngine().toData(task);
+        return submitToMember(taskData, member);
+    }
+
+    private  <T> Future<T> submitToMember(Data taskData, Member member) {
         NodeEngine nodeEngine = getNodeEngine();
-        Data taskData = nodeEngine.toData(task);
         String uuid = newUnsecureUuidString();
-        Address target = ((MemberImpl) member).getAddress();
+        Address target = member.getAddress();
 
         boolean sync = checkSync();
         MemberCallableTaskOperation op = new MemberCallableTaskOperation(name, uuid, taskData);
@@ -328,9 +331,12 @@ public class ExecutorServiceProxy
 
     @Override
     public <T> Map<Member, Future<T>> submitToMembers(Callable<T> task, Collection<Member> members) {
+        checkNotNull(task, "task can't be null");
+        checkNotShutdown();
+        Data taskData = getNodeEngine().toData(task);
         Map<Member, Future<T>> futures = createHashMap(members.size());
         for (Member member : members) {
-            futures.put(member, submitToMember(task, member));
+            futures.put(member, submitToMember(taskData, member));
         }
         return futures;
     }
@@ -394,19 +400,25 @@ public class ExecutorServiceProxy
         submitToPartitionOwner(task, callback, nodeEngine.getPartitionService().getPartitionId(key));
     }
 
+    private  <T> void submitToMember(Data taskData, Member member, ExecutionCallback<T> callback) {
+        checkNotShutdown();
+
+        NodeEngine nodeEngine = getNodeEngine();
+        String uuid = newUnsecureUuidString();
+        MemberCallableTaskOperation op = new MemberCallableTaskOperation(name, uuid, taskData);
+        OperationService operationService = nodeEngine.getOperationService();
+        Address address = member.getAddress();
+        operationService
+                .createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, address)
+                .setExecutionCallback((ExecutionCallback) callback).invoke();
+    }
+
     @Override
     public <T> void submitToMember(Callable<T> task, Member member, ExecutionCallback<T> callback) {
         checkNotShutdown();
 
-        NodeEngine nodeEngine = getNodeEngine();
-        Data taskData = nodeEngine.toData(task);
-        String uuid = newUnsecureUuidString();
-        MemberCallableTaskOperation op = new MemberCallableTaskOperation(name, uuid, taskData);
-        OperationService operationService = nodeEngine.getOperationService();
-        Address address = ((MemberImpl) member).getAddress();
-        operationService
-                .createInvocationBuilder(DistributedExecutorService.SERVICE_NAME, op, address)
-                .setExecutionCallback((ExecutionCallback) callback).invoke();
+        Data taskData = getNodeEngine().toData(task);
+        submitToMember(taskData, member, callback);
     }
 
     private String getRejectionMessage() {
@@ -420,8 +432,9 @@ public class ExecutorServiceProxy
         ExecutionCallbackAdapterFactory executionCallbackFactory = new ExecutionCallbackAdapterFactory(
                 nodeEngine.getLogger(ExecutionCallbackAdapterFactory.class), members, callback);
 
+        Data taskData = nodeEngine.toData(task);
         for (Member member : members) {
-            submitToMember(task, member, executionCallbackFactory.<T>callbackFor(member));
+            submitToMember(taskData, member, executionCallbackFactory.<T>callbackFor(member));
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
+++ b/hazelcast/src/test/java/com/hazelcast/executor/ExecutorServiceTestSupport.java
@@ -27,9 +27,13 @@ import com.hazelcast.core.Member;
 import com.hazelcast.core.MultiExecutionCallback;
 import com.hazelcast.core.PartitionAware;
 import com.hazelcast.durableexecutor.DurableExecutorService;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
 import com.hazelcast.spi.impl.executionservice.InternalExecutionService;
 import com.hazelcast.test.HazelcastTestSupport;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -155,6 +159,30 @@ public class ExecutorServiceTestSupport extends HazelcastTestSupport {
         @Override
         public String call() throws Exception {
             return "Completed";
+        }
+    }
+
+    public static class SerializationCountingCallable implements Callable<Void>, DataSerializable {
+
+        private AtomicInteger serializationCount = new AtomicInteger();
+
+        @Override
+        public void writeData(ObjectDataOutput out) throws IOException {
+            serializationCount.incrementAndGet();
+        }
+
+        @Override
+        public void readData(ObjectDataInput in) throws IOException {
+
+        }
+
+        @Override
+        public Void call() throws Exception {
+            return null;
+        }
+
+        public int getSerializationCount() {
+            return serializationCount.get();
         }
     }
 


### PR DESCRIPTION
ExecutorServiceProxy unnecessarily serialized the same task multiple times before submitting it to multiple members. Now it serializes only once. Issue is fixed both for server and client.

Fixes https://github.com/hazelcast/hazelcast/issues/15007

Backport of https://github.com/hazelcast/hazelcast/pull/15069