### PR TITLE
Smart clients default to 3+3 io threads

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -93,7 +93,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 @SuppressWarnings("checkstyle:classdataabstractioncoupling")
 public class ClientConnectionManagerImpl implements ClientConnectionManager {
 
-    private static final int DEFAULT_SSL_THREAD_COUNT = 3;
+    private static final int DEFAULT_SMART_CLIENT_THREAD_COUNT = 3;
 
     protected final AtomicInteger connectionIdGen = new AtomicInteger();
 
@@ -157,22 +157,22 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
     protected NioNetworking initNetworking(final HazelcastClientInstanceImpl client) {
         HazelcastProperties properties = client.getProperties();
 
-        SSLConfig sslConfig = client.getClientConfig().getNetworkConfig().getSSLConfig();
-        boolean sslEnabled = sslConfig != null && sslConfig.isEnabled();
+        ClientNetworkConfig networkConfig = client.getClientConfig().getNetworkConfig();
+        boolean smartClient = networkConfig == null ? true : networkConfig.isSmartRouting();
 
         int configuredInputThreads = properties.getInteger(IO_INPUT_THREAD_COUNT);
         int configuredOutputThreads = properties.getInteger(IO_OUTPUT_THREAD_COUNT);
 
         int inputThreads;
         if (configuredInputThreads == -1) {
-            inputThreads = sslEnabled ? DEFAULT_SSL_THREAD_COUNT : 1;
+            inputThreads = smartClient ? DEFAULT_SMART_CLIENT_THREAD_COUNT : 1;
         } else {
             inputThreads = configuredInputThreads;
         }
 
         int outputThreads;
         if (configuredOutputThreads == -1) {
-            outputThreads = sslEnabled ? DEFAULT_SSL_THREAD_COUNT : 1;
+            outputThreads = smartClient ? DEFAULT_SMART_CLIENT_THREAD_COUNT : 1;
         } else {
             outputThreads = configuredOutputThreads;
         }
@@ -189,7 +189,6 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
                         .writeThroughEnabled(properties.getBoolean(IO_WRITE_THROUGH_ENABLED))
                         .concurrencyDetection(client.getConcurrencyDetection()));
     }
-
 
     public ClientConnectionStrategy getConnectionStrategy() {
         return connectionStrategy;

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -157,7 +157,7 @@ public class ClientConnectionManagerImpl implements ClientConnectionManager {
         HazelcastProperties properties = client.getProperties();
 
         ClientNetworkConfig networkConfig = client.getClientConfig().getNetworkConfig();
-        boolean smartClient = networkConfig == null ? true : networkConfig.isSmartRouting();
+        boolean smartClient = networkConfig == null || networkConfig.isSmartRouting();
 
         int configuredInputThreads = properties.getInteger(IO_INPUT_THREAD_COUNT);
         int configuredOutputThreads = properties.getInteger(IO_OUTPUT_THREAD_COUNT);

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/connection/nio/ClientConnectionManagerImpl.java
@@ -36,7 +36,6 @@ import com.hazelcast.client.impl.protocol.codec.ClientIsFailoverSupportedCodec;
 import com.hazelcast.client.impl.spi.ClientExecutionService;
 import com.hazelcast.client.impl.spi.impl.ClientInvocation;
 import com.hazelcast.client.impl.spi.impl.ClientInvocationFuture;
-import com.hazelcast.config.SSLConfig;
 import com.hazelcast.core.ExecutionCallback;
 import com.hazelcast.core.HazelcastException;
 import com.hazelcast.instance.BuildInfo;

--- a/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/properties/ClientProperty.java
@@ -130,19 +130,17 @@ public final class ClientProperty {
             = new HazelcastProperty("hazelcast.discovery.public.ip.enabled", false);
 
     /**
-     * Controls the number of socket input threads. Defaults to -1, so the system will determine.
+     * Controls the number of IO input threads. Defaults to -1, so the system will decide.
      *
-     * If SSL is disabled, system will default to 1.
-     * If SSL is enabled, system will default to 3.
+     * If client is a smart client, it will default to 3 otherwise it will default to 1.
      */
     public static final HazelcastProperty IO_INPUT_THREAD_COUNT
             = new HazelcastProperty("hazelcast.client.io.input.thread.count", -1);
 
     /**
-     * Controls the number of socket output threads. Defaults to -1, so the system will determine.
+     * Controls the number of IO output threads. Defaults to -1, so the system will decide.
      *
-     * If SSL is disabled, system will default to 1.
-     * If SSL is enabled, system will default to 3.
+     * If client is a smart client, it will default to 3 otherwise it will default to 1.
      */
     public static final HazelcastProperty IO_OUTPUT_THREAD_COUNT
             = new HazelcastProperty("hazelcast.client.io.output.thread.count", -1);


### PR DESCRIPTION
So instead of having only 1(+1) io thread for smart clients,
they now default to 3. Just as with the members.

This is done to increase performance.

Mileage may vary. But the below table is from a simple AtomicLong.get test using 6 members, 3 clients and 32 threads per client. 

![image](https://user-images.githubusercontent.com/105243/58310086-7808df00-7e0e-11e9-9770-39600bc8dc79.png)

The throughput increase is 14%