### PR TITLE
[BACKPORT] Clarify default YAML config usage

### DIFF
--- a/hazelcast-client/src/main/resources/hazelcast-client-default.yaml
+++ b/hazelcast-client/src/main/resources/hazelcast-client-default.yaml
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The default Hazelcast client configuration.
+# The default Hazelcast client configuration. This configuration is identical
+# to hazelcast-client-default.xml.
 #
-# This XML file is used when no hazelcast-client.xml is present.
+# This YAML file is used when no hazelcast-client.yaml is present and the
+# Hazelcast client configuration is loaded from YAML configuration with
+# YamlClientConfigBuilder. If the configuration is loaded in another way,
+# hazelcast-client-default.xml is used as the default configuration.
 #
 # To learn how to configure Hazelcast, please see the Reference Manual
 # at https://hazelcast.org/documentation/

--- a/hazelcast/src/main/resources/hazelcast-default.yaml
+++ b/hazelcast/src/main/resources/hazelcast-default.yaml
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The default Hazelcast configuration.
+# The default Hazelcast YAML configuration. This configuration is identical
+# to hazelcast-default.xml.
 #
-# This YAML file is used when no hazelcast.yaml is present.
+# This YAML file is used when no hazelcast.yaml is present and the
+# Hazelcast configuration is loaded from YAML configuration with
+# YamlConfigBuilder. If the configuration is loaded in another way,
+# hazelcast-default.xml is used as the default configuration.
 #
 # To learn how to configure Hazelcast, please see the Reference Manual
 # at https://hazelcast.org/documentation/


### PR DESCRIPTION
XML configuration takes precedence over YAML configuration, hence the existence of the default YAML configuration seems unnecessary by the first look. This commit clarifies the case in which the default YAML
configuration is used.

1:1 backport of https://github.com/hazelcast/hazelcast/pull/15089