### PR TITLE
Issues/13540: Transaction Propagation feature implementation

### DIFF
--- a/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/TransactionContextHolder.java
+++ b/hazelcast-spring/src/main/java/com/hazelcast/spring/transaction/TransactionContextHolder.java
@@ -16,7 +16,15 @@
 
 package com.hazelcast.spring.transaction;
 
+import javax.transaction.xa.XAResource;
 import com.hazelcast.transaction.TransactionContext;
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionalList;
+import com.hazelcast.transaction.TransactionalMap;
+import com.hazelcast.transaction.TransactionalMultiMap;
+import com.hazelcast.transaction.TransactionalObject;
+import com.hazelcast.transaction.TransactionalQueue;
+import com.hazelcast.transaction.TransactionalSet;
 
 /**
  * Holder wrapping a Hazelcast TransactionContext.
@@ -24,9 +32,10 @@ import com.hazelcast.transaction.TransactionContext;
  * HazelcastTransactionManager binds instances of this class to the thread, for a given HazelcastInstance.
  *
  * @author Balint Krivan
+ * @author Sergey Bespalov
  * @see HazelcastTransactionManager
  */
-class TransactionContextHolder {
+class TransactionContextHolder implements TransactionContext {
 
     private final TransactionContext transactionContext;
     private boolean transactionActive;
@@ -35,23 +44,69 @@ class TransactionContextHolder {
         this.transactionContext = transactionContext;
     }
 
-    public boolean isTransactionActive() {
-        return transactionActive;
-    }
-
-    public TransactionContext getContext() {
-        return transactionContext;
-    }
-
-    /**
-     * @see TransactionContext#beginTransaction()
-     */
     public void beginTransaction() {
         transactionContext.beginTransaction();
         transactionActive = true;
     }
 
-    public void clear() {
-        transactionActive = false;
+    public void commitTransaction() throws TransactionException {
+        try {
+            transactionContext.commitTransaction();
+        } finally {
+            transactionActive = false;
+        }
     }
+
+    public void rollbackTransaction() {
+        try {
+            transactionContext.rollbackTransaction();
+        } finally {
+            transactionActive = false;
+        }
+    }
+
+    public boolean isTransactionActive() {
+        return transactionActive;
+    }
+
+    public <K, V> TransactionalMap<K, V> getMap(String name) {
+        return transactionContext.getMap(name);
+    }
+
+    public <E> TransactionalQueue<E> getQueue(String name) {
+        return transactionContext.getQueue(name);
+    }
+
+    public <K, V> TransactionalMultiMap<K, V> getMultiMap(String name) {
+        return transactionContext.getMultiMap(name);
+    }
+
+    public void suspendTransaction() {
+        transactionContext.suspendTransaction();
+    }
+
+    public void resumeTransaction() {
+        transactionContext.resumeTransaction();
+    }
+
+    public String getTxnId() {
+        return transactionContext.getTxnId();
+    }
+
+    public XAResource getXaResource() {
+        return transactionContext.getXaResource();
+    }
+
+    public <E> TransactionalList<E> getList(String name) {
+        return transactionContext.getList(name);
+    }
+
+    public <E> TransactionalSet<E> getSet(String name) {
+        return transactionContext.getSet(name);
+    }
+
+    public <T extends TransactionalObject> T getTransactionalObject(String serviceName, String name) {
+        return transactionContext.getTransactionalObject(serviceName, name);
+    }
+
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/DummyObject.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/DummyObject.java
@@ -20,11 +20,8 @@ import java.io.Serializable;
 
 public class DummyObject implements Serializable {
 
-    private Long id;
-    private String string;
-
-    public DummyObject() {
-    }
+    private final Long id;
+    private final String string;
 
     public DummyObject(long id, String string) {
         this.id = id;
@@ -35,15 +32,31 @@ public class DummyObject implements Serializable {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public String getString() {
         return string;
     }
 
-    public void setString(String string) {
-        this.string = string;
+    @Override
+    public int hashCode() {
+        if (id == null) {
+            return super.hashCode();
+        }
+
+        return id.hashCode();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof DummyObject)) {
+            return false;
+        }
+
+        DummyObject other = (DummyObject) obj;
+        if (id == other.id) {
+            return true;
+        }
+
+        return id != null && id.equals(other.id);
+    }
+
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/OtherServiceBeanWithTransactionalContext.java
@@ -36,13 +36,22 @@ public class OtherServiceBeanWithTransactionalContext {
     }
 
     @Transactional
+    public DummyObject get(Long id) {
+        return (DummyObject) transactionalContext.getMap("dummyObjectMap").get(id);
+    }
+
+    @Transactional
     public void putWithException(DummyObject object) {
         put(object);
         throw new RuntimeException("oops, let's rollback in " + this.getClass().getSimpleName() + "!");
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void putInNewTransaction(DummyObject object) {
-        put(object);
+    public void putInNewTransaction(DummyObject object1, DummyObject object2) {
+        if (get(object1.getId()) != null) {
+            return;
+        }
+        put(object2);
     }
+
 }

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/ServiceBeanWithTransactionalContext.java
@@ -37,6 +37,10 @@ public class ServiceBeanWithTransactionalContext {
         transactionalContext.getMap("dummyObjectMap").put(object.getId(), object);
     }
 
+    public DummyObject get(Long id) {
+        return (DummyObject) transactionalContext.getMap("dummyObjectMap").get(id);
+    }
+
     public void putWithException(DummyObject object) {
         put(object);
         throw new RuntimeException("oops, let's rollback!");
@@ -50,8 +54,11 @@ public class ServiceBeanWithTransactionalContext {
         otherService.putWithException(object);
     }
 
-    public void putUsingOtherBean_newTransaction(DummyObject object) {
-        otherService.putInNewTransaction(object);
+    public boolean putUsingOtherBean_newTransaction(DummyObject object1, DummyObject object2) {
+        put(object1);
+        otherService.putInNewTransaction(object1, object2);
+
+        return get(object2.getId()) != null;
     }
 
     public void putUsingSameBean_thenOtherBeanThrowingException_sameTransaction(DummyObject object, DummyObject otherObject) {

--- a/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
+++ b/hazelcast-spring/src/test/java/com/hazelcast/spring/transaction/TestSpringManagedHazelcastTransaction.java
@@ -19,6 +19,7 @@ package com.hazelcast.spring.transaction;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.map.IMap;
 import com.hazelcast.transaction.TransactionalMap;
 import com.hazelcast.spring.CustomSpringJUnit4ClassRunner;
 import com.hazelcast.test.annotation.QuickTest;
@@ -34,11 +35,11 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.NoTransactionException;
-import org.springframework.transaction.TransactionSuspensionNotSupportedException;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(CustomSpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = {"transaction-applicationContext-hazelcast.xml"})
@@ -185,15 +186,25 @@ public class TestSpringManagedHazelcastTransaction {
 
     /**
      * Tests that if propagation is set to {@link org.springframework.transaction.annotation.Propagation#REQUIRES_NEW REQUIRES_NEW},
-     * then an exception will be thrown, since Hazelcast doesn't support nested transaction, so {@link HazelcastTransactionManager}
-     * doesn't support transaction suspension.
+     * then nested transaction will be created.
      */
     @Test
     public void transactionalServiceBeanInvocation_nestedWithPropagationRequiresNew() {
         // given
-        expectedException.expect(TransactionSuspensionNotSupportedException.class);
+        DummyObject dummyObject1 = new DummyObject(1L, "magic1");
+        DummyObject dummyObject2 = new DummyObject(2L, "magic2");
+        IMap<Object, Object> dummyObjectMap = instance.getMap("dummyObjectMap");
 
         // when
-        service.putUsingOtherBean_newTransaction(new DummyObject(1L, "magic"));
+        boolean result = service.putUsingOtherBean_newTransaction(dummyObject1, dummyObject2);
+
+        // then
+        assertTrue("No data changes within nested transaction .", result);
+        assertEquals("Both transactions should have data changes.", 2L, dummyObjectMap.size());
+        assertTrue("No data changes within parent transaction.", dummyObjectMap.containsKey(1L));
+        assertEquals("Invalid data within parent transaction.", dummyObject1, dummyObjectMap.get(1L));
+        assertTrue("No data changes within nested transaction.", dummyObjectMap.containsKey(2L));
+        assertEquals("Invalid data within nested transaction.", dummyObject2, dummyObjectMap.get(2L));
     }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/TransactionContextProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/TransactionContextProxy.java
@@ -89,6 +89,18 @@ public class TransactionContextProxy implements ClientTransactionContext {
     }
 
     @Override
+    public void suspendTransaction() {
+        // TODO: implemet
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+    @Override
+    public void resumeTransaction() {
+        // TODO: implemet
+        throw new UnsupportedOperationException("Not implemented yet.");
+    }
+
+    @Override
     public <K, V> TransactionalMap<K, V> getMap(String name) {
         return getTransactionalObject(MapService.SERVICE_NAME, name);
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/xa/XATransactionContextProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/proxy/txn/xa/XATransactionContextProxy.java
@@ -92,6 +92,16 @@ public class XATransactionContextProxy implements ClientTransactionContext {
     }
 
     @Override
+    public void suspendTransaction() {
+        throw new UnsupportedOperationException("XA Transaction cannot be suspended manually!");
+    }
+
+    @Override
+    public void resumeTransaction() {
+        throw new UnsupportedOperationException("XA Transaction cannot be resumed manually!");
+    }
+
+    @Override
     public String getTxnId() {
         return transaction.getTxnId();
     }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionContext.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionContext.java
@@ -48,6 +48,16 @@ public interface TransactionContext extends TransactionalTaskContext {
     void rollbackTransaction();
 
     /**
+     * Suspend current transaction.
+     */
+    void suspendTransaction();
+
+    /**
+     * Resume suspended transaction.
+     */
+    void resumeTransaction();
+
+    /**
      * Gets the ID that uniquely identifies the transaction.
      *
      * @return the transaction ID

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/SuspendedTransaction.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/SuspendedTransaction.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions.TransactionType;
+
+/**
+ * Base class for suspended {@link Transaction} implementations.
+ *
+ * @author Sergey Bespalov
+ */
+public abstract class SuspendedTransaction implements Transaction {
+
+    private final Transaction transaction;
+
+    public SuspendedTransaction(Transaction transaction) {
+        this.transaction = transaction;
+        suspend(transaction);
+    }
+
+    protected Transaction getTransaction() {
+        return transaction;
+    }
+
+    public void begin() throws IllegalStateException {
+        throw new IllegalStateException("Transaction suspended.");
+    }
+
+    public void prepare() throws TransactionException {
+        throw new IllegalStateException("Transaction suspended.");
+    }
+
+    public void commit() throws TransactionException, IllegalStateException {
+        throw new IllegalStateException("Transaction suspended.");
+    }
+
+    public void rollback() throws IllegalStateException {
+        throw new IllegalStateException("Transaction suspended.");
+    }
+
+    public String getTxnId() {
+        return transaction.getTxnId();
+    }
+
+    public State getState() {
+        return transaction.getState();
+    }
+
+    public long getTimeoutMillis() {
+        return transaction.getTimeoutMillis();
+    }
+
+    public void add(TransactionLogRecord record) {
+        throw new IllegalStateException("Transaction suspended.");
+    }
+
+    public void remove(Object key) {
+        throw new IllegalStateException("Transaction suspended.");
+    }
+
+    public TransactionLogRecord get(Object key) {
+        throw new IllegalStateException("Transaction suspended.");
+    }
+
+    public String getOwnerUuid() {
+        return transaction.getOwnerUuid();
+    }
+
+    public boolean isOriginatedFromClient() {
+        return transaction.isOriginatedFromClient();
+    }
+
+    public TransactionType getTransactionType() {
+        return transaction.getTransactionType();
+    }
+
+    protected abstract void suspend(Transaction transaction);
+
+    public abstract void resume();
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionContextImpl.java
@@ -36,6 +36,7 @@ import com.hazelcast.transaction.TransactionNotActiveException;
 import com.hazelcast.transaction.TransactionOptions;
 import com.hazelcast.transaction.TransactionalObject;
 import com.hazelcast.transaction.impl.xa.XAService;
+import com.hazelcast.transaction.impl.TransactionImpl.SuspendedTransactionImpl;
 
 import javax.transaction.xa.XAResource;
 import java.util.HashMap;
@@ -46,14 +47,15 @@ import static com.hazelcast.transaction.impl.Transaction.State.ACTIVE;
 final class TransactionContextImpl implements TransactionContext {
 
     private final NodeEngineImpl nodeEngine;
-    private final TransactionImpl transaction;
+    private final TransactionWrapper transaction;
     private final Map<TransactionalObjectKey, TransactionalObject> txnObjectMap
             = new HashMap<TransactionalObjectKey, TransactionalObject>(2);
 
     TransactionContextImpl(TransactionManagerServiceImpl transactionManagerService, NodeEngineImpl nodeEngine,
                            TransactionOptions options, String ownerUuid, boolean originatedFromClient) {
         this.nodeEngine = nodeEngine;
-        this.transaction = new TransactionImpl(transactionManagerService, nodeEngine, options, ownerUuid, originatedFromClient);
+        this.transaction = new TransactionWrapper(
+                new TransactionImpl(transactionManagerService, nodeEngine, options, ownerUuid, originatedFromClient));
     }
 
     @Override
@@ -68,7 +70,7 @@ final class TransactionContextImpl implements TransactionContext {
 
     @Override
     public void commitTransaction() throws TransactionException {
-        if (transaction.requiresPrepare()) {
+        if (transaction.getTransactionOfRequiredType(TransactionImpl.class).requiresPrepare()) {
             transaction.prepare();
         }
         transaction.commit();
@@ -77,6 +79,18 @@ final class TransactionContextImpl implements TransactionContext {
     @Override
     public void rollbackTransaction() {
         transaction.rollback();
+    }
+
+    @Override
+    public void suspendTransaction() {
+        transaction.set(transaction.getTransactionOfRequiredType(TransactionImpl.class).new SuspendedTransactionImpl());
+    }
+
+    @Override
+    public void resumeTransaction() {
+        SuspendedTransactionImpl suspendedTransaction = transaction.getTransactionOfRequiredType(SuspendedTransactionImpl.class);
+        suspendedTransaction.resume();
+        transaction.set(suspendedTransaction.getTransaction());
     }
 
     @SuppressWarnings("unchecked")
@@ -115,7 +129,7 @@ final class TransactionContextImpl implements TransactionContext {
         checkActive(serviceName, name);
 
         if (requiresBackupLogs(serviceName)) {
-            transaction.ensureBackupLogsExist();
+            transaction.getTransactionOfRequiredType(TransactionImpl.class).ensureBackupLogsExist();
         }
 
         TransactionalObjectKey key = new TransactionalObjectKey(serviceName, name);

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionImpl.java
@@ -63,14 +63,13 @@ import static com.hazelcast.util.FutureUtil.logAllExceptions;
 import static com.hazelcast.util.FutureUtil.waitUntilAllRespondedWithDeadline;
 import static com.hazelcast.util.FutureUtil.waitWithDeadline;
 import static com.hazelcast.util.UuidUtil.newUnsecureUuidString;
-import static java.lang.Boolean.TRUE;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 @SuppressWarnings("checkstyle:methodcount")
 public class TransactionImpl implements Transaction {
 
     private static final Address[] EMPTY_ADDRESSES = new Address[0];
-    private static final ThreadLocal<Boolean> TRANSACTION_EXISTS = new ThreadLocal<Boolean>();
+    private static final ThreadLocal<TransactionImpl> ACTIVE_THREAD_TRANSACTION = new ThreadLocal<TransactionImpl>();
 
     private final ExceptionHandler rollbackExceptionHandler;
     private final ExceptionHandler rollbackTxExceptionHandler;
@@ -190,8 +189,20 @@ public class TransactionImpl implements Transaction {
     }
 
     private void checkThread() {
-        if (checkThreadAccess && threadId != null && threadId.longValue() != Thread.currentThread().getId()) {
+        if (!checkThreadAccess) {
+            return;
+        }
+        if (threadId != null && threadId.longValue() != Thread.currentThread().getId()) {
             throw new IllegalStateException("Transaction cannot span multiple threads!");
+        }
+        if (state == ACTIVE && ACTIVE_THREAD_TRANSACTION.get() != this) {
+            throw new IllegalStateException("Transaction is not active on current thread!");
+        }
+    }
+
+    private void checkActiveThreadBoundTransaction() {
+        if (hasThreadBoundTransactions()) {
+            throw new IllegalStateException("Current thread already bound with transaction!");
         }
     }
 
@@ -200,25 +211,35 @@ public class TransactionImpl implements Transaction {
         if (state == ACTIVE) {
             throw new IllegalStateException("Transaction is already active");
         }
-        if (TRANSACTION_EXISTS.get() != null) {
-            throw new IllegalStateException("Nested transactions are not allowed!");
-        }
+        checkActiveThreadBoundTransaction();
         startTime = currentTimeMillis();
         backupAddresses = transactionManagerService.pickBackupLogAddresses(durability);
 
         //init caller thread
         if (threadId == null) {
             threadId = Thread.currentThread().getId();
-            setThreadFlag(TRUE);
+            bindThread();
         }
         state = ACTIVE;
         transactionManagerService.startCount.inc();
     }
 
-    private void setThreadFlag(Boolean flag) {
+    private boolean hasThreadBoundTransactions() {
+        return ACTIVE_THREAD_TRANSACTION.get() != null;
+    }
+
+    private void setThreadFlag(TransactionImpl transaction) {
         if (checkThreadAccess) {
-            TRANSACTION_EXISTS.set(flag);
+            ACTIVE_THREAD_TRANSACTION.set(transaction);
         }
+    }
+
+    private void bindThread() {
+        setThreadFlag(this);
+    }
+
+    private void clearThread() {
+        setThreadFlag(null);
     }
 
     @Override
@@ -295,7 +316,7 @@ public class TransactionImpl implements Transaction {
                 purgeBackupLogs();
             }
         } finally {
-            setThreadFlag(null);
+            clearThread();
         }
     }
 
@@ -326,7 +347,7 @@ public class TransactionImpl implements Transaction {
                 transactionManagerService.rollbackCount.inc();
             }
         } finally {
-            setThreadFlag(null);
+            clearThread();
         }
     }
 
@@ -484,4 +505,32 @@ public class TransactionImpl implements Transaction {
             }
         };
     }
+
+    final class SuspendedTransactionImpl extends SuspendedTransaction {
+
+        SuspendedTransactionImpl() {
+            super(TransactionImpl.this);
+        }
+
+        @Override
+        protected void suspend(Transaction transaction) {
+            checkThread();
+            clearThread();
+            getTransaction().state = NO_TXN;
+        }
+
+        @Override
+        public void resume() {
+            checkActiveThreadBoundTransaction();
+            bindThread();
+            getTransaction().state = ACTIVE;
+        }
+
+        @Override
+        protected TransactionImpl getTransaction() {
+            return (TransactionImpl) super.getTransaction();
+        }
+
+    }
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionWrapper.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/TransactionWrapper.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.transaction.impl;
+
+import com.hazelcast.transaction.TransactionException;
+import com.hazelcast.transaction.TransactionOptions.TransactionType;
+
+/**
+ * This wrapper helps to manage the suspended transaction within {@link TransactionContextImpl}.
+ *
+ * @author Sergey Bespalov
+ *
+ * @see SuspendedTransaction
+ */
+class TransactionWrapper implements Transaction {
+
+    private Transaction transaction;
+
+    TransactionWrapper(Transaction transaction) {
+        this.transaction = transaction;
+    }
+
+    @Override
+    public void begin() throws IllegalStateException {
+        transaction.begin();
+    }
+
+    @Override
+    public void prepare() throws TransactionException {
+        transaction.prepare();
+    }
+
+    @Override
+    public void commit() throws TransactionException, IllegalStateException {
+        transaction.commit();
+    }
+
+    @Override
+    public void rollback() throws IllegalStateException {
+        transaction.rollback();
+    }
+
+    @Override
+    public String getTxnId() {
+        return transaction.getTxnId();
+    }
+
+    @Override
+    public State getState() {
+        return transaction.getState();
+    }
+
+    @Override
+    public long getTimeoutMillis() {
+        return transaction.getTimeoutMillis();
+    }
+
+    @Override
+    public void add(TransactionLogRecord record) {
+        transaction.add(record);
+    }
+
+    @Override
+    public void remove(Object key) {
+        transaction.remove(key);
+    }
+
+    @Override
+    public TransactionLogRecord get(Object key) {
+        return transaction.get(key);
+    }
+
+    @Override
+    public String getOwnerUuid() {
+        return transaction.getOwnerUuid();
+    }
+
+    @Override
+    public boolean isOriginatedFromClient() {
+        return transaction.isOriginatedFromClient();
+    }
+
+    @Override
+    public TransactionType getTransactionType() {
+        return transaction.getTransactionType();
+    }
+
+    void set(Transaction transaction) {
+        this.transaction = transaction;
+    }
+
+    <T extends Transaction> T getTransactionOfRequiredType(Class<T> type) {
+        if (transaction == null || !type.isAssignableFrom(transaction.getClass())) {
+            throw new IllegalStateException("Invalid transaction state.");
+        }
+        return type.cast(transaction);
+    }
+
+}

--- a/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/impl/xa/XATransactionContextImpl.java
@@ -69,6 +69,16 @@ public class XATransactionContextImpl implements TransactionContext {
     }
 
     @Override
+    public void suspendTransaction() {
+        throw new UnsupportedOperationException("XA Transaction cannot be suspended manually!");
+    }
+
+    @Override
+    public void resumeTransaction() {
+        throw new UnsupportedOperationException("XA Transaction cannot be resumed manually!");
+    }
+
+    @Override
     public String getTxnId() {
         return transaction.getTxnId();
     }


### PR DESCRIPTION
Fixes #13540 

Main changes:
- **suspend()** and **resume()** methods added for `TransactionContext` interface
- `Propagation.REQUIRES_NEW` support added for `HazelcastTransactionManager`
- thread bound transaction management reworked within `TransactionImpl` class