### PR TITLE
Add Nullable and Nonnull annotations to IQueue and fix some on IMap

### DIFF
--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientListProxy.java
@@ -52,6 +52,7 @@ import com.hazelcast.cluster.Member;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -230,8 +231,9 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
         invokeOnPartition(request);
     }
 
+    @Nonnull
     @Override
-    public String addItemListener(ItemListener<E> listener, boolean includeValue) {
+    public String addItemListener(@Nonnull ItemListener<E> listener, boolean includeValue) {
         isNotNull(listener, "listener");
         EventHandler<ClientMessage> eventHandler = new ItemEventHandler(listener);
         return registerListener(createItemListenerCodec(includeValue), eventHandler);
@@ -262,7 +264,7 @@ public class ClientListProxy<E> extends PartitionSpecificClientProxy implements 
     }
 
     @Override
-    public boolean removeItemListener(String registrationId) {
+    public boolean removeItemListener(@Nonnull String registrationId) {
         return deregisterListener(registrationId);
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -977,37 +977,39 @@ public class ClientMapProxy<K, V> extends ClientProxy
     @Override
     public String addEntryListener(@Nonnull MapListener listener,
                                    @Nonnull Predicate<K, V> predicate,
-                                   @Nonnull K key,
+                                   @Nullable K key,
                                    boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
-        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
         ListenerAdapter<IMapEvent> listenerAdaptor = createListenerAdapter(listener);
-        return addEntryListenerInternal(listenerAdaptor, predicate, key, includeValue);
+        return key == null
+                ? addEntryListenerInternal(listenerAdaptor, predicate, includeValue)
+                : addEntryListenerInternal(listenerAdaptor, predicate, key, includeValue);
     }
 
     @Override
     public String addEntryListener(@Nonnull EntryListener listener,
                                    @Nonnull Predicate<K, V> predicate,
-                                   @Nonnull K key,
+                                   @Nullable K key,
                                    boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
-        checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
         ListenerAdapter<IMapEvent> listenerAdaptor = createListenerAdapter(listener);
-        return addEntryListenerInternal(listenerAdaptor, predicate, key, includeValue);
+        return key == null
+                ? addEntryListenerInternal(listenerAdaptor, predicate, includeValue)
+                : addEntryListenerInternal(listenerAdaptor, predicate, key, includeValue);
     }
 
-    private String addEntryListenerInternal(ListenerAdapter<IMapEvent> listenerAdaptor,
-                                            Predicate<K, V> predicate,
-                                            K key,
+    private String addEntryListenerInternal(@Nonnull ListenerAdapter<IMapEvent> listenerAdaptor,
+                                            @Nonnull Predicate<K, V> predicate,
+                                            @Nullable K key,
                                             boolean includeValue) {
         int listenerFlags = setAndGetListenerFlags(listenerAdaptor);
         Data keyData = toData(key);
         Data predicateData = toData(predicate);
         EventHandler<ClientMessage> handler = createHandler(listenerAdaptor);
-        ListenerMessageCodec codec = createEntryListenerToKeyWithPredicateCodec(includeValue, listenerFlags, keyData,
-                predicateData);
+        ListenerMessageCodec codec = createEntryListenerToKeyWithPredicateCodec(
+                includeValue, listenerFlags, keyData, predicateData);
         return registerListener(codec, handler);
     }
 
@@ -1038,7 +1040,9 @@ public class ClientMapProxy<K, V> extends ClientProxy
     }
 
     @Override
-    public String addEntryListener(@Nonnull MapListener listener, @Nonnull Predicate<K, V> predicate, boolean includeValue) {
+    public String addEntryListener(@Nonnull MapListener listener,
+                                   @Nonnull Predicate<K, V> predicate,
+                                   boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
         ListenerAdapter<IMapEvent> listenerAdaptor = createListenerAdapter(listener);
@@ -1046,7 +1050,9 @@ public class ClientMapProxy<K, V> extends ClientProxy
     }
 
     @Override
-    public String addEntryListener(@Nonnull EntryListener listener, @Nonnull Predicate<K, V> predicate, boolean includeValue) {
+    public String addEntryListener(@Nonnull EntryListener listener,
+                                   @Nonnull Predicate<K, V> predicate,
+                                   boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
         ListenerAdapter<IMapEvent> listenerAdaptor = createListenerAdapter(listener);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientMapProxy.java
@@ -748,7 +748,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
     }
 
     @Override
-    public boolean tryLock(K key,
+    public boolean tryLock(@Nonnull K key,
                            long time, @Nullable TimeUnit timeunit,
                            long leaseTime, @Nullable TimeUnit leaseUnit) {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
@@ -807,7 +807,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
     @Override
     public String addLocalEntryListener(@Nonnull MapListener listener,
                                         @Nonnull Predicate<K, V> predicate,
-                                        K key,
+                                        @Nullable K key,
                                         boolean includeValue) {
         throw new UnsupportedOperationException("Locality is ambiguous for client!");
     }
@@ -815,7 +815,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
     @Override
     public String addLocalEntryListener(@Nonnull EntryListener listener,
                                         @Nonnull Predicate<K, V> predicate,
-                                        K key,
+                                        @Nullable K key,
                                         boolean includeValue) {
         throw new UnsupportedOperationException("Locality is ambiguous for client!");
     }
@@ -1178,7 +1178,7 @@ public class ClientMapProxy<K, V> extends ClientProxy
     }
 
     @Override
-    public Map<K, V> getAll(Set<K> keys) {
+    public Map<K, V> getAll(@Nullable Set<K> keys) {
         if (CollectionUtil.isEmpty(keys)) {
             // Wrap emptyMap() into unmodifiableMap to make sure put/putAll methods throw UnsupportedOperationException
             return Collections.unmodifiableMap(emptyMap());

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientQueueProxy.java
@@ -41,17 +41,18 @@ import com.hazelcast.client.impl.protocol.codec.QueueTakeCodec;
 import com.hazelcast.client.spi.ClientContext;
 import com.hazelcast.client.spi.EventHandler;
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
+import com.hazelcast.cluster.Member;
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.collection.ItemEvent;
+import com.hazelcast.collection.ItemListener;
 import com.hazelcast.collection.impl.common.DataAwareItemEvent;
 import com.hazelcast.collection.impl.queue.QueueIterator;
 import com.hazelcast.core.HazelcastException;
-import com.hazelcast.collection.IQueue;
-import com.hazelcast.collection.ItemEvent;
 import com.hazelcast.core.ItemEventType;
-import com.hazelcast.collection.ItemListener;
-import com.hazelcast.cluster.Member;
 import com.hazelcast.monitor.LocalQueueStats;
 import com.hazelcast.nio.serialization.Data;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -59,7 +60,6 @@ import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.CollectionUtil.objectToDataCollection;
 import static com.hazelcast.util.Preconditions.checkNotNull;
-import static com.hazelcast.util.Preconditions.isNotNull;
 import static java.lang.Thread.currentThread;
 
 /**
@@ -73,9 +73,10 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
         super(serviceName, name, context);
     }
 
+    @Nonnull
     @Override
-    public String addItemListener(final ItemListener<E> listener, final boolean includeValue) {
-        isNotNull(listener, "listener");
+    public String addItemListener(@Nonnull ItemListener<E> listener, boolean includeValue) {
+        checkNotNull(listener, "Null listener is not allowed!");
         EventHandler<ClientMessage> eventHandler = new ItemEventHandler(includeValue, listener);
         return registerListener(createItemListenerCodec(includeValue), eventHandler);
     }
@@ -137,7 +138,8 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public boolean removeItemListener(String registrationId) {
+    public boolean removeItemListener(@Nonnull String registrationId) {
+        checkNotNull(registrationId, "Null registrationId is not allowed!");
         return deregisterListener(registrationId);
     }
 
@@ -147,7 +149,7 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public boolean add(E e) {
+    public boolean add(@Nonnull E e) {
         if (offer(e)) {
             return true;
         }
@@ -165,7 +167,7 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
      * @throws HazelcastException if client loses the connected node.
      */
     @Override
-    public boolean offer(E e) {
+    public boolean offer(@Nonnull E e) {
         try {
             return offer(e, 0, TimeUnit.SECONDS);
         } catch (InterruptedException ex) {
@@ -175,15 +177,19 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public void put(E e) throws InterruptedException {
+    public void put(@Nonnull E e) throws InterruptedException {
+        checkNotNull(e, "Null item is not allowed!");
+
         Data data = toData(e);
         ClientMessage request = QueuePutCodec.encodeRequest(name, data);
         invokeOnPartitionInterruptibly(request);
     }
 
     @Override
-    public boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException {
-        checkNotNull(e, "item can't be null");
+    public boolean offer(@Nonnull E e,
+                         long timeout, @Nonnull TimeUnit unit) throws InterruptedException {
+        checkNotNull(e, "Null item is not allowed!");
+        checkNotNull(unit, "Null timeUnit is not allowed!");
 
         Data data = toData(e);
         ClientMessage request = QueueOfferCodec.encodeRequest(name, data, unit.toMillis(timeout));
@@ -192,6 +198,7 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
         return resultParameters.response;
     }
 
+    @Nonnull
     @Override
     public E take() throws InterruptedException {
         ClientMessage request = QueueTakeCodec.encodeRequest(name);
@@ -201,7 +208,9 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+    public E poll(long timeout, @Nonnull TimeUnit unit) throws InterruptedException {
+        checkNotNull(unit, "Null timeUnit is not allowed!");
+
         ClientMessage request = QueuePollCodec.encodeRequest(name, unit.toMillis(timeout));
         ClientMessage response = invokeOnPartitionInterruptibly(request);
         QueuePollCodec.ResponseParameters resultParameters = QueuePollCodec.decodeResponse(response);
@@ -217,7 +226,8 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public boolean remove(Object o) {
+    public boolean remove(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed!");
         Data data = toData(o);
         ClientMessage request = QueueRemoveCodec.encodeRequest(name, data);
         ClientMessage response = invokeOnPartition(request);
@@ -226,7 +236,8 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public boolean contains(Object o) {
+    public boolean contains(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed!");
         Data data = toData(o);
         ClientMessage request = QueueContainsCodec.encodeRequest(name, data);
         ClientMessage response = invokeOnPartition(request);
@@ -235,7 +246,9 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public int drainTo(Collection<? super E> objects) {
+    public int drainTo(@Nonnull Collection<? super E> objects) {
+        checkNotNull(objects, "Null objects parameter is not allowed!");
+
         ClientMessage request = QueueDrainToCodec.encodeRequest(name);
         ClientMessage response = invokeOnPartition(request);
         QueueDrainToCodec.ResponseParameters resultParameters = QueueDrainToCodec.decodeResponse(response);
@@ -248,7 +261,9 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public int drainTo(Collection<? super E> c, int maxElements) {
+    public int drainTo(@Nonnull Collection<? super E> c, int maxElements) {
+        checkNotNull(c, "Null collection parameter is not allowed!");
+
         ClientMessage request = QueueDrainToMaxSizeCodec.encodeRequest(name, maxElements);
         ClientMessage response = invokeOnPartition(request);
         QueueDrainToMaxSizeCodec.ResponseParameters resultParameters = QueueDrainToMaxSizeCodec.decodeResponse(response);
@@ -335,8 +350,11 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
         return array;
     }
 
+    @Nonnull
     @Override
-    public <T> T[] toArray(T[] ts) {
+    public <T> T[] toArray(@Nonnull T[] ts) {
+        checkNotNull(ts, "Null array parameter is not allowed!");
+
         ClientMessage request = QueueIteratorCodec.encodeRequest(name);
         ClientMessage response = invokeOnPartition(request);
         QueueIteratorCodec.ResponseParameters resultParameters = QueueIteratorCodec.decodeResponse(response);
@@ -353,8 +371,9 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public boolean containsAll(Collection<?> c) {
-        checkNotNull(c);
+    public boolean containsAll(@Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed!");
+
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = QueueContainsAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -363,8 +382,9 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public boolean addAll(Collection<? extends E> c) {
-        checkNotNull(c);
+    public boolean addAll(@Nonnull Collection<? extends E> c) {
+        checkNotNull(c, "Null collection is not allowed!");
+
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = QueueAddAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -373,8 +393,9 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public boolean removeAll(Collection<?> c) {
-        checkNotNull(c);
+    public boolean removeAll(@Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed!");
+
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = QueueCompareAndRemoveAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);
@@ -384,8 +405,9 @@ public final class ClientQueueProxy<E> extends PartitionSpecificClientProxy impl
     }
 
     @Override
-    public boolean retainAll(Collection<?> c) {
-        checkNotNull(c);
+    public boolean retainAll(@Nonnull Collection<?> c) {
+        checkNotNull(c, "Null collection is not allowed!");
+
         Collection<Data> dataCollection = objectToDataCollection(c, getSerializationService());
         ClientMessage request = QueueCompareAndRetainAllCodec.encodeRequest(name, dataCollection);
         ClientMessage response = invokeOnPartition(request);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/ClientSetProxy.java
@@ -44,6 +44,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.impl.UnmodifiableLazyList;
 import com.hazelcast.util.Preconditions;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -169,8 +170,9 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
         invokeOnPartition(request);
     }
 
+    @Nonnull
     @Override
-    public String addItemListener(final ItemListener<E> listener, final boolean includeValue) {
+    public String addItemListener(@Nonnull final ItemListener<E> listener, final boolean includeValue) {
         isNotNull(listener, "listener");
         EventHandler<ClientMessage> eventHandler = new ItemEventHandler(listener);
         return registerListener(createItemListenerCodec(includeValue), eventHandler);
@@ -201,7 +203,7 @@ public class ClientSetProxy<E> extends PartitionSpecificClientProxy implements I
     }
 
     @Override
-    public boolean removeItemListener(String registrationId) {
+    public boolean removeItemListener(@Nonnull String registrationId) {
         return deregisterListener(registrationId);
     }
 

--- a/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnQueueProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/proxy/txn/ClientTxnQueueProxy.java
@@ -27,6 +27,7 @@ import com.hazelcast.collection.impl.queue.QueueService;
 import com.hazelcast.transaction.TransactionalQueue;
 import com.hazelcast.nio.serialization.Data;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.ThreadUtil.getThreadId;
@@ -44,7 +45,7 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
     }
 
     @Override
-    public boolean offer(E e) {
+    public boolean offer(@Nonnull E e) {
         try {
             return offer(e, 0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e1) {
@@ -54,7 +55,7 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
     }
 
     @Override
-    public boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException {
+    public boolean offer(@Nonnull E e, long timeout, @Nonnull TimeUnit unit) throws InterruptedException {
         Data data = toData(e);
         ClientMessage request = TransactionalQueueOfferCodec
                 .encodeRequest(name, getTransactionId(), getThreadId(), data, unit.toMillis(timeout));
@@ -62,6 +63,7 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
         return TransactionalQueueOfferCodec.decodeResponse(response).response;
     }
 
+    @Nonnull
     @Override
     public E take() throws InterruptedException {
         ClientMessage request = TransactionalQueueTakeCodec.encodeRequest(name, getTransactionId(), getThreadId());
@@ -80,7 +82,7 @@ public class ClientTxnQueueProxy<E> extends ClientTxnProxy implements Transactio
     }
 
     @Override
-    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+    public E poll(long timeout, @Nonnull TimeUnit unit) throws InterruptedException {
         ClientMessage request = TransactionalQueuePollCodec
                 .encodeRequest(name, getTransactionId(), getThreadId(), unit.toMillis(timeout));
         ClientMessage response = invoke(request);

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientListenerService.java
@@ -18,16 +18,19 @@ package com.hazelcast.client.spi;
 
 import com.hazelcast.client.spi.impl.ListenerMessageCodec;
 
+import javax.annotation.Nonnull;
+
 /**
  * Client service to add/remove remote listeners.
- *
+ * <p>
  * For smart client, it registers local  listeners to all nodes in cluster.
  * For unisocket client, it registers global listener to one node.
  */
 public interface ClientListenerService {
 
+    @Nonnull
     String registerListener(ListenerMessageCodec listenerMessageCodec, EventHandler handler);
 
-    boolean deregisterListener(String registrationId);
+    boolean deregisterListener(@Nonnull String registrationId);
 
 }

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/ClientProxy.java
@@ -28,6 +28,7 @@ import com.hazelcast.partition.strategy.StringPartitioningStrategy;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.util.ExceptionUtil.rethrow;
@@ -52,11 +53,12 @@ public abstract class ClientProxy implements DistributedObject {
         this.serializationService = context.getSerializationService();
     }
 
-    protected final String registerListener(ListenerMessageCodec codec, EventHandler handler) {
+    protected final @Nonnull
+    String registerListener(ListenerMessageCodec codec, EventHandler handler) {
         return getContext().getListenerService().registerListener(codec, handler);
     }
 
-    protected final boolean deregisterListener(String registrationId) {
+    protected final boolean deregisterListener(@Nonnull String registrationId) {
         return getContext().getListenerService().deregisterListener(registrationId);
     }
 
@@ -87,6 +89,7 @@ public abstract class ClientProxy implements DistributedObject {
         return name;
     }
 
+    @Nonnull
     @Override
     public final String getName() {
         return name;

--- a/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/SmartClientListenerService.java
+++ b/hazelcast-client/src/main/java/com/hazelcast/client/spi/impl/listener/SmartClientListenerService.java
@@ -25,6 +25,7 @@ import com.hazelcast.core.OperationTimeoutException;
 import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +58,7 @@ public class SmartClientListenerService extends AbstractClientListenerService  {
         }, 1, 1, TimeUnit.SECONDS);
     }
 
+    @Nonnull
     @Override
     public String registerListener(final ListenerMessageCodec codec, final EventHandler handler) {
         trySyncConnectToAllMembers();

--- a/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientQueueNullTest.java
+++ b/hazelcast-client/src/test/java/com/hazelcast/client/queue/ClientQueueNullTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.queue;
+
+import com.hazelcast.client.test.TestHazelcastFactory;
+import com.hazelcast.collection.impl.queue.AbstractQueueNullTest;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic queue methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class ClientQueueNullTest extends AbstractQueueNullTest {
+
+    private final TestHazelcastFactory hazelcastFactory = new TestHazelcastFactory();
+    private HazelcastInstance member;
+    private HazelcastInstance client;
+
+    @Before
+    public void setup() {
+        member = hazelcastFactory.newHazelcastInstance();
+        client = hazelcastFactory.newHazelcastClient();
+    }
+
+    @After
+    public void tearDown() {
+        hazelcastFactory.terminateAll();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return client;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/collection/BaseQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/BaseQueue.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection;
 import com.hazelcast.core.DistributedObject;
 import com.hazelcast.transaction.TransactionalQueue;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -42,7 +43,7 @@ public interface BaseQueue<E> extends DistributedObject {
      * @return <code>true</code> if the element was added to this queue,
      *         <code>false</code> otherwise
      */
-    boolean offer(E e);
+    boolean offer(@Nonnull E e);
 
     /**
      * Inserts the specified element into this queue, waiting up to the
@@ -57,7 +58,7 @@ public interface BaseQueue<E> extends DistributedObject {
      *         the specified waiting time elapses before space is available
      * @throws InterruptedException if interrupted while waiting
      */
-    boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException;
+    boolean offer(@Nonnull E e, long timeout, @Nonnull TimeUnit unit) throws InterruptedException;
 
     /**
      * Retrieves and removes the head of this queue, waiting if necessary
@@ -66,7 +67,7 @@ public interface BaseQueue<E> extends DistributedObject {
      * @return the head of this queue
      * @throws InterruptedException if interrupted while waiting
      */
-    E take() throws InterruptedException;
+    @Nonnull E take() throws InterruptedException;
 
     /**
      * Retrieves and removes the head of this queue,
@@ -88,7 +89,7 @@ public interface BaseQueue<E> extends DistributedObject {
      *         specified waiting time elapses before an element is available
      * @throws InterruptedException if interrupted while waiting
      */
-    E poll(long timeout, TimeUnit unit) throws InterruptedException;
+    E poll(long timeout, @Nonnull TimeUnit unit) throws InterruptedException;
 
     /**
      * Returns the number of elements in this collection.  If this collection

--- a/hazelcast/src/main/java/com/hazelcast/collection/ICollection.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/ICollection.java
@@ -18,6 +18,7 @@ package com.hazelcast.collection;
 
 import com.hazelcast.core.DistributedObject;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 
 /**
@@ -30,6 +31,7 @@ public interface ICollection<E> extends Collection<E>, DistributedObject {
     /**
      * Returns the name of this collection.
      */
+    @Nonnull
     String getName();
 
     /**
@@ -41,7 +43,8 @@ public interface ICollection<E> extends Collection<E>, DistributedObject {
      *                     to the item listener, {@code false} otherwise
      * @return returns the registration ID
      */
-    String addItemListener(ItemListener<E> listener, boolean includeValue);
+    @Nonnull
+    String addItemListener(@Nonnull ItemListener<E> listener, boolean includeValue);
 
     /**
      * Removes the specified item listener.
@@ -50,5 +53,5 @@ public interface ICollection<E> extends Collection<E>, DistributedObject {
      * @param registrationId ID of the listener registration
      * @return {@code true} if the item listener is removed, {@code false} otherwise
      */
-    boolean removeItemListener(String registrationId);
+    boolean removeItemListener(@Nonnull String registrationId);
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/IQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/IQueue.java
@@ -19,6 +19,7 @@ package com.hazelcast.collection;
 import com.hazelcast.monitor.LocalQueueStats;
 import com.hazelcast.transaction.TransactionalQueue;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -56,11 +57,12 @@ public interface IQueue<E> extends BlockingQueue<E>, BaseQueue<E>, ICollection<E
     /**
      * {@inheritDoc}
      */
-    E poll(long timeout, TimeUnit unit) throws InterruptedException;
+    E poll(long timeout, @Nonnull TimeUnit unit) throws InterruptedException;
 
     /**
      * {@inheritDoc}
      */
+    @Nonnull
     E take() throws InterruptedException;
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/collection/AbstractCollectionProxyImpl.java
@@ -43,6 +43,7 @@ import com.hazelcast.spi.impl.UnmodifiableLazyList;
 import com.hazelcast.spi.serialization.SerializationService;
 import com.hazelcast.util.ExceptionUtil;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -95,6 +96,7 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
 
     protected abstract CollectionConfig getConfig(NodeEngine nodeEngine);
 
+    @Nonnull
     @Override
     public String getName() {
         return name;
@@ -217,14 +219,14 @@ public abstract class AbstractCollectionProxyImpl<S extends RemoteService, E> ex
         return new UnmodifiableLazyList<E>(collection, serializationService);
     }
 
-    public String addItemListener(ItemListener<E> listener, boolean includeValue) {
+    public @Nonnull String addItemListener(@Nonnull ItemListener<E> listener, boolean includeValue) {
         final EventService eventService = getNodeEngine().getEventService();
         final CollectionEventFilter filter = new CollectionEventFilter(includeValue);
         final EventRegistration registration = eventService.registerListener(getServiceName(), name, filter, listener);
         return registration.getId();
     }
 
-    public boolean removeItemListener(String registrationId) {
+    public boolean removeItemListener(@Nonnull String registrationId) {
         EventService eventService = getNodeEngine().getEventService();
         return eventService.deregisterListener(getServiceName(), name, registrationId);
     }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxyImpl.java
@@ -16,13 +16,14 @@
 
 package com.hazelcast.collection.impl.queue;
 
-import com.hazelcast.config.QueueConfig;
 import com.hazelcast.collection.IQueue;
+import com.hazelcast.config.QueueConfig;
 import com.hazelcast.monitor.LocalQueueStats;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.NodeEngine;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -39,7 +40,7 @@ import static java.lang.Thread.currentThread;
  *
  * @param <E>
  */
-public class QueueProxyImpl<E> extends QueueProxySupport implements IQueue<E>, InitializingObject {
+public class QueueProxyImpl<E> extends QueueProxySupport<E> implements IQueue<E>, InitializingObject {
 
     public QueueProxyImpl(String name, QueueService queueService, NodeEngine nodeEngine, QueueConfig config) {
         super(name, queueService, nodeEngine, config);
@@ -51,7 +52,7 @@ public class QueueProxyImpl<E> extends QueueProxySupport implements IQueue<E>, I
     }
 
     @Override
-    public boolean add(E e) {
+    public boolean add(@Nonnull E e) {
         if (offer(e)) {
             return true;
         }
@@ -59,7 +60,7 @@ public class QueueProxyImpl<E> extends QueueProxySupport implements IQueue<E>, I
     }
 
     @Override
-    public boolean offer(E e) {
+    public boolean offer(@Nonnull E e) {
         try {
             return offer(e, 0, TimeUnit.SECONDS);
         } catch (InterruptedException ex) {
@@ -69,53 +70,62 @@ public class QueueProxyImpl<E> extends QueueProxySupport implements IQueue<E>, I
     }
 
     @Override
-    public void put(E e) throws InterruptedException {
+    public void put(@Nonnull E e) throws InterruptedException {
         offer(e, -1, TimeUnit.MILLISECONDS);
     }
 
     @Override
-    public boolean offer(E e, long timeout, TimeUnit timeUnit) throws InterruptedException {
+    public boolean offer(@Nonnull E e,
+                         long timeout, @Nonnull TimeUnit timeUnit) throws InterruptedException {
+        checkNotNull(e, "Null item is not allowed!");
+        checkNotNull(timeUnit, "Null timeUnit is not allowed!");
+
         final NodeEngine nodeEngine = getNodeEngine();
         final Data data = nodeEngine.toData(e);
         return offerInternal(data, timeUnit.toMillis(timeout));
     }
 
+    @Nonnull
     @Override
     public E take() throws InterruptedException {
         return poll(-1, TimeUnit.MILLISECONDS);
     }
 
     @Override
-    public E poll(long timeout, TimeUnit timeUnit) throws InterruptedException {
+    public E poll(long timeout, @Nonnull TimeUnit timeUnit) throws InterruptedException {
+        checkNotNull(timeUnit, "Null timeUnit is not allowed!");
+
         final NodeEngine nodeEngine = getNodeEngine();
         final Object data = pollInternal(timeUnit.toMillis(timeout));
         return nodeEngine.toObject(data);
     }
 
     @Override
-    public boolean remove(Object o) {
+    public boolean remove(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed!");
         final NodeEngine nodeEngine = getNodeEngine();
         final Data data = nodeEngine.toData(o);
         return removeInternal(data);
     }
 
     @Override
-    public boolean contains(Object o) {
+    public boolean contains(@Nonnull Object o) {
+        checkNotNull(o, "Null item is not allowed!");
         final NodeEngine nodeEngine = getNodeEngine();
         final Data data = nodeEngine.toData(o);
-        List<Data> dataSet = new ArrayList<Data>(1);
+        List<Data> dataSet = new ArrayList<>(1);
         dataSet.add(data);
         return containsInternal(dataSet);
     }
 
     @Override
-    public int drainTo(Collection<? super E> objects) {
+    public int drainTo(@Nonnull Collection<? super E> objects) {
         return drainTo(objects, -1);
     }
 
     @Override
-    public int drainTo(Collection<? super E> objects, int i) {
-        checkNotNull(objects, "Collection is null");
+    public int drainTo(@Nonnull Collection<? super E> objects, int i) {
+        checkNotNull(objects, "Null objects parameter is not allowed!");
         checkFalse(this.equals(objects), "Can not drain to same Queue");
 
         final NodeEngine nodeEngine = getNodeEngine();
@@ -180,8 +190,11 @@ public class QueueProxyImpl<E> extends QueueProxySupport implements IQueue<E>, I
         return array;
     }
 
+    @Nonnull
     @Override
-    public <T> T[] toArray(T[] ts) {
+    public <T> T[] toArray(@Nonnull T[] ts) {
+        checkNotNull(ts, "Null array parameter is not allowed!");
+
         T[] tsParam = ts;
         final NodeEngine nodeEngine = getNodeEngine();
         List<Data> list = listInternal();
@@ -196,22 +209,30 @@ public class QueueProxyImpl<E> extends QueueProxySupport implements IQueue<E>, I
     }
 
     @Override
-    public boolean containsAll(Collection<?> objects) {
+    public boolean containsAll(@Nonnull Collection<?> objects) {
+        checkNotNull(objects, "Null collection is not allowed!");
+
         return containsInternal(getDataList(objects));
     }
 
     @Override
-    public boolean addAll(Collection<? extends E> es) {
+    public boolean addAll(@Nonnull Collection<? extends E> es) {
+        checkNotNull(es, "Null collection is not allowed!");
+
         return addAllInternal(toDataList(es));
     }
 
     @Override
-    public boolean removeAll(Collection<?> objects) {
+    public boolean removeAll(@Nonnull Collection<?> objects) {
+        checkNotNull(objects, "Null collection is not allowed!");
+
         return compareAndRemove(getDataList(objects), false);
     }
 
     @Override
-    public boolean retainAll(Collection<?> objects) {
+    public boolean retainAll(@Nonnull Collection<?> objects) {
+        checkNotNull(objects, "Null collection is not allowed!");
+
         return compareAndRemove(getDataList(objects), true);
     }
 

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxySupport.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/queue/QueueProxySupport.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.collection.impl.queue;
 
+import com.hazelcast.collection.ItemListener;
 import com.hazelcast.collection.impl.queue.operations.AddAllOperation;
 import com.hazelcast.collection.impl.queue.operations.ClearOperation;
 import com.hazelcast.collection.impl.queue.operations.CompareAndRemoveOperation;
@@ -33,25 +34,25 @@ import com.hazelcast.collection.impl.queue.operations.SizeOperation;
 import com.hazelcast.config.ItemListenerConfig;
 import com.hazelcast.config.QueueConfig;
 import com.hazelcast.core.HazelcastInstanceAware;
-import com.hazelcast.collection.ItemListener;
 import com.hazelcast.nio.ClassLoaderUtil;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.AbstractDistributedObject;
 import com.hazelcast.spi.InitializingObject;
 import com.hazelcast.spi.InternalCompletableFuture;
 import com.hazelcast.spi.NodeEngine;
+import com.hazelcast.spi.impl.SerializableList;
 import com.hazelcast.spi.impl.operationservice.Operation;
 import com.hazelcast.spi.impl.operationservice.OperationService;
-import com.hazelcast.spi.impl.SerializableList;
 import com.hazelcast.util.ExceptionUtil;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Future;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
 
-abstract class QueueProxySupport extends AbstractDistributedObject<QueueService> implements InitializingObject {
+abstract class QueueProxySupport<E> extends AbstractDistributedObject<QueueService> implements InitializingObject {
 
     final String name;
     final int partitionId;
@@ -202,16 +203,21 @@ abstract class QueueProxySupport extends AbstractDistributedObject<QueueService>
         return QueueService.SERVICE_NAME;
     }
 
+    @Nonnull
     @Override
     public final String getName() {
         return name;
     }
 
-    public String addItemListener(ItemListener listener, boolean includeValue) {
+    public @Nonnull
+    String addItemListener(@Nonnull ItemListener<E> listener,
+                           boolean includeValue) {
+        checkNotNull(listener, "Null listener is not allowed!");
         return getService().addItemListener(name, listener, includeValue, false);
     }
 
-    public boolean removeItemListener(String registrationId) {
+    public boolean removeItemListener(@Nonnull String registrationId) {
+        checkNotNull(registrationId, "Null registrationId is not allowed!");
         return getService().removeItemListener(name, registrationId);
     }
 }

--- a/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
+++ b/hazelcast/src/main/java/com/hazelcast/collection/impl/txnqueue/TransactionalQueueProxy.java
@@ -21,6 +21,7 @@ import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.spi.NodeEngine;
 import com.hazelcast.transaction.impl.Transaction;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.util.Preconditions.checkNotNull;
@@ -38,7 +39,7 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E
     }
 
     @Override
-    public boolean offer(E e) {
+    public boolean offer(@Nonnull E e) {
         try {
             return offer(e, 0, TimeUnit.MILLISECONDS);
         } catch (InterruptedException ignored) {
@@ -48,7 +49,7 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E
     }
 
     @Override
-    public boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException {
+    public boolean offer(@Nonnull E e, long timeout, @Nonnull TimeUnit unit) throws InterruptedException {
         checkNotNull(e, "Offered item should not be null.");
         checkNotNull(unit, "TimeUnit should not be null.");
 
@@ -57,6 +58,7 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E
         return offerInternal(data, unit.toMillis(timeout));
     }
 
+    @Nonnull
     @Override
     public E take() throws InterruptedException {
         return poll(-1, TimeUnit.MILLISECONDS);
@@ -73,7 +75,7 @@ public class TransactionalQueueProxy<E> extends TransactionalQueueProxySupport<E
     }
 
     @Override
-    public E poll(long timeout, TimeUnit unit) throws InterruptedException {
+    public E poll(long timeout, @Nonnull TimeUnit unit) throws InterruptedException {
         checkNotNull(unit, "TimeUnit should not be null.");
 
         checkTransactionState();

--- a/hazelcast/src/main/java/com/hazelcast/map/IMap.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/IMap.java
@@ -1934,7 +1934,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      * elapsed before the lock was acquired
      * @throws NullPointerException if the specified key is {@code null}
      */
-    boolean tryLock(K key,
+    boolean tryLock(@Nonnull K key,
                     long time, @Nullable TimeUnit timeunit,
                     long leaseTime, @Nullable TimeUnit leaseTimeunit)
             throws InterruptedException;
@@ -2080,7 +2080,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      */
     String addLocalEntryListener(@Nonnull MapListener listener,
                                  @Nonnull Predicate<K, V> predicate,
-                                 K key,
+                                 @Nullable K key,
                                  boolean includeValue);
 
     /**
@@ -2102,7 +2102,7 @@ public interface IMap<K, V> extends ConcurrentMap<K, V>, BaseMap<K, V> {
      */
     String addLocalEntryListener(@Nonnull EntryListener listener,
                                  @Nonnull Predicate<K, V> predicate,
-                                 K key,
+                                 @Nullable K key,
                                  boolean includeValue);
 
     /**

--- a/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
+++ b/hazelcast/src/main/java/com/hazelcast/map/impl/proxy/MapProxyImpl.java
@@ -418,7 +418,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     @Override
-    public Map<K, V> getAll(Set<K> keys) {
+    public Map<K, V> getAll(@Nullable Set<K> keys) {
         if (CollectionUtil.isEmpty(keys)) {
             // Wrap emptyMap() into unmodifiableMap to make sure put/putAll methods throw UnsupportedOperationException
             return Collections.unmodifiableMap(emptyMap());
@@ -469,7 +469,9 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     }
 
     @Override
-    public boolean tryLock(K key, long time, TimeUnit timeunit, long leaseTime, TimeUnit leaseTimeUnit)
+    public boolean tryLock(@Nonnull K key,
+                           long time, @Nullable TimeUnit timeunit,
+                           long leaseTime, @Nullable TimeUnit leaseTimeUnit)
             throws InterruptedException {
         checkNotNull(key, NULL_KEY_IS_NOT_ALLOWED);
 
@@ -541,7 +543,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public String addLocalEntryListener(@Nonnull MapListener listener,
                                         @Nonnull Predicate<K, V> predicate,
-                                        K key,
+                                        @Nullable K key,
                                         boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);
@@ -553,7 +555,7 @@ public class MapProxyImpl<K, V> extends MapProxySupport<K, V> implements EventJo
     @Override
     public String addLocalEntryListener(@Nonnull EntryListener listener,
                                         @Nonnull Predicate<K, V> predicate,
-                                        K key,
+                                        @Nullable K key,
                                         boolean includeValue) {
         checkNotNull(listener, NULL_LISTENER_IS_NOT_ALLOWED);
         checkNotNull(predicate, NULL_PREDICATE_IS_NOT_ALLOWED);

--- a/hazelcast/src/main/java/com/hazelcast/spi/EventService.java
+++ b/hazelcast/src/main/java/com/hazelcast/spi/EventService.java
@@ -16,6 +16,7 @@
 
 package com.hazelcast.spi;
 
+import javax.annotation.Nonnull;
 import java.util.Collection;
 
 /**
@@ -53,8 +54,10 @@ public interface EventService {
      * @param topic       topic name
      * @param listener    listener instance
      * @return event registration
+     * @throws IllegalArgumentException if the listener is {@code null}
      */
-    EventRegistration registerLocalListener(String serviceName, String topic, Object listener);
+    EventRegistration registerLocalListener(String serviceName, String topic,
+                                            @Nonnull Object listener);
 
     /**
      * Registers a local only listener with an event filter.
@@ -64,8 +67,11 @@ public interface EventService {
      * @param filter      event filter
      * @param listener    listener instance
      * @return event registration
+     * @throws IllegalArgumentException if the listener or filter is {@code null}
      */
-    EventRegistration registerLocalListener(String serviceName, String topic, EventFilter filter, Object listener);
+    EventRegistration registerLocalListener(String serviceName, String topic,
+                                            @Nonnull EventFilter filter,
+                                            @Nonnull Object listener);
 
     /**
      * Registers a listener on all cluster nodes.
@@ -74,8 +80,10 @@ public interface EventService {
      * @param topic       topic name
      * @param listener    listener instance
      * @return event registration
+     * @throws IllegalArgumentException if the listener is {@code null}
      */
-    EventRegistration registerListener(String serviceName, String topic, Object listener);
+    EventRegistration registerListener(String serviceName, String topic,
+                                       @Nonnull Object listener);
 
     /**
      * Registers a listener on all cluster nodes with an event filter.
@@ -85,8 +93,11 @@ public interface EventService {
      * @param filter      event filter
      * @param listener    listener instance
      * @return event registration
+     * @throws IllegalArgumentException if the listener or filter is {@code null}
      */
-    EventRegistration registerListener(String serviceName, String topic, EventFilter filter, Object listener);
+    EventRegistration registerListener(String serviceName, String topic,
+                                       @Nonnull EventFilter filter,
+                                       @Nonnull Object listener);
 
     /**
      * Deregisters a listener with the given registration ID.
@@ -99,7 +110,9 @@ public interface EventService {
      * @see #registerListener(String, String, Object)
      * @see #registerLocalListener(String, String, Object)
      */
-    boolean deregisterListener(String serviceName, String topic, Object id);
+    boolean deregisterListener(@Nonnull String serviceName,
+                               @Nonnull String topic,
+                               @Nonnull Object id);
 
     /**
      * Deregisters all listeners belonging to the given service and topic.

--- a/hazelcast/src/main/java/com/hazelcast/transaction/TransactionalQueue.java
+++ b/hazelcast/src/main/java/com/hazelcast/transaction/TransactionalQueue.java
@@ -19,6 +19,7 @@ package com.hazelcast.transaction;
 import com.hazelcast.collection.BaseQueue;
 import com.hazelcast.collection.IQueue;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -34,17 +35,18 @@ public interface TransactionalQueue<E> extends TransactionalObject, BaseQueue<E>
      * {@inheritDoc}
      */
     @Override
-    boolean offer(E e);
+    boolean offer(@Nonnull E e);
 
     /**
      * {@inheritDoc}
      */
     @Override
-    boolean offer(E e, long timeout, TimeUnit unit) throws InterruptedException;
+    boolean offer(@Nonnull E e, long timeout, @Nonnull TimeUnit unit) throws InterruptedException;
 
     /**
      * {@inheritDoc}
      */
+    @Nonnull
     @Override
     E take() throws InterruptedException;
 
@@ -58,7 +60,7 @@ public interface TransactionalQueue<E> extends TransactionalObject, BaseQueue<E>
      * {@inheritDoc}
      */
     @Override
-    E poll(long timeout, TimeUnit unit) throws InterruptedException;
+    E poll(long timeout, @Nonnull TimeUnit unit) throws InterruptedException;
 
     /**
      * {@inheritDoc}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/AbstractQueueNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/AbstractQueueNullTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.queue;
+
+import com.hazelcast.collection.IQueue;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastTestSupport;
+import com.hazelcast.util.ExceptionUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.fail;
+
+public abstract class AbstractQueueNullTest extends HazelcastTestSupport {
+
+    @Test
+    public void testNullability() {
+        TimeUnit sampleTimeUnit = TimeUnit.SECONDS;
+
+        assertThrowsNPE(q -> q.addItemListener(null, true));
+        assertThrowsNPE(q -> q.removeItemListener(null));
+        assertThrowsNPE(q -> q.add(null));
+        assertThrowsNPE(q -> q.offer(null));
+        assertThrowsNPE(q -> q.put(null));
+        assertThrowsNPE(q -> q.offer(null, -1, sampleTimeUnit));
+        assertThrowsNPE(q -> q.offer("a", -1, null));
+        assertThrowsNPE(q -> q.poll(-1, null));
+        assertThrowsNPE(q -> q.remove(null));
+        assertThrowsNPE(q -> q.contains(null));
+        assertThrowsNPE(q -> q.drainTo(null));
+        assertThrowsNPE(q -> q.drainTo(null, 1));
+        assertThrowsNPE(q -> q.toArray(null));
+        assertThrowsNPE(q -> q.containsAll(null));
+        assertThrowsNPE(q -> q.addAll(null));
+        assertThrowsNPE(q -> q.removeAll(null));
+        assertThrowsNPE(q -> q.retainAll(null));
+    }
+
+    private void assertThrowsNPE(ConsumerEx<IQueue<Object>> method) {
+        assertThrows(NullPointerException.class, method);
+    }
+
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<IQueue<Object>> method) {
+        try {
+            method.accept(getDriver().getQueue(randomName()));
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
+        } catch (Exception e) {
+            Assert.assertSame(expectedExceptionClass, e.getClass());
+        }
+    }
+
+    @FunctionalInterface
+    public interface ConsumerEx<T> extends Consumer<T> {
+        void acceptEx(T t) throws Exception;
+
+        @Override
+        default void accept(T t) {
+            try {
+                acceptEx(t);
+            } catch (Exception e) {
+                ExceptionUtil.sneakyThrow(e);
+            }
+        }
+    }
+
+    protected abstract HazelcastInstance getDriver();
+}

--- a/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/MemberQueueNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/collection/impl/queue/MemberQueueNullTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.collection.impl.queue;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.test.HazelcastParallelClassRunner;
+import com.hazelcast.test.TestHazelcastInstanceFactory;
+import com.hazelcast.test.annotation.ParallelJVMTest;
+import com.hazelcast.test.annotation.QuickTest;
+import org.junit.Before;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Member implementation for basic map methods nullability tests
+ */
+@RunWith(HazelcastParallelClassRunner.class)
+@Category({QuickTest.class, ParallelJVMTest.class})
+public class MemberQueueNullTest extends AbstractQueueNullTest {
+
+    private HazelcastInstance instance;
+
+    @Before
+    public void setup() {
+        TestHazelcastInstanceFactory factory = createHazelcastInstanceFactory();
+        instance = factory.newHazelcastInstance();
+    }
+
+    @Override
+    protected HazelcastInstance getDriver() {
+        return instance;
+    }
+}

--- a/hazelcast/src/test/java/com/hazelcast/listeners/AddListenerWithNullParameterTests.java
+++ b/hazelcast/src/test/java/com/hazelcast/listeners/AddListenerWithNullParameterTests.java
@@ -121,7 +121,7 @@ public class AddListenerWithNullParameterTests extends HazelcastTestSupport {
         instance.getSet("test").addItemListener(null, true);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NullPointerException.class)
     public void testQueueAddItemListener() {
         instance.getQueue("test").addItemListener(null, true);
     }

--- a/hazelcast/src/test/java/com/hazelcast/map/AbstractMapNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AbstractMapNullTest.java
@@ -33,6 +33,8 @@ import org.junit.Test;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static org.junit.Assert.fail;
+
 public abstract class AbstractMapNullTest extends HazelcastTestSupport {
 
     private static final String MAP_NAME = "map";
@@ -56,7 +58,6 @@ public abstract class AbstractMapNullTest extends HazelcastTestSupport {
         assertThrowsNPE(m -> m.remove("", null));
         assertThrowsNPE(m -> m.removeAll(null));
         assertThrowsNPE(m -> m.delete(null));
-        assertThrowsNPE(m -> m.getAll(null));
         assertThrowsNPE(m -> m.loadAll(null, true));
         assertThrowsNPE(m -> m.getAsync(null));
 
@@ -128,14 +129,10 @@ public abstract class AbstractMapNullTest extends HazelcastTestSupport {
 
         assertThrowsNPE(m -> m.lock(null));
         assertThrowsNPE(m -> m.lock(null, -1, sampleTimeUnit));
-        assertThrowsNPE(m -> m.lock("", 1, null));
 
         assertThrowsNPE(m -> m.tryLock(null));
         assertThrowsNPE(m -> m.tryLock(null, -1, sampleTimeUnit));
-        assertThrowsNPE(m -> m.tryLock("", -1, null));
         assertThrowsNPE(m -> m.tryLock(null, -1, sampleTimeUnit, -1, sampleTimeUnit));
-        assertThrowsNPE(m -> m.tryLock("", -1, null, -1, sampleTimeUnit));
-        assertThrowsNPE(m -> m.tryLock("", -1, sampleTimeUnit, -1, null));
 
         assertThrowsNPE(m -> m.unlock(null));
         assertThrowsNPE(m -> m.forceUnlock(null));
@@ -145,13 +142,11 @@ public abstract class AbstractMapNullTest extends HazelcastTestSupport {
             assertThrowsNPE(m -> m.addLocalEntryListener(sampleEntryListener, null, true));
             assertThrowsNPE(m -> m.addLocalEntryListener((EntryListener) null, samplePredicate, "", true));
             assertThrowsNPE(m -> m.addLocalEntryListener(sampleEntryListener, null, "", true));
-            assertThrowsNPE(m -> m.addLocalEntryListener(sampleEntryListener, samplePredicate, null, true));
             assertThrowsNPE(m -> m.addLocalEntryListener((MapListener) null));
             assertThrowsNPE(m -> m.addLocalEntryListener((MapListener) null, samplePredicate, true));
             assertThrowsNPE(m -> m.addLocalEntryListener(sampleMapListener, null, true));
             assertThrowsNPE(m -> m.addLocalEntryListener(null, samplePredicate, "", true));
             assertThrowsNPE(m -> m.addLocalEntryListener(sampleMapListener, null, "", true));
-            assertThrowsNPE(m -> m.addLocalEntryListener(sampleMapListener, samplePredicate, null, true));
             assertThrowsNPE(m -> m.localKeySet(null));
         }
 
@@ -163,14 +158,16 @@ public abstract class AbstractMapNullTest extends HazelcastTestSupport {
         assertThrowsNPE(m -> m.addEntryListener(sampleEntryListener, null, true));
         assertThrowsNPE(m -> m.addEntryListener((EntryListener) null, samplePredicate, "", true));
         assertThrowsNPE(m -> m.addEntryListener(sampleEntryListener, null, "", true));
-        assertThrowsNPE(m -> m.addEntryListener(sampleEntryListener, samplePredicate, null, true));
+        // there's a difference between member-side and client-side behaviour that needs to be fixed
+        // see https://github.com/hazelcast/hazelcast/issues/15155
+        // assertThrowsNPE(m -> m.addEntryListener(sampleEntryListener, samplePredicate, null, true));
+        // assertThrowsNPE(m -> m.addEntryListener(sampleMapListener, samplePredicate, null, true));
         assertThrowsNPE(m -> m.addEntryListener((MapListener) null, "", true));
         assertThrowsNPE(m -> m.addEntryListener((MapListener) null, (Object) null, true));
         assertThrowsNPE(m -> m.addEntryListener((MapListener) null, samplePredicate, true));
         assertThrowsNPE(m -> m.addEntryListener(sampleMapListener, null, true));
         assertThrowsNPE(m -> m.addEntryListener((MapListener) null, samplePredicate, "", true));
         assertThrowsNPE(m -> m.addEntryListener(sampleMapListener, null, "", true));
-        assertThrowsNPE(m -> m.addEntryListener(sampleMapListener, samplePredicate, null, true));
         assertThrowsNPE(m -> m.removeEntryListener(null));
         assertThrowsNPE(m -> m.addPartitionLostListener(null));
         assertThrowsNPE(m -> m.removePartitionLostListener(null));
@@ -199,11 +196,14 @@ public abstract class AbstractMapNullTest extends HazelcastTestSupport {
         assertThrows(NullPointerException.class, method);
     }
 
-    private void assertThrows(Class<? extends Exception> exceptionClass, ConsumerEx<IMap<Object, Object>> method) {
+    private void assertThrows(Class<? extends Exception> expectedExceptionClass,
+                              ConsumerEx<IMap<Object, Object>> method) {
         try {
             method.accept(getDriver().getMap(MAP_NAME));
+            fail("Expected " + expectedExceptionClass
+                    + " but there was no exception!");
         } catch (Exception e) {
-            Assert.assertSame(e.getClass(), exceptionClass);
+            Assert.assertSame(expectedExceptionClass, e.getClass());
         }
     }
 

--- a/hazelcast/src/test/java/com/hazelcast/map/AbstractMapNullTest.java
+++ b/hazelcast/src/test/java/com/hazelcast/map/AbstractMapNullTest.java
@@ -158,10 +158,6 @@ public abstract class AbstractMapNullTest extends HazelcastTestSupport {
         assertThrowsNPE(m -> m.addEntryListener(sampleEntryListener, null, true));
         assertThrowsNPE(m -> m.addEntryListener((EntryListener) null, samplePredicate, "", true));
         assertThrowsNPE(m -> m.addEntryListener(sampleEntryListener, null, "", true));
-        // there's a difference between member-side and client-side behaviour that needs to be fixed
-        // see https://github.com/hazelcast/hazelcast/issues/15155
-        // assertThrowsNPE(m -> m.addEntryListener(sampleEntryListener, samplePredicate, null, true));
-        // assertThrowsNPE(m -> m.addEntryListener(sampleMapListener, samplePredicate, null, true));
         assertThrowsNPE(m -> m.addEntryListener((MapListener) null, "", true));
         assertThrowsNPE(m -> m.addEntryListener((MapListener) null, (Object) null, true));
         assertThrowsNPE(m -> m.addEntryListener((MapListener) null, samplePredicate, true));

--- a/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
+++ b/hazelcast/src/test/java/com/hazelcast/nio/tcp/MockIOService.java
@@ -40,6 +40,7 @@ import com.hazelcast.spi.EventRegistration;
 import com.hazelcast.spi.EventService;
 import com.hazelcast.spi.properties.HazelcastProperties;
 
+import javax.annotation.Nonnull;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -237,27 +238,27 @@ public class MockIOService implements IOService {
             }
 
             @Override
-            public EventRegistration registerLocalListener(String serviceName, String topic, Object listener) {
+            public EventRegistration registerLocalListener(String serviceName, String topic, @Nonnull Object listener) {
                 return null;
             }
 
             @Override
-            public EventRegistration registerLocalListener(String serviceName, String topic, EventFilter filter, Object listener) {
+            public EventRegistration registerLocalListener(String serviceName, String topic, @Nonnull EventFilter filter, @Nonnull Object listener) {
                 return null;
             }
 
             @Override
-            public EventRegistration registerListener(String serviceName, String topic, Object listener) {
+            public EventRegistration registerListener(String serviceName, String topic, @Nonnull Object listener) {
                 return null;
             }
 
             @Override
-            public EventRegistration registerListener(String serviceName, String topic, EventFilter filter, Object listener) {
+            public EventRegistration registerListener(String serviceName, String topic, @Nonnull EventFilter filter, @Nonnull Object listener) {
                 return null;
             }
 
             @Override
-            public boolean deregisterListener(String serviceName, String topic, Object id) {
+            public boolean deregisterListener(@Nonnull String serviceName, @Nonnull String topic, @Nonnull Object id) {
                 return false;
             }
 


### PR DESCRIPTION
Why should IMap be the only structure with a nice and clean API? It shouldn't! So we now add `@Nullable` and `@Nonnull` annotations to `IQueue` and do some minor cleanup.

Second commit is a small fix for the difference in behaviour of client and member-side IMap.addEntryListener.

Fixes: #15155