### PR TITLE
Makes EventRegistration extend IdentifiedDataSerializable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/spi/EventRegistration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventRegistration.java
@@ -17,12 +17,12 @@
 package com.hazelcast.spi;
 
 import com.hazelcast.nio.Address;
-import com.hazelcast.nio.serialization.DataSerializable;
+import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 
 /**
  * The result of a Event Registration.
  */
-public interface EventRegistration extends DataSerializable {
+public interface EventRegistration extends IdentifiedDataSerializable {
 
     /**
      * Returns the event registration ID.

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/SpiDataSerializerHook.java
@@ -21,6 +21,7 @@ import com.hazelcast.internal.serialization.impl.FactoryIdHelper;
 import com.hazelcast.nio.serialization.DataSerializableFactory;
 import com.hazelcast.nio.serialization.IdentifiedDataSerializable;
 import com.hazelcast.spi.DistributedObjectNamespace;
+import com.hazelcast.spi.impl.eventservice.impl.Registration;
 import com.hazelcast.spi.impl.operationservice.BinaryOperationFactory;
 import com.hazelcast.spi.impl.operationservice.OperationControl;
 import com.hazelcast.spi.impl.eventservice.impl.EventEnvelope;
@@ -59,7 +60,7 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
     public static final int ERROR_RESPONSE = 9;
     public static final int DEREGISTRATION = 10;
     public static final int ON_JOIN_REGISTRATION = 11;
-    public static final int REGISTRATION = 12;
+    public static final int REGISTRATION_OPERATION = 12;
     public static final int SEND_EVENT = 13;
     public static final int DIST_OBJECT_INIT = 14;
     public static final int DIST_OBJECT_DESTROY = 15;
@@ -68,6 +69,7 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
     public static final int UNMODIFIABLE_LAZY_LIST = 18;
     public static final int OPERATION_CONTROL = 19;
     public static final int DISTRIBUTED_OBJECT_NS = 20;
+    public static final int REGISTRATION = 21;
 
     private static final DataSerializableFactory FACTORY = createFactoryInternal();
 
@@ -105,7 +107,7 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
                         return new DeregistrationOperation();
                     case ON_JOIN_REGISTRATION:
                         return new OnJoinRegistrationOperation();
-                    case REGISTRATION:
+                    case REGISTRATION_OPERATION:
                         return new RegistrationOperation();
                     case SEND_EVENT:
                         return new SendEventOperation();
@@ -123,6 +125,8 @@ public final class SpiDataSerializerHook implements DataSerializerHook {
                         return new OperationControl();
                     case DISTRIBUTED_OBJECT_NS:
                         return new DistributedObjectNamespace();
+                    case REGISTRATION:
+                        return new Registration();
                     default:
                         return null;
                 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/Registration.java
@@ -19,19 +19,13 @@ package com.hazelcast.spi.impl.eventservice.impl;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ObjectDataInput;
 import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.nio.serialization.BinaryInterface;
 import com.hazelcast.spi.EventFilter;
 import com.hazelcast.spi.EventRegistration;
+import com.hazelcast.spi.impl.SpiDataSerializerHook;
 import com.hazelcast.util.Preconditions;
 
 import java.io.IOException;
 
-// Even though this class is not used in client-member communication, we annotate it to be excluded from related tests, as it
-// cannot implement IdentifiedDataSerializable (both EventRegistration and IdentifiedDataSerializable interfaces define a
-// method {@code getId()} which differ in return type).
-// Since this class is still DataSerializable it should not be moved/renamed in 3.9, otherwise upgradability will be compromised.
-// TODO Above comment does not apply anymore. Make this class IdentifiedDataSerializable in another PR.
-@BinaryInterface
 public class Registration implements EventRegistration {
 
     private String id;
@@ -135,5 +129,15 @@ public class Registration implements EventRegistration {
                 + ", subscriber=" + subscriber
                 + ", listener=" + listener
                 + '}';
+    }
+
+    @Override
+    public int getFactoryId() {
+        return SpiDataSerializerHook.F_ID;
+    }
+
+    @Override
+    public int getClassId() {
+        return SpiDataSerializerHook.REGISTRATION;
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/RegistrationOperation.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/impl/eventservice/impl/operations/RegistrationOperation.java
@@ -61,6 +61,6 @@ public class RegistrationOperation extends AbstractRegistrationOperation {
 
     @Override
     public int getClassId() {
-        return SpiDataSerializerHook.REGISTRATION;
+        return SpiDataSerializerHook.REGISTRATION_OPERATION;
     }
 }


### PR DESCRIPTION
EventRegistration could not implement IDS before because they both had getId() method. Now IDS does not have it, EventRegistration can extend IDS and we can get rid of BinaryInterface annotation on Registration.

Depends on: https://github.com/hazelcast/hazelcast/pull/15127