### PR TITLE
[BACKPORT] Improve Config's URL and File getter javadoc

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/config/Config.java
+++ b/hazelcast/src/main/java/com/hazelcast/config/Config.java
@@ -3335,10 +3335,11 @@ public class Config {
     }
 
     /**
-     * Returns the {@link URL} to the XML configuration, which has been parsed
+     * Returns the {@link URL} to the declarative configuration, which has been parsed
      * to create this {@link Config} instance.
      *
-     * @return the configuration URL
+     * @return the configuration URL if the configuration loaded from a URL
+     * or {@code null} otherwise
      */
     public URL getConfigurationUrl() {
         return configurationUrl;
@@ -3360,10 +3361,11 @@ public class Config {
     }
 
     /**
-     * Returns the {@link File} to the XML configuration, which has been
+     * Returns the {@link File} to the declarative configuration, which has been
      * parsed to create this {@link Config} instance.
      *
-     * @return the configuration file
+     * @return the configuration file if the configuration loaded from a file
+     * or {@code null} otherwise
      */
     public File getConfigurationFile() {
         return configurationFile;

--- a/hazelcast/src/test/java/com/hazelcast/config/ConfigTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/ConfigTest.java
@@ -125,4 +125,11 @@ public class ConfigTest extends HazelcastTestSupport {
         assertEquals(endpointConfig,
                 config.getAdvancedNetworkConfig().getEndpointConfigs().get(qualifier));
     }
+
+    @Test
+    public void testProgrammaticConfigGetUrlAndGetFileReturnNull() {
+        Config config = new Config();
+        assertNull(config.getConfigurationUrl());
+        assertNull(config.getConfigurationFile());
+    }
 }

--- a/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/XMLConfigBuilderTest.java
@@ -109,6 +109,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         URL configURL = getClass().getClassLoader().getResource("hazelcast-default.xml");
         Config config = new XmlConfigBuilder(configURL).build();
         assertEquals(configURL, config.getConfigurationUrl());
+        assertNull(config.getConfigurationFile());
     }
 
     @Override
@@ -132,6 +133,7 @@ public class XMLConfigBuilderTest extends AbstractConfigBuilderTest {
         String path = file.getAbsolutePath();
         Config config = new XmlConfigBuilder(path).build();
         assertEquals(path, config.getConfigurationFile().getAbsolutePath());
+        assertNull(config.getConfigurationUrl());
     }
 
     @Override

--- a/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/config/YamlConfigBuilderTest.java
@@ -99,6 +99,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         URL configURL = getClass().getClassLoader().getResource("hazelcast-default.yaml");
         Config config = new YamlConfigBuilder(configURL).build();
         assertEquals(configURL, config.getConfigurationUrl());
+        assertNull(config.getConfigurationFile());
     }
 
     @Override
@@ -121,6 +122,7 @@ public class YamlConfigBuilderTest extends AbstractConfigBuilderTest {
         String path = file.getAbsolutePath();
         Config config = new YamlConfigBuilder(path).build();
         assertEquals(path, config.getConfigurationFile().getAbsolutePath());
+        assertNull(config.getConfigurationUrl());
     }
 
     @Override


### PR DESCRIPTION
Can be moved to `3.12.2`.

Javadoc is improved on `Config#getConfigurationUrl()` and `Config#getConfigurationFile()` to mention returning `null` if the `Config` instance was built from a different than `URL` or `File` source. Test cases added/modified to verify this.

1:1 backport of https://github.com/hazelcast/hazelcast/pull/15108

Addresses #14960 
